### PR TITLE
docs(content): definitional leads + FAQ + routing-rule prose (citability)

### DIFF
--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -1,5 +1,7 @@
 # Getting started
 
+**F1 StratLab is an open-source (Apache-2.0) multi-agent AI system for real-time Formula 1 race strategy**, combining seven ML models, six LangGraph sub-agents and one orchestrator. This page covers installation — for what it does and how it is wired, see the [architecture overview](#/architecture).
+
 Three ways to get F1 StratLab running on your machine, from fastest to deepest.
 
 ## 1. Install the latest wheel
@@ -51,3 +53,21 @@ For a reproducible all-in-one setup, see [Setup and deployment](#/setup) for the
 - Want to see the agents in action? Open [Arcade quick start](#/arcade-quick-start).
 - Looking for an API to call from your own code? Jump to [Multi-agent system](#/agents-api).
 - Curious about the numbers in the thesis? See [Thesis results](#/thesis).
+
+## FAQ
+
+### Do I need a GPU?
+
+No, but it helps. `uv sync` pulls the CUDA-routed PyTorch wheel on Windows and Linux (a CPU build on macOS), so the stack runs on CPU. A GPU mainly accelerates Whisper radio transcription and the TCN tire model — the benchmark latencies on the [thesis results](#/thesis) page (Whisper 233.9 ms, NLP pipeline 42.1 ms) are GPU figures; on CPU it is slower but fully functional.
+
+### Why is the first run slow?
+
+The first boot triggers a one-time download of the cached models and reference data into `~/.f1-strat/`; subsequent runs are offline. The simulation also pre-warms Whisper and the agents before lap 1, so a cold start takes a while — pass `--no-llm` for a fast headless run.
+
+### Which LLM providers are supported?
+
+OpenAI and LM Studio — the system is provider-agnostic and does not depend on a single vendor. Set `F1_LLM_PROVIDER=openai` to use the OpenAI API; the default is a local LM Studio server at `http://localhost:1234/v1`.
+
+### Do I need an API key?
+
+Only for the LLM synthesis layer. Run with `--no-llm` and the ML models plus Monte Carlo simulation still produce a recommendation with no key required. With LM Studio you need no key; with OpenAI, put `OPENAI_API_KEY` in your `.env`.

--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -1,5 +1,7 @@
 # Multi-Agent Strategy Architecture (N25–N31)
 
+**The F1 StratLab multi-agent system is a LangGraph pipeline of six sub-agents (N25–N30) and one orchestrator (N31) that turns a per-lap `lap_state` into a typed `StrategyRecommendation`**, fusing ML model inference, Monte Carlo simulation and LLM synthesis across three layers.
+
 ## Purpose
 
 The multi-agent system replaces the legacy Experta rule engine (`base_agent.py`, `strategy_agent.py`) with a LangGraph-based pipeline that combines ML model inference, Monte Carlo simulation, and LLM-driven synthesis to produce race strategy recommendations.
@@ -49,6 +51,13 @@ graph TD
     N30 --> LLM
     LLM --> REC[StrategyRecommendation]
 ```
+
+**Routing rules (text equivalent of the diagram above):**
+
+- The orchestrator always runs the four always-on agents: N25 Pace, N26 Tire, N27 Race Situation and N29 Radio.
+- N28 Pit Strategy activates when N26 reports `tire_warning == PIT_SOON`, when N29 raises a PROBLEM or WARNING alert, or when N27 reports an active Safety Car.
+- N30 RAG activates when N27 reports `sc_prob > 0.30`, when N28 is active, or under an active Safety Car.
+- Monte Carlo then draws 500 samples over four candidates (STAY_OUT, PIT_NOW, UNDERCUT, OVERCUT), scoring `score = α·E + (1−α)·P10`, and the LLM synthesises the final `StrategyRecommendation`.
 
 ## Three-window arcade
 

--- a/docs/pages/thesis.md
+++ b/docs/pages/thesis.md
@@ -1,6 +1,6 @@
 # Thesis results
 
-Visual and numeric outputs referenced by chapter 5 of the TFG thesis. Every figure on this page is regenerated automatically from the notebooks under `notebooks/agents/` so it always tracks the latest model artefacts.
+**This page reports the headline benchmark results for F1 StratLab — the accuracy and latency of its seven ML models and six sub-agents**, as referenced in chapter 5 of the TFG thesis. Every figure is regenerated automatically from the notebooks under `notebooks/agents/`, so it always tracks the latest model artefacts.
 
 ## Threshold sweeps
 


### PR DESCRIPTION
Closes #120. Part of #122.

Pure-markdown content edits to make passages quotable by AI engines (no rendering/build changes):
- **getting-started.md** — a self-contained definitional lead, and an **FAQ** (Do I need a GPU? / Why is the first run slow? / Which LLM providers? / Do I need an API key?). Q&A is the structure AI Overviews and Perplexity cite most; every answer is grounded in the existing docs.
- **multi-agent.md** — a definitional lead, plus a **text equivalent of the MoE routing diagram** so text-only crawlers (which cannot read Mermaid) can extract the routing rules.
- **thesis.md** — front-loaded a self-contained summary of what the page reports.

## Verification
Re-ran the prerender locally on the edited content: 20/20 pages render, markdown well-formed, FAQ + leads present in the generated HTML. Screenshot of `/getting-started/` confirms the FAQ renders cleanly and appears in the page TOC.

## Deferred (need rendering changes, not pure content)
- Visible per-page "last updated" dates (would touch the SPA/prerender).
- License + contact link in the docs footer (touches `components.jsx`).
Noted for a follow-up; out of scope for this content-only PR.