### PR TITLE
release: Sprint 1 backend hardening + testing safety net

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          submodules: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -54,8 +56,18 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --frozen
 
+      # Guard against a refactor silently dropping the suite to a handful of
+      # tests (broken import, accidental mass-skip). Collection counts nodes
+      # regardless of skip, so the floor is stable even though most tests are
+      # data-gated on CI runners (Testing audit T-4).
+      - name: Collected-count floor
+        run: |
+          n=$(uv run pytest --co -q | grep -c "::" || true)
+          echo "collected $n test nodes"
+          test "$n" -ge 40
+
       - name: Run tests
-        run: uv run pytest -v
+        run: uv run pytest -v --cov=src --cov-report=term-missing
 
   lint:
     name: lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,3 +206,13 @@ exclude = ["legacy/", ".nb_py/", "notebooks/", "src/agents/", "src/nlp/", "src/d
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 asyncio_mode = "auto"
+# -ra prints a summary of skips/xfails so CI shows the data/gpu/llm-gated tests
+# instead of silently swallowing them (Testing audit T-4).
+addopts = "-ra"
+markers = [
+    "unit: pure hermetic unit test (no data, network, GPU, or LLM)",
+    "contract: API/schema/SSE contract test (hermetic, fixture-backed)",
+    "data: requires the HF dataset/model weights (skipped on CI runners)",
+    "gpu: requires CUDA",
+    "llm: requires a live or stubbed LLM backend",
+]

--- a/tests/test_cli_no_llm.py
+++ b/tests/test_cli_no_llm.py
@@ -1,0 +1,54 @@
+"""Cover-first CLI smoke for the ``--no-llm`` path (#166, Testing audit #180).
+
+The ``--no-llm`` mode of the PMV (``f1-sim``) has been broken since 2026-05-09
+(a 3-tuple return the CLI consumer never adopted). This subprocess smoke is the
+*executable* debt for that bug: it is expected to fail (``xfail``) until the P2b
+shared engine lands and the CLI no-LLM path is fixed. It runs only where the
+Melbourne 2025 data is present (``data`` tier), so CI stays green.
+
+``scripts/run_simulation_cli.py`` is UNTOUCHABLE — this test only drives it as a
+black-box subprocess, never imports or edits it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+_PARQUET = ROOT / "data" / "processed" / "laps_featured_2025.parquet"
+_RACE_DIR = ROOT / "data" / "raw" / "2025" / "Melbourne"
+_HAS_DATA = _PARQUET.exists() and _RACE_DIR.exists()
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_DATA, reason="Melbourne 2025 parquet + race dir required")
+@pytest.mark.xfail(
+    reason="--no-llm broken since 2026-05-09 (#166); fixed with the P2b shared engine",
+    strict=False,
+)
+def test_cli_no_llm_smoke():
+    """`f1-sim Melbourne NOR McLaren --no-llm --laps 5-7` must exit 0 with no [ERROR]."""
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/run_simulation_cli.py",
+            "Melbourne",
+            "NOR",
+            "McLaren",
+            "--no-llm",
+            "--no-real-radios",
+            "--laps",
+            "5-7",
+        ],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode == 0, f"exit {proc.returncode}\n{combined[-2000:]}"
+    assert "[ERROR]" not in combined, "no-LLM run logged [ERROR]"

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -77,8 +77,8 @@ def test_simulate_race_emits_start_lap_summary():
     no LLM backend is required. Validates the exact ordering contract the
     SSE endpoint relies on: consumers (Arcade, curl probes) cannot lock the
     layout until ``start`` arrives, and cannot finalise stats until
-    ``summary`` arrives. Intermediate ``error`` events are tolerated but the
-    closing frame must always be the summary.
+    ``summary`` arrives. The happy path must emit ZERO ``error`` frames (this
+    guards the ``--no-llm`` class of bug, #166) and close with the summary.
     """
     _ensure_backend_on_path()
     from backend.services.simulation import SimConfig, simulate_race
@@ -103,6 +103,15 @@ def test_simulate_race_emits_start_lap_summary():
 
     lap_events = [e for e in events if e["type"] == "lap"]
     assert len(lap_events) >= 1, "expected at least one lap event in 3-lap window"
+
+    # The no-LLM happy path must not degrade to error frames. Tightened from the
+    # old "errors tolerated" contract: a per-lap crash here is exactly the
+    # --no-llm class of bug (#166) this test now guards against.
+    error_events = [e for e in events if e["type"] == "error"]
+    assert not error_events, (
+        f"no-LLM happy path emitted {len(error_events)} error frame(s) "
+        f"(--no-llm class, #166): {error_events[:2]}"
+    )
 
     # Spot-check the LapDecision schema on the first lap payload.
     first_lap = lap_events[0]["data"]


### PR DESCRIPTION
Promotes Sprint 1 to main.

Parent:
- test: cover-first safety net + CI tiers (submodule checkout, collected-count floor, markers, tightened simulate-SSE assert, xfail CLI --no-llm smoke) (#186, part of #180)
- chore: bump telemetry submodule to Sprint 1 fixes (#187)

Submodule (via the pointer bump, already merged to its main):
- ci: run the 45 chat/mcp unit tests (#61)
- fix(data): repo-root walker honors .git dir + F1_STRAT_DATA_ROOT (#62)
- fix(deps): drop dead openai-whisper, add fastmcp (#63)
- fix(voice): map TTS rate wpm to Edge-TTS percent (#64)