### PR TITLE
chore: promote P2b shared inference engine (rich + no-llm) to main

### DIFF
--- a/documents/audits/P2B_ENGINE_DESIGN.md
+++ b/documents/audits/P2B_ENGINE_DESIGN.md
@@ -1,0 +1,533 @@
+# P2b ENGINE DESIGN — `src/strategy/inference/engine.py` (#169, Phases 1.1 + 1.2)
+
+> **Author**: Fable 5 (design-before gate) · **Date**: 2026-07-10 · **Mode**: design only, NO code.
+> **Basis**: `documents/audits/AUDIT_P2B_CORE_COMPUTE.md` §7 (shared fast path), §8 (phased plan), §9 (risk register).
+> **Scope of #169**: Phase 1.1 (engine skeleton + `run_lap` + `rich` profile that reproduces today's
+> orchestrator behavior AND returns `agent_outputs`) + Phase 1.2 (true `no-llm` profile fixing the #166 crash).
+> **Out of scope, stated up front**: F6 4-way parallelism (Phase 2.2), the F2 one-line PMV hotfix (P4 duplicate),
+> F7 GP-filtered frame (Phase 1.3), F4 RAG cache (Phase 1.4), F5 silent-radio guard in rich mode (Phase 1.5),
+> the `fast` profile (Phase 2.1/3.1).
+> **Untouchability honored**: zero edits to `src/agents/**`, `scripts/run_simulation_cli.py`, `notebooks/**`, `legacy/**`.
+
+---
+
+## Gate decisions (Víctor, 2026-07-10)
+
+The design-before gate was reviewed and cleared with these answers to §7:
+- **Q1** — ratified: rich = option (a), engine re-drives the sequence via imported orchestrator layers.
+- **Q2** — **`_NullReActRunner` injection** into engine-private agent instances (zero `src/agents/` edits); revisit additive entry points at Phase 2.1.
+- **Q3** — per-stage timings now, per-agent in Phase 2.2 (accepted).
+- **Q4** — `PROFILES = ("rich", "no-llm")`; `fast` raises (accepted).
+- **Q5** — `no_llm.py` hosts the canonical `apply_guard_rails` (accepted).
+- **Q6** — **all four no-llm semantic deltas shipped** as part of the #166 fix (real numbers, `sc_currently_active` in routing, true-offline, never-attempt N28/N30).
+- **Q7** — private no-llm agent instances (accepted).
+- **Q8** — parity test as `data`+`llm` markers with in-file skips (accepted).
+
+Implementation note (deviation from §1): `__init__.py` is kept EMPTY (no re-export of `run_lap`) so the legacy `tire_predictor.py` importer (`src/agents/rules/degradation_rules.py:22`) is not coupled to the engine's model-heavy orchestrator import. Consumers import `from src.strategy.inference.engine import run_lap` directly.
+
+**Delivery split**: Phase 1.1 (rich profile + arcade delegate) lands first (live-smoke validated); Phase 1.2 (no-llm profile + parity/no-llm data-tier tests) lands second and closes #169 + #166.
+
+---
+
+## 0. The one-paragraph shape
+
+One new module family under `src/strategy/inference/` exposes
+`run_lap(race_state, laps_df, lap_state, *, profile, return_agent_outputs=True) -> (StrategyRecommendation, agent_outputs, stage_timings)`.
+The `rich` profile is the arcade's proven single-pass pattern (`src/arcade/strategy_pipeline.py:42-121`)
+promoted to its intended home: it re-drives the orchestrator's exact five-step sequence by **importing** the
+same seven layer functions the orchestrator itself calls (never copying their bodies), so `action` and
+`scenario_scores` are byte-identical to `run_strategy_orchestrator_from_state` by construction, while the
+intermediate sub-agent outputs are returned instead of discarded. The `no-llm` profile builds the deterministic
+path with **zero LLM clients constructed**: N25 and N29's numeric stages run through their existing no-LLM
+surfaces, N26/N27 run their real models through a deterministic tool-runner injected into engine-private agent
+instances (via the existing `_react_agent` lazy-cache seam), the 3-tuple from `_run_conditional_agents` is
+unpacked correctly (killing #166's `ValueError`), and the guard-rail policy already proven in the backend's
+`apply_guard_rails` is re-hosted as the canonical copy. Arcade's `strategy_pipeline.py` becomes a thin
+delegate; the CLI duplicate (P4) and the backend's `_run_no_llm_path` (P1) consume the same function later.
+
+---
+
+## 1. Module layout
+
+```
+src/strategy/inference/
+├── __init__.py          # re-exports: run_lap, PROFILES ("rich" | "no-llm")
+├── engine.py            # public API + rich profile + shared spine (~200 lines)
+├── no_llm.py            # no-llm profile internals (~200 lines)
+└── tire_predictor.py    # PRE-EXISTING legacy jupytext artifact (N06 era) — NOT touched by #169.
+                         # Flag for a separate cleanup/removal issue; unrelated to the engine.
+```
+
+Two files, split by concern per CLEAN_CODE (~300-line module rule): `engine.py` owns the profile-agnostic
+spine and the LLM-mode path; `no_llm.py` owns everything that exists only to make determinism possible.
+No class for the engine itself in #169: `run_lap` is a module-level function matching the audit §7 contract
+verbatim (three stateless consumers). Stateful construction (GP-filtered frame, RAG cache, warm agents) is
+Phase 1.3/1.4's decision and slots in later without changing the public signature.
+
+### 1.1 `engine.py` — contents
+
+| Symbol | Kind | Purpose |
+|---|---|---|
+| `run_lap(...)` | function (public) | Contract in §2. Dispatches on `profile`; wraps every stage in a `perf_counter` timer. |
+| `_run_rich(...)` | function | The five-step sequence (§3). Returns `(rec, agent_outputs, timings)`. |
+| `_build_default_lap_state(race_state, laps_df)` | function | Lifted verbatim from `src/arcade/strategy_pipeline.py:124-167` (itself a mirror of the orchestrator's inline block at `strategy_orchestrator.py:1327-1367`). The engine becomes the single non-orchestrator home; arcade's copy is deleted when it delegates. |
+| `_assemble_agent_outputs(...)` | function | Builds the dict in §2.2 — key set identical to arcade's today (`strategy_pipeline.py:108-120`) plus `guardrail_reason`. |
+| `_StageTimer` | tiny class | `perf_counter` context helper filling the `stage_timings` dict; ~15 lines. |
+| `PROFILES` | constant | `("rich", "no-llm")`. `"fast"` is intentionally rejected with a pointing error (§2.3). |
+
+**Imports from `src/agents/strategy_orchestrator.py`** (the complete list — all but two already precedented by
+`src/arcade/strategy_pipeline.py:28-36` and `backend/services/simulation/simulator.py:329-333`):
+
+| Symbol | Line | Precedent |
+|---|---|---|
+| `RaceState`, `StrategyRecommendation` | 157, 317 | public — everywhere |
+| `_run_always_on_agents_from_state` | 1049 | arcade |
+| `_decide_agents_to_call` | 475 | arcade, backend, CLI |
+| `_run_conditional_agents` (3-tuple, line 1165) | 1085 | arcade, backend, CLI |
+| `_run_mc_simulation` | 609 | arcade, backend, CLI |
+| `_build_orchestrator_prompt` | 741 | arcade |
+| `_get_orchestrator_llm` | 118 | arcade |
+| `_assemble_recommendation` | 1172 | arcade |
+| `_LLMSynthesis` | 246 | **new** — needed so the no-llm profile reuses `_assemble_recommendation` instead of hand-building the rec (§4.4) |
+| `_to_radio_message`, `_to_rcm_event` | 953, 970 | **new** — input coercion for the no-llm radio stage (§4.3); same coercion the orchestrator applies at 1063-1064 |
+
+The anti-F10 rule holds: every layer is the **same code object** the orchestrator executes. The only
+engine-owned "copies" are (a) the ~30-line call sequence itself (unavoidable — the sequence IS the module) and
+(b) `_build_default_lap_state` (quarantined in exactly one non-orchestrator place, and covered by the parity
+test's `lap_state=None` case, §5.2).
+
+### 1.2 `no_llm.py` — contents
+
+| Symbol | Kind | Purpose |
+|---|---|---|
+| `run_no_llm_lap(...)` | function | The deterministic path (§4). Called by `engine.run_lap` when `profile="no-llm"`. |
+| `_NullReActRunner` | class (~30 lines) | Deterministic stand-in for the LangGraph compiled graph: `invoke({'messages': [...]}) -> {'messages': [...]}`. Executes pre-bound tool closures, wraps their string outputs in real `langchain_core.messages.ToolMessage` objects, appends a final `AIMessage("[no-llm — deterministic tool pass]")`. |
+| `_get_no_llm_tire_agent()`, `_get_no_llm_situation_agent()` | lazy factories | Engine-private `TireAgent()` / `RaceSituationAgent()` instances (same lazy-singleton pattern as `_get_default_tire_agent`, `tire_agent.py:1191`). Private so the LLM-mode process singletons are never contaminated by the injected runner. |
+| `_run_radio_no_llm(...)` | function | N29 stages 1+2 without stage 3 (§4.3). |
+| `apply_guard_rails(action, lap, total_laps, compound, tyre_life, cliff_p10) -> (action, reason \| None)` | function | Canonical re-host of `src/telemetry/backend/services/simulation/guard_rails.py:30` (§4.5). |
+| `_deterministic_synthesis(best, guardrail_reason)` | function | Builds the `_LLMSynthesis` stand-in for `_assemble_recommendation` (§4.4). |
+
+**Imports from `src/agents/`** (all read-only; classes and module functions):
+
+- `pace_agent`: `run_pace_agent_from_state` (public; XGBoost only, zero LLM turns — audit §2.1 row 1).
+- `tire_agent`: `TireAgent` (class), `_compound_name_to_id` (line 599, needed to pre-bind tool args).
+- `race_situation_agent`: `RaceSituationAgent` (class).
+- `radio_agent`: `run_pipeline` (529), `run_rcm_pipeline` (604), `_build_alerts` (called at 985), `RadioOutput`, `RadioMessage`, `RCMEvent`.
+- `strategy_orchestrator`: the routing/MC/assembly symbols listed in §1.1.
+
+---
+
+## 2. The `run_lap` contract
+
+```python
+def run_lap(
+    race_state: RaceState,               # orchestrator's Pydantic model, unchanged
+    laps_df: pd.DataFrame,               # full laps frame (featured parquet or RSM slice)
+    lap_state: dict | None,              # RSM-shaped dict; None -> _build_default_lap_state
+    *,
+    profile: Literal["rich", "no-llm"] = "rich",
+    return_agent_outputs: bool = True,   # False -> slot 2 is None (compute is unchanged)
+) -> tuple[StrategyRecommendation, dict[str, Any] | None, dict[str, float]]:
+```
+
+Return type is **uniform across profiles** — always a real `StrategyRecommendation`, never the CLI's ad-hoc
+dict (`_run_no_llm`'s dict shape at `run_simulation_cli.py:1562-1576` is a consumer-side artifact the P4
+duplicate stops needing; the backend's `_parse_lap_decision` `isinstance(dict)` branch likewise becomes dead
+when P1 migrates).
+
+### 2.1 `StrategyRecommendation` (slot 1)
+
+- `rich`: exactly what `run_strategy_orchestrator_from_state` returns today (LLM synthesis via
+  `_get_orchestrator_llm().invoke(prompt)` + `_assemble_recommendation`). Parity contract: byte-identical
+  `action` and `scenario_scores` given identical LLM replies (§5).
+- `no-llm`: assembled through the **same** `_assemble_recommendation` helper from a deterministic
+  `_LLMSynthesis` (§4.4): `action` = guard-railed MC argmax, `reasoning` = `"[no-llm mode ...]"` string
+  (same wording family as CLI `run_simulation_cli.py:1558-1560`), `confidence=0.0`, `pace_mode="NEUTRAL"`,
+  `risk_posture="BALANCED"` (schema defaults), pit fields backfilled from `pit_out` (always `None` in
+  no-llm, so `None`), `scenario_scores` = full nested MC dict, `regulation_context=""`.
+
+### 2.2 `agent_outputs` (slot 2) — frozen key set
+
+Identical to arcade's existing contract (`strategy_pipeline.py:108-120`) so arcade's dashboard formatters
+work unchanged the day it delegates, plus one new key:
+
+| Key | Type | rich | no-llm |
+|---|---|---|---|
+| `pace_out` | `PaceOutput` | from `_run_always_on_agents_from_state` | real XGBoost numbers |
+| `tire_out` | `TireOutput` | same | real TCN + MC-dropout numbers via null runner |
+| `situation_out` | `RaceSituationOutput` | same | real LightGBM numbers + RCM SC override via null runner |
+| `radio_out` | `RadioOutput` | same | real NLP results + deterministic alerts; canned reasoning |
+| `pit_out` | `PitStrategyOutput \| None` | N28 when routed | **always `None`** (N28 is LLM-backed; §4.2) |
+| `regulation_context` | `str` | N30 answer or `""` | **always `""`** (N30 answer synthesis is LLM-backed) |
+| `rag` | `dict \| None` | structured N30 payload (question/answer/articles/chunks) | always `None` |
+| `active` | `list[str]` | routing result | routing result (still computed — the UI panel shows it) |
+| `guardrail_reason` | `str \| None` | **new** — always `None` | rail explanation or `None` |
+
+### 2.3 `stage_timings` (slot 3)
+
+`dict[str, float]` of seconds via `time.perf_counter`, stable extend-only key set:
+`{"always_on", "routing", "conditional", "mc", "synthesis", "total"}`.
+In `no-llm`, `"synthesis"` measures the deterministic assembly (≈0) and `"conditional"` the routing-only
+no-op. **Granularity note**: per-agent timings (audit Phase 0.2's wish) are NOT possible in #169 without
+unbundling `_run_always_on_agents_from_state`, which would copy its 2-thread-pool body (anti-F10). Stage-level
+lands now; per-agent granularity arrives naturally in Phase 2.2 when F6 forces the engine to own the pool.
+This partially folds Phase 0.2 into #169 — see open question Q3.
+
+**`profile="fast"`** raises `ValueError("profile 'fast' is P2b Phase 2 (audit F3/F11) — use 'rich' or 'no-llm'")`
+so consumers can already write the three-valued switch without silent fallthrough.
+
+---
+
+## 3. How `rich` returns `agent_outputs` without touching `src/agents/` — option (a), ratified
+
+**Chosen: (a) re-drive the orchestration in the engine by importing the same layer functions.** The engine's
+`_run_rich` is, statement for statement, the sequence of `run_strategy_orchestrator_from_state`
+(`strategy_orchestrator.py:1369-1418`):
+
+1. `_run_always_on_agents_from_state(race_state, laps_df, lap_state)` → `(pace, tire, situation, radio)`
+   — one imported call; keeps the exact N25∥N27 pool + serial N26/N29 threading of lines 1071-1081.
+2. `_decide_agents_to_call(tire.warning_level, situation.sc_prob_3lap, radio.alerts, situation.sc_currently_active)`.
+3. `_run_conditional_agents(active, lap_state, tire, situation, race_state, laps_df)` → **3-tuple**
+   `(pit_out, regulation_context, rag_dict)` — the engine is born on the post-`bfe5b46` contract, so the
+   F2 class of bug cannot recur here.
+4. `_run_mc_simulation(pace, tire, situation, pit_out, alpha=race_state.risk_tolerance)` → `best_mc` argmax.
+5. `_build_orchestrator_prompt(...)` → `_get_orchestrator_llm().invoke(prompt)` →
+   `_assemble_recommendation(synth, pit_out, mc_results, regulation_context)`.
+
+Then it keeps steps 1-3's intermediates and returns them as `agent_outputs` instead of discarding them.
+
+**Why (a) and not (b) "wrap the orchestrator and capture":** wrapping
+`run_strategy_orchestrator_from_state` would require runtime monkeypatching of the orchestrator module's
+helper references to interpose capturing shims — mutating untouchable module state at runtime, thread-unsafe
+for the backend, and invisible to a reader. Rejected in one line: patching a frozen module to spy on it is
+strictly worse than calling the same functions yourself.
+
+**Why parity is byte-identical in `action`/`scenario_scores`:** every layer function is imported, so the only
+code the engine "owns" is the argument plumbing between steps — and that plumbing is asserted equal by the
+parity test at the strongest possible level (the LLM prompt bytes, §5.3). `scenario_scores` additionally has
+no LLM in its lineage at all (`_run_mc_simulation` is seeded `default_rng(42)`, `strategy_orchestrator.py:637`,
+and frozen by `tests/test_strategy_goldens.py::_GOLDEN_ALPHA_05`), so it is deterministic given equal
+sub-agent outputs.
+
+**Arcade subsumption:** `src/arcade/strategy_pipeline.py::run_strategy_pipeline` keeps its public signature
+`(race_state, laps_df, lap_state=None) -> (rec, agent_outputs)` (its caller in `src/arcade/strategy.py` does
+not change) but its body becomes three lines: call `engine.run_lap(..., profile="rich")`, drop
+`stage_timings` (or forward it on the TCP stream later — P3's call), return `(rec, agent_outputs)`. Its
+private `_build_default_lap_state` and the seven orchestrator imports are deleted; the
+"mirror the change here" comment (`strategy_pipeline.py:19`) dies with them. That closes audit F10.
+
+---
+
+## 4. The `no-llm` profile (#166 fix) — deterministic, zero clients
+
+### 4.1 The sequence
+
+```
+1. pace_out      = run_pace_agent_from_state(lap_state)                # public, XGBoost only, no LLM by construction
+2. tire_out      = <no-llm TireAgent>.run_from_state(lap_state, laps_df)        # §4.2 — real TCN numbers, null runner
+3. situation_out = <no-llm RaceSituationAgent>.run_from_state(sit_lap_state, laps_df)  # §4.2 — real LightGBM + RCM override
+4. radio_out     = _run_radio_no_llm(race_state, lap_state)            # §4.3 — NLP stages 1+2, no stage 3
+5. active        = _decide_agents_to_call(tire.warning_level, situation.sc_prob_3lap,
+                                          radio.alerts, situation.sc_currently_active)
+6. pit_out, regulation_context, rag_dict = None, "", None              # §4.2 — N28/N30 never called (LLM-backed)
+   # NOTE: the 3-tuple contract is honored structurally: the engine never calls
+   # _run_conditional_agents in no-llm, so there is nothing to mis-unpack. #166's
+   # crash site (run_simulation_cli.py:1508 unpacking 2 of 3) is unreachable by design.
+7. mc            = _run_mc_simulation(pace, tire, situation, None, alpha=race_state.risk_tolerance)
+                   # pit_out=None -> the documented conservative prior Triangular(2.2, 2.8, 3.8), ucut 0.5
+                   # (strategy_orchestrator.py:670-683) — same degradation the CLI comment promises at :1503-1506
+8. best          = argmax(mc, key=score)
+9. best, reason  = apply_guard_rails(best, lap, total_laps, compound, tyre_life, tire.laps_to_cliff_p10)
+10. rec          = _assemble_recommendation(_deterministic_synthesis(best, reason), None, mc, "")
+```
+
+Steps 5-10 mirror the *intent* of CLI `_run_no_llm` (`run_simulation_cli.py:1408-1576`) and the backend's
+`_run_no_llm_path` (`simulator.py:308-442`) — with three deliberate semantic corrections, each named in §4.6.
+
+### 4.2 N26/N27 real numbers with zero clients: the `_NullReActRunner` injection
+
+**The problem**: `run_tire_agent_from_state` / `run_race_situation_agent_from_state` funnel into `_run_core`,
+which invokes a LangGraph ReAct agent (`tire_agent.py:1157-1163`, `race_situation_agent.py:1144-1147`). There
+is no public "numbers only" entry. Today's `--no-llm` therefore swaps in **hardcoded stubs** when the backend
+is down (CLI `:1451-1465` — `laps_to_cliff 20/25/30`, `deg_rate 0.05`), meaning the MC currently scores fake
+tire numbers in no-llm mode; and when LM Studio happens to be up, `--no-llm` silently makes real LLM calls
+(audit F8).
+
+**The seam**: both agent classes cache their compiled graph in `self._react_agent` and return it early when
+already set — `if self._react_agent is not None: return self._react_agent`
+(`tire_agent.py:980-981`, `race_situation_agent.py:973-974`). The engine constructs **its own private**
+`TireAgent()` / `RaceSituationAgent()` instances (classes are importable; same pattern as the
+`_get_default_*` factories) and pre-sets `instance._react_agent = _NullReActRunner(...)` before first use.
+Then the engine calls the instances' **public** `run_from_state(...)` end to end, which reuses with zero
+copies: the state-priming blocks (`tire_agent.py:1070-1114`, `race_situation_agent.py:1070-1104`), the
+wet-compound stub branch (`tire_agent.py:1142-1155`), `_parse_tool_outputs`, the output rounding, and the
+RCM SC override (`race_situation_agent.py:1149-1164` — `sc_currently_active` keeps working in no-llm, which
+today's stub path loses entirely).
+
+**The runner** (per lap, seeded by the engine with the args it already owns):
+
+- Tire instance: executes `agent._tools[0]` (`predict_tire_deg_tool`) and `agent._tools[1]`
+  (`estimate_laps_to_cliff_tool`) with `(driver, compound_id, tyre_life)`; `compound_id` comes from the
+  imported `_compound_name_to_id(compound, gp_name, year)` — the same call `run_from_state` makes at
+  `tire_agent.py:1082-1085`. The tool closures read the instance state that `run_from_state` just primed,
+  so the numbers are exactly what the LLM path's tools would compute (single TCN forward + the 50-pass
+  MC-dropout loop).
+- Situation instance: executes `predict_sc_tool(lap_number)` always, and
+  `predict_overtake_tool(driver_x, driver_y, lap_number)` only when a rival is derivable from
+  `lap_state["rivals"]` (the engine owns lap_state, so this is input prep, not a mirror). Skipping the
+  overtake tool on rival-less laps is safe: `_parse_tool_outputs` defaults every field to `0.0`
+  (`race_situation_agent.py:574`), which matches the agent's own system-prompt rule ("if gap > 2.5s ...
+  assume P(overtake) = 0.0", `race_situation_agent.py:628`).
+- Envelope: real `langchain_core.messages.ToolMessage` objects carrying the tools' string outputs (the same
+  strings the regex parsers were written against) + a final `AIMessage` whose content becomes the `reasoning`
+  field, satisfying both `_run_core` reasoning extractors (`tire_agent.py:1165-1170` skips tool-call
+  messages; `race_situation_agent.py:1147` takes `messages[-1].content`).
+
+**Why this over the alternatives:**
+
+- *Alt A — keep today's attempt-and-catch stubs*: keeps fake tire numbers in the MC, keeps the ~5-8 s/lap
+  retry backoff (audit F8), keeps the "silently LLM when LM Studio is up" semantic hole. Fails the audit's
+  Phase 1.2 exit ("no clients", real-inference 0.3-0.7 s target that explicitly includes "TCN 1+50 forwards").
+- *Alt B — mirror the tool bodies + state priming into the engine*: ~80-100 copied lines across two agents;
+  recreates exactly the F10 drift class this whole design exists to retire.
+- *Alt C — additive `run_direct_from_state()` entry points inside the agent modules*: cleanest long-term home
+  and permitted by the letter of the repo rule ("`src/agents/` internals — additive entry points only",
+  CLAUDE.md §0.2), but it edits untouchable files, which #169's charter forbids without Víctor's explicit
+  sanction. Kept on the table as open question **Q2** — if sanctioned, the null runner shrinks to nothing and
+  the injection seam disappears.
+
+The injection is the least-copy option available without touching `src/agents/`: one ~30-line class, zero
+duplicated model/feature logic, and the private-attribute dependency (`_react_agent`, `_tools`) is registered
+as a named risk (§6) exactly like the seven orchestrator helpers arcade already imports.
+
+**Why private instances, not the module singletons**: injecting into `_get_default_tire_agent()`'s singleton
+would leak the null runner into any later LLM-mode call in the same process (the backend serves both modes
+across requests). Cost of privacy: a second copy of the TCN bundles / LightGBM models in memory for no-llm
+processes — acceptable (bundle sizes are small; a no-llm CLI run typically never builds the LLM-mode
+singletons at all, so in practice memory is flat).
+
+### 4.3 N29 radio without stage 3
+
+`run_radio_agent` already computes everything load-bearing before its LLM: NLP inference
+(`run_pipeline`/`run_rcm_pipeline`, `radio_agent.py:977-978`) and deterministic alerts
+(`_build_alerts`, `:985`); the LLM only adds `reasoning`/`corrections` and is already internally optional
+(`:994-1006`). But calling `run_radio_agent_from_state` still constructs the client and pays retries when the
+backend is down, and really calls the LLM when it is up. The engine's `_run_radio_no_llm` therefore composes
+the same three imported functions directly:
+
+1. Coerce inputs with the orchestrator's own `_to_radio_message` / `_to_rcm_event` (the same coercion
+   `_run_always_on_agents_from_state` applies at `strategy_orchestrator.py:1063-1064`).
+2. `radio_results = [run_pipeline(m.text) for m in radio_msgs]`; `rcm_results = [run_rcm_pipeline(e) for e in rcm_events]`.
+3. `alerts = _build_alerts(radio_results, rcm_results, radio_msgs)`.
+4. `RadioOutput(radio_events=..., rcm_events=..., alerts=..., reasoning="[no-llm mode — radio synthesis skipped, NLP stages 1+2 applied]", corrections=[])`
+   — the same wording family `run_radio_agent` itself uses on LLM failure (`radio_agent.py:1005`).
+
+Empty lap: both lists are empty, all three calls are O(1) no-ops — the F5 guard is free here (rich-mode F5
+remains Phase 1.5). Note `run_radio_agent_from_state`'s `LAPS`/`SESSION_META` global priming is skipped; per
+its own docstring the laps frame is "not queried during inference" (`radio_agent.py:1034-1037`).
+
+### 4.4 Deterministic synthesis through the real assembly helper
+
+Rather than hand-building a `StrategyRecommendation` (a drift-prone field-by-field copy),
+`_deterministic_synthesis(best, guardrail_reason)` constructs a `_LLMSynthesis` (imported) with:
+`action=best`, `reasoning="[no-llm mode]" (+ " " + guardrail_reason when set)`, `confidence=0.0`,
+`pace_mode="NEUTRAL"`, `risk_posture="BALANCED"`, everything else default/None — and passes it through the
+imported `_assemble_recommendation(synth, pit_out=None, mc_results, regulation_context="")`. Any future field
+added to the schema flows through automatically; the no-llm rec can never structurally diverge from the rich
+rec.
+
+### 4.5 Guard-rails: where they live and why
+
+The deterministic decision policy exists today in two places: inline in the untouchable CLI
+(`run_simulation_cli.py:1529-1560`) and extracted as
+`apply_guard_rails(action, lap, total_laps, compound, tyre_life, cliff_p10) -> (action, reason | None)` in
+the backend (`src/telemetry/backend/services/simulation/guard_rails.py:30`). The engine cannot import the
+backend version — dependency direction would invert (the submodule imports the parent, e.g.
+`simulator.py:329`, never the reverse; parent surfaces like `f1-sim`/`f1-arcade` must not require the
+submodule checkout). So `no_llm.py` **re-hosts the backend's function with the identical signature and
+rule set** (no-pit-before-lap-5, no-pit-in-last-3 unless cliff P10 < 2, minimum stint SOFT 8 / MEDIUM 12 /
+HARD 15 — mirroring the LLM prompt rails at `strategy_orchestrator.py:862-877`). Yes, that is a third copy at
+birth — but it is the designated canonical one: the backend copy retires when P1 migrates
+`_run_no_llm_path` to `engine.run_lap`, and the CLI copy dies with the P4 duplicate. Net copies trend 3 → 1.
+
+### 4.6 Deliberate semantic deltas vs today's `_run_no_llm` (each is a fix, each must be in the PR text)
+
+1. **Real tire/situation numbers instead of hardcoded stubs** when no LLM backend is reachable (§4.2).
+2. **Routing sees `sc_currently_active`**: the CLI and backend no-llm paths call `_decide_agents_to_call`
+   with only 3 args (`run_simulation_cli.py:1497-1501`, `simulator.py:389-393`), silently defaulting the SC
+   flag to False; the engine passes `situation_out.sc_currently_active` like the orchestrator does
+   (`strategy_orchestrator.py:1375-1380`) — the RCMContextResolver lesson (Qatar V7) says this flag is
+   load-bearing.
+3. **True offline semantics**: no client construction at all, so `--no-llm` with LM Studio up no longer
+   silently becomes LLM mode (F8), and with it down there is no retry backoff.
+4. **N28/N30 never attempted** (vs attempted-then-caught): same end state (`pit_out=None`, `rag=""`) minus
+   the retry storm; `active` still reports what *would* have been routed, so panels stay honest.
+
+---
+
+## 5. Parity test design — `tests/test_engine_parity.py` (the audit §9 anti-drift guard)
+
+Tier: `@pytest.mark.data` + `@pytest.mark.llm` (markers registered in `pyproject.toml:214-220`), plus the
+`_skip_no_models` guard from `tests/test_strategy_goldens.py:29-33` — the `src.agents` import chain reads
+model configs at import time, so this is a data-tier test by construction (runs locally + on the data tier,
+skips on bare CI). FakeOpenAI is loaded from the submodule file
+(`src/telemetry/tests/fake_openai.py`) via `importlib.util.spec_from_file_location`, with
+`pytest.skip` when the submodule is not checked out and when port 1234 is taken (the server raises `OSError`
+on bind — its documented skip contract).
+
+### 5.1 Fixture and environment
+
+- `laps_df` = `tests/fixtures/mini_race.parquet` (9-lap Lusail 2025 slice, laps 5-13, SC on 7-10, drivers
+  VER/GAS/ANT/ALO/LEC/STR — `tests/fixtures/generate_mini_race.py:27-30`).
+- `race_state` = hand-built `RaceState` for a **quiet lap** (e.g. VER, lap 6, pre-SC, no radio/RCM buffers)
+  so routing activates neither N28 nor N30 and the LLM script stays short.
+- `monkeypatch.setenv("F1_LLM_PROVIDER", "lmstudio")` so every `ChatOpenAI` targets the stub's
+  `http://localhost:1234/v1`; `monkeypatch.setattr(strategy_orchestrator, "_orchestrator_llm", None)` to
+  reset the module-level LLM singleton between environments.
+
+### 5.2 Test 1 — rich-profile parity (engine == orchestrator)
+
+Script the stub with the quiet lap's exact 7-turn sequence, run the **orchestrator**, re-script the identical
+sequence, run the **engine**, compare:
+
+```
+turn 1  N27 ReAct  -> push_tool_call("predict_sc_tool", {"lap_number": 6})
+turn 2  N27 ReAct  -> push_text("<situation reasoning>")
+turn 3  N26 ReAct  -> push_tool_call("predict_tire_deg_tool", {driver, compound_id, tyre_life})
+turn 4  N26 ReAct  -> push_tool_call("estimate_laps_to_cliff_tool", {driver, compound_id, tyre_life})
+turn 5  N26 ReAct  -> push_text("<tire reasoning>")
+turn 6  N29 synth  -> push_tool_call("RadioSynthesis", {reasoning: "...", corrections: []})
+turn 7  N31 synth  -> push_tool_call("_LLMSynthesis", {action: "STAY_OUT", reasoning: "...", confidence: 0.7,
+                                                       pace_mode: "NEUTRAL", risk_posture: "BALANCED", ...})
+```
+
+(Structured-output turns must arrive as tool_calls whose function name matches what
+`with_structured_output` registers — verify the exact names against `fake.requests` during test bring-up;
+the stub records every request body precisely for this. Call ORDER is deterministic today because the only
+threaded pair is N25∥N27 and N25 makes zero LLM calls — `strategy_orchestrator.py:1071-1081`. When F6's
+4-way pool lands (Phase 2.2), FIFO scripting breaks and the stub needs content-based routing; flagged now.)
+
+Asserts, strongest first:
+
+1. `rec_engine.model_dump() == rec_orch.model_dump()` — full-recommendation equality (both runs consumed
+   byte-identical scripted replies, so everything downstream must match; `scenario_scores` is seed-42 MC and
+   would match even under different prose).
+2. **Prompt-byte parity**: `fake.requests[i]["messages"] == fake.requests[i + 7]["messages"]` for
+   `i in range(7)` — the engine sent the orchestrator's exact prompts, i.e. the argument plumbing between
+   the imported layers is identical. This is the single assert that makes silent drift impossible.
+3. `agent_outputs` sanity: keys per §2.2, `pit_out is None`, `active == []`, `regulation_context == ""`.
+4. Same test parametrized over `lap_state=None` (both sides build their default lap_state — covers the
+   engine's `_build_default_lap_state` copy against the orchestrator's inline block via assert 2) and an
+   explicit hand-built `lap_state` (the arcade/CLI calling convention).
+
+### 5.3 Test 2 — no-llm profile: zero error frames, zero LLM
+
+Sweep **all 9 fixture laps** (VER, laps 5-13; inject one synthetic `SAFETY_CAR_DEPLOYED` RCM dict on lap 8 to
+exercise the SC override + routing + guard-rails deterministically):
+
+1. **Zero clients, proven two ways**: (a) `monkeypatch.setattr(<each agent module>.ChatOpenAI, ...)` with a
+   class whose `__init__` raises `AssertionError("LLM client constructed in no-llm profile")` — patched in
+   `tire_agent`, `race_situation_agent`, `radio_agent`, `pit_strategy_agent`, `strategy_orchestrator`; and
+   (b) `assert fake.requests == []` (nothing ever reached the stub; the stub can even be omitted here — the
+   ChatOpenAI bomb is the real assert, making this sub-test hermetic apart from model weights).
+2. **Zero error frames**: every lap returns without raising; `rec.action` in the 5-value enum;
+   `rec.reasoning.startswith("[no-llm")`; `rec.scenario_scores` has all 4 strategies with the full
+   `{E, P10, P90, score}` shape (ties into `test_strategy_goldens.py`).
+3. **SC lap semantics**: on the injected-SC lap, `situation_out.sc_currently_active is True`,
+   `"N28" in active and "N30" in active` (routing parity with the orchestrator's truth table), yet
+   `pit_out is None` and no LLM constructed.
+4. **Determinism**: run lap 6 twice; `rec1.model_dump() == rec2.model_dump()` and
+   `timings` keys present both times.
+
+This pair of tests is also the enabler for the #180/#182 call-count spy (per
+`test_strategy_goldens.py:17-19`): with one inference path, a later test wraps the four `run_*_from_state`
+entry points with counters and asserts exactly one call per lap — designed-for here, not delivered in #169.
+
+---
+
+## 6. Untouchability and risk register
+
+**Nothing edited in**: `src/agents/**` (all engine access is imports of existing symbols plus attribute
+injection on engine-private instances), `scripts/run_simulation_cli.py` (the CLI keeps its broken `--no-llm`
+until the P4 duplicate consumes the engine; `tests/test_cli_no_llm.py` stays `xfail` and flips green with
+P4, or with the 1-line sanctioned hotfix if Víctor approves it via #166), `notebooks/**`, `legacy/**`.
+**Edited (allowed)**: new files under `src/strategy/inference/`, new `tests/test_engine_parity.py`,
+`src/arcade/strategy_pipeline.py` reduced to a delegate (arcade is explicitly editable; audit F10/P3).
+
+Private-symbol dependency register (the price of anti-F10; every one is named so a signature change is a
+findable event, and the parity test converts silent drift into a loud red):
+
+| Private symbol relied on | Where | Risk if it changes | Blast mitigation |
+|---|---|---|---|
+| `_run_always_on_agents_from_state` | orchestrator:1049 | signature/threading change alters rich parity | parity asserts 1+2 fail immediately |
+| `_run_conditional_agents` 3-tuple | orchestrator:1165 | a 4th element re-breaks consumers (the F2 pattern) | engine is the ONLY non-orchestrator caller left after P1/P4; change is 1 place |
+| `_decide_agents_to_call`, `_run_mc_simulation`, `_build_orchestrator_prompt`, `_get_orchestrator_llm`, `_assemble_recommendation`, `_LLMSynthesis`, `_to_radio_message`, `_to_rcm_event` | orchestrator | drift in routing/MC/prompt/assembly | goldens (`test_strategy_goldens.py`) freeze MC + routing; parity freezes prompt + assembly |
+| `TireAgent._react_agent` / `._tools` cache seam | tire_agent:709-710, 980-981 | renaming the attribute or eagerly building the graph breaks the injection | no-llm test 2 fails at first lap; seam documented in `no_llm.py` docstring with a "WHERE TO CHANGE IF" breadcrumb |
+| `RaceSituationAgent._react_agent` / `._tools` | race_situation_agent:973-974, 987 | same | same |
+| `_compound_name_to_id` | tire_agent:599 | arg-prep for the tire tools drifts from `run_from_state` | parity of tire numbers between profiles is asserted indirectly by test 2 shape checks; goldens cover thresholds |
+| `run_pipeline`, `run_rcm_pipeline`, `_build_alerts` | radio_agent:529/604/~660 | radio stages drift | these ARE the load-bearing logic (docstring at radio_agent:924-927); any change hits rich mode identically |
+
+Explicitly OUT of #169 (scheduled elsewhere): **F6** 4-way always-on parallelism (Phase 2.2, gated on the
+Phase 0.4 LM Studio concurrency probe; also breaks the FIFO stub scripting, §5.2 note). **F2 PMV hotfix**
+(P4 duplicate is the recommended fix vehicle; interim 1-liner only with Víctor's explicit sanction on #166).
+**F7** frame filtering, **F4** RAG cache, **F5** rich-mode silent-radio guard, **F11/`fast`** synthesis
+cadence. The engine's `run_lap` signature already leaves room for all of them without breaking consumers.
+
+---
+
+## 7. Open questions for Víctor (decisions needed before/while implementing)
+
+- **Q1 — rich approach**: ratify option (a) (engine re-drives the sequence via imported orchestrator layers,
+  subsuming arcade's pipeline) over wrapping the orchestrator. Recommendation: (a); (b) requires runtime
+  patching of an untouchable module.
+- **Q2 — the no-llm N26/N27 seam (the big one)**: sanction the `_NullReActRunner` injection on
+  engine-private agent instances (zero body copies, real TCN/LightGBM numbers, but a documented dependency on
+  the private `_react_agent`/`_tools` attributes), **or** authorize Alt C: small additive
+  `run_direct_from_state()` entry points inside `tire_agent.py`/`race_situation_agent.py` (permitted by the
+  letter of "additive entry points only", cleaner long-term, but it adds code to `src/agents/` files).
+  Recommendation: injection for #169 (keeps `src/agents/` byte-identical); revisit Alt C when Phase 2.1
+  builds direct mode for the LLM profiles anyway, which is the natural moment to bless additive entry points.
+- **Q3 — Phase 0.2 folding**: stage-level timings ship inside `run_lap` (§2.3), which covers most of the
+  Phase 0.2 timing harness. Accept "per-stage now, per-agent in Phase 2.2", or insist on per-agent timings in
+  #169 (would force unbundling `_run_always_on_agents_from_state` and copying its pool logic — not
+  recommended)?
+- **Q4 — `fast` boundary**: confirm `PROFILES = ("rich", "no-llm")` for #169 with `"fast"` raising a pointing
+  error (reserved for Phase 2.1/3.1: direct-mode sub-agents + event-triggered N31).
+- **Q5 — guard-rail canonical home**: accept `no_llm.py` hosting the third copy of `apply_guard_rails` as
+  canonical-going-forward (backend copy retires at P1 migration, CLI copy at P4)? The alternative (importing
+  from the submodule) inverts the dependency direction and is not recommended.
+- **Q6 — no-llm semantic deltas**: the four deltas in §4.6 (real numbers, `sc_currently_active` in routing,
+  true-offline, never-attempt N28/N30) are improvements but visible behavior changes vs today's broken path —
+  confirm they are wanted as part of the #166 fix narrative (they will be listed in the PR body).
+- **Q7 — private no-llm agent instances**: accept the small memory duplication (second TCN bundle set) in
+  exchange for zero contamination of the LLM-mode singletons? (Recommended; the alternative, injecting into
+  the process singletons, is only safe if a process is guaranteed single-profile, which the backend is not.)
+- **Q8 — test tier labeling**: parity test as `data` + `llm` markers with in-file skips for missing submodule
+  / occupied port 1234 — matches the existing marker taxonomy (`pyproject.toml:214-220`)?
+
+---
+
+## Appendix — evidence index (file:line)
+
+| Claim | Evidence |
+|---|---|
+| Orchestrator discards agent outputs; sequence to reproduce | `src/agents/strategy_orchestrator.py:1369-1418` |
+| 3-tuple contract of `_run_conditional_agents` | `strategy_orchestrator.py:1111-1120, 1165` |
+| Arcade single-pass verbose pipeline + 7 private imports + mirror warning | `src/arcade/strategy_pipeline.py:11-20, 28-36, 42-121` |
+| Arcade default lap_state copy | `strategy_pipeline.py:124-167` vs orchestrator inline `1327-1367` |
+| CLI probe+orchestrator double-run | `scripts/run_simulation_cli.py:1961-1964`; ack `:489-495` |
+| CLI broken 2-of-3 unpack (#166) | `run_simulation_cli.py:1508` |
+| CLI no-llm guard-rails (policy to preserve) | `run_simulation_cli.py:1529-1560` |
+| CLI no-llm hardcoded stubs (fake tire numbers) | `run_simulation_cli.py:1443-1472` |
+| CLI/backend routing omits `sc_currently_active` | `run_simulation_cli.py:1497-1501`; `simulator.py:389-393` |
+| Backend third mirror + extracted guard-rails | `src/telemetry/backend/services/simulation/simulator.py:308-442`; `guard_rails.py:30-37` |
+| Backend imports parent (dependency direction) | `simulator.py:329-333` |
+| Tire `_react_agent` cache seam + tools + `_run_core` | `src/agents/tire_agent.py:704-710, 828-946, 980-981, 1053-1181` |
+| Situation seam + `_parse_tool_outputs` defaults + RCM override | `src/agents/race_situation_agent.py:561-588, 973-974, 1046-1173` |
+| Radio NLP-first, internal LLM degradation, load-bearing stages | `src/agents/radio_agent.py:921-1014` (esp. 976-985, 994-1006) |
+| Pace agent no-LLM by construction | `src/agents/pace_agent.py:711-723`; audit §2.1 row 1 |
+| MC golden freeze + routing truth table | `tests/test_strategy_goldens.py:80-99, 160-182` |
+| CLI no-llm xfail smoke (flips with P4) | `tests/test_cli_no_llm.py:27-54` |
+| Fixture: 9-lap Lusail slice with SC | `tests/fixtures/generate_mini_race.py:27-30`; `tests/fixtures/README.md` |
+| FakeOpenAI stub on :1234, scripting + skip contracts | `src/telemetry/tests/fake_openai.py:1-49, 184-234` |
+| pytest marker taxonomy | `pyproject.toml:213-220` |

--- a/src/arcade/strategy_pipeline.py
+++ b/src/arcade/strategy_pipeline.py
@@ -1,22 +1,17 @@
-"""Arcade-local strategy pipeline.
+"""Arcade-local strategy pipeline — thin delegate over the shared engine.
 
-The arcade process runs the full N31 multi-agent pipeline without going
-through the backend SSE endpoint, so the dashboard subprocess can subscribe
-to the arcade TCP stream and receive both the synthesised
-``StrategyRecommendation`` and the raw per-sub-agent outputs (predicted lap
-time, CI bounds, tyre cliff percentiles, overtake and SC probabilities,
-undercut probability, pit duration percentiles, RAG text, …) on the same
-wire.
+The arcade process runs the full N31 multi-agent pipeline in-process (no backend
+SSE hop) so its dashboard subprocess can subscribe to the arcade TCP stream and
+receive both the synthesised ``StrategyRecommendation`` and the raw per-sub-agent
+outputs on the same wire.
 
-Body is a copy of ``src.agents.strategy_orchestrator.run_strategy_orchestrator_from_state``
-kept intentionally separate: the CLI and Streamlit paths import the
-orchestrator directly and must stay unaffected by anything the arcade
-does. Private helpers are imported from the orchestrator module — the same
-pattern ``backend/services/simulation/simulator.py::_run_no_llm_path``
-already uses (L339-L343), so it is an established way of reusing
-implementation details without touching ``src/agents/``.
-
-If you change the orchestrator body upstream, mirror the change here.
+This module used to be a body-copy of
+``src.agents.strategy_orchestrator.run_strategy_orchestrator_from_state`` with a
+"mirror the change here" warning — the exact drift the audit (AUDIT_P2B_CORE_COMPUTE
+F10) flagged and the #166 crash proved real. It now delegates to the single shared
+engine ``src.strategy.inference.engine.run_lap`` (``rich`` profile), which reproduces
+the orchestrator byte-for-byte AND returns the agent outputs. One code path, three
+surfaces; nothing to keep in sync by hand.
 """
 
 from __future__ import annotations
@@ -25,15 +20,7 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
-from src.agents.strategy_orchestrator import (
-    _assemble_recommendation,
-    _build_orchestrator_prompt,
-    _decide_agents_to_call,
-    _get_orchestrator_llm,
-    _run_always_on_agents_from_state,
-    _run_conditional_agents,
-    _run_mc_simulation,
-)
+from src.strategy.inference.engine import run_lap
 
 if TYPE_CHECKING:  # pragma: no cover — only for type hints
     from src.agents.strategy_orchestrator import RaceState, StrategyRecommendation
@@ -44,124 +31,14 @@ def run_strategy_pipeline(
     laps_df: pd.DataFrame,
     lap_state: dict | None = None,
 ) -> tuple["StrategyRecommendation", dict]:
-    """Run the full N31 pipeline and return both the recommendation and the
-    raw per-agent outputs.
+    """Run the full N31 pipeline; return the recommendation and per-agent outputs.
 
-    The agent outputs dict carries the six sub-agent dataclasses under
-    ``pace_out``, ``tire_out``, ``situation_out``, ``radio_out``,
-    ``pit_out``, plus ``regulation_context`` (string from N30 RAG) and
-    ``active`` (list of conditional agents that fired this lap). Shape is
-    identical to the intermediate state inside
-    ``run_strategy_orchestrator_from_state`` — so any formatter that knows
-    the orchestrator internals can be reused unchanged.
-
-    Pipeline order matches the orchestrator exactly: always-on agents →
-    routing decision → conditional agents → MC simulation → LLM synthesis.
+    Public signature is unchanged so ``src/arcade/strategy.py`` and the dashboard
+    formatters keep working. The ``agent_outputs`` dict carries the same keys as
+    before (``pace_out``/``tire_out``/``situation_out``/``radio_out``/``pit_out``/
+    ``regulation_context``/``rag``/``active``) plus ``guardrail_reason``; the
+    engine's third return value (stage timings) is dropped here (a future arcade
+    change may forward it on the TCP stream).
     """
-    if lap_state is None:
-        lap_state = _build_default_lap_state(race_state, laps_df)
-
-    pace_out, tire_out, situation_out, radio_out = _run_always_on_agents_from_state(
-        race_state, laps_df, lap_state
-    )
-
-    active = _decide_agents_to_call(
-        tire_warning=tire_out.warning_level,
-        sc_prob_3lap=situation_out.sc_prob_3lap,
-        radio_alerts=radio_out.alerts,
-        sc_currently_active=situation_out.sc_currently_active,
-    )
-
-    pit_out, regulation_context, rag_dict = _run_conditional_agents(
-        active=active,
-        lap_state=lap_state,
-        tire_out=tire_out,
-        situation_out=situation_out,
-        race_state=race_state,
-        laps_df=laps_df,
-    )
-    regulation_context = regulation_context or ""
-
-    mc_results = _run_mc_simulation(
-        pace_out=pace_out,
-        tire_out=tire_out,
-        situation_out=situation_out,
-        pit_out=pit_out,
-        alpha=race_state.risk_tolerance,
-    )
-    best_mc = max(mc_results, key=lambda s: mc_results[s]["score"])
-
-    prompt = _build_orchestrator_prompt(
-        race_state=race_state,
-        mc_results=mc_results,
-        best_mc=best_mc,
-        pace_out=pace_out,
-        tire_out=tire_out,
-        situation_out=situation_out,
-        pit_out=pit_out,
-        radio_out=radio_out,
-        regulation_context=regulation_context,
-    )
-    synth = _get_orchestrator_llm().invoke(prompt)
-    rec = _assemble_recommendation(synth, pit_out, mc_results, regulation_context)
-
-    agent_outputs = {
-        "pace_out": pace_out,
-        "tire_out": tire_out,
-        "situation_out": situation_out,
-        "radio_out": radio_out,
-        "pit_out": pit_out,
-        "regulation_context": regulation_context,
-        # Structured RAG payload (question / answer / articles / chunks)
-        # for the dashboard's RAG card. ``regulation_context`` above keeps
-        # the legacy answer string for the orchestrator's LLM prompt.
-        "rag": rag_dict,
-        "active": list(active),
-    }
+    rec, agent_outputs, _timings = run_lap(race_state, laps_df, lap_state, profile="rich")
     return rec, agent_outputs
-
-
-def _build_default_lap_state(race_state: "RaceState", laps_df: pd.DataFrame) -> dict:
-    """Build the minimal lap_state that every sub-agent expects.
-
-    Mirrors the default branch inside
-    ``run_strategy_orchestrator_from_state`` — kept private to this module
-    so the arcade pipeline stays self-contained and orchestrator internals
-    do not leak into the arcade's call sites.
-    """
-    driver_rows = laps_df[laps_df["Driver"] == race_state.driver]
-    lap_row = driver_rows[driver_rows["LapNumber"] == race_state.lap]
-    year = int(laps_df["Year"].iloc[0]) if "Year" in laps_df.columns else 2025
-    gp_name = str(laps_df["GP_Name"].iloc[0]) if "GP_Name" in laps_df.columns else ""
-    stint = int(lap_row["Stint"].iloc[0]) if not lap_row.empty else 1
-    team = str(lap_row["Team"].iloc[0]) if not lap_row.empty and "Team" in lap_row else "Unknown"
-    return {
-        "lap_number": race_state.lap,
-        "driver": {
-            "driver": race_state.driver,
-            "driver_number": 0,
-            "team": team,
-            "position": race_state.position,
-            "compound": race_state.compound,
-            "tyre_life": race_state.tyre_life,
-            "stint": stint,
-            "lap_time_s": None,
-            "speed_st": 300.0,
-            "fuel_load": 1 - race_state.lap / max(race_state.total_laps, 1),
-        },
-        "session_meta": {
-            "gp_name": gp_name,
-            "gp": gp_name,
-            "year": year,
-            "driver": race_state.driver,
-            "team": team,
-            "total_laps": race_state.total_laps,
-        },
-        "weather": {
-            "air_temp": race_state.air_temp,
-            "track_temp": race_state.track_temp,
-            "rainfall": race_state.rainfall,
-            "humidity": 50.0,
-        },
-        "rivals": [],
-    }

--- a/src/strategy/inference/engine.py
+++ b/src/strategy/inference/engine.py
@@ -1,0 +1,285 @@
+"""Shared strategy inference engine — one lap, one code path, three surfaces.
+
+Why this module exists
+----------------------
+Before this, three places ran the N31 pipeline as hand-mirrored body copies:
+``src/arcade/strategy_pipeline.py`` (verbose, returns agent outputs),
+``scripts/run_simulation_cli.py`` (probe + orchestrator, runs every agent twice),
+and the backend simulator's ``_run_no_llm_path``. The audit (AUDIT_P2B_CORE_COMPUTE
+F1/F10) showed this drift is a real bug source: the ``_run_conditional_agents``
+3-tuple change (commit bfe5b46) was mirrored into arcade but not the CLI, so every
+``--no-llm`` lap crashes (#166). This module is the single additive home the audit
+recommends (§7): CLI/Arcade/backend consume one ``run_lap`` instead of three copies.
+
+Design (per documents/audits/P2B_ENGINE_DESIGN.md, #169 Phases 1.1 + 1.2)
+--------------------------------------------------------------------------
+``run_lap`` dispatches on ``profile``:
+  * ``rich``   — reproduces ``run_strategy_orchestrator_from_state`` byte-for-byte
+                 (same ``action`` / ``scenario_scores``) by IMPORTING the exact
+                 orchestrator layer functions and re-driving their five-step
+                 sequence, but RETURNS the per-agent outputs the orchestrator's
+                 public API discards. This is arcade's proven pattern, promoted.
+  * ``no-llm`` — the deterministic, zero-LLM-client path (see ``no_llm.py``); fixes
+                 #166 by construction (it never calls ``_run_conditional_agents``).
+
+Untouchability: nothing in ``src/agents/`` is modified. Every strategy layer is the
+SAME code object the orchestrator runs (imported, never copied); the only
+engine-owned code is the call sequence itself and the default-lap_state builder.
+
+Anti-drift guard: ``tests/test_engine_parity.py`` asserts the engine's rich output
+equals the orchestrator's on a fixture lap, down to the byte-level LLM prompts.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Literal
+
+import pandas as pd
+
+from src.agents.strategy_orchestrator import (
+    RaceState,
+    StrategyRecommendation,
+    _assemble_recommendation,
+    _build_orchestrator_prompt,
+    _decide_agents_to_call,
+    _get_orchestrator_llm,
+    _run_always_on_agents_from_state,
+    _run_conditional_agents,
+    _run_mc_simulation,
+)
+
+# The profiles #169 delivers. ``fast`` (direct-mode sub-agents + event-triggered
+# N31, audit F3/F11) is a later phase and is rejected with a pointing error so
+# consumers can already write a three-valued switch without silent fallthrough.
+PROFILES: tuple[str, ...] = ("rich", "no-llm")
+
+Profile = Literal["rich", "no-llm"]
+
+
+class _StageTimer:
+    """``perf_counter`` context manager that records one stage's wall time.
+
+    Kept tiny and side-effect-local: it only writes its own key into the shared
+    ``timings`` dict on exit, so a stage's cost is captured even if it raises.
+    """
+
+    def __init__(self, timings: dict[str, float], key: str) -> None:
+        self._timings = timings
+        self._key = key
+
+    def __enter__(self) -> "_StageTimer":
+        self._start = time.perf_counter()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._timings[self._key] = time.perf_counter() - self._start
+
+
+def run_lap(
+    race_state: RaceState,
+    laps_df: pd.DataFrame,
+    lap_state: dict[str, Any] | None = None,
+    *,
+    profile: Profile = "rich",
+    return_agent_outputs: bool = True,
+) -> tuple[StrategyRecommendation, dict[str, Any] | None, dict[str, float]]:
+    """Run one lap of the N31 strategy pipeline and return everything a surface needs.
+
+    Args:
+        race_state: The orchestrator's Pydantic ``RaceState`` (unchanged).
+        laps_df: Full laps frame (featured parquet slice or an RSM-fed frame).
+        lap_state: RSM-shaped per-lap dict. ``None`` builds the minimal default
+            (``_build_default_lap_state``), matching the orchestrator's own inline
+            fallback so callers that only have a ``race_state`` still work.
+        profile: ``"rich"`` (LLM synthesis, full fidelity) or ``"no-llm"``
+            (deterministic, zero LLM clients). ``"fast"`` is reserved (raises).
+        return_agent_outputs: When ``False``, slot 2 is ``None`` (compute is
+            unchanged; only the assembly of the outputs dict is skipped).
+
+    Returns:
+        ``(recommendation, agent_outputs | None, stage_timings)`` where
+        ``recommendation`` is always a real ``StrategyRecommendation`` (never an
+        ad-hoc dict), ``agent_outputs`` carries the six sub-agent dataclasses +
+        routing/RAG context (see ``_assemble_agent_outputs``), and
+        ``stage_timings`` maps each stage name to its seconds.
+
+    Raises:
+        ValueError: on an unknown profile, or on the reserved ``"fast"`` profile.
+    """
+    if profile == "rich":
+        return _run_rich(race_state, laps_df, lap_state, return_agent_outputs)
+    if profile == "no-llm":
+        # Imported lazily so the rich path never pays the no_llm module's agent
+        # class imports, and so a circular import can never form.
+        from src.strategy.inference.no_llm import run_no_llm_lap
+
+        return run_no_llm_lap(race_state, laps_df, lap_state, return_agent_outputs)
+    if profile == "fast":
+        raise ValueError("profile 'fast' is P2b Phase 2 (audit F3/F11) — use 'rich' or 'no-llm'")
+    raise ValueError(f"unknown profile {profile!r}; expected one of {PROFILES}")
+
+
+def _run_rich(
+    race_state: RaceState,
+    laps_df: pd.DataFrame,
+    lap_state: dict[str, Any] | None,
+    return_agent_outputs: bool,
+) -> tuple[StrategyRecommendation, dict[str, Any] | None, dict[str, float]]:
+    """The rich profile: the orchestrator's five-step sequence, outputs retained.
+
+    Statement for statement this mirrors ``run_strategy_orchestrator_from_state``
+    (always-on agents -> routing -> conditional agents -> Monte Carlo -> LLM
+    synthesis), but every step is an IMPORTED orchestrator function, so the result
+    is byte-identical to the orchestrator's while the intermediate agent outputs
+    are returned instead of discarded.
+    """
+    timings: dict[str, float] = {}
+    if lap_state is None:
+        lap_state = _build_default_lap_state(race_state, laps_df)
+
+    with _StageTimer(timings, "always_on"):
+        pace_out, tire_out, situation_out, radio_out = _run_always_on_agents_from_state(
+            race_state, laps_df, lap_state
+        )
+
+    with _StageTimer(timings, "routing"):
+        active = _decide_agents_to_call(
+            tire_warning=tire_out.warning_level,
+            sc_prob_3lap=situation_out.sc_prob_3lap,
+            radio_alerts=radio_out.alerts,
+            sc_currently_active=situation_out.sc_currently_active,
+        )
+
+    with _StageTimer(timings, "conditional"):
+        pit_out, regulation_context, rag_dict = _run_conditional_agents(
+            active=active,
+            lap_state=lap_state,
+            tire_out=tire_out,
+            situation_out=situation_out,
+            race_state=race_state,
+            laps_df=laps_df,
+        )
+        regulation_context = regulation_context or ""
+
+    with _StageTimer(timings, "mc"):
+        mc_results = _run_mc_simulation(
+            pace_out=pace_out,
+            tire_out=tire_out,
+            situation_out=situation_out,
+            pit_out=pit_out,
+            alpha=race_state.risk_tolerance,
+        )
+        best_mc = max(mc_results, key=lambda s: mc_results[s]["score"])
+
+    with _StageTimer(timings, "synthesis"):
+        prompt = _build_orchestrator_prompt(
+            race_state=race_state,
+            mc_results=mc_results,
+            best_mc=best_mc,
+            pace_out=pace_out,
+            tire_out=tire_out,
+            situation_out=situation_out,
+            pit_out=pit_out,
+            radio_out=radio_out,
+            regulation_context=regulation_context,
+        )
+        synth = _get_orchestrator_llm().invoke(prompt)
+        rec = _assemble_recommendation(synth, pit_out, mc_results, regulation_context)
+
+    timings["total"] = sum(timings.values())
+
+    agent_outputs = None
+    if return_agent_outputs:
+        agent_outputs = _assemble_agent_outputs(
+            pace_out=pace_out,
+            tire_out=tire_out,
+            situation_out=situation_out,
+            radio_out=radio_out,
+            pit_out=pit_out,
+            regulation_context=regulation_context,
+            rag_dict=rag_dict,
+            active=active,
+            guardrail_reason=None,  # rich mode applies rails via the LLM prompt, not post-hoc
+        )
+    return rec, agent_outputs, timings
+
+
+def _assemble_agent_outputs(
+    *,
+    pace_out: Any,
+    tire_out: Any,
+    situation_out: Any,
+    radio_out: Any,
+    pit_out: Any,
+    regulation_context: str,
+    rag_dict: dict[str, Any] | None,
+    active: Any,
+    guardrail_reason: str | None,
+) -> dict[str, Any]:
+    """Build the per-agent outputs dict consumers (arcade dashboard) render.
+
+    The key set is identical to arcade's historical contract
+    (``strategy_pipeline.py``) so its formatters keep working the day it delegates,
+    plus ``guardrail_reason`` (``None`` in rich mode, populated in no-llm mode).
+    """
+    outputs = {
+        "pace_out": pace_out,
+        "tire_out": tire_out,
+        "situation_out": situation_out,
+        "radio_out": radio_out,
+        "pit_out": pit_out,
+        "regulation_context": regulation_context,
+        "rag": rag_dict,
+        "active": list(active),
+        "guardrail_reason": guardrail_reason,
+    }
+    return outputs
+
+
+def _build_default_lap_state(race_state: RaceState, laps_df: pd.DataFrame) -> dict[str, Any]:
+    """Build the minimal ``lap_state`` every sub-agent expects from a bare RaceState.
+
+    Lifted verbatim from ``src/arcade/strategy_pipeline._build_default_lap_state``
+    (itself a mirror of the orchestrator's inline fallback). The engine is now the
+    single non-orchestrator home for it; arcade's copy is deleted when it delegates.
+    The parity test's ``lap_state=None`` case guards this against the orchestrator's
+    inline block.
+    """
+    driver_rows = laps_df[laps_df["Driver"] == race_state.driver]
+    lap_row = driver_rows[driver_rows["LapNumber"] == race_state.lap]
+    year = int(laps_df["Year"].iloc[0]) if "Year" in laps_df.columns else 2025
+    gp_name = str(laps_df["GP_Name"].iloc[0]) if "GP_Name" in laps_df.columns else ""
+    stint = int(lap_row["Stint"].iloc[0]) if not lap_row.empty else 1
+    team = str(lap_row["Team"].iloc[0]) if not lap_row.empty and "Team" in lap_row else "Unknown"
+    lap_state = {
+        "lap_number": race_state.lap,
+        "driver": {
+            "driver": race_state.driver,
+            "driver_number": 0,
+            "team": team,
+            "position": race_state.position,
+            "compound": race_state.compound,
+            "tyre_life": race_state.tyre_life,
+            "stint": stint,
+            "lap_time_s": None,
+            "speed_st": 300.0,
+            "fuel_load": 1 - race_state.lap / max(race_state.total_laps, 1),
+        },
+        "session_meta": {
+            "gp_name": gp_name,
+            "gp": gp_name,
+            "year": year,
+            "driver": race_state.driver,
+            "team": team,
+            "total_laps": race_state.total_laps,
+        },
+        "weather": {
+            "air_temp": race_state.air_temp,
+            "track_temp": race_state.track_temp,
+            "rainfall": race_state.rainfall,
+            "humidity": 50.0,
+        },
+        "rivals": [],
+    }
+    return lap_state

--- a/src/strategy/inference/no_llm.py
+++ b/src/strategy/inference/no_llm.py
@@ -1,0 +1,333 @@
+"""Deterministic, zero-LLM-client inference profile for the shared engine.
+
+This is the ``no-llm`` half of ``engine.run_lap`` (P2b #169 Phase 1.2) and the real
+fix for #166. The broken CLI ``--no-llm`` path crashed because it unpacked 2 values
+from ``_run_conditional_agents`` (a 3-tuple since commit bfe5b46); here the crash is
+unreachable by construction — the no-llm path never calls that function (N28/N30 are
+LLM-backed and simply not run).
+
+What "no-llm" means here (design doc §4, gate decision Q6 = ship all four deltas):
+  * ZERO LLM clients are ever constructed (a test bombs ``ChatOpenAI.__init__`` to
+    prove it) — no retry storm, and ``--no-llm`` can never silently become LLM mode.
+  * N25/N26/N27/N29 produce REAL model numbers, not hardcoded stubs: pace via its
+    public XGBoost entry, tire/situation by injecting a deterministic tool-runner
+    (``_NullReActRunner``) into ENGINE-PRIVATE agent instances at the ``_react_agent``
+    cache seam, so ``run_from_state`` runs end to end (priming, tool execution, output
+    parsing, and the RCM Safety-Car override all reused, not reinvented).
+  * Routing sees ``sc_currently_active`` (the Qatar V7 lesson), so under a deployed SC
+    N28/N30 are correctly *routed* (reported in ``active``) even though, being
+    LLM-backed, they are not executed (``pit_out`` stays ``None``).
+  * The guard-rail decision policy is applied deterministically to the MC argmax.
+
+Untouchability: nothing in ``src/agents/`` is edited — the injection sets a private
+attribute on the engine's OWN agent instances (never the module singletons, so an
+LLM-mode call in the same process is never contaminated).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from src.agents.pace_agent import run_pace_agent_from_state
+from src.agents.race_situation_agent import RaceSituationAgent
+from src.agents.radio_agent import RadioOutput, _build_alerts, run_pipeline, run_rcm_pipeline
+from src.agents.strategy_orchestrator import (
+    RaceState,
+    StrategyRecommendation,
+    _assemble_recommendation,
+    _decide_agents_to_call,
+    _LLMSynthesis,
+    _run_mc_simulation,
+    _to_radio_message,
+    _to_rcm_event,
+)
+from src.agents.tire_agent import TireAgent, _compound_name_to_id
+from src.strategy.inference.engine import (
+    _assemble_agent_outputs,
+    _build_default_lap_state,
+    _StageTimer,
+)
+
+# ---------------------------------------------------------------------------
+# Guard-rails — canonical re-host of the backend's apply_guard_rails.
+# Identical rule set to src/telemetry/backend/services/simulation/guard_rails.py
+# and the CLI's inline copy (run_simulation_cli.py L1504-L1535). Re-hosted rather
+# than imported because the parent must never depend on the submodule; the backend
+# copy retires when P1 migrates, the CLI copy when the P4 duplicate lands (3 -> 1).
+# ---------------------------------------------------------------------------
+_PIT_ACTIONS = frozenset({"PIT_NOW", "UNDERCUT", "OVERCUT", "REACTIVE_SC"})
+_NO_PIT_BEFORE_LAP = 5
+_NO_PIT_LAST_N_LAPS = 3
+_CLIFF_P10_SAFE = 2
+_MIN_STINT_LAPS = {"SOFT": 8, "MEDIUM": 12, "HARD": 15}
+_DEFAULT_MIN_STINT = 10
+
+
+def apply_guard_rails(
+    action: str,
+    lap: int,
+    total_laps: int,
+    compound: str,
+    tyre_life: int,
+    cliff_p10: float = 99.0,
+) -> tuple[str, str | None]:
+    """Override *action* with STAY_OUT when a hard strategic constraint fires.
+
+    Rules: no pit before lap 5; no pit in the last 3 laps unless the cliff is
+    imminent (cliff_p10 < 2); minimum stint SOFT 8 / MEDIUM 12 / HARD 15. Returns
+    ``(action, reason)`` with ``reason=None`` when no rail fired.
+    """
+    if action not in _PIT_ACTIONS:
+        return action, None
+
+    remaining_laps = total_laps - lap
+
+    if lap < _NO_PIT_BEFORE_LAP:
+        return "STAY_OUT", f"guard-rail: pit window not open (lap < {_NO_PIT_BEFORE_LAP})"
+
+    if remaining_laps <= _NO_PIT_LAST_N_LAPS and cliff_p10 >= _CLIFF_P10_SAFE:
+        return "STAY_OUT", f"guard-rail: too late to pit (<={_NO_PIT_LAST_N_LAPS} laps left)"
+
+    min_life = _MIN_STINT_LAPS.get(compound, _DEFAULT_MIN_STINT)
+    if tyre_life < min_life:
+        return (
+            "STAY_OUT",
+            f"guard-rail: minimum stint not reached ({compound} {tyre_life}/{min_life} laps)",
+        )
+
+    return action, None
+
+
+# ---------------------------------------------------------------------------
+# The deterministic tool-runner injected at the agents' _react_agent seam.
+# ---------------------------------------------------------------------------
+class _NullReActRunner:
+    """Stand-in for the LangGraph ReAct graph — runs pre-bound tools, no LLM.
+
+    ``get_react_agent`` returns ``self._react_agent`` early when it is set, and
+    ``_run_core`` calls ``.invoke({'messages': [...]}) -> {'messages': [...]}`` then
+    regex-parses the tool outputs from the message contents. So this runner executes
+    the agent's real tool closures (the same TCN / LightGBM inference the LLM path
+    would trigger), wraps each returned string in a ``ToolMessage`` the parser reads,
+    and appends a final ``AIMessage`` that becomes the ``reasoning`` field.
+    """
+
+    def __init__(self, tool_calls: list[tuple[Any, dict[str, Any]]]) -> None:
+        # tool_calls: ordered list of (LangChain tool, kwargs) to execute this lap.
+        self._tool_calls = tool_calls
+
+    def invoke(self, payload: dict[str, Any]) -> dict[str, Any]:
+        from langchain_core.messages import AIMessage, ToolMessage
+
+        messages: list[Any] = []
+        for i, (tool, kwargs) in enumerate(self._tool_calls):
+            output = tool.invoke(kwargs)
+            messages.append(ToolMessage(content=str(output), tool_call_id=f"nullrun-{i}"))
+        messages.append(AIMessage(content="[no-llm — deterministic tool pass]"))
+        return {"messages": messages}
+
+
+# Engine-private agent instances (lazy). Kept separate from the module singletons
+# (_get_default_*), so injecting the null runner here never leaks into an LLM-mode
+# call served by the same process (the backend serves both modes).
+_tire_agent: TireAgent | None = None
+_situation_agent: RaceSituationAgent | None = None
+
+
+def _get_tire_agent() -> TireAgent:
+    global _tire_agent
+    if _tire_agent is None:
+        _tire_agent = TireAgent()
+    return _tire_agent
+
+
+def _get_situation_agent() -> RaceSituationAgent:
+    global _situation_agent
+    if _situation_agent is None:
+        _situation_agent = RaceSituationAgent()
+    return _situation_agent
+
+
+def _tire_no_llm(lap_state: dict[str, Any], laps_df: pd.DataFrame):
+    """Run N26 with real TCN numbers and no LLM, via the injected null runner.
+
+    Pre-binds both tire tools (predict_tire_deg + estimate_laps_to_cliff) with the
+    same (driver, compound_id, tyre_life) args ``run_from_state`` derives, then calls
+    the instance's public ``run_from_state`` so all its priming/parsing is reused.
+    """
+    agent = _get_tire_agent()
+    driver = lap_state["session_meta"]["driver"]
+    d = lap_state["driver"]
+    meta = lap_state["session_meta"]
+    compound = d.get("compound", "MEDIUM")
+    tyre_life = d.get("tyre_life", 1)
+    gp_name = meta.get("gp_name", "")
+    year = meta.get("year", 2025)
+    compound_id = (
+        compound if compound.startswith("C") else _compound_name_to_id(compound, gp_name, year)
+    )
+    args = {"driver": driver, "compound_id": compound_id, "tyre_life": tyre_life}
+    agent._react_agent = _NullReActRunner([(tool, args) for tool in agent._tools])
+    return agent.run_from_state(lap_state, laps_df)
+
+
+def _situation_no_llm(sit_lap_state: dict[str, Any], laps_df: pd.DataFrame):
+    """Run N27 with real LightGBM numbers + the RCM SC override, no LLM.
+
+    Executes predict_sc_tool always, predict_overtake_tool only when a rival ahead is
+    derivable (parser defaults overtake fields to 0.0 otherwise). ``run_from_state``
+    then applies the SafetyCar RCM override exactly as in LLM mode.
+    """
+    agent = _get_situation_agent()
+    meta = sit_lap_state["session_meta"]
+    d = sit_lap_state["driver"]
+    driver = meta["driver"]
+    lap_number = sit_lap_state["lap_number"]
+    rivals = sit_lap_state.get("rivals", []) or []
+    driver_pos = d.get("position", 20)
+    rival = next((r["driver"] for r in rivals if r.get("position") == driver_pos - 1), None)
+
+    tools = {tool.name: tool for tool in agent._tools}
+    calls: list[tuple[Any, dict[str, Any]]] = [
+        (tools["predict_sc_tool"], {"lap_number": lap_number})
+    ]
+    if rival:
+        calls.append(
+            (
+                tools["predict_overtake_tool"],
+                {"driver_x": driver, "driver_y": rival, "lap_number": lap_number},
+            )
+        )
+    agent._react_agent = _NullReActRunner(calls)
+    return agent.run_from_state(sit_lap_state, laps_df)
+
+
+def _run_radio_no_llm(radio_lap_state: dict[str, Any]) -> RadioOutput:
+    """Run N29 stages 1+2 (NLP inference + deterministic alerts), skipping the LLM.
+
+    ``radio_msgs`` / ``rcm_events`` are already coerced (RadioMessage / RCMEvent) by
+    the caller, mirroring run_radio_agent's own stages 1-2; stage 3 (synthesis) is the
+    only LLM step and is dropped, matching the wording run_radio_agent uses on failure.
+    """
+    radio_msgs = radio_lap_state.get("radio_msgs", []) or []
+    rcm_events = radio_lap_state.get("rcm_events", []) or []
+    radio_results = [run_pipeline(msg.text) for msg in radio_msgs]
+    rcm_results = [run_rcm_pipeline(ev) for ev in rcm_events]
+    alerts = _build_alerts(radio_results, rcm_results, radio_msgs)
+    return RadioOutput(
+        radio_events=radio_results,
+        rcm_events=rcm_results,
+        alerts=alerts,
+        reasoning="[no-LLM mode — radio synthesis skipped, NLP stages 1+2 still applied]",
+        corrections=[],
+    )
+
+
+def _deterministic_synthesis(action: str, guardrail_reason: str | None) -> "_LLMSynthesis":
+    """Build the synthesis stand-in fed to the real ``_assemble_recommendation``.
+
+    Using the schema object (not a hand-built StrategyRecommendation) means any future
+    field flows through automatically and the no-llm rec can never structurally diverge
+    from the rich rec.
+    """
+    reasoning = "[no-llm mode — MC argmax + guard-rails, no LLM synthesis]"
+    if guardrail_reason:
+        reasoning += " " + guardrail_reason
+    synth = _LLMSynthesis(
+        action=action,
+        reasoning=reasoning,
+        confidence=0.0,
+        pace_mode="NEUTRAL",
+        risk_posture="BALANCED",
+        contingencies=[],
+        key_risks=[],
+    )
+    return synth
+
+
+def run_no_llm_lap(
+    race_state: RaceState,
+    laps_df: pd.DataFrame,
+    lap_state: dict[str, Any] | None,
+    return_agent_outputs: bool,
+) -> tuple[StrategyRecommendation, dict[str, Any] | None, dict[str, float]]:
+    """Deterministic no-LLM lap — the ``no-llm`` profile of ``engine.run_lap``.
+
+    Mirrors the orchestrator's always-on feeding (radio/rcm coercion, sit_lap_state
+    carrying rcm_events for the SC override) but runs every agent with zero LLM
+    clients, then routes, runs the MC (pit_out=None -> conservative prior), guard-rails
+    the argmax, and assembles the recommendation through the real helper.
+    """
+    timings: dict[str, float] = {}
+    if lap_state is None:
+        lap_state = _build_default_lap_state(race_state, laps_df)
+
+    radio_msgs = [_to_radio_message(m) for m in race_state.radio_msgs]
+    rcm_events = [_to_rcm_event(e) for e in race_state.rcm_events]
+    radio_lap_state = {
+        **lap_state,
+        "lap": race_state.lap,
+        "radio_msgs": radio_msgs,
+        "rcm_events": rcm_events,
+    }
+    sit_lap_state = {**lap_state, "rcm_events": rcm_events}
+
+    with _StageTimer(timings, "always_on"):
+        pace_out = run_pace_agent_from_state(lap_state)
+        tire_out = _tire_no_llm(lap_state, laps_df)
+        situation_out = _situation_no_llm(sit_lap_state, laps_df)
+        radio_out = _run_radio_no_llm(radio_lap_state)
+
+    with _StageTimer(timings, "routing"):
+        active = _decide_agents_to_call(
+            tire_warning=tire_out.warning_level,
+            sc_prob_3lap=situation_out.sc_prob_3lap,
+            radio_alerts=radio_out.alerts,
+            sc_currently_active=situation_out.sc_currently_active,
+        )
+
+    with _StageTimer(timings, "conditional"):
+        # N28 (pit) and N30 (RAG) are LLM-backed, so they are never run in no-llm.
+        # `active` above still reports what WOULD have routed, so the panels stay honest.
+        pit_out, regulation_context, rag_dict = None, "", None
+
+    with _StageTimer(timings, "mc"):
+        mc_results = _run_mc_simulation(
+            pace_out=pace_out,
+            tire_out=tire_out,
+            situation_out=situation_out,
+            pit_out=pit_out,  # None -> conservative prior (Triangular 2.2/2.8/3.8, ucut 0.5)
+            alpha=race_state.risk_tolerance,
+        )
+        best_mc = max(mc_results, key=lambda s: mc_results[s]["score"])
+
+    with _StageTimer(timings, "synthesis"):
+        action, guardrail_reason = apply_guard_rails(
+            best_mc,
+            race_state.lap,
+            race_state.total_laps,
+            race_state.compound,
+            race_state.tyre_life,
+            tire_out.laps_to_cliff_p10,
+        )
+        synth = _deterministic_synthesis(action, guardrail_reason)
+        rec = _assemble_recommendation(synth, pit_out, mc_results, regulation_context)
+
+    timings["total"] = sum(timings.values())
+
+    agent_outputs = None
+    if return_agent_outputs:
+        agent_outputs = _assemble_agent_outputs(
+            pace_out=pace_out,
+            tire_out=tire_out,
+            situation_out=situation_out,
+            radio_out=radio_out,
+            pit_out=pit_out,
+            regulation_context=regulation_context,
+            rag_dict=rag_dict,
+            active=active,
+            guardrail_reason=guardrail_reason,
+        )
+    return rec, agent_outputs, timings

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,49 @@
+"""Contract tests for the shared inference engine's public dispatch.
+
+Covers the ``run_lap`` profile contract that CLI/Arcade/backend consumers rely on:
+the two delivered profiles, the reserved ``fast`` profile (a pointing error so a
+three-valued switch never falls through silently), and an unknown-profile guard.
+
+Data-tier: importing the engine pulls ``src.agents.strategy_orchestrator``, whose
+sub-agent modules read model configs at import time, so this carries the same
+``_skip_no_models`` guard as the other agent-touching tests. The full
+engine-vs-orchestrator byte-parity test (the anti-drift guard) lands with the
+no-llm profile in Phase 1.2 (it additionally needs the FakeOpenAI stub on :1234).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+_skip_no_models = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="data/models/ not present (CI runner without model weights)",
+)
+
+
+@_skip_no_models
+def test_profiles_are_rich_and_no_llm():
+    from src.strategy.inference.engine import PROFILES
+
+    assert PROFILES == ("rich", "no-llm")
+
+
+@_skip_no_models
+def test_fast_profile_is_reserved_with_a_pointing_error():
+    """``fast`` is Phase 2 — it must raise, not silently fall through to a default."""
+    from src.strategy.inference.engine import run_lap
+
+    with pytest.raises(ValueError, match="fast"):
+        run_lap(None, None, profile="fast")  # raises before touching race_state/laps_df
+
+
+@_skip_no_models
+def test_unknown_profile_raises():
+    from src.strategy.inference.engine import run_lap
+
+    with pytest.raises(ValueError):
+        run_lap(None, None, profile="does-not-exist")

--- a/tests/test_engine_no_llm.py
+++ b/tests/test_engine_no_llm.py
@@ -1,0 +1,131 @@
+"""No-LLM profile tests for the shared engine — the executable #166 fix.
+
+These prove the deterministic ``run_lap(profile="no-llm")`` path:
+  * constructs ZERO LLM clients (a bomb on every agent module's ``ChatOpenAI``
+    ``__init__`` fires if any client is built) — so ``--no-llm`` can never crash on
+    the old 3-tuple, never pays retry backoff, and never silently becomes LLM mode;
+  * runs every lap without raising, over the whole 9-lap mini_race fixture;
+  * respects the Safety-Car RCM override (``sc_currently_active`` -> routing forces
+    N28/N30) while still never running the LLM-backed N28/N30 (``pit_out`` stays None);
+  * is deterministic.
+
+Data-tier (`_skip_no_models`): importing the engine pulls the agent modules, which
+read model configs at import. Runs locally + on the data tier; skips on bare CI.
+Hermetic apart from model weights — the ``ChatOpenAI`` bomb, not a live server, is
+what proves "zero clients", so no port 1234 / FakeOpenAI stub is needed here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+_skip_no_models = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="data/models/ not present (CI runner without model weights)",
+)
+
+FIXTURE = ROOT / "tests" / "fixtures" / "mini_race.parquet"
+_ACTIONS = {"STAY_OUT", "PIT_NOW", "UNDERCUT", "OVERCUT", "ALERT"}
+_AGENT_MODULES = (
+    "src.agents.tire_agent",
+    "src.agents.race_situation_agent",
+    "src.agents.radio_agent",
+    "src.agents.pit_strategy_agent",
+    "src.agents.strategy_orchestrator",
+)
+
+
+class _LLMClientBomb:
+    """Explodes if any no-llm code path constructs an LLM client."""
+
+    def __init__(self, *args, **kwargs):
+        raise AssertionError("LLM client constructed in the no-llm profile")
+
+
+@pytest.fixture
+def no_llm_clients(monkeypatch):
+    """Bomb ``ChatOpenAI`` in every agent module — the zero-clients guarantee."""
+    import importlib
+
+    for module_path in _AGENT_MODULES:
+        module = importlib.import_module(module_path)
+        if hasattr(module, "ChatOpenAI"):
+            monkeypatch.setattr(module, "ChatOpenAI", _LLMClientBomb)
+
+
+def _race_state(df: pd.DataFrame, lap: int, rcm_events=None):
+    from src.agents.strategy_orchestrator import RaceState
+
+    row = df[(df["Driver"] == "VER") & (df["LapNumber"] == lap)].iloc[0]
+    return RaceState(
+        driver="VER",
+        lap=lap,
+        total_laps=13,
+        position=int(row["Position"]),
+        compound=str(row["Compound"]),
+        tyre_life=int(row["TyreLife"]),
+        gap_ahead_s=1.5,
+        pace_delta_s=0.2,
+        air_temp=28.0,
+        track_temp=35.0,
+        rcm_events=rcm_events or [],
+    )
+
+
+@pytest.fixture(scope="module")
+def rsm_and_df():
+    from src.simulation.race_state_manager import RaceStateManager
+
+    df = pd.read_parquet(FIXTURE)
+    team = df.loc[df["Driver"] == "VER", "Team"].iloc[0]
+    rsm = RaceStateManager(df, driver_code="VER", team=team, gp_name="Lusail", year=2025)
+    return rsm, df
+
+
+@_skip_no_models
+def test_no_llm_sweep_produces_a_decision_every_lap_with_zero_clients(no_llm_clients, rsm_and_df):
+    """The #166 fix: every fixture lap returns a valid recommendation, no LLM client."""
+    from src.strategy.inference.engine import run_lap
+
+    rsm, df = rsm_and_df
+    for lap in range(5, 14):
+        rec, outs, timings = run_lap(
+            _race_state(df, lap), df, rsm.get_lap_state(lap), profile="no-llm"
+        )
+        assert rec.action in _ACTIONS, f"lap {lap}: bad action {rec.action}"
+        assert rec.reasoning.startswith("[no-llm"), f"lap {lap}: {rec.reasoning[:40]}"
+        assert set(rec.scenario_scores) == {"STAY_OUT", "PIT_NOW", "UNDERCUT", "OVERCUT"}
+        for scores in rec.scenario_scores.values():
+            assert set(scores) == {"E", "P10", "P90", "score"}
+        assert outs["pit_out"] is None  # N28 is LLM-backed, never run in no-llm
+        assert "total" in timings
+
+
+@_skip_no_models
+def test_no_llm_safety_car_lap_routes_n28_n30_without_running_them(no_llm_clients, rsm_and_df):
+    """A deployed SC (RCM) forces sc_currently_active + N28/N30 routing, pit still None."""
+    from src.strategy.inference.engine import run_lap
+
+    rsm, df = rsm_and_df
+    sc_rcm = [{"message": "SAFETY CAR DEPLOYED", "category": "SafetyCar", "flag": "", "lap": 8}]
+    rec, outs, _ = run_lap(
+        _race_state(df, 8, rcm_events=sc_rcm), df, rsm.get_lap_state(8), profile="no-llm"
+    )
+    assert outs["situation_out"].sc_currently_active is True
+    assert {"N28", "N30"} <= set(outs["active"])
+    assert outs["pit_out"] is None  # routed but never executed (LLM-backed)
+
+
+@_skip_no_models
+def test_no_llm_is_deterministic(no_llm_clients, rsm_and_df):
+    from src.strategy.inference.engine import run_lap
+
+    rsm, df = rsm_and_df
+    first = run_lap(_race_state(df, 6), df, rsm.get_lap_state(6), profile="no-llm")[0]
+    second = run_lap(_race_state(df, 6), df, rsm.get_lap_state(6), profile="no-llm")[0]
+    assert first.model_dump() == second.model_dump()


### PR DESCRIPTION
Promotes the P2b shared inference engine from dev to main: Phase 1.1 (rich profile + arcade delegate, PR #350) and Phase 1.2 (no-llm profile fixing the --no-llm crash, PR #351). The underlying commit carries Closes #166, which fires on merge to main. Standard test/dev/main promotion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared race strategy engine supporting rich and deterministic no-LLM execution profiles.
  * Added deterministic lap recommendations with tire, situation, radio, simulation, routing, and guard-rail analysis.
  * Arcade strategy processing now uses the shared inference engine and returns agent-level results.
  * Added stage timing information and consistent strategy output formatting.

* **Documentation**
  * Added design and audit documentation describing engine behavior, profiles, parity expectations, and risks.

* **Tests**
  * Added coverage for profile validation, deterministic no-LLM execution, safety-car routing, and repeatable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->