### PR TITLE
feat(docs): GEO quick wins — llms.txt, JSON-LD, AI robots, prod React

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -25,6 +25,62 @@
   <meta name="twitter:description" content="Open-source multi-agent AI for real-time F1 race strategy. Architecture, agent API, arcade dashboard and deployment guides." />
   <meta name="twitter:image" content="https://docs.f1stratlab.com/assets/og-card.jpg" />
 
+  <!-- Structured data — entity graph for AI/search discovery.
+       Global (site-level) graph: lives in the shell so it ships in the initial
+       HTML and survives client-side rendering. Per-page TechArticle/BreadcrumbList
+       is added by the deploy-time prerender step (see .github/workflows/docs.yml). -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebSite",
+        "@id": "https://docs.f1stratlab.com/#website",
+        "url": "https://docs.f1stratlab.com/",
+        "name": "F1 StratLab Documentation",
+        "description": "Open-source multi-agent AI for real-time F1 race strategy. Architecture, agent API, arcade dashboard and deployment guides.",
+        "inLanguage": "en",
+        "about": { "@id": "https://docs.f1stratlab.com/#software" },
+        "publisher": { "@id": "https://docs.f1stratlab.com/#author" }
+      },
+      {
+        "@type": "SoftwareSourceCode",
+        "@id": "https://docs.f1stratlab.com/#software",
+        "name": "F1 StratLab",
+        "alternateName": "F1 Strategy Manager",
+        "description": "Multi-agent AI system that turns public Formula 1 telemetry and FIA regulations into real-time race-strategy recommendations, combining seven ML predictors, an NLP radio pipeline, a RAG layer over FIA rules and a LangGraph orchestrator.",
+        "url": "https://f1stratlab.com",
+        "codeRepository": "https://github.com/VforVitorio/F1-StratLab",
+        "license": "https://www.apache.org/licenses/LICENSE-2.0",
+        "programmingLanguage": "Python",
+        "applicationCategory": "DeveloperApplication",
+        "author": { "@id": "https://docs.f1stratlab.com/#author" },
+        "sameAs": [
+          "https://github.com/VforVitorio/F1-StratLab",
+          "https://deepwiki.com/VforVitorio/F1-StratLab",
+          "https://huggingface.co/datasets/VforVitorio/f1-strategy-dataset"
+        ]
+      },
+      {
+        "@type": "Person",
+        "@id": "https://docs.f1stratlab.com/#author",
+        "name": "Víctor Vega Sobral",
+        "alternateName": "VforVitorio",
+        "url": "https://victorvegasobral.com",
+        "jobTitle": "Intelligent Systems Engineering student; AI & Data Intern",
+        "affiliation": "UIE Campus Coruña",
+        "sameAs": [
+          "https://github.com/VforVitorio",
+          "https://www.linkedin.com/in/victorvegasobral/",
+          "https://huggingface.co/VforVitorio",
+          "https://victorvegasobral.com",
+          "https://f1stratlab.com"
+        ]
+      }
+    ]
+  }
+  </script>
+
   <!-- Theme color (mobile browsers) -->
   <meta name="theme-color" content="#0c0d14" media="(prefers-color-scheme: dark)" />
   <meta name="theme-color" content="#0c0d14" />
@@ -43,9 +99,9 @@
 <body>
   <div id="root"></div>
 
