### PR TITLE
R3: Voice chat redesign, Whisper+Edge-TTS migration, chart compound hover

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# ──────────────────────────────────────────────
+# F1 Strat Manager — Environment Variables
+# ──────────────────────────────────────────────
+# Copy this file to .env and fill in your values:
+#   cp .env.example .env
+#
+# NEVER commit .env — it is in .gitignore.
+# ──────────────────────────────────────────────
+
+# --- LLM provider (required) ---
+# "openai" uses the OpenAI API; "lmstudio" uses a local LM Studio server.
+F1_LLM_PROVIDER=openai
+
+# --- OpenAI (required when F1_LLM_PROVIDER=openai) ---
+OPENAI_API_KEY=sk-your-key-here
+
+# --- LM Studio (only when F1_LLM_PROVIDER=lmstudio) ---
+# LM_STUDIO_BASE_URL=http://host.docker.internal:1234/v1
+
+# --- Supabase (required for auth & database) ---
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_KEY=your-anon-key-here
+
+# --- Auth (backend JWT) ---
+SECRET_KEY=change-me-to-a-random-string
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=60

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -404,22 +404,47 @@ Wire the multi-agent system into the FastAPI backend, expose strategy tools via 
 - [ ] Tag v0.1.1, attach wheel to GitHub Release
 - [ ] README install section: `uv tool install <release-url>/*.whl`
 
-**Step 9 — FastAPI wiring (`src/telemetry/backend/`):**
+**Step 9 — FastAPI wiring (`src/telemetry/backend/`):** ✅ DONE
 
-- [ ] 9a: New router `api/v1/endpoints/strategy.py` — HTTP endpoints for each agent + orchestrator
-  - POST /strategy/pace, /tire, /situation, /pit, /radio, /rag, /recommend
-- [ ] 9b: Upgrade `chat.py` — route strategy-intent queries to orchestrator via MCP tools
-- [ ] Fix sys.path so telemetry backend imports from `src/agents/`
+- [X] 9a: Router `api/v1/endpoints/strategy.py` exposes all agents + orchestrator ✅
+  - POST /strategy/pace, /tire, /situation, /pit, /radio, /rag, /recommend — all live
+- [X] 9b: `chat.py` upgraded — strategy-intent queries route to N31 orchestrator ✅
+- [X] `sys.path` fix so telemetry backend imports cleanly from `src/agents/` ✅
 
-**Step 10 — FastMCP + Streamlit pages:**
+**Step 10 — FastMCP + Streamlit chat:** ✅ DONE
 
-- [ ] FastMCP server mounted alongside FastAPI (`app.mount("/mcp", ...)`)
-  - Tools: `get_strategy_recommendation`, `get_tire_status`, `get_race_situation`, `query_regulations`
-  - LangGraph agent in `/chat/` connects to MCP server for tool calls
-- [ ] `pages/strategy.py` — Live strategy card (action badge, confidence bar, scenario scores, reasoning)
+- [X] FastMCP server mounted alongside FastAPI; `/chat/` is an MCP client ✅
+- [X] Phase 1 — agent MCP tools: `predict_pace`, `predict_tire`, `predict_situation`, `predict_pit`, `analyze_radio`, `query_regulations`, `recommend_strategy` ✅
+- [X] Phase 2 — telemetry MCP tools via `FastMCP.from_openapi()`: `get_lap_times`, `get_telemetry`, `compare_drivers`, `get_race_data` (HTTP fallback for chat) ✅
+- [X] **2026-04-14 — inline Plotly chart rendering** for the 4 Phase 2 tools in the chat: new `chart_builders.py`, `_render_chart` dispatcher, purple-outlined bubbles matching the agent cards. Backend trim split via `_trim_for_llm` so the UI receives the full payload. Qdrant singleton fix (`@lru_cache` on `get_retriever`) ✅
+- [X] `pages/strategy.py` — Live strategy card (action badge, confidence bar, scenario scores, reasoning) ✅
   - Sub-agent tabs: Pace (CI ribbon), Tyres (cliff gauge), Race Situation (overtake + SC gauges), Pit Analysis (undercut + duration)
-- [ ] `pages/race_analysis.py` — 5-tab race view (Overview, Competitive, Gap Analysis, Degradation, Predictions)
+- [X] `pages/race_analysis.py` — 5-tab race view (Overview, Competitive, Gap Analysis, Degradation, Predictions) ✅
   - Port legacy components from `legacy/app_streamlit_v1/` with N25-N31 API data sources
+
+**Step 11 — CLI simulation demo (`scripts/run_simulation_cli.py`):** ✅ DONE
+
+- [X] Rich Live lap-by-lap rendering with inference detail panel (2,387 lines) ✅
+- [X] Decision column `ACTION·PACE·RISK` + Plan column (`→ L8 HARD vs NOR`) ✅
+- [X] Lap-1 path hardening, strategic guard-rails applied in N26/N27/N28/N31 prompts ✅
+- [X] Kafka descoped and documented; historical-only data source acknowledged ✅
+
+**Step 11.5 — Simulation SSE backend (infra for Arcade):** ✅ DONE
+
+- [X] `src/telemetry/backend/services/simulation/` — `simulate_race` generator + `guard_rails` module duplicated from CLI L1504-L1535 (CLI untouched) ✅
+- [X] `POST /api/v1/strategy/simulate` — `StreamingResponse(media_type="text/event-stream")` emitting `start` → N×`lap` → `summary` events ✅
+- [X] Validated via smoke unit (6-lap assertions) + FastAPI `TestClient` stream (5 frames, 200 OK, correct content-type) + CLI regression (no drift) ✅
+
+**Step 12 — Arcade simulation UI:** ⬜ Not started (see R2 block below)
+
+- [ ] Consume `/api/v1/strategy/simulate` SSE stream in the Arcade game loop
+- [ ] Animate `cars` positions per lap event; pit stop animations on `action == "PIT_NOW"`
+- [ ] Post-run panel rendering the 11 fields of `RunSummary`
+
+**Step 13 — Legacy cleanup:** ⬜ Not started
+
+- [ ] Archive `src/agents/base_agent.py`, `src/agents/strategy_agent.py`, `src/agents/rules/`
+- [ ] Replace legacy jupytext `src/nlp/pipeline.py` with N24-aligned implementation
 
 **Driver + Team selection (single-driver perspective):**
 
@@ -581,5 +606,5 @@ Complete project delivery with thesis documentation, defense materials, and thre
 
 ---
 
-**Last Updated:** April 2026
-**Version:** 1.6
+**Last Updated:** April 14, 2026
+**Version:** 1.7

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# F1 Strategy Manager — Developer Docs
+# F1 Strategy Manager -- Developer Docs
 
 Technical documentation for each `src/` module. Written for developers working on the codebase, not for end users.
 
@@ -6,13 +6,23 @@ Technical documentation for each `src/` module. Written for developers working o
 
 | Module | Status | Doc |
 |---|---|---|
-| `src/simulation/` | done (v0.9) | [overview](simulation/overview.md) |
-| `src/agents/` | done (v0.9) | [README](../src/agents/README.md) |
-| `src/rag/` | done | — |
-| `src/api/` | planned (Step 9) | — |
+| `src/agents/` | done (v0.9) | [Multi-Agent Architecture](architecture.md) |
+| `src/simulation/` | done (v0.9) | [Simulation Overview](simulation/overview.md) |
+| `src/telemetry/frontend/` | done | [Frontend (Streamlit)](frontend.md) |
+| `src/telemetry/backend/` | done | [Backend (FastAPI)](backend-api.md) |
+| `src/rag/` | done | -- |
+
+## Guides
+
+| Guide | Description |
+|---|---|
+| [Setup and Deployment](setup-and-deployment.md) | Docker, local dev, environment variables |
+| [Agents API Reference](agents-api-reference.md) | Entry points, output schemas, request/response models |
+| [Driver Colors](driver-colors.md) | Year-aware color palette system (2023--2025) |
+| [Frontend CSS Fixes](frontend-css-fixes.md) | Scroll fix, spinner removal, chart styling |
 
 ## Conventions
 
