### PR TITLE
feat(docs): wire docs.f1stratlab.com custom domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,14 @@ build/
 .eggs/
 
 # ===========================
+# Documentation site (mkdocs)
+# ===========================
+# mkdocs build output — published to gh-pages automatically by .github/workflows/docs.yml
+site/
+# Auto-copied by docs/_hooks/copy_external_images.py at build time
+docs/_external_images/
+
+# ===========================
 # IDE & Editors
 # ===========================
 .vscode/

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.f1stratlab.com

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: F1 StratLab Documentation
 site_description: Multi-agent AI system for Formula 1 race strategy recommendations.
 site_author: Victor Vega Sobral
-site_url: https://vforvitorio.github.io/F1-StratLab/
+site_url: https://docs.f1stratlab.com/
 repo_url: https://github.com/VforVitorio/F1-StratLab
 repo_name: VforVitorio/F1-StratLab
 edit_uri: edit/main/docs/


### PR DESCRIPTION
Points the published documentation site at docs.f1stratlab.com instead of the default vforvitorio.github.io/F1-StratLab/.

Two changes:

- docs/CNAME with the single line docs.f1stratlab.com. GitHub Pages reads this file on every gh-pages deploy and configures the custom domain automatically.
- mkdocs.yml site_url updated so the canonical URL in sitemap.xml and the og:url meta tag use the new domain.

DNS prerequisite (already done by maintainer): CNAME record docs -> vforvitorio.github.io in the Namecheap DNS panel for f1stratlab.com.

After this PR merges, the docs workflow runs, gh-pages picks up the new CNAME file, and GitHub Pages serves https://docs.f1stratlab.com/ with Let's Encrypt HTTPS. The default URL keeps redirecting via GitHub Pages internals.