-  <!-- React (pinned + integrity) -->
-  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
-  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <!-- React (pinned + integrity) — production builds: smaller, faster, no dev warnings -->
+  <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js" integrity="sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" integrity="sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
 
   <!-- Markdown + diagrams + syntax highlighting -->

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,36 @@
+# F1 StratLab
+
+> F1 StratLab is an open-source (Apache-2.0) multi-agent AI system that turns public Formula 1 telemetry (FastF1, OpenF1) and FIA regulations into real-time race-strategy recommendations. It combines seven ML predictors (lap-time delta, tire degradation, overtake, safety car, pit duration, undercut, circuit clustering), an NLP pipeline over team radio, a RAG layer over FIA rules, and a LangGraph orchestrator (N31). Built as a Final-Degree Project (TFG) by Víctor Vega Sobral for the 2022–2025 regulation era. Three delivery surfaces from one codebase: a headless CLI, a PySide6 arcade (2D replay + dashboards), and a Streamlit web app. The pages below link to the raw Markdown so AI systems can read the prose directly.
+
+## Start here
+- [Welcome](https://docs.f1stratlab.com/pages/home.md): What F1 StratLab is and how the layers connect.
+- [Getting started](https://docs.f1stratlab.com/pages/getting-started.md): Three ways to install — wheel, repo clone, Docker.
+- [Setup & deployment](https://docs.f1stratlab.com/pages/setup.md): Docker, local dev, environment variables.
+
+## Architecture
+- [How it is wired](https://docs.f1stratlab.com/pages/architecture.md): End-to-end tour of the codebase with the lap_state contract.
+- [Multi-agent system](https://docs.f1stratlab.com/pages/multi-agent.md): Sub-agents N25–N30 and orchestrator N31 (MoE routing, Monte Carlo, LLM synthesis).
+- [Race replay engine](https://docs.f1stratlab.com/pages/simulation.md): RaceReplayEngine, RaceStateManager, the lap_state schema.
+- [Agents API reference](https://docs.f1stratlab.com/pages/agents-api.md): Entry points, feature vectors, and Pydantic output schemas.
+
+## Surfaces
+- [Backend API](https://docs.f1stratlab.com/pages/backend-api.md): FastAPI routers + FastMCP — telemetry, chat, voice, strategy.
+- [Streamlit frontend](https://docs.f1stratlab.com/pages/streamlit.md): Multi-page app — dashboard, strategy, tool-calling chat.
+- [Arcade quick start](https://docs.f1stratlab.com/pages/arcade-quick-start.md): One-command launch of the three-window arcade.
+- [Dashboard architecture](https://docs.f1stratlab.com/pages/arcade-dashboard.md): PySide6 package layout, wire protocol, thread model.
+- [Arcade strategy pipeline](https://docs.f1stratlab.com/pages/arcade-strategy-pipeline.md): Why the arcade duplicates the N31 orchestrator body.
+- [Driver colors](https://docs.f1stratlab.com/pages/driver-colors.md): Year-aware color palette covering 2023–2025 seasons.
+
+## Results & development
+- [Thesis results](https://docs.f1stratlab.com/pages/thesis.md): Headline benchmark metrics for the TFG (chapter 5).
+- [Development overview](https://docs.f1stratlab.com/pages/development.md): Branch model, conventional commits, contribution workflow.
+- [CI/CD pipeline](https://docs.f1stratlab.com/pages/ci-cd.md): GitHub Actions, release-please automation, Dependabot.
+- [Docs maintenance](https://docs.f1stratlab.com/pages/docs-maintenance.md): How this documentation site is built and deployed.
+
+## Optional
+- [Meet the author](https://docs.f1stratlab.com/pages/meet-the-author.md): About Víctor Vega Sobral and how to reach him.
+- [Changelog](https://docs.f1stratlab.com/pages/changelog.md): Release history mirrored from the repo CHANGELOG.
+- [Source code (GitHub)](https://github.com/VforVitorio/F1-StratLab): Apache-2.0 repository, releases, and issues.
+- [DeepWiki](https://deepwiki.com/VforVitorio/F1-StratLab): Auto-generated per-file technical wiki.
+- [Hugging Face dataset](https://huggingface.co/datasets/VforVitorio/f1-strategy-dataset): Data and models.
+- [Project landing](https://f1stratlab.com/): Non-technical project overview.

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,5 +1,51 @@
+# F1 StratLab documentation — crawler policy
+# Open-source (Apache-2.0) project: AI crawling and citation are welcome.
+
+# --- AI / LLM crawlers: explicitly allowed -------------------------------
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+# --- Everyone else --------------------------------------------------------
 User-agent: *
 Allow: /
 Disallow: /uploads/
+# Content usage signal (https://contentsignals.org/): retrieval + AI search welcome.
+Content-Signal: search=yes, ai-train=yes, ai-input=yes
 
 Sitemap: https://docs.f1stratlab.com/sitemap.xml


### PR DESCRIPTION
Closes #117. Part of #122 (GEO/SEO overhaul, current score **36/100**).

## What
Zero-risk static-file GEO wins — no architecture change:
- **`docs/llms.txt`** — indexes all 18 pages as links to the raw `/pages/*.md`, so AI crawlers (GPTBot, ClaudeBot, PerplexityBot…) can read the prose *despite* the client-side rendering. Same-day visibility win.
- **JSON-LD `@graph`** in `docs/index.html <head>` — `WebSite` + `SoftwareSourceCode` + `Person`, all `sameAs`-linked (GitHub, Hugging Face, DeepWiki, LinkedIn, portfolio, landing). Ships in the initial HTML, so it survives CSR. This is the biggest entity-recognition lever.
- **`docs/robots.txt`** — explicit `Allow` stanzas for the AI crawlers + a `Content-Signal` line declaring retrieval/AI-search consent.
- **Production React** — swapped `react.development.js` → `react.production.min.js` (and react-dom), with refreshed SRI `integrity` hashes (computed from the exact unpkg files).

## Verification
- JSON-LD parses cleanly (`WebSite`, `SoftwareSourceCode`, `Person`).
- SRI hashes computed via `openssl dgst -sha384` from the pinned unpkg URLs.
- Local screenshot pass (served `docs/`, Playwright, 1440×900): home + `#/architecture` render correctly with the production build — no white-screen, Mermaid + graph view intact.

## Out of scope (later sprints)
- `llms-full.txt` (concatenated bodies) → generated in CI in Sprint 1 (#118) to avoid a hand-maintained file going stale.
- Per-page `TechArticle`/`BreadcrumbList` schema → needs prerendered per-page HTML (#118).