### PR TITLE
chore: remove vestigial .dvcignore (DVC not used)

### DIFF
--- a/.dvcignore
+++ b/.dvcignore
@@ -1,3 +1,0 @@
-# Add patterns of files dvc should ignore, which could improve
-# the performance. Learn more at
-# https://dvc.org/doc/user-guide/dvcignore


### PR DESCRIPTION
Repo-root hygiene before the implementation sprints. The project versions data via the Hugging Face Hub (models/dataset) and will use MLflow for the future Studio - never DVC. Verified: no `.dvc/` dir, no `dvc.yaml`/`dvc.lock`, zero DVC references anywhere; the file is the 3-line boilerplate default. Removing it stops it misleading contributors into thinking DVC is part of the stack.