### PR TITLE
fix(docs): hide prerendered placeholder until React mounts (no FOUC)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,21 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <!-- FOUC guard: each deployed page ships prerendered HTML inside #root (for
+       crawlers / no-JS). React mounts with createRoot (replace, not hydrate),
+       so without this the raw placeholder flashes before the app renders. Mark
+       JS as available so docs.css can hide that placeholder until React mounts.
+       Crawlers run no JS, so they keep the prerendered content. Safety net:
+       reveal it again if React never mounts. -->
+  <script>
+    (function () {
+      var d = document.documentElement;
+      d.classList.add("js");
+      setTimeout(function () { d.classList.remove("js"); }, 3000);
+    })();
+  </script>
+
   <title>F1 StratLab · Documentation</title>
   <meta name="description" content="Open-source multi-agent AI for real-time F1 race strategy. Architecture, agent API, arcade dashboard and deployment guides." />
 

--- a/docs/styles/docs.css
+++ b/docs/styles/docs.css
@@ -14,6 +14,12 @@ body {
 a { color: inherit; text-decoration: none; }
 button { font-family: inherit; }
 
+/* FOUC guard: hide the prerendered placeholder for JS users until the React app
+   mounts over #root and replaces it. The inline script in index.html adds .js
+   to <html> (and removes it after 3s as a safety net); crawlers without JS
+   never get .js, so they keep the prerendered content visible. */
+html.js .prerender-content { display: none; }
+
 /* Atmosphere — a single faint halo at top + faint grid wash */
 body::before {
   content: "";


### PR DESCRIPTION
## What

Removes the brief flash of raw, unstyled HTML on every docs page load.

## Why

Each deployed page ships prerendered HTML inside `#root` (via `prerender_docs.mjs`, for crawlers and no-JS). React then mounts with `createRoot` (replace, **not** `hydrateRoot`), so it discards that DOM and rebuilds the full app. Between first paint and mount, the unstyled placeholder (no nav/sidebar/article column, since `.prerender-content` has no CSS) was visible for a moment. Pre-existing; #136 shortened it (no more 4 MB Babel before mount) but did not remove it.

## Fix

- Early inline script in `<head>` marks `<html>` with a `js` class, and removes it after 3 s as a safety net (so the content still appears if React never mounts).
- `docs.css`: `html.js .prerender-content { display: none }` hides the placeholder for JS users until React replaces `#root`.

Crawlers and no-JS visitors run no script, so they never get `.js` and keep the prerendered content (SEO preserved).

## Checks

Verified against the real prerendered `_site` output (Playwright, 3 paths):
- JS on, app scripts blocked (the flash window): `html.js` set, placeholder `display:none`.
- JS on, normal: app mounts, article renders, placeholder replaced (no regression).
- JS off (crawler): placeholder stays visible with full content (~4.3 KB).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the brief flash of the pre-rendered page content before the app finishes loading.
  * If the app fails to load, the placeholder content can still remain visible instead of staying hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->