### PR TITLE
feat(eval): threshold-provenance + leakage hygiene report (#207)

### DIFF
--- a/documents/eval_reports/hygiene.json
+++ b/documents/eval_reports/hygiene.json
@@ -1,0 +1,101 @@
+{
+  "header": {
+    "harness_sha": "50b7ecf",
+    "dataset": "notebooks/strategy audit + 2024/2025 overtake holdout",
+    "seed_policy": "deterministic",
+    "era_tag": "2022-2025",
+    "llm": "none",
+    "schema_version": "1",
+    "generated_at": "2026-07-11T15:29:09+00:00",
+    "artifacts": {}
+  },
+  "findings": [
+    {
+      "item": "optimal_threshold=0.7976",
+      "kind": "threshold",
+      "model": "overtake",
+      "verdict": "contaminated",
+      "selection": "argmax-F1 on the 2025 test set",
+      "evidence": "N12_overtake_model.ipynb (threshold-analysis / step-5 cell)",
+      "impact": "operating-point P/R/F1 optimistic; AUC-PR 0.5491 / AUC-ROC 0.8758 unaffected (threshold-free)"
+    },
+    {
+      "item": "best_threshold=0.2335 + 3/5/7-lap window",
+      "kind": "threshold",
+      "model": "safety_car",
+      "verdict": "contaminated",
+      "selection": "argmax-F2 threshold AND the best target-window both on the 2025 test set",
+      "evidence": "N14_sc_model.ipynb (PR-curve + window-comparison cells)",
+      "impact": "threshold -> operating-point optimistic; window chosen by max-lift on test -> the headline AUC-PR 0.0723 is itself optimistic (a max over 3 candidates on test), NOT clean"
+    },
+    {
+      "item": "best_threshold=0.522",
+      "kind": "threshold",
+      "model": "undercut",
+      "verdict": "clean",
+      "selection": "argmax-F1 on the calibrated val-2024 split",
+      "evidence": "N16_undercut.ipynb (\"Threshold on calibrated val 2024\")",
+      "impact": "textbook-correct; the 2025 test set is only applied afterwards"
+    },
+    {
+      "item": "circuit_sc_rate",
+      "kind": "aggregate_feature",
+      "model": "safety_car",
+      "verdict": "clean",
+      "selection": "past-season only (year < yr); 2023 rows get a fixed SC_PRIOR=0.15",
+      "evidence": "N13_sc_eda.ipynb (compute_circuit_sc_rate)",
+      "impact": "no test-2025 in its own aggregate"
+    },
+    {
+      "item": "team_year_median",
+      "kind": "aggregate_feature",
+      "model": "pit_duration",
+      "verdict": "clean",
+      "selection": "lookup fit on train only, applied to test with recent-year fallback",
+      "evidence": "N15_pit_duration.ipynb (add_team_year_median)",
+      "impact": "companion circuit_traversal / baseline are likewise train-fit"
+    },
+    {
+      "item": "circuit_undercut_rate + team_x_undercut_rate",
+      "kind": "aggregate_feature",
+      "model": "undercut",
+      "verdict": "clean",
+      "selection": "target encoding fit on train only, train-mean fallback on test",
+      "evidence": "N16_undercut.ipynb (compute_target_encoding)",
+      "impact": "split precedes the encoding; no train<-test leak"
+    },
+    {
+      "item": "circuit_cluster (k-means)",
+      "kind": "aggregate_feature",
+      "model": "overtake/safety_car/laptime",
+      "verdict": "underdocumented",
+      "selection": "k-means fit window not year-restricted in code; 2025 holdout is intent-only",
+      "evidence": "N03_circuit_clustering.ipynb (load_all_races / fit_kmeans_final)",
+      "impact": "mild NON-target risk (unsupervised geometry bucket); pin a year filter to close"
+    },
+    {
+      "item": "year_circuit_median / team_pace_rank",
+      "kind": "aggregate_feature",
+      "model": "laptime",
+      "verdict": "clean",
+      "selection": "within-session per-year aggregates; flagged LEAKY and removed from the reported model",
+      "evidence": "N06_laptime_model.ipynb (add_context_features / FEATURES_PROD)",
+      "impact": "not in the reported IEEE delta model; 2025 held out until final eval"
+    }
+  ],
+  "overtake_correction": {
+    "leaked_threshold": 0.7976,
+    "corrected_threshold": 0.7626,
+    "leaked_test_operating_point": {
+      "precision": 0.5018,
+      "recall": 0.5556,
+      "f1": 0.5273
+    },
+    "corrected_test_operating_point": {
+      "precision": 0.4583,
+      "recall": 0.5827,
+      "f1": 0.5131
+    },
+    "note": "threshold selected on val-2024; both operating points evaluated on the 2025 test set"
+  }
+}

--- a/documents/eval_reports/hygiene.md
+++ b/documents/eval_reports/hygiene.md
@@ -1,0 +1,30 @@
+# hygiene
+
+- harness `50b7ecf` · schema v1 · generated 2026-07-11T15:29:09+00:00
+- era 2022-2025 · dataset notebooks/strategy audit + 2024/2025 overtake holdout · seed deterministic · llm none
+- artifacts: —
+
+| item | kind | model | verdict | selection | evidence |
+|---|---|---|---|---|---|
+| optimal_threshold=0.7976 | threshold | overtake | **contaminated** | argmax-F1 on the 2025 test set | N12_overtake_model.ipynb (threshold-analysis / step-5 cell) |
+| best_threshold=0.2335 + 3/5/7-lap window | threshold | safety_car | **contaminated** | argmax-F2 threshold AND the best target-window both on the 2025 test set | N14_sc_model.ipynb (PR-curve + window-comparison cells) |
+| circuit_cluster (k-means) | aggregate_feature | overtake/safety_car/laptime | **underdocumented** | k-means fit window not year-restricted in code; 2025 holdout is intent-only | N03_circuit_clustering.ipynb (load_all_races / fit_kmeans_final) |
+| best_threshold=0.522 | threshold | undercut | **clean** | argmax-F1 on the calibrated val-2024 split | N16_undercut.ipynb ("Threshold on calibrated val 2024") |
+| circuit_sc_rate | aggregate_feature | safety_car | **clean** | past-season only (year < yr); 2023 rows get a fixed SC_PRIOR=0.15 | N13_sc_eda.ipynb (compute_circuit_sc_rate) |
+| team_year_median | aggregate_feature | pit_duration | **clean** | lookup fit on train only, applied to test with recent-year fallback | N15_pit_duration.ipynb (add_team_year_median) |
+| circuit_undercut_rate + team_x_undercut_rate | aggregate_feature | undercut | **clean** | target encoding fit on train only, train-mean fallback on test | N16_undercut.ipynb (compute_target_encoding) |
+| year_circuit_median / team_pace_rank | aggregate_feature | laptime | **clean** | within-session per-year aggregates; flagged LEAKY and removed from the reported model | N06_laptime_model.ipynb (add_context_features / FEATURES_PROD) |
+
+## Correction (overtake threshold)
+
+- leaked threshold 0.7976 (selected on test): P 0.5018 / R 0.5556 / F1 0.5273 on 2025 test
+- corrected threshold 0.7626 (selected on val-2024): P 0.4583 / R 0.5827 / F1 0.5131 on 2025 test
+- threshold selected on val-2024; both operating points evaluated on the 2025 test set
+
+## Conclusion for the paper freeze
+
+- 2 contaminated items (overtake threshold; safety-car threshold + window). All other thresholds and aggregate features are clean or non-target.
+- **Overtake headline clears**: AUC-PR 0.5491 / AUC-ROC 0.8758 are threshold-free and involve no window selection; the threshold leakage touches only their operating point.
+- **Safety-car headline is optimistic, NOT clean**: AUC-PR 0.0723 is the max-lift window among {3,5,7} laps selected on test-2025, so the reported number is itself selection-biased (a max over 3 candidates on test), on top of the operating-point threshold leakage.
+- **Action before freeze**: (1) re-select the overtake + SC operating thresholds on val-2024 (the undercut N16 pattern) - the overtake correction above shows the honest operating point; (2) re-select the SC target window on the CV/val split (not test) and re-report SC AUC-PR, or caveat it as test-selected; (3) pin a year filter in N03 `load_all_races` to close the circuit_cluster underdocumentation.
+- Every other headline (undercut 0.6739, pit 0.487, pace 0.4104, tire 0.7078, sentiment 0.84) is unaffected by these findings.

--- a/src/strategy/eval/__init__.py
+++ b/src/strategy/eval/__init__.py
@@ -14,6 +14,7 @@ Public API:
 """
 
 from src.strategy.eval.calibration import build_calibration_report
+from src.strategy.eval.hygiene import build_hygiene_report
 from src.strategy.eval.registry import build_registry, load_registry
 from src.strategy.eval.reproduce import build_reproduction_report
 
@@ -22,4 +23,5 @@ __all__ = [
     "load_registry",
     "build_calibration_report",
     "build_reproduction_report",
+    "build_hygiene_report",
 ]

--- a/src/strategy/eval/calibration.py
+++ b/src/strategy/eval/calibration.py
@@ -123,8 +123,11 @@ def _add_overtake_features(df: "Any") -> "Any":
     return df
 
 
-def load_overtake_predictions() -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
-    """Load the overtake 2025 holdout and return ``(y, proba_raw, proba_cal)``.
+def load_overtake_predictions(year: int = 2025) -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
+    """Load an overtake season holdout (default 2025 test) -> ``(y, proba_raw, proba_cal)``.
+
+    ``year`` selects the season slice: 2025 = test (calibration/reproduction),
+    2024 = validation (the #207 hygiene threshold re-selection).
 
     Shared seam: both the calibration metrics here and the headline-metric
     reproduction (``reproduce.py``) need the same holdout + model + calibrator,
@@ -145,7 +148,7 @@ def load_overtake_predictions() -> tuple[np.ndarray, np.ndarray, np.ndarray] | N
         return None
 
     df = _add_overtake_features(pd.read_parquet(parquet))
-    test = df[df["Year"] == 2025].copy()
+    test = df[df["Year"] == year].copy()
     model = joblib.load(model_path)
     calibrator = joblib.load(calib_path)
 

--- a/src/strategy/eval/cli.py
+++ b/src/strategy/eval/cli.py
@@ -7,7 +7,8 @@ one-line summary of where it landed and what it flagged.
     f1-eval registry       # E-08 consolidated metrics table
     f1-eval calibration    # E-03 reliability/Brier/ECE + quantile coverage
     f1-eval models         # reproduce headline numbers vs the model_configs
-    f1-eval all            # all three
+    f1-eval hygiene        # E-02 threshold provenance + leakage verdicts (#207)
+    f1-eval all            # all four
 """
 
 from __future__ import annotations
@@ -16,6 +17,7 @@ import argparse
 from typing import Any, Callable
 
 from src.strategy.eval.calibration import build_calibration_report
+from src.strategy.eval.hygiene import build_hygiene_report
 from src.strategy.eval.registry import build_registry
 from src.strategy.eval.reproduce import build_reproduction_report
 
@@ -46,10 +48,18 @@ def _run_models() -> None:
     print("models " + _summarise(payload, "results", ("delta", "pending")))
 
 
+def _run_hygiene() -> None:
+    payload = build_hygiene_report()
+    findings = payload.get("findings", [])
+    flagged = [f for f in findings if f.get("verdict") in ("contaminated", "underdocumented")]
+    print(f"hygiene -> {payload['md_path']} ({len(findings)} items; {len(flagged)} flagged)")
+
+
 _COMMANDS: dict[str, Callable[[], None]] = {
     "registry": _run_registry,
     "calibration": _run_calibration,
     "models": _run_models,
+    "hygiene": _run_hygiene,
 }
 
 

--- a/src/strategy/eval/hygiene.py
+++ b/src/strategy/eval/hygiene.py
@@ -1,0 +1,252 @@
+"""E-02 threshold-provenance + aggregate-feature leakage verification (#207).
+
+Gates the IEEE paper freeze: rules out test-2025 contamination of the reported
+numbers. Every tuned decision threshold and every historical aggregate feature
+gets a verdict (clean / contaminated / underdocumented) traced to the training
+cell that produced it. The verdicts are the product of a read-only audit of
+``notebooks/strategy/`` (UNTOUCHABLE - this module only records the findings and
+demonstrates the correction; it does not modify a notebook).
+
+KEY CONCLUSION FOR THE PAPER: the two contaminated items (overtake threshold
+0.7976, safety-car threshold 0.2335 + its 3/5/7-lap window) were selected on
+the 2025 test set, so they inflate only the OPERATING-POINT metrics
+(precision/recall/F1 at that threshold). The threshold-FREE headline numbers the
+paper actually reports - AUC-PR and AUC-ROC - are computed from probabilities
+and are unaffected, so they clear. This module re-selects the overtake threshold
+on val-2024 (the honest split) to show the operating-point delta.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import numpy as np
+
+from src.strategy.eval.calibration import load_overtake_predictions
+from src.strategy.eval.report import build_header, write_report
+
+HYGIENE_NAME = "hygiene"
+
+# Verdicts (fixed vocabulary; kept as module constants so the report writer and
+# the golden test share one spelling).
+CLEAN = "clean"
+CONTAMINATED = "contaminated"
+UNDERDOCUMENTED = "underdocumented"
+
+# Overtake threshold sweep grid, mirrored from N12 Step 5 so the re-selection
+# uses the same candidate set the notebook did.
+_THRESHOLD_GRID = np.linspace(0.05, 0.92, 200)
+_LEAKED_OVERTAKE_THRESHOLD = 0.7976
+
+
+@dataclass
+class ProvenanceEntry:
+    """One threshold/feature provenance verdict.
+
+    ``kind`` is ``threshold`` or ``aggregate_feature``; ``verdict`` is one of the
+    module constants; ``selection`` names the split/window the value was chosen
+    or computed on; ``evidence`` points at the training notebook + cell; and
+    ``impact`` states what the verdict means for the paper's numbers.
+    """
+
+    item: str
+    kind: str
+    model: str
+    verdict: str
+    selection: str
+    evidence: str
+    impact: str
+
+
+def audit_findings() -> list[ProvenanceEntry]:
+    """The read-only provenance audit of ``notebooks/strategy/`` (issue #207).
+
+    Adversarially verified: the two contaminated threshold verdicts were
+    confirmed against the exact selection cells; every aggregate feature was
+    checked for a fit-on-train / past-season-only implementation.
+    """
+    return [
+        ProvenanceEntry(
+            "optimal_threshold=0.7976",
+            "threshold",
+            "overtake",
+            CONTAMINATED,
+            "argmax-F1 on the 2025 test set",
+            "N12_overtake_model.ipynb (threshold-analysis / step-5 cell)",
+            "operating-point P/R/F1 optimistic; AUC-PR 0.5491 / AUC-ROC 0.8758 unaffected (threshold-free)",
+        ),
+        ProvenanceEntry(
+            "best_threshold=0.2335 + 3/5/7-lap window",
+            "threshold",
+            "safety_car",
+            CONTAMINATED,
+            "argmax-F2 threshold AND the best target-window both on the 2025 test set",
+            "N14_sc_model.ipynb (PR-curve + window-comparison cells)",
+            "threshold -> operating-point optimistic; window chosen by max-lift on test -> the headline "
+            "AUC-PR 0.0723 is itself optimistic (a max over 3 candidates on test), NOT clean",
+        ),
+        ProvenanceEntry(
+            "best_threshold=0.522",
+            "threshold",
+            "undercut",
+            CLEAN,
+            "argmax-F1 on the calibrated val-2024 split",
+            'N16_undercut.ipynb ("Threshold on calibrated val 2024")',
+            "textbook-correct; the 2025 test set is only applied afterwards",
+        ),
+        ProvenanceEntry(
+            "circuit_sc_rate",
+            "aggregate_feature",
+            "safety_car",
+            CLEAN,
+            "past-season only (year < yr); 2023 rows get a fixed SC_PRIOR=0.15",
+            "N13_sc_eda.ipynb (compute_circuit_sc_rate)",
+            "no test-2025 in its own aggregate",
+        ),
+        ProvenanceEntry(
+            "team_year_median",
+            "aggregate_feature",
+            "pit_duration",
+            CLEAN,
+            "lookup fit on train only, applied to test with recent-year fallback",
+            "N15_pit_duration.ipynb (add_team_year_median)",
+            "companion circuit_traversal / baseline are likewise train-fit",
+        ),
+        ProvenanceEntry(
+            "circuit_undercut_rate + team_x_undercut_rate",
+            "aggregate_feature",
+            "undercut",
+            CLEAN,
+            "target encoding fit on train only, train-mean fallback on test",
+            "N16_undercut.ipynb (compute_target_encoding)",
+            "split precedes the encoding; no train<-test leak",
+        ),
+        ProvenanceEntry(
+            "circuit_cluster (k-means)",
+            "aggregate_feature",
+            "overtake/safety_car/laptime",
+            UNDERDOCUMENTED,
+            "k-means fit window not year-restricted in code; 2025 holdout is intent-only",
+            "N03_circuit_clustering.ipynb (load_all_races / fit_kmeans_final)",
+            "mild NON-target risk (unsupervised geometry bucket); pin a year filter to close",
+        ),
+        ProvenanceEntry(
+            "year_circuit_median / team_pace_rank",
+            "aggregate_feature",
+            "laptime",
+            CLEAN,
+            "within-session per-year aggregates; flagged LEAKY and removed from the reported model",
+            "N06_laptime_model.ipynb (add_context_features / FEATURES_PROD)",
+            "not in the reported IEEE delta model; 2025 held out until final eval",
+        ),
+    ]
+
+
+def _operating_point(y: np.ndarray, proba: np.ndarray, threshold: float) -> dict[str, float]:
+    """Precision / recall / F1 of ``proba >= threshold`` against ``y``."""
+    pred = (proba >= threshold).astype(int)
+    tp = int(((pred == 1) & (y == 1)).sum())
+    fp = int(((pred == 1) & (y == 0)).sum())
+    fn = int(((pred == 0) & (y == 1)).sum())
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    return {"precision": round(precision, 4), "recall": round(recall, 4), "f1": round(f1, 4)}
+
+
+def correct_overtake_threshold() -> dict[str, Any] | None:
+    """Re-select the overtake threshold on val-2024 and show the operating-point delta.
+
+    The E-02 correction for the worst contaminated item: pick the threshold by
+    argmax-F1 on the 2024 validation slice (never touching test), then report its
+    operating point on the 2025 test set next to the leaked 0.7976's operating
+    point on the same test set. The leaked threshold's F1 is maximal on test by
+    construction (it was fit there); the corrected threshold's F1 is the honest
+    number. Returns ``None`` if the holdout is absent.
+    """
+    val = load_overtake_predictions(year=2024)
+    test = load_overtake_predictions(year=2025)
+    if val is None or test is None:
+        return None
+
+    y_val, proba_val_raw, _ = val
+    y_test, proba_test_raw, _ = test
+
+    f1s = [_operating_point(y_val, proba_val_raw, t)["f1"] for t in _THRESHOLD_GRID]
+    corrected_threshold = float(_THRESHOLD_GRID[int(np.argmax(f1s))])
+
+    return {
+        "leaked_threshold": _LEAKED_OVERTAKE_THRESHOLD,
+        "corrected_threshold": round(corrected_threshold, 4),
+        "leaked_test_operating_point": _operating_point(
+            y_test, proba_test_raw, _LEAKED_OVERTAKE_THRESHOLD
+        ),
+        "corrected_test_operating_point": _operating_point(
+            y_test, proba_test_raw, corrected_threshold
+        ),
+        "note": "threshold selected on val-2024; both operating points evaluated on the 2025 test set",
+    }
+
+
+def _render(findings: list[ProvenanceEntry], correction: dict[str, Any] | None) -> str:
+    """Render the hygiene report: verdict table + correction + paper conclusion."""
+    header = "| item | kind | model | verdict | selection | evidence |"
+    rule = "|---|---|---|---|---|---|"
+    order = {CONTAMINATED: 0, UNDERDOCUMENTED: 1, CLEAN: 2}
+    ordered = sorted(findings, key=lambda f: order.get(f.verdict, 3))
+    rows = [
+        f"| {f.item} | {f.kind} | {f.model} | **{f.verdict}** | {f.selection} | {f.evidence} |"
+        for f in ordered
+    ]
+
+    lines = [header, rule, *rows, "", "## Correction (overtake threshold)", ""]
+    if correction is None:
+        lines.append("- holdout absent on disk; correction not computed this run")
+    else:
+        leaked = correction["leaked_test_operating_point"]
+        fixed = correction["corrected_test_operating_point"]
+        lines += [
+            f"- leaked threshold {correction['leaked_threshold']} (selected on test): "
+            f"P {leaked['precision']} / R {leaked['recall']} / F1 {leaked['f1']} on 2025 test",
+            f"- corrected threshold {correction['corrected_threshold']} (selected on val-2024): "
+            f"P {fixed['precision']} / R {fixed['recall']} / F1 {fixed['f1']} on 2025 test",
+            f"- {correction['note']}",
+        ]
+
+    contaminated = [f for f in findings if f.verdict == CONTAMINATED]
+    lines += [
+        "",
+        "## Conclusion for the paper freeze",
+        "",
+        f"- {len(contaminated)} contaminated items (overtake threshold; safety-car threshold + window). "
+        "All other thresholds and aggregate features are clean or non-target.",
+        "- **Overtake headline clears**: AUC-PR 0.5491 / AUC-ROC 0.8758 are threshold-free and involve no "
+        "window selection; the threshold leakage touches only their operating point.",
+        "- **Safety-car headline is optimistic, NOT clean**: AUC-PR 0.0723 is the max-lift window among "
+        "{3,5,7} laps selected on test-2025, so the reported number is itself selection-biased (a max over "
+        "3 candidates on test), on top of the operating-point threshold leakage.",
+        "- **Action before freeze**: (1) re-select the overtake + SC operating thresholds on val-2024 "
+        "(the undercut N16 pattern) - the overtake correction above shows the honest operating point; "
+        "(2) re-select the SC target window on the CV/val split (not test) and re-report SC AUC-PR, or "
+        "caveat it as test-selected; (3) pin a year filter in N03 `load_all_races` to close the "
+        "circuit_cluster underdocumentation.",
+        "- Every other headline (undercut 0.6739, pit 0.487, pace 0.4104, tire 0.7078, sentiment 0.84) is "
+        "unaffected by these findings.",
+    ]
+    return "\n".join(lines)
+
+
+def build_hygiene_report() -> dict[str, Any]:
+    """Regenerate the signed hygiene report (the #207 deliverable)."""
+    findings = audit_findings()
+    correction = correct_overtake_threshold()
+    header = build_header(dataset="notebooks/strategy audit + 2024/2025 overtake holdout")
+    payload = {"findings": [asdict(f) for f in findings], "overtake_correction": correction}
+    md_path, json_path = write_report(HYGIENE_NAME, header, _render(findings, correction), payload)
+    return {
+        "header": asdict(header),
+        "md_path": str(md_path),
+        "json_path": str(json_path),
+        **payload,
+    }

--- a/tests/eval/test_hygiene_golden.py
+++ b/tests/eval/test_hygiene_golden.py
@@ -1,0 +1,48 @@
+"""Golden tests for the #207 threshold-provenance / leakage report.
+
+The verdict assertions are hermetic (the audit findings are authored data).
+The overtake threshold-correction test is data-tier (it re-runs the model on
+the 2024/2025 holdout) and is skipped on CI without weights.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "overtake_probability" / "model_config.json").exists()
+
+
+def test_hygiene_verdicts_match_the_audit():
+    """Both contaminated thresholds, undercut clean, aggregates clean bar circuit_cluster."""
+    from src.strategy.eval.hygiene import CLEAN, CONTAMINATED, UNDERDOCUMENTED, audit_findings
+
+    findings = audit_findings()
+    thresholds = {f.model: f for f in findings if f.kind == "threshold"}
+
+    assert thresholds["overtake"].verdict == CONTAMINATED
+    assert thresholds["safety_car"].verdict == CONTAMINATED
+    assert thresholds["undercut"].verdict == CLEAN
+
+    aggregates = [f for f in findings if f.kind == "aggregate_feature"]
+    cluster = [f for f in aggregates if "circuit_cluster" in f.item]
+    assert cluster and cluster[0].verdict == UNDERDOCUMENTED
+    assert all(f.verdict == CLEAN for f in aggregates if "circuit_cluster" not in f.item)
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_MODELS, reason="data/models/ absent (CI runner without weights)")
+def test_overtake_threshold_correction_is_honest():
+    """Re-selecting on val-2024 yields a threshold whose test F1 <= the leaked (test-fit) one."""
+    from src.strategy.eval.hygiene import correct_overtake_threshold
+
+    correction = correct_overtake_threshold()
+    assert correction is not None
+    assert 0.0 < correction["corrected_threshold"] < 1.0
+    leaked_f1 = correction["leaked_test_operating_point"]["f1"]
+    corrected_f1 = correction["corrected_test_operating_point"]["f1"]
+    assert corrected_f1 <= leaked_f1 + 1e-9, (
+        "leaked threshold was fit on test, so its F1 is maximal there"
+    )


### PR DESCRIPTION
The E-02 hygiene audit that gates the IEEE paper freeze: rules out (or corrects) test-2025 contamination of the reported numbers. Builds on the #206 eval package with a new `hygiene.py` + `f1-eval hygiene` subcommand.

## Findings (each verdict adversarially verified against the exact selection cell)
| item | model | verdict |
|---|---|---|
| threshold 0.7976 | overtake | **contaminated** (argmax-F1 on test-2025) |
| threshold 0.2335 + 3/5/7 window | safety_car | **contaminated** (threshold + window both on test-2025) |
| threshold 0.522 | undercut | clean (val-2024) |
| circuit_sc_rate / team_year_median / undercut encodings / laptime aggregates | - | clean (fit-on-train / past-season) |
| circuit_cluster k-means | - | underdocumented (non-target, unsupervised) |

## Conclusion for the freeze
- **Overtake headline clears**: AUC-PR 0.5491 / AUC-ROC 0.8758 are threshold-free with no window selection.
- **Safety-car headline is optimistic, not clean**: AUC-PR 0.0723 is the max-lift window among {3,5,7} selected on test-2025, so the reported number is itself selection-biased (a max over 3 candidates on test).
- The report re-selects the overtake threshold on val-2024 to show the honest operating point (F1 0.5273 leaked -> 0.5131 corrected on 2025 test).
- Actions before freeze: re-select overtake+SC thresholds on val-2024; re-select the SC window on CV/val (or caveat); pin a year filter in N03 to close circuit_cluster.

## Verification
ruff clean; 5/5 eval golden tests pass locally (verdicts + correction). Verdicts confirmed by an adversarial verify-after pass (Fable gate, epic #205) that re-read the exact selection cells: overtake argmax-F1 on `y_test`, SC F2-threshold + max-lift-window on `y_test`, AUC-PR/AUC-ROC confirmed threshold-free.

Closes #207.