-- **lap_state dict**: canonical data contract between simulation and agents. Schema in [simulation/overview.md](simulation/overview.md#lap_state-schema).
+- **lap_state dict**: canonical data contract between simulation and agents. Schema in [simulation/overview.md](simulation/overview.md#data-boundary-architectural-constraint).
 - **data/models/**: all trained model artifacts. Layout mirrors the agent that owns them.
 - **data/raw/2025/<GP>/**: race parquets from FastF1. Each GP dir has `laps.parquet`, `weather.parquet`, `metadata.json`.

--- a/docs/agents-api-reference.md
+++ b/docs/agents-api-reference.md
@@ -1,0 +1,185 @@
+# Agents API Reference
+
+## Module Location
+
+All agents live in `src/agents/`. Each file is extracted from its corresponding notebook (N25--N31).
+
+## Entry Points
+
+Every agent has two entry points:
+
+| Agent | FastF1 Entry | RSM Adapter (no FastF1 session) |
+|---|---|---|
+| N25 Pace | `run_pace_agent(**kwargs)` | `run_pace_agent_from_state(lap_state, laps_df)` |
+| N26 Tire | `run_tire_agent(stint_state)` | `run_tire_agent_from_state(lap_state, laps_df)` |
+| N27 Situation | `run_race_situation_agent(lap_state)` | `run_race_situation_agent_from_state(lap_state, laps_df)` |
+| N28 Pit | `run_pit_strategy_agent(lap_state)` | `run_pit_strategy_agent_from_state(lap_state, laps_df)` |
+| N29 Radio | `run_radio_agent(lap_state)` | `run_radio_agent_from_state(lap_state, laps_df)` |
+| N30 RAG | `run_rag_agent(question)` | `run_rag_agent_from_state(lap_state)` |
+| N31 Orchestrator | `run_strategy_orchestrator(race_state, lap_state)` | `run_strategy_orchestrator_from_state(race_state, laps_df)` |
+
+Each agent also exposes a `get_*_react_agent()` factory that returns a compiled LangGraph `CompiledGraph` for direct LangGraph usage.
+
+## Output Dataclasses
+
+### PaceOutput (N25)
+
+| Field | Type | Description |
+|---|---|---|
+| `lap_time_pred` | float | Predicted lap time in seconds |
+| `delta_vs_prev` | float | Delta vs previous lap (negative = faster) |
+| `delta_vs_median` | float | Delta vs session median |
+| `ci_p10` | float | 10th percentile bootstrap CI |
+| `ci_p90` | float | 90th percentile bootstrap CI |
+| `reasoning` | str | LLM-generated reasoning text |
+
+### TireOutput (N26)
+
+| Field | Type | Description |
+|---|---|---|
+| `compound` | str | Current compound name (SOFT, MEDIUM, HARD) |
+| `current_tyre_life` | int | Current tire age in laps |
+| `deg_rate` | float | Degradation rate (seconds lost per lap) |
+| `laps_to_cliff_p10` | float | 10th percentile laps until cliff |
+| `laps_to_cliff_p50` | float | 50th percentile laps until cliff |
+| `laps_to_cliff_p90` | float | 90th percentile laps until cliff |
+| `warning_level` | str | OK, MONITOR, PIT_SOON, or CRITICAL |
+| `reasoning` | str | LLM-generated reasoning text |
+
+### RaceSituationOutput (N27)
+
+| Field | Type | Description |
+|---|---|---|
+| `overtake_prob` | float | Probability of being overtaken (0--1) |
+| `sc_prob_3lap` | float | Safety car probability within 3 laps (0--1) |
+| `threat_level` | str | LOW, MEDIUM, HIGH, CRITICAL |
+| `gap_ahead_s` | float | Gap to car ahead in seconds |
+| `pace_delta_s` | float | Pace difference vs car ahead |
+| `reasoning` | str | LLM-generated reasoning text |
+
+### PitStrategyOutput (N28)
+
+| Field | Type | Description |
+|---|---|---|
+| `action` | str | STAY_OUT, PIT_NOW, UNDERCUT, OVERCUT |
+| `recommended_lap` | int or None | Suggested pit lap |
+| `compound_recommendation` | str | Suggested next compound |
+| `stop_duration_p05` | float | 5th percentile stop duration (seconds) |
+| `stop_duration_p50` | float | Median stop duration (seconds) |
+| `stop_duration_p95` | float | 95th percentile stop duration (seconds) |
+| `undercut_prob` | float or None | Undercut success probability (0--1) |
+| `undercut_target` | str or None | Target driver for undercut |
+| `sc_reactive` | bool | Whether recommendation is SC-reactive |
+| `reasoning` | str | LLM-generated reasoning text |
+
+### RadioOutput (N29)
+
+| Field | Type | Description |
+|---|---|---|
+| `radio_events` | list | Processed radio messages with sentiment, intent, NER |
+| `rcm_events` | list | Processed Race Control Messages |
+| `alerts` | list | Deterministic alert flags from NLP pipeline |
+| `reasoning` | str | LLM-generated reasoning text |
+| `corrections` | list | Driver-reported corrections (e.g., damage, handling issues) |
+
+### RegulationContext (N30)
+
+| Field | Type | Description |
+|---|---|---|
+| `answer` | str | Synthesized answer from regulation passages |
+| `articles` | list[str] | Referenced FIA article numbers |
+| `chunks` | list | Raw retrieved text chunks |
+| `reasoning` | str | Alias for `answer` |
+
+### StrategyRecommendation (N31)
+
+| Field | Type | Description |
+|---|---|---|
+| `action` | str | STAY_OUT, PIT_NOW, UNDERCUT, OVERCUT, ALERT |
+| `pace_mode` | str | PUSH, NEUTRAL, MANAGE, LIFT_AND_COAST |
+| `risk_posture` | str | AGGRESSIVE, BALANCED, DEFENSIVE |
+| `reasoning` | str | Multi-sentence LLM synthesis |
+| `confidence` | float | 0--1 confidence score |
+| `scenario_scores` | dict | MC scores per strategy candidate |
+| `contingencies` | list[Contingency] | Conditional plan branches |
+| `regulation_context` | str | RAG answer if N30 was activated |
+
+### Contingency
+
+| Field | Type | Description |
+|---|---|---|
+| `trigger` | str | Event description that activates this branch |
+| `switch_to` | str | Replacement action (same enum as primary action) |
+| `priority` | str | HIGH, MEDIUM, LOW |
+
+## RaceState Input (N31)
+
+The orchestrator accepts a `RaceState` Pydantic model:
+
+```python
+class RaceState(BaseModel):
+    driver: str           # Three-letter driver code
+    lap: int              # Current lap number
+    total_laps: int       # Total race laps
+    position: int         # Current race position
+    compound: str         # Current tire compound
+    tyre_life: int        # Current tire age (laps)
+    gap_ahead_s: float    # Gap to car ahead (seconds)
+    pace_delta_s: float   # Pace delta vs car ahead
+    air_temp: float       # Air temperature (C)
+    track_temp: float     # Track temperature (C)
+    rainfall: bool = False
+    radio_msgs: list = []   # RadioMessage dicts for current lap window
+    rcm_events: list = []   # RCMEvent dicts for current lap window
+    risk_tolerance: float = 0.5  # 0=conservative, 1=aggressive
+```
+
+## Model Artifacts
+
+| Agent | Model Directory | Files |
+|---|---|---|
+| N25 | `data/models/lap_time/` | XGBoost model |
+| N26 | `data/models/tire_degradation/` | TireDegTCN `.pt` files + calibration JSON |
+| N27 | `data/models/overtake_probability/` | LightGBM + calibrator + config |
+| N27 | `data/models/safety_car_probability/` | LightGBM + calibrator + feature list |
+| N28 | `data/models/pit_prediction/` | HistGBT P05/P50/P95 + undercut LightGBM |
+| N29 | `data/models/nlp/` | pipeline_config_v1.json + .pt state dicts |
+| N30 | `data/rag/` | Qdrant index (built by `scripts/build_rag_index.py`) |
+
+## Testing Examples
+
+**Tool-level (no LLM needed):**
+
+```python
+from src.agents.radio_agent import process_radio_tool
+result = process_radio_tool.invoke({
+    "driver": "NOR", "lap": 18, "text": "Box this lap."
+})
+```
+
+**Agent-level (no LLM needed):**
+
+```python
+from src.agents.pace_agent import run_pace_agent_from_state
+import pandas as pd
+
+laps_df = pd.read_parquet("data/processed/laps_featured_2025.parquet")
+lap_state = {"driver": "VER", "lap_number": 20, ...}
+output = run_pace_agent_from_state(lap_state, laps_df)
+```
+
+**Full orchestrator (requires LM Studio or OpenAI):**
+
+```python
+from src.agents.strategy_orchestrator import RaceState, run_strategy_orchestrator_from_state
+import pandas as pd
+
+laps_df = pd.read_parquet("data/processed/laps_featured_2025.parquet")
+race_state = RaceState(
+    driver="NOR", lap=18, total_laps=57, position=3,
+    compound="C2", tyre_life=20, gap_ahead_s=1.2, pace_delta_s=-0.3,
+    air_temp=32.0, track_temp=48.0,
+)
+rec = run_strategy_orchestrator_from_state(race_state, laps_df)
+print(rec.action, rec.confidence, rec.reasoning)
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,154 @@
+# Multi-Agent Strategy Architecture (N25--N31)
+
+## Purpose
+
+The multi-agent system replaces the legacy Experta rule engine (`base_agent.py`, `strategy_agent.py`) with a LangGraph-based pipeline that combines ML model inference, Monte Carlo simulation, and LLM-driven synthesis to produce race strategy recommendations.
+
+## System Overview
+
+```mermaid
+graph TD
+    RSM[RaceStateManager] -->|lap_state dict| ORCH[Strategy Orchestrator N31]
+
+    subgraph "Layer 1 -- Always-On Agents"
+        N25[N25 Pace Agent<br/>XGBoost + Bootstrap CI]
+        N26[N26 Tire Agent<br/>TireDegTCN + MC Dropout]
+        N27[N27 Race Situation Agent<br/>LightGBM Overtake + SC]
+        N29[N29 Radio Agent<br/>RoBERTa + SetFit + BERT NER]
+    end
+
+    subgraph "Layer 1 -- Conditional Agents (MoE Routing)"
+        N28[N28 Pit Strategy Agent<br/>N15 Quantiles + N16 Undercut]
+        N30[N30 RAG Agent<br/>Qdrant + BGE-M3]
+    end
+
+    ORCH --> N25
+    ORCH --> N26
+    ORCH --> N27
+    ORCH --> N29
+
+    N26 -->|tire_warning == PIT_SOON| N28
+    N29 -->|PROBLEM or WARNING alert| N28
+    N27 -->|sc_prob > 0.30| N30
+    N28 -->|always when N28 active| N30
+
+    subgraph "Layer 2 -- Monte Carlo Simulation"
+        MC[500 draws x 4 candidates<br/>STAY_OUT / PIT_NOW / UNDERCUT / OVERCUT<br/>score = alpha * E + 1-alpha * P10]
+    end
+
+    subgraph "Layer 3 -- LLM Synthesis"
+        LLM[ChatOpenAI.with_structured_output<br/>StrategyRecommendation]
+    end
+
+    N25 --> MC
+    N26 --> MC
+    N27 --> MC
+    N28 --> MC
+    MC --> LLM
+    N29 --> LLM
+    N30 --> LLM
+    LLM --> REC[StrategyRecommendation]
+```
+
+## Agent Details
+
+### N25 -- Pace Agent (`pace_agent.py`)
+
+Wraps the N06 XGBoost delta-lap-time model. Returns predicted lap time, delta signals against previous lap and session median, and bootstrap confidence intervals (N=200 draws with 2% Gaussian noise on continuous features).
+
+- **Model**: XGBoost trained on 2023--2025 lap data
+- **Output**: `PaceOutput` (lap_time_pred, delta_vs_prev, delta_vs_median, ci_p10, ci_p90)
+
+### N26 -- Tire Agent (`tire_agent.py`)
+
+Wraps per-compound TireDegTCN models (N09/N10) with MC Dropout inference. Answers: how many laps remain before the degradation cliff?
+
+- **Model**: Causal TCN per compound + Platt calibration
+- **Output**: `TireOutput` (laps_to_cliff_p10/p50/p90, warning_level, deg_rate)
+- **Warning levels**: OK, MONITOR, PIT_SOON, CRITICAL
+
+### N27 -- Race Situation Agent (`race_situation_agent.py`)
+
+Combines N12 (overtake probability via LightGBM) and N14 (safety car probability via LightGBM) into a single threat assessment per lap.
+
+- **Models**: LightGBM overtake (AUC-PR 0.5491) + LightGBM SC (AUC-PR 0.0723)
+- **Output**: `RaceSituationOutput` (overtake_prob, sc_prob_3lap, threat_level)
+
+### N28 -- Pit Strategy Agent (`pit_strategy_agent.py`)
+
+Wraps N15 (physical pit stop duration P05/P50/P95 via HistGBT) and N16 (undercut success probability via LightGBM). Recommends when to pit, what compound to fit, and whether to undercut.
+
+- **Models**: HistGBT quantile pit duration + LightGBM undercut
+- **Output**: `PitStrategyOutput` (action, compound_recommendation, stop_duration_p05/p50/p95, undercut_prob)
+- **Activation**: conditional -- only runs when tire_warning is PIT_SOON or radio flags PROBLEM/WARNING
+
+### N29 -- Radio Agent (`radio_agent.py`)
+
+Two-stream NLP pipeline. Driver radio goes through RoBERTa-base sentiment, SetFit intent classification, and BERT-large NER. Race Control Messages go through a deterministic rule-based parser. Alerts are built deterministically from NLP is_alert flags -- the LLM cannot miss or hallucinate alerts.
+
+- **Models**: RoBERTa-base, SetFit, BERT-large-conll03 (radio); rule parser (RCM)
+- **Output**: `RadioOutput` (radio_events, rcm_events, alerts, corrections)
+
+### N30 -- RAG Agent (`rag_agent.py`)
+
+Answers regulation questions by retrieving relevant FIA Sporting Regulation passages from a local Qdrant vector store (built by `scripts/build_rag_index.py`), using BGE-M3 embeddings and a LangGraph ReAct agent.
+
+- **Retriever**: Qdrant + BGE-M3 embeddings
+- **Output**: `RegulationContext` (answer, articles, chunks)
+- **Activation**: conditional -- only runs when sc_prob > 0.30 or N28 is active
+
+### N31 -- Strategy Orchestrator (`strategy_orchestrator.py`)
+
+Three-layer pipeline:
+
+1. **MoE Routing**: deterministic if-else rules decide which conditional agents (N28, N30) to activate based on always-on agent outputs.
+2. **Monte Carlo Simulation**: draws 500 samples from sub-agent probability distributions and evaluates four strategy candidates (STAY_OUT, PIT_NOW, UNDERCUT, OVERCUT). Score = alpha * E[S] + (1-alpha) * P10[S].
+3. **LLM Synthesis**: structured-output LLM aggregates all reasoning strings and MC scores into a `StrategyRecommendation`.
+
+- **Output**: `StrategyRecommendation` (action, reasoning, confidence, scenario_scores, contingencies)
+- **Action values**: STAY_OUT, PIT_NOW, UNDERCUT, OVERCUT, ALERT
+- **Pace modes**: PUSH, NEUTRAL, MANAGE, LIFT_AND_COAST
+- **Risk levels**: AGGRESSIVE, BALANCED, DEFENSIVE
+
+## RSM Adapter Pattern
+
+Every agent exposes two entry points:
+
+```python
+# FastF1 entry point (requires populated module globals)
+run_*_agent(lap_state)
+
+# RSM adapter (no FastF1 session required, works from parquet)
+run_*_agent_from_state(lap_state, laps_df)
+```
+
+The RSM adapter builds `SESSION_META` from `laps_df` and calls the same core logic. The orchestrator uses `run_strategy_orchestrator_from_state(race_state, laps_df)` for the full pipeline.
+
+## LLM Configuration
+
+| Layer | Model | Provider |
+|---|---|---|
+| Sub-agents N25--N29 | gpt-4.1-mini | OpenAI or LM Studio |
+| Orchestrator N31 | gpt-5.4-mini | OpenAI or LM Studio |
+
+Set `F1_LLM_PROVIDER=openai` env var to use the real OpenAI API. Default is LM Studio at `http://localhost:1234/v1`.
+
+## Data Flow
+
+```
+data/raw/2025/<GP>/laps.parquet
+       |
+  RaceReplayEngine --> RaceStateManager.get_lap_state()
+       |
+  lap_state dict --> Strategy Orchestrator
+       |
+  StrategyRecommendation --> FastAPI /api/v1/strategy/recommend
+       |
+  JSON response --> Streamlit Strategy Page
+```
+
+## References
+
+- Heilmeier et al. (2020) ApplSci 10/4229 -- MC motorsport simulation
+- Wang et al. (2024) arXiv:2406.04692 -- MoA reasoning aggregation
+- Liu et al. (2024) arXiv:2402.02392 -- DeLLMa decision under uncertainty with LLM

--- a/docs/backend-api.md
+++ b/docs/backend-api.md
@@ -1,0 +1,159 @@
+# Backend API Reference (FastAPI)
+
+## Overview
+
+The backend is a FastAPI application at `src/telemetry/backend/`. It serves telemetry data, driver comparisons, chat (LM Studio proxy), voice (STT/TTS), and the N25--N31 strategy agent pipeline. All endpoints are prefixed with `/api/v1`.
+
+Entry point: `backend/main.py` -- creates the FastAPI app and registers all routers.
+
+## Router Map
+
+| Router | Prefix | Tags | Source |
+|---|---|---|---|
+| auth | `/api/v1` | auth | `endpoints/auth.py` |
+| telemetry | `/api/v1/telemetry` | telemetry | `endpoints/telemetry.py` |
+| circuit_domination | `/api/v1` | circuit_domination | `endpoints/circuit_domination.py` |
+| comparison | `/api/v1/comparison` | comparison | `endpoints/comparison.py` |
+| chat | `/api/v1/chat` | chat | `endpoints/chat.py` |
+| voice | `/api/v1/voice` | voice | `endpoints/voice.py` |
+| strategy | `/api/v1/strategy` | strategy | `endpoints/strategy.py` |
+
+## Telemetry Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/api/v1/telemetry/data` | Fetch telemetry for year/gp/session/drivers |
+| GET | `/api/v1/telemetry/gps` | List available GPs for a year |
+| GET | `/api/v1/telemetry/sessions` | List sessions for a GP |
+| GET | `/api/v1/telemetry/drivers` | List drivers for a session |
+
+**Query parameters**: `year` (int), `gp` (str), `session` (str), `drivers` (comma-separated).
+
+## Comparison Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/api/v1/comparison/compare` | Compare fastest-lap telemetry between two drivers |
+
+**Query parameters**: `year`, `gp`, `session`, `driver1`, `driver2`. Returns qualifying-phase-matched telemetry with driver colors.
+
+## Chat Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/api/v1/chat/health` | LM Studio health check |
+| GET | `/api/v1/chat/models` | List available LM Studio models |
+| POST | `/api/v1/chat/message` | Non-streaming chat message |
+| POST | `/api/v1/chat/stream` | Streaming chat response (SSE) |
+| POST | `/api/v1/chat/query` | Routed query (detects intent, dispatches) |
+
+Chat proxies to a local LM Studio instance. The `QueryRouter` classifies user intent and dispatches to specialized handlers.
+
+## Voice Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| POST | `/api/v1/voice/transcribe` | Speech-to-text (Whisper) |
+| POST | `/api/v1/voice/tts` | Text-to-speech |
+| GET | `/api/v1/voice/health` | Voice service health check |
+
+## Strategy Endpoints (N25--N31)
+
+All strategy endpoints live under `/api/v1/strategy/`. They accept JSON bodies and return `StrategyResponse` envelopes.
+
+### Metadata (GET)
+
+| Path | Description |
+|---|---|
+| `/api/v1/strategy/available-gps` | GP names in the featured parquet (query: `year`) |
+| `/api/v1/strategy/available-drivers` | Driver codes for a GP (query: `gp`, `year`) |
+| `/api/v1/strategy/lap-range` | Min/max lap for a driver at a GP (query: `gp`, `driver`, `year`) |
+| `/api/v1/strategy/lap-state` | Build canonical lap_state dict from parquet (query: `gp`, `driver`, `lap`, `year`) |
+
+### Agent Endpoints (POST)
+
+| Path | Request Body | Agent | Description |
+|---|---|---|---|
+| `/api/v1/strategy/pace` | `PaceRequest` | N25 | Lap time prediction + CI |
+| `/api/v1/strategy/pace-range` | `PaceRangeRequest` | N25 | Batch predictions over lap range |
+| `/api/v1/strategy/tire` | `TireRequest` | N26 | Tire cliff estimation |
+| `/api/v1/strategy/situation` | `SituationRequest` | N27 | Overtake + SC probability |
+| `/api/v1/strategy/pit` | `PitRequest` | N28 | Pit duration + undercut analysis |
+| `/api/v1/strategy/radio` | `RadioRequest` | N29 | NLP radio pipeline |
+| `/api/v1/strategy/rag` | `RagRequest` | N30 | Regulation retrieval |
+| `/api/v1/strategy/recommend` | `RecommendRequest` | N31 | Full orchestrator pipeline |
+
+### Request Schemas
+
+```python
+class PaceRequest(BaseModel):
+    lap_state: Dict[str, Any]
+
+class TireRequest(BaseModel):
+    lap_state: Dict[str, Any]
+
+class SituationRequest(BaseModel):
+    lap_state: Dict[str, Any]
+
+class PitRequest(BaseModel):
+    lap_state: Dict[str, Any]
+
+class RadioRequest(BaseModel):
+    lap_state: Dict[str, Any]
+    radio_msgs: List[Dict[str, Any]] = []
+    rcm_events: List[Dict[str, Any]] = []
+
+class RagRequest(BaseModel):
+    question: str
+
+class RecommendRequest(BaseModel):
+    lap_state: Dict[str, Any]
+    gp_name: str = ""
+    year: int = 2025
+    gap_ahead_s: float = 2.0
+    pace_delta_s: float = 0.0
+    risk_tolerance: float = 0.5
+    radio_msgs: Optional[List[Dict[str, Any]]] = None
+    rcm_events: Optional[List[Dict[str, Any]]] = None
+```
+
+### Response Schemas
+
+All agent endpoints return `StrategyResponse`:
+
+```python
+class StrategyResponse(BaseModel):
+    agent: str       # e.g. "pace", "tire", "orchestrator"
+    result: Dict[str, Any]  # agent-specific output as dict
+```
+
+Typed result models for Swagger documentation:
+
+| Model | Key Fields |
+|---|---|
+| `PaceResult` | lap_time_pred, delta_vs_prev, delta_vs_median, ci_p10, ci_p90, reasoning |
+| `TireResult` | compound, current_tyre_life, deg_rate, laps_to_cliff_p10/p50/p90, warning_level, reasoning |
+| `SituationResult` | overtake_prob, sc_prob_3lap, threat_level, gap_ahead_s, pace_delta_s, reasoning |
+| `PitResult` | action, recommended_lap, compound_recommendation, stop_duration_p05/p50/p95, undercut_prob, reasoning |
+| `RadioResult` | radio_events, rcm_events, alerts, reasoning, corrections |
+| `RagResult` | question, answer, articles, reasoning |
+
+### Error Handling
+
+Strategy endpoints return structured errors:
+
+```json
+{
+  "error": "ValueError",
+  "agent": "pace",
+  "detail": "Missing feature: compound_id"
+}
+```
+
+## CORS
+
+The backend allows requests from the frontend URL (default `http://localhost:8501`) via `CORSMiddleware`.
+
+## Swagger / OpenAPI
+
+Auto-generated at `http://localhost:8000/docs` when the backend is running.

--- a/docs/backend-api.md
+++ b/docs/backend-api.md
@@ -49,6 +49,22 @@ Entry point: `backend/main.py` -- creates the FastAPI app and registers all rout
 
 Chat proxies to a local LM Studio instance. The `QueryRouter` classifies user intent and dispatches to specialized handlers.
 
+### Tool Results and Display Hints
+
+Handlers under `services/chatbot/handlers/` can invoke MCP-style tools (pace, tire, situation, pit, regulations, and the Phase 2 telemetry tools `get_lap_times`, `get_telemetry`, `compare_drivers`, `get_race_data`). Each tool entry in `TOOL_DISPLAY_MAP` (`models/tool_schemas.py`) carries a `DisplayType` hint the frontend uses for rendering:
+
+| DisplayType | Used by |
+|---|---|
+| `METRICS` | `predict_pace`, `predict_situation` |
+| `STRATEGY_CARD` | `predict_tire`, `predict_pit`, `recommend_strategy` |
+| `TABLE` | `analyze_radio` |
+| `TEXT` | `query_regulations`, `list_gps`, `list_drivers`, `get_lap_range` |
+| `CHART` | `get_lap_times`, `get_telemetry`, `compare_drivers`, `get_race_data` |
+
+The four telemetry tools are wired to `CHART` so the frontend renders them as inline Plotly figures (see [Frontend -- Chat Tool-Result Rendering](frontend.md#chat-tool-result-rendering)).
+
+`StrategyHandler._execute_telemetry_tool` returns the raw tool payload unchanged on `tool_result.data`. A separate static helper `_trim_for_llm(raw)` produces a 20-record-capped shallow copy that is only fed to the LLM summariser. This split keeps the LLM context small without starving the UI of the full series needed to draw the chart.
+
 ## Voice Endpoints
 
 | Method | Path | Description |

--- a/docs/diagrams/backend_api.drawio
+++ b/docs/diagrams/backend_api.drawio
@@ -1,0 +1,214 @@
+<mxfile host="app.diagrams.net" modified="2026-04-13" agent="Claude" version="24.7.17">
+  <diagram id="be-api-1" name="Backend API Endpoint Map">
+    <mxGraphModel dx="1600" dy="1200" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="1200" math="0" shadow="0" background="#0a0a1a">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+
+        <!-- TITLE -->
+        <mxCell id="title" value="FastAPI Backend — Endpoint Map (/api/v1)" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#2dd4bf;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="350" y="10" width="900" height="40" as="geometry"/>
+        </mxCell>
+
+        <!-- ROOT -->
+        <mxCell id="root_ep" value="&lt;b&gt;FastAPI app&lt;/b&gt;&lt;br&gt;GET / &amp;rarr; health" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#2dd4bf;strokeWidth=3;fontColor=#99f6e4;fontSize=13;" vertex="1" parent="1">
+          <mxGeometry x="650" y="70" width="200" height="50" as="geometry"/>
+        </mxCell>
+
+        <!-- ======= TELEMETRY ROUTER ======= -->
+        <mxCell id="r_tele" value="" style="swimlane;html=1;startSize=30;fillColor=#121127;strokeColor=#a78bfa;strokeWidth=2;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="30" y="170" width="220" height="310" as="geometry"/>
+        </mxCell>
+        <mxCell id="r_tele_title" value="/telemetry" style="text;html=1;align=left;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="r_tele">
+          <mxGeometry x="5" y="0" width="200" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="t1" value="GET /data" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_tele">
+          <mxGeometry x="10" y="40" width="200" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="t2" value="GET /gps" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_tele">
+          <mxGeometry x="10" y="78" width="200" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="t3" value="GET /sessions" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_tele">
+          <mxGeometry x="10" y="116" width="200" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="t4" value="GET /drivers" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_tele">
+          <mxGeometry x="10" y="154" width="200" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="t5" value="GET /lap-times" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_tele">
+          <mxGeometry x="10" y="192" width="200" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="t6" value="GET /lap-telemetry" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_tele">
+          <mxGeometry x="10" y="230" width="200" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="t7" value="GET /race-data" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_tele">
+          <mxGeometry x="10" y="268" width="200" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- ======= STRATEGY ROUTER ======= -->
+        <mxCell id="r_strat" value="" style="swimlane;html=1;startSize=30;fillColor=#121127;strokeColor=#ec4899;strokeWidth=2;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="280" y="170" width="240" height="590" as="geometry"/>
+        </mxCell>
+        <mxCell id="r_strat_title" value="/strategy (N25-N31)" style="text;html=1;align=left;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#ec4899;fillColor=none;strokeColor=none;" vertex="1" parent="r_strat">
+          <mxGeometry x="5" y="0" width="220" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="s1" value="GET /available-gps" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#2d1a2e;strokeColor=#be185d;fontColor=#fce7f3;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_strat">
+          <mxGeometry x="10" y="40" width="220" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="s2" value="GET /available-drivers" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#2d1a2e;strokeColor=#be185d;fontColor=#fce7f3;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_strat">
+          <mxGeometry x="10" y="78" width="220" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="s3" value="GET /lap-range" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#2d1a2e;strokeColor=#be185d;fontColor=#fce7f3;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_strat">
+          <mxGeometry x="10" y="116" width="220" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="s4" value="GET /lap-state" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#2d1a2e;strokeColor=#be185d;fontColor=#fce7f3;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_strat">
+          <mxGeometry x="10" y="154" width="220" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="s5" value="POST /pace  (N25)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=9;align=left;spacingLeft=6;fontStyle=1;" vertex="1" parent="r_strat">
+          <mxGeometry x="10" y="200" width="220" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="s5b" value="POST /pace-range" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=9;align=left;spacingLeft=6;fontStyle=1;" vertex="1" parent="r_strat">
+          <mxGeometry x="10" y="238" width="220" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="s6" value="POST /tire  (N26)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=9;align=left;spacingLeft=6;fontStyle=1;" vertex="1" parent="r_strat">
+          <mxGeometry x="10" y="276" width="220" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="s7" value="POST /situation  (N27)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=9;align=left;spacingLeft=6;fontStyle=1;" vertex="1" parent="r_strat">
+          <mxGeometry x="10" y="314" width="220" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="s8" value="POST /pit  (N28)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=9;align=left;spacingLeft=6;fontStyle=1;" vertex="1" parent="r_strat">
+          <mxGeometry x="10" y="352" width="220" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="s9" value="POST /radio  (N29)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=9;align=left;spacingLeft=6;fontStyle=1;" vertex="1" parent="r_strat">
+          <mxGeometry x="10" y="390" width="220" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="s10" value="POST /rag  (N30)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=9;align=left;spacingLeft=6;fontStyle=1;" vertex="1" parent="r_strat">
+          <mxGeometry x="10" y="428" width="220" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="s11" value="POST /recommend  (N31 full)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#f59e0b;fontColor=#fef3c7;fontSize=9;align=left;spacingLeft=6;fontStyle=1;strokeWidth=2;" vertex="1" parent="r_strat">
+          <mxGeometry x="10" y="470" width="220" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="s12" value="GET /radio-available-gps" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#2d1a2e;strokeColor=#be185d;fontColor=#fce7f3;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_strat">
+          <mxGeometry x="10" y="510" width="220" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="s13" value="GET /radio-laps" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#2d1a2e;strokeColor=#be185d;fontColor=#fce7f3;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_strat">
+          <mxGeometry x="10" y="548" width="220" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- ======= CHAT ROUTER ======= -->
+        <mxCell id="r_chat" value="" style="swimlane;html=1;startSize=30;fillColor=#121127;strokeColor=#22d3ee;strokeWidth=2;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="550" y="170" width="220" height="280" as="geometry"/>
+        </mxCell>
+        <mxCell id="r_chat_title" value="/chat" style="text;html=1;align=left;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#22d3ee;fillColor=none;strokeColor=none;" vertex="1" parent="r_chat">
+          <mxGeometry x="5" y="0" width="200" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="c1" value="GET /health" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0c2e3e;strokeColor=#0891b2;fontColor=#cffafe;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_chat">
+          <mxGeometry x="10" y="40" width="200" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="c2" value="GET /models" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0c2e3e;strokeColor=#0891b2;fontColor=#cffafe;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_chat">
+          <mxGeometry x="10" y="78" width="200" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="c3" value="POST /message" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#164e63;strokeColor=#22d3ee;fontColor=#cffafe;fontSize=9;align=left;spacingLeft=6;fontStyle=1;" vertex="1" parent="r_chat">
+          <mxGeometry x="10" y="116" width="200" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="c4" value="POST /stream  (SSE)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#164e63;strokeColor=#22d3ee;fontColor=#cffafe;fontSize=9;align=left;spacingLeft=6;fontStyle=1;" vertex="1" parent="r_chat">
+          <mxGeometry x="10" y="154" width="200" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="c5" value="POST /query  (QueryRouter)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#164e63;strokeColor=#f59e0b;fontColor=#fef3c7;fontSize=9;align=left;spacingLeft=6;fontStyle=1;strokeWidth=2;" vertex="1" parent="r_chat">
+          <mxGeometry x="10" y="192" width="200" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- ======= VOICE ROUTER ======= -->
+        <mxCell id="r_voice" value="" style="swimlane;html=1;startSize=30;fillColor=#121127;strokeColor=#a78bfa;strokeWidth=2;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="800" y="170" width="220" height="270" as="geometry"/>
+        </mxCell>
+        <mxCell id="r_voice_title" value="/voice" style="text;html=1;align=left;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="r_voice">
+          <mxGeometry x="5" y="0" width="200" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="v1" value="POST /transcribe" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_voice">
+          <mxGeometry x="10" y="40" width="200" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="v2" value="POST /process-voice" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_voice">
+          <mxGeometry x="10" y="78" width="200" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="v3" value="POST /complete-voice" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_voice">
+          <mxGeometry x="10" y="116" width="200" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="v4" value="GET /models" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_voice">
+          <mxGeometry x="10" y="154" width="200" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="v5" value="GET /status" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_voice">
+          <mxGeometry x="10" y="192" width="200" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- ======= AUTH + COMPARISON + CIRCUIT ROUTERS ======= -->
+        <mxCell id="r_auth" value="" style="swimlane;html=1;startSize=30;fillColor=#121127;strokeColor=#64748b;strokeWidth=2;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="1050" y="170" width="200" height="230" as="geometry"/>
+        </mxCell>
+        <mxCell id="r_auth_title" value="/auth" style="text;html=1;align=left;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#94a3b8;fillColor=none;strokeColor=none;" vertex="1" parent="r_auth">
+          <mxGeometry x="5" y="0" width="180" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="a1" value="POST /signup" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_auth">
+          <mxGeometry x="10" y="40" width="180" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="a2" value="POST /signin" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_auth">
+          <mxGeometry x="10" y="78" width="180" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="a3" value="GET /me" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_auth">
+          <mxGeometry x="10" y="116" width="180" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="a4" value="POST /signout" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_auth">
+          <mxGeometry x="10" y="154" width="180" height="30" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="r_comp" value="" style="swimlane;html=1;startSize=30;fillColor=#121127;strokeColor=#64748b;strokeWidth=2;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="1280" y="170" width="200" height="120" as="geometry"/>
+        </mxCell>
+        <mxCell id="r_comp_title" value="/compare" style="text;html=1;align=left;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#94a3b8;fillColor=none;strokeColor=none;" vertex="1" parent="r_comp">
+          <mxGeometry x="5" y="0" width="180" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="cp1" value="GET /compare" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_comp">
+          <mxGeometry x="10" y="40" width="180" height="30" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="r_circuit" value="" style="swimlane;html=1;startSize=30;fillColor=#121127;strokeColor=#64748b;strokeWidth=2;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="1280" y="310" width="200" height="120" as="geometry"/>
+        </mxCell>
+        <mxCell id="r_circuit_title" value="/circuit-domination" style="text;html=1;align=left;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#94a3b8;fillColor=none;strokeColor=none;" vertex="1" parent="r_circuit">
+          <mxGeometry x="5" y="0" width="190" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="cd1" value="GET /" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_circuit">
+          <mxGeometry x="10" y="40" width="180" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- Root to routers arrows -->
+        <mxCell id="er1" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#334155;strokeWidth=1;exitX=0;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="root_ep" target="r_tele"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="er2" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#334155;strokeWidth=1;exitX=0.25;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="root_ep" target="r_strat"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="er3" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#334155;strokeWidth=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="root_ep" target="r_chat"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="er4" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#334155;strokeWidth=1;exitX=0.75;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="root_ep" target="r_voice"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="er5" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#334155;strokeWidth=1;exitX=1;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="root_ep" target="r_auth"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="er6" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#334155;strokeWidth=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="root_ep" target="r_comp"><mxGeometry relative="1" as="geometry"/></mxCell>
+
+        <!-- ============ LEGEND ============ -->
+        <mxCell id="legend" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1a1a2e;strokeColor=#334155;strokeWidth=1;" vertex="1" parent="1">
+          <mxGeometry x="550" y="500" width="250" height="100" as="geometry"/>
+        </mxCell>
+        <mxCell id="leg_t" value="&lt;b&gt;Legend&lt;/b&gt;" style="text;html=1;align=left;fontSize=11;fontColor=#e2e8f0;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="560" y="505" width="80" height="20" as="geometry"/>
+        </mxCell>
+        <mxCell id="lg1" value="GET = read endpoints" style="text;html=1;align=left;fontSize=9;fontColor=#94a3b8;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="560" y="530" width="200" height="16" as="geometry"/>
+        </mxCell>
+        <mxCell id="lg2" value="POST (bold) = agent / action endpoints" style="text;html=1;align=left;fontSize=9;fontColor=#ec4899;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="560" y="548" width="230" height="16" as="geometry"/>
+        </mxCell>
+        <mxCell id="lg3" value="Amber border = key entry points" style="text;html=1;align=left;fontSize=9;fontColor=#f59e0b;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="560" y="566" width="230" height="16" as="geometry"/>
+        </mxCell>
+        <mxCell id="lg4" value="Gray = utility routers" style="text;html=1;align=left;fontSize=9;fontColor=#64748b;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="560" y="584" width="200" height="16" as="geometry"/>
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/diagrams/chat_mcp_flow.drawio
+++ b/docs/diagrams/chat_mcp_flow.drawio
@@ -1,13 +1,16 @@
-<mxfile host="app.diagrams.net" modified="2026-04-13" agent="Claude" version="24.7.17">
+<mxfile host="app.diagrams.net" modified="2026-04-14" agent="Claude" version="24.7.17">
   <diagram id="chat-mcp-1" name="Chat MCP Flow">
-    <mxGraphModel dx="1600" dy="1000" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="1000" math="0" shadow="0" background="#0a0a1a">
+    <mxGraphModel dx="1600" dy="1200" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="1200" math="0" shadow="0" background="#0a0a1a">
       <root>
         <mxCell id="0"/>
         <mxCell id="1" parent="0"/>
 
         <!-- TITLE -->
-        <mxCell id="title" value="Chat &amp; QueryRouter Flow — From User Message to Rich Rendering" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+        <mxCell id="title" value="Chat &amp; QueryRouter Flow — From User Message to Inline Plotly Charts" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="1">
           <mxGeometry x="300" y="10" width="1000" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="subtitle" value="Phase 2 update: tool payload split (full → UI, trimmed → LLM) + CHART display type renders inline Plotly figures" style="text;html=1;align=center;verticalAlign=middle;fontSize=11;fontStyle=2;fontColor=#94a3b8;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="300" y="48" width="1000" height="22" as="geometry"/>
         </mxCell>
 
         <!-- ============ STEP 1: USER INPUT ============ -->
@@ -212,6 +215,163 @@
         </mxCell>
         <mxCell id="voice3" value="text &amp;rarr; /chat/query" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
           <mxGeometry x="345" y="430" width="100" height="35" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ PHASE 2: TOOL EXECUTION + PAYLOAD SPLIT + CHART RENDER ============ -->
+        <mxCell id="p2_band" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#10172a;strokeColor=#ec4899;strokeWidth=2;dashed=1;opacity=70;" vertex="1" parent="1">
+          <mxGeometry x="20" y="690" width="1560" height="470" as="geometry"/>
+        </mxCell>
+        <mxCell id="p2_label" value="Phase 2 — StrategyHandler.handle_with_tools()  ·  Tool execution → Payload split → Inline Plotly rendering" style="text;html=1;align=center;verticalAlign=middle;fontSize=13;fontStyle=1;fontColor=#ec4899;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="40" y="700" width="900" height="24" as="geometry"/>
+        </mxCell>
+
+        <!-- Strategy handler entry -->
+        <mxCell id="sh_entry" value="&lt;b&gt;StrategyHandler&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;handlers/strategy_handler.py&lt;br&gt;handle_with_tools(message)&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;strokeWidth=2;fontColor=#fce7f3;fontSize=11;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="50" y="750" width="200" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- LLM ToolCall extraction -->
+        <mxCell id="llm_extract" value="&lt;b&gt;LLM ToolCall extraction&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;LM Studio decides which tool&lt;br&gt;+ arguments from user prompt&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;strokeWidth=2;fontColor=#fef3c7;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="290" y="750" width="200" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Tool dispatch decision -->
+        <mxCell id="tool_dispatch" value="&lt;b&gt;Tool dispatcher&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;agent tool vs. telemetry tool&lt;/font&gt;" style="rhombus;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;fontColor=#fef3c7;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="540" y="745" width="200" height="90" as="geometry"/>
+        </mxCell>
+
+        <!-- Branch A: agent tool -->
+        <mxCell id="agent_tool" value="&lt;b&gt;Agent tool exec&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;run_tire_agent / run_pace_agent&lt;br&gt;run_pit_agent / run_radio_agent&lt;br&gt;in-process LangGraph call&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#164e63;strokeColor=#22d3ee;strokeWidth=2;fontColor=#cffafe;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="800" y="700" width="220" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Branch B: telemetry HTTP -->
+        <mxCell id="telemetry_http" value="&lt;b&gt;Telemetry tool (HTTP)&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;FastAPI /telemetry/* endpoint:&lt;br&gt;get_lap_times · get_telemetry&lt;br&gt;compare_drivers · get_race_data&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#2dd4bf;strokeWidth=2;fontColor=#99f6e4;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="800" y="800" width="220" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- TOOL_DISPLAY_MAP lookup -->
+        <mxCell id="display_map" value="&lt;b&gt;TOOL_DISPLAY_MAP&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;models/tool_schemas.py&lt;br&gt;Phase 2 tools → DisplayType.CHART&lt;br&gt;(was TABLE)&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0a3b;strokeColor=#d946ef;strokeWidth=2;fontColor=#f5d0fe;fontSize=10;verticalAlign=top;spacingTop=4;dashed=0;" vertex="1" parent="1">
+          <mxGeometry x="1080" y="750" width="220" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ PAYLOAD SPLIT ============ -->
+        <mxCell id="split" value="&lt;b&gt;Payload split&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;raw response&lt;/font&gt;" style="rhombus;whiteSpace=wrap;html=1;fillColor=#7c1d6f;strokeColor=#ec4899;strokeWidth=3;fontColor=#fce7f3;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="540" y="900" width="200" height="100" as="geometry"/>
+        </mxCell>
+
+        <!-- Full payload -> UI -->
+        <mxCell id="full_payload" value="&lt;b&gt;tool_result.data&lt;/b&gt; (FULL)&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;every record kept&lt;br&gt;feeds frontend renderer&lt;br&gt;→ Plotly figure&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#14532d;strokeColor=#22c55e;strokeWidth=2;fontColor=#bbf7d0;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="290" y="910" width="220" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Trimmed payload -> LLM -->
+        <mxCell id="trim_payload" value="&lt;b&gt;_trim_for_llm&lt;/b&gt; (TRIM)&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;cap 20 records&lt;br&gt;feeds LLM summariser&lt;br&gt;→ short text answer&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;strokeWidth=2;fontColor=#fef3c7;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="800" y="910" width="220" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- LLM summariser -->
+        <mxCell id="llm_sum" value="&lt;b&gt;LM Studio summariser&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;writes natural-language reply&lt;br&gt;based on TRIMMED data only&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;strokeWidth=2;fontColor=#fef3c7;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="1080" y="910" width="220" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ FRONTEND CHART RENDERING ============ -->
+        <mxCell id="tool_result_renderer" value="&lt;b&gt;tool_result_renderer.py&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;dispatch on display_type:&lt;br&gt;_RENDERERS[&quot;chart&quot;] → _render_chart&lt;br&gt;try/except → _render_text fallback&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#a78bfa;strokeWidth=2;fontColor=#c4b5fd;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="50" y="1040" width="240" height="90" as="geometry"/>
+        </mxCell>
+
+        <!-- chart_builders.py -->
+        <mxCell id="chart_builders" value="&lt;b&gt;chart_builders.py&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;build_figure(tool_name, data) → go.Figure&lt;br&gt;• lap_times: line per driver&lt;br&gt;• telemetry: speed/throttle/brake panels&lt;br&gt;• compare_drivers: speed overlay + delta&lt;br&gt;• race_data: dual subplot pos + lap times&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0a3b;strokeColor=#d946ef;strokeWidth=2;fontColor=#f5d0fe;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="340" y="1040" width="320" height="100" as="geometry"/>
+        </mxCell>
+
+        <!-- Plotly figure inline -->
+        <mxCell id="plotly_inline" value="&lt;b&gt;Plotly figure inline&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;st.plotly_chart() inside&lt;br&gt;st.chat_message bubble&lt;br&gt;+ LLM text summary above&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#14532d;strokeColor=#22c55e;strokeWidth=2;fontColor=#bbf7d0;fontSize=11;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="710" y="1040" width="240" height="90" as="geometry"/>
+        </mxCell>
+
+        <!-- Note: bug fix -->
+        <mxCell id="bug_note" value="&lt;b&gt;Side-effect:&lt;/b&gt; compare_drivers &quot;N/A&quot; bug&lt;br&gt;is fixed by design — chart consumes&lt;br&gt;raw nested payload directly, no flattening" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f0f2e;strokeColor=#22c55e;strokeWidth=1;dashed=1;fontColor=#bbf7d0;fontSize=9;verticalAlign=middle;align=center;" vertex="1" parent="1">
+          <mxGeometry x="1000" y="1050" width="280" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ PHASE 2 EDGES ============ -->
+        <!-- StrategyHandler (h6) → SH entry -->
+        <mxCell id="pe0" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#ec4899;strokeWidth=2;dashed=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="h6" target="sh_entry"><mxGeometry relative="1" as="geometry"/></mxCell>
+
+        <!-- SH → LLM extract -->
+        <mxCell id="pe1" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#f59e0b;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="sh_entry" target="llm_extract"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="pe1_l" value="A" style="ellipse;whiteSpace=wrap;html=1;fillColor=#f59e0b;strokeColor=none;fontColor=#0a0a1a;fontSize=10;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="258" y="780" width="22" height="22" as="geometry"/>
+        </mxCell>
+
+        <!-- LLM extract → dispatch -->
+        <mxCell id="pe2" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#f59e0b;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="llm_extract" target="tool_dispatch"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="pe2_l" value="B" style="ellipse;whiteSpace=wrap;html=1;fillColor=#f59e0b;strokeColor=none;fontColor=#0a0a1a;fontSize=10;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="508" y="780" width="22" height="22" as="geometry"/>
+        </mxCell>
+
+        <!-- dispatch → agent_tool -->
+        <mxCell id="pe3a" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#22d3ee;strokeWidth=2;exitX=1;exitY=0.25;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="tool_dispatch" target="agent_tool"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="pe3a_l" value="agent" style="text;html=1;align=center;verticalAlign=middle;fontSize=9;fontColor=#22d3ee;fillColor=#0a0a1a;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="745" y="730" width="50" height="18" as="geometry"/>
+        </mxCell>
+
+        <!-- dispatch → telemetry_http -->
+        <mxCell id="pe3b" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#2dd4bf;strokeWidth=2;exitX=1;exitY=0.75;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="tool_dispatch" target="telemetry_http"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="pe3b_l" value="telemetry" style="text;html=1;align=center;verticalAlign=middle;fontSize=9;fontColor=#2dd4bf;fillColor=#0a0a1a;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="740" y="833" width="60" height="18" as="geometry"/>
+        </mxCell>
+
+        <!-- telemetry → display_map (annotation) -->
+        <mxCell id="pe_dm" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#d946ef;strokeWidth=1;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;endArrow=open;" edge="1" parent="1" source="telemetry_http" target="display_map"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="pe_dm_l" value="lookup" style="text;html=1;align=center;verticalAlign=middle;fontSize=9;fontColor=#d946ef;fillColor=#0a0a1a;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1025" y="828" width="50" height="18" as="geometry"/>
+        </mxCell>
+
+        <!-- agent_tool → split -->
+        <mxCell id="pe4a" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#ec4899;strokeWidth=2;exitX=0;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.25;entryDx=0;entryDy=0;" edge="1" parent="1" source="agent_tool" target="split"><mxGeometry relative="1" as="geometry"/></mxCell>
+
+        <!-- telemetry → split -->
+        <mxCell id="pe4b" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#ec4899;strokeWidth=2;exitX=0;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.75;entryDx=0;entryDy=0;" edge="1" parent="1" source="telemetry_http" target="split"><mxGeometry relative="1" as="geometry"/></mxCell>
+
+        <!-- split → full -->
+        <mxCell id="pe5a" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#22c55e;strokeWidth=3;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="split" target="full_payload"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="pe5a_l" value="FULL → UI" style="text;html=1;align=center;verticalAlign=middle;fontSize=10;fontStyle=1;fontColor=#22c55e;fillColor=#0a0a1a;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="510" y="935" width="80" height="20" as="geometry"/>
+        </mxCell>
+
+        <!-- split → trim -->
+        <mxCell id="pe5b" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#f59e0b;strokeWidth=3;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="split" target="trim_payload"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="pe5b_l" value="TRIM → LLM" style="text;html=1;align=center;verticalAlign=middle;fontSize=10;fontStyle=1;fontColor=#f59e0b;fillColor=#0a0a1a;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="743" y="935" width="90" height="20" as="geometry"/>
+        </mxCell>
+
+        <!-- trim → llm summariser -->
+        <mxCell id="pe6" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#f59e0b;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="trim_payload" target="llm_sum"><mxGeometry relative="1" as="geometry"/></mxCell>
+
+        <!-- full → renderer -->
+        <mxCell id="pe7" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#22c55e;strokeWidth=2;exitX=0.25;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="full_payload" target="tool_result_renderer"><mxGeometry relative="1" as="geometry"/></mxCell>
+
+        <!-- renderer → chart_builders -->
+        <mxCell id="pe8" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#d946ef;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="tool_result_renderer" target="chart_builders"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="pe8_l" value="display_type==&quot;chart&quot;" style="text;html=1;align=center;verticalAlign=middle;fontSize=9;fontStyle=2;fontColor=#d946ef;fillColor=#0a0a1a;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="295" y="1015" width="140" height="18" as="geometry"/>
+        </mxCell>
+
+        <!-- chart_builders → plotly_inline -->
+        <mxCell id="pe9" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#22c55e;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="chart_builders" target="plotly_inline"><mxGeometry relative="1" as="geometry"/></mxCell>
+
+        <!-- llm_sum → plotly_inline (text alongside chart) -->
+        <mxCell id="pe10" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#f59e0b;strokeWidth=1;dashed=1;exitX=0;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;endArrow=open;" edge="1" parent="1" source="llm_sum" target="plotly_inline"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="pe10_l" value="text caption" style="text;html=1;align=center;verticalAlign=middle;fontSize=9;fontStyle=2;fontColor=#f59e0b;fillColor=#0a0a1a;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="970" y="1010" width="80" height="18" as="geometry"/>
+        </mxCell>
+
+        <!-- plotly_inline → render (existing Streamlit Chat UI) -->
+        <mxCell id="pe11" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#a78bfa;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="1" source="plotly_inline" target="render"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="pe11_l" value="rendered in chat bubble" style="text;html=1;align=center;verticalAlign=middle;fontSize=9;fontStyle=2;fontColor=#a78bfa;fillColor=#0a0a1a;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="960" y="700" width="160" height="18" as="geometry"/>
         </mxCell>
 
       </root>

--- a/docs/diagrams/chat_mcp_flow.drawio
+++ b/docs/diagrams/chat_mcp_flow.drawio
@@ -1,0 +1,220 @@
+<mxfile host="app.diagrams.net" modified="2026-04-13" agent="Claude" version="24.7.17">
+  <diagram id="chat-mcp-1" name="Chat MCP Flow">
+    <mxGraphModel dx="1600" dy="1000" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="1000" math="0" shadow="0" background="#0a0a1a">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+
+        <!-- TITLE -->
+        <mxCell id="title" value="Chat &amp; QueryRouter Flow — From User Message to Rich Rendering" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="300" y="10" width="1000" height="40" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ STEP 1: USER INPUT ============ -->
+        <mxCell id="user" value="&lt;b&gt;User Message&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Text / Voice / Image&lt;br&gt;from Streamlit chat UI&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#a78bfa;strokeWidth=2;fontColor=#c4b5fd;fontSize=12;" vertex="1" parent="1">
+          <mxGeometry x="30" y="150" width="180" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ STEP 2: FRONTEND SERVICE ============ -->
+        <mxCell id="fe_svc" value="&lt;b&gt;chat_service.py&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Frontend service layer&lt;br&gt;formats request, sends to backend&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="30" y="280" width="180" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ STEP 3: CHAT ENDPOINT ============ -->
+        <mxCell id="chat_ep" value="&lt;b&gt;POST /api/v1/chat/query&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Main intelligent endpoint&lt;br&gt;(also: /message, /stream)&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#2dd4bf;strokeWidth=2;fontColor=#99f6e4;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="280" y="150" width="200" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ STEP 4: QUERY CLASSIFIER ============ -->
+        <mxCell id="classifier" value="&lt;b&gt;QueryClassifier&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;LLM-based classification&lt;br&gt;Detects query type from message&lt;/font&gt;" style="rhombus;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;fontColor=#fef3c7;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="530" y="100" width="200" height="120" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ QUERY TYPES ============ -->
+        <mxCell id="qt_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f0f2e;strokeColor=#f59e0b;strokeWidth=1;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="530" y="260" width="200" height="230" as="geometry"/>
+        </mxCell>
+        <mxCell id="qt_label" value="Query Types" style="text;html=1;align=center;verticalAlign=middle;fontSize=11;fontStyle=1;fontColor=#f59e0b;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="560" y="265" width="140" height="20" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="qt1" value="BASIC_QUERY" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#d97706;fontColor=#fef3c7;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="545" y="290" width="170" height="25" as="geometry"/>
+        </mxCell>
+        <mxCell id="qt2" value="TECHNICAL_QUERY" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#d97706;fontColor=#fef3c7;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="545" y="320" width="170" height="25" as="geometry"/>
+        </mxCell>
+        <mxCell id="qt3" value="COMPARISON_QUERY" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#d97706;fontColor=#fef3c7;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="545" y="350" width="170" height="25" as="geometry"/>
+        </mxCell>
+        <mxCell id="qt4" value="REPORT_REQUEST" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#d97706;fontColor=#fef3c7;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="545" y="380" width="170" height="25" as="geometry"/>
+        </mxCell>
+        <mxCell id="qt5" value="DOWNLOAD_REQUEST" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#d97706;fontColor=#fef3c7;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="545" y="410" width="170" height="25" as="geometry"/>
+        </mxCell>
+        <mxCell id="qt6" value="STRATEGY_QUERY" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=9;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="545" y="440" width="170" height="25" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ STEP 5: QUERY ROUTER ============ -->
+        <mxCell id="router" value="&lt;b&gt;QueryRouter&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Routes to specialized handler&lt;br&gt;based on detected QueryType&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#164e63;strokeColor=#22d3ee;strokeWidth=2;fontColor=#cffafe;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="800" y="150" width="200" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ STEP 6: HANDLERS ============ -->
+        <mxCell id="h_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f0f2e;strokeColor=#22d3ee;strokeWidth=1;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="780" y="260" width="250" height="230" as="geometry"/>
+        </mxCell>
+        <mxCell id="h_label" value="Handlers" style="text;html=1;align=center;verticalAlign=middle;fontSize=11;fontStyle=1;fontColor=#22d3ee;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="850" y="265" width="100" height="20" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="h1" value="BasicQueryHandler" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#164e63;strokeColor=#0891b2;fontColor=#cffafe;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="795" y="290" width="220" height="25" as="geometry"/>
+        </mxCell>
+        <mxCell id="h2" value="TechnicalQueryHandler" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#164e63;strokeColor=#0891b2;fontColor=#cffafe;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="795" y="320" width="220" height="25" as="geometry"/>
+        </mxCell>
+        <mxCell id="h3" value="ComparisonQueryHandler" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#164e63;strokeColor=#0891b2;fontColor=#cffafe;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="795" y="350" width="220" height="25" as="geometry"/>
+        </mxCell>
+        <mxCell id="h4" value="ReportHandler" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#164e63;strokeColor=#0891b2;fontColor=#cffafe;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="795" y="380" width="220" height="25" as="geometry"/>
+        </mxCell>
+        <mxCell id="h5" value="DownloadHandler" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#164e63;strokeColor=#0891b2;fontColor=#cffafe;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="795" y="410" width="220" height="25" as="geometry"/>
+        </mxCell>
+        <mxCell id="h6" value="StrategyHandler (N25-N31)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=9;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="795" y="440" width="220" height="25" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ STEP 7: LM STUDIO ============ -->
+        <mxCell id="lm_studio" value="&lt;b&gt;LM Studio&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;gpt-4.1-mini / gpt-5.4-mini&lt;br&gt;OpenAI-compatible API :1234&lt;br&gt;Processes query or summarizes agent output&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;strokeWidth=2;fontColor=#fef3c7;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="1100" y="260" width="240" height="90" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ STEP 8: RESPONSE ============ -->
+        <mxCell id="response" value="&lt;b&gt;Rich Response&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Text + Charts + Tables&lt;br&gt;base64 images + dataframes&lt;br&gt;strategy cards, recommendations&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#14532d;strokeColor=#22c55e;strokeWidth=2;fontColor=#bbf7d0;fontSize=11;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="1100" y="420" width="240" height="90" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ STEP 9: STREAMLIT RENDER ============ -->
+        <mxCell id="render" value="&lt;b&gt;Streamlit Chat UI&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;st.chat_message rendering&lt;br&gt;inline charts, tables, text&lt;br&gt;voice playback (if voice input)&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#a78bfa;strokeWidth=2;fontColor=#c4b5fd;fontSize=11;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="1100" y="570" width="240" height="90" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ FLOW ARROWS ============ -->
+        <!-- User to service -->
+        <mxCell id="e1" style="rounded=1;html=1;strokeColor=#a78bfa;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="user" target="fe_svc"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e1_l" value="1" style="ellipse;whiteSpace=wrap;html=1;fillColor=#a78bfa;strokeColor=none;fontColor=#0a0a1a;fontSize=10;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="110" y="230" width="22" height="22" as="geometry"/>
+        </mxCell>
+
+        <!-- Service to endpoint -->
+        <mxCell id="e2" style="rounded=1;html=1;strokeColor=#2dd4bf;strokeWidth=2;exitX=1;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="fe_svc" target="chat_ep"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e2_l" value="2" style="ellipse;whiteSpace=wrap;html=1;fillColor=#2dd4bf;strokeColor=none;fontColor=#0a0a1a;fontSize=10;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="230" y="195" width="22" height="22" as="geometry"/>
+        </mxCell>
+
+        <!-- Endpoint to classifier -->
+        <mxCell id="e3" style="rounded=1;html=1;strokeColor=#f59e0b;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="chat_ep" target="classifier"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e3_l" value="3" style="ellipse;whiteSpace=wrap;html=1;fillColor=#f59e0b;strokeColor=none;fontColor=#0a0a1a;fontSize=10;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="498" y="173" width="22" height="22" as="geometry"/>
+        </mxCell>
+
+        <!-- Classifier to query types -->
+        <mxCell id="e4" style="rounded=1;html=1;strokeColor=#f59e0b;strokeWidth=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="classifier" target="qt_box"><mxGeometry relative="1" as="geometry"/></mxCell>
+
+        <!-- Classifier to router -->
+        <mxCell id="e5" style="rounded=1;html=1;strokeColor=#22d3ee;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="classifier" target="router"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e5_l" value="4" style="ellipse;whiteSpace=wrap;html=1;fillColor=#22d3ee;strokeColor=none;fontColor=#0a0a1a;fontSize=10;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="748" y="173" width="22" height="22" as="geometry"/>
+        </mxCell>
+
+        <!-- Router to handlers -->
+        <mxCell id="e6" style="rounded=1;html=1;strokeColor=#22d3ee;strokeWidth=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="router" target="h_box"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e6_l" value="5" style="ellipse;whiteSpace=wrap;html=1;fillColor=#22d3ee;strokeColor=none;fontColor=#0a0a1a;fontSize=10;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="895" y="232" width="22" height="22" as="geometry"/>
+        </mxCell>
+
+        <!-- Handlers to LM Studio -->
+        <mxCell id="e7" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#f59e0b;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="h_box" target="lm_studio"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e7_l" value="6" style="ellipse;whiteSpace=wrap;html=1;fillColor=#f59e0b;strokeColor=none;fontColor=#0a0a1a;fontSize=10;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="1060" y="355" width="22" height="22" as="geometry"/>
+        </mxCell>
+
+        <!-- LM Studio to response -->
+        <mxCell id="e8" style="rounded=1;html=1;strokeColor=#22c55e;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="lm_studio" target="response"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e8_l" value="7" style="ellipse;whiteSpace=wrap;html=1;fillColor=#22c55e;strokeColor=none;fontColor=#0a0a1a;fontSize=10;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="1210" y="375" width="22" height="22" as="geometry"/>
+        </mxCell>
+
+        <!-- Response to render -->
+        <mxCell id="e9" style="rounded=1;html=1;strokeColor=#a78bfa;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="response" target="render"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e9_l" value="8" style="ellipse;whiteSpace=wrap;html=1;fillColor=#a78bfa;strokeColor=none;fontColor=#0a0a1a;fontSize=10;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="1210" y="530" width="22" height="22" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ ALTERNATIVE PATH: Direct Chat ============ -->
+        <mxCell id="alt_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f0f2e;strokeColor=#64748b;strokeWidth=1;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="280" y="530" width="600" height="110" as="geometry"/>
+        </mxCell>
+        <mxCell id="alt_label" value="Alternative Path: Direct LM Studio Chat (no routing)" style="text;html=1;align=center;verticalAlign=middle;fontSize=11;fontStyle=1;fontColor=#64748b;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="340" y="535" width="480" height="22" as="geometry"/>
+        </mxCell>
+        <mxCell id="alt1" value="POST /chat/message" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="300" y="570" width="160" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="alt_arrow" value="" style="shape=flexArrow;endArrow=classic;html=1;strokeColor=#475569;fillColor=#1e293b;width=8;endSize=4;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="470" y="587" as="sourcePoint"/>
+            <mxPoint x="530" y="587" as="targetPoint"/>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="alt2" value="lmstudio_service.py&lt;br&gt;(build_messages + send)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="540" y="565" width="180" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="alt_arrow2" value="" style="shape=flexArrow;endArrow=classic;html=1;strokeColor=#475569;fillColor=#1e293b;width=8;endSize=4;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="730" y="587" as="sourcePoint"/>
+            <mxPoint x="790" y="587" as="targetPoint"/>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="alt3" value="LM Studio :1234&lt;br&gt;(raw completion)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="800" y="565" width="150" height="45" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ VOICE PATH ============ -->
+        <mxCell id="voice_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f0f2e;strokeColor=#64748b;strokeWidth=1;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="30" y="400" width="430" height="90" as="geometry"/>
+        </mxCell>
+        <mxCell id="voice_label" value="Voice Input Path (optional)" style="text;html=1;align=center;verticalAlign=middle;fontSize=10;fontStyle=1;fontColor=#64748b;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="140" y="405" width="220" height="20" as="geometry"/>
+        </mxCell>
+        <mxCell id="voice1" value="Audio recording" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="45" y="430" width="100" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="va1" value="" style="shape=flexArrow;endArrow=classic;html=1;strokeColor=#475569;fillColor=#1e293b;width=6;endSize=3;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="150" y="447" as="sourcePoint"/>
+            <mxPoint x="170" y="447" as="targetPoint"/>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="voice2" value="POST /voice/transcribe" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="175" y="430" width="140" height="35" as="geometry"/>
+        </mxCell>
+        <mxCell id="va2" value="" style="shape=flexArrow;endArrow=classic;html=1;strokeColor=#475569;fillColor=#1e293b;width=6;endSize=3;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="320" y="447" as="sourcePoint"/>
+            <mxPoint x="340" y="447" as="targetPoint"/>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="voice3" value="text &amp;rarr; /chat/query" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="345" y="430" width="100" height="35" as="geometry"/>
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/diagrams/data_pipeline.drawio
+++ b/docs/diagrams/data_pipeline.drawio
@@ -1,0 +1,195 @@
+<mxfile host="app.diagrams.net" modified="2026-04-13" agent="Claude" version="24.7.17">
+  <diagram id="data-pipe-1" name="Data Pipeline">
+    <mxGraphModel dx="1600" dy="900" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0" background="#0a0a1a">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+
+        <!-- TITLE -->
+        <mxCell id="title" value="Data Pipeline — From Raw Telemetry to Strategy Recommendations" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="250" y="10" width="1100" height="40" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ STAGE 1: DATA SOURCES ============ -->
+        <mxCell id="s1_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f0f2e;strokeColor=#f59e0b;strokeWidth=1;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="30" y="80" width="240" height="300" as="geometry"/>
+        </mxCell>
+        <mxCell id="s1_label" value="1. DATA SOURCES" style="text;html=1;align=center;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#f59e0b;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="50" y="85" width="200" height="25" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="fastf1" value="&lt;b&gt;FastF1 API&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Official F1 telemetry&lt;br&gt;2023-2025 seasons&lt;br&gt;lap, car, weather data&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;fontColor=#fef3c7;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="50" y="120" width="200" height="80" as="geometry"/>
+        </mxCell>
+        <mxCell id="openf1" value="&lt;b&gt;OpenF1 API&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Team radio MP3s&lt;br&gt;pit stop sensor data&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;fontColor=#fef3c7;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="50" y="210" width="200" height="60" as="geometry"/>
+        </mxCell>
+        <mxCell id="fia_docs" value="&lt;b&gt;FIA Documents&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;RCM events, steward&lt;br&gt;decisions, regulations&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;fontColor=#fef3c7;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="50" y="285" width="200" height="60" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ STAGE 2: PROCESSED DATA ============ -->
+        <mxCell id="s2_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f0f2e;strokeColor=#a78bfa;strokeWidth=1;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="320" y="80" width="280" height="300" as="geometry"/>
+        </mxCell>
+        <mxCell id="s2_label" value="2. PROCESSED DATA (data/)" style="text;html=1;align=center;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="330" y="85" width="260" height="25" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="parquets" value="&lt;b&gt;Parquet Files&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;overtake_pairs_2023_2025&lt;br&gt;sc_labeled_2023_2025&lt;br&gt;tire degradation series&lt;/font&gt;" style="shape=cylinder3;size=10;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=10;verticalAlign=top;spacingTop=8;" vertex="1" parent="1">
+          <mxGeometry x="340" y="120" width="240" height="90" as="geometry"/>
+        </mxCell>
+        <mxCell id="json_config" value="&lt;b&gt;Config JSON&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;tire_compounds_by_race&lt;br&gt;encoding_maps&lt;br&gt;model configs&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="340" y="225" width="240" height="70" as="geometry"/>
+        </mxCell>
+        <mxCell id="rag_corpus" value="&lt;b&gt;RAG Corpus&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Qdrant vectors&lt;br&gt;regulation embeddings&lt;/font&gt;" style="shape=cylinder3;size=10;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=10;verticalAlign=top;spacingTop=8;" vertex="1" parent="1">
+          <mxGeometry x="340" y="305" width="240" height="65" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ STAGE 3: ML MODELS ============ -->
+        <mxCell id="s3_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f0f2e;strokeColor=#ec4899;strokeWidth=1;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="650" y="80" width="280" height="300" as="geometry"/>
+        </mxCell>
+        <mxCell id="s3_label" value="3. ML MODELS (data/models/)" style="text;html=1;align=center;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#ec4899;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="660" y="85" width="260" height="25" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="m_pace" value="XGBoost pace (N06)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="670" y="120" width="240" height="28" as="geometry"/>
+        </mxCell>
+        <mxCell id="m_tire" value="TCN tire deg (N09-N10) + calibration" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="670" y="156" width="240" height="28" as="geometry"/>
+        </mxCell>
+        <mxCell id="m_overtake" value="LightGBM overtake (N12) + calibrator" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="670" y="192" width="240" height="28" as="geometry"/>
+        </mxCell>
+        <mxCell id="m_sc" value="LightGBM SC prob (N14) + calibrator" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="670" y="228" width="240" height="28" as="geometry"/>
+        </mxCell>
+        <mxCell id="m_pit" value="HistGBT pit duration (N15) P05/50/95" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="670" y="264" width="240" height="28" as="geometry"/>
+        </mxCell>
+        <mxCell id="m_undercut" value="LightGBM undercut (N16) + calibrator" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="670" y="300" width="240" height="28" as="geometry"/>
+        </mxCell>
+        <mxCell id="m_nlp" value="NLP pipeline (N24) RoBERTa + BERT" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="670" y="336" width="240" height="28" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ STAGE 4: AGENTS ============ -->
+        <mxCell id="s4_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f0f2e;strokeColor=#2dd4bf;strokeWidth=1;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="980" y="80" width="230" height="300" as="geometry"/>
+        </mxCell>
+        <mxCell id="s4_label" value="4. AGENT PREDICTIONS" style="text;html=1;align=center;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#2dd4bf;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="990" y="85" width="210" height="25" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="a_pace" value="N25: PaceOutput" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#14b8a6;fontColor=#99f6e4;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="1000" y="120" width="190" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="a_tire" value="N26: TireOutput" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#14b8a6;fontColor=#99f6e4;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="1000" y="160" width="190" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="a_race" value="N27: RaceSituationOutput" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#14b8a6;fontColor=#99f6e4;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="1000" y="200" width="190" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="a_pit" value="N28: PitStrategyOutput" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#14b8a6;fontColor=#99f6e4;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="1000" y="240" width="190" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="a_radio" value="N29: RadioOutput" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#14b8a6;fontColor=#99f6e4;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="1000" y="280" width="190" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="a_rag" value="N30: RAGOutput" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#14b8a6;fontColor=#99f6e4;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="1000" y="320" width="190" height="30" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ STAGE 5: ORCHESTRATOR ============ -->
+        <mxCell id="s5_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f0f2e;strokeColor=#22c55e;strokeWidth=1;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="1260" y="80" width="280" height="300" as="geometry"/>
+        </mxCell>
+        <mxCell id="s5_label" value="5. ORCHESTRATOR + UI" style="text;html=1;align=center;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#22c55e;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1270" y="85" width="260" height="25" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="orch_mc" value="&lt;b&gt;N31 Orchestrator&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;MoE routing&lt;br&gt;MC simulation (500 draws)&lt;br&gt;LLM synthesis&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#14532d;strokeColor=#22c55e;fontColor=#bbf7d0;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="1280" y="120" width="240" height="80" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="strat_rec" value="&lt;b&gt;StrategyRecommendation&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;decision, plan, confidence,&lt;br&gt;risk_level, reasoning&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#14532d;strokeColor=#16a34a;fontColor=#bbf7d0;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="1280" y="220" width="240" height="60" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="ui_render" value="&lt;b&gt;Streamlit UI&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Strategy page cards&lt;br&gt;Chat rich rendering&lt;br&gt;Model Lab charts&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#14532d;strokeColor=#16a34a;fontColor=#bbf7d0;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="1280" y="300" width="240" height="70" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="e_orch_rec" style="rounded=1;html=1;strokeColor=#22c55e;strokeWidth=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="orch_mc" target="strat_rec"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e_rec_ui" style="rounded=1;html=1;strokeColor=#22c55e;strokeWidth=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="strat_rec" target="ui_render"><mxGeometry relative="1" as="geometry"/></mxCell>
+
+        <!-- ============ HORIZONTAL FLOW ARROWS ============ -->
+        <mxCell id="flow1" style="shape=flexArrow;endArrow=classic;html=1;strokeColor=#f59e0b;fillColor=#422006;width=12;endSize=6;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="275" y="230" as="sourcePoint"/>
+            <mxPoint x="315" y="230" as="targetPoint"/>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="flow2" style="shape=flexArrow;endArrow=classic;html=1;strokeColor=#a78bfa;fillColor=#1e1b4b;width=12;endSize=6;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="605" y="230" as="sourcePoint"/>
+            <mxPoint x="645" y="230" as="targetPoint"/>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="flow3" style="shape=flexArrow;endArrow=classic;html=1;strokeColor=#ec4899;fillColor=#4a1942;width=12;endSize=6;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="935" y="230" as="sourcePoint"/>
+            <mxPoint x="975" y="230" as="targetPoint"/>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="flow4" style="shape=flexArrow;endArrow=classic;html=1;strokeColor=#2dd4bf;fillColor=#0f3433;width=12;endSize=6;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="1215" y="230" as="sourcePoint"/>
+            <mxPoint x="1255" y="230" as="targetPoint"/>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- ============ BOTTOM: NOTEBOOKS THAT BUILT EACH STAGE ============ -->
+        <mxCell id="nb_header" value="NOTEBOOKS (offline training pipeline)" style="text;html=1;align=center;verticalAlign=middle;fontSize=13;fontStyle=1;fontColor=#64748b;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="400" y="420" width="800" height="25" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="nb_row" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1a1a2e;strokeColor=#334155;strokeWidth=1;" vertex="1" parent="1">
+          <mxGeometry x="30" y="455" width="1510" height="70" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="nb1" value="N06 Pace&lt;br&gt;N07-N10 Tire" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="50" y="465" width="120" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="nb2" value="N11-N12&lt;br&gt;Overtake" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="190" y="465" width="100" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="nb3" value="N13-N14&lt;br&gt;Safety Car" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="310" y="465" width="100" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="nb4" value="N15-N16&lt;br&gt;Pit/Undercut" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="430" y="465" width="100" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="nb5" value="N17-N24&lt;br&gt;NLP Pipeline" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="550" y="465" width="100" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="nb6" value="N25 Pace Agent&lt;br&gt;N26 Tire Agent" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="680" y="465" width="120" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="nb7" value="N27 Race Sit.&lt;br&gt;N28 Pit Strat." style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="820" y="465" width="120" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="nb8" value="N29 Radio&lt;br&gt;N30 RAG" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="960" y="465" width="100" height="45" as="geometry"/>
+        </mxCell>
+        <mxCell id="nb9" value="N31&lt;br&gt;Orchestrator" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="1080" y="465" width="100" height="45" as="geometry"/>
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/diagrams/docker_deployment.drawio
+++ b/docs/diagrams/docker_deployment.drawio
@@ -1,0 +1,126 @@
+<mxfile host="app.diagrams.net" modified="2026-04-13" agent="Claude" version="24.7.17">
+  <diagram id="docker-1" name="Docker Deployment">
+    <mxGraphModel dx="1200" dy="800" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1200" pageHeight="800" math="0" shadow="0" background="#0a0a1a">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+
+        <!-- TITLE -->
+        <mxCell id="title" value="Docker Deployment — docker-compose.yml" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="250" y="10" width="700" height="40" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ HOST MACHINE ============ -->
+        <mxCell id="host" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f0f2e;strokeColor=#64748b;strokeWidth=2;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="30" y="60" width="1140" height="700" as="geometry"/>
+        </mxCell>
+        <mxCell id="host_label" value="HOST MACHINE (Windows 11)" style="text;html=1;align=left;verticalAlign=middle;fontSize=13;fontStyle=1;fontColor=#64748b;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="40" y="65" width="300" height="25" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ DOCKER NETWORK ============ -->
+        <mxCell id="network" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#121127;strokeColor=#a78bfa;strokeWidth=2;" vertex="1" parent="1">
+          <mxGeometry x="60" y="100" width="1080" height="540" as="geometry"/>
+        </mxCell>
+        <mxCell id="net_label" value="f1_network (bridge)" style="text;html=1;align=left;verticalAlign=middle;fontSize=13;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="75" y="105" width="250" height="25" as="geometry"/>
+        </mxCell>
+
+        <!-- ======= FRONTEND CONTAINER ======= -->
+        <mxCell id="fe_container" value="" style="swimlane;html=1;startSize=35;fillColor=#1e1b4b;strokeColor=#7c3aed;strokeWidth=2;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="100" y="150" width="440" height="350" as="geometry"/>
+        </mxCell>
+        <mxCell id="fe_label" value="f1_telemetry_frontend" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="fe_container">
+          <mxGeometry x="10" y="0" width="250" height="35" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="fe_img" value="&lt;b&gt;Image&lt;/b&gt;: python:3.11-slim&lt;br&gt;&lt;b&gt;Dockerfile&lt;/b&gt;: frontend/Dockerfile&lt;br&gt;&lt;b&gt;Context&lt;/b&gt;: ./src/telemetry" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#312e81;strokeColor=#6366f1;fontColor=#a5b4fc;fontSize=10;align=left;spacingLeft=8;verticalAlign=top;spacingTop=4;" vertex="1" parent="fe_container">
+          <mxGeometry x="20" y="45" width="400" height="60" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="fe_port" value="&lt;font style=&quot;font-size:16px&quot;&gt;:8501&lt;/font&gt;&lt;br&gt;Streamlit" style="ellipse;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#a855f7;fontColor=#e9d5ff;fontSize=11;fontStyle=1;" vertex="1" parent="fe_container">
+          <mxGeometry x="20" y="120" width="100" height="60" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="fe_env" value="&lt;b&gt;Environment&lt;/b&gt;&lt;br&gt;PYTHONUNBUFFERED=1&lt;br&gt;BACKEND_URL=http://backend:8000" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#312e81;strokeColor=#6366f1;fontColor=#a5b4fc;fontSize=9;align=left;spacingLeft=8;verticalAlign=top;spacingTop=4;" vertex="1" parent="fe_container">
+          <mxGeometry x="140" y="120" width="280" height="60" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="fe_vol" value="&lt;b&gt;Volume Mount&lt;/b&gt;&lt;br&gt;./src/telemetry &amp;rarr; /app" style="shape=cylinder3;size=10;whiteSpace=wrap;html=1;fillColor=#312e81;strokeColor=#6366f1;fontColor=#a5b4fc;fontSize=10;verticalAlign=middle;" vertex="1" parent="fe_container">
+          <mxGeometry x="20" y="210" width="200" height="60" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="fe_depends" value="depends_on: backend&lt;br&gt;restart: unless-stopped" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#312e81;strokeColor=#6366f1;fontColor=#818cf8;fontSize=9;align=left;spacingLeft=8;" vertex="1" parent="fe_container">
+          <mxGeometry x="20" y="290" width="200" height="40" as="geometry"/>
+        </mxCell>
+
+        <!-- ======= BACKEND CONTAINER ======= -->
+        <mxCell id="be_container" value="" style="swimlane;html=1;startSize=35;fillColor=#0f3433;strokeColor=#14b8a6;strokeWidth=2;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="600" y="150" width="440" height="350" as="geometry"/>
+        </mxCell>
+        <mxCell id="be_label" value="f1_telemetry_backend" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#2dd4bf;fillColor=none;strokeColor=none;" vertex="1" parent="be_container">
+          <mxGeometry x="10" y="0" width="250" height="35" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="be_img" value="&lt;b&gt;Image&lt;/b&gt;: python:3.11-slim&lt;br&gt;&lt;b&gt;Dockerfile&lt;/b&gt;: backend/Dockerfile&lt;br&gt;&lt;b&gt;Context&lt;/b&gt;: ./src/telemetry" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#134e4a;strokeColor=#0d9488;fontColor=#5eead4;fontSize=10;align=left;spacingLeft=8;verticalAlign=top;spacingTop=4;" vertex="1" parent="be_container">
+          <mxGeometry x="20" y="45" width="400" height="60" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="be_port" value="&lt;font style=&quot;font-size:16px&quot;&gt;:8000&lt;/font&gt;&lt;br&gt;FastAPI" style="ellipse;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#2dd4bf;fontColor=#99f6e4;fontSize=11;fontStyle=1;" vertex="1" parent="be_container">
+          <mxGeometry x="20" y="120" width="100" height="60" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="be_env" value="&lt;b&gt;Environment&lt;/b&gt;&lt;br&gt;PYTHONUNBUFFERED=1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#134e4a;strokeColor=#0d9488;fontColor=#5eead4;fontSize=9;align=left;spacingLeft=8;verticalAlign=top;spacingTop=4;" vertex="1" parent="be_container">
+          <mxGeometry x="140" y="120" width="280" height="50" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="be_vol" value="&lt;b&gt;Volume Mount&lt;/b&gt;&lt;br&gt;./src/telemetry &amp;rarr; /app" style="shape=cylinder3;size=10;whiteSpace=wrap;html=1;fillColor=#134e4a;strokeColor=#0d9488;fontColor=#5eead4;fontSize=10;verticalAlign=middle;" vertex="1" parent="be_container">
+          <mxGeometry x="20" y="210" width="200" height="60" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="be_restart" value="restart: unless-stopped" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#134e4a;strokeColor=#0d9488;fontColor=#2dd4bf;fontSize=9;align=left;spacingLeft=8;" vertex="1" parent="be_container">
+          <mxGeometry x="20" y="290" width="200" height="35" as="geometry"/>
+        </mxCell>
+
+        <!-- ======= ARROW: Frontend to Backend ======= -->
+        <mxCell id="fe_to_be" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#67e8f9;strokeWidth=3;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="fe_container" target="be_container">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="fe_be_label" value="&lt;b&gt;HTTP&lt;/b&gt;&lt;br&gt;http://backend:8000" style="edgeLabel;html=1;fontSize=10;fontColor=#67e8f9;fillColor=#0a0a1a;" vertex="1" connectable="0" parent="fe_to_be">
+          <mxGeometry relative="1" as="geometry"><mxPoint as="offset"/></mxGeometry>
+        </mxCell>
+
+        <!-- ======= EXTERNAL: LM Studio ======= -->
+        <mxCell id="lms_ext" value="&lt;b&gt;LM Studio&lt;/b&gt;&lt;br&gt;:1234&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;(host machine)&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;fontColor=#fef3c7;fontSize=11;fontStyle=0;" vertex="1" parent="1">
+          <mxGeometry x="800" y="660" width="150" height="70" as="geometry"/>
+        </mxCell>
+        <mxCell id="be_to_lms" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#f59e0b;strokeWidth=2;dashed=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="be_container" target="lms_ext">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="lms_label" value="OpenAI-compat API" style="edgeLabel;html=1;fontSize=9;fontColor=#f59e0b;fillColor=none;" vertex="1" connectable="0" parent="be_to_lms">
+          <mxGeometry relative="1" as="geometry"><mxPoint as="offset"/></mxGeometry>
+        </mxCell>
+
+        <!-- ======= EXTERNAL: Browser ======= -->
+        <mxCell id="browser" value="&lt;b&gt;Browser&lt;/b&gt;&lt;br&gt;localhost:8501" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1a1a2e;strokeColor=#a78bfa;fontColor=#c4b5fd;fontSize=11;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="200" y="660" width="150" height="70" as="geometry"/>
+        </mxCell>
+        <mxCell id="browser_to_fe" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#a78bfa;strokeWidth=2;dashed=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="1" source="browser" target="fe_container">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="browser_label" value="HTTP :8501" style="edgeLabel;html=1;fontSize=9;fontColor=#a78bfa;fillColor=none;" vertex="1" connectable="0" parent="browser_to_fe">
+          <mxGeometry relative="1" as="geometry"><mxPoint as="offset"/></mxGeometry>
+        </mxCell>
+
+        <!-- Port mapping annotations -->
+        <mxCell id="port_note_fe" value="&lt;font style=&quot;font-size:9px&quot;&gt;host 8501 &amp;rarr; container 8501&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;fontColor=#818cf8;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="100" y="530" width="180" height="18" as="geometry"/>
+        </mxCell>
+        <mxCell id="port_note_be" value="&lt;font style=&quot;font-size:9px&quot;&gt;host 8000 &amp;rarr; container 8000&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;fontColor=#5eead4;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="600" y="530" width="180" height="18" as="geometry"/>
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/diagrams/frontend_pages.drawio
+++ b/docs/diagrams/frontend_pages.drawio
@@ -1,0 +1,150 @@
+<mxfile host="app.diagrams.net" modified="2026-04-13" agent="Claude" version="24.7.17">
+  <diagram id="fe-pages-1" name="Frontend Page Hierarchy">
+    <mxGraphModel dx="1400" dy="1000" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1400" pageHeight="1000" math="0" shadow="0" background="#0a0a1a">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+
+        <!-- TITLE -->
+        <mxCell id="title" value="Streamlit Frontend — Page Hierarchy &amp; Components" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="250" y="10" width="900" height="40" as="geometry"/>
+        </mxCell>
+
+        <!-- main.py Router -->
+        <mxCell id="main" value="&lt;b&gt;app/main.py&lt;/b&gt;&lt;br&gt;Streamlit Router&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;sidebar navigation + auth check&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#a78bfa;strokeWidth=3;fontColor=#c4b5fd;fontSize=12;" vertex="1" parent="1">
+          <mxGeometry x="540" y="70" width="220" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ======= 6 PAGES ======= -->
+        <!-- Dashboard -->
+        <mxCell id="p_dash" value="&lt;b&gt;Dashboard&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Session overview&lt;br&gt;lap times, positions&lt;br&gt;tire strategy summary&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#a855f7;fontColor=#e9d5ff;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="30" y="200" width="170" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Race Analysis -->
+        <mxCell id="p_race" value="&lt;b&gt;Race Analysis&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;5 tabs: Telemetry,&lt;br&gt;Lap Times, Tires,&lt;br&gt;Positions, GPS Track&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#a855f7;fontColor=#e9d5ff;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="230" y="200" width="170" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Strategy -->
+        <mxCell id="p_strat" value="&lt;b&gt;Strategy&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Agent pipeline UI&lt;br&gt;N25-N31 execution&lt;br&gt;recommendation cards&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="430" y="200" width="170" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Model Lab -->
+        <mxCell id="p_lab" value="&lt;b&gt;Model Lab&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;ML model exploration&lt;br&gt;feature importance&lt;br&gt;interactive predictions&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#a855f7;fontColor=#e9d5ff;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="630" y="200" width="170" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Comparison -->
+        <mxCell id="p_comp" value="&lt;b&gt;Comparison&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Driver vs Driver&lt;br&gt;telemetry overlay&lt;br&gt;sector analysis&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#a855f7;fontColor=#e9d5ff;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="830" y="200" width="170" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Chat -->
+        <mxCell id="p_chat" value="&lt;b&gt;Chat&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;LM Studio chatbot&lt;br&gt;voice input, images&lt;br&gt;QueryRouter integration&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="1030" y="200" width="170" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- Router to pages arrows -->
+        <mxCell id="e1" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#7c3aed;strokeWidth=1;exitX=0;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="main" target="p_dash"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e2" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#7c3aed;strokeWidth=1;exitX=0.2;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="main" target="p_race"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e3" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#7c3aed;strokeWidth=1;exitX=0.4;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="main" target="p_strat"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e4" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#7c3aed;strokeWidth=1;exitX=0.6;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="main" target="p_lab"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e5" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#7c3aed;strokeWidth=1;exitX=0.8;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="main" target="p_comp"><mxGeometry relative="1" as="geometry"/></mxCell>
+        <mxCell id="e6" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#7c3aed;strokeWidth=1;exitX=1;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="main" target="p_chat"><mxGeometry relative="1" as="geometry"/></mxCell>
+
+        <!-- ======= COMPONENTS ROW ======= -->
+        <mxCell id="comp_header" value="COMPONENTS (shared)" style="text;html=1;align=center;verticalAlign=middle;fontSize=13;fontStyle=1;fontColor=#2dd4bf;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="450" y="330" width="400" height="25" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="c_layout" value="&lt;b&gt;layout/&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;sidebar, header&lt;br&gt;page containers&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#14b8a6;fontColor=#99f6e4;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="30" y="370" width="120" height="70" as="geometry"/>
+        </mxCell>
+        <mxCell id="c_auth" value="&lt;b&gt;auth/&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;login, signup&lt;br&gt;session state&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#14b8a6;fontColor=#99f6e4;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="170" y="370" width="120" height="70" as="geometry"/>
+        </mxCell>
+        <mxCell id="c_chatbot" value="&lt;b&gt;chatbot/&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;chat UI, message&lt;br&gt;bubbles, input&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#14b8a6;fontColor=#99f6e4;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="310" y="370" width="120" height="70" as="geometry"/>
+        </mxCell>
+        <mxCell id="c_voice" value="&lt;b&gt;voice/&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;audio recording&lt;br&gt;STT integration&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#14b8a6;fontColor=#99f6e4;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="450" y="370" width="120" height="70" as="geometry"/>
+        </mxCell>
+        <mxCell id="c_telemetry" value="&lt;b&gt;telemetry/&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;lap charts, speed&lt;br&gt;traces, throttle/brake&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#14b8a6;fontColor=#99f6e4;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="590" y="370" width="120" height="70" as="geometry"/>
+        </mxCell>
+        <mxCell id="c_dashboard" value="&lt;b&gt;dashboard/&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;overview cards&lt;br&gt;summary panels&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#14b8a6;fontColor=#99f6e4;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="730" y="370" width="120" height="70" as="geometry"/>
+        </mxCell>
+        <mxCell id="c_race" value="&lt;b&gt;race_analysis/&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;5-tab analysis&lt;br&gt;detailed charts&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#14b8a6;fontColor=#99f6e4;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="870" y="370" width="120" height="70" as="geometry"/>
+        </mxCell>
+        <mxCell id="c_strategy" value="&lt;b&gt;strategy/&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;agent cards&lt;br&gt;recommendation panel&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#14b8a6;fontColor=#99f6e4;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="1010" y="370" width="130" height="70" as="geometry"/>
+        </mxCell>
+        <mxCell id="c_comp" value="&lt;b&gt;comparison/&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;overlay charts&lt;br&gt;delta analysis&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#14b8a6;fontColor=#99f6e4;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="1160" y="370" width="120" height="70" as="geometry"/>
+        </mxCell>
+
+        <!-- ======= SERVICES ROW ======= -->
+        <mxCell id="svc_header" value="SERVICES (API clients)" style="text;html=1;align=center;verticalAlign=middle;fontSize=13;fontStyle=1;fontColor=#f59e0b;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="450" y="480" width="400" height="25" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="s_tele" value="telemetry_service" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;fontColor=#fef3c7;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="100" y="520" width="140" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="s_chat" value="chat_service" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;fontColor=#fef3c7;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="280" y="520" width="140" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="s_strat" value="strategy_service" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;fontColor=#fef3c7;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="460" y="520" width="140" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="s_auth" value="auth_service" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;fontColor=#fef3c7;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="640" y="520" width="140" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="s_voice" value="voice_api" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;fontColor=#fef3c7;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="820" y="520" width="140" height="40" as="geometry"/>
+        </mxCell>
+
+        <!-- Backend box at bottom -->
+        <mxCell id="backend_arrow" value="To FastAPI Backend :8000" style="text;html=1;align=center;verticalAlign=middle;fontSize=11;fontStyle=1;fontColor=#94a3b8;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="400" y="590" width="500" height="25" as="geometry"/>
+        </mxCell>
+
+        <!-- Service to backend connector -->
+        <mxCell id="svc_be_arrow" value="" style="shape=flexArrow;endArrow=classic;html=1;strokeColor=#64748b;fillColor=#334155;width=20;endSize=8;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="530" y="570" as="sourcePoint"/>
+            <mxPoint x="530" y="610" as="targetPoint"/>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- ======= SHARED UTILITIES ======= -->
+        <mxCell id="shared_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1a1a2e;strokeColor=#334155;strokeWidth=1;" vertex="1" parent="1">
+          <mxGeometry x="30" y="640" width="500" height="80" as="geometry"/>
+        </mxCell>
+        <mxCell id="shared_label" value="&lt;b&gt;Shared Utilities&lt;/b&gt;" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontColor=#94a3b8;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="40" y="645" width="150" height="20" as="geometry"/>
+        </mxCell>
+        <mxCell id="sh_config" value="config.py" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="45" y="675" width="80" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="sh_styles" value="styles.py" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="135" y="675" width="80" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="sh_track" value="track_data.py" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="225" y="675" width="90" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="sh_utils" value="utils/" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="325" y="675" width="80" height="30" as="geometry"/>
+        </mxCell>
+        <mxCell id="sh_shared" value="shared/" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="415" y="675" width="80" height="30" as="geometry"/>
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/diagrams/multi_agent_flow.drawio
+++ b/docs/diagrams/multi_agent_flow.drawio
@@ -1,0 +1,191 @@
+<mxfile host="app.diagrams.net" modified="2026-04-13" agent="Claude" version="24.7.17">
+  <diagram id="agent-flow-1" name="Multi-Agent Flow (N25-N31)">
+    <mxGraphModel dx="1600" dy="1100" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="1100" math="0" shadow="0" background="#0a0a1a">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+
+        <!-- ============ TITLE ============ -->
+        <mxCell id="title" value="Multi-Agent Strategy System — Data Flow (N25-N31)" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="300" y="10" width="1000" height="40" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ INPUT ============ -->
+        <mxCell id="input_race" value="&lt;b&gt;RaceState&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;driver, lap, total_laps,&lt;br&gt;compound, tyre_life,&lt;br&gt;gap_ahead_s, pace_delta_s,&lt;br&gt;weather, radio_msgs,&lt;br&gt;rcm_events, risk_tolerance&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#a78bfa;strokeWidth=2;fontColor=#c4b5fd;fontSize=11;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="30" y="240" width="190" height="140" as="geometry"/>
+        </mxCell>
+        <mxCell id="input_laps" value="&lt;b&gt;lap_state dict&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;FastF1 session features&lt;br&gt;or RaceStateManager DF&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#a78bfa;strokeWidth=2;fontColor=#c4b5fd;fontSize=11;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="30" y="410" width="190" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ LAYER 0: PARALLEL SUB-AGENTS (ALWAYS) ============ -->
+        <mxCell id="layer0_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f0f2e;strokeColor=#7c3aed;strokeWidth=1;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="290" y="70" width="440" height="570" as="geometry"/>
+        </mxCell>
+        <mxCell id="layer0_label" value="LAYER 0 — Parallel Sub-Agent Execution (ThreadPoolExecutor)" style="text;html=1;align=center;verticalAlign=middle;fontSize=11;fontStyle=1;fontColor=#7c3aed;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="300" y="75" width="420" height="25" as="geometry"/>
+        </mxCell>
+
+        <!-- N25 Pace -->
+        <mxCell id="n25" value="&lt;b&gt;N25 Pace Agent&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;XGBoost lap-time prediction&lt;br&gt;+ bootstrap CI (p10/p90)&lt;br&gt;&lt;b&gt;Output:&lt;/b&gt; PaceOutput&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#a855f7;fontColor=#e9d5ff;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="310" y="110" width="190" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- N26 Tire -->
+        <mxCell id="n26" value="&lt;b&gt;N26 Tire Agent&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;TCN degradation + MC Dropout&lt;br&gt;remaining stint, cliff detection&lt;br&gt;&lt;b&gt;Output:&lt;/b&gt; TireOutput&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#a855f7;fontColor=#e9d5ff;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="520" y="110" width="190" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- N27 Race Situation -->
+        <mxCell id="n27" value="&lt;b&gt;N27 Race Situation Agent&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;P(overtake), P(SC in 3 laps)&lt;br&gt;gap analysis + position forecast&lt;br&gt;&lt;b&gt;Output:&lt;/b&gt; RaceSituationOutput&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#a855f7;fontColor=#e9d5ff;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="310" y="210" width="190" height="90" as="geometry"/>
+        </mxCell>
+
+        <!-- N29 Radio -->
+        <mxCell id="n29" value="&lt;b&gt;N29 Radio Agent&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;NLP pipeline (sentiment,&lt;br&gt;intent, NER) + RCM parser&lt;br&gt;&lt;b&gt;Output:&lt;/b&gt; RadioOutput&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#a855f7;fontColor=#e9d5ff;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="520" y="210" width="190" height="90" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ LAYER 1: MoE CONDITIONAL ============ -->
+        <mxCell id="moe_diamond" value="&lt;b&gt;MoE Routing&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;if-else rules&lt;/font&gt;" style="rhombus;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="410" y="340" width="150" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- N28 Pit (conditional) -->
+        <mxCell id="n28" value="&lt;b&gt;N28 Pit Strategy Agent&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Undercut/overcut probability&lt;br&gt;pit window, stop duration&lt;br&gt;&lt;b&gt;Output:&lt;/b&gt; PitStrategyOutput&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=10;verticalAlign=top;spacingTop=4;dashed=1;dashPattern=5 5;" vertex="1" parent="1">
+          <mxGeometry x="310" y="450" width="190" height="90" as="geometry"/>
+        </mxCell>
+
+        <!-- N30 RAG (conditional) -->
+        <mxCell id="n30" value="&lt;b&gt;N30 RAG Agent&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Qdrant vector search&lt;br&gt;SC regulation context&lt;br&gt;&lt;b&gt;Output:&lt;/b&gt; RAGOutput&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=10;verticalAlign=top;spacingTop=4;dashed=1;dashPattern=5 5;" vertex="1" parent="1">
+          <mxGeometry x="520" y="450" width="190" height="90" as="geometry"/>
+        </mxCell>
+
+        <!-- MoE conditions -->
+        <mxCell id="e_moe_n28" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#ec4899;strokeWidth=1;dashed=1;exitX=0.25;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="moe_diamond" target="n28">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_moe_n28_label" value="tire cliff OR&lt;br&gt;pit window open" style="edgeLabel;html=1;fontSize=8;fontColor=#ec4899;fillColor=none;" vertex="1" connectable="0" parent="e_moe_n28">
+          <mxGeometry relative="1" as="geometry"><mxPoint as="offset"/></mxGeometry>
+        </mxCell>
+
+        <mxCell id="e_moe_n30" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#ec4899;strokeWidth=1;dashed=1;exitX=0.75;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="moe_diamond" target="n30">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_moe_n30_label" value="sc_prob &gt; 0.30" style="edgeLabel;html=1;fontSize=8;fontColor=#ec4899;fillColor=none;" vertex="1" connectable="0" parent="e_moe_n30">
+          <mxGeometry relative="1" as="geometry"><mxPoint as="offset"/></mxGeometry>
+        </mxCell>
+
+        <!-- Arrows from sub-agents to MoE -->
+        <mxCell id="e_n25_moe" style="rounded=1;html=1;strokeColor=#a855f7;strokeWidth=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="n25" target="moe_diamond">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_n26_moe" style="rounded=1;html=1;strokeColor=#a855f7;strokeWidth=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="n26" target="moe_diamond">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_n27_moe" style="rounded=1;html=1;strokeColor=#a855f7;strokeWidth=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.25;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="n27" target="moe_diamond">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_n29_moe" style="rounded=1;html=1;strokeColor=#a855f7;strokeWidth=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="n29" target="moe_diamond">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Input arrows -->
+        <mxCell id="e_race_n25" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#a78bfa;strokeWidth=2;exitX=1;exitY=0.25;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="input_race" target="n25">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_race_n27" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#a78bfa;strokeWidth=2;exitX=1;exitY=0.75;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="input_race" target="n27">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ LAYER 2: MONTE CARLO ============ -->
+        <mxCell id="layer2_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f0f2e;strokeColor=#22d3ee;strokeWidth=1;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="800" y="120" width="340" height="280" as="geometry"/>
+        </mxCell>
+        <mxCell id="layer2_label" value="LAYER 2 — Monte Carlo Simulation (500 draws)" style="text;html=1;align=center;verticalAlign=middle;fontSize=11;fontStyle=1;fontColor=#22d3ee;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="810" y="125" width="320" height="25" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="mc_candidates" value="&lt;b&gt;4 Strategy Candidates&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;1. STAY OUT&lt;br&gt;2. PIT NOW (same compound)&lt;br&gt;3. PIT NOW (harder)&lt;br&gt;4. PIT NOW (softer)&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#164e63;strokeColor=#22d3ee;fontColor=#cffafe;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="820" y="160" width="200" height="90" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="mc_sim" value="&lt;b&gt;MC Scoring&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;For each candidate:&lt;br&gt;score = alpha * E[S] + (1-alpha) * P10[S]&lt;br&gt;Samples from tire/pace/SC distributions&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#164e63;strokeColor=#22d3ee;fontColor=#cffafe;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="820" y="270" width="300" height="80" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="e_cand_sim" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#22d3ee;strokeWidth=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="mc_candidates" target="mc_sim">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ LAYER 3: LLM SYNTHESIS ============ -->
+        <mxCell id="layer3_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f0f2e;strokeColor=#f59e0b;strokeWidth=1;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="800" y="440" width="340" height="200" as="geometry"/>
+        </mxCell>
+        <mxCell id="layer3_label" value="LAYER 3 — LLM Synthesis (gpt-5.4-mini)" style="text;html=1;align=center;verticalAlign=middle;fontSize=11;fontStyle=1;fontColor=#f59e0b;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="810" y="445" width="320" height="25" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="llm_synth" value="&lt;b&gt;Structured-Output LLM&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Aggregates all reasoning strings&lt;br&gt;+ MC scores into final recommendation&lt;br&gt;Temperature=0.0 (deterministic)&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;fontColor=#fef3c7;fontSize=10;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="820" y="480" width="300" height="80" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ OUTPUT ============ -->
+        <mxCell id="output" value="&lt;b&gt;StrategyRecommendation&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;decision (ACTION/PACE/RISK)&lt;br&gt;plan (lap-by-lap)&lt;br&gt;confidence, risk_level&lt;br&gt;reasoning, scenario_scores&lt;br&gt;regulation_context&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#14532d;strokeColor=#22c55e;strokeWidth=2;fontColor=#bbf7d0;fontSize=11;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="860" y="680" width="220" height="120" as="geometry"/>
+        </mxCell>
+
+        <!-- Layer connections -->
+        <mxCell id="e_l0_l2" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#a855f7;strokeWidth=2;exitX=1;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="layer0_box" target="layer2_box">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_l0_l2_label" value="sub-agent outputs&lt;br&gt;(distributions)" style="edgeLabel;html=1;fontSize=8;fontColor=#a855f7;fillColor=none;" vertex="1" connectable="0" parent="e_l0_l2">
+          <mxGeometry relative="1" as="geometry"><mxPoint as="offset"/></mxGeometry>
+        </mxCell>
+
+        <mxCell id="e_l2_l3" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#22d3ee;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="layer2_box" target="layer3_box">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_l2_l3_label" value="scenario_scores dict" style="edgeLabel;html=1;fontSize=8;fontColor=#22d3ee;fillColor=none;" vertex="1" connectable="0" parent="e_l2_l3">
+          <mxGeometry relative="1" as="geometry"><mxPoint as="offset"/></mxGeometry>
+        </mxCell>
+
+        <mxCell id="e_l3_out" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#22c55e;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="layer3_box" target="output">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- Conditional agents feed into Layer 2 too -->
+        <mxCell id="e_n28_l2" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#ec4899;strokeWidth=1;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.8;entryDx=0;entryDy=0;" edge="1" parent="1" source="n28" target="layer2_box">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_n30_l3" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#ec4899;strokeWidth=1;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="n30" target="layer3_box">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ LEGEND ============ -->
+        <mxCell id="legend_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1a1a2e;strokeColor=#334155;strokeWidth=1;" vertex="1" parent="1">
+          <mxGeometry x="1200" y="700" width="220" height="120" as="geometry"/>
+        </mxCell>
+        <mxCell id="legend_t" value="&lt;b&gt;Legend&lt;/b&gt;" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontColor=#e2e8f0;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1210" y="705" width="80" height="20" as="geometry"/>
+        </mxCell>
+        <mxCell id="leg1" value="Solid border = always active" style="text;html=1;align=left;fontSize=9;fontColor=#a855f7;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1210" y="730" width="200" height="16" as="geometry"/>
+        </mxCell>
+        <mxCell id="leg2" value="Dashed border = conditional (MoE)" style="text;html=1;align=left;fontSize=9;fontColor=#ec4899;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1210" y="748" width="200" height="16" as="geometry"/>
+        </mxCell>
+        <mxCell id="leg3" value="Cyan = Monte Carlo layer" style="text;html=1;align=left;fontSize=9;fontColor=#22d3ee;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1210" y="766" width="200" height="16" as="geometry"/>
+        </mxCell>
+        <mxCell id="leg4" value="Amber = LLM synthesis layer" style="text;html=1;align=left;fontSize=9;fontColor=#f59e0b;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1210" y="784" width="200" height="16" as="geometry"/>
+        </mxCell>
+        <mxCell id="leg5" value="Green = final output" style="text;html=1;align=left;fontSize=9;fontColor=#22c55e;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1210" y="802" width="200" height="16" as="geometry"/>
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/diagrams/system_architecture.drawio
+++ b/docs/diagrams/system_architecture.drawio
@@ -1,0 +1,220 @@
+<mxfile host="app.diagrams.net" modified="2026-04-13" agent="Claude" version="24.7.17">
+  <diagram id="sys-arch-1" name="System Architecture">
+    <mxGraphModel dx="1600" dy="1000" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="1000" math="0" shadow="0" background="#0a0a1a">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+
+        <!-- ============ TITLE ============ -->
+        <mxCell id="title" value="F1 Strategy Manager — System Architecture" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="400" y="15" width="800" height="40" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ USER LAYER ============ -->
+        <mxCell id="user_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1a1a2e;strokeColor=#a78bfa;strokeWidth=2;arcSize=8;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="620" y="70" width="360" height="70" as="geometry"/>
+        </mxCell>
+        <mxCell id="user_icon" value="&lt;b&gt;User / Browser&lt;/b&gt;&lt;br&gt;Race Engineer" style="shape=mxgraph.basic.smiley;fillColor=#a78bfa;strokeColor=#7c3aed;fontColor=#e2e8f0;fontSize=11;verticalAlign=bottom;spacingBottom=2;" vertex="1" parent="1">
+          <mxGeometry x="770" y="78" width="40" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="user_label" value="localhost:8501" style="text;html=1;align=center;verticalAlign=middle;fontSize=10;fontColor=#94a3b8;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="720" y="118" width="160" height="18" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ FRONTEND CONTAINER ============ -->
+        <mxCell id="fe_container" value="" style="swimlane;html=1;startSize=30;fillColor=#121127;strokeColor=#a78bfa;strokeWidth=2;rounded=1;arcSize=6;fontStyle=1;fontSize=13;fontColor=#a78bfa;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="180" width="520" height="280" as="geometry"/>
+        </mxCell>
+        <mxCell id="fe_title" value="FRONTEND  —  Streamlit  :8501" style="text;html=1;align=left;verticalAlign=middle;fontSize=13;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="fe_container">
+          <mxGeometry x="10" y="0" width="300" height="30" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="fe_pages" value="&lt;b&gt;Pages&lt;/b&gt;&lt;br&gt;Dashboard&lt;br&gt;Race Analysis&lt;br&gt;Strategy (agents)&lt;br&gt;Model Lab&lt;br&gt;Comparison&lt;br&gt;Chat" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=10;align=left;spacingLeft=8;verticalAlign=top;spacingTop=4;" vertex="1" parent="fe_container">
+          <mxGeometry x="20" y="40" width="140" height="130" as="geometry"/>
+        </mxCell>
+        <mxCell id="fe_components" value="&lt;b&gt;Components&lt;/b&gt;&lt;br&gt;Layout / Auth&lt;br&gt;Chatbot UI&lt;br&gt;Voice Input&lt;br&gt;Telemetry Charts&lt;br&gt;Strategy Panels&lt;br&gt;Comparison Views" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=10;align=left;spacingLeft=8;verticalAlign=top;spacingTop=4;" vertex="1" parent="fe_container">
+          <mxGeometry x="180" y="40" width="150" height="130" as="geometry"/>
+        </mxCell>
+        <mxCell id="fe_services" value="&lt;b&gt;Services&lt;/b&gt;&lt;br&gt;telemetry_service&lt;br&gt;chat_service&lt;br&gt;strategy_service&lt;br&gt;auth_service&lt;br&gt;voice_api" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=10;align=left;spacingLeft=8;verticalAlign=top;spacingTop=4;" vertex="1" parent="fe_container">
+          <mxGeometry x="350" y="40" width="150" height="130" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="fe_config" value="config.py&lt;br&gt;styles.py" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#312e81;strokeColor=#6366f1;fontColor=#a5b4fc;fontSize=9;" vertex="1" parent="fe_container">
+          <mxGeometry x="20" y="190" width="100" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="fe_shared" value="shared/&lt;br&gt;utils/" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#312e81;strokeColor=#6366f1;fontColor=#a5b4fc;fontSize=9;" vertex="1" parent="fe_container">
+          <mxGeometry x="140" y="190" width="100" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="fe_docker" value="Dockerfile&lt;br&gt;(python:3.11-slim)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#312e81;strokeColor=#6366f1;fontColor=#a5b4fc;fontSize=9;" vertex="1" parent="fe_container">
+          <mxGeometry x="260" y="190" width="120" height="40" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ BACKEND CONTAINER ============ -->
+        <mxCell id="be_container" value="" style="swimlane;html=1;startSize=30;fillColor=#121127;strokeColor=#2dd4bf;strokeWidth=2;rounded=1;arcSize=6;fontStyle=1;fontSize=13;fontColor=#2dd4bf;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="620" y="180" width="520" height="280" as="geometry"/>
+        </mxCell>
+        <mxCell id="be_title" value="BACKEND  —  FastAPI  :8000" style="text;html=1;align=left;verticalAlign=middle;fontSize=13;fontStyle=1;fontColor=#2dd4bf;fillColor=none;strokeColor=none;" vertex="1" parent="be_container">
+          <mxGeometry x="10" y="0" width="300" height="30" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="be_routers" value="&lt;b&gt;API Routers (/api/v1)&lt;/b&gt;&lt;br&gt;telemetry&lt;br&gt;strategy (N25-N31)&lt;br&gt;chat&lt;br&gt;comparison&lt;br&gt;voice&lt;br&gt;auth&lt;br&gt;circuit_domination" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#14b8a6;fontColor=#99f6e4;fontSize=10;align=left;spacingLeft=8;verticalAlign=top;spacingTop=4;" vertex="1" parent="be_container">
+          <mxGeometry x="20" y="40" width="160" height="150" as="geometry"/>
+        </mxCell>
+        <mxCell id="be_services" value="&lt;b&gt;Services&lt;/b&gt;&lt;br&gt;chatbot/&lt;br&gt;&amp;nbsp; QueryRouter&lt;br&gt;&amp;nbsp; QueryClassifier&lt;br&gt;&amp;nbsp; Handlers&lt;br&gt;telemetry/&lt;br&gt;voice/" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#14b8a6;fontColor=#99f6e4;fontSize=10;align=left;spacingLeft=8;verticalAlign=top;spacingTop=4;" vertex="1" parent="be_container">
+          <mxGeometry x="200" y="40" width="140" height="150" as="geometry"/>
+        </mxCell>
+        <mxCell id="be_models" value="&lt;b&gt;Pydantic Models&lt;/b&gt;&lt;br&gt;ChatRequest&lt;br&gt;ChatResponse&lt;br&gt;StrategyResponse&lt;br&gt;QueryResponse" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f3433;strokeColor=#14b8a6;fontColor=#99f6e4;fontSize=10;align=left;spacingLeft=8;verticalAlign=top;spacingTop=4;" vertex="1" parent="be_container">
+          <mxGeometry x="360" y="40" width="140" height="110" as="geometry"/>
+        </mxCell>
+        <mxCell id="be_docker" value="Dockerfile&lt;br&gt;(python:3.11-slim)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#134e4a;strokeColor=#0d9488;fontColor=#5eead4;fontSize=9;" vertex="1" parent="be_container">
+          <mxGeometry x="360" y="160" width="120" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="be_cors" value="CORS&lt;br&gt;middleware" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#134e4a;strokeColor=#0d9488;fontColor=#5eead4;fontSize=9;" vertex="1" parent="be_container">
+          <mxGeometry x="20" y="210" width="100" height="40" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ ML / AGENTS LAYER ============ -->
+        <mxCell id="ml_container" value="" style="swimlane;html=1;startSize=30;fillColor=#121127;strokeColor=#f472b6;strokeWidth=2;rounded=1;arcSize=6;fontStyle=1;fontSize=13;fontColor=#f472b6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="520" width="700" height="200" as="geometry"/>
+        </mxCell>
+        <mxCell id="ml_title" value="ML MODELS &amp; MULTI-AGENT SYSTEM  (src/agents/)" style="text;html=1;align=left;verticalAlign=middle;fontSize=13;fontStyle=1;fontColor=#f472b6;fillColor=none;strokeColor=none;" vertex="1" parent="ml_container">
+          <mxGeometry x="10" y="0" width="500" height="30" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="ml_orch" value="&lt;b&gt;N31 Orchestrator&lt;/b&gt;&lt;br&gt;MoE + MC Sim + LLM" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#4a1942;strokeColor=#ec4899;fontColor=#fce7f3;fontSize=10;fontStyle=0;" vertex="1" parent="ml_container">
+          <mxGeometry x="260" y="40" width="160" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="ml_n25" value="N25&lt;br&gt;Pace" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#a855f7;fontColor=#e9d5ff;fontSize=10;" vertex="1" parent="ml_container">
+          <mxGeometry x="20" y="110" width="80" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="ml_n26" value="N26&lt;br&gt;Tire" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#a855f7;fontColor=#e9d5ff;fontSize=10;" vertex="1" parent="ml_container">
+          <mxGeometry x="120" y="110" width="80" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="ml_n27" value="N27&lt;br&gt;Race Sit." style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#a855f7;fontColor=#e9d5ff;fontSize=10;" vertex="1" parent="ml_container">
+          <mxGeometry x="220" y="110" width="80" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="ml_n28" value="N28&lt;br&gt;Pit Strat." style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#a855f7;fontColor=#e9d5ff;fontSize=10;" vertex="1" parent="ml_container">
+          <mxGeometry x="320" y="110" width="80" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="ml_n29" value="N29&lt;br&gt;Radio" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#a855f7;fontColor=#e9d5ff;fontSize=10;" vertex="1" parent="ml_container">
+          <mxGeometry x="420" y="110" width="80" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="ml_n30" value="N30&lt;br&gt;RAG" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#a855f7;fontColor=#e9d5ff;fontSize=10;" vertex="1" parent="ml_container">
+          <mxGeometry x="520" y="110" width="80" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="ml_trained" value="&lt;b&gt;Trained Models&lt;/b&gt;&lt;br&gt;XGBoost (N06)&lt;br&gt;TCN (N09-N10)&lt;br&gt;LightGBM (N12,N14,N16)&lt;br&gt;HistGBT (N15)&lt;br&gt;NLP pipeline (N24)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#d946ef;fontColor=#f5d0fe;fontSize=9;align=left;spacingLeft=6;verticalAlign=top;spacingTop=4;" vertex="1" parent="ml_container">
+          <mxGeometry x="620" y="40" width="160" height="120" as="geometry"/>
+        </mxCell>
+
+        <!-- Orchestrator to sub-agents arrows -->
+        <mxCell id="e_orch_n25" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#a855f7;strokeWidth=1;exitX=0;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="ml_container" source="ml_orch" target="ml_n25">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_orch_n26" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#a855f7;strokeWidth=1;exitX=0.25;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="ml_container" source="ml_orch" target="ml_n26">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_orch_n27" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#a855f7;strokeWidth=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="ml_container" source="ml_orch" target="ml_n27">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_orch_n28" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#ec4899;strokeWidth=1;dashed=1;exitX=0.75;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="ml_container" source="ml_orch" target="ml_n28">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_orch_n29" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#a855f7;strokeWidth=1;exitX=1;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="ml_container" source="ml_orch" target="ml_n29">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_orch_n30" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#ec4899;strokeWidth=1;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="ml_container" source="ml_orch" target="ml_n30">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ EXTERNAL SERVICES ============ -->
+        <mxCell id="ext_container" value="" style="swimlane;html=1;startSize=30;fillColor=#121127;strokeColor=#fbbf24;strokeWidth=2;rounded=1;arcSize=6;fontStyle=1;fontSize=13;fontColor=#fbbf24;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="800" y="520" width="360" height="200" as="geometry"/>
+        </mxCell>
+        <mxCell id="ext_title" value="EXTERNAL SERVICES" style="text;html=1;align=left;verticalAlign=middle;fontSize=13;fontStyle=1;fontColor=#fbbf24;fillColor=none;strokeColor=none;" vertex="1" parent="ext_container">
+          <mxGeometry x="10" y="0" width="250" height="30" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="ext_lms" value="&lt;b&gt;LM Studio&lt;/b&gt;&lt;br&gt;:1234&lt;br&gt;gpt-4.1-mini&lt;br&gt;gpt-5.4-mini" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;fontColor=#fef3c7;fontSize=10;align=center;" vertex="1" parent="ext_container">
+          <mxGeometry x="20" y="40" width="100" height="80" as="geometry"/>
+        </mxCell>
+        <mxCell id="ext_qdrant" value="&lt;b&gt;Qdrant&lt;/b&gt;&lt;br&gt;Vector DB&lt;br&gt;RAG index" style="shape=cylinder3;size=10;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;fontColor=#fef3c7;fontSize=10;" vertex="1" parent="ext_container">
+          <mxGeometry x="140" y="40" width="90" height="80" as="geometry"/>
+        </mxCell>
+        <mxCell id="ext_fastf1" value="&lt;b&gt;FastF1&lt;/b&gt;&lt;br&gt;F1 Telemetry&lt;br&gt;API" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#f59e0b;fontColor=#fef3c7;fontSize=10;" vertex="1" parent="ext_container">
+          <mxGeometry x="250" y="40" width="90" height="80" as="geometry"/>
+        </mxCell>
+        <mxCell id="ext_data" value="&lt;b&gt;data/&lt;/b&gt;&lt;br&gt;parquets, models/, processed/" style="shape=cylinder3;size=10;whiteSpace=wrap;html=1;fillColor=#422006;strokeColor=#d97706;fontColor=#fef3c7;fontSize=9;" vertex="1" parent="ext_container">
+          <mxGeometry x="20" y="135" width="200" height="55" as="geometry"/>
+        </mxCell>
+
+        <!-- ============ CONNECTORS between containers ============ -->
+        <!-- User to Frontend -->
+        <mxCell id="e_user_fe" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#a78bfa;strokeWidth=2;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="1" source="user_box" target="fe_container">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_user_fe_label" value="HTTP :8501" style="edgeLabel;html=1;fontSize=9;fontColor=#94a3b8;fillColor=none;" vertex="1" connectable="0" parent="e_user_fe">
+          <mxGeometry x="-0.2" relative="1" as="geometry"><mxPoint as="offset"/></mxGeometry>
+        </mxCell>
+
+        <!-- Frontend to Backend -->
+        <mxCell id="e_fe_be" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#67e8f9;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="fe_container" target="be_container">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_fe_be_label" value="REST API&lt;br&gt;/api/v1/*" style="edgeLabel;html=1;fontSize=9;fontColor=#67e8f9;fillColor=none;" vertex="1" connectable="0" parent="e_fe_be">
+          <mxGeometry relative="1" as="geometry"><mxPoint as="offset"/></mxGeometry>
+        </mxCell>
+
+        <!-- Backend to ML Agents -->
+        <mxCell id="e_be_ml" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#f472b6;strokeWidth=2;exitX=0.3;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="be_container" target="ml_container">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_be_ml_label" value="Python import&lt;br&gt;strategy_service" style="edgeLabel;html=1;fontSize=9;fontColor=#f472b6;fillColor=none;" vertex="1" connectable="0" parent="e_be_ml">
+          <mxGeometry relative="1" as="geometry"><mxPoint as="offset"/></mxGeometry>
+        </mxCell>
+
+        <!-- Backend to External (LM Studio) -->
+        <mxCell id="e_be_lms" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#fbbf24;strokeWidth=2;exitX=1;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="be_container" target="ext_container">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_be_lms_label" value="OpenAI-compat&lt;br&gt;HTTP :1234" style="edgeLabel;html=1;fontSize=9;fontColor=#fbbf24;fillColor=none;" vertex="1" connectable="0" parent="e_be_lms">
+          <mxGeometry relative="1" as="geometry"><mxPoint as="offset"/></mxGeometry>
+        </mxCell>
+
+        <!-- ML to External (data, Qdrant) -->
+        <mxCell id="e_ml_ext" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;strokeColor=#fbbf24;strokeWidth=1;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="ml_container" target="ext_container">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_ml_ext_label" value="model files,&lt;br&gt;RAG queries,&lt;br&gt;FastF1 data" style="edgeLabel;html=1;fontSize=9;fontColor=#fbbf24;fillColor=none;" vertex="1" connectable="0" parent="e_ml_ext">
+          <mxGeometry relative="1" as="geometry"><mxPoint as="offset"/></mxGeometry>
+        </mxCell>
+
+        <!-- ============ LEGEND ============ -->
+        <mxCell id="legend_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1a1a2e;strokeColor=#334155;strokeWidth=1;" vertex="1" parent="1">
+          <mxGeometry x="1200" y="750" width="200" height="130" as="geometry"/>
+        </mxCell>
+        <mxCell id="legend_title" value="&lt;b&gt;Legend&lt;/b&gt;" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontColor=#e2e8f0;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1210" y="755" width="80" height="20" as="geometry"/>
+        </mxCell>
+        <mxCell id="legend_solid" value="&amp;nbsp;Solid = always active" style="text;html=1;align=left;verticalAlign=middle;fontSize=9;fontColor=#94a3b8;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1210" y="780" width="180" height="18" as="geometry"/>
+        </mxCell>
+        <mxCell id="legend_dashed" value="&amp;nbsp;Dashed = conditional (MoE)" style="text;html=1;align=left;verticalAlign=middle;fontSize=9;fontColor=#94a3b8;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1210" y="800" width="180" height="18" as="geometry"/>
+        </mxCell>
+        <mxCell id="legend_purple" value="&amp;nbsp;Purple = Frontend" style="text;html=1;align=left;verticalAlign=middle;fontSize=9;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1210" y="820" width="150" height="18" as="geometry"/>
+        </mxCell>
+        <mxCell id="legend_teal" value="&amp;nbsp;Teal = Backend" style="text;html=1;align=left;verticalAlign=middle;fontSize=9;fontColor=#2dd4bf;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1210" y="838" width="150" height="18" as="geometry"/>
+        </mxCell>
+        <mxCell id="legend_pink" value="&amp;nbsp;Pink = ML Agents" style="text;html=1;align=left;verticalAlign=middle;fontSize=9;fontColor=#f472b6;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1210" y="856" width="150" height="18" as="geometry"/>
+        </mxCell>
+        <mxCell id="legend_yellow" value="&amp;nbsp;Yellow = External" style="text;html=1;align=left;verticalAlign=middle;fontSize=9;fontColor=#fbbf24;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1210" y="874" width="150" height="18" as="geometry"/>
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/driver-colors.md
+++ b/docs/driver-colors.md
@@ -1,0 +1,70 @@
+# Driver Colors -- Year-Aware System
+
+## Location
+
+`src/telemetry/frontend/components/common/driver_colors.py`
+
+Also used by the backend: `src/telemetry/backend/core/driver_colors.py`.
+
+## Purpose
+
+F1 driver lineups change every season. A driver may switch teams between years, so the color associated with a driver abbreviation must be season-specific. This module provides a year-aware color palette covering 2023--2025 seasons.
+
+## Design
+
+### Team Base Colors
+
+Each team has two hex constants -- one for the primary driver, one for the secondary. For example:
+
+```python
+_RED_BULL   = '#3671C6'   # Primary (e.g., VER)
+_RED_BULL_2 = '#1B3D8E'   # Secondary (e.g., LAW in 2025, PER in 2024)
+```
+
+All ten teams follow this pattern: Ferrari, Mercedes, McLaren, Aston Martin, Alpine, Williams, Racing Bulls (RB), Sauber, Haas.
+
+### Per-Year Mapping
+
+`DRIVER_COLORS_BY_YEAR` is a dict keyed by year (2023, 2024, 2025), each containing a driver-code-to-hex mapping. Mid-season replacements are included (e.g., COL and LAW in 2024).
+
+Notable changes across seasons:
+- **Alpine** switched from pink (`#FF87BC`) in 2023--2024 to blue (`#0093CC`) in 2025.
+- **HAM** moved from Mercedes (teal) to Ferrari (red) in 2025.
+- **SAI** moved from Ferrari to Williams in 2025.
+
+### Flat Fallback
+
+`DRIVER_COLORS = DRIVER_COLORS_BY_YEAR[2025]` provides backward compatibility for code that does not pass a year.
+
+## Public API
+
+### `get_driver_color(driver_code, default='#A259F7', year=None) -> str`
+
+Returns the hex color for a driver in a given season. Falls back to the 2025 flat dict when `year` is None. Returns `default` if the driver code is not found.
+
+### `get_driver_colors_for_list(driver_codes, year=None) -> list`
+
+Batch version -- returns a list of hex colors matching the input list of driver codes.
+
+## Usage
+
+```python
+from components.common.driver_colors import get_driver_color
+
+# Year-aware lookup
+color = get_driver_color("HAM", year=2024)  # '#27F4D2' (Mercedes teal)
+color = get_driver_color("HAM", year=2025)  # '#A30000' (Ferrari dark red)
+
+# Fallback (uses 2025)
+color = get_driver_color("VER")  # '#3671C6'
+```
+
+## Where It Is Used
+
+- `pages/race_analysis.py` -- tire and gap chart color assignment
+- `components/race_analysis/tire_charts.py` -- per-driver tire degradation plots
+- `components/race_analysis/gap_charts.py` -- gap evolution charts
+- `utils/race_viz.py` -- general race visualization helpers
+- `components/dashboard/data_selectors.py` -- dashboard driver selector
+- `backend/core/driver_colors.py` -- server-side comparison endpoint color assignment
+- `backend/services/telemetry_service.py` -- telemetry data color tagging

--- a/docs/frontend-css-fixes.md
+++ b/docs/frontend-css-fixes.md
@@ -1,0 +1,86 @@
+# Frontend CSS Fixes
+
+## Scroll Fix on Plotly Charts (stElementContainer)
+
+### Problem
+
+Streamlit wraps Plotly charts in `div.stElementContainer` elements that can develop unwanted horizontal scrollbars. This happens because the Plotly SVG layout occasionally renders a few pixels wider than the container, triggering overflow.
+
+### Solution
+
+Located in `src/telemetry/frontend/components/common/chart_styles.py`, the `apply_telemetry_chart_styles()` function injects CSS that hides the scrollbar on the parent wrapper without clipping chart content:
+
+```css
+/* Hide scrollbar on the parent wrapper */
+div.stElementContainer:has(div[data-testid="stPlotlyChart"]) {
+    scrollbar-width: none !important;          /* Firefox */
+    -ms-overflow-style: none !important;       /* IE/Edge */
+}
+div.stElementContainer:has(div[data-testid="stPlotlyChart"])::-webkit-scrollbar {
+    display: none !important;                  /* Chrome/Safari */
+}
+```
+
+The selector uses `:has()` to target only containers that wrap Plotly charts, avoiding side effects on other Streamlit elements.
+
+### Chart Styling
+
+The same function also applies a consistent visual treatment to all Plotly charts:
+
+```css
+div[data-testid="stPlotlyChart"] {
+    outline: 2px solid #a78bfa !important;     /* Purple border */
+    outline-offset: -2px !important;           /* Inset so no extra pixels */
+    border-radius: 12px !important;
+    background-color: #181633 !important;      /* Dark background */
+    box-shadow: 0 4px 12px rgba(167, 139, 250, 0.2) !important;
+}
+```
+
+`outline` is used instead of `border` because outlines do not affect the box model and cannot cause layout shifts or trigger scrollbars.
+
+### Usage
+
+Call `apply_telemetry_chart_styles()` once at the top of any page that renders Plotly charts:
+
+```python
+from components.common.chart_styles import apply_telemetry_chart_styles
+st.markdown(apply_telemetry_chart_styles(), unsafe_allow_html=True)
+```
+
+## Loading Spinner Removal
+
+### Location
+
+`src/telemetry/frontend/components/common/loading.py`
+
+### What It Does
+
+`render_loading_spinner()` renders an animated CSS spinner inside a purple-bordered container that matches Plotly chart dimensions (400px height). It shows "Waiting for telemetry data..." text with five vertical bars that animate in sequence.
+
+### Why It Should Be Removed From Empty States
+
+The spinner was designed to display while telemetry data is actively loading. However, it was also used as a placeholder in empty states (before the user selects a session/driver), where no loading is actually happening. This confuses users because:
+
+1. The "Waiting for telemetry data..." text implies the system is fetching data when it is not.
+2. The animation suggests an ongoing operation, but nothing will complete until the user makes a selection.
+3. Multiple spinners on a page (one per chart placeholder) create visual noise.
+
+The correct pattern for empty states is a static placeholder or no content at all -- spinners should only appear during actual asynchronous operations.
+
+### Current Status
+
+The spinner is still present in several telemetry graph components under `components/telemetry/` and `components/comparison/`. Removal is tracked as a pending task.
+
+### Files Using the Spinner
+
+- `components/telemetry/speed_graph.py`
+- `components/telemetry/brake_graph.py`
+- `components/telemetry/throttle_graph.py`
+- `components/telemetry/gear_graph.py`
+- `components/telemetry/rpm_graph.py`
+- `components/telemetry/drs_graph.py`
+- `components/telemetry/delta_graph.py`
+- `components/telemetry/circuit_domination.py`
+- `components/comparison/synchronized_comparison_animation.py`
+- `components/comparison/legacy/*.py` (5 files)

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -29,7 +29,8 @@ frontend/
   pages/               -- One file per page
   components/
     auth/              -- Login form
-    chatbot/           -- Chat UI components
+    chatbot/           -- Chat UI components (history, input, message, sidebar,
+                          tool_result_renderer, chart_builders)
     common/            -- Shared: driver_colors, chart_styles, loading, data_selectors
     comparison/        -- Driver comparison charts (+ legacy/ subfolder)
     dashboard/         -- Dashboard-specific CSS and selectors
@@ -77,6 +78,37 @@ The Strategy page (`pages/strategy.py`) is the primary interface for the N25--N3
    - `render_strategy_card()` -- recommendation card with action, confidence, reasoning
    - `render_scenario_chart()` -- bar chart comparing MC scenario scores
    - `render_agent_tabs()` -- tabbed detail view for each sub-agent output
+
+## Chat Tool-Result Rendering
+
+The Chat page (`pages/chat.py`) consumes the MCP-style tool results returned by `/api/v1/chat/query`. Each tool result carries a `display_type` hint (see `TOOL_DISPLAY_MAP` in `src/telemetry/backend/models/tool_schemas.py`) that tells the frontend how to render the payload.
+
+Dispatch lives in `components/chatbot/tool_result_renderer.py`:
+
+```python
+_RENDERERS = {
+    "metrics":        _render_metrics,
+    "strategy_card":  _render_strategy_card,
+    "table":          _render_table,
+    "text":           _render_text,
+    "chart":          _render_chart,
+}
+```
+
+### Inline Plotly charts (Phase 2 MCP telemetry tools)
+
+The four telemetry tools (`get_lap_times`, `get_telemetry`, `compare_drivers`, `get_race_data`) are mapped to `DisplayType.CHART` and render as inline Plotly figures inside the chat bubble. `_render_chart(data, tool_name)` calls `build_figure(tool_name, data)` from `components/chatbot/chart_builders.py`, which dispatches to one of:
+
+| Tool | Builder | Figure |
+|---|---|---|
+| `get_lap_times` | `build_lap_times_figure` | Lap-time line per driver |
+| `get_telemetry` | `build_telemetry_figure` | Speed / throttle / brake traces for one lap |
+| `compare_drivers` | `build_compare_drivers_figure` | Fastest-lap side-by-side comparison |
+| `get_race_data` | `build_race_data_figure` | Full race overview (positions / gaps) |
+
+Builders are Streamlit-free: they take the raw tool payload, pull per-driver colors via `get_driver_color` from `components/common/driver_colors.py`, and apply the shared dark theme through `_apply_base_layout()`. The renderer wraps the figure with `apply_telemetry_chart_styles()` so the chart inherits the purple-outlined chat bubble look, and falls back to `_render_text` if the builder returns `None` (unknown tool or malformed payload).
+
+On the backend, `_execute_telemetry_tool` in `services/chatbot/handlers/strategy_handler.py` no longer mutates or trims the raw tool response; a separate `_trim_for_llm(raw)` static helper produces a 20-record-capped shallow copy that is passed only to the LLM summariser. The full payload is forwarded to the UI via `tool_result.data`, which is what enables the chart builders to plot complete series rather than a truncated LLM-view sample. As a side effect, the previous `compare_drivers` "N/A" rendering bug disappears because `_render_chart` reads `data.pilot1.lap_time` / `data.pilot2.lap_time` directly from the untrimmed payload.
 
 ## Services Layer
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,0 +1,105 @@
+# Frontend Documentation (Streamlit)
+
+## Overview
+
+The frontend is a multi-page Streamlit application at `src/telemetry/frontend/`. It communicates with the FastAPI backend via HTTP and renders telemetry visualizations, strategy recommendations, driver comparisons, and a chat interface.
+
+Entry point: `frontend/app/main.py`.
+
+## Page Map
+
+| Page | File | Description |
+|---|---|---|
+| Dashboard | `pages/dashboard.py` | Telemetry charts for selected session/driver |
+| Comparison | `pages/comparison.py` | Side-by-side telemetry for two drivers |
+| Race Analysis | `pages/race_analysis.py` | Tire, gap, and radio analysis tabs |
+| Strategy | `pages/strategy.py` | N25--N31 strategy advisor with agent tabs |
+| Chat | `pages/chat.py` | LM Studio chat interface |
+| Model Lab | `pages/model_lab.py` | Interactive ML model exploration |
+
+## Directory Structure
+
+```
+frontend/
+  app/
+    main.py            -- Streamlit entry point, page routing, auth check
+    setup_path.py      -- sys.path configuration
+    styles.py          -- GLOBAL_CSS constant
+    track_data.py      -- Track metadata
+  pages/               -- One file per page
+  components/
+    auth/              -- Login form
+    chatbot/           -- Chat UI components
+    common/            -- Shared: driver_colors, chart_styles, loading, data_selectors
+    comparison/        -- Driver comparison charts (+ legacy/ subfolder)
+    dashboard/         -- Dashboard-specific CSS and selectors
+    layout/            -- Navbar
+    race_analysis/     -- Tire charts, gap charts, radio panel
+    strategy/          -- Strategy card, scenario chart, agent tabs
+    streamlit_audio_viz/ -- Custom React component for audio visualization
+    telemetry/         -- Individual telemetry graphs (speed, brake, DRS, etc.)
+    voice/             -- Voice input UI
+  services/
+    auth_service.py    -- Authentication HTTP client
+    chat_service.py    -- Chat HTTP client
+    strategy_service.py -- Strategy endpoints HTTP client
+    telemetry_service.py -- Telemetry HTTP client
+    voice_api.py       -- Voice HTTP client
+  utils/
+    audio_utils.py     -- Audio processing helpers
+    chat_navigation.py -- Chat page navigation state
+    chat_state.py      -- Chat session state management
+    data_loaders.py    -- Data loading utilities
+    race_processing.py -- Race data transformations
+    race_viz.py        -- Race visualization helpers
+    report_storage.py  -- Report persistence
+    time_formatters.py -- Lap time formatting
+  shared/
+    img/               -- Static image assets
+  config.py            -- BACKEND_URL, API_BASE_URL from env vars
+```
+
+## Authentication
+
+The app uses a simple session-state authentication gate. When `st.session_state['authenticated']` is False, `render_auth_form()` is shown. After login, the navbar and page router are displayed.
+
+## Navigation
+
+Page routing uses `st.session_state['current_page']`. The navbar (`components/layout/navbar.py`) sets this value. Pages are rendered conditionally in `main.py`.
+
+## Strategy Page
+
+The Strategy page (`pages/strategy.py`) is the primary interface for the N25--N31 agent system:
+
+1. **Selectors**: Year (hardcoded 2025), GP, Driver, Lap range, Analysis lap, Risk tolerance
+2. **Run button**: calls `StrategyService.get_recommend()` which hits `/api/v1/strategy/recommend`
+3. **Results**:
+   - `render_strategy_card()` -- recommendation card with action, confidence, reasoning
+   - `render_scenario_chart()` -- bar chart comparing MC scenario scores
+   - `render_agent_tabs()` -- tabbed detail view for each sub-agent output
+
+## Services Layer
+
+All HTTP calls go through service classes in `services/`. Each method returns a `(success: bool, data: dict | None, error: str | None)` triple so callers handle results consistently.
+
+```python
+class StrategyService:
+    @staticmethod
+    def get_pace(lap_state) -> Tuple[bool, Optional[Dict], Optional[str]]: ...
+    @staticmethod
+    def get_tire(lap_state) -> Tuple[bool, Optional[Dict], Optional[str]]: ...
+    @staticmethod
+    def get_recommend(...) -> Tuple[bool, Optional[Dict], Optional[str]]: ...
+    # ... etc.
+```
+
+Timeout is set to 300 seconds because first-call model loading (RoBERTa + SetFit + BERT-large + BGE-M3) is slow.
+
+## Configuration
+
+Environment variables read by the frontend:
+
+| Variable | Default | Description |
+|---|---|---|
+| `BACKEND_URL` | `http://localhost:8000` | FastAPI backend base URL |
+| `FRONTEND_URL` | `http://localhost:8501` | Frontend self-reference |

--- a/docs/setup-and-deployment.md
+++ b/docs/setup-and-deployment.md
@@ -1,0 +1,147 @@
+# Setup and Deployment Guide
+
+## Prerequisites
+
+- Python 3.10+
+- Node.js 18+ (for the audio visualization React component build)
+- Docker and Docker Compose (for containerized deployment)
+- LM Studio or OpenAI API key (for LLM-powered agents)
+
+## Local Development
+
+### 1. Clone and install
+
+```bash
+git clone https://github.com/VforVitorio/F1_Strat_Manager.git
+cd F1_Strat_Manager
+pip install -e .
+```
+
+Or with uv:
+
+```bash
+uv pip install -e .
+```
+
+### 2. Data
+
+The project requires pre-computed data artifacts. Download from HuggingFace:
+
+```
+https://huggingface.co/datasets/VforVitorio/f1-strategy-dataset
+```
+
+Place contents under `data/` at the repo root. Expected layout:
+
+```
+data/
+  raw/2025/<GP>/laps.parquet
+  processed/laps_featured_2025.parquet
+  models/lap_time/          -- N06 XGBoost
+  models/tire_degradation/  -- N09/N10 TireDegTCN
+  models/overtake_probability/ -- N12 LightGBM
+  models/safety_car_probability/ -- N14 LightGBM
+  models/pit_prediction/    -- N15 HistGBT + N16 undercut
+  models/nlp/               -- pipeline_config_v1.json
+  models/agents/            -- agent config JSONs
+  rag/                      -- Qdrant index (built by scripts/build_rag_index.py)
+  tire_compounds_by_race.json
+```
+
+### 3. Environment variables
+
+Create a `.env` file at the repo root (or export these):
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `BACKEND_URL` | no | `http://localhost:8000` | Backend URL for frontend |
+| `FRONTEND_URL` | no | `http://localhost:8501` | Frontend URL for CORS |
+| `F1_LLM_PROVIDER` | no | `lmstudio` | Set to `openai` for OpenAI API |
+| `OPENAI_API_KEY` | if provider=openai | -- | OpenAI API key |
+| `F1_STRAT_DATA_ROOT` | no | repo `data/` | Override data directory |
+
+### 4. Run the backend
+
+```bash
+cd src/telemetry
+uvicorn backend.main:app --host 0.0.0.0 --port 8000 --reload
+```
+
+Verify at `http://localhost:8000/docs` (Swagger UI).
+
+### 5. Run the frontend
+
+```bash
+cd src/telemetry
+streamlit run frontend/app/main.py --server.port 8501
+```
+
+Open `http://localhost:8501`.
+
+### 6. LM Studio (for LLM agents)
+
+Start LM Studio with a model loaded, serving on `http://localhost:1234/v1`. The orchestrator defaults to this endpoint. Sub-agents use `gpt-4.1-mini` model name; the orchestrator uses `gpt-5.4-mini`.
+
+## Docker Deployment
+
+### Root docker-compose.yml
+
+The repo root `docker-compose.yml` provides a simple two-service setup:
+
+```bash
+docker-compose up --build
+```
+
+Services:
+- **backend**: FastAPI on port 8000
+- **frontend**: Streamlit on port 8501
+
+### Telemetry docker-compose.yml
+
+A more detailed compose file at `src/telemetry/docker-compose.yml` mounts volumes for live code reload and data access:
+
+```bash
+cd src/telemetry
+docker-compose up --build
+```
+
+Key volume mounts:
+- `../../src:/app/src:ro` -- read-only source code (agents import from here)
+- `../../data:/app/data:ro` -- read-only data directory
+- `../../data/rag:/app/data/rag:rw` -- writable RAG index (N30 may write here)
+
+The `:ro` mount means agents handle `OSError` / `PermissionError` gracefully when they attempt to create export directories inside Docker.
+
+### Frontend Dockerfile (multi-stage)
+
+The frontend Dockerfile (`frontend/Dockerfile`) has two stages:
+
+1. **node-builder**: builds the React audio visualization component from `components/streamlit_audio_viz/frontend/`
+2. **python app**: installs Python deps, copies frontend code, copies compiled React build
+
+### Backend Dockerfile
+
+The backend Dockerfile (`backend/Dockerfile`) installs `setuptools` and `wheel` first (needed by `openai-whisper` for `pkg_resources`), then installs all requirements with `--no-build-isolation`.
+
+## Building the RAG Index
+
+Before using the RAG Agent (N30), build the Qdrant vector index:
+
+```bash
+python scripts/build_rag_index.py
+```
+
+This processes FIA Sporting Regulations PDFs and stores embeddings in `data/rag/`.
+
+## Network Architecture (Docker)
+
+```
+                    f1_network (bridge)
+                    |                |
+    frontend:8501 --+                +-- backend:8000
+    (Streamlit)     |                |   (FastAPI + uvicorn)
+                    +-- LM Studio --+
+                        :1234 (host)
+```
+
+The frontend calls the backend via `http://backend:8000` (Docker service name). LM Studio runs on the host machine and is accessed at `http://host.docker.internal:1234/v1` or via host networking.

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -99,7 +99,10 @@ class PitAgentCFG:
 
     def __post_init__(self) -> None:
         self.export_dir = _AGENTS
-        self.export_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            self.export_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass  # read-only mount in Docker
 
         _pit = _MODELS / 'pit_prediction'
 

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -98,7 +98,10 @@ class RaceSituationConfig:
 
     def __post_init__(self) -> None:
         self.export_dir = _AGENTS
-        self.export_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            self.export_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass  # read-only mount in Docker
 
         # Overtake model (N12)
         _ov = _MODELS / 'overtake_probability'

--- a/src/agents/radio_agent.py
+++ b/src/agents/radio_agent.py
@@ -899,12 +899,18 @@ def _save_nlp_json(lap: int, radio_results: list, rcm_results: list) -> Path:
     Returns the Path of the saved file.
     """
     out_dir   = _DATA_ROOT / "processed" / "radio_outputs"
-    out_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        out_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None  # read-only mount in Docker — skip persist
     timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
     path      = out_dir / f"radio_nlp_lap{lap:03d}_{timestamp}.json"
     payload   = {"lap": lap, "radio_results": radio_results, "rcm_results": rcm_results}
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(payload, f, indent=2, ensure_ascii=False, default=str)
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, ensure_ascii=False, default=str)
+    except OSError:
+        return None
     return path
 
 

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -195,7 +195,10 @@ class TireAgentConfig:
     def __post_init__(self) -> None:
         self._model_dir = _MODEL_DIR
         self.export_dir = _AGENTS_DIR
-        self.export_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            self.export_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass  # read-only mount in Docker
 
         self.routing_cfg                              = self._load_routing_cfg()
         self.mc_calibration, self.mc_sigma_fallback   = self._load_mc_calibration()

--- a/src/rag/retriever.py
+++ b/src/rag/retriever.py
@@ -280,6 +280,7 @@ class RagRetriever:
 # Module-level singleton + LangGraph tool wrapper
 # ---------------------------------------------------------------------------
 
+
 @lru_cache(maxsize=1)
 def get_retriever(
     qdrant_path: Path | str | None = None,

--- a/src/rag/retriever.py
+++ b/src/rag/retriever.py
@@ -13,6 +13,7 @@ Public interface::
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -279,21 +280,20 @@ class RagRetriever:
 # Module-level singleton + LangGraph tool wrapper
 # ---------------------------------------------------------------------------
 
-_default_retriever: RagRetriever | None = None
-
-
+@lru_cache(maxsize=1)
 def get_retriever(
     qdrant_path: Path | str | None = None,
     collection_name: str | None = None,
     embedding_model: str | None = None,
     top_k: int | None = None,
 ) -> RagRetriever:
-    """Return the module-level singleton ``RagRetriever``, creating it on first call.
+    """Return the process-level singleton ``RagRetriever``, creating it on first call.
 
-    The singleton pattern avoids reloading the sentence-transformers model on every
-    agent invocation — loading ``BAAI/bge-m3`` takes ~1–2 s and should happen
-    exactly once per process. Subsequent calls return the cached instance regardless
-    of the arguments passed, so always configure via the first call or via ``CFG``.
+    Wrapped in ``functools.lru_cache`` so the embedded Qdrant client is
+    instantiated exactly once per process. A second ``QdrantClient(path=...)``
+    on the same storage directory raises ``AlreadyLocked`` (local mode holds a
+    file lock), which would break any caller — N31 orchestrator, the chat tool
+    ``query_rag_tool`` — that reaches into the retriever more than once.
 
     Args:
         qdrant_path:     Path to the on-disk Qdrant storage. Defaults to
@@ -305,15 +305,12 @@ def get_retriever(
         top_k:           Default number of chunks returned per query. Defaults to
                          ``CFG.top_k``.
     """
-    global _default_retriever
-    if _default_retriever is None:
-        _default_retriever = RagRetriever(
-            qdrant_path=qdrant_path or CFG.qdrant_path,
-            collection_name=collection_name or CFG.collection_name,
-            embedding_model=embedding_model or CFG.embedding_model,
-            top_k=top_k or CFG.top_k,
-        )
-    return _default_retriever
+    return RagRetriever(
+        qdrant_path=qdrant_path or CFG.qdrant_path,
+        collection_name=collection_name or CFG.collection_name,
+        embedding_model=embedding_model or CFG.embedding_model,
+        top_k=top_k or CFG.top_k,
+    )
 
 
 @tool

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -229,9 +229,8 @@ def test_tire_request_defaults():
     sys.path.insert(0, str(ROOT / "src" / "telemetry"))
     from backend.api.v1.endpoints.strategy import TireRequest
 
-    req = TireRequest(lap_state={})
-    assert req.gp_name == ""
-    assert req.year == 2025
+    req = TireRequest(lap_state={"driver": {}})
+    assert "driver" in req.lap_state
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,219 @@
+"""
+Tests for the simulation service and its SSE endpoint.
+
+Two kinds of coverage live here:
+
+1. Unit test against ``simulate_race`` directly — confirms the generator emits
+   the documented frame order (``start`` first, at least one ``lap``, one
+   ``summary`` last) when driven with a ``SimConfig(no_llm=True)`` config on a
+   small lap window. The no-LLM path is chosen deliberately so that LM Studio
+   / OpenAI do not have to be running in CI: sub-agent stubs kick in whenever
+   an ``APIConnectionError`` surfaces, keeping the run deterministic.
+
+2. Integration test against the ``/api/v1/strategy/simulate`` endpoint using
+   ``fastapi.testclient.TestClient.stream`` — the exact pattern the manual
+   smoke test used. The mini-app only mounts ``strategy.router`` so we avoid
+   pulling ``backend.main`` (which imports FastMCP, Supabase, etc.) and the
+   test stays hermetic.
+
+Both tests skip cleanly when either the featured parquet or the race
+directory for ``2025/Melbourne`` is missing, so contributors without the
+full data set still get a green suite.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+
+# Guard: simulation service needs laps_featured_YYYY.parquet + raw race dir.
+_PARQUET = ROOT / "data" / "processed" / "laps_featured_2025.parquet"
+_RACE_DIR = ROOT / "data" / "raw" / "2025" / "Melbourne"
+_HAS_DATA = _PARQUET.exists() and _RACE_DIR.exists()
+_skip_no_data = pytest.mark.skipif(
+    not _HAS_DATA,
+    reason="Melbourne 2025 parquet + race dir required for simulation tests",
+)
+
+# Guard: the telemetry backend must be importable — the simulation service
+# lives inside ``src/telemetry/backend`` and we need ``backend.*`` on sys.path
+# to import it without starting the full FastAPI app.
+_BACKEND_ROOT = ROOT / "src" / "telemetry"
+_HAS_BACKEND = (_BACKEND_ROOT / "backend").is_dir()
+_skip_no_backend = pytest.mark.skipif(
+    not _HAS_BACKEND,
+    reason="src/telemetry/backend not present in this checkout",
+)
+
+
+def _ensure_backend_on_path() -> None:
+    """Insert ``src/telemetry`` at the front of ``sys.path``.
+
+    The simulation service and the strategy router both import via ``backend.*``
+    absolute paths; this mirrors what ``conftest.py`` inside the submodule does
+    for its own suite. Safe to call multiple times — we guard against duplicate
+    insertions so pytest's module discovery stays stable across tests.
+    """
+    path_str = str(_BACKEND_ROOT)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)
+
+
+# ---------------------------------------------------------------------------
+# Unit — simulate_race generator contract
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_data
+@_skip_no_backend
+def test_simulate_race_emits_start_lap_summary():
+    """Generator must yield ``start`` first, at least one ``lap``, then ``summary``.
+
+    Uses a 3-lap window (laps 5..7) on Melbourne 2025 with ``no_llm=True`` so
+    no LLM backend is required. Validates the exact ordering contract the
+    SSE endpoint relies on: consumers (Arcade, curl probes) cannot lock the
+    layout until ``start`` arrives, and cannot finalise stats until
+    ``summary`` arrives. Intermediate ``error`` events are tolerated but the
+    closing frame must always be the summary.
+    """
+    _ensure_backend_on_path()
+    from backend.services.simulation import SimConfig, simulate_race
+
+    config = SimConfig(
+        year=2025,
+        gp="Melbourne",
+        driver="NOR",
+        team="McLaren",
+        lap_range=(5, 7),
+        no_llm=True,
+        interval_s=0.0,
+    )
+
+    events = list(simulate_race(config))
+
+    assert events, "simulate_race yielded nothing"
+    assert events[0]["type"] == "start", f"first event should be start, got {events[0]['type']}"
+    assert events[-1]["type"] == "summary", (
+        f"last event should be summary, got {events[-1]['type']}"
+    )
+
+    lap_events = [e for e in events if e["type"] == "lap"]
+    assert len(lap_events) >= 1, "expected at least one lap event in 3-lap window"
+
+    # Spot-check the LapDecision schema on the first lap payload.
+    first_lap = lap_events[0]["data"]
+    assert "lap_number" in first_lap
+    assert "action" in first_lap
+    assert "scenario_scores" in first_lap
+    assert isinstance(first_lap["scenario_scores"], dict)
+
+
+# ---------------------------------------------------------------------------
+# Integration — /api/v1/strategy/simulate SSE endpoint
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_data
+@_skip_no_backend
+def test_simulate_endpoint_streams_sse_frames():
+    """POST /api/v1/strategy/simulate must return an SSE stream with 4+ frames.
+
+    Mounts only ``strategy.router`` on a bare FastAPI app so the test does not
+    pull ``backend.main`` (which imports FastMCP, Supabase, voice stack, etc.).
+    This mirrors the pattern used by the manual smoke test and keeps the
+    integration cost low enough for CI.
+
+    We assert:
+      * HTTP 200 on the streaming response,
+      * at least 4 SSE ``data:`` frames (start + >=2 laps + summary),
+      * the first ``data:`` frame parses as JSON and declares ``type=start``.
+    """
+    import json
+
+    _ensure_backend_on_path()
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from backend.api.v1.endpoints import strategy
+
+    app = FastAPI()
+    app.include_router(strategy.router, prefix="/api/v1")
+
+    payload = {
+        "year": 2025,
+        "gp": "Melbourne",
+        "driver": "NOR",
+        "team": "McLaren",
+        "lap_range": [5, 7],
+        "no_llm": True,
+        "interval_s": 0.0,
+    }
+
+    with TestClient(app) as client:
+        with client.stream("POST", "/api/v1/strategy/simulate", json=payload) as response:
+            assert response.status_code == 200, response.text
+            assert "text/event-stream" in response.headers.get("content-type", "")
+
+            data_frames: list[str] = []
+            for line in response.iter_lines():
+                if line and line.startswith("data:"):
+                    data_frames.append(line[len("data:"):].strip())
+
+    assert len(data_frames) >= 4, (
+        f"expected >=4 SSE data frames (start + laps + summary), got {len(data_frames)}"
+    )
+
+    first = json.loads(data_frames[0])
+    assert first.get("type") == "start"
+    last = json.loads(data_frames[-1])
+    assert last.get("type") == "summary"
+
+
+# ---------------------------------------------------------------------------
+# Unit — SimulateRequest Pydantic validation
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_backend
+def test_simulate_request_schema_defaults():
+    """SimulateRequest must default to ``no_llm=False`` with lmstudio provider.
+
+    Protects the public API contract documented in ``project_sim_sse_endpoint_plan.md``:
+    callers posting the minimum payload (year + gp + driver + team) must get a
+    well-formed request with the expected defaults — ``risk_tolerance=0.5``,
+    ``provider="lmstudio"``, ``interval_s=0.0``. Changing any default here is a
+    breaking change for Arcade and the manual curl probes.
+    """
+    _ensure_backend_on_path()
+    from backend.api.v1.endpoints.strategy import SimulateRequest
+
+    req = SimulateRequest(year=2025, gp="Melbourne", driver="NOR", team="McLaren")
+    assert req.no_llm is False
+    assert req.provider == "lmstudio"
+    assert req.risk_tolerance == 0.5
+    assert req.interval_s == 0.0
+    assert req.lap_range is None
+
+
+@_skip_no_backend
+def test_simulate_request_rejects_invalid_provider():
+    """Provider must match the ``^(lmstudio|openai)$`` pattern.
+
+    The orchestrator reads ``F1_LLM_PROVIDER`` to pick the LLM client; allowing
+    arbitrary strings here would silently fall back to the default and make
+    provider bugs hard to diagnose downstream. Pydantic's pattern validator is
+    our first line of defence — this test pins the behaviour.
+    """
+    _ensure_backend_on_path()
+    from pydantic import ValidationError
+
+    from backend.api.v1.endpoints.strategy import SimulateRequest
+
+    with pytest.raises(ValidationError):
+        SimulateRequest(
+            year=2025, gp="Melbourne", driver="NOR", team="McLaren", provider="anthropic"
+        )

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -160,7 +160,7 @@ def test_simulate_endpoint_streams_sse_frames():
             data_frames: list[str] = []
             for line in response.iter_lines():
                 if line and line.startswith("data:"):
-                    data_frames.append(line[len("data:"):].strip())
+                    data_frames.append(line[len("data:") :].strip())
 
     assert len(data_frames) >= 4, (
         f"expected >=4 SSE data frames (start + laps + summary), got {len(data_frames)}"

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -135,10 +135,9 @@ def test_simulate_endpoint_streams_sse_frames():
     import json
 
     _ensure_backend_on_path()
+    from backend.api.v1.endpoints import strategy
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
-
-    from backend.api.v1.endpoints import strategy
 
     app = FastAPI()
     app.include_router(strategy.router, prefix="/api/v1")
@@ -209,9 +208,8 @@ def test_simulate_request_rejects_invalid_provider():
     our first line of defence — this test pins the behaviour.
     """
     _ensure_backend_on_path()
-    from pydantic import ValidationError
-
     from backend.api.v1.endpoints.strategy import SimulateRequest
+    from pydantic import ValidationError
 
     with pytest.raises(ValidationError):
         SimulateRequest(


### PR DESCRIPTION
Voice backend migrated to Whisper STT plus Edge-TTS plus provider-agnostic LLM. Voice chat UI redesigned with material icons, triadic palette, native st.audio_input, voice selector, orb state badge, audio-reactive animations. Chart builders now show tyre compound in hover and per-driver pit-stop vlines. Regression: CLI simulation, telemetry and compare_drivers charts unchanged.