### PR TITLE
fix(tests): suppress catboost_info dir creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,11 @@ docker-compose.override.yml
 .cache/
 uv.lock
 
+# CatBoost writes per-training metadata here whenever .fit() runs without
+# allow_writing_files=False. The dep-imports test suppresses this, but
+# any ad-hoc CatBoost run from a notebook / script will recreate it.
+catboost_info/
+
 # Notebook Python dumps (read-only knowledge base for Claude)
 .nb_py/
 

--- a/tests/test_dep_imports.py
+++ b/tests/test_dep_imports.py
@@ -163,7 +163,10 @@ def test_catboost_fit():
     rng = np.random.default_rng(0)
     X = rng.random((20, 3))
     y = (X[:, 0] > 0.5).astype(int)
-    model = CatBoostClassifier(iterations=5, verbose=False)
+    # allow_writing_files=False stops CatBoost from creating a
+    # ``catboost_info/`` directory next to the test run with per-fit
+    # logs. Without it, every pytest invocation pollutes the repo root.
+    model = CatBoostClassifier(iterations=5, verbose=False, allow_writing_files=False)
     model.fit(X, y)
     assert model.predict(X).shape == (20,)
 


### PR DESCRIPTION
Stops the dep-imports CatBoost test from littering the repo root with a catboost_info/ folder on every run. Also adds the folder to .gitignore as a backstop.