### PR TITLE
chore: gitignore ruff/mypy caches, code-review-graph dir and uv cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,10 +107,13 @@ Thumbs.db
 desktop.ini
 
 # ===========================
-# Testing
+# Testing & linting caches
 # ===========================
 .coverage
+coverage.xml
 .pytest_cache/
+.ruff_cache/
+.mypy_cache/
 htmlcov/
 .tox/
 .nox/
@@ -136,9 +139,16 @@ uv.lock
 # ===========================
 # code-review-graph
 # ===========================
+# Tool working directory (cached graph DB, indexes, intermediate files)
+.code-review-graph/
 # Persistent knowledge graph DB and generated artifacts (visualize/wiki)
 graph.db
 graph.db-shm
 graph.db-wal
 graph_visualization.html
 graph_wiki/
+
+# ===========================
+# uv (Python package manager)
+# ===========================
+.uv-cache/


### PR DESCRIPTION
Completes the gitignore coverage spotted while cleaning up the post-mkdocs working tree. Adds explicit entries for ruff/mypy caches, the code-review-graph tool's working directory, the uv package-manager cache and pytest's coverage XML output. No tracked files removed; this only stops future builds and tooling runs from polluting git status.