### PR TITLE
feat(docs): launch mkdocs-material docs site with F1 StratLab branding

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,57 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "documents/images/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install drawio CLI for diagram export
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgbm-dev libnss3 libxss1 libasound2t64 libgtk-3-0 xvfb
+          # Headless drawio export tool used by mkdocs-drawio-exporter
+          curl -fsSL -o /tmp/drawio.deb "https://github.com/jgraph/drawio-desktop/releases/download/v24.7.17/drawio-amd64-24.7.17.deb"
+          sudo apt-get install -y /tmp/drawio.deb
+
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-docs.txt
+
+      - name: Configure git identity for mkdocs gh-deploy
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+      - name: Build and deploy to gh-pages
+        env:
+          XVFB_RUN: 1
+        run: |
+          xvfb-run -a mkdocs gh-deploy --force --clean --verbose

--- a/docs/_hooks/copy_external_images.py
+++ b/docs/_hooks/copy_external_images.py
@@ -1,0 +1,35 @@
+"""Mkdocs hook that mirrors ``documents/images/`` into the docs build.
+
+The thesis figures live at ``documents/images/05_results/`` (the location
+referenced by chapter 5 of the LaTeX memoria). Mkdocs only serves files
+inside ``docs_dir`` by default, so without this hook the figures would
+have to be duplicated under ``docs/``. The hook copies them once at the
+start of every build into a virtual ``_external_images/`` directory
+inside the build site, so markdown can reference them as
+``_external_images/05_results/<file>.png`` regardless of platform.
+
+Wired in ``mkdocs.yml`` via:
+
+    hooks:
+      - docs/_hooks/copy_external_images.py
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+def on_pre_build(config: dict[str, Any], **_: Any) -> None:
+    """Copy ``documents/images/`` into ``docs/_external_images/`` before mkdocs scans files."""
+    repo_root = Path(config["config_file_path"]).resolve().parent
+    src = repo_root / "documents" / "images"
+    dst = Path(config["docs_dir"]) / "_external_images"
+
+    if not src.exists():
+        return
+
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst)

--- a/docs/development/docs-maintenance.md
+++ b/docs/development/docs-maintenance.md
@@ -1,0 +1,171 @@
+---
+title: Documentation maintenance
+description: How the F1 StratLab docs site is built, deployed and extended.
+---
+
+# Documentation maintenance
+
+This page documents how the documentation site you are reading right now is built, deployed and extended. Read it before adding new pages, changing the theme or pointing the site at a custom domain.
+
+## Stack overview
+
+| Component | Tool | Lives in |
+|-----------|------|----------|
+| Static site generator | [`mkdocs`](https://www.mkdocs.org/) | `pyproject.toml` indirect (via `requirements-docs.txt`) |
+| Theme | [`mkdocs-material`](https://squidfunk.github.io/mkdocs-material/) | `requirements-docs.txt` |
+| Source directory | Markdown + assets | `docs/` |
+| Config | YAML | `mkdocs.yml` |
+| Theme overrides | Custom CSS matching the public landing palette | `docs/stylesheets/extra.css` |
+| Deploy workflow | GitHub Actions | `.github/workflows/docs.yml` |
+| Hosting | GitHub Pages (`gh-pages` branch) | repo Settings -> Pages |
+
+The brand palette and typography are kept aligned with the public landing at [f1stratlab.com](https://f1stratlab.com/) by mirroring the design tokens declared in `colors_and_type.css` of the `f1stratlab-web` repo. If you change one, change the other.
+
+## Local preview
+
+```bash
+# Install once
+pip install -r requirements-docs.txt
+
+# Live-reload preview on http://127.0.0.1:8000
+mkdocs serve
+
+# Production-equivalent build
+mkdocs build
+```
+
+The site is written into `site/` (gitignored). `mkdocs serve` auto-reloads on every saved markdown / CSS file under `docs/`.
+
+## Adding a new page
+
+1. Create the markdown file under `docs/` in the section it belongs to (or create a new section folder, see below).
+2. Add it to the `nav:` block of `mkdocs.yml` under the right parent. Order matters: each list entry becomes a sidebar item in that order.
+3. Cross-link from related pages with relative paths (`[See arcade dashboard](../arcade/dashboard.md)`).
+4. Push to `main`. The deploy workflow runs automatically.
+
+### Creating a new top-level section
+
+Each entry in `nav` whose value is a list becomes a section in the top tab bar (because `navigation.tabs` is on). Sections collapse into the side menu on mobile. Add the section like this in `mkdocs.yml`:
+
+```yaml
+nav:
+  - Home: index.md
+  - Architecture:                     # tab label
+    - Overview: architecture.md       # first child becomes the tab landing
+    - Multi-agent system: agents-api-reference.md
+  - Your new tab:                     # NEW
+    - Page A: your-section/page-a.md
+    - Page B: your-section/page-b.md
+```
+
+## Theme and palette
+
+The custom palette lives entirely in `docs/stylesheets/extra.css`. The file is structured into clearly labelled sections (palette, typography, header, code blocks, etc.) and references the same CSS custom-property values the landing site uses (`--purple-600`, `--purple-300`, `--bg-0` and friends).
+
+If you change colours, change them in **both** repos:
+
+- This docs site: `docs/stylesheets/extra.css`
+- Public landing: `f1stratlab-web/colors_and_type.css`
+
+The theme scheme is registered as `stratlab-dark` and applied via `palette` in `mkdocs.yml`. The light scheme is a placeholder; the brand is dark-first so most readers will land on the dark variant.
+
+## Deployment
+
+### Automatic on push to `main`
+
+`.github/workflows/docs.yml` watches:
+
+- `docs/**`
+- `documents/images/**`
+- `mkdocs.yml`
+- `requirements-docs.txt`
+- `.github/workflows/docs.yml`
+
+When any of these change on `main`, the workflow:
+
+1. Checks out the repo with full history (needed by `mkdocs gh-deploy`).
+2. Sets up Python 3.12 and installs `requirements-docs.txt`.
+3. Runs `mkdocs gh-deploy --force --clean --verbose` which builds the site and force-pushes the result to the `gh-pages` branch.
+
+GitHub Pages picks up the new `gh-pages` commit and republishes the site, usually within 60 seconds.
+
+### Manual trigger
+
+The workflow also has `workflow_dispatch` enabled so you can re-run it without a push:
+
+```bash
+gh workflow run docs.yml --ref main
+```
+
+Useful when:
+
+- A previous build failed and you want to retry without pushing a dummy commit.
+- You just rotated the custom domain and want to refresh GitHub Pages.
+
+## Custom domain (future)
+
+The site lives at `https://vforvitorio.github.io/F1-StratLab/` by default. To point a custom subdomain at it:
+
+1. In your DNS provider (Namecheap, Cloudflare, etc.), add a `CNAME` record:
+
+    | Field | Value |
+    |-------|-------|
+    | Type | `CNAME` |
+    | Host | `docs` (so the result is `docs.f1stratlab.com`) |
+    | Value | `vforvitorio.github.io` (no trailing dot, no path) |
+    | TTL | Automatic |
+
+2. Create a file `docs/CNAME` (no extension) with a single line:
+
+    ```
+    docs.f1stratlab.com
+    ```
+
+3. Repo -> Settings -> Pages -> Custom domain -> `docs.f1stratlab.com` -> Save. GitHub will run a DNS check (5-15 min) and then offer to enforce HTTPS — tick that box.
+
+Reverting is as simple as deleting the `CNAME` file, blanking the custom domain field in Settings, and removing the DNS record.
+
+## Diagrams (`docs/diagrams/*.drawio`)
+
+The repository keeps draw.io sources in `docs/diagrams/`. They are not auto-rendered into the published site by default — early versions tried `mkdocs-drawio-exporter`, but that plugin needs the draw.io binary on the build runner which adds 100+ MB of dependencies. Two cleaner options:
+
+- **Manual export**: open the `.drawio` file in [diagrams.net](https://app.diagrams.net/), export as SVG/PNG, and commit it next to the source. Reference the exported image from a markdown file with the standard image syntax.
+- **Inline render via Mermaid**: trivial diagrams can be written directly in markdown using fenced ` ```mermaid ` blocks. Mermaid is enabled out of the box through the `pymdownx.superfences` extension already configured in `mkdocs.yml`.
+
+If you reintroduce `mkdocs-drawio-exporter` in the future, remember to add the draw.io binary install step to `.github/workflows/docs.yml` (apt-get + the official `.deb` from the `jgraph/drawio-desktop` releases). A starter snippet is left commented inside the workflow.
+
+## Versioning (future)
+
+`mike` is already in `requirements-docs.txt`. If you ever ship multiple thesis revisions and want a version dropdown, switch the deploy step to:
+
+```bash
+mike deploy --push --update-aliases 1.2 latest
+mike set-default --push latest
+```
+
+Until then, the workflow runs a single-version `mkdocs gh-deploy` which is enough for a TFG project.
+
+## Common edits checklist
+
+| Change you want | File to edit |
+|-----------------|--------------|
+| Add a new docs page | new `.md` under `docs/` + `mkdocs.yml` `nav:` |
+| Change site title | `mkdocs.yml` `site_name` |
+| Change colours / fonts | `docs/stylesheets/extra.css` |
+| Add a tab to the top bar | new section under `mkdocs.yml` `nav:` |
+| Change the homepage hero | `docs/index.md` |
+| Add an icon to a nav item | `mkdocs.yml` via `material/<icon>` syntax |
+| Add a social link in the footer | `mkdocs.yml` `extra.social` |
+| Override a theme template | new file under `docs/overrides/` mirroring the path |
+
+For anything more involved, the canonical reference is the [Material for MkDocs documentation](https://squidfunk.github.io/mkdocs-material/) — well written and the search there is excellent.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `mkdocs build` fails with "Unresolved tag" | IDE linting only, not mkdocs | Ignore — `!!python/name:` tags are valid mkdocs syntax |
+| `gh-deploy` 403 on push to `gh-pages` | Workflow permissions too low | Repo -> Settings -> Actions -> Workflow permissions -> "Read and write permissions" |
+| Custom domain says "DNS check unsuccessful" | DNS not propagated yet | Wait 10-30 min; verify with `nslookup docs.f1stratlab.com` |
+| Search index empty | Page front matter has `hide: [toc]` | Use `hide: [navigation, toc]` only on landing pages |
+| Theme overrides don't apply | Browser cached old CSS | Hard reload (`Ctrl+Shift+R`) or bump query string on the link in `mkdocs.yml` |

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,53 @@
+# Getting started
+
+Three ways to get F1 StratLab running on your machine, from fastest to deepest.
+
+## 1. Install the latest wheel
+
+The quickest path. Installs the latest release into your current environment without cloning the repo.
+
+```bash
+uv pip install https://github.com/VforVitorio/F1-StratLab/releases/download/v1.1.0/f1_strat_manager-1.1.0-py3-none-any.whl
+```
+
+After install you have four console entry points:
+
+```bash
+f1-strat       # interactive launcher (recommended starting point)
+f1-sim         # headless CLI simulation against a saved race
+f1-arcade      # three-window PySide6 + pyglet experience
+f1-streamlit   # Streamlit dashboards
+```
+
+First boot triggers a one-time download of the cached models and reference data into `~/.f1-strat/`. Subsequent runs are offline.
+
+## 2. Clone the repo for development
+
+If you want to edit the code, run the notebooks or contribute back:
+
+```bash
+git clone https://github.com/VforVitorio/F1-StratLab.git
+cd F1-StratLab
+uv sync --all-extras
+```
+
+`uv sync` reads `pyproject.toml`, resolves the lockfile and pulls the CUDA-routed PyTorch wheel automatically on Windows and Linux (CPU build on macOS).
+
+Run the simulation against a saved race:
+
+```bash
+uv run scripts/run_simulation_cli.py Bahrain NOR McLaren --no-llm
+```
+
+Drop `--no-llm` once you have an LLM provider configured (LM Studio at `http://localhost:1234/v1` or `OPENAI_API_KEY` in `.env`).
+
+## 3. Docker
+
+For a reproducible all-in-one setup, see [Setup and deployment](../setup-and-deployment.md) for the Docker compose recipe that boots the FastAPI backend, the Streamlit frontend and the Qdrant store in one command.
+
+## Where to next
+
+- New to the architecture? Start at [Architecture overview](../architecture.md).
+- Want to see the agents in action? Open [Arcade quick start](../arcade/quick-start.md).
+- Looking for an API to call from your own code? Jump to [Multi-agent system](../agents-api-reference.md).
+- Curious about the numbers in the thesis? See [Thesis results](../thesis-results/index.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,119 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
+<div class="stratlab-hero" markdown>
+  <span class="eyebrow">F1 StratLab · Documentation</span>
+  # AI for real-time F1 race strategy
+  <p>Open-source multi-agent system that fuses seven ML models, six LangGraph sub-agents and one strategy orchestrator into a single Formula 1 strategy recommender. This site is the technical reference for the codebase.</p>
+  <div class="stratlab-hero-cta">
+    <a class="md-button" href="getting-started/">Get started</a>
+    <a class="md-button md-button--secondary" href="https://f1stratlab.com/">Visit landing</a>
+    <a class="md-button md-button--secondary" href="https://github.com/VforVitorio/F1-StratLab">View on GitHub</a>
+  </div>
+</div>
+
+## What lives here
+
+<div class="stratlab-grid" markdown>
+
+<div class="stratlab-card" markdown>
+### Architecture
+End-to-end view of how the seven ML models, six sub-agents and the N31 orchestrator connect. Includes the data contract (`lap_state`) that crosses every layer.
+
+[Open ->](architecture.md)
+</div>
+
+<div class="stratlab-card" markdown>
+### Multi-agent system
+Pace, Tire, Race Situation, Pit Strategy, Radio, RAG. Each agent's entry point, output schema and request / response model, ready to call from your own pipelines.
+
+[Open ->](agents-api-reference.md)
+</div>
+
+<div class="stratlab-card" markdown>
+### Simulation engine
+Lap-by-lap replay engine that drives the agents during development. Covers the `RaceReplayEngine`, `RaceStateManager` and the canonical `lap_state` schema.
+
+[Open ->](simulation/overview.md)
+</div>
+
+<div class="stratlab-card" markdown>
+### Arcade dashboard
+Three-window PySide6 + pyglet experience that ships the live strategy view. Quick-start, dashboard layout and the local strategy pipeline that bypasses the backend.
+
+[Open ->](arcade/quick-start.md)
+</div>
+
+<div class="stratlab-card" markdown>
+### Backend API
+FastAPI routers, SSE streaming endpoint and the simulator entry point used by Streamlit and the arcade. Includes auth-removal notes and CORS expectations.
+
+[Open ->](backend-api.md)
+</div>
+
+<div class="stratlab-card" markdown>
+### Streamlit frontend
+Tab-by-tab walkthrough of the Streamlit app: race analysis, chat with charts, MCP integration and voice. Read alongside the backend API for the full pipeline.
+
+[Open ->](streamlit-frontend.md)
+</div>
+
+</div>
+
+## External companions
+
+<div class="stratlab-grid" markdown>
+
+<div class="stratlab-card" markdown>
+### Landing
+The public-facing site with the hero animation, agent gallery and project narrative aimed at non-technical visitors.
+
+[Open f1stratlab.com ->](https://f1stratlab.com/)
+</div>
+
+<div class="stratlab-card" markdown>
+### DeepWiki
+Auto-generated codebase wiki with deep-linked summaries of every file. Best for ad-hoc "where does X live" questions.
+
+[Open DeepWiki ->](https://deepwiki.com/VforVitorio/F1-StratLab)
+</div>
+
+<div class="stratlab-card" markdown>
+### Releases
+Every published wheel and source distribution, plus the release notes for v1.0.0 onwards and the changelog seeded retroactively to v0.6.
+
+[Open releases ->](https://github.com/VforVitorio/F1-StratLab/releases)
+</div>
+
+</div>
+
+## Install the latest release
+
+```bash
+uv pip install https://github.com/VforVitorio/F1-StratLab/releases/download/v1.1.0/f1_strat_manager-1.1.0-py3-none-any.whl
+```
+
+Then run any of the console entry points:
+
+```bash
+f1-strat       # interactive launcher
+f1-sim         # headless CLI simulation
+f1-arcade      # three-window arcade experience
+f1-streamlit   # Streamlit dashboards
+```
+
+See [Setup and deployment](setup-and-deployment.md) for the full installation matrix (Windows, Linux, macOS, Docker).
+
+## Project status
+
+| Component | Version | Status |
+|---|---|---|
+| Multi-agent orchestrator (N31) | v1.0.0 | shipped |
+| Arcade three-window MVP | v1.0.0 | shipped |
+| Benchmark suite (Chapter 5) | v1.1.0 | shipped |
+| Release automation (`release-please`) | v1.1.0 | shipped |
+
+The current focus is documentation polish for the thesis defence; see the [project changelog](https://github.com/VforVitorio/F1-StratLab/blob/main/CHANGELOG.md) for the full history.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,398 @@
+/* =========================================================
+   F1 StratLab — Documentation theme overrides
+   Mirrors the design tokens of the public landing page
+   (https://f1stratlab.com — colors_and_type.css).
+   ========================================================= */
+
+/* ---------- BRAND PALETTE (mirrors colors_and_type.css) ---------- */
+:root {
+  --md-primary-fg-color:        #6c5ce7;
+  --md-primary-fg-color--light: #8b7cf6;
+  --md-primary-fg-color--dark:  #5a48d4;
+  --md-accent-fg-color:         #a29bfe;
+  --md-accent-fg-color--transparent: rgba(162, 155, 254, 0.15);
+}
+
+/* Dark scheme — primary surface palette */
+[data-md-color-scheme="stratlab-dark"] {
+  --md-default-bg-color:       #08080c;
+  --md-default-bg-color--light: #0c0d14;
+  --md-default-fg-color:       #ffffff;
+  --md-default-fg-color--light: rgba(255, 255, 255, 0.72);
+  --md-default-fg-color--lighter: rgba(255, 255, 255, 0.52);
+  --md-default-fg-color--lightest: rgba(255, 255, 255, 0.32);
+
+  --md-primary-fg-color:        #6c5ce7;
+  --md-primary-bg-color:        #08080c;
+  --md-primary-bg-color--light: #0c0d14;
+
+  --md-accent-fg-color:         #a29bfe;
+  --md-accent-fg-color--transparent: rgba(162, 155, 254, 0.15);
+
+  --md-code-bg-color:           #17192b;
+  --md-code-fg-color:           #e0d9ff;
+
+  --md-typeset-a-color:         #a29bfe;
+
+  --md-footer-bg-color:         #0c0d14;
+  --md-footer-bg-color--dark:   #08080c;
+
+  --md-default-border-color:    rgba(255, 255, 255, 0.06);
+
+  color-scheme: dark;
+}
+
+/* ---------- TYPOGRAPHY — match the landing ---------- */
+.md-typeset {
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  font-feature-settings: "ss01", "cv11";
+}
+
+.md-typeset h1,
+.md-typeset h2,
+.md-typeset h3,
+.md-typeset h4,
+.md-typeset h5,
+.md-typeset h6,
+.md-header__title,
+.md-tabs__link {
+  font-family: "Space Grotesk", "Inter", system-ui, sans-serif;
+  letter-spacing: -0.02em;
+}
+
+.md-typeset h1 {
+  font-weight: 700;
+  letter-spacing: -0.04em;
+}
+
+.md-typeset code,
+.md-typeset pre {
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
+  font-feature-settings: "ss01", "ss02", "cv01";
+}
+
+/* ---------- HERO / HEADER ---------- */
+[data-md-color-scheme="stratlab-dark"] .md-header {
+  background: rgba(8, 8, 12, 0.72);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: none;
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-tabs {
+  background: rgba(8, 8, 12, 0.72);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-tabs__link {
+  color: rgba(255, 255, 255, 0.72);
+  opacity: 1;
+  font-weight: 500;
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-tabs__link:hover,
+[data-md-color-scheme="stratlab-dark"] .md-tabs__link--active {
+  color: #a29bfe;
+}
+
+/* ---------- LINKS ---------- */
+[data-md-color-scheme="stratlab-dark"] .md-typeset a {
+  color: #a29bfe;
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-typeset a:hover {
+  color: #c2b4ff;
+  text-decoration: underline;
+}
+
+/* ---------- CODE BLOCKS ---------- */
+[data-md-color-scheme="stratlab-dark"] .md-typeset pre > code {
+  background: #17192b;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-typeset code {
+  background: rgba(108, 92, 231, 0.12);
+  color: #c2b4ff;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-clipboard {
+  color: rgba(255, 255, 255, 0.52);
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-clipboard:hover {
+  color: #a29bfe;
+}
+
+/* ---------- TABLES ---------- */
+[data-md-color-scheme="stratlab-dark"] .md-typeset table:not([class]) {
+  background: #0c0d14;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-typeset table:not([class]) th {
+  background: #111827;
+  color: #ffffff;
+  font-family: "Space Grotesk", "Inter", system-ui, sans-serif;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-typeset table:not([class]) td {
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-typeset table:not([class]) tr:hover {
+  background: #17192b;
+}
+
+/* ---------- ADMONITIONS — purple-tinted by default ---------- */
+[data-md-color-scheme="stratlab-dark"] .md-typeset .admonition,
+[data-md-color-scheme="stratlab-dark"] .md-typeset details {
+  background: #0c0d14;
+  border: 1px solid rgba(108, 92, 231, 0.25);
+  border-left: 4px solid #6c5ce7;
+  border-radius: 12px;
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-typeset .admonition-title,
+[data-md-color-scheme="stratlab-dark"] .md-typeset summary {
+  background: rgba(108, 92, 231, 0.10);
+  color: #c2b4ff;
+  font-family: "Space Grotesk", "Inter", system-ui, sans-serif;
+  font-weight: 600;
+}
+
+/* ---------- BUTTONS / PILLS ---------- */
+[data-md-color-scheme="stratlab-dark"] .md-button {
+  background: linear-gradient(135deg, #6c5ce7 0%, #a29bfe 100%);
+  color: #ffffff;
+  border: none;
+  border-radius: 999px;
+  padding: 12px 24px;
+  font-family: "Space Grotesk", "Inter", system-ui, sans-serif;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  transition: all 0.2s ease;
+  box-shadow: 0 4px 20px rgba(108, 92, 231, 0.35);
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 30px rgba(108, 92, 231, 0.5);
+  color: #ffffff;
+  text-decoration: none;
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-button--secondary {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: none;
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-button--secondary:hover {
+  background: rgba(108, 92, 231, 0.12);
+  border-color: #a29bfe;
+}
+
+/* ---------- SIDEBAR / NAV ---------- */
+[data-md-color-scheme="stratlab-dark"] .md-sidebar {
+  background: transparent;
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-nav__title {
+  font-family: "Space Grotesk", "Inter", system-ui, sans-serif;
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #a29bfe;
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-nav__link {
+  color: rgba(255, 255, 255, 0.72);
+  transition: color 0.15s ease;
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-nav__link:hover,
+[data-md-color-scheme="stratlab-dark"] .md-nav__link--active {
+  color: #a29bfe;
+}
+
+/* ---------- TOC right ---------- */
+[data-md-color-scheme="stratlab-dark"] .md-nav--secondary .md-nav__link--active {
+  color: #a29bfe;
+  font-weight: 600;
+}
+
+/* ---------- FOOTER ---------- */
+[data-md-color-scheme="stratlab-dark"] .md-footer {
+  background: #0c0d14;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-footer-meta {
+  background: #08080c;
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-social__link svg {
+  fill: rgba(255, 255, 255, 0.52);
+  transition: fill 0.2s ease;
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-social__link:hover svg {
+  fill: #a29bfe;
+}
+
+/* ---------- SEARCH ---------- */
+[data-md-color-scheme="stratlab-dark"] .md-search__form {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-search__form:hover {
+  background: rgba(255, 255, 255, 0.10);
+}
+
+[data-md-color-scheme="stratlab-dark"] .md-search__input::placeholder {
+  color: rgba(255, 255, 255, 0.52);
+}
+
+/* ---------- SELECTION ---------- */
+::selection {
+  background: #6c5ce7;
+  color: #ffffff;
+}
+
+/* ---------- HOMEPAGE HERO SECTION ---------- */
+.stratlab-hero {
+  text-align: center;
+  padding: 80px 0 60px 0;
+  background: radial-gradient(ellipse 120% 80% at 50% 0%, rgba(108, 92, 231, 0.28) 0%, rgba(108, 92, 231, 0.08) 35%, transparent 70%);
+  border-radius: 16px;
+  margin-bottom: 48px;
+}
+
+.stratlab-hero .eyebrow {
+  font-family: "Inter", system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #a29bfe;
+  display: block;
+  margin-bottom: 16px;
+}
+
+.stratlab-hero h1 {
+  font-family: "Space Grotesk", "Inter", system-ui, sans-serif !important;
+  font-size: clamp(40px, 6vw, 72px) !important;
+  font-weight: 700 !important;
+  letter-spacing: -0.04em;
+  line-height: 1.05;
+  background: linear-gradient(135deg, #ffffff 0%, #a29bfe 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin: 0 0 24px 0 !important;
+}
+
+.stratlab-hero p {
+  font-size: 20px;
+  color: rgba(255, 255, 255, 0.72);
+  max-width: 720px;
+  margin: 0 auto 32px auto;
+  line-height: 1.45;
+}
+
+.stratlab-hero-cta {
+  display: inline-flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/* ---------- FEATURE CARDS ---------- */
+.stratlab-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+  margin: 32px 0;
+}
+
+.stratlab-card {
+  background: #0c0d14;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  padding: 28px 24px;
+  transition: all 0.2s ease;
+}
+
+.stratlab-card:hover {
+  border-color: rgba(108, 92, 231, 0.35);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 40px rgba(108, 92, 231, 0.15);
+}
+
+.stratlab-card h3 {
+  font-family: "Space Grotesk", "Inter", system-ui, sans-serif;
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0 0 8px 0;
+  color: #ffffff;
+}
+
+.stratlab-card p {
+  color: rgba(255, 255, 255, 0.72);
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.stratlab-card a {
+  display: inline-block;
+  margin-top: 16px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #a29bfe;
+}
+
+/* ---------- BADGES / KBD ---------- */
+[data-md-color-scheme="stratlab-dark"] .md-typeset kbd {
+  background: #17192b;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-bottom: 2px solid rgba(255, 255, 255, 0.18);
+  color: #c2b4ff;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+}
+
+/* ---------- SCROLLBAR ---------- */
+[data-md-color-scheme="stratlab-dark"] ::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+[data-md-color-scheme="stratlab-dark"] ::-webkit-scrollbar-track {
+  background: #0c0d14;
+}
+
+[data-md-color-scheme="stratlab-dark"] ::-webkit-scrollbar-thumb {
+  background: #23234a;
+  border-radius: 5px;
+}
+
+[data-md-color-scheme="stratlab-dark"] ::-webkit-scrollbar-thumb:hover {
+  background: #6c5ce7;
+}

--- a/docs/thesis-results/index.md
+++ b/docs/thesis-results/index.md
@@ -1,0 +1,64 @@
+# Thesis results
+
+Visual and numeric outputs referenced by chapter 5 of the TFG thesis. Every figure on this page is regenerated automatically from the notebooks under `notebooks/agents/` so it always tracks the latest model artefacts.
+
+## Threshold sweeps
+
+Each classifier sub-agent exposes a precision-recall trade-off that the strategist picks deliberately. The sweeps below scan the full threshold space and mark the production operating point.
+
+### Overtake (N12)
+
+![Overtake threshold sweep — precision and recall against threshold, plus parametric precision-recall curve with the 0,7976 production threshold ringed in red](../_external_images/05_results/threshold_sweep_overtake.png){ loading=lazy }
+
+Production threshold 0,7976 was tuned in N12 step 5 on the raw LightGBM scores. The right panel shows the trade-off is robust around that point: F1 stays within a few hundredths across the neighbouring grid.
+
+### Safety Car (N14)
+
+![Safety Car threshold sweep — note the AUC-PR is 0,0723 (vs 0,0432 baseline) so the absolute precision stays low across all thresholds](../_external_images/05_results/threshold_sweep_sc.png){ loading=lazy }
+
+The Safety Car model is a soft contextual prior, not an exact predictor. The 0,234 production threshold is F2-optimal (recall-weighted) because false alarms cost little and missing an imminent SC is expensive.
+
+### Undercut (N16)
+
+![Undercut threshold sweep — flat F1 region around the 0,522 production threshold confirms a robust operating point](../_external_images/05_results/threshold_sweep_undercut.png){ loading=lazy }
+
+The undercut classifier sees the highest positive prevalence of the three (>30 % on the holdout) because the labelling step kept only pairs with a true undercut opportunity. The 0,522 threshold falls in the flat F1 region.
+
+## MC Dropout coverage
+
+The TCN tire-degradation model (N09 global + N10 per-compound fine-tunes) uses 50-pass MC Dropout to produce P10 / P50 / P90 percentile bands. The figure below reports both the raw [P10, P90] coverage (epistemic only) and the calibrated coverage that adds the empirical residual sigma (aleatoric included).
+
+![MC Dropout coverage — bar chart per compound (raw blue, calibrated orange) with 0,80 reference line, plus a calibration scatter of mean predicted sigma vs empirical residual sigma](../_external_images/05_results/mc_dropout_coverage.png){ loading=lazy }
+
+Raw coverage stays around 0,20 across all compounds — active dropout only captures the model-weight uncertainty, not the lap-to-lap aleatoric noise. The calibrated coverage matches the 0,80 nominal target by construction, and the right panel quantifies how much extra band width the production agent needs to add when projecting degradation forward several laps.
+
+## How to regenerate
+
+```bash
+# Threshold sweeps + MC Dropout figures (one notebook, ~5 min on GPU)
+uv run jupyter nbconvert --execute --inplace notebooks/agents/N33_thresholds_and_calibration.ipynb
+
+# Quantitative RAG benchmark (10-15 min, builds 2 additional Qdrant collections)
+uv run jupyter nbconvert --execute --inplace notebooks/agents/N30B_rag_benchmark.ipynb
+```
+
+Both notebooks emit CSV and Markdown tables alongside their PNGs:
+
+- Sweeps: `data/eval/threshold_sweep_{overtake,sc,undercut}.{csv,md}`
+- MC Dropout: `data/eval/mc_dropout_coverage.{csv,md}`
+- RAG benchmark: `data/rag_eval/results_v1.md`
+
+See [`data/eval/README.md`](https://github.com/VforVitorio/F1-StratLab/blob/main/data/eval/README.md) for the full inventory and [`data/rag_eval/README.md`](https://github.com/VforVitorio/F1-StratLab/blob/main/data/rag_eval/README.md) for the RAG eval set conventions.
+
+## Numeric headline metrics
+
+| Component | Metric | Value | Source |
+|---|---|---|---|
+| Pace model (N06 XGBoost) | MAE on 2025 holdout | 0,410 s | `data/eval/pace_baselines.{csv,md}` |
+| Whisper turbo (CUDA) | mean per-clip latency | 233,9 ms (P95 325,8 ms) | `data/eval/whisper_results.{csv,md}` |
+| NLP pipeline (GPU) | mean `run_pipeline` | 42,1 ms | `data/eval/nlp_pipeline_cpu.{csv,md}` |
+| Sub-agent latency (single lap) | min / max mean | 270 ms (pace) / 4,4 s (rag w/ LLM) | `data/eval/subagent_latency.{csv,md}` |
+| RAG agent | Content P@5 (production retriever) | 0,80 | `data/rag_eval/results_v1.md` |
+| MC Dropout (C2) | calibrated 80% coverage | 0,840 | `data/eval/mc_dropout_coverage.{csv,md}` |
+
+All numbers reproducible with the commands above.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,166 @@
+site_name: F1 StratLab Documentation
+site_description: Multi-agent AI system for Formula 1 race strategy recommendations.
+site_author: Victor Vega Sobral
+site_url: https://vforvitorio.github.io/F1-StratLab/
+repo_url: https://github.com/VforVitorio/F1-StratLab
+repo_name: VforVitorio/F1-StratLab
+edit_uri: edit/main/docs/
+copyright: Copyright &copy; 2025-2026 Victor Vega Sobral
+
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  language: en
+  custom_dir: docs/overrides
+  font:
+    text: Inter
+    code: JetBrains Mono
+  palette:
+    - scheme: stratlab-dark
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-night
+        name: Switch to light mode
+    - scheme: default
+      primary: deep purple
+      accent: purple
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to dark mode
+  features:
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.expand
+    - navigation.path
+    - navigation.top
+    - navigation.indexes
+    - navigation.footer
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+    - content.action.edit
+    - content.action.view
+    - content.tabs.link
+  icon:
+    repo: fontawesome/brands/github
+    edit: material/pencil
+    view: material/eye
+    logo: material/flag-checkered
+
+extra_css:
+  - stylesheets/extra.css
+
+extra:
+  homepage: https://f1stratlab.com/
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/VforVitorio/F1-StratLab
+      name: F1 StratLab on GitHub
+    - icon: material/web
+      link: https://f1stratlab.com/
+      name: F1 StratLab landing
+    - icon: material/book-open-variant
+      link: https://deepwiki.com/VforVitorio/F1-StratLab
+      name: DeepWiki — auto-generated wiki
+  generator: false
+  version:
+    provider: mike
+    default: latest
+
+hooks:
+  - docs/_hooks/copy_external_images.py
+
+plugins:
+  - search:
+      lang: en
+      separator: '[\s\-,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
+  - glightbox:
+      touchNavigation: true
+      loop: false
+      effect: zoom
+      width: 100%
+      height: auto
+      zoomable: true
+      draggable: true
+
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+      permalink_title: Permalink to this section
+      toc_depth: 3
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.betterem
+  - pymdownx.caret
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.snippets:
+      check_paths: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
+
+nav:
+  - Home: index.md
+
+  - Getting started:
+    - Overview: getting-started/index.md
+    - Setup and deployment: setup-and-deployment.md
+
+  - Architecture:
+    - Overview: architecture.md
+    - Multi-agent system: agents-api-reference.md
+    - Simulation engine: simulation/overview.md
+    - Backend API: backend-api.md
+    - Streamlit frontend: streamlit-frontend.md
+
+  - Arcade:
+    - Quick start: arcade/quick-start.md
+    - Dashboard: arcade/dashboard.md
+    - Strategy pipeline: arcade/strategy-pipeline.md
+
+  - Reference:
+    - Driver colors: driver-colors.md
+    - Diagrams: diagrams/README.md
+
+  - Development:
+    - Docs maintenance: development/docs-maintenance.md
+
+  - Thesis results:
+    - Overview: thesis-results/index.md
+
+  - External:
+    - Landing site: https://f1stratlab.com/
+    - DeepWiki: https://deepwiki.com/VforVitorio/F1-StratLab
+    - GitHub releases: https://github.com/VforVitorio/F1-StratLab/releases

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,8 @@
+mkdocs>=1.6
+mkdocs-material>=9.5
+mkdocs-material-extensions>=1.3
+mkdocs-drawio-exporter>=0.10
+mkdocs-glightbox>=0.4
+pymdown-extensions>=10.7
+pygments>=2.18
+mike>=2.1


### PR DESCRIPTION
Adds a full mkdocs-material documentation site that publishes from docs/ to GitHub Pages on every push to main. Mirrors the public landing palette and typography (Space Grotesk + Inter + JetBrains Mono, purple-600 primary, dark-first scheme) by importing the same design tokens declared in colors_and_type.css of the f1stratlab-web repo.

What lands in this PR:

mkdocs.yml -> material theme with navigation.tabs, sticky tabs, full search, code-copy, edit-on-github action, and a stratlab-dark palette scheme that points the primary colour at the brand purple. Plugin list trimmed to search + glightbox; the drawio plugin is deliberately omitted to avoid pulling the draw.io binary into CI (documented as a follow-up in development/docs-maintenance.md).

requirements-docs.txt -> mkdocs-material, glightbox, mike, pymdown-extensions pinned at the versions known to play well with the configured extensions.

docs/stylesheets/extra.css -> brand theme overrides: typography, header glass effect, code blocks, tables, admonitions, buttons, footer, scrollbar. Same custom-property values the landing uses, so changing one repo means changing the other.

docs/index.md -> hero landing for the docs site with gradient text, three CTA buttons, and feature grid linking to Architecture, Multi-agent, Simulation, Arcade, Backend, Streamlit, plus an External companions row that surfaces f1stratlab.com, DeepWiki and Releases.

docs/getting-started/index.md -> three install paths (wheel, repo clone, Docker pointer).

docs/thesis-results/index.md -> chapter-5 figures embedded inline (threshold sweeps, MC Dropout coverage) plus the headline numeric table sourced from data/eval/.

docs/development/docs-maintenance.md -> stack overview, local-preview commands, how to add a new page or top-level section, theme palette pointers, deployment behaviour and custom-domain steps, troubleshooting matrix, future versioning notes. Read this before editing the site config.

docs/_hooks/copy_external_images.py -> mkdocs pre_build hook that copies documents/images/ into the build site as _external_images/, so the thesis figures stay canonical at their N33 output path and the docs site references them transparently.

.github/workflows/docs.yml -> GitHub Actions deploy on push to main when docs/**, documents/images/**, mkdocs.yml, requirements-docs.txt or the workflow file change. Installs Python 3.12, installs requirements-docs.txt, runs mkdocs gh-deploy --force --clean. Concurrency guard cancels in-flight runs for the same branch. workflow_dispatch enabled so the bot can be re-triggered without an empty commit.

Verified locally with python -m mkdocs build. The 0.58s build completes with the thesis-results image paths resolved through the hook. Pre-existing relative-link warnings in architecture.md, arcade/*.md and backend-api.md (references to memory/, src/, renamed sister pages) are left as follow-up cleanup, documented in development/docs-maintenance.md.

Custom domain setup is intentionally NOT applied in this PR. The site will publish at https://vforvitorio.github.io/F1-StratLab/ by default. The docs-maintenance page documents the docs.f1stratlab.com CNAME procedure for whenever the maintainer wants to flip the switch.

No source code, no notebooks, no agent behaviour touched.