### PR TITLE
fix(docs): Sprint 3 - correct docs-maintenance framework label

### DIFF
--- a/docs/app/nav.js
+++ b/docs/app/nav.js
@@ -165,8 +165,8 @@ window.PAGES = [
     title: "Docs maintenance",
     section: "Development",
     file: "pages/docs-maintenance.md",
-    description: "How this MkDocs site is built and deployed.",
-    eyebrow: "MkDocs",
+    description: "How this React + Babel docs site is built and deployed.",
+    eyebrow: "React + Babel",
     tags: ["dev", "mkdocs", "github-actions"],
   },
   {

--- a/docs/index.html
+++ b/docs/index.html
@@ -120,7 +120,7 @@
   <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-typescript.min.js"></script>
 
   <!-- App -->
-  <script src="app/nav.js?v=7"></script>
+  <script src="app/nav.js?v=8"></script>
   <script type="text/babel" data-presets="env,react" src="app/markdown.jsx?v=4"></script>
   <script type="text/babel" data-presets="env,react" src="app/components.jsx?v=8"></script>
   <script type="text/babel" data-presets="env,react" src="app/graph.jsx?v=7"></script>


### PR DESCRIPTION
## What

Sprint 3 (Responsive & polish) of the docs-site UX audit (epic #149).

- Change the docs-maintenance nav `eyebrow` from `MkDocs` to `React + Babel`, and fix the adjacent `description` (same wrong framework name in the same nav entry). The docs site is built with React + Babel on gh-pages and never used MkDocs.

## Note on scope

Sprint 3's other finding (#147, constrain images/video on mobile) was already shipped in Sprint 1, because the GIF->video swap required the `.article img, .article video { max-width:100% }` rule then. So this PR is the remaining #148 only.

A larger, separate finding surfaced while fixing this: the **body** of `docs-maintenance.md` (plus parts of `ci-cd.md` / `development.md` and the `mkdocs` tag) still document a MkDocs workflow that the project never used. That is a multi-page content rewrite outside the UX-audit backlog and is left as a follow-up.

## Checks

- Headless: nav.js parses, PAGES load, the page renders (H1 intact), corrected eyebrow + description confirmed in the nav data. No JSX/console errors (bar the unrelated Cloudflare beacon).

Closes #148