### PR TITLE
fix(ci): use GITHUB_TOKEN for release-please instead of expired PAT

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,13 @@ jobs:
       - id: release
         uses: googleapis/release-please-action@v5
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          # ponytail: use the built-in GITHUB_TOKEN, not a PAT. `main` has no
+          # required status checks, so a PAT (whose only benefit is making the
+          # release PR trigger CI) buys nothing here. An expired RELEASE_PLEASE_TOKEN
+          # secret is still truthy, so `|| GITHUB_TOKEN` does NOT fall back — it
+          # fails with "Bad credentials". Bring the PAT back only if main starts
+          # requiring checks on the release PR.
+          token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
main no exige status checks (required_checks: null), asi que el unico beneficio de un PAT (que la PR de release dispare CI) no aporta nada aqui. Se pasa a GITHUB_TOKEN, mismo patron que Marginalia. publish-wheel ya usaba GITHUB_TOKEN.

Nota: release-please solo corre en main, asi que el fix surte efecto cuando dev se promociona a main." 2>&1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release automation reliability by using a consistent authentication method, reducing credential-related failures during release runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->