### PR TITLE
ci: add concurrency cancel-in-progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main, dev]
 
+# Cancel any in-flight CI for the same ref when a newer push lands.  Keeps
+# the queue from piling up when release-please pushes back-to-back PR
+# refreshes (which previously stranded 3+ runs in "queued" for 20+ min).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: test


### PR DESCRIPTION
Cancels stale CI runs on new pushes to the same ref. Prevents the queue pile-up we saw on PR #51 release-please refreshes.