### PR TITLE
chore(brand): rename public surfaces to F1 StratLab

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # ──────────────────────────────────────────────
-# F1 Strat Manager — Environment Variables
+# F1 StratLab — Environment Variables
 # ──────────────────────────────────────────────
 # Copy this file to .env and fill in your values:
 #   cp .env.example .env

--- a/INDEX.md
+++ b/INDEX.md
@@ -1,4 +1,4 @@
-# F1 Strategy Manager — Project Index
+# F1 StratLab — Project Index
 
 _Revolutionising strategic decision-making in Formula 1 through AI-powered predictive models, computer vision, NLP radio analysis, and a multi-agent expert system._
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,4 @@
-# Install Guide — F1 Strategy Manager
+# Install Guide — F1 StratLab
 
 Three install paths, one per surface, each a **single command** once the
 prerequisites are on the machine.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# F1 Strategy Manager -- Developer Docs
+# F1 StratLab — Developer Docs
 
 Technical documentation for each `src/` module. Written for developers working on the codebase, not for end users.
 

--- a/docs/arcade/quick-start.md
+++ b/docs/arcade/quick-start.md
@@ -1,6 +1,6 @@
 # Arcade Quick Start
 
-End-user guide for running the F1 Strategy Manager arcade replay with the
+End-user guide for running the F1 StratLab arcade replay with the
 live strategy dashboard. Aimed at someone who has cloned the repository
 and wants to see three synchronised windows on screen inside ten minutes.
 

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -1,6 +1,6 @@
 # `docs/diagrams/` — draw.io sources
 
