### PR TITLE
Dashboard polish: agent card density, radio/RAG tooltips, TireChart

### DIFF
--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -1093,8 +1093,15 @@ def _run_conditional_agents(
         When provided, N28 is called via run_pit_strategy_agent_from_state.
         When None, run_pit_strategy_agent is used (FastF1 entry point).
 
-    Returns (pit_out, regulation_context_str). Both may be None if the
-    respective agent was not activated this lap.
+    Returns ``(pit_out, regulation_context_str, rag_dict)``. ``pit_out`` and
+    ``regulation_context_str`` may be ``None`` when the respective agent was
+    not activated this lap; ``rag_dict`` is the structured payload from N30
+    (``question`` / ``answer`` / ``articles`` / ``chunks``) for downstream
+    consumers that need more than just the answer string (the arcade
+    dashboard surfaces article references and chunk text in its RAG card).
+    The legacy ``regulation_context_str`` is preserved verbatim for the
+    orchestrator's own LLM prompt and for ``StrategyRecommendation``,
+    neither of which depend on the structured shape.
     """
     pit_out = None
     if "N28" in active:
@@ -1108,7 +1115,8 @@ def _run_conditional_agents(
         else:
             pit_out = run_pit_strategy_agent(pit_lap_state)
 
-    regulation_context = None
+    regulation_context: str | None = None
+    rag_dict: dict | None          = None
     if "N30" in active:
         pit_action = pit_out.action if pit_out else None
         question   = _build_rag_question(
@@ -1118,8 +1126,24 @@ def _run_conditional_agents(
         )
         reg_out            = run_rag_agent(question)
         regulation_context = reg_out.answer
+        rag_dict = {
+            "question": reg_out.question,
+            "answer":   reg_out.answer,
+            "articles": list(reg_out.articles),
+            "chunks":   [
+                {
+                    "text":          c.text,
+                    "article":       c.article,
+                    "doc_type":      c.doc_type,
+                    "year":          c.year,
+                    "score":         c.score,
+                    "section_title": c.section_title,
+                }
+                for c in reg_out.chunks
+            ],
+        }
 
-    return pit_out, regulation_context
+    return pit_out, regulation_context, rag_dict
 
 
 # ==============================================================================
@@ -1217,8 +1241,9 @@ def run_strategy_orchestrator(
         radio_alerts = radio_out.alerts,
     )
 
-    # Layer 1c — conditional agents
-    pit_out, regulation_context = _run_conditional_agents(
+    # Layer 1c — conditional agents. The structured RAG dict is only used by
+    # the arcade dashboard; the orchestrator path keeps the answer string.
+    pit_out, regulation_context, _rag_dict = _run_conditional_agents(
         active        = active,
         lap_state     = lap_state,
         tire_out      = tire_out,
@@ -1333,8 +1358,9 @@ def run_strategy_orchestrator_from_state(
         radio_alerts = radio_out.alerts,
     )
 
-    # Layer 1c — conditional agents (RSM variants)
-    pit_out, regulation_context = _run_conditional_agents(
+    # Layer 1c — conditional agents (RSM variants). Same RAG-dict treatment
+    # as the FastF1 entry point: discarded here, consumed only by the arcade.
+    pit_out, regulation_context, _rag_dict = _run_conditional_agents(
         active        = active,
         lap_state     = lap_state,
         tire_out      = tire_out,

--- a/src/arcade/dashboard/agent_formatters.py
+++ b/src/arcade/dashboard/agent_formatters.py
@@ -18,6 +18,7 @@ serialised by ``src/arcade/strategy.py::_dump_dataclass``.
 
 from __future__ import annotations
 
+import html
 from typing import Any
 
 from src.arcade.dashboard.theme import (
@@ -48,11 +49,41 @@ def _signed(x: float, decimals: int = 3) -> str:
     return f"{sign}{x:.{decimals}f}"
 
 
+def _truncate(text: str | None, limit: int = 70) -> str:
+    """Collapse a free-text string to ``limit`` visible characters with an ellipsis suffix.
+
+    Used by the radio/RAG tickers and tooltips to keep transcript snippets
+    inside the body QLabel width budget (the cards are ~280-340 px wide and
+    the body labels render at 11 px, so 70 chars fits without forcing a
+    second wrapped line at typical zoom). Treats ``None`` as the empty
+    string at the boundary so callers do not need to guard before calling.
+
+    The ``limit`` is exposed as a parameter so the tooltip path can request
+    a longer cap (chunk text in regulation snippets) without spawning a
+    near-duplicate helper. The literal ``"..."`` suffix (three ASCII dots)
+    is preferred over the unicode ellipsis to keep the project ASCII-only
+    in dashboard text and avoid font-fallback artefacts.
+    """
+    s = (text or "").strip().replace("\n", " ")
+    if len(s) <= limit:
+        return s
+    return s[: max(limit - 3, 0)].rstrip() + "..."
+
+
 # --- N25 Pace -----------------------------------------------------------
 
 
 def format_pace(p: dict[str, Any] | None) -> Formatted:
-    """CLI §1.1 — headline Δnext, context pred / median / CI."""
+    """CLI §1.1 — pace delta to next predicted lap, with absolute predicted lap time.
+
+    The headline pairs the signed delta vs the previous lap with the
+    absolute predicted lap time in parentheses. The delta is the actionable
+    signal (is the car about to slow), and the absolute time anchors that
+    delta to the current pace baseline so the user can tell a 92 s lap
+    apart from a 105 s safety-car lap at a glance without scanning the
+    body. Body rows expand into the median delta and the credible-interval
+    half-width for users who want the full distribution.
+    """
     if not p:
         return (
             "no prediction — stub",
@@ -74,7 +105,7 @@ def format_pace(p: dict[str, Any] | None) -> Formatted:
     else:
         status = STATUS_ALERT
 
-    headline = f"Δnext {_signed(delta_prev, 3)}s"
+    headline = f"Δnext {_signed(delta_prev, 3)}s ({pred:.2f}s)"
     body: list[Line] = [
         (f"pred {pred:.2f}s", TEXT_SECONDARY),
         (f"vs median {_signed(delta_med, 2)}s", TEXT_SECONDARY),
@@ -90,7 +121,14 @@ _TIRE_CLIFF_MAX_SANE: float = 100.0  # laps — anything above this is early-sti
 
 
 def format_tire(t: dict[str, Any] | None) -> Formatted:
-    """CLI §1.2 — cliff p50, range p10-p90, deg rate, warning_level.
+    """CLI §1.2 — cliff p50, range p10-p90, deg rate, warning_level, and stint length.
+
+    The headline pairs the cliff projection (median laps remaining before
+    the compound falls off) with the laps already run on the current set,
+    formatted as ``L{n}``. This stint-length anchor is preserved on both
+    the normal and the stabilising branches because how deep the driver
+    already is into the stint is always strategically meaningful, even
+    when the cliff prediction itself is unreliable.
 
     Early-stint outputs (lap 1-3) can produce absurd cliff projections
     (tens of thousands of laps) because the TCN's MC Dropout samples
@@ -109,6 +147,7 @@ def format_tire(t: dict[str, Any] | None) -> Formatted:
     p50 = float(t.get("laps_to_cliff_p50", 0.0) or 0.0)
     p90 = float(t.get("laps_to_cliff_p90", 0.0) or 0.0)
     deg = float(t.get("deg_rate", 0.0) or 0.0)
+    life = float(t.get("current_tyre_life", 0.0) or 0.0)
     warning = str(t.get("warning_level") or "OK").upper()
     compound = str(t.get("compound") or "--")
 
@@ -119,10 +158,11 @@ def format_tire(t: dict[str, Any] | None) -> Formatted:
     # render an em-dash so the user sees "no reading yet" not "0 s/lap".
     deg_text = f"{deg:.3f}s/lap" if deg > 0.0 else "— s/lap"
     compound_label = compound if compound != "0" else "—"
+    life_suffix = f" · L{int(life)}"
 
     cliff_unreliable = p50 > _TIRE_CLIFF_MAX_SANE or p50 <= 0
     if cliff_unreliable:
-        headline = "cliff stabilising…"
+        headline = f"cliff stabilising…{life_suffix}"
         pill = compound_pill_html(compound_label)
         body: list[Line] = [
             (f"deg {deg_text} · {pill}", TEXT_SECONDARY),
@@ -130,7 +170,7 @@ def format_tire(t: dict[str, Any] | None) -> Formatted:
         ]
         return headline, TEXT_TERTIARY, body, STATUS_WATCH if status == STATUS_OK else status
 
-    headline = f"Cliff ~{int(p50)} laps"
+    headline = f"Cliff ~{int(p50)} laps{life_suffix}"
     pill = compound_pill_html(compound_label)
     body = [
         (f"range {int(p10)}–{int(p90)} laps", TEXT_SECONDARY),
@@ -144,7 +184,18 @@ def format_tire(t: dict[str, Any] | None) -> Formatted:
 
 
 def format_situation(s: dict[str, Any] | None) -> Formatted:
-    """CLI §1.3 — threat level, overtake/SC probabilities, SC gold if >15%."""
+    """CLI §1.3 — threat level headline, with overtake / SC probabilities and gap-plus-pace context.
+
+    The headline carries the categorical threat level and is colour-coded
+    by the same status mapping used for the other agent cards. Body rows
+    expand into the underlying numerics: the calibrated overtake
+    probability, the 3-lap safety-car probability (highlighted in WARNING
+    when above 15 % so the user notices an imminent SC risk), and a
+    composite line that pairs the gap to the car ahead with the 3-lap
+    rolling pace delta. The pace delta uses the project's signed-number
+    convention so a faster driver reads as a negative value, matching the
+    sign convention in the situation agent's own dataclass.
+    """
     if not s:
         return (
             "no prediction — stub",
@@ -155,6 +206,7 @@ def format_situation(s: dict[str, Any] | None) -> Formatted:
     ot = float(s.get("overtake_prob", 0.0) or 0.0)
     sc = float(s.get("sc_prob_3lap", 0.0) or 0.0)
     gap = float(s.get("gap_ahead_s", 0.0) or 0.0)
+    pace_delta = float(s.get("pace_delta_s", 0.0) or 0.0)
     threat = str(s.get("threat_level") or "LOW").upper()
 
     status_map = {"HIGH": STATUS_ALERT, "MEDIUM": STATUS_WATCH, "LOW": STATUS_OK}
@@ -165,7 +217,7 @@ def format_situation(s: dict[str, Any] | None) -> Formatted:
     body: list[Line] = [
         (f"overtake {ot * 100:.0f}%", TEXT_SECONDARY),
         (f"safety car {sc * 100:.0f}%", sc_color),
-        (f"gap ahead {gap:.1f}s", TEXT_TERTIARY),
+        (f"gap {gap:.1f}s · Δpace {_signed(pace_delta, 2)}s/lap", TEXT_TERTIARY),
     ]
     return f"Threat {threat}", headline_color, body, status
 
@@ -173,8 +225,109 @@ def format_situation(s: dict[str, Any] | None) -> Formatted:
 # --- N29 Radio ----------------------------------------------------------
 
 
+def _rcm_label(event: dict[str, Any]) -> str:
+    """Best human-readable tag for a Race Control Message.
+
+    Prefers the broadcast ``flag`` token (``YELLOW``, ``SC``, ``RED``…)
+    because that is what the strategist sees on the official feed; falls
+    back to the structured ``event_type`` for non-flag entries (penalties,
+    investigations) and finally to the literal ``RCM`` so the line never
+    renders an empty bracket. Pulled into its own helper so both the body
+    ticker and the tooltip render the same label for the same event.
+    """
+    return str(event.get("flag") or event.get("event_type") or "RCM")
+
+
+def _radio_driver(event: dict[str, Any]) -> str:
+    """Driver three-letter code carried by a radio entry, with a safe fallback.
+
+    The ``RadioOutput.alerts`` list is built by ``_build_alerts`` in the
+    radio agent and always carries ``driver``; the raw ``radio_events``
+    list is the upstream NLP pipeline output and may not carry it on
+    every entry depending on serialisation. ``UNKNOWN`` matches the same
+    fallback string used in the agent itself, so the dashboard never
+    invents a driver code that does not exist.
+    """
+    return str(event.get("driver") or "UNKNOWN")
+
+
+def _radio_intent(event: dict[str, Any]) -> str:
+    """Intent label produced by the N21 SetFit classifier for a radio entry.
+
+    Defaults to ``INFO`` when the analysis sub-dict is absent so the body
+    line still renders an intent column. Trusting the dict shape produced
+    by ``run_pipeline`` (``analysis.intent``); only the boundary against
+    missing keys is guarded, per the project's no-defensive-checks rule.
+    """
+    return str((event.get("analysis") or {}).get("intent") or "INFO")
+
+
+def radio_tooltip_html(r: dict[str, Any] | None) -> str:
+    """Build the Qt rich-text tooltip listing every radio and RCM in the lap.
+
+    The tooltip exists because the body ticker only shows the most recent
+    radio and the most recent RCM — the strategist sometimes needs the
+    full transcript of the lap (e.g. several PROBLEM radios in a row, or
+    a chain of yellow flags clearing) and the body labels do not have the
+    vertical budget for that. Returning the empty string is the documented
+    Qt convention to suppress the tooltip popup, so callers can always
+    invoke ``setToolTip(radio_tooltip_html(r))`` without an explicit
+    "clear" branch.
+
+    HTML primitives are limited to ``<b>``, ``<br>`` and ``&nbsp;``
+    because Qt's tooltip rich-text subset rejects CSS and most layout
+    tags. Free-text fields (driver, intent, message, RCM label) are
+    HTML-escaped so a stray ``<`` or ``&`` in a transcript cannot break
+    the tooltip's rich-text parser.
+    """
+    if r is None:
+        return ""
+    radio_events = r.get("radio_events") or []
+    rcm_events = r.get("rcm_events") or []
+    if not radio_events and not rcm_events:
+        return ""
+
+    sections: list[str] = []
+    if rcm_events:
+        rcm_lines = ["<b>RCM</b>"]
+        for ev in rcm_events:
+            lap = ev.get("lap", "?")
+            label = html.escape(_rcm_label(ev))
+            msg = html.escape(_truncate(ev.get("message"), 70))
+            rcm_lines.append(f"L{lap}&nbsp;{label}: {msg}")
+        sections.append("<br>".join(rcm_lines))
+
+    if radio_events:
+        radio_lines = ["<b>Radio</b>"]
+        for ev in radio_events:
+            driver = html.escape(_radio_driver(ev))
+            intent = html.escape(_radio_intent(ev))
+            msg = html.escape(_truncate(ev.get("message"), 70))
+            radio_lines.append(f'{driver}&nbsp;{intent}: "{msg}"')
+        sections.append("<br>".join(radio_lines))
+
+    return "<br><br>".join(sections)
+
+
 def format_radio(r: dict[str, Any] | None) -> Formatted:
-    """CLI §1.4 — alert intents if any, else "quiet" / "no alerts"."""
+    """CLI §1.4 — alert intents headline, plus a per-lap transcript ticker.
+
+    The headline branches the same way as the CLI: chip row when the
+    deterministic alert filter fires (PROBLEM / WARNING radios or
+    SAFETY_CAR / RED_FLAG / YELLOW RCMs), ``no alerts`` when there is
+    radio activity but nothing critical, and ``quiet`` when the lap is
+    silent. Body rows replace the previous count-only display with a
+    three-tier ticker that surfaces the actual transcripts the strategist
+    cares about: a counter line (always present), the most recent RCM
+    (present only when ``rcm_events`` is non-empty) and the most recent
+    driver radio (present only when ``radio_events`` is non-empty).
+
+    Each transcript line is truncated to 70 characters so the body
+    QLabel renders on a single visual row at the current card width.
+    The full lap transcript is exposed via ``radio_tooltip_html`` and
+    wired by the window onto the card's ``setToolTip`` so a hover gives
+    the engineer the unabridged content.
+    """
     if r is None:
         return (
             "no radio/rcm pipeline output",
@@ -211,6 +364,25 @@ def format_radio(r: dict[str, Any] | None) -> Formatted:
     body: list[Line] = [
         (f"{n_radios} radios · {n_rcms} rcm", TEXT_SECONDARY),
     ]
+    if rcm_events:
+        last_rcm = rcm_events[-1]
+        body.append(
+            (
+                f"RCM L{last_rcm.get('lap', '?')} "
+                f"{_rcm_label(last_rcm)}: {_truncate(last_rcm.get('message'), 70)}",
+                TEXT_SECONDARY,
+            )
+        )
+    if radio_events:
+        last_radio = radio_events[-1]
+        body.append(
+            (
+                f"{_radio_driver(last_radio)} "
+                f"{_radio_intent(last_radio)}: "
+                f'"{_truncate(last_radio.get("message"), 70)}"',
+                TEXT_TERTIARY,
+            )
+        )
     return headline, headline_color, body, status
 
 
@@ -218,7 +390,19 @@ def format_radio(r: dict[str, Any] | None) -> Formatted:
 
 
 def format_pit(p: dict[str, Any] | None, active: bool) -> Formatted:
-    """CLI §1.5 — active shows pit p50 → compound; idle shows trigger hint."""
+    """CLI §1.5 — active shows pit p50 → compound; idle shows trigger hint.
+
+    When the upstream ``PitDecision`` flags ``sc_reactive=True`` the
+    headline is suffixed with ``" · SC"`` to disclose to the engineer
+    that the recommendation is driven by Safety Car pressure (N27
+    probability) rather than tyre cliff or compound logic. This enables
+    at-a-glance distinction between proactive cliff-driven stops and
+    reactive SC-window opportunism, which carry different risk profiles
+    (an SC stop saves around ten seconds but only pays off if the SC
+    actually deploys within the window). The headline colour stays
+    ``WARNING`` in both active sub-cases — the suffix alone communicates
+    SC reactivity, preserving non-SC active rendering exactly as before.
+    """
     if not active or not p:
         return (
             "triggers on cliff pressure, compound change, or problem radio",
@@ -232,8 +416,9 @@ def format_pit(p: dict[str, Any] | None, active: bool) -> Formatted:
     compound = str(p.get("compound_recommendation") or "--")
     up = p.get("undercut_prob")
     target = p.get("undercut_target")
+    sc_reactive = bool(p.get("sc_reactive", False))
 
-    headline = f"pit {p50:.2f}s → {compound}"
+    headline = f"pit {p50:.2f}s → {compound}" + (" · SC" if sc_reactive else "")
     lines: list[Line] = [(f"range {p05:.2f}–{p95:.2f}s", TEXT_SECONDARY)]
     if up is not None and target:
         lines.append((f"UCUT {float(up) * 100:.0f}% → {target}", WARNING))
@@ -245,8 +430,113 @@ def format_pit(p: dict[str, Any] | None, active: bool) -> Formatted:
 # --- N30 RAG (conditional) ---------------------------------------------
 
 
-def format_rag(regulation_context: str | None, active: bool) -> Formatted:
-    """CLI §1.6 — active shows "regulation loaded" + first 60 chars; idle shows hint."""
+def _format_article_refs(articles: list[Any] | None) -> str:
+    """Render a compact ``"Art. X.Y, X.Z"`` line for the body ticker.
+
+    The retriever already deduplicates and normalises article identifiers
+    (``"Article 48.3"``, ``"Article 55.1"``); we strip the redundant
+    ``"Article "`` / ``"Art. "`` prefix from each so a single ``"Art. "``
+    leads the line and the bare identifiers stay legible. Capped at three
+    references with a ``", ..."`` suffix when the source list carries
+    more, because the body QLabel does not have horizontal budget for a
+    fourth identifier on a typical card width and the full list is always
+    available in the tooltip.
+
+    Returns the empty string when no usable identifier survives the
+    filtering — callers then skip the body line and ``AgentCard`` hides
+    it automatically.
+    """
+    if not articles:
+        return ""
+    cleaned: list[str] = []
+    for raw in articles:
+        s = str(raw or "").strip()
+        if not s:
+            continue
+        low = s.lower()
+        for prefix in ("article ", "art. ", "art "):
+            if low.startswith(prefix):
+                s = s[len(prefix):].strip()
+                break
+        if s:
+            cleaned.append(s)
+    if not cleaned:
+        return ""
+    head = cleaned[:3]
+    tail = ", ..." if len(cleaned) > 3 else ""
+    return "Art. " + ", ".join(head) + tail
+
+
+def rag_tooltip_html(r: dict[str, Any] | None) -> str:
+    """Build the Qt rich-text tooltip listing every regulation chunk for the lap.
+
+    The tooltip exists because the body shows only a 70-character snippet
+    of the LLM answer plus a compact article-refs line; the strategist
+    sometimes needs to read the verbatim regulation passages the answer
+    is grounded on (especially during a contested SC restart or a pit
+    sequence near a procedural article). Returning the empty string is
+    the documented Qt convention to suppress the tooltip popup, so
+    callers can always invoke ``setToolTip(rag_tooltip_html(r))`` without
+    an explicit "clear" branch.
+
+    The original question is shown above the chunks so the engineer sees
+    what the orchestrator actually asked. Up to four chunks are rendered
+    in full (truncated at ~280 chars each); any extra retrieval results
+    collapse to a ``+N more`` footer to keep the tooltip box tight. HTML
+    primitives are limited to ``<b>``, ``<br>`` and ``&nbsp;``; free-text
+    fields (question, chunk text, article id) are HTML-escaped so a
+    stray ``<`` or ``&`` in the regulation cannot break the parser.
+    """
+    if r is None:
+        return ""
+    chunks = r.get("chunks") or []
+    question = (r.get("question") or "").strip()
+    if not chunks:
+        return ""
+
+    parts: list[str] = []
+    if question:
+        parts.append(f"<b>Question:</b><br>{html.escape(question)}")
+
+    head = chunks[:4]
+    extra = len(chunks) - len(head)
+    for c in head:
+        article = str(c.get("article") or "").strip()
+        doc_type = str(c.get("doc_type") or "").strip()
+        year = c.get("year")
+        header_bits: list[str] = []
+        if doc_type:
+            header_bits.append(html.escape(doc_type))
+        if year is not None:
+            header_bits.append(str(year))
+        if article:
+            header_bits.append("— " + html.escape(article))
+        header = "<b>" + " ".join(header_bits) + "</b>" if header_bits else "<b>Chunk</b>"
+        body_html = html.escape(_truncate(c.get("text"), 280))
+        parts.append(f"{header}<br>{body_html}")
+    if extra > 0:
+        parts.append(f"+{extra} more")
+
+    return "<br><br>".join(parts)
+
+
+def format_rag(rag: dict[str, Any] | str | None, active: bool) -> Formatted:
+    """CLI §1.6 — answer snippet plus article references for the active branch.
+
+    The active branch surfaces a 70-character snippet of the LLM answer
+    on body line 1 and the first three deduplicated article references
+    (``"Art. 48.3, 55.1"``) on body line 2. The 70-char cap mirrors the
+    radio ticker so the two cards read as a balanced pair; the full
+    answer text and every retrieved chunk live in the tooltip, which the
+    window wires onto the card via ``rag_tooltip_html``.
+
+    The parameter is typed permissively (``dict | str | None``) because
+    the upstream wire historically carried only the answer string; when
+    a bare string is received it is wrapped as ``{"answer": rag}`` so
+    legacy producers do not break the card. The structured form
+    (``question`` / ``answer`` / ``articles`` / ``chunks``) is what
+    populates the article-refs line and the tooltip.
+    """
     if not active:
         return (
             "triggers on compound change, SC >30%, or FIA warning/penalty",
@@ -254,7 +544,10 @@ def format_rag(regulation_context: str | None, active: bool) -> Formatted:
             [],
             STATUS_IDLE,
         )
-    text = (regulation_context or "").strip()
+    if isinstance(rag, str):
+        rag = {"answer": rag}
+    rag = rag or {}
+    text = (rag.get("answer") or "").strip()
     if not text:
         return (
             "regulation loaded",
@@ -262,8 +555,10 @@ def format_rag(regulation_context: str | None, active: bool) -> Formatted:
             [("(empty context)", TEXT_TERTIARY)],
             STATUS_OK,
         )
-    snippet = text[:120].replace("\n", " ")
-    body: list[Line] = [(snippet + ("…" if len(text) > 120 else ""), TEXT_SECONDARY)]
+    body: list[Line] = [(_truncate(text, 70), TEXT_SECONDARY)]
+    refs = _format_article_refs(rag.get("articles"))
+    if refs:
+        body.append((refs, TEXT_TERTIARY))
     return "regulation loaded", TEXT_PRIMARY, body, STATUS_OK
 
 

--- a/src/arcade/dashboard/agent_formatters.py
+++ b/src/arcade/dashboard/agent_formatters.py
@@ -456,7 +456,7 @@ def _format_article_refs(articles: list[Any] | None) -> str:
         low = s.lower()
         for prefix in ("article ", "art. ", "art "):
             if low.startswith(prefix):
-                s = s[len(prefix):].strip()
+                s = s[len(prefix) :].strip()
                 break
         if s:
             cleaned.append(s)

--- a/src/arcade/dashboard/tire_chart.py
+++ b/src/arcade/dashboard/tire_chart.py
@@ -118,7 +118,9 @@ class TireChart(pg.PlotWidget):
         band_color = QColor(*WARNING)
         band_color.setAlpha(40)
         self._cliff_band = pg.FillBetweenItem(
-            self._cliff_lo, self._cliff_hi, brush=band_color,
+            self._cliff_lo,
+            self._cliff_hi,
+            brush=band_color,
         )
         self.addItem(self._cliff_band)
         self.addItem(self._cliff_lo)
@@ -398,8 +400,7 @@ def _build_stints(history: list[dict[str, Any]]) -> list[_Stint]:
             x = float(row.get("lap", 0))
         except (TypeError, ValueError):
             continue
-        compound = (str(row.get("compound") or "").upper().strip()
-                    or last_compound or "MEDIUM")
+        compound = str(row.get("compound") or "").upper().strip() or last_compound or "MEDIUM"
         if current is None or compound != current.compound:
             current = _Stint(compound=compound, xs=[], ys=[])
             stints.append(current)

--- a/src/arcade/dashboard/tire_chart.py
+++ b/src/arcade/dashboard/tire_chart.py
@@ -1,26 +1,43 @@
-"""Tire chart — tyre_life over laps + cliff projection lines.
+"""Tire chart — lap time over laps with per-stint colour and cliff projection.
 
-Embedded inside the Tire N26 AgentCard (chart slot reserved in C5).
-Two items on the plot:
+Embedded inside the Tire N26 ``AgentCard`` (chart slot reserved in C5).
+The previous version plotted ``tyre_life`` (laps on the current set) on
+the Y axis, which conveyed stint progression but never the *cost* of
+running on those tyres. This rewrite mirrors the ``PaceChart`` model so
+the user reads degradation the same way an engineer does on a pit-wall:
 
-- Actual ``tyre_life`` line coloured by compound (COMPOUND_NAMES map).
-  Stint boundaries (compound changes between adjacent laps) show up as
-  vertical grey InfiniteLines.
-- Three horizontal InfiniteLines at ``current_lap + laps_to_cliff_p10 /
-  p50 / p90``, coloured red / amber / green so the distance to the
-  cliff is visible at a glance next to the actual series.
+- **X axis** is the lap number, identical to ``PaceChart`` so the two
+  cards line up vertically and the eye does not have to recalibrate.
+- **Y axis** is the lap time in seconds — every climb on the curve is
+  literal degradation, every drop is a fresh tyre.
+- **One ``PlotDataItem`` per stint**, coloured with the Pirelli palette
+  for that compound (red / yellow / white / green / blue). pyqtgraph
+  draws no line between consecutive stints because each is its own item,
+  so the compound change appears as a visual break instead of a
+  misleading line that walks through the in/out laps.
+- **A dashed white overlay** carries a 3-lap centred rolling mean of
+  the actual lap times. It mirrors the dashed-line idiom from
+  ``PaceChart`` (predicted vs actual) and gives the strategist the
+  smoothed degradation trend without losing the per-lap colour story.
+- **A translucent vertical band** between ``current_lap + p10`` and
+  ``current_lap + p90`` from the latest ``TireOutput`` shades the lap
+  range in which the cliff is expected. The single dashed marker at
+  ``current_lap + p50`` collapses the previous three-line view into a
+  cleaner "where is the cliff" annotation.
 
 Data model (fed by ``MainWindow._tire_history``):
 
-    [{lap: int, tyre_life: float, compound: str}, ...]
+    [{lap: int, lap_time_s: float | None,
+      tyre_life: float | None, compound: str | None}, ...]
 
-The chart keeps no state of its own — window rebuilds it on every
-update. At ≤30 points per series the cost is negligible (<1 ms).
+The widget keeps no domain state of its own — the per-stint segment list
+is rebuilt on every ``update_from`` call. At the dashboard's 30-lap
+window the cost is well under a millisecond.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, NamedTuple
 
 import pyqtgraph as pg
 from PySide6.QtCore import Qt
@@ -29,18 +46,46 @@ from PySide6.QtGui import QColor
 from src.arcade.dashboard.theme import (
     BG_COLOR,
     BORDER_COLOR,
-    COMPOUND_NAMES,
-    DANGER,
-    SUCCESS,
+    TEXT_PRIMARY,
     TEXT_SECONDARY,
     TEXT_TERTIARY,
     WARNING,
+    compound_color,
     qcolor,
 )
 
 
+class _Stint(NamedTuple):
+    """A contiguous run of laps on a single compound.
+
+    Holds the X (lap number) and Y (lap time in seconds) sequences for
+    one ``PlotDataItem`` so the segmentation pass can be expressed as a
+    flat for-loop without nesting list-builders inline. ``compound`` is
+    the canonical upper-cased label used by ``compound_color`` to pick
+    the Pirelli RGB.
+    """
+
+    compound: str
+    xs: list[float]
+    ys: list[float]
+
+
 class TireChart(pg.PlotWidget):
-    """PlotWidget with tyre_life series + cliff-projection lines."""
+    """PlotWidget that pairs per-stint lap-time segments with a cliff band.
+
+    The widget is intentionally a thin renderer over ``MainWindow``'s
+    ``_tire_history`` dict — every render rebuilds segments and the
+    cliff annotations from scratch so a stale stint cannot survive a
+    pit stop or a mid-stream reconnect. Pre-allocated items (the cliff
+    band edges, the median marker, the dashed smoothing overlay) keep
+    the per-update cost to ``setData`` and ``setValue`` calls; the
+    per-stint ``PlotDataItem``s are added and removed on the fly because
+    their count depends on how many compound changes the window sees.
+    """
+
+    # Cliff projections above this horizon are TCN early-stint noise —
+    # hide the band and marker rather than stretch the X-axis to 50k laps.
+    _CLIFF_MAX_SANE: float = 100.0
 
     def __init__(self) -> None:
         super().__init__()
@@ -52,30 +97,50 @@ class TireChart(pg.PlotWidget):
             axis = self.getAxis(side)
             axis.setPen(axis_pen)
             axis.setTextPen(QColor(*TEXT_SECONDARY))
-        self.setLabel("left", "Tyre life (laps)", color="#d1d5db")
+        self.setLabel("left", "Lap time (s)", color="#d1d5db")
         self.setLabel("bottom", "Lap", color="#d1d5db")
         self.getPlotItem().showGrid(x=True, y=True, alpha=0.15)
         self.getPlotItem().enableAutoRange("y", True)
 
-        # Actual tyre_life — one PlotDataItem, colour set per update.
-        self._tyre = pg.PlotDataItem(pen=pg.mkPen(QColor(*TEXT_SECONDARY), width=2))
-        self.addItem(self._tyre)
+        # Per-stint segments and stint-boundary markers — rebuilt every
+        # update because the count is data-driven.
+        self._segments: list[pg.PlotDataItem] = []
+        self._stint_markers: list[pg.InfiniteLine] = []
 
-        # Stint-boundary InfiniteLines are added/removed dynamically because
-        # their count depends on how many compound changes the window sees.
-        self._stint_lines: list[pg.InfiniteLine] = []
+        # Cliff band — vertical translucent rectangle between p10 and p90
+        # forward-projected laps. ``FillBetweenItem`` needs two
+        # ``PlotDataItem`` edges, each of which is a 2-point vertical
+        # segment whose Y endpoints we refresh from the visible Y range
+        # so the band always covers the current chart area.
+        edge_pen = pg.mkPen(QColor(*WARNING), width=0)
+        self._cliff_lo = pg.PlotDataItem(pen=edge_pen)
+        self._cliff_hi = pg.PlotDataItem(pen=edge_pen)
+        band_color = QColor(*WARNING)
+        band_color.setAlpha(40)
+        self._cliff_band = pg.FillBetweenItem(
+            self._cliff_lo, self._cliff_hi, brush=band_color,
+        )
+        self.addItem(self._cliff_band)
+        self.addItem(self._cliff_lo)
+        self.addItem(self._cliff_hi)
 
-        # Cliff projection lines — pre-allocated at p10/p50/p90.
-        self._cliff_p10 = self._make_cliff_line(DANGER)
-        self._cliff_p50 = self._make_cliff_line(WARNING)
-        self._cliff_p90 = self._make_cliff_line(SUCCESS)
-        for ln in (self._cliff_p10, self._cliff_p50, self._cliff_p90):
-            ln.setVisible(False)
-            self.addItem(ln)
+        # Median cliff marker — single dashed vertical line at p50.
+        median_pen = pg.mkPen(QColor(*WARNING), width=2, style=Qt.DashLine)
+        self._cliff_p50 = pg.InfiniteLine(pos=0.0, angle=90, pen=median_pen)
+        self._cliff_p50.setVisible(False)
+        self.addItem(self._cliff_p50)
 
-    # Cliff projections above this horizon are TCN early-stint noise —
-    # hide the lines rather than stretch the X-axis to 50k laps.
-    _CLIFF_MAX_SANE: float = 100.0
+        # Smoothed lap-time overlay — dashed translucent white line on
+        # top of the per-stint segments, conveying the trend the engineer
+        # reasons about without obscuring the raw per-lap colour story.
+        trend_color = QColor(TEXT_PRIMARY[0], TEXT_PRIMARY[1], TEXT_PRIMARY[2], 150)
+        self._actual_dashed = pg.PlotDataItem(
+            pen=pg.mkPen(trend_color, width=1, style=Qt.DashLine),
+            name="trend",
+        )
+        self.addItem(self._actual_dashed)
+
+    # --- Public API ---------------------------------------------------
 
     def update_from(
         self,
@@ -83,73 +148,142 @@ class TireChart(pg.PlotWidget):
         current_lap: int | None,
         tire_out: dict[str, Any] | None,
     ) -> None:
-        """Rebuild the tyre_life series + cliff lines.
+        """Rebuild segments, smoothing overlay and cliff annotations.
 
-        ``history`` is a chronological list of per-lap tyre snapshots.
-        ``current_lap`` anchors the cliff-projection lines; ``tire_out``
-        carries ``laps_to_cliff_p10/p50/p90`` from the current TireOutput.
-        Missing or implausibly large cliff values hide the lines without
-        clearing the series so the tyre curve stays readable while the
-        TCN warms up."""
-        self._clear_stint_lines()
+        ``history`` is a chronological list of per-lap snapshots, one
+        dict per lap with the ``lap``, ``lap_time_s`` and ``compound``
+        keys at minimum. ``current_lap`` anchors the cliff band and
+        median marker; ``tire_out`` carries the percentile projections
+        from the latest ``TireOutput``. Missing or implausibly large
+        values hide the band and marker without clearing the segments
+        so the curve stays readable while the TCN warms up.
+        """
+        self._clear_segments()
+        self._clear_stint_markers()
 
-        if not history:
-            self._tyre.setData([], [])
+        stints = _build_stints(history)
+        for stint in stints:
+            colour = QColor(*compound_color(stint.compound))
+            item = pg.PlotDataItem(
+                stint.xs,
+                stint.ys,
+                pen=pg.mkPen(colour, width=2),
+                symbol="o",
+                symbolSize=4,
+                symbolBrush=colour,
+                symbolPen=pg.mkPen(colour, width=0),
+                name=stint.compound,
+            )
+            self.addItem(item)
+            self._segments.append(item)
+
+        # Stint-boundary markers — one thin dashed vertical line per
+        # compound change, kept faint because the colour break itself
+        # already communicates the change.
+        boundary_pen = pg.mkPen(
+            QColor(TEXT_TERTIARY[0], TEXT_TERTIARY[1], TEXT_TERTIARY[2], 80),
+            width=1,
+            style=Qt.DashLine,
+        )
+        for stint in stints[1:]:
+            if not stint.xs:
+                continue
+            line = pg.InfiniteLine(pos=stint.xs[0], angle=90, pen=boundary_pen)
+            self.addItem(line)
+            self._stint_markers.append(line)
+
+        # Smoothed overlay — flatten every stint's lap times in order
+        # and apply a 3-lap centred mean. Smoothing across stint
+        # boundaries is acceptable because the dashed line is a trend
+        # cue, not a per-lap claim; the per-stint solid lines own the
+        # truth axis.
+        all_xs: list[float] = []
+        all_ys: list[float] = []
+        for stint in stints:
+            all_xs.extend(stint.xs)
+            all_ys.extend(stint.ys)
+        if all_ys:
+            self._actual_dashed.setData(all_xs, _rolling_mean(all_ys, window=3))
         else:
-            xs = [float(row.get("lap", 0)) for row in history]
-            ys = [float(row.get("tyre_life", 0.0)) for row in history]
-            last_compound = str(history[-1].get("compound") or "MEDIUM").upper()
-            colour = QColor(*COMPOUND_NAMES.get(last_compound, (200, 200, 200)))
-            self._tyre.setData(xs, ys, pen=pg.mkPen(colour, width=2))
+            self._actual_dashed.setData([], [])
 
-            # Vertical stint-boundary line whenever compound changes between
-            # two adjacent history points.
-            prev = None
-            for row in history:
-                comp = str(row.get("compound") or "").upper()
-                if prev is not None and comp and comp != prev:
-                    line = pg.InfiniteLine(
-                        pos=float(row.get("lap", 0)),
-                        angle=90,
-                        pen=pg.mkPen(QColor(*TEXT_TERTIARY), width=1, style=Qt.DashLine),
-                    )
-                    self.addItem(line)
-                    self._stint_lines.append(line)
-                prev = comp or prev
+        # Cliff annotations.
+        self._refresh_cliff(history, current_lap, tire_out)
 
+        # X range — clamp to the actual lap window plus a few laps of
+        # forward headroom (or the full sane cliff horizon when the
+        # band is visible) so a bad p90 cannot stretch the view.
+        self._anchor_x_range(history, current_lap, tire_out)
+
+    # --- Cliff annotations -------------------------------------------
+
+    def _refresh_cliff(
+        self,
+        history: list[dict[str, Any]],
+        current_lap: int | None,
+        tire_out: dict[str, Any] | None,
+    ) -> None:
+        """Position the cliff band edges and the median marker.
+
+        Reads ``laps_to_cliff_p10/p50/p90`` from ``tire_out`` and
+        renders the band only when both p10 and p90 are present and
+        within the sane horizon. The band edges are drawn from the
+        bottom to the top of the visible Y range so the rectangle
+        spans the chart area regardless of autoscale.
+        """
         if current_lap is None or not tire_out:
-            for ln in (self._cliff_p10, self._cliff_p50, self._cliff_p90):
-                ln.setVisible(False)
-            self._anchor_x_range(history, current_lap)
+            self._hide_cliff()
             return
 
+        p10 = _sane_cliff(tire_out.get("laps_to_cliff_p10"), self._CLIFF_MAX_SANE)
+        p50 = _sane_cliff(tire_out.get("laps_to_cliff_p50"), self._CLIFF_MAX_SANE)
+        p90 = _sane_cliff(tire_out.get("laps_to_cliff_p90"), self._CLIFF_MAX_SANE)
         cur = float(current_lap)
-        any_visible = False
-        for attr, ln in (
-            ("laps_to_cliff_p10", self._cliff_p10),
-            ("laps_to_cliff_p50", self._cliff_p50),
-            ("laps_to_cliff_p90", self._cliff_p90),
-        ):
-            val = tire_out.get(attr)
-            if val is None or not 0 < float(val) <= self._CLIFF_MAX_SANE:
-                ln.setVisible(False)
-                continue
-            ln.setValue(cur + float(val))
-            ln.setVisible(True)
-            any_visible = True
 
-        self._anchor_x_range(history, current_lap, include_cliff=any_visible)
+        ys = [_sane_lap_time(row.get("lap_time_s")) for row in history]
+        ys = [y for y in ys if y is not None]
+        if ys:
+            y_lo = min(ys) - 1.0
+            y_hi = max(ys) + 5.0
+        else:
+            # No history yet — fall back to a generous window so the
+            # band still renders if the cliff is the only signal.
+            y_lo, y_hi = 60.0, 130.0
+
+        if p10 is not None and p90 is not None:
+            x_p10 = cur + p10
+            x_p90 = cur + p90
+            self._cliff_lo.setData([x_p10, x_p10], [y_lo, y_hi])
+            self._cliff_hi.setData([x_p90, x_p90], [y_lo, y_hi])
+        else:
+            self._cliff_lo.setData([], [])
+            self._cliff_hi.setData([], [])
+
+        if p50 is not None:
+            self._cliff_p50.setValue(cur + p50)
+            self._cliff_p50.setVisible(True)
+        else:
+            self._cliff_p50.setVisible(False)
+
+    def _hide_cliff(self) -> None:
+        self._cliff_lo.setData([], [])
+        self._cliff_hi.setData([], [])
+        self._cliff_p50.setVisible(False)
+
+    # --- X axis -------------------------------------------------------
 
     def _anchor_x_range(
         self,
         history: list[dict[str, Any]],
         current_lap: int | None,
-        include_cliff: bool = False,
+        tire_out: dict[str, Any] | None,
     ) -> None:
-        """Clamp the X axis to the actual lap window so a bad cliff value
-        cannot stretch the view to 50k. When cliff lines are hidden (or
-        clearly implausible) the range tracks only the history + a few
-        laps ahead for visual headroom."""
+        """Clamp the X axis so a bad cliff value cannot blow the view.
+
+        When the cliff band is visible the right edge extends to the
+        sane cliff horizon so the band has room; otherwise the range
+        tracks history plus three laps of headroom for the next tick.
+        """
         xs: list[float] = [float(row.get("lap", 0)) for row in history]
         if current_lap is not None:
             xs.append(float(current_lap))
@@ -158,23 +292,118 @@ class TireChart(pg.PlotWidget):
             return
         x_min = min(xs) - 0.5
         x_max = max(xs)
-        if include_cliff:
+        cliff_visible = (
+            tire_out is not None
+            and current_lap is not None
+            and _sane_cliff(tire_out.get("laps_to_cliff_p90"), self._CLIFF_MAX_SANE) is not None
+        )
+        if cliff_visible:
             x_max += self._CLIFF_MAX_SANE
         else:
             x_max += 3
         self.setXRange(x_min, x_max, padding=0.02)
 
-    @staticmethod
-    def _make_cliff_line(rgb: tuple[int, int, int]) -> pg.InfiniteLine:
-        colour = QColor(*rgb)
-        colour.setAlpha(180)
-        return pg.InfiniteLine(
-            pos=0.0,
-            angle=90,
-            pen=pg.mkPen(colour, width=2, style=Qt.DotLine),
-        )
+    # --- Item lifecycle ----------------------------------------------
 
-    def _clear_stint_lines(self) -> None:
-        for ln in self._stint_lines:
-            self.removeItem(ln)
-        self._stint_lines.clear()
+    def _clear_segments(self) -> None:
+        for item in self._segments:
+            self.removeItem(item)
+        self._segments.clear()
+
+    def _clear_stint_markers(self) -> None:
+        for line in self._stint_markers:
+            self.removeItem(line)
+        self._stint_markers.clear()
+
+
+# --- Module-level helpers ------------------------------------------------
+
+
+def _sane_lap_time(value: Any) -> float | None:
+    """Accept only lap-time values plausible for an F1 race (30-200 s).
+
+    Filters out ``None`` and the occasional pipeline stub that can
+    return a value orders of magnitude off on the first laps. Mirrors
+    the helper in ``pace_chart`` rather than importing it so the two
+    chart widgets stay independently substitutable.
+    """
+    if value is None:
+        return None
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return None
+    if 30.0 <= v <= 200.0:
+        return v
+    return None
+
+
+def _sane_cliff(value: Any, ceiling: float) -> float | None:
+    """Return the cliff-projection value when it is strictly positive and
+    below ``ceiling``; otherwise ``None``. Used to suppress TCN warm-up
+    noise (negative or absurdly large projections) without injecting
+    placeholder values into the chart.
+    """
+    if value is None:
+        return None
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return None
+    if 0.0 < v <= ceiling:
+        return v
+    return None
+
+
+def _rolling_mean(ys: list[float], window: int = 3) -> list[float]:
+    """3-point centred rolling mean over a list of lap times.
+
+    The window is small on purpose — heavier smoothing (5 or more)
+    visibly lags the underlying trend in the 25-30-lap windows the
+    dashboard renders, defeating the point of the overlay. ``min_periods=1``
+    semantics: edges are averaged over whatever points exist so the line
+    starts at lap 1 instead of lap ``window // 2``.
+    """
+    if not ys:
+        return []
+    n = len(ys)
+    half = window // 2
+    out: list[float] = []
+    for i in range(n):
+        lo = max(0, i - half)
+        hi = min(n, i + half + 1)
+        chunk = ys[lo:hi]
+        out.append(sum(chunk) / len(chunk))
+    return out
+
+
+def _build_stints(history: list[dict[str, Any]]) -> list[_Stint]:
+    """Group a chronological history list into per-compound stints.
+
+    A stint ends and a new one begins as soon as the compound label
+    changes between two consecutive observed laps. Rows with no usable
+    lap time are skipped so a missing measurement does not split a
+    stint into two artificial halves; rows with no compound inherit
+    the previous compound (so the chart never paints a "blank" segment
+    when the broadcast briefly drops the field).
+    """
+    stints: list[_Stint] = []
+    current: _Stint | None = None
+    last_compound: str | None = None
+    for row in history:
+        y = _sane_lap_time(row.get("lap_time_s"))
+        if y is None:
+            continue
+        try:
+            x = float(row.get("lap", 0))
+        except (TypeError, ValueError):
+            continue
+        compound = (str(row.get("compound") or "").upper().strip()
+                    or last_compound or "MEDIUM")
+        if current is None or compound != current.compound:
+            current = _Stint(compound=compound, xs=[], ys=[])
+            stints.append(current)
+        current.xs.append(x)
+        current.ys.append(y)
+        last_compound = compound
+    return stints

--- a/src/arcade/dashboard/window.py
+++ b/src/arcade/dashboard/window.py
@@ -41,6 +41,8 @@ from src.arcade.dashboard.agent_formatters import (
     format_rag,
     format_situation,
     format_tire,
+    radio_tooltip_html,
+    rag_tooltip_html,
 )
 from src.arcade.dashboard.orchestrator_card import OrchestratorCard
 from src.arcade.dashboard.pace_chart import PaceChart
@@ -245,6 +247,7 @@ class MainWindow(QMainWindow):
             tire_row = self._tire_history.setdefault(lap, {})
             tire_row.setdefault("tyre_life", row.get("tyre_life"))
             tire_row.setdefault("compound", row.get("compound"))
+            tire_row.setdefault("lap_time_s", row.get("lap_time_s"))
         self._trim_history()
 
     def _ingest_latest_history(self, latest: dict[str, Any]) -> None:
@@ -267,6 +270,8 @@ class MainWindow(QMainWindow):
             trow["tyre_life"] = latest.get("tyre_life")
         if latest.get("compound"):
             trow["compound"] = latest.get("compound")
+        if latest.get("lap_time_s") is not None:
+            trow["lap_time_s"] = latest.get("lap_time_s")
         self._trim_history()
 
     def _tire_history_list(self) -> list[dict[str, Any]]:
@@ -299,15 +304,26 @@ class MainWindow(QMainWindow):
                 card.render(*fmt(None))
             self._card_pit.render(*format_pit(None, active=False))
             self._card_rag.render(*format_rag(None, active=False))
+            # Clear any tooltip left over from a prior tick — Qt keeps the
+            # last rich-text content cached on the widget otherwise.
+            self._card_radio.setToolTip("")
+            self._card_rag.setToolTip("")
             return
 
         active = set(per.get("active") or [])
         self._card_pace.render(*format_pace(per.get("pace")))
         self._card_tire.render(*format_tire(per.get("tire")))
         self._card_situation.render(*format_situation(per.get("situation")))
-        self._card_radio.render(*format_radio(per.get("radio")))
+        radio_block = per.get("radio")
+        self._card_radio.render(*format_radio(radio_block))
+        self._card_radio.setToolTip(radio_tooltip_html(radio_block))
         self._card_pit.render(*format_pit(per.get("pit"), active="N28" in active))
-        self._card_rag.render(*format_rag(per.get("regulation_context"), active="N30" in active))
+        # ``rag`` is the structured payload; ``regulation_context`` stays as a
+        # legacy fallback for producers that have not yet been updated.
+        rag_block = per.get("rag") or per.get("regulation_context")
+        rag_active = "N30" in active
+        self._card_rag.render(*format_rag(rag_block, active=rag_active))
+        self._card_rag.setToolTip(rag_tooltip_html(rag_block) if rag_active else "")
 
     def _on_conn_status(self, status: str) -> None:
         self._header.set_connection(status)

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -87,8 +87,12 @@ class PerAgentOutputsDTO:
     dashboard process.
 
     ``regulation_context`` is the string from N30 RAG (empty when the
-    agent did not fire). ``active`` lists the conditional agents routed
-    this lap so the dashboard can dim the cards that are idle.
+    agent did not fire). ``rag`` is the structured form of the same
+    output (``question`` / ``answer`` / ``articles`` / ``chunks``) used
+    by the dashboard's RAG card to render article references and the
+    full chunk transcripts on hover; ``None`` when the agent did not
+    fire. ``active`` lists the conditional agents routed this lap so
+    the dashboard can dim the cards that are idle.
     """
 
     pace: dict[str, Any] | None = None
@@ -97,6 +101,7 @@ class PerAgentOutputsDTO:
     radio: dict[str, Any] | None = None
     pit: dict[str, Any] | None = None
     regulation_context: str = ""
+    rag: dict[str, Any] | None = None
     active: list[str] = field(default_factory=list)
 
 
@@ -577,6 +582,7 @@ def _build_per_agent(agent_outputs: dict[str, Any]) -> PerAgentOutputsDTO:
         radio=_dump_dataclass(agent_outputs.get("radio_out")),
         pit=_dump_dataclass(agent_outputs.get("pit_out")),
         regulation_context=str(agent_outputs.get("regulation_context") or ""),
+        rag=agent_outputs.get("rag"),
         active=list(agent_outputs.get("active") or []),
     )
 

