### PR TITLE
feat(eval): ML metrics-registry + calibration harness (f1-eval, #206)

### DIFF
--- a/documents/eval_reports/calibration.json
+++ b/documents/eval_reports/calibration.json
@@ -1,0 +1,90 @@
+{
+  "header": {
+    "harness_sha": "91b98d3",
+    "dataset": "2025 holdout + frozen calibration artifacts",
+    "seed_policy": "deterministic",
+    "era_tag": "2022-2025",
+    "llm": "none",
+    "schema_version": "1",
+    "generated_at": "2026-07-11T15:07:21+00:00",
+    "artifacts": {
+      "overtake_model": "cbb9d0eb0beb",
+      "pit_cfg": "41dd673a93fb",
+      "tcn_mc_calib": "e03a170f6de4"
+    }
+  },
+  "results": [
+    {
+      "model": "overtake",
+      "metric": "brier_calibrated",
+      "value": 0.05199088812235834,
+      "nominal": null,
+      "status": "ok",
+      "detail": "n=10217; brier raw 0.1304 -> cal 0.0520 (Platt val-2024)"
+    },
+    {
+      "model": "overtake",
+      "metric": "ece_calibrated",
+      "value": 0.03191338187300733,
+      "nominal": 0.05,
+      "status": "ok",
+      "detail": "n=10217; 10-bin equal-width"
+    },
+    {
+      "model": "pit_duration",
+      "metric": "p05_p95_coverage",
+      "value": 0.7047,
+      "nominal": 0.9,
+      "status": "drift",
+      "detail": "config-declared (recompute pending N15 holdout); 0.7047 vs 0.90 nominal"
+    },
+    {
+      "model": "tire_degradation[C2]",
+      "metric": "mc_mean_sigma_s",
+      "value": 0.1244,
+      "nominal": null,
+      "status": "ok",
+      "detail": "deployed epistemic sigma; empirical coverage wired-pending (N33-D)"
+    },
+    {
+      "model": "tire_degradation[C4]",
+      "metric": "mc_mean_sigma_s",
+      "value": 0.1504,
+      "nominal": null,
+      "status": "ok",
+      "detail": "deployed epistemic sigma; empirical coverage wired-pending (N33-D)"
+    },
+    {
+      "model": "tire_degradation[C5]",
+      "metric": "mc_mean_sigma_s",
+      "value": 0.1549,
+      "nominal": null,
+      "status": "ok",
+      "detail": "deployed epistemic sigma; empirical coverage wired-pending (N33-D)"
+    },
+    {
+      "model": "tire_degradation[C6]",
+      "metric": "mc_mean_sigma_s",
+      "value": 0.2621,
+      "nominal": null,
+      "status": "ok",
+      "detail": "deployed epistemic sigma; empirical coverage wired-pending (N33-D)"
+    },
+    {
+      "model": "safety_car",
+      "metric": "ece_calibrated",
+      "value": null,
+      "nominal": 0.05,
+      "status": "pending",
+      "detail": "engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from sc_labeled holdout (#207)"
+    },
+    {
+      "model": "undercut",
+      "metric": "ece_calibrated",
+      "value": null,
+      "nominal": 0.05,
+      "status": "pending",
+      "detail": "historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207)"
+    }
+  ]
+}

--- a/documents/eval_reports/calibration.md
+++ b/documents/eval_reports/calibration.md
@@ -1,0 +1,17 @@
+# calibration
+
+- harness `91b98d3` · schema v1 · generated 2026-07-11T15:07:21+00:00
+- era 2022-2025 · dataset 2025 holdout + frozen calibration artifacts · seed deterministic · llm none
+- artifacts: overtake_model=`cbb9d0eb0beb`, pit_cfg=`41dd673a93fb`, tcn_mc_calib=`e03a170f6de4`
+
+| model | metric | value | nominal | status | detail |
+|---|---|---|---|---|---|
+| pit_duration | p05_p95_coverage | 0.7047 | 0.9 | drift | config-declared (recompute pending N15 holdout); 0.7047 vs 0.90 nominal |
+| safety_car | ece_calibrated | - | 0.05 | pending | engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from sc_labeled holdout (#207) |
+| undercut | ece_calibrated | - | 0.05 | pending | historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207) |
+| overtake | brier_calibrated | 0.0520 | - | ok | n=10217; brier raw 0.1304 -> cal 0.0520 (Platt val-2024) |
+| overtake | ece_calibrated | 0.0319 | 0.05 | ok | n=10217; 10-bin equal-width |
+| tire_degradation[C2] | mc_mean_sigma_s | 0.1244 | - | ok | deployed epistemic sigma; empirical coverage wired-pending (N33-D) |
+| tire_degradation[C4] | mc_mean_sigma_s | 0.1504 | - | ok | deployed epistemic sigma; empirical coverage wired-pending (N33-D) |
+| tire_degradation[C5] | mc_mean_sigma_s | 0.1549 | - | ok | deployed epistemic sigma; empirical coverage wired-pending (N33-D) |
+| tire_degradation[C6] | mc_mean_sigma_s | 0.2621 | - | ok | deployed epistemic sigma; empirical coverage wired-pending (N33-D) |

--- a/documents/eval_reports/metrics_registry.json
+++ b/documents/eval_reports/metrics_registry.json
@@ -1,0 +1,118 @@
+{
+  "header": {
+    "harness_sha": "91b98d3",
+    "dataset": "model_configs + thesis Tabla 6.1",
+    "seed_policy": "deterministic",
+    "era_tag": "2022-2025",
+    "llm": "none",
+    "schema_version": "1",
+    "generated_at": "2026-07-11T15:07:44+00:00",
+    "artifacts": {
+      "overtake_cfg": "f72ef54ebbc8",
+      "undercut_cfg": "b0250c8522a2",
+      "pit_cfg": "41dd673a93fb",
+      "sc_cfg": "4691fb9c30c1"
+    }
+  },
+  "entries": [
+    {
+      "model": "overtake",
+      "family": "classification",
+      "metric": "auc_pr_test",
+      "value": 0.5491,
+      "threshold": 0.7976,
+      "split": "train [2023, 2024] / test 2025",
+      "source": "config: overtake_probability/model_config.json",
+      "canonical": true,
+      "note": "LightGBM + Platt(val 2024); auc_roc 0.8758"
+    },
+    {
+      "model": "undercut",
+      "family": "classification",
+      "metric": "auc_pr_test",
+      "value": 0.6739,
+      "threshold": 0.522,
+      "split": "train [2023, 2024] / test 2025",
+      "source": "config: pit_prediction/model_config_undercut_v1.json",
+      "canonical": true,
+      "note": "LightGBM + Platt(val 2024); baseline_pr 0.3452"
+    },
+    {
+      "model": "pit_duration",
+      "family": "quantile",
+      "metric": "p50_mae_test_s",
+      "value": 0.487,
+      "threshold": null,
+      "split": "train [2023, 2024] / test 2025",
+      "source": "config: pit_prediction/model_config.json",
+      "canonical": true,
+      "note": "HistGBT P05/P50/P95; baseline_mae 1.677; P05-P95 coverage 0.7047 vs 0.90 nominal (see calibration report)"
+    },
+    {
+      "model": "safety_car",
+      "family": "classification",
+      "metric": "auc_pr_test",
+      "value": 0.0723,
+      "threshold": 0.2335,
+      "split": "train [2023, 2024] / test 2025",
+      "source": "config: safety_car_probability/feature_list_v1.json",
+      "canonical": true,
+      "note": "LightGBM + Platt(val 2024); baseline 0.0432; 3-lap lift 1.673; target sc_within_3_laps"
+    },
+    {
+      "model": "pace",
+      "family": "regression",
+      "metric": "mae_test_s",
+      "value": 0.4104,
+      "threshold": null,
+      "split": "test 2025",
+      "source": "thesis Tabla 6.1 (final)",
+      "canonical": true,
+      "note": "XGBoost delta lap time; split provenance pending (#207)"
+    },
+    {
+      "model": "pace",
+      "family": "regression",
+      "metric": "mae_test_s",
+      "value": 0.392,
+      "threshold": null,
+      "split": "test 2025",
+      "source": "notebook N06 (superseded)",
+      "canonical": false,
+      "note": "notebook-era value; superseded by thesis-final 0.4104"
+    },
+    {
+      "model": "tire_degradation",
+      "family": "regression",
+      "metric": "mae_test_s",
+      "value": 0.7078,
+      "threshold": null,
+      "split": "test 2025",
+      "source": "thesis Tabla 6.1 (global)",
+      "canonical": true,
+      "note": "TireDegTCN; per-compound best C2 0.5501s; missed R2 target; split provenance pending (#207)"
+    },
+    {
+      "model": "sentiment",
+      "family": "nlp",
+      "metric": "accuracy",
+      "value": 0.84,
+      "threshold": null,
+      "split": "held-out radio set",
+      "source": "thesis Tabla 6.1 (final)",
+      "canonical": true,
+      "note": "RoBERTa; macro-F1 0.75; NLP harness in #304"
+    },
+    {
+      "model": "sentiment",
+      "family": "nlp",
+      "metric": "accuracy",
+      "value": 0.875,
+      "threshold": null,
+      "split": "held-out radio set",
+      "source": "published-era (superseded)",
+      "canonical": false,
+      "note": "87.5% published; superseded by thesis-final 0.84"
+    }
+  ]
+}

--- a/documents/eval_reports/metrics_registry.md
+++ b/documents/eval_reports/metrics_registry.md
@@ -1,0 +1,22 @@
+# metrics_registry
+
+- harness `91b98d3` · schema v1 · generated 2026-07-11T15:07:44+00:00
+- era 2022-2025 · dataset model_configs + thesis Tabla 6.1 · seed deterministic · llm none
+- artifacts: overtake_cfg=`f72ef54ebbc8`, undercut_cfg=`b0250c8522a2`, pit_cfg=`41dd673a93fb`, sc_cfg=`4691fb9c30c1`
+
+| model | metric | value | thr | split | canonical | source |
+|---|---|---|---|---|---|---|
+| overtake | auc_pr_test | 0.5491 | 0.7976 | train [2023, 2024] / test 2025 | yes | config: overtake_probability/model_config.json |
+| undercut | auc_pr_test | 0.6739 | 0.522 | train [2023, 2024] / test 2025 | yes | config: pit_prediction/model_config_undercut_v1.json |
+| pit_duration | p50_mae_test_s | 0.487 | - | train [2023, 2024] / test 2025 | yes | config: pit_prediction/model_config.json |
+| safety_car | auc_pr_test | 0.0723 | 0.2335 | train [2023, 2024] / test 2025 | yes | config: safety_car_probability/feature_list_v1.json |
+| pace | mae_test_s | 0.4104 | - | test 2025 | yes | thesis Tabla 6.1 (final) |
+| pace | mae_test_s | 0.392 | - | test 2025 | no | notebook N06 (superseded) |
+| tire_degradation | mae_test_s | 0.7078 | - | test 2025 | yes | thesis Tabla 6.1 (global) |
+| sentiment | accuracy | 0.84 | - | held-out radio set | yes | thesis Tabla 6.1 (final) |
+| sentiment | accuracy | 0.875 | - | held-out radio set | no | published-era (superseded) |
+
+## Divergences reconciled
+
+- **pace mae_test_s**: 0.392 (notebook N06 (superseded)) -> **0.4104** (thesis Tabla 6.1 (final))
+- **sentiment accuracy**: 0.875 (published-era (superseded)) -> **0.84** (thesis Tabla 6.1 (final))

--- a/documents/eval_reports/reproduction.json
+++ b/documents/eval_reports/reproduction.json
@@ -1,0 +1,64 @@
+{
+  "header": {
+    "harness_sha": "91b98d3",
+    "dataset": "2025 holdout vs published model_configs",
+    "seed_policy": "deterministic",
+    "era_tag": "2022-2025",
+    "llm": "none",
+    "schema_version": "1",
+    "generated_at": "2026-07-11T15:07:22+00:00",
+    "artifacts": {
+      "overtake_model": "cbb9d0eb0beb"
+    }
+  },
+  "results": [
+    {
+      "model": "overtake",
+      "metric": "auc_pr_test",
+      "published": 0.5491,
+      "reproduced": 0.5491139336464441,
+      "status": "reproduced",
+      "detail": "|delta| 0.0000 vs tol 0.01"
+    },
+    {
+      "model": "undercut",
+      "metric": "auc_pr_test",
+      "published": 0.6739,
+      "reproduced": null,
+      "status": "pending",
+      "detail": "historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207)"
+    },
+    {
+      "model": "pit_duration",
+      "metric": "p50_mae_test_s",
+      "published": 0.487,
+      "reproduced": null,
+      "status": "pending",
+      "detail": "pit_labeled holdout empty on disk (#207)"
+    },
+    {
+      "model": "safety_car",
+      "metric": "auc_pr_test",
+      "published": 0.0723,
+      "reproduced": null,
+      "status": "pending",
+      "detail": "engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from holdout (#207)"
+    },
+    {
+      "model": "pace",
+      "metric": "mae_test_s",
+      "published": 0.4104,
+      "reproduced": null,
+      "status": "pending",
+      "detail": "laptime holdout feature build not wired this phase"
+    },
+    {
+      "model": "tire_degradation",
+      "metric": "mae_test_s",
+      "published": 0.7078,
+      "reproduced": null,
+      "status": "pending",
+      "detail": "TCN MC forward pass not run this phase (see calibration MC-sigma)"
+    }
+  ]
+}

--- a/documents/eval_reports/reproduction.md
+++ b/documents/eval_reports/reproduction.md
@@ -1,0 +1,14 @@
+# reproduction
+
+- harness `91b98d3` · schema v1 · generated 2026-07-11T15:07:22+00:00
+- era 2022-2025 · dataset 2025 holdout vs published model_configs · seed deterministic · llm none
+- artifacts: overtake_model=`cbb9d0eb0beb`
+
+| model | metric | published | reproduced | status | detail |
+|---|---|---|---|---|---|
+| overtake | auc_pr_test | 0.5491 | 0.5491 | reproduced | |delta| 0.0000 vs tol 0.01 |
+| undercut | auc_pr_test | 0.6739 | - | pending | historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207) |
+| pit_duration | p50_mae_test_s | 0.487 | - | pending | pit_labeled holdout empty on disk (#207) |
+| safety_car | auc_pr_test | 0.0723 | - | pending | engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from holdout (#207) |
+| pace | mae_test_s | 0.4104 | - | pending | laptime holdout feature build not wired this phase |
+| tire_degradation | mae_test_s | 0.7078 | - | pending | TCN MC forward pass not run this phase (see calibration MC-sigma) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ f1-strat     = "scripts.f1_cli:main"
 f1-sim       = "scripts.run_simulation_cli:main"
 f1-arcade    = "src.arcade.main:main"
 f1-streamlit = "scripts.run_streamlit:main"
+f1-eval      = "src.strategy.eval.cli:main"
 
 [project.optional-dependencies]
 dev = [

--- a/src/strategy/eval/__init__.py
+++ b/src/strategy/eval/__init__.py
@@ -1,0 +1,25 @@
+"""Additive evaluation harness for the F1 StratLab ML predictors (issue #206).
+
+The measurement foundation the paper builds on: a reproducible metrics
+registry (E-08) + calibration verification (E-03), launched by the ``f1-eval``
+console script. Nothing here touches the UNTOUCHABLE trees (``src/agents/``
+internals, ``notebooks/``, ``run_simulation_cli.py``); it only reads frozen
+artifacts under ``data/models/`` and the labeled holdouts under
+``data/processed/``.
+
+Public API:
+- ``build_registry`` / ``load_registry`` - the consolidated metrics table.
+- ``build_calibration_report`` - reliability/Brier/ECE + quantile coverage.
+- ``build_reproduction_report`` - headline numbers re-derived vs the configs.
+"""
+
+from src.strategy.eval.calibration import build_calibration_report
+from src.strategy.eval.registry import build_registry, load_registry
+from src.strategy.eval.reproduce import build_reproduction_report
+
+__all__ = [
+    "build_registry",
+    "load_registry",
+    "build_calibration_report",
+    "build_reproduction_report",
+]

--- a/src/strategy/eval/calibration.py
+++ b/src/strategy/eval/calibration.py
@@ -1,0 +1,337 @@
+"""E-03 calibration verification for the ML predictors.
+
+The audit's finding is "calibration asserted, never verified": the pit
+P05-P95 interval is already published broken (coverage 0.7047 vs 0.90
+nominal), yet nothing re-checks it. This module makes calibration a measured
+quantity so the paper can state it as fact, and it deliberately "finds" the
+known pit breakage as a retro-validation of the harness itself.
+
+Scope this phase (#206):
+- **overtake** - reliability (Brier + ECE) recomputed on the 2025 holdout,
+  wiring N33 Section A's proven loader + interaction-feature logic.
+- **pit_duration** - the P05-P95 quantile coverage, flagged as drift vs the
+  0.90 nominal.
+- **tire_degradation** - the deployed MC-Dropout sigma per compound.
+- **safety_car / undercut** - recompute from scratch is blocked on-disk (SC
+  needs 5 engineered features - lap_time_*_z, anomaly_and_yellow, lap1_chaos -
+  absent from the holdout; undercut historical aggregates absent too) so they
+  are reported as ``pending`` rather than hidden - Phase-2 (#207) territory.
+  Their headline numbers are still config-sourced in the registry.
+
+ponytail: pit coverage + the MC sigma are read from frozen artifacts, not
+re-run from a holdout (``pit_labeled`` is empty on disk; the MC pass needs a
+torch forward pass x N). Upgrade path when the holdouts land: recompute both
+from data, the same way N33 Section D already does for the TCN.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import numpy as np
+
+from src.f1_strat_manager.data_cache import get_data_root, get_models_root
+from src.strategy.eval.report import build_header, write_report
+
+CAL_NAME = "calibration"
+NOMINAL_COVERAGE = 0.90
+ECE_BINS = 10
+ECE_DRIFT = 0.05  # expected-calibration-error above this is flagged as drift
+
+# Reproduced verbatim from N33 Section A / the overtake model_config so the
+# harness feeds the LightGBM the exact 15-feature vector it was trained on.
+_OVERTAKE_FEATURES = [
+    "gap_ahead_s",
+    "pace_delta_s",
+    "tyre_life_x",
+    "tyre_life_y",
+    "tyre_life_diff",
+    "speed_trap_delta",
+    "LapNumber",
+    "drs_window",
+    "compound_x",
+    "compound_y",
+    "circuit_cluster",
+    "gap_pace_product",
+    "drs_ready_gap",
+    "gap_trend",
+    "pace_delta_rolling3",
+]
+_OVERTAKE_CAT = ["compound_x", "compound_y", "circuit_cluster"]
+_OVERTAKE_PAIR_KEYS = ["Year", "GP_Name", "driver_x", "driver_y"]
+
+
+@dataclass
+class CalibrationResult:
+    """One calibration measurement.
+
+    ``status`` is ``ok`` (within nominal), ``drift`` (measured worse than
+    nominal - the harness caught a miscalibration), or ``pending`` (cannot be
+    recomputed on-disk this phase; deferred to #207 / holdout availability).
+    """
+
+    model: str
+    metric: str
+    value: float | None
+    nominal: float | None
+    status: str
+    detail: str
+
+
+def _ece(y_true: np.ndarray, proba: np.ndarray, n_bins: int = ECE_BINS) -> float:
+    """Expected Calibration Error: bin-weighted gap between confidence and accuracy.
+
+    A perfectly calibrated classifier has ECE 0 (in each confidence bin, the
+    predicted probability equals the empirical positive rate). Standard
+    equal-width binning over [0, 1].
+    """
+    edges = np.linspace(0.0, 1.0, n_bins + 1)
+    total = len(y_true)
+    error = 0.0
+    for lo, hi in zip(edges[:-1], edges[1:]):
+        in_bin = (proba > lo) & (proba <= hi)
+        count = int(in_bin.sum())
+        if count == 0:
+            continue
+        confidence = float(proba[in_bin].mean())
+        accuracy = float(y_true[in_bin].mean())
+        error += (count / total) * abs(confidence - accuracy)
+    return error
+
+
+def _add_overtake_features(df: "Any") -> "Any":
+    """Reproduce the N12 interaction + rolling features from the base columns.
+
+    The labeled parquet stores only the base columns; the four derived
+    features (products + per-pair rolling/diff) are rebuilt here exactly as the
+    training notebook did, or the LightGBM sees a different feature space and
+    the numbers do not reproduce.
+    """
+    df = df.copy()
+    df["gap_pace_product"] = df["gap_ahead_s"] * df["pace_delta_s"]
+    df["drs_ready_gap"] = df["gap_ahead_s"] * df["drs_window"]
+    df = df.sort_values(_OVERTAKE_PAIR_KEYS + ["LapNumber"]).copy()
+    grp = df.groupby(_OVERTAKE_PAIR_KEYS)
+    df["gap_trend"] = grp["gap_ahead_s"].diff().fillna(0.0)
+    df["pace_delta_rolling3"] = grp["pace_delta_s"].transform(
+        lambda x: x.rolling(3, min_periods=1).mean()
+    )
+    for col in _OVERTAKE_CAT:
+        df[col] = df[col].astype("category")
+    return df
+
+
+def load_overtake_predictions() -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
+    """Load the overtake 2025 holdout and return ``(y, proba_raw, proba_cal)``.
+
+    Shared seam: both the calibration metrics here and the headline-metric
+    reproduction (``reproduce.py``) need the same holdout + model + calibrator,
+    so the load lives in one place. Returns ``None`` when the artifacts or the
+    holdout parquet are absent, letting each caller degrade to a ``pending``
+    result instead of crashing.
+    """
+    import joblib
+    import pandas as pd
+
+    model_dir = get_models_root() / "overtake_probability"
+    parquet = (
+        get_data_root() / "processed" / "overtake_labeled" / "overtake_pairs_2023_2025.parquet"
+    )
+    model_path = model_dir / "lgbm_overtake_v1.pkl"
+    calib_path = model_dir / "calibrator.pkl"
+    if not (parquet.exists() and model_path.exists() and calib_path.exists()):
+        return None
+
+    df = _add_overtake_features(pd.read_parquet(parquet))
+    test = df[df["Year"] == 2025].copy()
+    model = joblib.load(model_path)
+    calibrator = joblib.load(calib_path)
+
+    x = test[_OVERTAKE_FEATURES]
+    y = test["overtake"].astype(int).to_numpy()
+    proba_raw = model.predict_proba(x)[:, 1]
+    proba_cal = calibrator.predict_proba(proba_raw.reshape(-1, 1))[:, 1]
+    return y, proba_raw, proba_cal
+
+
+def _overtake_calibration() -> list[CalibrationResult]:
+    """Recompute Brier + ECE for the overtake classifier on the 2025 holdout.
+
+    Uses the calibrated probabilities (Platt on val-2024) - the quantity the
+    production agent actually consumes. Returns a ``pending`` result instead of
+    raising if the artifacts are absent, so a partial install still reports.
+    """
+    loaded = load_overtake_predictions()
+    if loaded is None:
+        return [
+            CalibrationResult(
+                "overtake", "ece", None, ECE_DRIFT, "pending", "artifacts or holdout absent on disk"
+            )
+        ]
+    y, proba_raw, proba_cal = loaded
+
+    brier_raw = float(np.mean((proba_raw - y) ** 2))
+    brier_cal = float(np.mean((proba_cal - y) ** 2))
+    ece_cal = _ece(y, proba_cal)
+    status = "drift" if ece_cal > ECE_DRIFT else "ok"
+    detail = f"n={len(y)}; brier raw {brier_raw:.4f} -> cal {brier_cal:.4f} (Platt val-2024)"
+
+    return [
+        CalibrationResult("overtake", "brier_calibrated", brier_cal, None, "ok", detail),
+        CalibrationResult(
+            "overtake",
+            "ece_calibrated",
+            ece_cal,
+            ECE_DRIFT,
+            status,
+            f"n={len(y)}; {ECE_BINS}-bin equal-width",
+        ),
+    ]
+
+
+def _pit_quantile_coverage() -> list[CalibrationResult]:
+    """Surface the pit P05-P95 empirical coverage and flag it vs nominal.
+
+    ponytail: read from the frozen ``model_config`` (the value is published
+    there) rather than re-run - ``pit_labeled`` is empty on disk so there is no
+    holdout to predict on. Upgrade path: recompute empirical coverage from the
+    hist_pit P05/P95 models over the N15 holdout once it lands. This is the
+    retro-validation target: the harness must surface the known 0.7047 break.
+    """
+    cfg_path = get_models_root() / "pit_prediction" / "model_config.json"
+    if not cfg_path.exists():
+        return [
+            CalibrationResult(
+                "pit_duration",
+                "p05_p95_coverage",
+                None,
+                NOMINAL_COVERAGE,
+                "pending",
+                "model_config absent",
+            )
+        ]
+
+    cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+    coverage = float(cfg["eval"]["p05_p95_coverage_test"])
+    status = "drift" if coverage < NOMINAL_COVERAGE else "ok"
+    detail = f"config-declared (recompute pending N15 holdout); {coverage:.4f} vs {NOMINAL_COVERAGE:.2f} nominal"
+    return [
+        CalibrationResult(
+            "pit_duration", "p05_p95_coverage", coverage, NOMINAL_COVERAGE, status, detail
+        )
+    ]
+
+
+def _tcn_mc_sigma() -> list[CalibrationResult]:
+    """Report the deployed MC-Dropout sigma per compound from the frozen JSON.
+
+    The stored ``mean_sigma_s`` is the epistemic band the tire agent uses at
+    runtime. Empirical coverage validation (predicted vs residual sigma) needs
+    the torch MC pass N33 Section D runs and is wired-pending here.
+    """
+    calib_path = get_models_root() / "tire_degradation" / "mc_dropout_calibration.json"
+    if not calib_path.exists():
+        return [
+            CalibrationResult(
+                "tire_degradation",
+                "mc_mean_sigma_s",
+                None,
+                None,
+                "pending",
+                "mc_dropout_calibration.json absent",
+            )
+        ]
+
+    calib = json.loads(calib_path.read_text(encoding="utf-8"))
+    results = []
+    for compound in sorted(calib):
+        sigma = float(calib[compound]["mean_sigma_s"])
+        detail = "deployed epistemic sigma; empirical coverage wired-pending (N33-D)"
+        results.append(
+            CalibrationResult(
+                f"tire_degradation[{compound}]", "mc_mean_sigma_s", sigma, None, "ok", detail
+            )
+        )
+    return results
+
+
+def _pending_classifiers() -> list[CalibrationResult]:
+    """Honest deltas for the two classifiers that cannot recompute on-disk.
+
+    Recording the blocker (not a fabricated number) is the point: both blockers
+    are precisely what Phase-2 provenance work (#207) resolves.
+    """
+    return [
+        CalibrationResult(
+            "safety_car",
+            "ece_calibrated",
+            None,
+            ECE_DRIFT,
+            "pending",
+            "engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from sc_labeled holdout (#207)",
+        ),
+        CalibrationResult(
+            "undercut",
+            "ece_calibrated",
+            None,
+            ECE_DRIFT,
+            "pending",
+            "historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207)",
+        ),
+    ]
+
+
+def collect_results() -> list[CalibrationResult]:
+    """All calibration results across the predictors."""
+    return [
+        *_overtake_calibration(),
+        *_pit_quantile_coverage(),
+        *_tcn_mc_sigma(),
+        *_pending_classifiers(),
+    ]
+
+
+def _render_table(results: list[CalibrationResult]) -> str:
+    """Render calibration results as a markdown table, drift rows first."""
+    order = {"drift": 0, "pending": 1, "ok": 2}
+    ordered = sorted(results, key=lambda r: order.get(r.status, 3))
+    header = "| model | metric | value | nominal | status | detail |"
+    rule = "|---|---|---|---|---|---|"
+    rows = []
+    for r in ordered:
+        value = "-" if r.value is None else f"{r.value:.4f}"
+        nominal = "-" if r.nominal is None else f"{r.nominal:g}"
+        rows.append(f"| {r.model} | {r.metric} | {value} | {nominal} | {r.status} | {r.detail} |")
+    return "\n".join([header, rule, *rows])
+
+
+def build_calibration_report() -> dict[str, Any]:
+    """Regenerate the calibration report and write the versioned output.
+
+    Returns the payload dict (also written to
+    ``documents/eval_reports/calibration.json``). The report always contains
+    the pit P05-P95 coverage row flagged as drift - the retro-validation that
+    proves the harness finds a known-broken calibration.
+    """
+    results = collect_results()
+    models = get_models_root()
+    artifacts = {
+        "overtake_model": models / "overtake_probability" / "lgbm_overtake_v1.pkl",
+        "pit_cfg": models / "pit_prediction" / "model_config.json",
+        "tcn_mc_calib": models / "tire_degradation" / "mc_dropout_calibration.json",
+    }
+    header = build_header(
+        dataset="2025 holdout + frozen calibration artifacts",
+        seed_policy="deterministic",
+        artifacts=artifacts,
+    )
+    payload = {"results": [asdict(r) for r in results]}
+    md_path, json_path = write_report(CAL_NAME, header, _render_table(results), payload)
+    return {
+        "header": asdict(header),
+        "md_path": str(md_path),
+        "json_path": str(json_path),
+        **payload,
+    }

--- a/src/strategy/eval/cli.py
+++ b/src/strategy/eval/cli.py
@@ -1,0 +1,75 @@
+"""``f1-eval`` console entry point: regenerate the eval reports.
+
+Thin argparse dispatch over the three report builders. Each subcommand writes
+its versioned markdown + JSON under ``documents/eval_reports/`` and prints a
+one-line summary of where it landed and what it flagged.
+
+    f1-eval registry       # E-08 consolidated metrics table
+    f1-eval calibration    # E-03 reliability/Brier/ECE + quantile coverage
+    f1-eval models         # reproduce headline numbers vs the model_configs
+    f1-eval all            # all three
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any, Callable
+
+from src.strategy.eval.calibration import build_calibration_report
+from src.strategy.eval.registry import build_registry
+from src.strategy.eval.reproduce import build_reproduction_report
+
+
+def _summarise(payload: dict[str, Any], rows_key: str, flag_statuses: tuple[str, ...]) -> str:
+    """One-line summary: report path + count of flagged rows."""
+    rows = payload.get(rows_key, [])
+    flagged = [r for r in rows if r.get("status") in flag_statuses]
+    tail = f"; {len(flagged)} flagged ({', '.join(flag_statuses)})" if flag_statuses else ""
+    return f"-> {payload['md_path']} ({len(rows)} rows{tail})"
+
+
+def _run_registry() -> None:
+    payload = build_registry()
+    divergences = [e for e in payload["entries"] if not e["canonical"]]
+    print(
+        f"registry -> {payload['md_path']} ({len(payload['entries'])} entries; {len(divergences)} divergences reconciled)"
+    )
+
+
+def _run_calibration() -> None:
+    payload = build_calibration_report()
+    print("calibration " + _summarise(payload, "results", ("drift", "pending")))
+
+
+def _run_models() -> None:
+    payload = build_reproduction_report()
+    print("models " + _summarise(payload, "results", ("delta", "pending")))
+
+
+_COMMANDS: dict[str, Callable[[], None]] = {
+    "registry": _run_registry,
+    "calibration": _run_calibration,
+    "models": _run_models,
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse args and run the requested report builder(s)."""
+    parser = argparse.ArgumentParser(
+        prog="f1-eval", description="F1 StratLab ML evaluation harness (#206)."
+    )
+    parser.add_argument(
+        "command",
+        choices=[*_COMMANDS, "all"],
+        help="which report to regenerate",
+    )
+    args = parser.parse_args(argv)
+
+    commands = _COMMANDS.values() if args.command == "all" else [_COMMANDS[args.command]]
+    for run in commands:
+        run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/strategy/eval/registry.py
+++ b/src/strategy/eval/registry.py
@@ -1,0 +1,300 @@
+"""E-08 consolidated metrics registry: the single citable source of truth.
+
+Today the headline numbers live scattered across ``model_config`` JSONs,
+notebook cells, thesis chapters and memory files, and at least one diverges
+(pace MAE 0.392 notebook-era vs 0.4104 thesis-final). Every downstream
+document (IEEE paper, AEPIA 5-pager, docs site, model cards) copies numbers by
+hand from that mess. This module regenerates ONE versioned table so the drift
+ends here.
+
+Two kinds of entry:
+
+- **config-sourced** - the model pins its own numbers in a ``model_config``
+  JSON (overtake, undercut, pit); the registry just surfaces them verbatim.
+  ``reproduce.py`` is what re-derives and checks they still reproduce.
+- **doc-pinned** - the number is NOT in any config (pace, tire-deg,
+  sentiment); it lives in the thesis (Tabla 6.1) / IEEE report. The
+  registry records the canonical (thesis-final) value AND the divergent
+  published/notebook-era value, so the reconciliation is documented in one
+  place forever. Docs reconciliation (#213) propagates the canonical from here;
+  provenance *verification* of these splits is Phase 2 (#207), not this phase.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from src.f1_strat_manager.data_cache import get_models_root
+from src.strategy.eval.report import build_header, write_report
+
+REGISTRY_NAME = "metrics_registry"
+
+
+@dataclass
+class MetricEntry:
+    """One headline metric consolidated into the registry.
+
+    Fields:
+    - ``model`` / ``family`` - which predictor and its problem type.
+    - ``metric`` / ``value`` / ``threshold`` - the number and its decision
+      threshold (``None`` for regressors).
+    - ``split`` - the train/test season split behind the number.
+    - ``source`` - where the number came from (config path or thesis).
+    - ``canonical`` - True for the citable authority value; a False entry is a
+      superseded/divergent value kept only to document the reconciliation.
+    - ``note`` - provenance / divergence commentary.
+    """
+
+    model: str
+    family: str
+    metric: str
+    value: float
+    threshold: float | None
+    split: str
+    source: str
+    canonical: bool
+    note: str
+
+
+def _config_entries() -> list[MetricEntry]:
+    """Read headline metrics straight from the ``model_config`` JSONs.
+
+    These models pin their own numbers, so the registry surfaces them without
+    re-deriving. The broken pit P05-P95 coverage (0.7047 vs 0.90 nominal) is
+    published inside its config too - the registry does not hide it; the
+    calibration report is what flags it as drift.
+    """
+    models = get_models_root()
+
+    overtake = json.loads(
+        (models / "overtake_probability" / "model_config.json").read_text(encoding="utf-8")
+    )
+    undercut = json.loads(
+        (models / "pit_prediction" / "model_config_undercut_v1.json").read_text(encoding="utf-8")
+    )
+    pit = json.loads((models / "pit_prediction" / "model_config.json").read_text(encoding="utf-8"))
+    sc = json.loads(
+        (models / "safety_car_probability" / "feature_list_v1.json").read_text(encoding="utf-8")
+    )
+
+    ov_split = f"train {overtake['train_seasons']} / test {overtake['test_season']}"
+    uc_split = f"train {undercut['train_years']} / test {undercut['test_year']}"
+    pit_split = f"train {pit['train_years']} / test {pit['test_year']}"
+    sc_split = f"train {sc['train_years']} / test {sc['test_year']}"
+
+    return [
+        MetricEntry(
+            "overtake",
+            "classification",
+            "auc_pr_test",
+            overtake["auc_pr_test"],
+            overtake["optimal_threshold"],
+            ov_split,
+            "config: overtake_probability/model_config.json",
+            True,
+            f"LightGBM + Platt(val 2024); auc_roc {overtake['auc_roc_test']}",
+        ),
+        MetricEntry(
+            "undercut",
+            "classification",
+            "auc_pr_test",
+            undercut["metrics"]["auc_pr_test"],
+            undercut["best_threshold"],
+            uc_split,
+            "config: pit_prediction/model_config_undercut_v1.json",
+            True,
+            f"LightGBM + Platt(val 2024); baseline_pr {undercut['metrics']['baseline_pr']}",
+        ),
+        MetricEntry(
+            "pit_duration",
+            "quantile",
+            "p50_mae_test_s",
+            pit["eval"]["p50_mae_test"],
+            None,
+            pit_split,
+            "config: pit_prediction/model_config.json",
+            True,
+            f"HistGBT P05/P50/P95; baseline_mae {pit['eval']['baseline_mae_test']}; "
+            f"P05-P95 coverage {pit['eval']['p05_p95_coverage_test']} vs 0.90 nominal (see calibration report)",
+        ),
+        MetricEntry(
+            "safety_car",
+            "classification",
+            "auc_pr_test",
+            sc["metrics"]["test_auc_pr"],
+            sc["best_threshold"],
+            sc_split,
+            "config: safety_car_probability/feature_list_v1.json",
+            True,
+            f"LightGBM + Platt(val 2024); baseline {sc['metrics']['baseline_auc_pr']}; "
+            f"3-lap lift {sc['target_comparison']['3-lap']['lift']}; target sc_within_3_laps",
+        ),
+    ]
+
+
+def _doc_pinned_entries() -> list[MetricEntry]:
+    """Encode the metrics that live in the thesis, not in any config.
+
+    Each divergent number produces two rows: the canonical (thesis-final) row
+    and the superseded row, so the reconciliation is self-documenting. Numbers
+    are sourced to the thesis Tabla 6.1 / IEEE report and issue #213; the
+    precise season splits for these are marked "verify in #207" rather than
+    asserted, because split provenance is exactly Phase 2's job.
+    """
+    verify = "split provenance pending (#207)"
+    entries: list[MetricEntry] = []
+
+    # Pace / lap-time delta (XGBoost, N06) - the canonical 0.392 -> 0.4104 case.
+    entries.append(
+        MetricEntry(
+            "pace",
+            "regression",
+            "mae_test_s",
+            0.4104,
+            None,
+            "test 2025",
+            "thesis Tabla 6.1 (final)",
+            True,
+            "XGBoost delta lap time; " + verify,
+        )
+    )
+    entries.append(
+        MetricEntry(
+            "pace",
+            "regression",
+            "mae_test_s",
+            0.392,
+            None,
+            "test 2025",
+            "notebook N06 (superseded)",
+            False,
+            "notebook-era value; superseded by thesis-final 0.4104",
+        )
+    )
+
+    # Tire degradation (TCN + MC Dropout, N07-10) - global MAE; best compound C2.
+    entries.append(
+        MetricEntry(
+            "tire_degradation",
+            "regression",
+            "mae_test_s",
+            0.7078,
+            None,
+            "test 2025",
+            "thesis Tabla 6.1 (global)",
+            True,
+            "TireDegTCN; per-compound best C2 0.5501s; missed R2 target; " + verify,
+        )
+    )
+
+    # Radio sentiment (RoBERTa, N20) - the 87.5% -> 0.84 case.
+    entries.append(
+        MetricEntry(
+            "sentiment",
+            "nlp",
+            "accuracy",
+            0.84,
+            None,
+            "held-out radio set",
+            "thesis Tabla 6.1 (final)",
+            True,
+            "RoBERTa; macro-F1 0.75; NLP harness in #304",
+        )
+    )
+    entries.append(
+        MetricEntry(
+            "sentiment",
+            "nlp",
+            "accuracy",
+            0.875,
+            None,
+            "held-out radio set",
+            "published-era (superseded)",
+            False,
+            "87.5% published; superseded by thesis-final 0.84",
+        )
+    )
+
+    return entries
+
+
+def collect_entries() -> list[MetricEntry]:
+    """All registry entries: config-sourced first, then doc-pinned."""
+    return _config_entries() + _doc_pinned_entries()
+
+
+def _render_table(entries: list[MetricEntry]) -> str:
+    """Render the registry as a markdown table + a divergences section."""
+    header = "| model | metric | value | thr | split | canonical | source |"
+    rule = "|---|---|---|---|---|---|---|"
+    rows = []
+    for entry in entries:
+        thr = "-" if entry.threshold is None else f"{entry.threshold:g}"
+        mark = "yes" if entry.canonical else "no"
+        rows.append(
+            f"| {entry.model} | {entry.metric} | {entry.value:g} | {thr} | "
+            f"{entry.split} | {mark} | {entry.source} |"
+        )
+
+    divergences = [e for e in entries if not e.canonical]
+    div_lines = ["", "## Divergences reconciled", ""]
+    if divergences:
+        for entry in divergences:
+            canonical = next(
+                c
+                for c in entries
+                if c.canonical and c.model == entry.model and c.metric == entry.metric
+            )
+            div_lines.append(
+                f"- **{entry.model} {entry.metric}**: {entry.value:g} "
+                f"({entry.source}) -> **{canonical.value:g}** ({canonical.source})"
+            )
+    else:
+        div_lines.append("- none")
+
+    return "\n".join([header, rule, *rows, *div_lines])
+
+
+def build_registry() -> dict[str, Any]:
+    """Regenerate the consolidated registry and write the versioned report.
+
+    Returns the payload dict (also written to
+    ``documents/eval_reports/metrics_registry.json``). This is the single
+    citable source that replaces the scattered numbers.
+    """
+    entries = collect_entries()
+    models = get_models_root()
+    artifacts = {
+        "overtake_cfg": models / "overtake_probability" / "model_config.json",
+        "undercut_cfg": models / "pit_prediction" / "model_config_undercut_v1.json",
+        "pit_cfg": models / "pit_prediction" / "model_config.json",
+        "sc_cfg": models / "safety_car_probability" / "feature_list_v1.json",
+    }
+    header = build_header(dataset="model_configs + thesis Tabla 6.1", artifacts=artifacts)
+    payload = {"entries": [asdict(e) for e in entries]}
+
+    md_path, json_path = write_report(REGISTRY_NAME, header, _render_table(entries), payload)
+    return {
+        "header": asdict(header),
+        "md_path": str(md_path),
+        "json_path": str(json_path),
+        **payload,
+    }
+
+
+def load_registry() -> dict[str, Any]:
+    """Read the committed registry JSON back (for #213 / #304 / tests).
+
+    Raises ``FileNotFoundError`` if the registry has never been generated, so
+    a stale consumer fails loudly instead of silently using no data.
+    """
+    from src.strategy.eval.report import eval_reports_dir
+
+    path = eval_reports_dir() / f"{REGISTRY_NAME}.json"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"registry not generated yet; run `f1-eval registry` (looked in {path})"
+        )
+    return json.loads(path.read_text(encoding="utf-8"))

--- a/src/strategy/eval/report.py
+++ b/src/strategy/eval/report.py
@@ -1,0 +1,167 @@
+"""E-15 provenance-header contract shared by every eval report.
+
+Every report the harness emits (metrics registry, calibration, regeneration)
+carries the same header so any number can be traced back to the exact
+artifacts, dataset snapshot, regulation era and harness version that produced
+it. Without this stamp a 2026 retraining makes every old report ambiguous
+(which model? which season? which code?).
+
+WHERE TO CHANGE IF THE PROVENANCE CONTRACT CHANGES:
+- add a field to ``ReportHeader`` + set it in ``build_header``; every report
+  writer downstream picks it up for free (registry.py, calibration.py, ...).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.f1_strat_manager.data_cache import _find_repo_root
+
+SCHEMA_VERSION = "1"
+ERA_TAG = "2022-2025"  # regulation era these numbers are valid for
+
+
+def _harness_sha() -> str:
+    """Short git SHA of the repo the harness runs from, or ``unknown``.
+
+    Returns ``unknown`` when running outside a checkout (e.g. an installed
+    tool venv) so a report is never blocked on git being available.
+    """
+    repo = _find_repo_root()
+    if repo is None:
+        return "unknown"
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        )
+        return out.stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        return "unknown"
+
+
+def artifact_hash(path: Path) -> str:
+    """First 12 hex chars of the SHA-256 of a model artifact.
+
+    Short enough to stay readable inside a committed markdown header, long
+    enough to pin an artifact version unambiguously in practice.
+    """
+    digest = hashlib.sha256(Path(path).read_bytes()).hexdigest()
+    return digest[:12]
+
+
+@dataclass
+class ReportHeader:
+    """Provenance stamp attached to every eval report (E-15).
+
+    Invariants:
+    - ``harness_sha`` pins the code; ``artifacts`` pins the model weights;
+      together they make a report reproducible.
+    - ``generated_at`` is provenance only and is NOT part of report equality
+      (two runs of the same code on the same data are "equal" bar the clock).
+    - ``llm`` is ``none`` for pure-ML reports; NLP/orchestrator reports that
+      call a model record ``provider/model/version`` (never Anthropic).
+    """
+
+    harness_sha: str
+    dataset: str
+    seed_policy: str
+    era_tag: str = ERA_TAG
+    llm: str = "none"
+    schema_version: str = SCHEMA_VERSION
+    generated_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat(timespec="seconds")
+    )
+    artifacts: dict[str, str] = field(default_factory=dict)
+
+
+def build_header(
+    *,
+    dataset: str,
+    seed_policy: str = "deterministic",
+    llm: str = "none",
+    artifacts: dict[str, Path] | None = None,
+) -> ReportHeader:
+    """Assemble a report header, hashing each artifact path that exists.
+
+    Missing artifact paths are skipped rather than raising, so a partial
+    install still produces a report (with a shorter artifact list) instead of
+    crashing the whole run.
+    """
+    hashed = {
+        name: artifact_hash(path) for name, path in (artifacts or {}).items() if Path(path).exists()
+    }
+    return ReportHeader(
+        harness_sha=_harness_sha(),
+        dataset=dataset,
+        seed_policy=seed_policy,
+        llm=llm,
+        artifacts=hashed,
+    )
+
+
+def eval_reports_dir() -> Path:
+    """``documents/eval_reports/`` (created on demand): committed, diffable.
+
+    Falls back to a user-cache directory when running outside a checkout so
+    the writer never fails; in that mode the reports simply are not version
+    controlled.
+    """
+    repo = _find_repo_root()
+    base = (
+        (repo / "documents" / "eval_reports")
+        if repo
+        else (Path.home() / ".f1-strat" / "eval_reports")
+    )
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def write_report(
+    name: str,
+    header: ReportHeader,
+    table_md: str,
+    payload: dict[str, Any],
+) -> tuple[Path, Path]:
+    """Write a report as a diffable markdown table + a machine-readable JSON.
+
+    The markdown is the human / paper-facing citable artifact; the JSON is
+    what downstream consumers (#213 docs reconciliation, #304 NLP harness,
+    the golden tests) read so they never have to re-parse prose.
+
+    Returns the ``(markdown_path, json_path)`` pair.
+    """
+    out = eval_reports_dir()
+    md_path = out / f"{name}.md"
+    json_path = out / f"{name}.json"
+    md_path.write_text(_render_md(name, header, table_md), encoding="utf-8")
+    json_path.write_text(
+        json.dumps({"header": asdict(header), **payload}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return md_path, json_path
+
+
+def _render_md(name: str, header: ReportHeader, table_md: str) -> str:
+    """Render a report: title, provenance header block, then the table body."""
+    artifacts = ", ".join(f"{k}=`{v}`" for k, v in header.artifacts.items()) or "—"
+    lines = [
+        f"# {name}",
+        "",
+        f"- harness `{header.harness_sha}` · schema v{header.schema_version} · generated {header.generated_at}",
+        f"- era {header.era_tag} · dataset {header.dataset} · seed {header.seed_policy} · llm {header.llm}",
+        f"- artifacts: {artifacts}",
+        "",
+        table_md,
+        "",
+    ]
+    return "\n".join(lines)

--- a/src/strategy/eval/reproduce.py
+++ b/src/strategy/eval/reproduce.py
@@ -1,0 +1,169 @@
+"""Headline-metric reproduction check (the ``f1-eval models`` deliverable).
+
+The registry consolidates the published numbers; this module re-derives them
+from the frozen model + holdout and reports reproduced-vs-config deltas. Where
+the on-disk data does not support a clean re-derivation, it documents the delta
+explicitly rather than inventing a number - which is the deliverable's own
+"reproduces every headline number within tolerance, or documents the delta".
+
+This phase only overtake AUC-PR reproduces cleanly (its holdout + derived
+features are fully reconstructable). The rest are blocked on the same on-disk
+gaps the calibration report names, and are handed to Phase 2 (#207).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from src.f1_strat_manager.data_cache import get_models_root
+from src.strategy.eval.calibration import load_overtake_predictions
+from src.strategy.eval.report import build_header, write_report
+
+REPRO_NAME = "reproduction"
+TOLERANCE = 0.01  # |reproduced - published| within this counts as reproduced
+
+
+@dataclass
+class ReproResult:
+    """One headline-metric reproduction check.
+
+    ``status`` is ``reproduced`` (within tolerance of the published value),
+    ``delta`` (re-derived but diverges), or ``pending`` (cannot re-derive
+    on-disk this phase).
+    """
+
+    model: str
+    metric: str
+    published: float
+    reproduced: float | None
+    status: str
+    detail: str
+
+
+def _overtake_auc_pr() -> ReproResult:
+    """Re-derive overtake AUC-PR on the 2025 holdout and compare to the config.
+
+    AUC-PR is threshold-free, so it is computed on the raw model scores (the
+    same quantity N12 reported). ``sklearn.average_precision_score`` is the
+    AUC-PR estimator.
+    """
+    cfg = json.loads(
+        (get_models_root() / "overtake_probability" / "model_config.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    published = float(cfg["auc_pr_test"])
+
+    loaded = load_overtake_predictions()
+    if loaded is None:
+        return ReproResult(
+            "overtake",
+            "auc_pr_test",
+            published,
+            None,
+            "pending",
+            "holdout or artifacts absent on disk",
+        )
+
+    from sklearn.metrics import average_precision_score
+
+    y, proba_raw, _ = loaded
+    reproduced = float(average_precision_score(y, proba_raw))
+    delta = abs(reproduced - published)
+    status = "reproduced" if delta <= TOLERANCE else "delta"
+    return ReproResult(
+        "overtake",
+        "auc_pr_test",
+        published,
+        reproduced,
+        status,
+        f"|delta| {delta:.4f} vs tol {TOLERANCE}",
+    )
+
+
+def _pending_metrics() -> list[ReproResult]:
+    """Document the headline numbers that cannot re-derive on-disk this phase.
+
+    Each carries the same blocker its calibration/registry entry names, so the
+    reproduction report and the calibration report agree on why.
+    """
+    return [
+        ReproResult(
+            "undercut",
+            "auc_pr_test",
+            0.6739,
+            None,
+            "pending",
+            "historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207)",
+        ),
+        ReproResult(
+            "pit_duration",
+            "p50_mae_test_s",
+            0.487,
+            None,
+            "pending",
+            "pit_labeled holdout empty on disk (#207)",
+        ),
+        ReproResult(
+            "safety_car",
+            "auc_pr_test",
+            0.0723,
+            None,
+            "pending",
+            "engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from holdout (#207)",
+        ),
+        ReproResult(
+            "pace",
+            "mae_test_s",
+            0.4104,
+            None,
+            "pending",
+            "laptime holdout feature build not wired this phase",
+        ),
+        ReproResult(
+            "tire_degradation",
+            "mae_test_s",
+            0.7078,
+            None,
+            "pending",
+            "TCN MC forward pass not run this phase (see calibration MC-sigma)",
+        ),
+    ]
+
+
+def collect_results() -> list[ReproResult]:
+    """All reproduction checks, reproduced/delta rows first."""
+    results = [_overtake_auc_pr(), *_pending_metrics()]
+    order = {"delta": 0, "reproduced": 1, "pending": 2}
+    return sorted(results, key=lambda r: order.get(r.status, 3))
+
+
+def _render_table(results: list[ReproResult]) -> str:
+    """Render reproduction results as a markdown table."""
+    header = "| model | metric | published | reproduced | status | detail |"
+    rule = "|---|---|---|---|---|---|"
+    rows = []
+    for r in results:
+        reproduced = "-" if r.reproduced is None else f"{r.reproduced:.4f}"
+        rows.append(
+            f"| {r.model} | {r.metric} | {r.published:g} | {reproduced} | {r.status} | {r.detail} |"
+        )
+    return "\n".join([header, rule, *rows])
+
+
+def build_reproduction_report() -> dict[str, Any]:
+    """Regenerate the reproduction report and write the versioned output."""
+    results = collect_results()
+    models = get_models_root()
+    artifacts = {"overtake_model": models / "overtake_probability" / "lgbm_overtake_v1.pkl"}
+    header = build_header(dataset="2025 holdout vs published model_configs", artifacts=artifacts)
+    payload = {"results": [asdict(r) for r in results]}
+    md_path, json_path = write_report(REPRO_NAME, header, _render_table(results), payload)
+    return {
+        "header": asdict(header),
+        "md_path": str(md_path),
+        "json_path": str(json_path),
+        **payload,
+    }

--- a/tests/eval/test_registry_golden.py
+++ b/tests/eval/test_registry_golden.py
@@ -1,0 +1,63 @@
+"""Golden acceptance tests for the eval harness (#206).
+
+Data-tier: these need ``data/models/`` + the labeled holdouts, so they are
+skipped on CI runners (marked ``data`` and guarded like the other model-backed
+tests) and run locally where the weights are present. They lock the harness's
+retro-validation contract - the three claims #206 must keep true:
+
+- the registry reconciles the pace 0.392 -> 0.4104 divergence to the canonical;
+- calibration "finds" the known-broken pit P05-P95 coverage (0.7047) as drift;
+- reproduction re-derives overtake AUC-PR back to its published 0.5491.
+
+They call the ``collect_*`` functions (pure, no report I/O) so the assertions
+test the harness logic, not the markdown writer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "overtake_probability" / "model_config.json").exists()
+
+pytestmark = [
+    pytest.mark.data,
+    pytest.mark.skipif(not _HAS_MODELS, reason="data/models/ absent (CI runner without weights)"),
+]
+
+
+def test_registry_reconciles_pace_divergence():
+    """The registry pins pace canonical = 0.4104 and keeps 0.392 as superseded."""
+    from src.strategy.eval.registry import collect_entries
+
+    pace = [e for e in collect_entries() if e.model == "pace" and e.metric == "mae_test_s"]
+    canonical = [e for e in pace if e.canonical]
+    superseded = [e for e in pace if not e.canonical]
+
+    assert len(canonical) == 1, "exactly one canonical pace entry"
+    assert canonical[0].value == pytest.approx(0.4104)
+    assert any(e.value == pytest.approx(0.392) for e in superseded), "0.392 kept for provenance"
+
+
+def test_calibration_flags_pit_coverage_drift():
+    """The pit P05-P95 coverage (0.7047) surfaces and is flagged as drift."""
+    from src.strategy.eval.calibration import collect_results
+
+    pit = [
+        r for r in collect_results() if r.model == "pit_duration" and r.metric == "p05_p95_coverage"
+    ]
+    assert len(pit) == 1
+    assert pit[0].value == pytest.approx(0.7047)
+    assert pit[0].status == "drift", "coverage below 0.90 nominal must flag drift"
+
+
+def test_reproduction_matches_overtake_auc_pr():
+    """Overtake AUC-PR re-derives to the published 0.5491 within tolerance."""
+    from src.strategy.eval.reproduce import collect_results
+
+    overtake = [r for r in collect_results() if r.model == "overtake" and r.metric == "auc_pr_test"]
+    assert len(overtake) == 1
+    assert overtake[0].status == "reproduced"
+    assert overtake[0].reproduced == pytest.approx(0.5491, abs=0.01)


### PR DESCRIPTION
Additive `src/strategy/eval` harness for #206 (E-08 registry + E-03 calibration + f1-eval console script).

## What
- **Registry** (`f1-eval registry`): consolidates every headline metric into one citable versioned table under `documents/eval_reports/`; reconciles the pace 0.392->0.4104 and sentiment 0.875->0.84 divergences explicitly.
- **Calibration** (`f1-eval calibration`): recomputes overtake Brier (raw 0.1304 -> cal 0.0520) + ECE (0.0319) on the 2025 holdout; surfaces the known-broken pit P05-P95 coverage (0.7047 vs 0.90) as drift; reports the TCN MC-Dropout sigma per compound.
- **Reproduction** (`f1-eval models`): re-derives overtake AUC-PR to 0.5491 exactly (average_precision_score, not an echo); documents deltas for SC/undercut/pit whose recompute is blocked by absent on-disk holdouts (deferred to #207).
- **E-15 header contract** on every report (git-SHA, artifact hashes, era, seed, provider).
- **Golden test** `tests/eval/test_registry_golden.py` (data-tier, skipped on CI without weights) locks the retro-validation contract.

## Verification
- ruff check + format clean; 3/3 golden tests pass locally.
- Passed an adversarial verify-after pass (Fable gate for epic #205): overtake reproduction + calibration confirmed real to the digit, untouchable trees honored, zero fabricated numbers. One provenance bug (safety-car misclassified as thesis-only) was caught and fixed -> SC is now config-sourced from `feature_list_v1.json`.

## Out of scope (-> #207)
Full recompute of SC/undercut/pit headline metrics (blocked on-disk: undercut historical aggregates absent, pit_labeled empty, SC engineered features absent from the holdout). Documented as honest `pending`.

Closes #206.