-Architecture and data-flow diagrams for the F1 Strategy Manager TFG.
+Architecture and data-flow diagrams for the F1 StratLab TFG.
 Open any `.drawio` file with [draw.io desktop](https://www.drawio.com/)
 or [diagrams.net](https://app.diagrams.net/). The same files render as
 PNG on demand via `File → Export as → PNG` inside the editor.

--- a/docs/diagrams/arcade_3window_architecture.drawio
+++ b/docs/diagrams/arcade_3window_architecture.drawio
@@ -11,7 +11,7 @@
         </mxCell>
 
         <!-- Title Header -->
-        <mxCell id="title" value="F1 Strategy Manager &#8212; Digital Twin Multi-Agent System" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#E6E8EF;" vertex="1" parent="1">
+        <mxCell id="title" value="F1 StratLab &#8212; Digital Twin Multi-Agent System" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#E6E8EF;" vertex="1" parent="1">
           <mxGeometry x="360" y="20" width="1200" height="36" as="geometry"/>
         </mxCell>
         <mxCell id="subtitle" value="Arcade MVP &#8212; Phase 3.5 Proceso B &#183; Three-Window Subprocess Architecture" style="text;html=1;align=center;verticalAlign=middle;fontSize=14;fontStyle=2;fontColor=#8B5CF6;" vertex="1" parent="1">

--- a/docs/diagrams/strategy_pipeline_flow.drawio
+++ b/docs/diagrams/strategy_pipeline_flow.drawio
@@ -10,7 +10,7 @@
         </mxCell>
 
         <!-- Title -->
-        <mxCell id="title" value="F1 Strategy Manager &#8212; Digital Twin Multi-Agent System" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#E6E8EF;" vertex="1" parent="1">
+        <mxCell id="title" value="F1 StratLab &#8212; Digital Twin Multi-Agent System" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#E6E8EF;" vertex="1" parent="1">
           <mxGeometry x="360" y="20" width="1200" height="36" as="geometry"/>
         </mxCell>
         <mxCell id="subtitle" value="N31 Strategy Orchestrator &#8212; 3-Layer Multi-Agent Flow" style="text;html=1;align=center;verticalAlign=middle;fontSize=14;fontStyle=2;fontColor=#8B5CF6;" vertex="1" parent="1">

--- a/docs/diagrams/subprocess_launch_sequence.drawio
+++ b/docs/diagrams/subprocess_launch_sequence.drawio
@@ -10,7 +10,7 @@
         </mxCell>
 
         <!-- Title -->
-        <mxCell id="title" value="F1 Strategy Manager &#8212; Digital Twin Multi-Agent System" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#E6E8EF;" vertex="1" parent="1">
+        <mxCell id="title" value="F1 StratLab &#8212; Digital Twin Multi-Agent System" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#E6E8EF;" vertex="1" parent="1">
           <mxGeometry x="360" y="20" width="1200" height="36" as="geometry"/>
         </mxCell>
         <mxCell id="subtitle" value="Subprocess Launch Sequence &#8212; python -m src.arcade.main --viewer --strategy" style="text;html=1;align=center;verticalAlign=middle;fontSize=14;fontStyle=2;fontColor=#8B5CF6;" vertex="1" parent="1">

--- a/docs/diagrams/system_architecture.drawio
+++ b/docs/diagrams/system_architecture.drawio
@@ -1,5 +1,5 @@
 <mxfile host="app.diagrams.net" modified="2026-04-18T00:00:00.000Z" agent="Claude" version="24.7.17">
-  <diagram id="system-architecture" name="F1 Strat Manager System Architecture">
+  <diagram id="system-architecture" name="F1 StratLab System Architecture">
     <mxGraphModel dx="1920" dy="1400" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1920" pageHeight="1400" math="0" shadow="0" background="#0F1724">
       <root>
         <mxCell id="0"/>
@@ -9,7 +9,7 @@
           <mxGeometry x="0" y="0" width="1920" height="1400" as="geometry"/>
         </mxCell>
 
-        <mxCell id="title" value="F1 Strategy Manager &#8212; Digital Twin Multi-Agent System" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#E6E8EF;" vertex="1" parent="1">
+        <mxCell id="title" value="F1 StratLab &#8212; Digital Twin Multi-Agent System" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#E6E8EF;" vertex="1" parent="1">
           <mxGeometry x="360" y="20" width="1200" height="36" as="geometry"/>
         </mxCell>
         <mxCell id="subtitle" value="System Overview &#8212; Three User-Facing Surfaces Sharing a Single Core" style="text;html=1;align=center;verticalAlign=middle;fontSize=14;fontStyle=2;fontColor=#8B5CF6;" vertex="1" parent="1">

--- a/docs/diagrams/tcp_broadcast_dataflow.drawio
+++ b/docs/diagrams/tcp_broadcast_dataflow.drawio
@@ -9,7 +9,7 @@
           <mxGeometry x="0" y="0" width="1920" height="1400" as="geometry"/>
         </mxCell>
 
-        <mxCell id="title" value="F1 Strategy Manager &#8212; Digital Twin Multi-Agent System" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#E6E8EF;" vertex="1" parent="1">
+        <mxCell id="title" value="F1 StratLab &#8212; Digital Twin Multi-Agent System" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#E6E8EF;" vertex="1" parent="1">
           <mxGeometry x="360" y="20" width="1200" height="36" as="geometry"/>
         </mxCell>
         <mxCell id="subtitle" value="FastF1 &#8594; Arcade &#8594; TCP localhost:9998 &#8594; PySide6 Windows" style="text;html=1;align=center;verticalAlign=middle;fontSize=14;fontStyle=2;fontColor=#8B5CF6;" vertex="1" parent="1">

--- a/documents/dev_docs/SIMULATION_GUIDE.md
+++ b/documents/dev_docs/SIMULATION_GUIDE.md
@@ -1,4 +1,4 @@
-# F1 Strategy Manager — Dev Testing & Simulation Guide
+# F1 StratLab — Dev Testing & Simulation Guide
 
 Quick reference for running, testing, and verifying every layer of the stack.
 

--- a/documents/dev_docs/diagrams/multi_agent_architecture.drawio
+++ b/documents/dev_docs/diagrams/multi_agent_architecture.drawio
@@ -6,7 +6,7 @@
         <mxCell id="1" parent="0" />
 
         <!-- TITLE -->
-        <mxCell id="title" value="F1 Strat Manager — Multi-Agent System Architecture" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;fontSize=18;fontStyle=1;" vertex="1" parent="1">
+        <mxCell id="title" value="F1 StratLab — Multi-Agent System Architecture" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;fontSize=18;fontStyle=1;" vertex="1" parent="1">
           <mxGeometry x="300" y="12" width="900" height="30" as="geometry" />
         </mxCell>
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # scripts — Top-level CLI tools
 
-Headless command-line tools for the F1 Strategy Manager. Each script is
+Headless command-line tools for F1 StratLab. Each script is
 self-contained: it imports from `src/`, walks up to the repo root, and is
 runnable directly with `python scripts/<name>.py` from any working
 directory.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,1 +1,1 @@
-"""F1 Strategy Manager CLI entry-point package (installable via pyproject.toml)."""
+"""F1 StratLab CLI entry-point package (installable via pyproject.toml)."""

--- a/scripts/cli/theme.py
+++ b/scripts/cli/theme.py
@@ -59,7 +59,7 @@ _ART_STRAT = [
 _COMPACT = (
     f"[bold {F1_RED}]F1[/bold {F1_RED}] "
     f"[bold {F1_WHITE}]STRAT[/bold {F1_WHITE}]"
-    f"  [dim]Formula 1 Strategy Manager[/dim]"
+    f"  [dim]F1 StratLab[/dim]"
 )
 
 
@@ -85,7 +85,7 @@ def make_banner() -> Panel:
 
     lines += [
         Text(""),
-        Align.center(Text("Formula 1 Strategy Manager", style=f"bold {F1_GRAY}")),
+        Align.center(Text("F1 StratLab", style=f"bold {F1_GRAY}")),
         Align.center(Text("Multi-Agent Race Intelligence System · v0.9", style=F1_GRAY)),
     ]
 

--- a/scripts/f1_cli.py
+++ b/scripts/f1_cli.py
@@ -1,5 +1,5 @@
 """
-F1 Strategy Manager — Interactive CLI Launcher
+F1 StratLab — Interactive CLI Launcher
 
 Usage
 -----

--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -1729,7 +1729,7 @@ def run(args: argparse.Namespace) -> None:
     console.print(
         Panel(
             header_body,
-            title="[bold cyan]F1 Strategy Manager[/bold cyan]",
+            title="[bold cyan]F1 StratLab[/bold cyan]",
             title_align="center",
             border_style="cyan",
             padding=(1, 2),
@@ -2307,7 +2307,7 @@ def _default_featured() -> str:
 
 def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(
-        description="F1 Strategy Manager — headless CLI simulation demo",
+        description="F1 StratLab — headless CLI simulation demo",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )

--- a/scripts/upload_radio_corpus.py
+++ b/scripts/upload_radio_corpus.py
@@ -1,4 +1,4 @@
-"""Upload the static OpenF1 radio corpus to the F1 Strategy Manager dataset on HF Hub.
+"""Upload the static OpenF1 radio corpus to the F1 StratLab dataset on HF Hub.
 
 The corpus is built locally by ``scripts/build_radio_dataset.py`` and lives in
 two parallel trees on disk:
@@ -171,7 +171,7 @@ def _upload_tree(
 
 def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(
-        description="Upload the static OpenF1 radio corpus to the F1 Strategy Manager dataset on HF Hub.",
+        description="Upload the static OpenF1 radio corpus to the F1 StratLab dataset on HF Hub.",
     )
     p.add_argument(
         "--year",
@@ -241,7 +241,7 @@ def run(args: argparse.Namespace) -> None:
     console.print(
         Panel(
             grid,
-            title="[bold gold1]F1 Strategy Manager — radio corpus upload[/bold gold1]",
+            title="[bold gold1]F1 StratLab — radio corpus upload[/bold gold1]",
             title_align="center",
             border_style="gold1",
             padding=(1, 2),

--- a/src/agents/strategy_agent.py
+++ b/src/agents/strategy_agent.py
@@ -1,5 +1,5 @@
 """
-F1 Strategy Manager - Rule Merging Module
+F1 StratLab - Rule Merging Module
 
 This module provides the integrated strategy engine that combines all rule systems:
 - Tire degradation rules

--- a/src/arcade/__init__.py
+++ b/src/arcade/__init__.py
@@ -1,4 +1,4 @@
-"""F1 Strategy Manager — Arcade race replay UI.
+"""F1 StratLab — Arcade race replay UI.
 
 This package exposes a Python Arcade window that consumes the backend
 SSE simulation stream (/api/v1/strategy/simulate) and renders the race

--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -26,7 +26,7 @@ SEEK_RATE_MULTIPLIER: Final[float] = 3.0
 # --- Window geometry ------------------------------------------------------
 SCREEN_WIDTH: Final[int] = 1280
 SCREEN_HEIGHT: Final[int] = 720
-WINDOW_TITLE: Final[str] = "F1 Strategy Manager - Race Replay"
+WINDOW_TITLE: Final[str] = "F1 StratLab - Race Replay"
 
 # --- Viewport margins (reserve UI space before fitting track) -------------
 MARGIN_LEFT: Final[int] = 340
@@ -174,7 +174,7 @@ STREAM_BROADCAST_EVERY_N_FRAMES: Final[int] = 6
 STREAM_HISTORY_TAIL: Final[int] = 30
 
 # --- Menu view ------------------------------------------------------------
-MENU_TITLE: Final[str] = "F1 STRATEGY MANAGER"
+MENU_TITLE: Final[str] = "F1 STRATLAB"
 MENU_ROW_HEIGHT: Final[int] = 40
 MENU_ROW_WIDTH: Final[int] = 540
 MENU_LABEL_FONT: Final[int] = 13

--- a/src/arcade/main.py
+++ b/src/arcade/main.py
@@ -41,7 +41,7 @@ def main() -> None:
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="f1-arcade",
-        description="F1 Strategy Manager - visual race replay.",
+        description="F1 StratLab - visual race replay.",
     )
     parser.add_argument(
         "--viewer", action="store_true", help="Skip the menu and boot straight into the replay."

--- a/src/data_extraction/__init__.py
+++ b/src/data_extraction/__init__.py
@@ -1,1 +1,1 @@
-# Data extraction utilities for F1 Strategy Manager
+# Data extraction utilities for F1 StratLab

--- a/src/f1_strat_manager/__init__.py
+++ b/src/f1_strat_manager/__init__.py
@@ -1,4 +1,4 @@
-"""Cross-cutting infrastructure package for the F1 Strategy Manager CLI.
+"""Cross-cutting infrastructure package for the F1 StratLab CLI.
 
 Hosts modules that do not fit any single domain sub-package under ``src/``
 (`agents`, `nlp`, `rag`, `simulation`, …) — currently just the first-run

--- a/src/f1_strat_manager/data_cache.py
+++ b/src/f1_strat_manager/data_cache.py
@@ -336,7 +336,7 @@ def _render_header(console, data_root: Path) -> None:
     console.print(
         Panel(
             grid,
-            title=f"[bold {COL_WATCH}]F1 Strategy Manager — first-run setup[/bold {COL_WATCH}]",
+            title=f"[bold {COL_WATCH}]F1 StratLab — first-run setup[/bold {COL_WATCH}]",
             title_align="center",
             border_style=COL_WATCH,
             padding=(1, 2),
@@ -398,7 +398,7 @@ def ensure_setup(
         local_dir = _snapshot_download(patterns, show_progress=show_progress)
     except Exception as exc:
         raise RuntimeError(
-            "Failed to download F1 Strategy Manager assets from HuggingFace Hub.\n"
+            "Failed to download F1 StratLab assets from HuggingFace Hub.\n"
             f"  Dataset: {HF_DATASET_REPO_ID}\n"
             f"  Cache  : {data_root}\n"
             "  Check your internet connection, set HF_TOKEN if the dataset is\n"


### PR DESCRIPTION
Renames every user-facing reference (Arcade window, CLI banners, Streamlit tab, Rich panels, drawio titles, top-level docs, internal docstrings) from F1 Strategy Manager / F1 Strat Manager / Formula 1 Strategy Manager to F1 StratLab. Package name (f1-strat-manager), console scripts, Docker, legacy/ and notebooks/ are intentionally left as-is. Spec: documents/dev_docs/tasks/RENAME_TO_STRATLAB_TASK.md.