--- a/src/arcade/strategy_pipeline.py
+++ b/src/arcade/strategy_pipeline.py
@@ -71,7 +71,7 @@ def run_strategy_pipeline(
         radio_alerts=radio_out.alerts,
     )
 
-    pit_out, regulation_context = _run_conditional_agents(
+    pit_out, regulation_context, rag_dict = _run_conditional_agents(
         active=active,
         lap_state=lap_state,
         tire_out=tire_out,
@@ -111,6 +111,10 @@ def run_strategy_pipeline(
         "radio_out": radio_out,
         "pit_out": pit_out,
         "regulation_context": regulation_context,
+        # Structured RAG payload (question / answer / articles / chunks)
+        # for the dashboard's RAG card. ``regulation_context`` above keeps
+        # the legacy answer string for the orchestrator's LLM prompt.
+        "rag": rag_dict,
         "active": list(active),
     }
     return rec, agent_outputs


### PR DESCRIPTION
Radio card adds a 70-char ticker with the last RCM and last driver radio plus a hover tooltip with the full lap transcript.

Pace, Tire and Situation headlines now show the absolute predicted lap time, the stint length suffix, and a gap + Δpace composite.

Pit headline appends · SC when the recommendation is reactive to a Safety Car.

RAG card consumes a new structured payload (question, answer, articles, chunks) wired end to end from the orchestrator and renders article refs plus a tooltip with the regulation chunks.

TireChart switched to lap_time_s vs lap with one segment per stint in Pirelli colours, a dashed rolling-mean trend, and a FillBetweenItem cliff band between p10 and p90.