### PR TITLE
ci: auto-rebase dependency PRs on push to main / dev

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -1,0 +1,39 @@
+name: auto-update-prs
+
+# Triggers whenever main or dev advances. The autoupdate action walks
+# all open PRs targeting the pushed branch, filters them by label, and
+# rebases the head branch on top of the new base commit. The rebase
+# triggers a fresh CI run on each touched PR.
+#
+# Without this workflow, Dependabot PRs (and any PR that piles up
+# behind a busy week) sit with the "This branch is out-of-date with the
+# base branch" notice and require a manual "Update branch" click. The
+# branch protection rule on main is `strict: true`, so out-of-date PRs
+# block merge until someone clicks that button.
+
+on:
+  push:
+    branches: [main, dev]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update labelled PRs
+        uses: chinthakagodawita/autoupdate@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Only auto-update PRs tagged with one of the label values
+          # below. Keeps the action narrow: dependency bumps and CI
+          # tweaks rebase automatically, while a human-authored feature
+          # branch is left alone so the author controls the merge order.
+          PR_FILTER: "labelled"
+          PR_LABELS: "area: deps,area: ci-cd"
+          # Skip PRs in draft state — they are still being prepared and
+          # rebasing them just churns CI for no reason.
+          EXCLUDED_LABELS: "do-not-rebase"
+          MERGE_CONFLICT_ACTION: "ignore"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,19 @@ first, then add a matching block to `.github/labeler.yml`. Labels do
 not auto-create — the workflow silently skips entries pointing to
 non-existent labels.
 
+### Auto-update of dependency PRs
+
+`.github/workflows/auto-update-prs.yml` watches every push to `main` and
+`dev` and rebases any open PR labelled `area: deps` or `area: ci-cd` on
+top of the new base commit. Combined with the branch-protection setting
+`required_status_checks.strict: true`, this removes the manual "Update
+branch" click that used to be needed every time a Dependabot PR fell
+out-of-date.
+
+Human-authored PRs are deliberately excluded from the filter so the
+author keeps control of the merge order. Add the `do-not-rebase` label
+on any PR you want the workflow to skip.
+
 ### Dependency-bump safety net
 
 `.github/dependabot.yml` opens weekly PRs whenever an upstream library


### PR DESCRIPTION
Adds a workflow that rebases every open PR labelled area:deps or area:ci-cd whenever main or dev advances. Removes the manual 'Update branch' click on every Dependabot PR. Opt-out via do-not-rebase label.