### PR TITLE
fix(ci): use PAT for release-please so required checks run on release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
       - id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary
- Switch `release-please-action` token to `secrets.RELEASE_PLEASE_TOKEN` (falling back to `GITHUB_TOKEN` until the secret is added) so Release-Please PRs trigger the required CI workflows.

## Why
The required status checks on `main` (`test`, `lint`, `typecheck`) never report on Release-Please PRs (see #33: `mergeStateStatus=BLOCKED`, empty `statusCheckRollup`). GitHub documents this behavior: events triggered by `secrets.GITHUB_TOKEN` do not start new workflow runs, as an anti-recursion safeguard. Using a PAT (or GitHub App token) bypasses that guard.

## Follow-up
After this merges, add a `RELEASE_PLEASE_TOKEN` repo secret (PAT with `contents:write` + `pull-requests:write`). The next release PR will trigger CI normally.

## Test plan
- [ ] CI green on this PR
- [ ] After merge + secret creation, close & reopen #33 (or wait for the next release) and confirm `test` / `lint` / `typecheck` report