### PR TITLE
ci: cache uv wheels and trim dep installs per job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
 
       - name: Ruff check
         run: uvx ruff check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,20 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Notes on dependency strategy across the three jobs:
+#   - All three jobs enable uv's built-in cache (`enable-cache: true`).  The
+#     cache key is keyed off `uv.lock`, so it only invalidates when the
+#     lockfile actually changes; same-lock runs reuse the wheel store and
+#     drop "Install dependencies" from ~60s to <10s.
+#   - `lint` does NOT call `uv sync`.  Ruff is the only tool it needs, so
+#     `uvx ruff` runs it as an ephemeral tool — skips installing the full
+#     ML/torch stack just to lint Python style.
+#   - `typecheck` calls `uv sync --extra dev` (mypy lives in the dev extra)
+#     but skips `--all-extras` since the `voice` extra is irrelevant to
+#     `src/rag/`.
+#   - `test` keeps `uv sync --all-extras` because the test suite touches
+#     voice / streamlit / arcade paths that need every extra installed.
+
 jobs:
   test:
     name: test
@@ -24,6 +38,8 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - name: Set up Python
         run: uv python install 3.12
@@ -42,15 +58,14 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
-
-      - name: Install dependencies
-        run: uv sync --all-extras
+        with:
+          enable-cache: true
 
       - name: Ruff check
-        run: uv run ruff check .
+        run: uvx ruff check .
 
       - name: Ruff format check
-        run: uv run ruff format --check .
+        run: uvx ruff format --check .
 
   typecheck:
     name: typecheck
@@ -60,9 +75,12 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --extra dev
 
       - name: Mypy
         run: uv run mypy src/rag/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,10 @@ concurrency:
 
 # Notes on dependency strategy across the three jobs:
 #   - All three jobs enable uv's built-in cache (`enable-cache: true`).  The
-#     cache key is keyed off `uv.lock`, so it only invalidates when the
-#     lockfile actually changes; same-lock runs reuse the wheel store and
-#     drop "Install dependencies" from ~60s to <10s.
+#     cache key is keyed off `pyproject.toml` because `uv.lock` is
+#     gitignored in this repo (see .gitignore line 134); pyproject changes
+#     are a fine invalidation proxy.  Same-pyproject runs reuse the wheel
+#     store and drop "Install dependencies" from ~60s to <10s.
 #   - `lint` does NOT call `uv sync`.  Ruff is the only tool it needs, so
 #     `uvx ruff` runs it as an ephemeral tool — skips installing the full
 #     ML/torch stack just to lint Python style.
@@ -39,7 +40,7 @@ jobs:
         with:
           version: "latest"
           enable-cache: true
-          cache-dependency-glob: "uv.lock"
+          cache-dependency-glob: "pyproject.toml"
 
       - name: Set up Python
         run: uv python install 3.12
@@ -77,7 +78,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
-          cache-dependency-glob: "uv.lock"
+          cache-dependency-glob: "pyproject.toml"
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,26 @@ these safeguards trigger there. They are no-ops on POSIX.
 - [ ] If you added a new sub-agent output, update
       `docs/agents-api-reference.md`.
 
+## CI pipeline
+
+Three parallel jobs run on every push and PR (`.github/workflows/ci.yml`):
+
+| Job | Installs | Runs |
+|---|---|---|
+| `lint` | nothing — ruff via `uvx` | `ruff check .` + `ruff format --check .` |
+| `typecheck` | `uv sync --extra dev` (mypy + project deps, no voice extras) | `mypy src/rag/` |
+| `test` | `uv sync --all-extras` (full ML/voice/arcade stack) | `pytest -v` |
+
+All jobs share uv's wheel cache (`enable-cache: true`, keyed off
+`uv.lock`), so only the first run after a lockfile change pays the full
+download cost. Subsequent runs drop "Install dependencies" from ~60s to
+<10s.
+
+A `concurrency:` block at the top of the workflow cancels in-flight runs
+when a newer commit lands on the same ref. This was added after
+release-please's back-to-back PR refreshes piled 4+ runs into the queue
+at once and stranded them for 20+ minutes.
+
 ## Issue templates
 
 File an issue via the GitHub UI. Three templates are available under

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,8 +121,8 @@ Three parallel jobs run on every push and PR (`.github/workflows/ci.yml`):
 | `test` | `uv sync --all-extras` (full ML/voice/arcade stack) | `pytest -v` |
 
 All jobs share uv's wheel cache (`enable-cache: true`, keyed off
-`uv.lock`), so only the first run after a lockfile change pays the full
-download cost. Subsequent runs drop "Install dependencies" from ~60s to
+`pyproject.toml` since `uv.lock` is gitignored), so only the first run
+after a `pyproject.toml` change pays the full download cost. Subsequent runs drop "Install dependencies" from ~60s to
 <10s.
 
 A `concurrency:` block at the top of the workflow cancels in-flight runs


### PR DESCRIPTION
Three optimizations to the CI pipeline:

1. **uv cache on all jobs** — `enable-cache: true` keyed off `uv.lock`. After the first run, `Install dependencies` drops from ~60s to <10s.
2. **Lint runs ruff via `uvx`** — no full `uv sync` needed for a linter. Skips installing the whole ML/torch stack just to check style.
3. **Typecheck drops `--all-extras`** — voice extras are irrelevant to `src/rag/`. Uses `--extra dev` instead.

Strategy documented in CONTRIBUTING.md (new "CI pipeline" section).