### PR TITLE
docs(audits): add arcade, ML-eval and docs-accuracy audit plans

### DIFF
--- a/documents/audits/AUDIT_DOCS_ACCURACY.md
+++ b/documents/audits/AUDIT_DOCS_ACCURACY.md
@@ -1,0 +1,165 @@
+# AUDIT — Documentation accuracy (metrics + structural claims)
+
+**Auditor:** Fable 5 · **Date:** 2026-07-05 · **Repo:** `F1_Strat_Manager` (read-only pass, no docs or code changed)
+**Scope:** factual accuracy of every published claim in `README.md`, `INSTALL.md`, `ARCHITECTURE.md`, `CONTRIBUTING.md`, `ROADMAP.md`, the docs site (`docs/pages/*.md`, `docs/app/*.js`) and the project `CLAUDE.md`, cross-checked against (a) the AUTHORITATIVE final figures in `documents/thesis/F1StratLab_TFG_thesis.pdf` (ch. 5-6, esp. Tabla 6.1 p. 113) and `documents/thesis/F1StratLab_IEEE_technical_report.pdf` (consolidated results tables), and (b) the actual code (argparse signatures, routers, workflows, pyproject).
+**Out of scope:** editing the thesis or IEEE PDFs themselves; the `site/` directory (gitignored MkDocs-era build); `docs/pages/changelog.md` entries that are verbatim CHANGELOG history (annotation policy is an open question, not a finding).
+**Rule applied throughout:** where the notebook-era number and the thesis/IEEE final number differ, the thesis/IEEE final is authoritative (per `project_ieee_paper` memory and the thesis's own statement on p. 98 that only re-runnable figures are reported).
+
+---
+
+## 0. Executive summary
+
+The docs site (`docs/pages/`) is in good shape after the June audit sprints: its hero framing ("seven ML models, six LangGraph sub-agents and one orchestrator") matches the thesis, and its changelog already anchors the pace model to the final 0.4104 s figure. The rot is concentrated in three places:
+
+1. **`ROADMAP.md` (and the docs roadmap page) still publish two superseded metrics as achievements.** Lap-time MAE **0.392 s** appears 4 times in ROADMAP.md and once in `docs/pages/roadmap.md`; the thesis final (Tabla 6.1, p. 113) and the IEEE report both say **0.4104 s / 0.410 s**. Sentiment accuracy **87.5%** appears 3 times in ROADMAP.md and twice in `docs/pages/roadmap.md`; the thesis (p. 98) explicitly rules that figure out ("el encabezado del cuaderno N20 anuncia un 87,5% ... el classification_report devuelve 0,84; se reporta esta segunda cifra como autoritativa") and the IEEE report publishes **0.84**. ROADMAP.md also still marks tire degradation as "pending formal evaluation" when the thesis/IEEE publish final numbers (global MAE 0.7078 s, C2 fine-tune 0.5501 s).
+2. **Three copy-paste commands in root docs are broken.** README and INSTALL show `f1-sim VER Melbourne "Red Bull Racing"` (positional order is `gp_name driver team`, so VER is parsed as the GP), INSTALL's verification command uses a nonexistent `--lap-range 1 1` flag (real flag: `--laps 1-1`), and CONTRIBUTING's data-bootstrap one-liner imports `f1_strat_manager.data_cache` (the installed package root is `src.`, so the import fails).
+3. **`ARCHITECTURE.md` links to a docs tree that no longer exists** (`docs/architecture.md`, `docs/arcade/*.md`, `docs/diagrams/*.drawio`, etc. - 11 dead relative links; the pages live under `docs/pages/` and the diagrams under `documents/dev_docs/diagrams/`).
+
+**One suspected inconsistency is RESOLVED as a non-issue:** the "NLP latency 47.8 ms vs 43.7 ms" contradiction does not exist. No document says 43.7 ms; the string comes from **243.7 ms**, which is the RAG retrieval P95 (thesis p. 101, IEEE report). The published NLP pipeline figures are mean 47.8 ms / P95 59.4 ms (IEEE report table; thesis quotes the P95), and `docs/pages/changelog.md` matches them. The only genuine latency divergence is `docs/pages/thesis.md` reporting a **regenerated** mean of 42.1 ms from `data/eval/nlp_pipeline_cpu.md` (42.069 ms measured), which is a different, later measurement run, self-labelled as regenerated; it needs a reconciliation note, not a correction.
+
+Counts also drift: README calls the system "seven specialised agents coordinated by an orchestrator" and ROADMAP says "Seven specialised sub-agents (N25-N30)" and "eight ML predictive models"; the thesis and IEEE report are unambiguous (**six** specialised sub-agents + one supervisor orchestrator N31; IEEE: "a family of six supervised predictors"; thesis objective: "familia de siete modelos predictivos"; docs count seven by including circuit clustering).
+
+---
+
+## 1. Authoritative baseline (thesis + IEEE report, extracted this audit)
+
+| Metric | Final published value | Where extracted |
+|---|---|---|
+| Lap-time delta MAE (2025 holdout) | **0.4104 s** (IEEE rounds to 0.410; R² 0.9947; persistence baseline 0.408) | Thesis Tabla 6.1 p. 113; IEEE report results table |
+| Tire degradation TCN | global MAE **0.7078 s** (R² 0.605); C2 fine-tune **0.5501 s** | Thesis p. 113; IEEE (0.708 / 0.550) |
+| Overtake (N12 LightGBM) | AUC-PR **0.5491**, AUC-ROC 0.8758 (IEEE: 0.549 / 0.876, base rate 0.076) | Thesis p. 113; IEEE |
+| Safety car (N14 LightGBM) | AUC-PR **0.0723** vs baseline 0.0432, lift **1.67x** | Thesis p. 113/115; IEEE (0.072 / 0.043) |
+| Pit duration (N15 HistGBT) | P50 MAE **0.487 s** vs baseline 0.555 s, coverage 70.5%, pinball P05/P95 0.038/0.110 | Thesis pp. 96, 113; IEEE |
+| Undercut (N16 LightGBM) | AUC-ROC **0.7708**, AUC-PR **0.6739** (baseline 0.345), lift 1.95x | Thesis p. 113; IEEE (0.771 / 0.674) |
+| Sentiment (RoBERTa) | accuracy **0.84**, macro F1 0.75 (87.5% notebook header explicitly ruled non-authoritative) | Thesis p. 98 + Tabla 6.1; IEEE |
+| Intent (SetFit + ModernBERT) | accuracy 0.61, macro F1 **0.5338** | Thesis p. 113; IEEE (0.53) |
+| NER (BERT-large BIO) | token F1 **0.4151** | Thesis p. 113; IEEE (0.415) |
+| NLP pipeline latency (GPU) | mean **47.8 ms**, P95 **59.4 ms** | IEEE report table + prose; thesis p. 74 (P95) |
+| RAG retrieval | 2,279 chunks; Content P@5 0.800; MRR 0.235; **P95 243.7 ms** | Thesis pp. 101, 113; IEEE |
+| Radio corpus | **530** hand-labelled messages (sentiment split 371/79/80); intent subset 529 (370/79/80); +28 msgs / 76 RCMs Bahrain sub-corpus | Thesis pp. 97-98; IEEE |
+| System shape | **six** specialised sub-agents (Pace, Tire, Race Situation, Pit Strategy, Radio, RAG) + orchestrator N31; "familia de siete modelos predictivos" (thesis) / "family of six supervised predictors" (IEEE) | Thesis pp. 18, 113; IEEE report |
+| Clustering | K=4, silhouette 0.201, fitted 2023-2024, applied to 2025 without refit | Thesis p. 113 |
+
+Regenerated local eval artifacts (`data/eval/`, produced by N33/N30B, the source for `docs/pages/thesis.md`) differ slightly and are a separate measurement lineage: pace MAE 0.410 (matches), NLP mean 42.069 ms / P95 44.246 ms (`data/eval/nlp_pipeline_cpu.md`), Whisper mean 233.9 ms.
+
+---
+
+## 2. Inconsistency register (metric claims)
+
+| # | Claim | Where it appears (doc side) | Current value | Authoritative value | Source of truth |
+|---|---|---|---|---|---|
+| M-01 | Lap-time MAE | `ROADMAP.md:100`, `ROADMAP.md:117`, `ROADMAP.md:583`, `ROADMAP.md:612`; `docs/pages/roadmap.md:267` | 0.392 s | **0.4104 s** | Thesis Tabla 6.1 p. 113; IEEE table (0.410). Already correct: `docs/pages/changelog.md:86` (0.4104 anchor), `docs/pages/thesis.md:47` (0.410), `docs/app/home.js:6` (0.41 s) |
+| M-02 | RoBERTa sentiment accuracy | `ROADMAP.md:251`, `ROADMAP.md:280`, `ROADMAP.md:586`; `docs/pages/roadmap.md:301`, `docs/pages/roadmap.md:303` | 87.5% | **0.84** (84%) | Thesis p. 98 (declares 0.84 the only reproducible figure); IEEE table. The 87.5% is the N20 notebook header the thesis explicitly overrides |
+| M-03 | Tire degradation evaluation status | `ROADMAP.md:110` ("pending formal evaluation"), `ROADMAP.md:613` ("Pending formal holdout evaluation") | pending / no number | **Evaluated: global MAE 0.7078 s (R² 0.605), C2 fine-tune 0.5501 s**; R² > 0.85 target not met, reframed | Thesis p. 113; IEEE (0.708 / 0.550) |
+| M-04 | NLP pipeline mean latency | `docs/pages/thesis.md:49` (42.1 ms) vs `docs/pages/changelog.md:206` (47.8 ms) | two lineages coexist | Published = **47.8 ms mean / 59.4 ms P95** (IEEE); regenerated = 42.1/44.2 (`data/eval/nlp_pipeline_cpu.md`) | IEEE report. Not an error (thesis.md self-labels as regenerated) but needs a one-line reconciliation note so readers do not flag it as a contradiction |
+| M-05 | "47.8 vs 43.7 ms" suspected contradiction | (audit brief / memory) | 43.7 ms alleged | **Non-issue.** 43.7 only exists inside **243.7 ms** = RAG retrieval P95 | Thesis p. 101 (Tabla 5.12), IEEE report. Record in memory so it is not re-hunted |
+| M-06 | Sub-agent count | `README.md:45` ("seven specialised agents coordinated by an orchestrator"); `ROADMAP.md:341` ("Seven specialised sub-agents (N25-N30)"); `docs/pages/simulation.md:5,24` ("all seven strategy agents" / "all 7 agents") | seven sub-agents | **Six sub-agents + one orchestrator N31** ("seven agents" is only valid as the TOTAL incl. N31) | Thesis pp. 18, 113 ("seis sub-agentes especializados"); IEEE ("Six specialised sub-agents"); `src/agents/` = 6 sub-agent modules + `strategy_orchestrator.py`. Already correct: `README.md:5` tagline, `docs/pages/multi-agent.md:3`, `docs/pages/home.md:3`, `docs/pages/architecture.md:3` |
+| M-07 | ML model count | `ROADMAP.md:11` ("eight ML predictive models") | eight | **seven** (canonical docs phrasing: 6 supervised predictors + circuit clustering; IEEE says "six supervised predictors" - see OQ-1) | Thesis p. 18 ("familia de siete modelos predictivos"); `docs/app/home.js:103` enumerates the seven |
+| M-08 | Overtake production threshold | `ROADMAP.md:143` (0.80) vs `docs/pages/thesis.md:11` (0.7976) | rounding split | 0.7976 exact, 0.80 as rounded display is acceptable | N12 step 5; no fix required, note only |
+| M-09 | NER F1 | `ROADMAP.md:263` (0.42) | 0.42 | 0.4151 (0.42 is fair rounding) | Thesis p. 113; IEEE (0.415). No fix required |
+| M-10 | NLP latency budget | `ROADMAP.md:274` (target < 500 ms) vs thesis p. 74 (RNF-01 ceiling **100 ms**) vs IEEE ("500 ms operational budget") | 500 vs 100 ms | ambiguous between the two authoritative sources | See OQ-2; no repo change until resolved |
+| M-11 | Radio corpus size | `ROADMAP.md:319` ("529 MP3s + 48 parquets") vs thesis "530 mensajes" | 529 vs 530 | Both correct: 530 = labelled text corpus (sentiment), 529 = intent subset AND the HF audio count is a separate inventory | Thesis pp. 97-98. No fix; optionally disambiguate wording |
+
+Metrics verified CONSISTENT everywhere they appear (no action): overtake 0.5491/0.8758, SC 0.0723 + lift 1.67x, pit 0.487 vs 0.555, undercut 0.6739/0.7708 + threshold 0.522, RAG 2,279 chunks + scores 0.62-0.76, MC Dropout 50 passes, MC 500 samples x 4 candidates, 14-field `StrategyRecommendation`, 28,494 overtake pairs, K=4 clustering.
+
+---
+
+## 3. Findings register (P0 -> P3)
+
+Priorities: **P0** = broken commands users copy-paste, or wrong published research figures in live claim sections. **P1** = wrong structural claims (counts, dead links, defaults, phantom API surface). **P2** = stale-but-harmless drift (renames, descoped features, versions). **P3** = polish/completeness.
+
+| ID | P | Finding | Doc-side anchor | Truth-side anchor |
+|---|---|---|---|---|
+| F-01 | **P0** | `f1-sim VER Melbourne "Red Bull Racing" --year 2025` has the positional args in the wrong order (parses VER as the GP); correct order is `gp_name driver team` | `README.md:53`; `INSTALL.md:132` | `scripts/run_simulation_cli.py:2314-2316` (positionals: gp_name, driver, team). Correct examples exist at `INSTALL.md:44` and `CLAUDE.md` §5 |
+| F-02 | **P0** | Verification command uses nonexistent flag `--lap-range 1 1`; the real flag is `--laps` with a range string (`--laps 1-1`) | `INSTALL.md:132` | `scripts/run_simulation_cli.py:2339-2343` |
+| F-03 | **P0** | Data-bootstrap one-liner imports `f1_strat_manager.data_cache`, which is not an importable root; the installed packages are `src*`/`scripts*`, so the command raises ModuleNotFoundError. Correct: `from src.f1_strat_manager.data_cache import ensure_setup` | `CONTRIBUTING.md:34` | `pyproject.toml:140-142` (`include = ["src*", "scripts*"]`); `src/f1_strat_manager/data_cache.py:348` (signature with `show_progress` confirmed) |
+| F-04 | **P0** | Lap-time MAE 0.392 s published as the achieved result in live claim sections (v0.7 goals, success metrics, milestone table) | `ROADMAP.md:100,117,583,612`; `docs/pages/roadmap.md:267` | Thesis Tabla 6.1 p. 113 (0.4104 s); IEEE table (0.410) |
+| F-05 | **P0** | Sentiment 87.5% published as the achieved result; the thesis explicitly rules this figure non-authoritative in favour of 0.84 | `ROADMAP.md:251,280,586`; `docs/pages/roadmap.md:301,303` | Thesis p. 98 + Tabla 6.1; IEEE (0.84 / macro F1 0.75) |
+| F-06 | **P1** | Tire-degradation evaluation marked "pending" although the thesis/IEEE publish final holdout numbers (and the R² > 0.85 target was missed and reframed) | `ROADMAP.md:110,613` | Thesis p. 113 (0.7078 global / 0.5501 C2); IEEE (0.708 / 0.550, R² 0.605) |
+| F-07 | **P1** | "Seven specialised agents coordinated by an orchestrator" / "Seven specialised sub-agents (N25-N30)" - N25-N30 is six sub-agents; seven is only the total including N31 | `README.md:45`; `ROADMAP.md:341`; `docs/pages/simulation.md:5,24` | Thesis pp. 18, 113; IEEE report; `src/agents/` (6 sub-agent modules + orchestrator) |
+| F-08 | **P1** | "Eight ML predictive models" - canonical count is seven (docs) / six supervised predictors (IEEE) | `ROADMAP.md:11` | Thesis p. 18; IEEE report; `docs/app/home.js:103` |
+| F-09 | **P1** | ARCHITECTURE.md carries 11 dead relative links to a pre-React docs tree: `docs/architecture.md`, `docs/arcade/strategy-pipeline.md`, `docs/arcade/dashboard.md`, `docs/agents-api-reference.md`, `docs/backend-api.md`, `docs/streamlit-frontend.md`, `docs/simulation/overview.md`, `docs/diagrams/{strategy_pipeline_flow,arcade_3window_architecture,tcp_broadcast_dataflow,data_pipeline}.drawio`, `docs/diagrams/` | `ARCHITECTURE.md:24,32-33,47-49,61-63,69-73` | Real paths: `docs/pages/{architecture,arcade-strategy-pipeline,arcade-dashboard,agents-api,backend-api,streamlit,simulation}.md`; diagrams at `documents/dev_docs/diagrams/*.drawio` (`docs/diagrams/` does not exist; `site/` is gitignored) |
+| F-10 | **P1** | Same class of dead link: INSTALL points at `docs/arcade-quick-start.md`, CONTRIBUTING at `docs/agents-api-reference.md` | `INSTALL.md:73`; `CONTRIBUTING.md:126` | `docs/pages/arcade-quick-start.md`; `docs/pages/agents-api.md` |
+| F-11 | **P1** | LLM provider defaults contradict each other and the code. INSTALL says "Arcade and CLI paths use OpenAI gpt-4.1-mini by default"; the CLI default is **lmstudio** and gpt-4.1-mini is the sub-agent model (orchestrator uses gpt-5.4-mini). multi-agent.md and getting-started say "default is LM Studio" with no Arcade exception; the Arcade default is **openai** | `INSTALL.md:13-15`; `docs/pages/multi-agent.md:184`; `docs/pages/getting-started.md:75` | `scripts/run_simulation_cli.py:2350-2353` (`--provider` default `lmstudio`); `src/arcade/main.py:57` (default `openai`); thesis p. 80 (gpt-5.4-mini orchestrator / gpt-4.1-mini sub-agents) |
+| F-12 | **P1** | INSTALL "Data bootstrap" says the HF first-run download "would be downloaded ... deferred past the first release" - it shipped in v0.9 and is invoked automatically by the CLI entry points | `INSTALL.md:118-122` | `src/f1_strat_manager/data_cache.py:348-360` (`ensure_setup`, "Invoked by the CLI entry points"); `ROADMAP.md:324` ("Lazy first-run data download ✅") |
+| F-13 | **P1** | Backend API docs list an `auth` router at `endpoints/auth.py`; the file no longer exists and main.py registers six routers, not seven | `docs/pages/backend-api.md:13` | `src/telemetry/backend/main.py:48-63`; `src/telemetry/backend/api/v1/endpoints/` (no auth.py, only a stale .pyc) |
+| F-14 | **P2** | Old repo slug `VforVitorio/F1_Strat_Manager` in live install/clone commands (works only via GitHub redirect); canonical is `VforVitorio/F1-StratLab` | `INSTALL.md:30,58,81`; `CONTRIBUTING.md:24`; `ROADMAP.md:325`; `docs/pages/setup.md:15` | `git remote -v` (origin = F1-StratLab); README badges/URLs already correct |
+| F-15 | **P2** | Python version stated as "3.10 or 3.11" / "3.10 / 3.11" while the pin (quoted in the same sentence) allows 3.12 | `INSTALL.md:10`; `README.md:82` | `pyproject.toml:11` (`requires-python = ">=3.10,<3.13"`); CI typechecks on 3.12; `CLAUDE.md` §2 says 3.10-3.12 |
+| F-16 | **P2** | "uv tool install drops two global binaries" - it installs four entry points | `INSTALL.md:34-41` | `pyproject.toml:113-117` (f1-strat, f1-sim, f1-arcade, f1-streamlit); `docs/pages/getting-started.md:21-28` already says four |
+| F-17 | **P2** | Simulation docs still present Kafka as the committed live path ("will replace the iterator in v0.14+", "Future - Kafka integration (v0.14)"); Kafka was descoped in v0.12 and the planned live path is the OpenF1 WebSocket | `docs/pages/simulation.md:7,178-180` | `ROADMAP.md:35,509` (descope note), `ROADMAP.md:643` (v1.8.0 OpenF1 WebSocket) |
+| F-18 | **P2** | Docker claims drift: getting-started says compose "boots the FastAPI backend, the Streamlit frontend and the Qdrant store"; ROADMAP's R3 bullet still lists "Qdrant + Kafka + LM Studio sidecar". The compose file has exactly two services (backend, frontend); Qdrant is an embedded on-disk client, LM Studio is reached via host.docker.internal | `docs/pages/getting-started.md:54`; `ROADMAP.md:513` | `docker-compose.yml:1-55`; `docs/pages/setup.md:95-98` (correct two-service description) |
+| F-19 | **P2** | Docs roadmap page still describes the docs site as "React + Babel"; Babel was dropped in #136/PR #157 | `docs/pages/roadmap.md:436` | `docs/index.html:136` ("no JSX, no Babel, no build step"); memory `project_docs_audit_plan` |
+| F-20 | **P2** | setup.md instructs a fully manual HF download + hand-placement under `data/` without mentioning the automatic `ensure_setup()` first-run path (and uses the old repo slug, F-14) | `docs/pages/setup.md:26-49` | `src/f1_strat_manager/data_cache.py:348` |
+| F-21 | **P2** | thesis.md (docs) presents regenerated eval numbers (NLP mean 42.1 ms) on a page titled "as referenced in chapter 5 of the TFG thesis"; the published chapter figure is 47.8 ms mean / 59.4 P95. Needs an explicit two-lineage note ("published vs regenerated") rather than a silent divergence | `docs/pages/thesis.md:3,49` | IEEE report (47.8/59.4); `data/eval/nlp_pipeline_cpu.md` (42.069/44.246) |
+| F-22 | **P3** | CONTRIBUTING cites `actions/labeler@v5` (actual: v6) and "three templates" (actual: four - bug report, feature request, data issue, epic) | `CONTRIBUTING.md:162,224-226` | `.github/workflows/labeler.yml:19`; `.github/ISSUE_TEMPLATE/` (4 templates + config) |
+| F-23 | **P3** | ci-cd.md drift: "Three workflows" (actual: five - ci, docs, release-please, labeler, auto-update-prs), push triggers omit `test` and `docs/**`, and release-please pinned at @v4 (actual @v5) | `docs/pages/ci-cd.md:35,39,51` | `.github/workflows/` (5 files); `ci.yml:5`; `release-please.yml:19` |
+| F-24 | **P3** | backend-api.md strategy table omits three live GET endpoints: `/radio-available-gps`, `/radio-laps`, `/radio-transcript` (completeness, nothing wrong listed) | `docs/pages/backend-api.md:110-131` | `src/telemetry/backend/api/v1/endpoints/strategy.py:745,763,823` |
+| F-25 | **P3** | architecture.md (docs) names the 14-field orchestrator output `StrategyState`; the Pydantic contract is `StrategyRecommendation` (`StrategyState` is the Arcade snapshot dataclass). Naming conflation, risk of confusion in the paper era | `docs/pages/architecture.md:58-60` | `src/agents/strategy_orchestrator.py` (StrategyRecommendation, 14 fields); `src/arcade/` (StrategyState.snapshot_dict) |
+| F-26 | **P3** | README project-layout line says `docs/` contains "draw.io diagrams"; the .drawio sources live under `documents/dev_docs/diagrams/` | `README.md:94` | Glob: no `docs/**/*.drawio`; `documents/dev_docs/diagrams/*.drawio` |
+
+**Verified accurate (spot-checked, no action):** project `CLAUDE.md` factual claims (Python 3.10-3.12, command examples, CI jobs, agent/orchestrator description); CI description in CONTRIBUTING (jobs, `--frozen`, mypy scope, cache strategy); `docker-compose.yml` vs INSTALL's Streamlit section (ports 8000/8501, mounts); `f1-arcade` example flags vs `src/arcade/main.py` argparse; `~/.f1-strat/` first-run location (`data_cache.py:168`); `uv tool uninstall f1-strat-manager` (pyproject name); backend router map minus auth; strategy endpoint list vs `strategy.py` decorators; agents-api entry-point table (`run_*_from_state` adapters exist across `src/agents/`); nav.js page registry vs `docs/pages/*.md`; README badges and repo URLs; docs home/getting-started/multi-agent/architecture count framing; MkDocs references fully purged from live docs pages (#156).
+
+---
+
+## 4. Phased fix plan (each phase = one future GitHub sub-issue)
+
+All phases are docs-only PRs (`docs:` commits). No code changes anywhere. Suggested order = listed order; phases 1-3 are the ones that matter before any paper/award submission links back to the repo.
+
+### Phase 1 — Fix broken copy-paste commands (P0) — **S**
+- `README.md:53` and `INSTALL.md:132`: swap to `f1-sim Melbourne VER "Red Bull Racing" --year 2025`.
+- `INSTALL.md:132`: replace `--lap-range 1 1` with `--laps 1-1` (and keep `--no-llm`).
+- `CONTRIBUTING.md:34`: `python -c "from src.f1_strat_manager.data_cache import ensure_setup; ensure_setup(show_progress=True)"`.
+- Acceptance: every shell command in README/INSTALL/CONTRIBUTING runs (or at least parses args) against the current wheel.
+
+### Phase 2 — Reconcile published metrics to thesis/IEEE finals (P0/P1) — **M**
+- ROADMAP.md: 0.392 -> 0.4104 s at lines 100, 117, 583, 612 (keep the "target < 0.5 s met" framing, it still holds).
+- ROADMAP.md: 87.5% -> 0.84 accuracy (macro F1 0.75) at lines 251, 280, 586, with a one-line note mirroring the thesis rationale (notebook header vs reproducible classification_report).
+- ROADMAP.md:110 + 613: replace "pending formal evaluation" with the final figures (global TCN MAE 0.7078 s, R² 0.605; C2 fine-tune 0.5501 s) and mark the R² > 0.85 target as not met / reframed.
+- `docs/pages/roadmap.md`: same three metrics (lines 267, 301, 303).
+- Decide and apply the changelog policy from OQ-3 (recommended: leave `docs/pages/changelog.md` verbatim as release history; it already carries the 0.4104 anchor at line 86).
+- Acceptance: `grep -rn "0\.392\|87\.5" README.md ROADMAP.md docs/pages/roadmap.md` returns nothing (changelog exempt per policy).
+
+### Phase 3 — Normalize agent/model counts (P1) — **S**
+- `README.md:45`: "six specialised agents coordinated by an orchestrator" (or "six sub-agents + one orchestrator").
+- `ROADMAP.md:341`: "Six specialised sub-agents (N25-N30) coordinate under a Supervisor Orchestrator (N31)".
+- `ROADMAP.md:11`: "eight ML predictive models" -> "seven ML models" (pending OQ-1 wording).
+- `docs/pages/simulation.md:5,24`: "the six sub-agents (plus the N31 orchestrator)".
+- Adopt the canonical sentence used by docs home/getting-started everywhere: "seven ML models, six LangGraph sub-agents and one strategy orchestrator".
+
+### Phase 4 — Repair dead docs links in root markdown (P1) — **S/M**
+- ARCHITECTURE.md: retarget the 11 links to `docs/pages/*.md` (or the deployed `https://docs.f1stratlab.com/#/<slug>` URLs, pick one convention) and the four .drawio links to `documents/dev_docs/diagrams/`.
+- `INSTALL.md:73` -> `docs/pages/arcade-quick-start.md`; `CONTRIBUTING.md:126` -> `docs/pages/agents-api.md`.
+- Acceptance: a link-checker pass over root .md files reports zero broken relative links.
+
+### Phase 5 — One truth table for LLM provider defaults (P1) — **S**
+- Write the per-surface defaults once and reuse: CLI `f1-sim` defaults to **lmstudio** (`--provider openai` to switch); Arcade defaults to **openai**; backend/agents read `F1_LLM_PROVIDER` (default lmstudio); sub-agents = gpt-4.1-mini, orchestrator = gpt-5.4-mini.
+- Fix `INSTALL.md:13-15`, `docs/pages/multi-agent.md:184`, `docs/pages/getting-started.md:75` (setup.md:59 is already right for the backend path).
+
+### Phase 6 — Backend/CI reference sync (P1/P2) — **M**
+- `docs/pages/backend-api.md`: drop the `auth` router row (F-13); add the three `/radio-*` endpoints (F-24).
+- `docs/pages/ci-cd.md`: five workflows, add `test` + `docs/**` to the trigger list, release-please @v5 (F-23).
+- `CONTRIBUTING.md`: labeler@v6, four issue templates (F-22).
+
+### Phase 7 — Freshness sweep on install/runtime claims (P2) — **M**
+- Repo slug normalization to `F1-StratLab` (F-14: INSTALL x3, CONTRIBUTING, ROADMAP, setup.md).
+- Python "3.10-3.12" wording (F-15: INSTALL, README).
+- "four console entry points" in INSTALL (F-16).
+- INSTALL data-bootstrap section rewritten around `ensure_setup()` automatic first-run + `~/.f1-strat/` (F-12); setup.md gains the automatic path as the primary flow (F-20).
+- Kafka -> OpenF1 WebSocket in `docs/pages/simulation.md` (F-17); Docker service list corrected in getting-started + ROADMAP R3 (F-18); "React + Babel" -> "React (no build step)" in docs roadmap (F-19).
+
+### Phase 8 — Two-lineage metrics note + naming polish (P2/P3) — **S**
+- `docs/pages/thesis.md`: add a short "published vs regenerated" note (published: mean 47.8 ms / P95 59.4 ms, IEEE report; regenerated on current hardware: 42.1 / 44.2 ms from `data/eval/`), so the page cannot be read as contradicting the paper (F-21).
+- `docs/pages/architecture.md`: rename the output contract to `StrategyRecommendation` (F-25).
+- `README.md:94`: point diagrams at `documents/dev_docs/diagrams/` (F-26).
+- Update project memory: record M-05 (43.7 = 243.7 RAG P95, non-issue) so the "47.8 vs 43.7" ghost is laid to rest.
+
+---
+
+## 5. Open questions (resolve with the author before/while executing)
+
+- **OQ-1 — What exactly are the "seven models"?** Docs enumerate 6 supervised predictors + circuit clustering (`docs/app/home.js:103`); the IEEE report says "a family of six supervised predictors"; the thesis objective says "familia de siete modelos predictivos" listing six target variables (p. 18) with clustering named separately (p. 113), and p. 50 even says "los seis modelos del sistema". Recommendation: standardize on "seven ML models (six supervised predictors + circuit clustering)" in repo docs, which keeps every current headline true; confirm the phrasing that the IEEE paper will use so repo and paper match.
+- **OQ-2 — NLP latency budget: 100 ms or 500 ms?** Thesis p. 74 cites RNF-01 with a 100 ms ceiling; the IEEE report and ROADMAP use a 500 ms operational budget. Both hold (59.4 << 100 << 500), but the repo should quote one. Which is the RNF as finally written in ch. 3?
+- **OQ-3 — Historical-entry policy.** `docs/pages/changelog.md` (verbatim CHANGELOG) and the v0.7/v0.8.2 release narratives contain the notebook-era 0.392/87.5/47.8 figures as release history. Recommendation: leave CHANGELOG verbatim, fix ROADMAP + docs roadmap page (they read as current claims). Confirm.
+- **OQ-4 — `docs/pages/thesis.md` charter.** Is the page meant to track the latest regenerated artifacts (then keep 42.1 ms and label the lineage, per Phase 8) or to mirror the publication (then pin 47.8/59.4 and drop the auto-regeneration claim)? Phase 8 assumes the former.
+- **OQ-5 — Thesis-internal slips (out of repo scope, relevant for the paper/AEPIA derivations):** the thesis annex p. 141 says "siete sub-agentes" once, and the bibliography annotation p. 119 still carries MAE 0.392 s for the XGBoost citation. The IEEE report already uses 0.410 everywhere. Worth a note in the `feat/paper` branch backlog.
+- **OQ-6 — Wheel asset naming.** `docs/pages/getting-started.md:18` builds the wheel URL as `f1_strat_manager-<version>-py3-none-any.whl` for every release; release-please's `publish-wheel` job should guarantee this, but verify the v1.6.2 release actually carries that asset before treating the command as gospel.

--- a/documents/audits/AUDIT_ML_AGENTS_EVAL.md
+++ b/documents/audits/AUDIT_ML_AGENTS_EVAL.md
@@ -1,0 +1,201 @@
+# AUDIT ML-EVAL - ML / multi-agent evaluation and robustness framework
+
+**Auditor:** Fable 5 · **Date:** 2026-07-05 · **Repo:** `F1_Strat_Manager` (read-only pass, no code changed)
+**Scope:** the scientific evaluation of the seven ML predictors (N06-N16), the six sub-agents (N25-N30), and the orchestrator N31 (MoE routing + 500-sample Monte Carlo + LLM synthesis): per-model metrics and calibration, test-set hygiene and leakage checks, orchestrator-layer validation (MC, routing, guardrails, 14-field output), robustness / failure-mode cataloging, and the ablation framework the IEEE TETCI paper and the future Rival Agent TFM need.
+**Hard constraints honored in every remedy:** plan only, no code; UNTOUCHABLE (additive entry points only, duplicate before modifying): `src/agents/` internals, `scripts/run_simulation_cli.py`, `notebooks/**`, `legacy/**`; LLM = OpenAI / LM Studio, never Anthropic; no eval run ever calls Anthropic.
+**Inputs read:** `src/agents/*.py` (orchestrator, pace, tire, situation, pit, radio, rag), every `model_config*.json` / `feature_manifest*.json` / calibration JSON under `data/models/` and `data/processed/`, `strategy_orchestrator_config_v1.json`, notebooks N30B / N31-viz / N32 / N33 (headers and eval cells), `tests/` (all files), `documents/audits/AUDIT_2026_REG_CONCEPT_DRIFT.md`, `AUDIT_TESTING_QA.md`, `AUDIT_P2B_CORE_COMPUTE.md`, `AUDITS_BACKLOG.md`.
+
+---
+
+## 1. Framing
+
+The TFG is defended (10.0) and the tribunal unanimously recommended the IEEE paper. The paper's own Discussion section concedes the system's weakest scientific flank: end-to-end validation rests on three curated case studies, not a systematic protocol, and calibration was asserted but never verified. This audit designs the evaluation harness and ablation framework that turns "the system works on Melbourne, Hungary and Qatar" into "the system's quality is measured, calibrated, ablated and reproducible over a full season". Everything here is additive: a new `src/strategy/eval/` package plus `tests/eval/` goldens, never edits to agent internals, notebooks or the PMV.
+
+**Boundary with the two sibling efforts (read this before converting to issues):**
+
+- **AUDIT_2026_REG_CONCEPT_DRIFT Phase 1 ("measurement layer", findings F-03/F-04)** already specifies the calibration verification harness (reliability + Brier for the 3 classifiers, quantile coverage for N15, MC-sigma ratio for the TCN) and the per-GP drift monitors. This audit does NOT re-specify them. It treats that layer as the shared substrate and adds what a *paper* needs on top: leakage and threshold-provenance verification, per-slice breakdowns as citable reports, orchestrator-layer validation, guardrail conformance, the season-scale replay protocol and the ablation matrix. One codebase (`src/strategy/eval/`), two consumers: drift monitoring (2026-reg) and scientific reporting (here).
+- **AUDIT_TESTING_QA** owns pass/fail PR gates. Its fixtures (FakeOpenAI stub T-3, canned lap_states / mini parquet T-6, engine golden scenarios T-2/T-10, guard-rail table tests) are the same artifacts this audit's harness consumes. Division of labor: tests assert contracts and gate PRs; the eval harness produces *measurements* (metrics, distributions, rates, tables) that gate *claims*. The fixtures carve-out already landed (`tests/fixtures/README.md`).
+
+---
+
+## 2. Executive summary
+
+The system's predictive layer has good notebook-era evaluation hygiene (temporal splits 2023-2024 train / 2025 test, documented leakage exclusions in the manifests, a dedicated thresholds-and-calibration notebook N33, a quantitative RAG benchmark N30B) but **none of it is reproducible, automated, or complete enough to defend the paper's claims**. Headline metrics live scattered across `model_config` JSONs, notebook cells and the thesis, with at least one divergence between sources (pace MAE 0.392 vs the thesis-final 0.4104). The provenance of the three published decision thresholds and of every historical-aggregate feature is unrecorded, so test-set contamination of the published numbers cannot currently be ruled out. That is a pre-submission blocker for the paper.
+
+The orchestrator layer is worse off: it has **zero quantitative evaluation of any kind**. The Monte Carlo layer draws pace samples it never uses (`strategy_orchestrator.py:685`, `noqa: F841`), runs on a fixed seed 42 embedded in the function (`:637`), claims a convergence property in a docstring that was never measured (`:92-93`), feeds a 3-lap SC probability into a 5-lap Bernoulli window (`:668`, `:687`, `WINDOW_LAPS` at `:545`), and rests on five hardcoded physics constants (`:545-549`) whose sensitivity was never tested. The MoE routing runs on a scalar SC threshold (`:108`, `:521`) while the shipped config documents per-cluster thresholds that were never wired in. The strategic guardrails are mostly prompt text (`:862-877`); their conformance rate under a real LLM has never been measured, and the RCM-SC failure (Qatar V7, fixed by RCMContextResolver) proved that this layer can silently invert an outcome. No ablation exists for any architecture claim, which is a problem because the three-layer orchestrator IS the paper's novelty hook.
+
+Plan: 5 phases. Phase 1 builds the metrics registry + per-model eval harness on the shared calibration substrate. Phase 2 is the hygiene audit (threshold provenance + aggregate-feature leakage), which must land before the paper's results table freezes. Phase 3 validates the MC and routing layers (deterministic, no LLM needed). Phase 4 measures guardrail conformance, output semantic quality and robustness. Phase 5 delivers the season-scale counterfactual replay protocol and the ablation matrix: the tables the paper cites and the baseline the Rival Agent TFM compares against.
+
+---
+
+## 3. Current evaluation state inventory
+
+### 3.1 What exists (and its ceiling)
+
+| Artifact | What it gives | Ceiling |
+|---|---|---|
+| `model_config*.json` per model (`data/models/*/`) | Frozen headline metrics: overtake AUC-PR 0.5491 / threshold 0.7976; SC AUC-PR 0.0723 / threshold 0.2335 + Platt coef; undercut AUC-PR 0.6739 / threshold 0.522 + Platt coef; pit P50 MAE 0.487 / **P05-P95 coverage 0.7047 vs 0.90 nominal**; train/test season declarations | Static snapshots, not regenerable; no per-slice breakdowns; provenance of thresholds unrecorded; the broken pit coverage sits published inside the config |
+| Feature manifests (`data/processed/feature_manifest_laptime.json`, `tiredeg_feature_manifest.json`) | Documented leakage exclusions (`features_out.leakage`, `leaky_columns`) and the lag rule for `DegradationRate`/`DegAcceleration` | The exclusions are documentation; nothing verifies the inference path honors them |
+| `N33_thresholds_and_calibration.ipynb` | Threshold sweeps for N12/N14/N16 + MC-Dropout empirical coverage, visual | One-shot notebook, untouchable, not regenerable as a gate; which split the sweeps ran on is exactly the E-02 question |
+| `N30B_rag_benchmark.ipynb` | 15 Spanish queries with manual article-level ground truth; Precision@k, MRR, latency across 3 retriever configs | Small n, notebook-only; does not cover the 3 canned production questions of `_build_rag_question` (`strategy_orchestrator.py:717-738`) |
+| `N31_mc_visualization.ipynb`, `N32_smoke_test.ipynb` | MC distribution plots on one real lap; per-agent smoke pass criteria | Visualization and smoke only; no acceptance metrics |
+| `data/models/tire_degradation/mc_dropout_calibration.json` | Per-compound frozen sigmas (C2/C4/C5/C6) | Frozen on validation-era data; the sigma-vs-realized-error ratio is never re-measured (2026-reg F-03 territory) |
+| `scripts/bench_*.py` (pace baselines, sub-agent latency, NLP CPU, Whisper) | Ad hoc latency/baseline probes; Radio P95 59.4 ms is a thesis RNF number | Latency is P2b's domain; not integrated into any report format |
+| `tests/` | Qatar 2025 V7 SC-override regression (`test_smoke.py:59`, data-gated), structural agent tests, `test_cli_no_llm.py` fixture smoke; `tests/fixtures/` carve-out README landed | Contracts, not measurements; nearly all data-gated in CI (Testing audit T-4) |
+
+### 3.2 What "defensible" requires that does not exist
+
+1. **Reproducibility:** one command that regenerates every published metric from the frozen artifacts + the HF dataset, with versioned output. Today the numbers are archaeology.
+2. **Hygiene proof:** documented, checked provenance for thresholds and aggregate features. Today it is trust.
+3. **Orchestrator measurement:** any number at all about Layer 1 routing, Layer 2 MC, or Layer 3 synthesis quality. Today there is none.
+4. **Ablation evidence:** any measured delta supporting "the MoE routing helps", "the MC layer helps", "guardrails help", "the LLM synthesis helps". Today there is none.
+5. **Scale:** validation on ~24 races, not 3. The paper's own future-work list names this.
+
+---
+
+## 4. Findings register (P0-P3)
+
+| ID | P | Finding | Why / risk | Size |
+|---|---|---|---|---|
+| **E-01** | **P0** | **End-to-end validation is 3 case studies; no systematic protocol exists.** Melbourne + Bahrain/Hungary + Qatar demos carry every architecture claim; the paper's Discussion admits it and its future work names a systematic multi-race protocol | The IEEE paper's central claims are anecdotally supported; a reviewer asking "over how many races?" has no good answer. Also blocks the Rival Agent TFM, which needs this system as a measured baseline | **L** |
+| **E-02** | **P0** | **Threshold and aggregate-feature provenance unrecorded; test-set contamination of published metrics cannot be ruled out.** `optimal_threshold: 0.7976` (`data/models/overtake_probability/model_config.json`), `best_threshold: 0.2335` (`safety_car_probability/feature_list_v1.json`), `best_threshold: 0.522` (`pit_prediction/model_config_undercut_v1.json`) do not record which split selected them; historical aggregates consumed as features (`circuit_sc_rate`, `circuit_undercut_rate`, `team_x_undercut_rate`, `team_year_median`, `year_circuit_median`, `team_pace_rank`, `Cluster`) do not record their computation window relative to the 2025 test season | If any threshold was tuned on test-2025 or any aggregate includes test-season rows, the headline numbers destined for the paper's results table are optimistic and the "strict temporal split" claim is false. Must be verified BEFORE submission; cheap to check, catastrophic to discover in review | **M** |
+| **E-03** | **P0** | **Calibration is asserted, not verified** (thesis limitation admits it; pit P05-P95 coverage already measured broken at 0.7047 vs 0.90 in `pit_prediction/model_config.json` "eval"). SHARED with 2026-reg F-03: that audit specifies the verification harness; this audit requires its outputs to become citable, versioned report artifacts with acceptance bands, because the orchestrator's MC layer consumes these distributions directly (`_run_mc_simulation`, `strategy_orchestrator.py:609-710`) | The paper says probabilities are calibrated (Platt as the integration bridge is a named design decision); one of the four calibration families is already known to be wrong. Cross-reference, do not duplicate: build once in the shared measurement layer | **M** (shared) |
+| **E-04** | **P1** | **The Monte Carlo layer is scientifically unvalidated.** (a) pace samples drawn then discarded: `pace_s = rng.normal(...)  # noqa: F841` (`strategy_orchestrator.py:685`), so N25's uncertainty contributes nothing to MC scores; (b) fixed `seed=42` inside the function (`:637`): identical noise stream every lap, seed-sensitivity never estimated; (c) docstring claims "500 draws keep variance of the mean below 0.01 position units" (`:92-93`), never measured; (d) horizon mismatch: `sc_prob_3lap` drives the Bernoulli SC draw (`:668`, `:687`) over a `WINDOW_LAPS = 5` window (`:545`); (e) five hardcoded constants `FRESH_GAIN 0.25 / CLIFF_LOSS 0.80 / POS_GAP_S 1.50 / SC_PIT_BONUS 8.0 / WINDOW_LAPS 5` (`:545-549`) with no sensitivity analysis; (f) when N28 is not routed, MC silently substitutes prior Triangular(2.2, 2.8, 3.8) and `undercut_prob = 0.5` (`:681-683`), a coin-flip that still scores UNDERCUT every lap | The MC layer is the paper's Layer 2 and the score `alpha*E + (1-alpha)*P10` (`:702`) decides actions in no-LLM mode outright. Unmeasured convergence, dead inputs and unsourced constants are reviewer bait; the coin-flip fallback can dominate decisions on quiet laps without anyone knowing how often | **M** |
+| **E-05** | **P1** | **Guardrail conformance is unmeasured.** The six strategic rails are prompt text (`strategy_orchestrator.py:862-877`); only two code-level guards exist (SC-active STAY_OUT to PIT_NOW override, `pit_strategy_agent.py:1006-1008`; the no-LLM guards, `scripts/run_simulation_cli.py:1529-1560`). No adversarial battery exercises the rails; no violation rate exists. The Qatar V7 incident (fixed by RCMContextResolver, regression pinned in `tests/test_smoke.py:59`) is proof this layer can invert an outcome | "Guardrails encode F1 realism" is a paper claim with zero supporting measurement. Prompt-level constraints are exactly the kind an LLM violates a few percent of the time; without a rate, the claim is unfalsifiable | **M** |
+| **E-06** | **P1** | **MoE routing correctness never evaluated, and config/code diverge.** `_decide_agents_to_call` (`strategy_orchestrator.py:475-537`) has truth-table unit tests (Testing audit) but no data-driven evaluation (did N28 activate ahead of actual pit events? how often does N30 fire?); the code uses scalar `sc_prob_threshold = 0.30` (`:108`, used `:521`) while `data/models/agents/strategy_orchestrator_config_v1.json` documents `sc_prob_threshold_by_cluster` 0.20-0.35 and its own `v09_handoff` note says the cluster-aware swap is still pending (N26 DID get its cluster-aware cliff thresholds: `tire_agent.py:246-257`) | Routing determines which distributions the MC gets real vs fallback (see E-04f), so routing errors propagate numerically. And the paper/docs must not describe cluster-aware SC routing that production does not perform | **S-M** |
+| **E-07** | **P1** | **Zero ablation evidence for any architecture claim.** No with/without-agent, with/without-guardrails, with/without-RCMContextResolver, alpha sweep, MC-sample sweep, or LLM-vs-no-LLM comparison has ever been run | The three-layer orchestrator is the paper's novelty hook; without an ablation table it reads as engineering description, not evaluated architecture. The tribunal-recommended venue (IEEE TETCI) will expect Table-style ablations | **M** (framework) |
+| **E-08** | **P1** | **No single reproducible metrics registry.** Numbers live in model_config JSONs, notebook cells, thesis chapters and memory files; at least one divergence exists (pace MAE 0.392 notebook-era vs 0.4104 thesis-final); the paper plan already had to declare a metrics authority by fiat | Every downstream document (paper, AEPIA 5-pager, docs site, model cards) copies numbers by hand today. One regenerable registry ends the drift | **S** |
+| **E-09** | **P2** | **14-field output semantic quality unmeasured.** Pydantic guarantees types (`StrategyRecommendation`, `strategy_orchestrator.py:317`), but nothing measures: `pit_lap_target` within race bounds, `target_lap_time_s` inside the pace CI as the prompt itself demands (`:932-933`), `compound_next` consistent with rail 5, `undercut_target` an actual rival, contingency triggers concrete, reasoning-rubric adherence (`:898-905`: must cite cliff P50, pace delta, a situational signal, a regulation article when present). The `confidence` field has never been compared to outcomes (Qatar first run: 92% confident in the wrong action) | Output quality is what the demo surfaces show users and what the paper quotes; today its quality is vibes. Confidence calibration is a cheap, novel-ish result for the paper's Discussion | **M** |
+| **E-10** | **P2** | **Robustness catalog is informal.** Known edge classes are handled ad hoc: lap-1 degenerate distributions crash-fixed by `_clamp_triangular` (`strategy_orchestrator.py:642-660`, the comment documents the original crash), FastF1 incomplete-lap guard (`run_simulation_cli.py:1825`), missing-rival / empty-radio behavior undocumented, unseen-category behavior untested (N15 LabelEncoder raises, per 2026-reg F-06). The single-driver boundary (full telemetry for our driver, timing-only for rivals: `strategy_orchestrator_config_v1.json` "data_boundary", enforced in `RaceStateManager`) has no information-leakage test asserting agents never consume `rival_fields_NOT_available` | Failure modes get discovered in demos (the Qatar way). A catalog + executable battery converts each one into a regression the moment it is found. The boundary test is also a thesis-integrity check: the "realistic pit wall" claim depends on it | **M** |
+| **E-11** | **P2** | **RAG evaluation is small and unwired.** N30B exists (15 queries, P@k/MRR, manual ground truth, 3 configs) but is notebook-only; the production orchestrator asks only 3 canned question shapes (`_build_rag_question`, `strategy_orchestrator.py:717-738`) which the benchmark does not cover verbatim; the paper's limitations list already concedes the RAG ground-truth gap | The regulation citation in the Qatar case (Article 36.3) is a headline demo moment resting on an unevaluated retrieval path for exactly those production questions | **S-M** |
+| **E-12** | **P2** | **NLP pipeline evaluation frozen at notebook-era.** N17-N24 metrics (sentiment, intent, NER F1 0.4151, latency) are one-shot; radio-alert intents feed routing (`_decide_agents_to_call` consumes PROBLEM/WARNING/PENALTY intents, `strategy_orchestrator.py:517-525`) but alert precision on the live pipeline was never measured; no label-stability regression exists (Testing T-11 covers the test side) | A noisy radio-alert channel silently degrades routing; measuring it also quantifies how much the Radio agent contributes (feeds the E-07 ablation) | **S** |
+| **E-13** | **P3** | **N33's threshold sweeps and coverage plots are not regenerable.** Visual, notebook-bound, split-provenance unclear (part of E-02) | Once the harness exists, N33's content becomes `f1-eval` reports; notebook stays as the historical record | **S** |
+| **E-14** | **P3** | **Latency benches are ad hoc and separate.** `bench_subagent_latency.py` etc. produce thesis numbers but no versioned report; P2b owns runtime optimization | Fold bench outputs into the same report format so RNF claims regenerate too; no new measurement work here | **S** |
+| **E-15** | **P3** | **No era/version labeling convention for eval outputs** (2026-reg F-15 names the docs side) | Every report must carry model-artifact hashes, dataset version, era tag and LLM model+version from day one, or 2026 retraining makes all reports ambiguous | **S** |
+
+---
+
+## 5. Target harness design (additive only)
+
+**Home:** new package `src/strategy/eval/` (the empty `src/strategy/training/` sibling is 2026-reg Phase 0's home; same package family, consistent with `src/strategy/README.md` marking the old jupytext exports as stale). Deterministic goldens that gate PRs live in `tests/eval/` and follow the Testing audit's tier markers. Heavy runs are launched by an additive `f1-eval` console script (pyproject entry point, like `f1-strat`/`f1-sim`).
+
+**Modules (conceptual, one concern each):**
+
+| Module | Concern | Consumes |
+|---|---|---|
+| `metrics_registry` | Regenerate + version every headline metric; emit the single citable table | frozen artifacts under `data/models/`, HF dataset holdouts |
+| `calibration` | The 2026-reg F-03 substrate: reliability/Brier/ECE, quantile coverage, MC-sigma ratio | same; shared with drift monitors |
+| `hygiene` | Threshold-provenance + aggregate-feature-window + manifest-lag verification (E-02) | notebooks read-only as evidence, featured parquets |
+| `mc_eval` | Convergence, seed variance, horizon analysis, constants sensitivity, fallback-usage tracking (E-04) | `_run_mc_simulation` via public import, canned sub-agent outputs |
+| `routing_eval` | Activation stats vs realized events; scalar-vs-cluster threshold comparison (E-06) | `_decide_agents_to_call` via public import, 2025 replays |
+| `conformance` | Guardrail battery, 14-field semantic validator, reasoning-rubric scorer, confidence calibration (E-05/E-09) | orchestrator entry points + FakeOpenAI (plumbing) / real LLM (rates) |
+| `robustness` | Edge-input battery + single-driver boundary leakage test (E-10) | canned/mutated lap_states |
+| `replay` | Season-scale counterfactual protocol (E-01) | `RaceStateManager` replays, full-season data |
+| `ablation` | Knockout/sweep matrix runner + LaTeX table emitter (E-07) | all of the above |
+
+**Untouchable-boundary technique:** everything runs through the public entry points (`run_*_from_state`, `run_strategy_orchestrator_from_state`, `_run_mc_simulation` and `_decide_agents_to_call` are importable pure functions, a pattern `tests/test_agents.py` already uses). Knockouts and sweeps are done by (a) constructing inputs, (b) monkeypatching at the entry-point seam from eval code, (c) config-side variation. If a sweep genuinely needs a parameter the internals hardcode (the MC seed is the known case, `strategy_orchestrator.py:637`), the eval code wraps or monkeypatches; proposing an internal edit requires the same case-by-case ruling as 2026-reg open question 4.
+
+**Outputs:** small versioned reports (markdown + CSV) in `documents/eval_reports/`, committed; heavy per-lap parquets in `data/eval/` (gitignored, HF-synced like the rest of `data/`). Every report header carries: artifact hashes, dataset snapshot, era tag, seed policy, LLM provider+model+version (OpenAI gpt-4.1-mini or the LM Studio local model; never Anthropic), and the git SHA of the harness (E-15).
+
+---
+
+## 6. Ablation framework (the paper's tables)
+
+All arms run the same 2025 replay set (subset for LLM arms, full season for no-LLM arms) and report the same outcome metrics (defined in Phase 5): action distribution, agreement rate with actual wall decisions, pit-call lead time, guardrail violation rate, mean MC score of chosen action, confidence calibration.
+
+| Ablation | Arms | Answers | LLM needed |
+|---|---|---|---|
+| Sub-agent knockout | full system vs minus-N25 / minus-N26 / minus-N28 (forces the Triangular fallback, E-04f) / minus-N29 / minus-N30 | contribution of each expert; formalizes the MoA claim | no-LLM arm first, LLM arm confirmatory |
+| Guardrails on/off | prompt rails present vs stripped; no-LLM guards on vs off | violation rate delta; "guardrails encode realism" evidence | yes (rails are prompt-level) |
+| RCMContextResolver on/off | resolver active vs bypassed on SC-containing races | the Qatar case generalized: how many SC laps flip decision | no (deterministic path dominates) |
+| Alpha sweep | risk_tolerance in {0, 0.25, 0.5, 0.75, 1.0} | decision-frontier sensitivity of `score = alpha*E + (1-alpha)*P10` | no |
+| MC sample count | n_sim in {50, 100, 250, 500, 1000, 2000} | validates the ":92-93" convergence claim; latency/quality trade (feeds P2b) | no |
+| Classifier thresholds | +/- sweep around 0.7976 / 0.2335 / 0.522 | decision stability vs threshold choice; pairs with E-02 re-derivation | no |
+| Layer 3 on/off | LLM synthesis vs no-LLM argmax path | what the LLM adds beyond MC argmax (action deltas, override frequency) | yes |
+| LLM model swap | gpt-4.1-mini vs LM Studio local model | provider robustness of Layer 3; supports the provider-agnostic claim | yes |
+
+The knockout, alpha, n_sim and threshold ablations are deterministic (seed-controlled, below Layer 3) and therefore cheap and CI-friendly at small scale; the LLM arms are data-tier runs with recorded transcripts.
+
+---
+
+## 7. Robustness / failure-mode catalog (initial population)
+
+Each entry becomes an executable battery case in Phase 4; the catalog is append-only and grows from every future demo incident.
+
+| # | Failure mode | Status today | Evidence |
+|---|---|---|---|
+| R-1 | SC active but wall-bias STAY_OUT replicated (RCM signal not propagated) | FIXED by RCMContextResolver; regression exists but data-gated | `tests/test_smoke.py:59`; resolver contract in `race_situation_agent.py` (`_sc_active_from_rcm`) |
+| R-2 | Lap-1 degenerate distributions (identical p10/p50/p90) crashed the MC | FIXED by `_clamp_triangular`; behavior at the clamp never characterized | `strategy_orchestrator.py:642-660` |
+| R-3 | N28 not routed: coin-flip undercut prior silently scores UNDERCUT | LIVE, unmeasured | `strategy_orchestrator.py:681-683` |
+| R-4 | LLM violates a prompt rail (pit lap 1-4, wrong compound-vs-laps, REACTIVE_SC on prediction) | Unmeasured; only the SC-active rail has a code backstop | `strategy_orchestrator.py:862-877`; `pit_strategy_agent.py:1006` |
+| R-5 | Missing / partial rival rows, empty radio window, NaN telemetry fields | Undocumented behavior | `run_simulation_cli.py:1825` guards one FastF1 case; agents' tolerance unknown |
+| R-6 | Unseen categories (new team/compound/GP) raise or silently mis-encode | Known future break (2026-reg F-06); no current-era test that the failure is LOUD | N15 LabelEncoder classes in `pit_prediction/model_config.json` |
+| R-7 | Single-driver boundary breach (an agent consuming rival-forbidden fields) | Never asserted | `strategy_orchestrator_config_v1.json` "data_boundary" `rival_fields_NOT_available` |
+| R-8 | Confidence miscalibration (high confidence on wrong action) | One anecdote (Qatar 92%); no rate | E-09 |
+| R-9 | Regulation citation wrong-season or hallucinated article | Unmeasured; N30B checks retrieval, not the cited-article faithfulness in synthesis | `_build_rag_question` + reasoning rubric step 3 |
+| R-10 | Future resolver classes: red flag, applied penalty, pit-lane closed | Not implemented (thesis future-work); catalog placeholders so batteries exist the day they land | RCM resolver extension list |
+
+---
+
+## 8. Phased, chunkable plan (each phase = one GitHub sub-issue set)
+
+Ordering rationale: registry before hygiene (you need regeneration to re-derive corrected numbers), hygiene before the paper's results freeze, deterministic orchestrator eval before LLM-dependent conformance, everything before the season-scale protocol that consumes it. Phases 1-2 are the paper's minimum; 3-5 are what makes the paper strong and the TFM baseline real.
+
+**Phase 1 - Metrics registry + per-model eval harness (M)**
+- `src/strategy/eval/` skeleton + `f1-eval` entry point + report/versioning conventions (E-15 header contract).
+- Regenerate the seven predictors' headline metrics from frozen artifacts on the 2025 holdout; add per-season, per-circuit, per-cluster and per-compound breakdown slices (none exist today).
+- Wire the calibration substrate WITH the 2026-reg Phase 1 work (E-03: reliability/Brier/ECE, N15 coverage, MC-sigma ratio); one implementation, two report consumers.
+- Emit the consolidated metrics registry (versioned JSON + markdown table): the single citable source replacing scattered numbers (E-08); reconcile the 0.392-vs-0.4104 class of divergences explicitly.
+- Deliverable: `f1-eval models` reproduces every `model_config` headline number within stated tolerance, or documents the delta.
+
+**Phase 2 - Hygiene: threshold provenance + leakage verification (M)**
+- Trace the derivation split of the three published thresholds through N12/N14/N16/N33 (read-only); record a verdict per threshold: val-derived / test-derived / undocumented.
+- Trace the computation window of every historical-aggregate feature (`circuit_sc_rate`, `circuit_undercut_rate`, `team_x_undercut_rate`, `team_year_median`, `year_circuit_median`, `team_pace_rank`, `Cluster` membership) relative to the 2025 test season.
+- Verify the tire-deg lag rule (manifest notes: `DegradationRate`/`DegAcceleration` must enter lagged) holds in the production inference path (`src/strategy/inference/tire_predictor.py`) and in each agent's feature assembly.
+- If contamination is found: re-derive thresholds on val-2024 only, recompute affected metrics, publish registry v2 with corrected numbers BEFORE the paper's results table freezes; if clean: record the provenance in the model_configs' successor registry so the question is answered forever.
+- Deliverable: a signed hygiene report (clean / contaminated / underdocumented per item) + registry v2 if needed. **This phase gates the IEEE submission.**
+
+**Phase 3 - Orchestrator decision-layer eval: MC + routing (M)**
+- MC validation suite (E-04): convergence curve over n_sim in {50...2000} with score standard errors (tests the `:92-93` claim); seed-variance estimate (multiple seeds via wrapper/monkeypatch, since seed 42 is hardcoded); quantified impact of the 3-vs-5-lap SC horizon mismatch; one-at-a-time sensitivity on the five constants (`:545-549`); fallback-prior usage frequency measured over a season replay (how often N28-absent laps' decisions would flip with real quantiles).
+- Ruling item for Víctor: the dead pace samples (`:685`): either document "N25 uncertainty deliberately excluded from MC, prompt-only" as a design decision in the paper, or plan the additive fix; the ablation (Phase 5) measures which answer is true.
+- Routing evaluation (E-06): activation confusion analysis on 2025 replays (N28 activations vs actual pit events within k laps; N30 firing rate and trigger mix); scalar-vs-cluster SC threshold comparison to resolve the config/code divergence with data (then either wire the cluster thresholds additively or delete them from the config and docs).
+- Deliverable: MC validation report + routing report; both deterministic, no LLM required.
+
+**Phase 4 - Conformance, output quality and robustness batteries (M-L)**
+- Guardrail battery (E-05): adversarial lap_state set per rail (6 rails x boundary variants); plumbing determinism via the Testing audit's FakeOpenAI; measured conformance RATE via the real-LLM data tier (OpenAI gpt-4.1-mini and the LM Studio model; recorded transcripts; never Anthropic); code-backstop rails asserted as hard PR-gating tests in `tests/eval/`.
+- Semantic output validator (E-09): deterministic cross-checks of the 14 fields (ranges, CI containment, rail-5 compound consistency, rival existence, contingency-trigger concreteness) + reasoning-rubric adherence scorer (string-level checks first: does reasoning cite cliff P50, pace delta, a named signal, an article when regulation_context is present); confidence-vs-outcome calibration over replay results.
+- Robustness battery (E-10): execute the §7 catalog (R-2/R-3/R-5/R-6 edge inputs, loud-failure asserts for unseen categories) + the single-driver boundary leakage test (R-7).
+- RAG production-question eval (E-11): extend N30B's ground-truth method to the 3 canned `_build_rag_question` shapes as harness cases, plus cited-article faithfulness checks in synthesis output (R-9).
+- NLP alert-precision probe (E-12): measure radio-alert intent precision on the committed transcript pairs; feeds the N29 knockout arm.
+- Deliverable: conformance report with per-rail violation rates; robustness battery green or catalogued-red; batteries wired to the Testing audit's tier markers.
+
+**Phase 5 - Season-scale replay protocol + ablation matrix (L)**
+- The systematic protocol the paper's future work names: counterfactual replay over the 2025 season (~24 races) through `RaceStateManager` + orchestrator entry points; no-LLM arm full-season, LLM arm on a budgeted subset.
+- Outcome metrics defined and frozen BEFORE running (agreement rate with actual wall pit decisions, pit-call lead time distribution, action distribution per race phase, guardrail violation rate, confidence calibration at scale, per-race failure harvest into §7).
+- The §6 ablation matrix executed; LaTeX-ready tables emitted for the paper (knockouts, alpha, n_sim, thresholds, rails, resolver, Layer 3 on/off, model swap).
+- Freeze the whole run (configs, seeds, transcripts, reports) as the **Rival Agent TFM baseline**: the TFM's rival-aware system must beat these numbers on the same protocol.
+- Deliverable: the paper's evaluation section artifacts + a tagged baseline snapshot.
+
+Dependency spine: Phase 1 first (Phase 2 needs regeneration; 3-5 need the report/versioning substrate). Phase 2 gates the paper freeze. Phase 3 is parallel-safe with Phase 2. Phase 4 needs the Testing audit's FakeOpenAI + fixtures (its Phase 1). Phase 5 needs all of the above.
+
+---
+
+## 9. Open questions (need Víctor's decision)
+
+1. **Paper timeline coupling:** which phases must land before TETCI submission? Minimum defensible: Phases 1-2 (registry + hygiene). Strongly recommended: Phase 3 + the no-LLM ablation arms of Phase 5, because the novelty hook needs at least one ablation table. Decide the cut line against the writing calendar.
+2. **Reference LLM for reported numbers:** conformance rates and Layer-3 ablations depend on the model. Propose: gpt-4.1-mini as the citable reference (stable, cheap), LM Studio local as the secondary arm; every report records model+version. Ratify.
+3. **Ground-truth oracle for agreement metrics:** actual wall pit decisions (from race data) are a biased oracle; the Qatar case is precisely one where the wall was wrong. Proposal: report agreement AND divergence-with-outcome analysis (when we diverge, did the MC-projected outcome materialize?), not agreement alone. A full Heilmeier-style outcome simulator is out of scope here (TFM territory). Ratify the framing.
+4. **If Phase 2 finds contamination:** silently replace numbers, or report both with an erratum note in the thesis-to-paper delta? Proposal: registry v2 with corrected numbers + one honest sentence in the paper (the N12B negative-result precedent shows honesty reads well). Decide.
+5. **LLM budget for Phase 4-5:** the full-season LLM arm at ~50-70 decisions/race x 24 races is thousands of calls; propose budgeted subset (2 races per cluster archetype, 8 races) for LLM arms, full 24 for no-LLM. Approve the subset design.
+6. **Seed-policy ruling (E-04b):** exposing the MC seed needs either a wrapper/monkeypatch (pure-eval, zero prod change) or a tiny additive parameter on the entry point (agent-internals adjacent). Same decision gate as 2026-reg open question 4; the wrapper works without any ruling if preferred.
+7. **Where eval reports live long-term:** `documents/eval_reports/` in-repo (proposed) vs HF; and whether the report format should anticipate the `pitlab` dashboard contract (2026-reg §6) now or later. Proposal: in-repo markdown/CSV now, format kept dumb enough that pitlab can ingest it later.
+
+---
+
+## 10. Verification protocol (when this plan is executed)
+
+- **Phase 1:** `f1-eval models` regenerates every headline metric in the current model_configs within documented tolerance from frozen artifacts + HF data on a clean machine; the registry report is committed and diffable; the known pit-coverage 0.7047 appears in the calibration report (the harness must "find" the already-known breakage, same retro-validation trick as 2026-reg Phase 1).
+- **Phase 2:** every threshold and every aggregate feature has a written verdict with notebook-cell evidence; any "contaminated" verdict has a corrected val-only number in registry v2; the tire-deg lag rule is verified in the production path or filed as a bug issue (issue-first per house rules).
+- **Phase 3:** the convergence report either confirms or refutes the docstring claim at `:92-93` with standard errors; the routing report includes the activation confusion analysis over at least 5 races; the config/code threshold divergence (E-06) is resolved in one direction with a data-backed rationale.
+- **Phase 4:** per-rail conformance rates reported with LLM model+version and n; the two code-level guards have hard tests that fail on regression; the R-7 boundary leakage test runs in the hermetic CI tier; every §7 catalog row is either green or an open catalogued issue.
+- **Phase 5:** the full no-LLM season replay completes without unexplained error frames; ablation tables compile in the paper's LaTeX; every architecture claim in the paper's methodology maps to at least one table or report artifact; the baseline snapshot is tagged and reproducible for the TFM.

--- a/documents/audits/AUDIT_P3_ARCADE.md
+++ b/documents/audits/AUDIT_P3_ARCADE.md
@@ -1,0 +1,294 @@
+# AUDIT P3 - Arcade surface (pyglet replay + PySide6 dashboard + TCP stream)
+
+> **Auditor**: Fable 5 · **Date**: 2026-07-05 · **Mode**: read-only, decision-grade, NO code.
+> **Scope**: `src/arcade/` end to end: the pyglet 2D replay (`app.py`, `views.py`, `overlays.py`,
+> `track.py`, `data.py`, `config.py`, `main.py`), the arcade-local strategy driver
+> (`strategy.py`, `strategy_pipeline.py`), the TCP broadcast (`stream.py`, newline-delimited JSON
+> at ~10 Hz), and the PySide6 dashboard package (`dashboard/`, 3 windows: strategy + telemetry,
+> spawned as one Qt subprocess). `RaceReplayEngine` / `RaceStateManager` reviewed as consumers only.
+> **Out of scope (owned elsewhere)**: session-load latency, the AoS pickle cache and the serial
+> extraction path (audit P2, findings F-05/F-06/F-09 and remedies A1-A7); per-lap agent/LLM/MC
+> compute cost (audit P2b, findings F1-F16); the FastAPI layer (P1); the CLI (P4).
+> **Baseline**: this audit builds on the 2026-05-13 memory backlog `project_arcade_refactor_backlog`
+> (quick wins 1-5, medium 1-6, heavy 1-4). Every baseline item is re-verified against current code
+> below; items already absorbed by P2/P2b are cross-referenced, not re-planned.
+> **Constraints honored**: `src/agents/` internals UNTOUCHABLE (the duplication is resolved by an
+> ADDITIVE shared entry point, never by editing agent internals); `scripts/run_simulation_cli.py`
+> untouchable; LLM = OpenAI / LM Studio, never Anthropic. Arcade is native PySide6/pyglet, so any
+> visual verification uses Qt `grab()` / `arcade.get_image()`, not Playwright.
+
+---
+
+## 1. Executive summary
+
+The Arcade surface is architecturally sound for a defended TFG PMV: clean view separation, correct
+process isolation between pyglet and Qt, a sensible stdlib-only TCP link, and two good cost-control
+mechanisms (lap gating and stale-skip) that the CLI still lacks. The debt concentrates in four places:
+
+1. **The known #1 heavy item is confirmed and has grown a fourth copy.** `src/arcade/strategy_pipeline.py`
+   is a body-copy of `run_strategy_orchestrator_from_state` importing seven private orchestrator
+   helpers (`strategy_pipeline.py:28-36`), with a "mirror the change here" comment (`:19`) that audit
+   P2b proved is a real failure mode (the 3-tuple change that broke the CLI's `--no-llm` was mirrored
+   here but not there). On top of the two known copies there are two more duplication sites:
+   `_build_default_lap_state` (`strategy_pipeline.py:124-167` duplicates
+   `strategy_orchestrator.py:1327-1367`) and `SimConnector._build_race_state` (`strategy.py:516-561`
+   duplicates the backend simulator's `_local_build_race_state`, admitted in its own docstring).
+   P2b's finding F10 already designed the fix: one additive engine module at
+   `src/strategy/inference/engine.py`. **This audit's P0 is the arcade side of that resolution:
+   turn `strategy_pipeline.py` into a thin delegate and delete the three local copies.**
+2. **The replay shows fabricated data in two places.** The weather panel renders hardcoded constants
+   (45.0 C track, 18.0 C air, 55% humidity, 12 km/h wind) every frame (`app.py:648-656`) even though
+   `SessionLoader` loads the weather DataFrame and throws it away (`data.py:268`). The progress-bar
+   flag markers never render because `SessionData.events` is always `[]` (`data.py:312`), leaving
+   `ProgressBar._draw_event` (`overlays.py:717-727`) dead, despite the loader already extracting
+   exactly the data needed (`track_status_by_lap`). For a system whose thesis is data fidelity,
+   placeholder values displayed as real readings are the highest-priority UX/correctness fix.
+3. **The render path does per-frame work that should be per-resize or per-change.** The static track
+   is re-tessellated into Python tuple lists and re-submitted in immediate mode every frame
+   (`track.py:183-190`, roughly 4,000 `tuple()` calls plus 20 chequer `draw_line` calls at 60 FPS);
+   every visible panel rewrites `arcade.Text.text` per frame whether or not the value changed; and
+   `_build_frame_dict` allocates a 20-driver × 13-field dict every frame (`app.py:620-657`). On the
+   dashboard side, every 10 Hz broadcast re-renders all six agent cards, the orchestrator card, six
+   syntax-highlighted QTextEdits and a full tire-chart item rebuild, even though decisions change
+   once per lap (`window.py:211-233`, `reasoning_tabs.py:210-229`, `tire_chart.py:163-218`).
+   None of this is a confirmed frame-rate problem yet, so Phase C starts with a frame-time probe.
+4. **Small real bugs and dead weight.** `f1-arcade --provider lmstudio` is parsed and silently ignored
+   (`main.py:57`), so a user can believe they are on LM Studio while the strategy layer defaults to
+   OpenAI unless the env var happens to be set. The menu's round stepper is capped at a hardcoded 23
+   (`views.py:188`), making round 24 (Yas Island) unreachable for 2024/2025 and letting 2023 step
+   into a nonexistent round. The idle-dim on conditional agent cards is a no-op because `opacity`
+   is not a Qt stylesheet property (`agent_card.py:156-158`). The SSE-era config block
+   (`config.py:160-165`) and the `backend_url` parameter (`strategy.py:205`) are dead.
+
+Test coverage for the whole surface is one import-smoke file (`tests/test_arcade_dashboard_imports.py`).
+The pure formatter/helper layer (agent_formatters, `_normalize_scores`, `classify_alerts`,
+`RaceEventsPanel._status_for`, `_build_stints`, ProgressBar seek math) is cheap to test and untested.
+
+---
+
+## 2. Baseline reconciliation (memory backlog vs current code)
+
+| Backlog item (2026-05-13) | Status today | Owner |
+|---|---|---|
+| QW1 `views.py:66` nested lambda default | Still present (`views.py:66`) | P3 Phase E |
+| QW2 14 field lambdas with `setattr` | Still present (`views.py:174-227`) | P3 Phase E |
+| QW3 magic strings + `_autofill_team` | Still present (`views.py:333-345`) | P3 Phase E |
+| QW4 `_frame_to_telemetry` inline normalisation | Partially done: hoisted to module scope (`app.py:65-96`), still lives in `app.py` | P3 Phase E (fold into broadcast service) |
+| QW5 `_fmt` inside `__init__` | Still present (`reasoning_tabs.py:60-65`) | P3 Phase E |
+| M1 `F1ArcadeView` god class | Still present, now 614 lines (`app.py:99-712`) | P3 Phase E |
+| M2 `_init_strategy_layer` coupling | Still present (`app.py:268-341`) | P3 Phase E |
+| M3 `SimConnector` 310-line thread | Still present, now ~380 lines (`strategy.py:182-561`) | P3 Phase E |
+| M4 blocking `SessionLoader.load()` on ENTER | Confirmed (`views.py:396-424`); remedy owned by **P2 (F-06)** | P2; P3 consumes |
+| M5 two independent stream clients | Confirmed (`window.py:205`, `telemetry_window.py:53`) | P3 Phase D |
+| M6 `telemetry_panel` init blob | Improved (chart factory `_make_chart` exists, `telemetry_panel.py:365-435`); residual init length acceptable | Closed |
+| H1 pipeline duplication | Confirmed + 2 extra copies; resolution designed by **P2b F10** | **P3 Phase A (arcade side)** |
+| H2 broadcast dict without schema | Still ad-hoc dicts (`app.py:426-488`); DTO exists only for strategy half | P3 Phase D (light) |
+| H3 overlays 100+ field mutations per frame | Confirmed, plus static-track re-tessellation is the bigger cost | P3 Phase C (measure first) |
+| H4 SessionLoader Pool + pickle cache | Superseded: serial `POOL_SIZE=1` since the P2 correction (2026-07-04); SoA cache + threading owned by **P2 (F-05/F-06/F-09)** | P2; do not re-litigate |
+
+---
+
+## 3. Findings register (P0 -> P3)
+
+| ID | P | Finding (what / why) | Evidence | Size |
+|---|---|---|---|---|
+| A1 | **P0** | Strategy pipeline duplicated 4x: arcade body-copy of the orchestrator + private-helper imports + local `lap_state` and `RaceState` builders. Every orchestrator change must be manually mirrored; P2b F2 proved the mirror fails. Resolve INTO the shared additive engine (P2b F10), arcade becomes a delegate. | `strategy_pipeline.py:11-20, 28-36, 42-121, 124-167`; `strategy_orchestrator.py:1303-1418, 1327-1367`; `strategy.py:516-561` | M (arcade side) |
+| A2 | **P1** | Weather panel renders hardcoded placeholder values as live data on every frame; loader fetches weather and discards it. Misleading on a defended surface. | `app.py:648-656`; `overlays.py:125-157`; `data.py:268` | S/M |
+| A3 | **P1** | Timeline flag markers are dead: `SessionData.events` always empty, yet the loader already extracts per-lap `TrackStatus`. SC/VSC/red-flag spans could render today. | `data.py:312, 469-489`; `overlays.py:682-683, 717-727` | S |
+| A4 | **P1** | `--provider` CLI flag parsed and never used (strategy layer reads only `F1_LLM_PROVIDER` env); `--viewer` path also skips the strategy-year validation the menu enforces. Silent wrong-provider risk (OpenAI spend when the user asked for LM Studio). | `main.py:57, 67-123`; `app.py:288` | S |
+| A5 | **P1** | Static track re-tessellated per frame: two ~2,000-point polylines converted to tuple lists + immediate-mode `draw_line_strip` + 20 finish-chequer `draw_line` calls, 60 times per second, for geometry that only changes on resize. | `track.py:183-192, 309-324`; screen polylines already precomputed in `update_scaling` (`track.py:151-158`) | M |
+| A6 | **P1** | Dashboard re-renders everything at broadcast rate (10 Hz) though strategy content changes once per lap: 6 agent cards, orchestrator card, scenario bars, 6 `setPlainText` calls that re-run the regex syntax highlighter, and a full tire-chart `removeItem`/`addItem` rebuild. | `window.py:211-233`; `reasoning_tabs.py:210-229`; `tire_chart.py:163-218` | S/M |
+| A7 | P2 | Two independent `TelemetryStreamClient` sockets in the same Qt process: every broadcast is received, decoded and JSON-parsed twice, and the two windows drift out of sync (baseline M5). | `window.py:205-209`; `telemetry_window.py:53-57` | S/M |
+| A8 | P2 | Broadcast serialisation on the render thread: `snapshot_dict` re-runs recursive `asdict` over the 30-decision history tail 10x per second even when no new decision exists, and `sendall` to each client is blocking, so one stalled subscriber can hitch the pyglet frame loop. | `strategy.py:155-176`; `stream.py:91, 99-103`; called from `app.py:416-436` | S/M |
+| A9 | P2 | Per-frame allocation churn in the replay: `_build_frame_dict` rebuilds a 20-driver dict every frame; Weather/DriverInfo panels reuse ONE shared `arcade.Text` per role and mutate `.text/.x/.y` per row per frame (layout cost per mutation); leaderboard writes `.text` per slot per frame with no change check. Should become read-through views over the P2 SoA arrays plus write-on-change text updates. | `app.py:620-657, 659-678`; `overlays.py:103-156, 216-288, 438-481` | M |
+| A10 | P2 | `F1ArcadeView` god class (614 lines): playback state machine, HUD, strategy layer lifecycle, TCP broadcast assembly, dashboard subprocess management and input handling in one class (baseline M1/M2). | `app.py:99-712` (esp. `:268-341, 358-374, 416-488, 532-575`) | M |
+| A11 | P2 | `SimConnector` mixes five concerns (replay iteration, model warmup, radio corpus, race-state build, shared-state mutation) and reaches into `StrategyState._lock` 11 times (private-attribute coupling). `StrategyState` should own its mutators; warmup should route through the shared prewarm facade (P2 X-03). | `strategy.py:182-561`; lock reach-ins at `strategy.py:285-464` | M |
+| A12 | P2 | Menu round stepper hardcodes `min(23, ...)`: round 24 (Yas Island) unreachable for 2024/2025 (both have 24 rounds in the canonical JSON); 2023 (22 rounds) can step to a nonexistent round 23 showing `?`. Cap must derive from `len(get_gp_names(year))`. | `views.py:186-189`; `config.py:266-292`; verified against `data/tire_compounds_by_race.json` | S |
+| A13 | P2 | Teardown and navigation gaps: ESC in the replay calls `window.close()` directly; nothing routes back to `MenuView`, and `on_hide_view` (which stops the connector, stream server and dashboard subprocess) only runs on `show_view`. Whether arcade fires it on window close needs verification; if not, the Qt subprocess is orphaned on ESC. The stream server's per-client keepalive thread also never detects remote close (no read), so pruning relies solely on broadcast failures. | `app.py:532-534, 358-374`; `views.py:459`; `stream.py:131-143` | S/M |
+| A14 | P2 | Idle-dim of conditional agent cards is a silent no-op: `opacity` is not a supported QSS property on QFrame, so N28/N30 idle cards look identical to active ones except for the glyph. | `agent_card.py:155-158` | S |
+| A15 | P2 | Dead code and dead config: SSE-era constants (`BACKEND_URL`, `STRATEGY_ENDPOINT`, `SSE_*`) unused anywhere in `src/arcade`; `SimConnector.backend_url` kept "for backwards compat, unused"; stale `GP_NAMES` fallback table (23 rounds, `Monza` listed twice at rounds 15 and 23, order wrong for every season it might serve). | `config.py:160-165, 216-240`; `strategy.py:205` | S |
+| A16 | P2 | Palette/classification constants triplicated with no drift guard: `config.py` (arcade) vs `dashboard/theme.py` (Qt) vs `telemetry/frontend/app/styles.py` (Streamlit); `classify_action` + alert severity duplicated between `strategy.py:567-603` and `theme.py:58-90`. The duplication is deliberate (process isolation), but nothing detects drift; a cheap parity test closes the gap without coupling imports at runtime. | `config.py:66-147`; `theme.py:1-13, 22-90` | S |
+| A17 | P3 | Baseline quick wins still open in `views.py` (nested lambda default, 14 `setattr` lambdas, magic-string autofill) plus `_fmt` defined inside `__init__` in `reasoning_tabs.py`. Pure hygiene. | `views.py:66, 174-227, 333-345`; `reasoning_tabs.py:60-65` | S |
+| A18 | P3 | Test coverage is import-smoke only. The formatter layer and pure helpers (`agent_formatters.*`, `_normalize_scores`, `classify_alerts`, `_status_for`, `_build_stints`, `_rolling_mean`, ProgressBar frame/x math, `_frame_to_telemetry`) are dict-in/tuple-out and trivially testable without Qt or pyglet. Coordinate with the Testing epic (#179). | `tests/test_arcade_dashboard_imports.py`; e.g. `overlays.py:592-610`, `strategy.py:578-626` | S/M |
+| A19 | P3 | Season-wide parquet handed unfiltered to the pipeline each lap (arcade half of P2b F7) and arcade path resolution bypasses `get_data_root()` (P2 F-11). Listed for traceability only; both are inherited when the engine (Phase A) and P2's resolver work land. | `strategy.py:487-492, 506` | inherited |
+
+### What NOT to do (explicit non-goals)
+
+- **Do not re-litigate `POOL_SIZE=1`.** The serial default is the correct 2026-07-04 P2 correction;
+  cold-path parallelism (pre-sliced per-driver inputs) and the numpy SoA cache are P2 deliverables.
+- **Do not edit `src/agents/` internals** to fix A1. The engine module is additive
+  (`src/strategy/inference/` already exists and holds only `tire_predictor.py`).
+- **Do not schedule rendering refactors before measuring.** A5/A9 get a frame-time probe first;
+  arcade at 20 dots + 5 panels may already hold 60 FPS on target hardware, in which case only the
+  track baking (clear win, low risk) proceeds.
+- **Do not build a schema/versioning layer for the TCP wire yet** (baseline H2). One producer, two
+  consumers, same repo, same process boundary; a Pydantic `BroadcastPayload` is worth it only if an
+  external consumer appears. Phase D adds the minimal thing instead: one constant for key names and
+  a golden-payload test.
+
+---
+
+## 4. The duplication decoupling plan (A1, the P0)
+
+**Target state**: one function computes a lap decision with per-agent outputs; every surface calls it.
+
+- **Home**: `src/strategy/inference/engine.py`, per P2b §7. API (P2b's contract, restated):
+  `run_lap(race_state, laps_df, lap_state, *, profile, return_agent_outputs=True) -> (StrategyRecommendation, agent_outputs, stage_timings)`.
+  The engine imports the orchestrator's private helpers in ONE place (the precedent
+  `strategy_pipeline.py` itself established) so there is exactly one mirror surface left, covered by
+  a contract test instead of a comment.
+- **Arcade change** (this audit's deliverable): `strategy_pipeline.run_strategy_pipeline` becomes a
+  3-line delegate to `engine.run_lap` that adapts the return tuple; keep the function name and
+  signature so `SimConnector._step_once` (`strategy.py:360-370`) and its DTO mapping
+  (`_build_per_agent`, `_build_decision`) do not change. Delete `_build_default_lap_state`
+  (the engine owns the default lap_state build, currently line-for-line identical to
+  `strategy_orchestrator.py:1327-1367`).
+- **RaceState builder**: move `SimConnector._build_race_state` (`strategy.py:516-561`) into the
+  engine as an additive `build_race_state(lap_state, prev_lap_time, *, radio_msgs, rcm_events, risk_tolerance)`
+  helper so the arcade, the backend simulator and the future CLI duplicate stop hand-rolling the
+  same mapping. The radio lookup stays arcade-side (it owns `RadioPipelineRunner`).
+- **Sequencing / ownership**: the engine module itself is P2b Phase 1.1. If P2b executes first, this
+  phase is pure deletion + delegation. If P3 executes first, this phase BUILDS the minimal engine
+  (verbose pass-through, `rich` profile only, stage timings optional) and P2b's later profiles land
+  inside it; either order avoids double work because the API is already agreed.
+- **Safety net**: a contract test asserting `engine.run_lap(...)[0] == run_strategy_orchestrator_from_state(...)`
+  on a fixture lap (mocked LLM), so the "mirror the change here" comment can be deleted for good.
+- **Untouchability**: zero edits inside `src/agents/`; `strategy_orchestrator.py` keeps its public
+  entry points unchanged; the CLI PMV is not touched (its migration is P4's duplicate-and-improve).
+
+---
+
+## 5. Phased plan (each phase = one future GitHub sub-issue; S/M/L effort)
+
+Dependency chain: **A -> (B, C, D in any order) -> E**. B, C, D are mutually independent.
+
+### Phase A - Retire the pipeline duplication (M)
+| Chunk | What | Effort |
+|---|---|---|
+| A.1 | Land / adopt `src/strategy/inference/engine.py` `run_lap` (coordinate with P2b 1.1; build minimal verbose engine if P2b has not executed) | M |
+| A.2 | `strategy_pipeline.py` -> thin delegate; delete `_build_default_lap_state`; move `_build_race_state` into the engine as an additive builder | S |
+| A.3 | Contract test: engine vs `run_strategy_orchestrator_from_state` on a fixture lap (LLM mocked); remove the mirror comment | S |
+
+Exit: `src/arcade` contains no copied orchestrator logic; one arcade smoke replay (strategy ON) produces identical decisions to before.
+
+### Phase B - Truth on screen: real data, real args (M)
+| Chunk | What | Effort |
+|---|---|---|
+| B.1 | Real weather: extract per-lap weather in `SessionLoader` (session already loads it), thread through `_build_frame_dict`; render "N/A" when absent. Bump `CACHE_VERSION` once, coordinated with P2's SoA change (one v7 bump, not two) | M |
+| B.2 | Timeline events: derive SC/VSC/yellow/red spans from `track_status_by_lap` into `SessionData.events` so `ProgressBar._draw_event` finally draws; RaceEventsPanel stays the live pill | S |
+| B.3 | Fix `--provider` (set `F1_LLM_PROVIDER` from the flag or pass through to `SimulateRequestDTO`) and add strategy-year validation to the `--viewer` path; file the bug issue first per repo rule | S |
+| B.4 | Menu round cap from `len(get_gp_names(year))`; regenerate or shrink the stale `GP_NAMES` fallback | S |
+| B.5 | Fix the idle-dim no-op on `AgentCard` (QGraphicsOpacityEffect or muted text/border palette) | S |
+
+### Phase C - Replay render path: measure, then bake (M)
+| Chunk | What | Effort |
+|---|---|---|
+| C.1 | Frame-time probe: avg/p95 frame ms with all-cars ON/OFF, strategy ON/OFF, on target hardware; keep as a dev flag. Gates C.3/C.4 | S |
+| C.2 | Bake static track geometry into retained arcade shape lists rebuilt only in `update_scaling` (edges, DRS segments, chequer); `on_draw` submits, never re-tessellates | M |
+| C.3 | Write-on-change text updates in panels (skip `.text` assignment when unchanged); per-row Text instances where a shared label forces per-row relayout (Weather, DriverInfo) | S |
+| C.4 | SoA-native frame access: once P2's numpy cache lands, replace `_build_frame_dict`/per-frame `FrameData` indexing with array reads; keep the dict only at the broadcast boundary | M |
+
+### Phase D - Stream and dashboard efficiency (M)
+| Chunk | What | Effort |
+|---|---|---|
+| D.1 | `StreamBroker`: one `TelemetryStreamClient` per Qt process, fan-out via Qt signals to both windows (baseline M5); halves socket + JSON work, synchronises windows | S/M |
+| D.2 | Lap-gated strategy rendering: orchestrator card, agent cards, reasoning tabs, scenario bars and tire chart refresh only when `latest.lap_number` (or an error/finished flag) changes; telemetry panel stays at 10 Hz | S |
+| D.3 | Broadcast hygiene: cache the serialised `latest`/`history_tail` in `StrategyState` behind a dirty flag (new decision invalidates); non-blocking or timeout sends in `TelemetryStreamServer.broadcast` so a stalled client cannot hitch the frame loop; fix or remove the no-op keepalive read | S/M |
+| D.4 | Dead code: delete SSE constants + `backend_url` param; add the palette/classification parity test (arcade config vs dashboard theme vs Streamlit styles; `classify_action`/severity maps) | S |
+
+### Phase E - Structure, UX and tests (M/L)
+| Chunk | What | Effort |
+|---|---|---|
+| E.1 | Decompose `F1ArcadeView`: extract `PlaybackState` (7 booleans + speed + seek), `StrategyLayerController` (init/spawn/teardown, `app.py:268-374`), `BroadcastService` (`_broadcast_if_due` + snapshot builders + `_frame_to_telemetry`) | M |
+| E.2 | Decompose `SimConnector`: `StrategyState` grows mutator methods (`set_error`, `push_decision`, `mark_finished`) killing the 11 `_lock` reach-ins; warmup + radio-corpus load delegate to the shared prewarm facade when P2 X-03 lands | M |
+| E.3 | `views.py` quick wins (backlog QW1-3): named steppers instead of 14 `setattr` lambdas, `LaunchConfig.autofill_team()`, plain default for `visible` | S |
+| E.4 | ESC/navigation: decide ESC = back-to-menu (replay -> `show_view(MenuView)`, which triggers `on_hide_view` teardown) with a second ESC to quit; verify and, if needed, harden dashboard-subprocess teardown on window close | S/M |
+| E.5 | Unit tests for the pure layer (formatters, `_normalize_scores`, `classify_alerts`, `_status_for`, `_build_stints`, `_rolling_mean`, ProgressBar math, `_frame_to_telemetry`) + a broadcast golden-payload test; coordinate scope with the Testing epic (#179) | M |
+
+---
+
+## 6. Open questions (need Víctor's call)
+
+1. **Engine ownership and order**: does Phase A execute as part of P2b's Phase 1 (engine first, arcade
+   delegates after) or does the P3 epic own the minimal engine? Same API either way; pick to avoid
+   parallel PRs on the same new module.
+2. **ESC semantics**: back-to-menu (recommended: the menu exists and currently can never be reached
+   again) or keep quit-on-ESC and add a separate key for menu?
+3. **Weather granularity**: per-lap values (cheap, matches `track_status_by_lap`, enough for a
+   strategy product) or time-interpolated per-frame (prettier, more loader work)? Recommendation: per-lap.
+4. **CACHE_VERSION coordination**: single v7 bump covering P2's SoA shape + B.1 weather + B.2 events,
+   to avoid invalidating users' 1.9 GB of session caches twice.
+5. **Frame-rate acceptance bar**: what hardware defines "good"? Proposal: p95 frame time <= 16.6 ms
+   with all cars + strategy + one connected dashboard on the dev laptop; C.3/C.4 are dropped if C.2
+   alone reaches it.
+6. **Bug-issue ceremony**: A4 (`--provider` ignored), A2 (fabricated weather) and A12 (round cap)
+   qualify as file-the-bug-first issues under the repo rule; confirm they get individual issues
+   rather than riding the phase issue.
+
+---
+
+## 7. Verification protocol
+
+- **Phase A**: contract test green (engine == orchestrator recommendation on fixture, both with mocked
+  LLM); one live arcade replay (Suzuka 2025, strategy ON) with decisions diffed lap-by-lap against a
+  pre-change run (actions must match; prose may differ); `rtk grep "_run_always_on_agents_from_state" src/arcade`
+  returns nothing outside the engine delegate.
+- **Phase B**: Qt/OS screenshot of the replay (via `arcade.get_image()` or OS capture) showing real
+  weather values changing across laps and SC spans on the timeline for a race with a known SC
+  (e.g. Suzuka/Qatar 2025); `f1-arcade --viewer --strategy --provider lmstudio` observed hitting
+  LM Studio (server log) with no `F1_LLM_PROVIDER` exported; menu can reach round 24 of 2025 and
+  cannot exceed round 22 of 2023.
+- **Phase C**: frame-time probe numbers in the PR description, before/after, same scene (all cars ON,
+  strategy ON, dashboard connected); acceptance bar from open question 5.
+- **Phase D**: dashboard smoke with both windows on one broker (single "Connected" transition in logs);
+  CPU sample of the Qt process before/after lap-gating during a paused replay (should drop to ~idle);
+  kill-the-dashboard-mid-race test: arcade frame time unaffected (non-blocking send path).
+- **Phase E**: `uv run pytest tests/ -v` green including the new pure-layer tests; manual smoke matrix:
+  menu -> 1-driver replay, menu -> 2-driver, strategy ON end-to-end, seek during strategy, ESC back to
+  menu -> relaunch a second replay in the same process (teardown proven by the second run working),
+  final quit leaves no orphaned Qt process (checked in Task Manager / `Get-Process`).
+- **Every phase**: `uvx ruff check . && uvx ruff format --check .`; the arcade import-smoke test suite
+  stays green on a PySide6-less environment (skip path intact).
+
+## 8. Alignment with sibling audits
+
+- **P2 (loading)**: owns the SoA cache (F-05), threaded menu load (F-06), cold-path extraction + quali
+  geometry (F-09), `get_data_root()` routing (F-11) and the prewarm facade (X-03). P3's C.4 and E.2
+  consume those; B.1's cache bump must be coordinated with F-05's.
+- **P2b (compute)**: owns the engine internals, profiles and every LLM/MC lever. P3 Phase A is the
+  arcade-side landing of its F10; A19 defers the season-frame filter to its F7.
+- **P4 (CLI)**: the engine + `build_race_state` from Phase A are exactly what the CLI duplicate should
+  consume; Phase A's contract test doubles as the CLI duplicate's acceptance oracle.
+- **Testing epic (#179)**: E.5's pure-layer tests slot into its fixture/golden strategy; avoid
+  duplicating scope by keeping arcade tests dict-in/tuple-out (no QApplication requirement).
+
+---
+
+### Appendix A - Evidence index (file:line)
+
+| Claim | Evidence |
+|---|---|
+| Body-copy + 7 private-helper imports + mirror comment | `src/arcade/strategy_pipeline.py:11-20, 28-36, 42-121` |
+| `_build_default_lap_state` copy of orchestrator block | `strategy_pipeline.py:124-167` vs `src/agents/strategy_orchestrator.py:1327-1367` |
+| `_build_race_state` duplicate of simulator helper (admitted) | `src/arcade/strategy.py:516-561` (docstring line 517-519) |
+| 3-tuple `_run_conditional_agents` (the mirror-failure precedent) | `strategy_orchestrator.py:1085-1165`; P2b audit F2 |
+| Hardcoded weather constants rendered as live data | `src/arcade/app.py:648-656`; `src/arcade/overlays.py:125-157` |
+| Weather loaded then discarded; events always empty | `src/arcade/data.py:268, 312` |
+| Dead flag-marker path; TrackStatus already extracted | `overlays.py:717-727`; `data.py:469-489` |
+| `--provider` parsed, never consumed; env-only provider | `src/arcade/main.py:57`; `app.py:288` |
+| Viewer path skips strategy-year validation | `main.py:67-123` vs `views.py:402-413` |
+| Track re-tessellation + immediate mode per frame | `src/arcade/track.py:183-192, 309-324`; precomputed screens at `:151-158` |
+| Per-frame 20-driver dict + shared-Text row mutation | `app.py:620-657`; `overlays.py:103-156, 216-288, 438-481` |
+| 10 Hz full dashboard re-render; highlighter re-runs; chart item churn | `dashboard/window.py:211-233`; `dashboard/reasoning_tabs.py:210-229`; `dashboard/tire_chart.py:163-218` |
+| Two stream clients in one Qt process | `dashboard/window.py:205-209`; `dashboard/telemetry_window.py:53-57` |
+| `asdict` of 30-decision tail per broadcast; blocking `sendall`; no-op keepalive | `strategy.py:155-176`; `src/arcade/stream.py:91, 99-103, 131-143` |
+| God class extents | `app.py:99-712` (strategy layer `:268-374`, broadcast `:416-488`, input `:532-575`) |
+| `SimConnector` concerns + 11 `_lock` reach-ins | `strategy.py:182-561`; reach-ins `:285-464` |
+| Round cap `min(23, ...)` vs 24-round calendars | `views.py:186-189`; `data/tire_compounds_by_race.json` (2024: 24, 2025: 24, 2023: 22 rounds, verified) |
+| ESC bypasses teardown path; no route back to menu | `app.py:532-534, 358-374`; only `views.py:459` calls `show_view` |
+| QSS `opacity` no-op idle dim | `dashboard/agent_card.py:155-158` |
+| Dead SSE config; unused `backend_url`; stale GP_NAMES (Monza twice) | `config.py:160-165, 216-240`; `strategy.py:205` |
+| Palette/classification triplication (deliberate, unguarded) | `config.py:66-147`; `dashboard/theme.py:1-13, 58-90`; `strategy.py:567-603` |
+| Only import-smoke tests exist | `tests/test_arcade_dashboard_imports.py` |
+| Season parquet unfiltered + `REPO_ROOT` paths (inherited) | `strategy.py:487-492, 506`; P2b F7, P2 F-11 |
+| Good patterns to keep: lap gate, stale-skip, Text pre-allocation, process isolation | `strategy.py:228-260`; `overlays.py:1-9`; `app.py:321-341` |


### PR DESCRIPTION
Add the three Fable audit plans from the 2026-07-05 batch (plan-only docs, no code touched). Each is tracked by an epic with per-phase sub-issues.

- `AUDIT_P3_ARCADE.md` - Arcade surface audit (pipeline duplication now 4x, fabricated on-screen weather, render/stream efficiency). Epic #199.
- `AUDIT_ML_AGENTS_EVAL.md` - ML / multi-agent evaluation & robustness (eval harness, calibration, MC + routing validation, ablation matrix). The test-set-contamination check gates the IEEE paper freeze. Epic #205.
- `AUDIT_DOCS_ACCURACY.md` - documentation accuracy (reconcile published metrics to the thesis/IEEE finals, fix broken commands and dead links). Epic #211.

Joins the earlier audit plans already in `documents/audits/`.
