### PR TITLE
ci: add path-based PR labeler with area tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+      - "area: deps"
     ignore:
       # torch / torchvision are routed through CUDA-specific indexes in
       # pyproject.toml [tool.uv.sources]. Dependabot bumps would break the
@@ -46,4 +47,4 @@ updates:
     open-pull-requests-limit: 3
     labels:
       - "dependencies"
-      - "ci"
+      - "area: ci-cd"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,45 @@
+# actions/labeler v5 configuration.
+#
+# Each top-level key is a label name (it must already exist in the repo;
+# the workflow does not create labels, only applies them). The value is
+# a list of conditions evaluated against the files changed in the PR.
+#
+# We use ``changed-files`` with ``any-glob-to-any-file`` so a single file
+# matching any of the globs is enough to trigger the label — a PR that
+# touches src/ AND tests/ gets BOTH ``area: codebase`` and ``area: tests``.
+
+"area: codebase":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/**"
+          - "scripts/**"
+          - "notebooks/**"
+
+"area: deps":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "pyproject.toml"
+          - "uv.lock"
+
+"area: ci-cd":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - ".github/dependabot.yml"
+          - ".github/labeler.yml"
+
+"area: docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "**/*.md"
+          - "README.md"
+          - "CONTRIBUTING.md"
+          - "ARCHITECTURE.md"
+          - "INSTALL.md"
+          - "ROADMAP.md"
+
+"area: tests":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tests/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,26 @@
+name: labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+# pull_request_target runs in the context of the BASE branch (not the PR
+# head), which lets the workflow read repo secrets safely while still
+# applying labels to PRs from forks. The labeler action only needs read
+# access to changed-file metadata, never to PR source code.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          # Re-evaluate from scratch on each sync so labels that no longer
+          # apply (e.g. a follow-up commit drops the only file touching
+          # docs/) get removed instead of sticking around forever.
+          sync-labels: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,32 @@ when a newer commit lands on the same ref. This was added after
 release-please's back-to-back PR refreshes piled 4+ runs into the queue
 at once and stranded them for 20+ minutes.
 
+### PR labels
+
+Every pull request gets auto-tagged with one or more `area:` labels by
+`.github/workflows/labeler.yml` (path-based via `actions/labeler@v5`).
+Dependabot PRs additionally get their label set by `dependabot.yml` so
+the tag is in place the moment the PR opens — no need to wait for the
+labeler workflow to run.
+
+| Label | Triggered by | Quick risk read |
+|---|---|---|
+| `area: codebase` | `src/`, `scripts/`, `notebooks/` | Default to careful review — touches product code |
+| `area: deps` | `pyproject.toml`, `uv.lock`, pip Dependabot | Low-medium; `test_dep_imports.py` is the safety net |
+| `area: ci-cd` | `.github/workflows/`, `.github/dependabot.yml`, `.github/labeler.yml`, GitHub Actions Dependabot | Low impact on product; max damage is breaking the pipeline |
+| `area: docs` | `docs/`, root `.md` files | Merge and forget |
+| `area: tests` | `tests/` | Low impact on shipping code; useful diff signal |
+
+PRs that combine labels (e.g. `area: codebase` + `area: deps`) get more
+attention than single-area PRs, since they couple a code change with a
+dependency move. The labeler workflow re-evaluates on each push, so
+labels stay in sync with the actual file diff over the life of the PR.
+
+To add a new label, create it via `gh label create "area: <name>" --color <hex>`
+first, then add a matching block to `.github/labeler.yml`. Labels do
+not auto-create — the workflow silently skips entries pointing to
+non-existent labels.
+
 ### Dependency-bump safety net
 
 `.github/dependabot.yml` opens weekly PRs whenever an upstream library


### PR DESCRIPTION
Adds an actions/labeler@v5 workflow plus Dependabot label rules so every PR auto-tags itself with one or more of:

- `area: codebase` — touches src/, scripts/, notebooks/
- `area: deps` — touches pyproject.toml, uv.lock, or is a pip Dependabot PR
- `area: ci-cd` — touches .github/workflows/, dependabot.yml, labeler.yml, or is a github-actions Dependabot PR
- `area: docs` — touches docs/ or root .md files
- `area: tests` — touches tests/

Combined labels (e.g. codebase+deps) signal higher-risk PRs at a glance. CONTRIBUTING.md documents the scheme.