### PR TITLE
chore(ci): make dev and test delete-proof in branch protection

### DIFF
--- a/scripts/setup-github.sh
+++ b/scripts/setup-github.sh
@@ -10,11 +10,18 @@ REPO="${GITHUB_REPOSITORY:-VforVitorio/F1-StratLab}"
 # Exact CI job names from .github/workflows/ci.yml — these are the required checks.
 REQUIRED_CONTEXTS=(test lint typecheck)
 
-# Stable branches that get protected. `test` is the active dev line and stays
-# unprotected so daily work can land directly; promotion flows test -> dev -> main.
-PROTECTED_BRANCHES=(main dev)
+# Release-only branch: strict CI + no force-push + no deletion.
+STRICT_BRANCHES=(main)
 
-PROTECTION_PAYLOAD() {
+# Long-lived working branches (three-branch flow: test -> dev -> main). They must
+# NEVER be deleted on a PR merge, but must still accept DIRECT work: `test` is the
+# daily dev line, `dev` receives plain merges from `test` and is the PR head into
+# `main`. So: delete-proof only (allow_deletions:false), NO required checks (they
+# would block the test->dev direct merge), force-push allowed (for the periodic
+# fast-forward resets of test). Quality is gated at `main`.
+DELETE_PROOF_BRANCHES=(dev test)
+
+STRICT_PAYLOAD() {
   cat <<EOF
 {
   "required_status_checks": {"strict": true, "contexts": [$(printf '"%s",' "${REQUIRED_CONTEXTS[@]}" | sed 's/,$//')]},
@@ -29,11 +36,39 @@ PROTECTION_PAYLOAD() {
 EOF
 }
 
-echo "==> Branch protection"
-for br in "${PROTECTED_BRANCHES[@]}"; do
+# Minimal protection: the ONLY guarantee is "cannot be deleted". Everything else
+# stays open so direct commits, merges and FF resets keep working.
+DELETE_PROOF_PAYLOAD() {
+  cat <<EOF
+{
+  "required_status_checks": null,
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "required_conversation_resolution": false,
+  "restrictions": null,
+  "lock_branch": false,
+  "allow_force_pushes": true,
+  "allow_deletions": false
+}
+EOF
+}
+
+echo "==> Branch protection (strict, release-only)"
+for br in "${STRICT_BRANCHES[@]}"; do
   echo "  - $br (strict checks: ${REQUIRED_CONTEXTS[*]})"
-  gh api -X PUT "repos/$REPO/branches/$br/protection" --input - <<< "$(PROTECTION_PAYLOAD)" >/dev/null
+  gh api -X PUT "repos/$REPO/branches/$br/protection" --input - <<< "$(STRICT_PAYLOAD)" >/dev/null
 done
+
+echo "==> Branch protection (delete-proof, direct work still allowed)"
+for br in "${DELETE_PROOF_BRANCHES[@]}"; do
+  echo "  - $br (never deleted on merge)"
+  gh api -X PUT "repos/$REPO/branches/$br/protection" --input - <<< "$(DELETE_PROOF_PAYLOAD)" >/dev/null
+done
+
+# Never auto-delete a head branch on merge (this is what deleted `dev` once). Feature
+# branches are cleaned explicitly with `gh pr merge --delete-branch`.
+echo "==> Disable auto-delete-on-merge"
+gh api -X PATCH "repos/$REPO" -F delete_branch_on_merge=false >/dev/null
 
 echo "==> Labels"
 # name|color|description — mirrors .github/labeler.yml + dependabot.yml.


### PR DESCRIPTION
Make the long-lived branches delete-proof so a PR merge can never remove them again.

- What: split the branch-protection setup into a strict tier (`main`) and a delete-proof tier (`dev`, `test`), and disable `delete_branch_on_merge`.
- Why: a `dev -> main` merge silently auto-deleted `dev`, because `dev` was unprotected and the repo had "automatically delete head branches" on.
- How: `dev` and `test` get `allow_deletions:false` with force-push still allowed (for the periodic fast-forward resets) and no required checks (so the `test -> dev` direct merge keeps working). `main` keeps its strict required-checks profile.

Config already applied live via the API; this makes it reproducible per the bootstrap discipline.
