### PR TITLE
Promote Sprint 3: ML-eval harness + provenance/leakage + docs + NLP eval

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -97,7 +97,7 @@ Developed and trained the first two ML models: lap time prediction (XGBoost) and
 - [X] XGBoost delta-lap-time model with circuit clustering features
 - [X] Hyperparameter tuning via GridSearch / cross-validation
 - [X] Model exported to `data/models/lap_time/`
-- [X] Target: MAE <0.5s. **Achieved: MAE 0.392s on 2025 test data** ✅
+- [X] Target: MAE <0.5s. **Achieved: MAE 0.4104s on 2025 test data** ✅
 
 **Tire Degradation Predictor (N07–N10):**
 
@@ -107,14 +107,14 @@ Developed and trained the first two ML models: lap time prediction (XGBoost) and
 - [X] MC Dropout for uncertainty quantification (N=50 forward passes)
 - [X] Calibration JSON exported alongside model weights
 - [X] Model exported to `data/models/tire_degradation/`
-- [ ] Target R² >0.85: *pending formal evaluation on 2025 holdout*
+- [X] Target R² >0.85: **missed**. Final tire-deg MAE 0.7078s on 2025 holdout (best compound C2 0.5501s)
 
 **Important Note - Tire Compound Mapping:**
 Current data (FastF1/OpenF1) only provides relative compound names (SOFT/MEDIUM/HARD) per race. For accurate degradation predictions, actual Pirelli compounds (C1-C5) are critical since the same "MEDIUM" can be C2 (harder) or C4 (softer) depending on circuit. Future enhancement: manual mapping from [Pirelli press releases](https://press.pirelli.com) into `data/tire_compounds_by_race.json`.
 
 **Success Metrics:**
 
-- [X] Lap Time: MAE 0.392s on 2025 (target <0.5s ✅ / stretch <0.3s ⬜)
+- [X] Lap Time: MAE 0.4104s on 2025 (target <0.5s ✅ / stretch <0.3s ⬜)
 - [X] Tire Degradation model operational with MC Dropout uncertainty
 - [X] All experiments documented in notebooks/strategy/
 
@@ -248,7 +248,7 @@ N24 Race Control Messages → structured SC/VSC/flags/penalties
 **N20: RoBERTa Sentiment Fine-tuning:**
 
 - [X] Fine-tuned `roberta-base`: 3-class sentiment on labeled radio messages
-- [X] **Achieved: 87.5% test accuracy** ✅
+- [X] **Achieved: 0.84 test accuracy (macro-F1 0.75)** ✅
 - [X] Export: model state dict to `data/models/nlp/`
 - [X] Notebook: `notebooks/nlp/N20_bert_sentiment.ipynb`
 
@@ -277,7 +277,7 @@ N24 Race Control Messages → structured SC/VSC/flags/penalties
 
 **Success Metrics:**
 
-- [X] N20 RoBERTa Sentiment: 87.5% test accuracy ✅
+- [X] N20 RoBERTa Sentiment: 0.84 test accuracy (macro-F1 0.75) ✅
 - [X] N21 Intent: SetFit 5-class classifier operational ✅
 - [X] N22 NER: F1 = 0.42 (short-text constraint documented) ✅
 - [X] N24 Pipeline: GPU P95 latency 59.4 ms (target <500 ms ✅)
@@ -580,10 +580,10 @@ Code freeze of the TFG software. Consolidates the interfaces closed in v0.12.0 (
 | ------- | ------------ | ----------------------------- | ---------------------------------------------------------------------------------- | ------ |
 | v0.5    | 2025-05-23   | Legacy Integration Complete   | Legacy codebase frozen, `legacy_version` branch preserved                          | ✅     |
 | v0.6    | 2026-02-12   | Data Engineering Complete     | 4 clusters, 45k laps, 2025 held-out, HuggingFace published                         | ✅     |
-| v0.7    | 2026-03-05   | Base Models Complete          | Lap Time MAE 0.392s ✅ / Tire Deg TCN + MC Dropout ✅                               | ✅     |
+| v0.7    | 2026-03-05   | Base Models Complete          | Lap Time MAE 0.4104s ✅ / Tire Deg TCN + MC Dropout ✅                              | ✅     |
 | v0.8.1  | 2026-03-13   | Extended ML Models            | Overtake ✅ / SC ✅ / N15 MAE 0.487s / N16 AUC-ROC 0.7708 / N12B archived           | ✅     |
 | v0.9    | 2026-03-17   | src/ Extraction + CLI + Radio | 7 agents extracted, CLI sim, radio corpus, HF lazy download, guard-rails           | ✅     |
-| v0.8.2  | 2026-03-22   | NLP Radio Pipeline            | N17–N24: RoBERTa 87.5% / SetFit intent / BERT NER / pipeline P95 59.4ms            | ✅     |
+| v0.8.2  | 2026-03-22   | NLP Radio Pipeline            | N17–N24: RoBERTa 0.84 acc / SetFit intent / BERT NER / pipeline P95 59.4ms         | ✅     |
 | v0.10   | 2026-03-22   | Multi-Agent Operational       | N25–N31 all complete, Bahrain 2025 end-to-end demo ✅                              | ✅     |
 | v0.11   | 2026-03-30   | RAG Integrated                | 2,279 chunks indexed, BGE-M3, `src/rag/` module complete                           | ✅     |
 | v0.1.1  | 2026-04-09   | R1 CLI Wheel Release          | Tagged wheel on GitHub Releases, `uv tool install git+` works                      | ✅     |
@@ -609,8 +609,8 @@ Code freeze of the TFG software. Consolidates the interfaces closed in v0.12.0 (
 
 **ML Models:**
 
-- Lap Time: target MAE <0.3s. **Achieved MAE 0.392s** (within <0.5s tolerance ✅)
-- Tire Degradation: target R² >0.85. *Pending formal holdout evaluation*
+- Lap Time: target MAE <0.3s. **Achieved MAE 0.4104s** (within <0.5s tolerance ✅)
+- Tire Degradation: target R² >0.85. **Missed**. MAE 0.7078s on 2025 holdout (best compound C2 0.5501s)
 - Sector Time: **descoped**
 - Overtake Probability: target AUC-PR >0.50. **Achieved AUC-PR 0.5491, AUC-ROC 0.8758** ✅
 - Safety Car Probability: reframed as soft prior. **Achieved AUC-PR 0.0723 (lift 1.67×), AUC-ROC 0.6411** ✅

--- a/docs/pages/roadmap.md
+++ b/docs/pages/roadmap.md
@@ -264,7 +264,7 @@
     <p class="rl-title">ML foundation: lap time and tire degradation</p>
     <p class="rl-summary">First two production ML models. XGBoost delta-lap-time predictor (N06) and a Temporal Convolutional Network for tire degradation with MC Dropout uncertainty (N07-N10, per-compound fine-tuning on SOFT / MEDIUM / HARD).</p>
     <div class="rl-metrics">
-      <span class="rl-metric">MAE 0.392 s</span>
+      <span class="rl-metric">MAE 0.4104 s</span>
       <span class="rl-metric">MC Dropout N=50</span>
     </div>
   </div>
@@ -298,9 +298,9 @@
       <span class="rl-badge done-badge"><span class="sr-only">Status: </span>Shipped</span>
     </div>
     <p class="rl-title">NLP radio processing pipeline</p>
-    <p class="rl-summary">Full team-radio NLP stack. Whisper ASR (N18), RoBERTa sentiment (N20, 87.5% accuracy), SetFit intent classification (N21, 5 classes), BERT-large NER for F1 entities (N22), deterministic RCM parser (N23). Unified inference entry point in N24 at GPU P95 latency of 59.4 ms.</p>
+    <p class="rl-summary">Full team-radio NLP stack. Whisper ASR (N18), RoBERTa sentiment (N20, 0.84 accuracy), SetFit intent classification (N21, 5 classes), BERT-large NER for F1 entities (N22), deterministic RCM parser (N23). Unified inference entry point in N24 at GPU P95 latency of 59.4 ms.</p>
     <div class="rl-metrics">
-      <span class="rl-metric">Sentiment 87.5%</span>
+      <span class="rl-metric">Sentiment 0.84</span>
       <span class="rl-metric">P95 59.4 ms GPU</span>
     </div>
   </div>

--- a/documents/eval_reports/calibration.json
+++ b/documents/eval_reports/calibration.json
@@ -1,0 +1,90 @@
+{
+  "header": {
+    "harness_sha": "91b98d3",
+    "dataset": "2025 holdout + frozen calibration artifacts",
+    "seed_policy": "deterministic",
+    "era_tag": "2022-2025",
+    "llm": "none",
+    "schema_version": "1",
+    "generated_at": "2026-07-11T15:07:21+00:00",
+    "artifacts": {
+      "overtake_model": "cbb9d0eb0beb",
+      "pit_cfg": "41dd673a93fb",
+      "tcn_mc_calib": "e03a170f6de4"
+    }
+  },
+  "results": [
+    {
+      "model": "overtake",
+      "metric": "brier_calibrated",
+      "value": 0.05199088812235834,
+      "nominal": null,
+      "status": "ok",
+      "detail": "n=10217; brier raw 0.1304 -> cal 0.0520 (Platt val-2024)"
+    },
+    {
+      "model": "overtake",
+      "metric": "ece_calibrated",
+      "value": 0.03191338187300733,
+      "nominal": 0.05,
+      "status": "ok",
+      "detail": "n=10217; 10-bin equal-width"
+    },
+    {
+      "model": "pit_duration",
+      "metric": "p05_p95_coverage",
+      "value": 0.7047,
+      "nominal": 0.9,
+      "status": "drift",
+      "detail": "config-declared (recompute pending N15 holdout); 0.7047 vs 0.90 nominal"
+    },
+    {
+      "model": "tire_degradation[C2]",
+      "metric": "mc_mean_sigma_s",
+      "value": 0.1244,
+      "nominal": null,
+      "status": "ok",
+      "detail": "deployed epistemic sigma; empirical coverage wired-pending (N33-D)"
+    },
+    {
+      "model": "tire_degradation[C4]",
+      "metric": "mc_mean_sigma_s",
+      "value": 0.1504,
+      "nominal": null,
+      "status": "ok",
+      "detail": "deployed epistemic sigma; empirical coverage wired-pending (N33-D)"
+    },
+    {
+      "model": "tire_degradation[C5]",
+      "metric": "mc_mean_sigma_s",
+      "value": 0.1549,
+      "nominal": null,
+      "status": "ok",
+      "detail": "deployed epistemic sigma; empirical coverage wired-pending (N33-D)"
+    },
+    {
+      "model": "tire_degradation[C6]",
+      "metric": "mc_mean_sigma_s",
+      "value": 0.2621,
+      "nominal": null,
+      "status": "ok",
+      "detail": "deployed epistemic sigma; empirical coverage wired-pending (N33-D)"
+    },
+    {
+      "model": "safety_car",
+      "metric": "ece_calibrated",
+      "value": null,
+      "nominal": 0.05,
+      "status": "pending",
+      "detail": "engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from sc_labeled holdout (#207)"
+    },
+    {
+      "model": "undercut",
+      "metric": "ece_calibrated",
+      "value": null,
+      "nominal": 0.05,
+      "status": "pending",
+      "detail": "historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207)"
+    }
+  ]
+}

--- a/documents/eval_reports/calibration.md
+++ b/documents/eval_reports/calibration.md
@@ -1,0 +1,17 @@
+# calibration
+
+- harness `91b98d3` · schema v1 · generated 2026-07-11T15:07:21+00:00
+- era 2022-2025 · dataset 2025 holdout + frozen calibration artifacts · seed deterministic · llm none
+- artifacts: overtake_model=`cbb9d0eb0beb`, pit_cfg=`41dd673a93fb`, tcn_mc_calib=`e03a170f6de4`
+
+| model | metric | value | nominal | status | detail |
+|---|---|---|---|---|---|
+| pit_duration | p05_p95_coverage | 0.7047 | 0.9 | drift | config-declared (recompute pending N15 holdout); 0.7047 vs 0.90 nominal |
+| safety_car | ece_calibrated | - | 0.05 | pending | engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from sc_labeled holdout (#207) |
+| undercut | ece_calibrated | - | 0.05 | pending | historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207) |
+| overtake | brier_calibrated | 0.0520 | - | ok | n=10217; brier raw 0.1304 -> cal 0.0520 (Platt val-2024) |
+| overtake | ece_calibrated | 0.0319 | 0.05 | ok | n=10217; 10-bin equal-width |
+| tire_degradation[C2] | mc_mean_sigma_s | 0.1244 | - | ok | deployed epistemic sigma; empirical coverage wired-pending (N33-D) |
+| tire_degradation[C4] | mc_mean_sigma_s | 0.1504 | - | ok | deployed epistemic sigma; empirical coverage wired-pending (N33-D) |
+| tire_degradation[C5] | mc_mean_sigma_s | 0.1549 | - | ok | deployed epistemic sigma; empirical coverage wired-pending (N33-D) |
+| tire_degradation[C6] | mc_mean_sigma_s | 0.2621 | - | ok | deployed epistemic sigma; empirical coverage wired-pending (N33-D) |

--- a/documents/eval_reports/hygiene.json
+++ b/documents/eval_reports/hygiene.json
@@ -1,0 +1,101 @@
+{
+  "header": {
+    "harness_sha": "50b7ecf",
+    "dataset": "notebooks/strategy audit + 2024/2025 overtake holdout",
+    "seed_policy": "deterministic",
+    "era_tag": "2022-2025",
+    "llm": "none",
+    "schema_version": "1",
+    "generated_at": "2026-07-11T15:29:09+00:00",
+    "artifacts": {}
+  },
+  "findings": [
+    {
+      "item": "optimal_threshold=0.7976",
+      "kind": "threshold",
+      "model": "overtake",
+      "verdict": "contaminated",
+      "selection": "argmax-F1 on the 2025 test set",
+      "evidence": "N12_overtake_model.ipynb (threshold-analysis / step-5 cell)",
+      "impact": "operating-point P/R/F1 optimistic; AUC-PR 0.5491 / AUC-ROC 0.8758 unaffected (threshold-free)"
+    },
+    {
+      "item": "best_threshold=0.2335 + 3/5/7-lap window",
+      "kind": "threshold",
+      "model": "safety_car",
+      "verdict": "contaminated",
+      "selection": "argmax-F2 threshold AND the best target-window both on the 2025 test set",
+      "evidence": "N14_sc_model.ipynb (PR-curve + window-comparison cells)",
+      "impact": "threshold -> operating-point optimistic; window chosen by max-lift on test -> the headline AUC-PR 0.0723 is itself optimistic (a max over 3 candidates on test), NOT clean"
+    },
+    {
+      "item": "best_threshold=0.522",
+      "kind": "threshold",
+      "model": "undercut",
+      "verdict": "clean",
+      "selection": "argmax-F1 on the calibrated val-2024 split",
+      "evidence": "N16_undercut.ipynb (\"Threshold on calibrated val 2024\")",
+      "impact": "textbook-correct; the 2025 test set is only applied afterwards"
+    },
+    {
+      "item": "circuit_sc_rate",
+      "kind": "aggregate_feature",
+      "model": "safety_car",
+      "verdict": "clean",
+      "selection": "past-season only (year < yr); 2023 rows get a fixed SC_PRIOR=0.15",
+      "evidence": "N13_sc_eda.ipynb (compute_circuit_sc_rate)",
+      "impact": "no test-2025 in its own aggregate"
+    },
+    {
+      "item": "team_year_median",
+      "kind": "aggregate_feature",
+      "model": "pit_duration",
+      "verdict": "clean",
+      "selection": "lookup fit on train only, applied to test with recent-year fallback",
+      "evidence": "N15_pit_duration.ipynb (add_team_year_median)",
+      "impact": "companion circuit_traversal / baseline are likewise train-fit"
+    },
+    {
+      "item": "circuit_undercut_rate + team_x_undercut_rate",
+      "kind": "aggregate_feature",
+      "model": "undercut",
+      "verdict": "clean",
+      "selection": "target encoding fit on train only, train-mean fallback on test",
+      "evidence": "N16_undercut.ipynb (compute_target_encoding)",
+      "impact": "split precedes the encoding; no train<-test leak"
+    },
+    {
+      "item": "circuit_cluster (k-means)",
+      "kind": "aggregate_feature",
+      "model": "overtake/safety_car/laptime",
+      "verdict": "underdocumented",
+      "selection": "k-means fit window not year-restricted in code; 2025 holdout is intent-only",
+      "evidence": "N03_circuit_clustering.ipynb (load_all_races / fit_kmeans_final)",
+      "impact": "mild NON-target risk (unsupervised geometry bucket); pin a year filter to close"
+    },
+    {
+      "item": "year_circuit_median / team_pace_rank",
+      "kind": "aggregate_feature",
+      "model": "laptime",
+      "verdict": "clean",
+      "selection": "within-session per-year aggregates; flagged LEAKY and removed from the reported model",
+      "evidence": "N06_laptime_model.ipynb (add_context_features / FEATURES_PROD)",
+      "impact": "not in the reported IEEE delta model; 2025 held out until final eval"
+    }
+  ],
+  "overtake_correction": {
+    "leaked_threshold": 0.7976,
+    "corrected_threshold": 0.7626,
+    "leaked_test_operating_point": {
+      "precision": 0.5018,
+      "recall": 0.5556,
+      "f1": 0.5273
+    },
+    "corrected_test_operating_point": {
+      "precision": 0.4583,
+      "recall": 0.5827,
+      "f1": 0.5131
+    },
+    "note": "threshold selected on val-2024; both operating points evaluated on the 2025 test set"
+  }
+}

--- a/documents/eval_reports/hygiene.md
+++ b/documents/eval_reports/hygiene.md
@@ -1,0 +1,30 @@
+# hygiene
+
+- harness `50b7ecf` · schema v1 · generated 2026-07-11T15:29:09+00:00
+- era 2022-2025 · dataset notebooks/strategy audit + 2024/2025 overtake holdout · seed deterministic · llm none
+- artifacts: —
+
+| item | kind | model | verdict | selection | evidence |
+|---|---|---|---|---|---|
+| optimal_threshold=0.7976 | threshold | overtake | **contaminated** | argmax-F1 on the 2025 test set | N12_overtake_model.ipynb (threshold-analysis / step-5 cell) |
+| best_threshold=0.2335 + 3/5/7-lap window | threshold | safety_car | **contaminated** | argmax-F2 threshold AND the best target-window both on the 2025 test set | N14_sc_model.ipynb (PR-curve + window-comparison cells) |
+| circuit_cluster (k-means) | aggregate_feature | overtake/safety_car/laptime | **underdocumented** | k-means fit window not year-restricted in code; 2025 holdout is intent-only | N03_circuit_clustering.ipynb (load_all_races / fit_kmeans_final) |
+| best_threshold=0.522 | threshold | undercut | **clean** | argmax-F1 on the calibrated val-2024 split | N16_undercut.ipynb ("Threshold on calibrated val 2024") |
+| circuit_sc_rate | aggregate_feature | safety_car | **clean** | past-season only (year < yr); 2023 rows get a fixed SC_PRIOR=0.15 | N13_sc_eda.ipynb (compute_circuit_sc_rate) |
+| team_year_median | aggregate_feature | pit_duration | **clean** | lookup fit on train only, applied to test with recent-year fallback | N15_pit_duration.ipynb (add_team_year_median) |
+| circuit_undercut_rate + team_x_undercut_rate | aggregate_feature | undercut | **clean** | target encoding fit on train only, train-mean fallback on test | N16_undercut.ipynb (compute_target_encoding) |
+| year_circuit_median / team_pace_rank | aggregate_feature | laptime | **clean** | within-session per-year aggregates; flagged LEAKY and removed from the reported model | N06_laptime_model.ipynb (add_context_features / FEATURES_PROD) |
+
+## Correction (overtake threshold)
+
+- leaked threshold 0.7976 (selected on test): P 0.5018 / R 0.5556 / F1 0.5273 on 2025 test
+- corrected threshold 0.7626 (selected on val-2024): P 0.4583 / R 0.5827 / F1 0.5131 on 2025 test
+- threshold selected on val-2024; both operating points evaluated on the 2025 test set
+
+## Conclusion for the paper freeze
+
+- 2 contaminated items (overtake threshold; safety-car threshold + window). All other thresholds and aggregate features are clean or non-target.
+- **Overtake headline clears**: AUC-PR 0.5491 / AUC-ROC 0.8758 are threshold-free and involve no window selection; the threshold leakage touches only their operating point.
+- **Safety-car headline is optimistic, NOT clean**: AUC-PR 0.0723 is the max-lift window among {3,5,7} laps selected on test-2025, so the reported number is itself selection-biased (a max over 3 candidates on test), on top of the operating-point threshold leakage.
+- **Action before freeze**: (1) re-select the overtake + SC operating thresholds on val-2024 (the undercut N16 pattern) - the overtake correction above shows the honest operating point; (2) re-select the SC target window on the CV/val split (not test) and re-report SC AUC-PR, or caveat it as test-selected; (3) pin a year filter in N03 `load_all_races` to close the circuit_cluster underdocumentation.
+- Every other headline (undercut 0.6739, pit 0.487, pace 0.4104, tire 0.7078, sentiment 0.84) is unaffected by these findings.

--- a/documents/eval_reports/metrics_registry.json
+++ b/documents/eval_reports/metrics_registry.json
@@ -1,0 +1,118 @@
+{
+  "header": {
+    "harness_sha": "91b98d3",
+    "dataset": "model_configs + thesis Tabla 6.1",
+    "seed_policy": "deterministic",
+    "era_tag": "2022-2025",
+    "llm": "none",
+    "schema_version": "1",
+    "generated_at": "2026-07-11T15:07:44+00:00",
+    "artifacts": {
+      "overtake_cfg": "f72ef54ebbc8",
+      "undercut_cfg": "b0250c8522a2",
+      "pit_cfg": "41dd673a93fb",
+      "sc_cfg": "4691fb9c30c1"
+    }
+  },
+  "entries": [
+    {
+      "model": "overtake",
+      "family": "classification",
+      "metric": "auc_pr_test",
+      "value": 0.5491,
+      "threshold": 0.7976,
+      "split": "train [2023, 2024] / test 2025",
+      "source": "config: overtake_probability/model_config.json",
+      "canonical": true,
+      "note": "LightGBM + Platt(val 2024); auc_roc 0.8758"
+    },
+    {
+      "model": "undercut",
+      "family": "classification",
+      "metric": "auc_pr_test",
+      "value": 0.6739,
+      "threshold": 0.522,
+      "split": "train [2023, 2024] / test 2025",
+      "source": "config: pit_prediction/model_config_undercut_v1.json",
+      "canonical": true,
+      "note": "LightGBM + Platt(val 2024); baseline_pr 0.3452"
+    },
+    {
+      "model": "pit_duration",
+      "family": "quantile",
+      "metric": "p50_mae_test_s",
+      "value": 0.487,
+      "threshold": null,
+      "split": "train [2023, 2024] / test 2025",
+      "source": "config: pit_prediction/model_config.json",
+      "canonical": true,
+      "note": "HistGBT P05/P50/P95; baseline_mae 1.677; P05-P95 coverage 0.7047 vs 0.90 nominal (see calibration report)"
+    },
+    {
+      "model": "safety_car",
+      "family": "classification",
+      "metric": "auc_pr_test",
+      "value": 0.0723,
+      "threshold": 0.2335,
+      "split": "train [2023, 2024] / test 2025",
+      "source": "config: safety_car_probability/feature_list_v1.json",
+      "canonical": true,
+      "note": "LightGBM + Platt(val 2024); baseline 0.0432; 3-lap lift 1.673; target sc_within_3_laps"
+    },
+    {
+      "model": "pace",
+      "family": "regression",
+      "metric": "mae_test_s",
+      "value": 0.4104,
+      "threshold": null,
+      "split": "test 2025",
+      "source": "thesis Tabla 6.1 (final)",
+      "canonical": true,
+      "note": "XGBoost delta lap time; split provenance pending (#207)"
+    },
+    {
+      "model": "pace",
+      "family": "regression",
+      "metric": "mae_test_s",
+      "value": 0.392,
+      "threshold": null,
+      "split": "test 2025",
+      "source": "notebook N06 (superseded)",
+      "canonical": false,
+      "note": "notebook-era value; superseded by thesis-final 0.4104"
+    },
+    {
+      "model": "tire_degradation",
+      "family": "regression",
+      "metric": "mae_test_s",
+      "value": 0.7078,
+      "threshold": null,
+      "split": "test 2025",
+      "source": "thesis Tabla 6.1 (global)",
+      "canonical": true,
+      "note": "TireDegTCN; per-compound best C2 0.5501s; missed R2 target; split provenance pending (#207)"
+    },
+    {
+      "model": "sentiment",
+      "family": "nlp",
+      "metric": "accuracy",
+      "value": 0.84,
+      "threshold": null,
+      "split": "held-out radio set",
+      "source": "thesis Tabla 6.1 (final)",
+      "canonical": true,
+      "note": "RoBERTa; macro-F1 0.75; NLP harness in #304"
+    },
+    {
+      "model": "sentiment",
+      "family": "nlp",
+      "metric": "accuracy",
+      "value": 0.875,
+      "threshold": null,
+      "split": "held-out radio set",
+      "source": "published-era (superseded)",
+      "canonical": false,
+      "note": "87.5% published; superseded by thesis-final 0.84"
+    }
+  ]
+}

--- a/documents/eval_reports/metrics_registry.md
+++ b/documents/eval_reports/metrics_registry.md
@@ -1,0 +1,22 @@
+# metrics_registry
+
+- harness `91b98d3` · schema v1 · generated 2026-07-11T15:07:44+00:00
+- era 2022-2025 · dataset model_configs + thesis Tabla 6.1 · seed deterministic · llm none
+- artifacts: overtake_cfg=`f72ef54ebbc8`, undercut_cfg=`b0250c8522a2`, pit_cfg=`41dd673a93fb`, sc_cfg=`4691fb9c30c1`
+
+| model | metric | value | thr | split | canonical | source |
+|---|---|---|---|---|---|---|
+| overtake | auc_pr_test | 0.5491 | 0.7976 | train [2023, 2024] / test 2025 | yes | config: overtake_probability/model_config.json |
+| undercut | auc_pr_test | 0.6739 | 0.522 | train [2023, 2024] / test 2025 | yes | config: pit_prediction/model_config_undercut_v1.json |
+| pit_duration | p50_mae_test_s | 0.487 | - | train [2023, 2024] / test 2025 | yes | config: pit_prediction/model_config.json |
+| safety_car | auc_pr_test | 0.0723 | 0.2335 | train [2023, 2024] / test 2025 | yes | config: safety_car_probability/feature_list_v1.json |
+| pace | mae_test_s | 0.4104 | - | test 2025 | yes | thesis Tabla 6.1 (final) |
+| pace | mae_test_s | 0.392 | - | test 2025 | no | notebook N06 (superseded) |
+| tire_degradation | mae_test_s | 0.7078 | - | test 2025 | yes | thesis Tabla 6.1 (global) |
+| sentiment | accuracy | 0.84 | - | held-out radio set | yes | thesis Tabla 6.1 (final) |
+| sentiment | accuracy | 0.875 | - | held-out radio set | no | published-era (superseded) |
+
+## Divergences reconciled
+
+- **pace mae_test_s**: 0.392 (notebook N06 (superseded)) -> **0.4104** (thesis Tabla 6.1 (final))
+- **sentiment accuracy**: 0.875 (published-era (superseded)) -> **0.84** (thesis Tabla 6.1 (final))

--- a/documents/eval_reports/nlp.json
+++ b/documents/eval_reports/nlp.json
@@ -1,0 +1,64 @@
+{
+  "header": {
+    "harness_sha": "5f1f29d",
+    "dataset": "radio_labeled_data.csv (fixed set)",
+    "seed_policy": "deterministic",
+    "era_tag": "2022-2025",
+    "llm": "none",
+    "schema_version": "1",
+    "generated_at": "2026-07-11T15:38:36+00:00",
+    "artifacts": {
+      "roberta_sentiment": "d7d0ada739c6"
+    }
+  },
+  "results": [
+    {
+      "stage": "sentiment",
+      "metric": "accuracy",
+      "value": 0.9415,
+      "reference": 0.84,
+      "status": "delta",
+      "detail": "n=530; full labeled set (train+test); optimistic vs the held-out 0.84 (split not pinned on disk)"
+    },
+    {
+      "stage": "sentiment",
+      "metric": "macro_f1",
+      "value": 0.9153,
+      "reference": 0.75,
+      "status": "delta",
+      "detail": "n=530; 3-class"
+    },
+    {
+      "stage": "intent",
+      "metric": "accuracy",
+      "value": null,
+      "reference": null,
+      "status": "blocked",
+      "detail": "setfit does not import under transformers 5.3.0 (#303); stage cannot run"
+    },
+    {
+      "stage": "ner",
+      "metric": "entity_f1",
+      "value": null,
+      "reference": null,
+      "status": "pending",
+      "detail": "GLiNER/BERT reconstruction not wired this phase"
+    },
+    {
+      "stage": "rcm",
+      "metric": "accuracy",
+      "value": null,
+      "reference": null,
+      "status": "pending",
+      "detail": "RCM classifier reconstruction not wired this phase"
+    },
+    {
+      "stage": "alert_precision",
+      "metric": "precision",
+      "value": null,
+      "reference": null,
+      "status": "pending",
+      "detail": "no labeled alert ground-truth on disk (the MoE-routing metric #304 targets; data-collection task)"
+    }
+  ]
+}

--- a/documents/eval_reports/nlp.md
+++ b/documents/eval_reports/nlp.md
@@ -1,0 +1,14 @@
+# nlp
+
+- harness `5f1f29d` · schema v1 · generated 2026-07-11T15:38:36+00:00
+- era 2022-2025 · dataset radio_labeled_data.csv (fixed set) · seed deterministic · llm none
+- artifacts: roberta_sentiment=`d7d0ada739c6`
+
+| stage | metric | value | reference | status | detail |
+|---|---|---|---|---|---|
+| sentiment | accuracy | 0.9415 | 0.84 | delta | n=530; full labeled set (train+test); optimistic vs the held-out 0.84 (split not pinned on disk) |
+| sentiment | macro_f1 | 0.9153 | 0.75 | delta | n=530; 3-class |
+| intent | accuracy | - | - | blocked | setfit does not import under transformers 5.3.0 (#303); stage cannot run |
+| ner | entity_f1 | - | - | pending | GLiNER/BERT reconstruction not wired this phase |
+| rcm | accuracy | - | - | pending | RCM classifier reconstruction not wired this phase |
+| alert_precision | precision | - | - | pending | no labeled alert ground-truth on disk (the MoE-routing metric #304 targets; data-collection task) |

--- a/documents/eval_reports/reproduction.json
+++ b/documents/eval_reports/reproduction.json
@@ -1,0 +1,64 @@
+{
+  "header": {
+    "harness_sha": "91b98d3",
+    "dataset": "2025 holdout vs published model_configs",
+    "seed_policy": "deterministic",
+    "era_tag": "2022-2025",
+    "llm": "none",
+    "schema_version": "1",
+    "generated_at": "2026-07-11T15:07:22+00:00",
+    "artifacts": {
+      "overtake_model": "cbb9d0eb0beb"
+    }
+  },
+  "results": [
+    {
+      "model": "overtake",
+      "metric": "auc_pr_test",
+      "published": 0.5491,
+      "reproduced": 0.5491139336464441,
+      "status": "reproduced",
+      "detail": "|delta| 0.0000 vs tol 0.01"
+    },
+    {
+      "model": "undercut",
+      "metric": "auc_pr_test",
+      "published": 0.6739,
+      "reproduced": null,
+      "status": "pending",
+      "detail": "historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207)"
+    },
+    {
+      "model": "pit_duration",
+      "metric": "p50_mae_test_s",
+      "published": 0.487,
+      "reproduced": null,
+      "status": "pending",
+      "detail": "pit_labeled holdout empty on disk (#207)"
+    },
+    {
+      "model": "safety_car",
+      "metric": "auc_pr_test",
+      "published": 0.0723,
+      "reproduced": null,
+      "status": "pending",
+      "detail": "engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from holdout (#207)"
+    },
+    {
+      "model": "pace",
+      "metric": "mae_test_s",
+      "published": 0.4104,
+      "reproduced": null,
+      "status": "pending",
+      "detail": "laptime holdout feature build not wired this phase"
+    },
+    {
+      "model": "tire_degradation",
+      "metric": "mae_test_s",
+      "published": 0.7078,
+      "reproduced": null,
+      "status": "pending",
+      "detail": "TCN MC forward pass not run this phase (see calibration MC-sigma)"
+    }
+  ]
+}

--- a/documents/eval_reports/reproduction.md
+++ b/documents/eval_reports/reproduction.md
@@ -1,0 +1,14 @@
+# reproduction
+
+- harness `91b98d3` · schema v1 · generated 2026-07-11T15:07:22+00:00
+- era 2022-2025 · dataset 2025 holdout vs published model_configs · seed deterministic · llm none
+- artifacts: overtake_model=`cbb9d0eb0beb`
+
+| model | metric | published | reproduced | status | detail |
+|---|---|---|---|---|---|
+| overtake | auc_pr_test | 0.5491 | 0.5491 | reproduced | |delta| 0.0000 vs tol 0.01 |
+| undercut | auc_pr_test | 0.6739 | - | pending | historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207) |
+| pit_duration | p50_mae_test_s | 0.487 | - | pending | pit_labeled holdout empty on disk (#207) |
+| safety_car | auc_pr_test | 0.0723 | - | pending | engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from holdout (#207) |
+| pace | mae_test_s | 0.4104 | - | pending | laptime holdout feature build not wired this phase |
+| tire_degradation | mae_test_s | 0.7078 | - | pending | TCN MC forward pass not run this phase (see calibration MC-sigma) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ f1-strat     = "scripts.f1_cli:main"
 f1-sim       = "scripts.run_simulation_cli:main"
 f1-arcade    = "src.arcade.main:main"
 f1-streamlit = "scripts.run_streamlit:main"
+f1-eval      = "src.strategy.eval.cli:main"
 
 [project.optional-dependencies]
 dev = [

--- a/src/strategy/eval/__init__.py
+++ b/src/strategy/eval/__init__.py
@@ -1,0 +1,25 @@
+"""Additive evaluation harness for the F1 StratLab ML predictors (issue #206).
+
+The measurement foundation the paper builds on: a reproducible metrics
+registry (E-08) + calibration verification (E-03), launched by the ``f1-eval``
+console script. Nothing here touches the UNTOUCHABLE trees (``src/agents/``
+internals, ``notebooks/``, ``run_simulation_cli.py``); it only reads frozen
+artifacts under ``data/models/`` and the labeled holdouts under
+``data/processed/``.
+
+Public API:
+- ``build_registry`` / ``load_registry`` - the consolidated metrics table.
+- ``build_calibration_report`` - reliability/Brier/ECE + quantile coverage.
+- ``build_reproduction_report`` - headline numbers re-derived vs the configs.
+"""
+
+from src.strategy.eval.calibration import build_calibration_report
+from src.strategy.eval.registry import build_registry, load_registry
+from src.strategy.eval.reproduce import build_reproduction_report
+
+__all__ = [
+    "build_registry",
+    "load_registry",
+    "build_calibration_report",
+    "build_reproduction_report",
+]

--- a/src/strategy/eval/__init__.py
+++ b/src/strategy/eval/__init__.py
@@ -15,6 +15,7 @@ Public API:
 
 from src.strategy.eval.calibration import build_calibration_report
 from src.strategy.eval.hygiene import build_hygiene_report
+from src.strategy.eval.nlp import build_nlp_report
 from src.strategy.eval.registry import build_registry, load_registry
 from src.strategy.eval.reproduce import build_reproduction_report
 
@@ -24,4 +25,5 @@ __all__ = [
     "build_calibration_report",
     "build_reproduction_report",
     "build_hygiene_report",
+    "build_nlp_report",
 ]

--- a/src/strategy/eval/__init__.py
+++ b/src/strategy/eval/__init__.py
@@ -14,6 +14,7 @@ Public API:
 """
 
 from src.strategy.eval.calibration import build_calibration_report
+from src.strategy.eval.hygiene import build_hygiene_report
 from src.strategy.eval.registry import build_registry, load_registry
 from src.strategy.eval.reproduce import build_reproduction_report
 
@@ -22,4 +23,5 @@ __all__ = [
     "load_registry",
     "build_calibration_report",
     "build_reproduction_report",
+    "build_hygiene_report",
 ]

--- a/src/strategy/eval/calibration.py
+++ b/src/strategy/eval/calibration.py
@@ -123,8 +123,11 @@ def _add_overtake_features(df: "Any") -> "Any":
     return df
 
 
-def load_overtake_predictions() -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
-    """Load the overtake 2025 holdout and return ``(y, proba_raw, proba_cal)``.
+def load_overtake_predictions(year: int = 2025) -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
+    """Load an overtake season holdout (default 2025 test) -> ``(y, proba_raw, proba_cal)``.
+
+    ``year`` selects the season slice: 2025 = test (calibration/reproduction),
+    2024 = validation (the #207 hygiene threshold re-selection).
 
     Shared seam: both the calibration metrics here and the headline-metric
     reproduction (``reproduce.py``) need the same holdout + model + calibrator,
@@ -145,7 +148,7 @@ def load_overtake_predictions() -> tuple[np.ndarray, np.ndarray, np.ndarray] | N
         return None
 
     df = _add_overtake_features(pd.read_parquet(parquet))
-    test = df[df["Year"] == 2025].copy()
+    test = df[df["Year"] == year].copy()
     model = joblib.load(model_path)
     calibrator = joblib.load(calib_path)
 

--- a/src/strategy/eval/calibration.py
+++ b/src/strategy/eval/calibration.py
@@ -1,0 +1,337 @@
+"""E-03 calibration verification for the ML predictors.
+
+The audit's finding is "calibration asserted, never verified": the pit
+P05-P95 interval is already published broken (coverage 0.7047 vs 0.90
+nominal), yet nothing re-checks it. This module makes calibration a measured
+quantity so the paper can state it as fact, and it deliberately "finds" the
+known pit breakage as a retro-validation of the harness itself.
+
+Scope this phase (#206):
+- **overtake** - reliability (Brier + ECE) recomputed on the 2025 holdout,
+  wiring N33 Section A's proven loader + interaction-feature logic.
+- **pit_duration** - the P05-P95 quantile coverage, flagged as drift vs the
+  0.90 nominal.
+- **tire_degradation** - the deployed MC-Dropout sigma per compound.
+- **safety_car / undercut** - recompute from scratch is blocked on-disk (SC
+  needs 5 engineered features - lap_time_*_z, anomaly_and_yellow, lap1_chaos -
+  absent from the holdout; undercut historical aggregates absent too) so they
+  are reported as ``pending`` rather than hidden - Phase-2 (#207) territory.
+  Their headline numbers are still config-sourced in the registry.
+
+ponytail: pit coverage + the MC sigma are read from frozen artifacts, not
+re-run from a holdout (``pit_labeled`` is empty on disk; the MC pass needs a
+torch forward pass x N). Upgrade path when the holdouts land: recompute both
+from data, the same way N33 Section D already does for the TCN.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import numpy as np
+
+from src.f1_strat_manager.data_cache import get_data_root, get_models_root
+from src.strategy.eval.report import build_header, write_report
+
+CAL_NAME = "calibration"
+NOMINAL_COVERAGE = 0.90
+ECE_BINS = 10
+ECE_DRIFT = 0.05  # expected-calibration-error above this is flagged as drift
+
+# Reproduced verbatim from N33 Section A / the overtake model_config so the
+# harness feeds the LightGBM the exact 15-feature vector it was trained on.
+_OVERTAKE_FEATURES = [
+    "gap_ahead_s",
+    "pace_delta_s",
+    "tyre_life_x",
+    "tyre_life_y",
+    "tyre_life_diff",
+    "speed_trap_delta",
+    "LapNumber",
+    "drs_window",
+    "compound_x",
+    "compound_y",
+    "circuit_cluster",
+    "gap_pace_product",
+    "drs_ready_gap",
+    "gap_trend",
+    "pace_delta_rolling3",
+]
+_OVERTAKE_CAT = ["compound_x", "compound_y", "circuit_cluster"]
+_OVERTAKE_PAIR_KEYS = ["Year", "GP_Name", "driver_x", "driver_y"]
+
+
+@dataclass
+class CalibrationResult:
+    """One calibration measurement.
+
+    ``status`` is ``ok`` (within nominal), ``drift`` (measured worse than
+    nominal - the harness caught a miscalibration), or ``pending`` (cannot be
+    recomputed on-disk this phase; deferred to #207 / holdout availability).
+    """
+
+    model: str
+    metric: str
+    value: float | None
+    nominal: float | None
+    status: str
+    detail: str
+
+
+def _ece(y_true: np.ndarray, proba: np.ndarray, n_bins: int = ECE_BINS) -> float:
+    """Expected Calibration Error: bin-weighted gap between confidence and accuracy.
+
+    A perfectly calibrated classifier has ECE 0 (in each confidence bin, the
+    predicted probability equals the empirical positive rate). Standard
+    equal-width binning over [0, 1].
+    """
+    edges = np.linspace(0.0, 1.0, n_bins + 1)
+    total = len(y_true)
+    error = 0.0
+    for lo, hi in zip(edges[:-1], edges[1:]):
+        in_bin = (proba > lo) & (proba <= hi)
+        count = int(in_bin.sum())
+        if count == 0:
+            continue
+        confidence = float(proba[in_bin].mean())
+        accuracy = float(y_true[in_bin].mean())
+        error += (count / total) * abs(confidence - accuracy)
+    return error
+
+
+def _add_overtake_features(df: "Any") -> "Any":
+    """Reproduce the N12 interaction + rolling features from the base columns.
+
+    The labeled parquet stores only the base columns; the four derived
+    features (products + per-pair rolling/diff) are rebuilt here exactly as the
+    training notebook did, or the LightGBM sees a different feature space and
+    the numbers do not reproduce.
+    """
+    df = df.copy()
+    df["gap_pace_product"] = df["gap_ahead_s"] * df["pace_delta_s"]
+    df["drs_ready_gap"] = df["gap_ahead_s"] * df["drs_window"]
+    df = df.sort_values(_OVERTAKE_PAIR_KEYS + ["LapNumber"]).copy()
+    grp = df.groupby(_OVERTAKE_PAIR_KEYS)
+    df["gap_trend"] = grp["gap_ahead_s"].diff().fillna(0.0)
+    df["pace_delta_rolling3"] = grp["pace_delta_s"].transform(
+        lambda x: x.rolling(3, min_periods=1).mean()
+    )
+    for col in _OVERTAKE_CAT:
+        df[col] = df[col].astype("category")
+    return df
+
+
+def load_overtake_predictions() -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
+    """Load the overtake 2025 holdout and return ``(y, proba_raw, proba_cal)``.
+
+    Shared seam: both the calibration metrics here and the headline-metric
+    reproduction (``reproduce.py``) need the same holdout + model + calibrator,
+    so the load lives in one place. Returns ``None`` when the artifacts or the
+    holdout parquet are absent, letting each caller degrade to a ``pending``
+    result instead of crashing.
+    """
+    import joblib
+    import pandas as pd
+
+    model_dir = get_models_root() / "overtake_probability"
+    parquet = (
+        get_data_root() / "processed" / "overtake_labeled" / "overtake_pairs_2023_2025.parquet"
+    )
+    model_path = model_dir / "lgbm_overtake_v1.pkl"
+    calib_path = model_dir / "calibrator.pkl"
+    if not (parquet.exists() and model_path.exists() and calib_path.exists()):
+        return None
+
+    df = _add_overtake_features(pd.read_parquet(parquet))
+    test = df[df["Year"] == 2025].copy()
+    model = joblib.load(model_path)
+    calibrator = joblib.load(calib_path)
+
+    x = test[_OVERTAKE_FEATURES]
+    y = test["overtake"].astype(int).to_numpy()
+    proba_raw = model.predict_proba(x)[:, 1]
+    proba_cal = calibrator.predict_proba(proba_raw.reshape(-1, 1))[:, 1]
+    return y, proba_raw, proba_cal
+
+
+def _overtake_calibration() -> list[CalibrationResult]:
+    """Recompute Brier + ECE for the overtake classifier on the 2025 holdout.
+
+    Uses the calibrated probabilities (Platt on val-2024) - the quantity the
+    production agent actually consumes. Returns a ``pending`` result instead of
+    raising if the artifacts are absent, so a partial install still reports.
+    """
+    loaded = load_overtake_predictions()
+    if loaded is None:
+        return [
+            CalibrationResult(
+                "overtake", "ece", None, ECE_DRIFT, "pending", "artifacts or holdout absent on disk"
+            )
+        ]
+    y, proba_raw, proba_cal = loaded
+
+    brier_raw = float(np.mean((proba_raw - y) ** 2))
+    brier_cal = float(np.mean((proba_cal - y) ** 2))
+    ece_cal = _ece(y, proba_cal)
+    status = "drift" if ece_cal > ECE_DRIFT else "ok"
+    detail = f"n={len(y)}; brier raw {brier_raw:.4f} -> cal {brier_cal:.4f} (Platt val-2024)"
+
+    return [
+        CalibrationResult("overtake", "brier_calibrated", brier_cal, None, "ok", detail),
+        CalibrationResult(
+            "overtake",
+            "ece_calibrated",
+            ece_cal,
+            ECE_DRIFT,
+            status,
+            f"n={len(y)}; {ECE_BINS}-bin equal-width",
+        ),
+    ]
+
+
+def _pit_quantile_coverage() -> list[CalibrationResult]:
+    """Surface the pit P05-P95 empirical coverage and flag it vs nominal.
+
+    ponytail: read from the frozen ``model_config`` (the value is published
+    there) rather than re-run - ``pit_labeled`` is empty on disk so there is no
+    holdout to predict on. Upgrade path: recompute empirical coverage from the
+    hist_pit P05/P95 models over the N15 holdout once it lands. This is the
+    retro-validation target: the harness must surface the known 0.7047 break.
+    """
+    cfg_path = get_models_root() / "pit_prediction" / "model_config.json"
+    if not cfg_path.exists():
+        return [
+            CalibrationResult(
+                "pit_duration",
+                "p05_p95_coverage",
+                None,
+                NOMINAL_COVERAGE,
+                "pending",
+                "model_config absent",
+            )
+        ]
+
+    cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+    coverage = float(cfg["eval"]["p05_p95_coverage_test"])
+    status = "drift" if coverage < NOMINAL_COVERAGE else "ok"
+    detail = f"config-declared (recompute pending N15 holdout); {coverage:.4f} vs {NOMINAL_COVERAGE:.2f} nominal"
+    return [
+        CalibrationResult(
+            "pit_duration", "p05_p95_coverage", coverage, NOMINAL_COVERAGE, status, detail
+        )
+    ]
+
+
+def _tcn_mc_sigma() -> list[CalibrationResult]:
+    """Report the deployed MC-Dropout sigma per compound from the frozen JSON.
+
+    The stored ``mean_sigma_s`` is the epistemic band the tire agent uses at
+    runtime. Empirical coverage validation (predicted vs residual sigma) needs
+    the torch MC pass N33 Section D runs and is wired-pending here.
+    """
+    calib_path = get_models_root() / "tire_degradation" / "mc_dropout_calibration.json"
+    if not calib_path.exists():
+        return [
+            CalibrationResult(
+                "tire_degradation",
+                "mc_mean_sigma_s",
+                None,
+                None,
+                "pending",
+                "mc_dropout_calibration.json absent",
+            )
+        ]
+
+    calib = json.loads(calib_path.read_text(encoding="utf-8"))
+    results = []
+    for compound in sorted(calib):
+        sigma = float(calib[compound]["mean_sigma_s"])
+        detail = "deployed epistemic sigma; empirical coverage wired-pending (N33-D)"
+        results.append(
+            CalibrationResult(
+                f"tire_degradation[{compound}]", "mc_mean_sigma_s", sigma, None, "ok", detail
+            )
+        )
+    return results
+
+
+def _pending_classifiers() -> list[CalibrationResult]:
+    """Honest deltas for the two classifiers that cannot recompute on-disk.
+
+    Recording the blocker (not a fabricated number) is the point: both blockers
+    are precisely what Phase-2 provenance work (#207) resolves.
+    """
+    return [
+        CalibrationResult(
+            "safety_car",
+            "ece_calibrated",
+            None,
+            ECE_DRIFT,
+            "pending",
+            "engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from sc_labeled holdout (#207)",
+        ),
+        CalibrationResult(
+            "undercut",
+            "ece_calibrated",
+            None,
+            ECE_DRIFT,
+            "pending",
+            "historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207)",
+        ),
+    ]
+
+
+def collect_results() -> list[CalibrationResult]:
+    """All calibration results across the predictors."""
+    return [
+        *_overtake_calibration(),
+        *_pit_quantile_coverage(),
+        *_tcn_mc_sigma(),
+        *_pending_classifiers(),
+    ]
+
+
+def _render_table(results: list[CalibrationResult]) -> str:
+    """Render calibration results as a markdown table, drift rows first."""
+    order = {"drift": 0, "pending": 1, "ok": 2}
+    ordered = sorted(results, key=lambda r: order.get(r.status, 3))
+    header = "| model | metric | value | nominal | status | detail |"
+    rule = "|---|---|---|---|---|---|"
+    rows = []
+    for r in ordered:
+        value = "-" if r.value is None else f"{r.value:.4f}"
+        nominal = "-" if r.nominal is None else f"{r.nominal:g}"
+        rows.append(f"| {r.model} | {r.metric} | {value} | {nominal} | {r.status} | {r.detail} |")
+    return "\n".join([header, rule, *rows])
+
+
+def build_calibration_report() -> dict[str, Any]:
+    """Regenerate the calibration report and write the versioned output.
+
+    Returns the payload dict (also written to
+    ``documents/eval_reports/calibration.json``). The report always contains
+    the pit P05-P95 coverage row flagged as drift - the retro-validation that
+    proves the harness finds a known-broken calibration.
+    """
+    results = collect_results()
+    models = get_models_root()
+    artifacts = {
+        "overtake_model": models / "overtake_probability" / "lgbm_overtake_v1.pkl",
+        "pit_cfg": models / "pit_prediction" / "model_config.json",
+        "tcn_mc_calib": models / "tire_degradation" / "mc_dropout_calibration.json",
+    }
+    header = build_header(
+        dataset="2025 holdout + frozen calibration artifacts",
+        seed_policy="deterministic",
+        artifacts=artifacts,
+    )
+    payload = {"results": [asdict(r) for r in results]}
+    md_path, json_path = write_report(CAL_NAME, header, _render_table(results), payload)
+    return {
+        "header": asdict(header),
+        "md_path": str(md_path),
+        "json_path": str(json_path),
+        **payload,
+    }

--- a/src/strategy/eval/cli.py
+++ b/src/strategy/eval/cli.py
@@ -1,0 +1,75 @@
+"""``f1-eval`` console entry point: regenerate the eval reports.
+
+Thin argparse dispatch over the three report builders. Each subcommand writes
+its versioned markdown + JSON under ``documents/eval_reports/`` and prints a
+one-line summary of where it landed and what it flagged.
+
+    f1-eval registry       # E-08 consolidated metrics table
+    f1-eval calibration    # E-03 reliability/Brier/ECE + quantile coverage
+    f1-eval models         # reproduce headline numbers vs the model_configs
+    f1-eval all            # all three
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any, Callable
+
+from src.strategy.eval.calibration import build_calibration_report
+from src.strategy.eval.registry import build_registry
+from src.strategy.eval.reproduce import build_reproduction_report
+
+
+def _summarise(payload: dict[str, Any], rows_key: str, flag_statuses: tuple[str, ...]) -> str:
+    """One-line summary: report path + count of flagged rows."""
+    rows = payload.get(rows_key, [])
+    flagged = [r for r in rows if r.get("status") in flag_statuses]
+    tail = f"; {len(flagged)} flagged ({', '.join(flag_statuses)})" if flag_statuses else ""
+    return f"-> {payload['md_path']} ({len(rows)} rows{tail})"
+
+
+def _run_registry() -> None:
+    payload = build_registry()
+    divergences = [e for e in payload["entries"] if not e["canonical"]]
+    print(
+        f"registry -> {payload['md_path']} ({len(payload['entries'])} entries; {len(divergences)} divergences reconciled)"
+    )
+
+
+def _run_calibration() -> None:
+    payload = build_calibration_report()
+    print("calibration " + _summarise(payload, "results", ("drift", "pending")))
+
+
+def _run_models() -> None:
+    payload = build_reproduction_report()
+    print("models " + _summarise(payload, "results", ("delta", "pending")))
+
+
+_COMMANDS: dict[str, Callable[[], None]] = {
+    "registry": _run_registry,
+    "calibration": _run_calibration,
+    "models": _run_models,
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse args and run the requested report builder(s)."""
+    parser = argparse.ArgumentParser(
+        prog="f1-eval", description="F1 StratLab ML evaluation harness (#206)."
+    )
+    parser.add_argument(
+        "command",
+        choices=[*_COMMANDS, "all"],
+        help="which report to regenerate",
+    )
+    args = parser.parse_args(argv)
+
+    commands = _COMMANDS.values() if args.command == "all" else [_COMMANDS[args.command]]
+    for run in commands:
+        run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/strategy/eval/cli.py
+++ b/src/strategy/eval/cli.py
@@ -7,7 +7,8 @@ one-line summary of where it landed and what it flagged.
     f1-eval registry       # E-08 consolidated metrics table
     f1-eval calibration    # E-03 reliability/Brier/ECE + quantile coverage
     f1-eval models         # reproduce headline numbers vs the model_configs
-    f1-eval all            # all three
+    f1-eval hygiene        # E-02 threshold provenance + leakage verdicts (#207)
+    f1-eval all            # all four
 """
 
 from __future__ import annotations
@@ -16,6 +17,7 @@ import argparse
 from typing import Any, Callable
 
 from src.strategy.eval.calibration import build_calibration_report
+from src.strategy.eval.hygiene import build_hygiene_report
 from src.strategy.eval.registry import build_registry
 from src.strategy.eval.reproduce import build_reproduction_report
 
@@ -46,10 +48,18 @@ def _run_models() -> None:
     print("models " + _summarise(payload, "results", ("delta", "pending")))
 
 
+def _run_hygiene() -> None:
+    payload = build_hygiene_report()
+    findings = payload.get("findings", [])
+    flagged = [f for f in findings if f.get("verdict") in ("contaminated", "underdocumented")]
+    print(f"hygiene -> {payload['md_path']} ({len(findings)} items; {len(flagged)} flagged)")
+
+
 _COMMANDS: dict[str, Callable[[], None]] = {
     "registry": _run_registry,
     "calibration": _run_calibration,
     "models": _run_models,
+    "hygiene": _run_hygiene,
 }
 
 

--- a/src/strategy/eval/cli.py
+++ b/src/strategy/eval/cli.py
@@ -8,7 +8,8 @@ one-line summary of where it landed and what it flagged.
     f1-eval calibration    # E-03 reliability/Brier/ECE + quantile coverage
     f1-eval models         # reproduce headline numbers vs the model_configs
     f1-eval hygiene        # E-02 threshold provenance + leakage verdicts (#207)
-    f1-eval all            # all four
+    f1-eval nlp            # NLP per-stage eval: sentiment + gated stages (#304)
+    f1-eval all            # every report
 """
 
 from __future__ import annotations
@@ -18,6 +19,7 @@ from typing import Any, Callable
 
 from src.strategy.eval.calibration import build_calibration_report
 from src.strategy.eval.hygiene import build_hygiene_report
+from src.strategy.eval.nlp import build_nlp_report
 from src.strategy.eval.registry import build_registry
 from src.strategy.eval.reproduce import build_reproduction_report
 
@@ -55,11 +57,17 @@ def _run_hygiene() -> None:
     print(f"hygiene -> {payload['md_path']} ({len(findings)} items; {len(flagged)} flagged)")
 
 
+def _run_nlp() -> None:
+    payload = build_nlp_report()
+    print("nlp " + _summarise(payload, "results", ("delta", "blocked", "pending")))
+
+
 _COMMANDS: dict[str, Callable[[], None]] = {
     "registry": _run_registry,
     "calibration": _run_calibration,
     "models": _run_models,
     "hygiene": _run_hygiene,
+    "nlp": _run_nlp,
 }
 
 

--- a/src/strategy/eval/hygiene.py
+++ b/src/strategy/eval/hygiene.py
@@ -1,0 +1,252 @@
+"""E-02 threshold-provenance + aggregate-feature leakage verification (#207).
+
+Gates the IEEE paper freeze: rules out test-2025 contamination of the reported
+numbers. Every tuned decision threshold and every historical aggregate feature
+gets a verdict (clean / contaminated / underdocumented) traced to the training
+cell that produced it. The verdicts are the product of a read-only audit of
+``notebooks/strategy/`` (UNTOUCHABLE - this module only records the findings and
+demonstrates the correction; it does not modify a notebook).
+
+KEY CONCLUSION FOR THE PAPER: the two contaminated items (overtake threshold
+0.7976, safety-car threshold 0.2335 + its 3/5/7-lap window) were selected on
+the 2025 test set, so they inflate only the OPERATING-POINT metrics
+(precision/recall/F1 at that threshold). The threshold-FREE headline numbers the
+paper actually reports - AUC-PR and AUC-ROC - are computed from probabilities
+and are unaffected, so they clear. This module re-selects the overtake threshold
+on val-2024 (the honest split) to show the operating-point delta.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import numpy as np
+
+from src.strategy.eval.calibration import load_overtake_predictions
+from src.strategy.eval.report import build_header, write_report
+
+HYGIENE_NAME = "hygiene"
+
+# Verdicts (fixed vocabulary; kept as module constants so the report writer and
+# the golden test share one spelling).
+CLEAN = "clean"
+CONTAMINATED = "contaminated"
+UNDERDOCUMENTED = "underdocumented"
+
+# Overtake threshold sweep grid, mirrored from N12 Step 5 so the re-selection
+# uses the same candidate set the notebook did.
+_THRESHOLD_GRID = np.linspace(0.05, 0.92, 200)
+_LEAKED_OVERTAKE_THRESHOLD = 0.7976
+
+
+@dataclass
+class ProvenanceEntry:
+    """One threshold/feature provenance verdict.
+
+    ``kind`` is ``threshold`` or ``aggregate_feature``; ``verdict`` is one of the
+    module constants; ``selection`` names the split/window the value was chosen
+    or computed on; ``evidence`` points at the training notebook + cell; and
+    ``impact`` states what the verdict means for the paper's numbers.
+    """
+
+    item: str
+    kind: str
+    model: str
+    verdict: str
+    selection: str
+    evidence: str
+    impact: str
+
+
+def audit_findings() -> list[ProvenanceEntry]:
+    """The read-only provenance audit of ``notebooks/strategy/`` (issue #207).
+
+    Adversarially verified: the two contaminated threshold verdicts were
+    confirmed against the exact selection cells; every aggregate feature was
+    checked for a fit-on-train / past-season-only implementation.
+    """
+    return [
+        ProvenanceEntry(
+            "optimal_threshold=0.7976",
+            "threshold",
+            "overtake",
+            CONTAMINATED,
+            "argmax-F1 on the 2025 test set",
+            "N12_overtake_model.ipynb (threshold-analysis / step-5 cell)",
+            "operating-point P/R/F1 optimistic; AUC-PR 0.5491 / AUC-ROC 0.8758 unaffected (threshold-free)",
+        ),
+        ProvenanceEntry(
+            "best_threshold=0.2335 + 3/5/7-lap window",
+            "threshold",
+            "safety_car",
+            CONTAMINATED,
+            "argmax-F2 threshold AND the best target-window both on the 2025 test set",
+            "N14_sc_model.ipynb (PR-curve + window-comparison cells)",
+            "threshold -> operating-point optimistic; window chosen by max-lift on test -> the headline "
+            "AUC-PR 0.0723 is itself optimistic (a max over 3 candidates on test), NOT clean",
+        ),
+        ProvenanceEntry(
+            "best_threshold=0.522",
+            "threshold",
+            "undercut",
+            CLEAN,
+            "argmax-F1 on the calibrated val-2024 split",
+            'N16_undercut.ipynb ("Threshold on calibrated val 2024")',
+            "textbook-correct; the 2025 test set is only applied afterwards",
+        ),
+        ProvenanceEntry(
+            "circuit_sc_rate",
+            "aggregate_feature",
+            "safety_car",
+            CLEAN,
+            "past-season only (year < yr); 2023 rows get a fixed SC_PRIOR=0.15",
+            "N13_sc_eda.ipynb (compute_circuit_sc_rate)",
+            "no test-2025 in its own aggregate",
+        ),
+        ProvenanceEntry(
+            "team_year_median",
+            "aggregate_feature",
+            "pit_duration",
+            CLEAN,
+            "lookup fit on train only, applied to test with recent-year fallback",
+            "N15_pit_duration.ipynb (add_team_year_median)",
+            "companion circuit_traversal / baseline are likewise train-fit",
+        ),
+        ProvenanceEntry(
+            "circuit_undercut_rate + team_x_undercut_rate",
+            "aggregate_feature",
+            "undercut",
+            CLEAN,
+            "target encoding fit on train only, train-mean fallback on test",
+            "N16_undercut.ipynb (compute_target_encoding)",
+            "split precedes the encoding; no train<-test leak",
+        ),
+        ProvenanceEntry(
+            "circuit_cluster (k-means)",
+            "aggregate_feature",
+            "overtake/safety_car/laptime",
+            UNDERDOCUMENTED,
+            "k-means fit window not year-restricted in code; 2025 holdout is intent-only",
+            "N03_circuit_clustering.ipynb (load_all_races / fit_kmeans_final)",
+            "mild NON-target risk (unsupervised geometry bucket); pin a year filter to close",
+        ),
+        ProvenanceEntry(
+            "year_circuit_median / team_pace_rank",
+            "aggregate_feature",
+            "laptime",
+            CLEAN,
+            "within-session per-year aggregates; flagged LEAKY and removed from the reported model",
+            "N06_laptime_model.ipynb (add_context_features / FEATURES_PROD)",
+            "not in the reported IEEE delta model; 2025 held out until final eval",
+        ),
+    ]
+
+
+def _operating_point(y: np.ndarray, proba: np.ndarray, threshold: float) -> dict[str, float]:
+    """Precision / recall / F1 of ``proba >= threshold`` against ``y``."""
+    pred = (proba >= threshold).astype(int)
+    tp = int(((pred == 1) & (y == 1)).sum())
+    fp = int(((pred == 1) & (y == 0)).sum())
+    fn = int(((pred == 0) & (y == 1)).sum())
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    return {"precision": round(precision, 4), "recall": round(recall, 4), "f1": round(f1, 4)}
+
+
+def correct_overtake_threshold() -> dict[str, Any] | None:
+    """Re-select the overtake threshold on val-2024 and show the operating-point delta.
+
+    The E-02 correction for the worst contaminated item: pick the threshold by
+    argmax-F1 on the 2024 validation slice (never touching test), then report its
+    operating point on the 2025 test set next to the leaked 0.7976's operating
+    point on the same test set. The leaked threshold's F1 is maximal on test by
+    construction (it was fit there); the corrected threshold's F1 is the honest
+    number. Returns ``None`` if the holdout is absent.
+    """
+    val = load_overtake_predictions(year=2024)
+    test = load_overtake_predictions(year=2025)
+    if val is None or test is None:
+        return None
+
+    y_val, proba_val_raw, _ = val
+    y_test, proba_test_raw, _ = test
+
+    f1s = [_operating_point(y_val, proba_val_raw, t)["f1"] for t in _THRESHOLD_GRID]
+    corrected_threshold = float(_THRESHOLD_GRID[int(np.argmax(f1s))])
+
+    return {
+        "leaked_threshold": _LEAKED_OVERTAKE_THRESHOLD,
+        "corrected_threshold": round(corrected_threshold, 4),
+        "leaked_test_operating_point": _operating_point(
+            y_test, proba_test_raw, _LEAKED_OVERTAKE_THRESHOLD
+        ),
+        "corrected_test_operating_point": _operating_point(
+            y_test, proba_test_raw, corrected_threshold
+        ),
+        "note": "threshold selected on val-2024; both operating points evaluated on the 2025 test set",
+    }
+
+
+def _render(findings: list[ProvenanceEntry], correction: dict[str, Any] | None) -> str:
+    """Render the hygiene report: verdict table + correction + paper conclusion."""
+    header = "| item | kind | model | verdict | selection | evidence |"
+    rule = "|---|---|---|---|---|---|"
+    order = {CONTAMINATED: 0, UNDERDOCUMENTED: 1, CLEAN: 2}
+    ordered = sorted(findings, key=lambda f: order.get(f.verdict, 3))
+    rows = [
+        f"| {f.item} | {f.kind} | {f.model} | **{f.verdict}** | {f.selection} | {f.evidence} |"
+        for f in ordered
+    ]
+
+    lines = [header, rule, *rows, "", "## Correction (overtake threshold)", ""]
+    if correction is None:
+        lines.append("- holdout absent on disk; correction not computed this run")
+    else:
+        leaked = correction["leaked_test_operating_point"]
+        fixed = correction["corrected_test_operating_point"]
+        lines += [
+            f"- leaked threshold {correction['leaked_threshold']} (selected on test): "
+            f"P {leaked['precision']} / R {leaked['recall']} / F1 {leaked['f1']} on 2025 test",
+            f"- corrected threshold {correction['corrected_threshold']} (selected on val-2024): "
+            f"P {fixed['precision']} / R {fixed['recall']} / F1 {fixed['f1']} on 2025 test",
+            f"- {correction['note']}",
+        ]
+
+    contaminated = [f for f in findings if f.verdict == CONTAMINATED]
+    lines += [
+        "",
+        "## Conclusion for the paper freeze",
+        "",
+        f"- {len(contaminated)} contaminated items (overtake threshold; safety-car threshold + window). "
+        "All other thresholds and aggregate features are clean or non-target.",
+        "- **Overtake headline clears**: AUC-PR 0.5491 / AUC-ROC 0.8758 are threshold-free and involve no "
+        "window selection; the threshold leakage touches only their operating point.",
+        "- **Safety-car headline is optimistic, NOT clean**: AUC-PR 0.0723 is the max-lift window among "
+        "{3,5,7} laps selected on test-2025, so the reported number is itself selection-biased (a max over "
+        "3 candidates on test), on top of the operating-point threshold leakage.",
+        "- **Action before freeze**: (1) re-select the overtake + SC operating thresholds on val-2024 "
+        "(the undercut N16 pattern) - the overtake correction above shows the honest operating point; "
+        "(2) re-select the SC target window on the CV/val split (not test) and re-report SC AUC-PR, or "
+        "caveat it as test-selected; (3) pin a year filter in N03 `load_all_races` to close the "
+        "circuit_cluster underdocumentation.",
+        "- Every other headline (undercut 0.6739, pit 0.487, pace 0.4104, tire 0.7078, sentiment 0.84) is "
+        "unaffected by these findings.",
+    ]
+    return "\n".join(lines)
+
+
+def build_hygiene_report() -> dict[str, Any]:
+    """Regenerate the signed hygiene report (the #207 deliverable)."""
+    findings = audit_findings()
+    correction = correct_overtake_threshold()
+    header = build_header(dataset="notebooks/strategy audit + 2024/2025 overtake holdout")
+    payload = {"findings": [asdict(f) for f in findings], "overtake_correction": correction}
+    md_path, json_path = write_report(HYGIENE_NAME, header, _render(findings, correction), payload)
+    return {
+        "header": asdict(header),
+        "md_path": str(md_path),
+        "json_path": str(json_path),
+        **payload,
+    }

--- a/src/strategy/eval/nlp.py
+++ b/src/strategy/eval/nlp.py
@@ -1,0 +1,234 @@
+"""NLP evaluation harness on the shared eval package (issue #304).
+
+Per-stage evaluation of the radio NLP pipeline, built ON ``src/strategy/eval``
+(NOT a parallel harness - it reuses report.py's header + writer). This phase
+reproduces the RoBERTa sentiment stage on a fixed labeled set; the other stages
+are gated with their exact blocker, the same honest-delta convention the ML-eval
+harness (#206) uses.
+
+Stage status this phase:
+- **sentiment** (RoBERTa) - reproduced over the fixed 530-row labeled radio set
+  (accuracy + macro-F1), compared to the thesis-final 0.84 / macro-F1 0.75. The
+  labeled CSV is the full set (train+test), so the number is expected to run
+  optimistic vs the held-out 0.84; the held-out split is not pinned on disk.
+- **intent** (SetFit) - BLOCKED: setfit does not import under transformers 5.3.0
+  (#303), so the intent stage cannot be reproduced until that is fixed.
+- **NER / RCM** - pending: their model reconstruction is not wired this phase.
+- **alert precision** (the MoE-routing signal the orchestrator depends on) -
+  pending a labeled alert ground-truth set; none exists on disk today. This is
+  the metric #304 most wants and it is a data-collection task, not a code one.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from src.f1_strat_manager.data_cache import get_data_root, get_models_root
+from src.strategy.eval.report import build_header, write_report
+
+NLP_NAME = "nlp"
+_SENTIMENT_ACC = 0.84  # thesis-final RoBERTa accuracy
+_SENTIMENT_MACRO_F1 = 0.75  # thesis-final macro-F1
+_TOLERANCE = 0.03
+_SENTIMENT_BATCH = 32
+
+
+@dataclass
+class StageResult:
+    """One NLP stage measurement.
+
+    ``status`` is ``reproduced`` (within tolerance of the thesis number),
+    ``delta`` (measured but diverges - e.g. full-set vs held-out), ``blocked``
+    (a dependency prevents the stage from running at all), or ``pending`` (not
+    wired / no ground-truth this phase).
+    """
+
+    stage: str
+    metric: str
+    value: float | None
+    reference: float | None
+    status: str
+    detail: str
+
+
+def _load_roberta_sentiment() -> tuple[Any, Any, str, list[str], int] | None:
+    """Reconstruct the RoBERTa sentiment classifier from its Lightning ``.ckpt``.
+
+    The checkpoint stores a ``model.roberta.* / model.classifier.*`` state dict
+    (a ``RobertaForSequenceClassification`` wrapped by a Lightning module); we
+    strip the ``model.`` prefix and load it into a fresh HF head configured from
+    ``model_config.json``. Returns ``(model, tokenizer, device, names, max_len)``
+    or ``None`` when the artifacts are absent.
+    """
+    import torch
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+    model_dir = get_models_root() / "nlp" / "sentiment_classifier_v1"
+    ckpt = model_dir / "best_roberta_sentiment.ckpt"
+    cfg_path = model_dir / "model_config.json"
+    if not (ckpt.exists() and cfg_path.exists()):
+        return None
+
+    cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+    tokenizer = AutoTokenizer.from_pretrained(cfg["model_name"])
+    model = AutoModelForSequenceClassification.from_pretrained(
+        cfg["model_name"], num_labels=cfg["num_labels"]
+    )
+    state = torch.load(ckpt, map_location="cpu", weights_only=False)["state_dict"]
+    prefix = "model."
+    stripped = {
+        k[len(prefix) :]: v
+        for k, v in state.items()
+        if k.startswith(prefix + "roberta") or k.startswith(prefix + "classifier")
+    }
+    model.load_state_dict(stripped, strict=True)
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model.to(device).eval()
+    return model, tokenizer, device, cfg["sentiment_names"], cfg["max_length"]
+
+
+def reproduce_sentiment() -> list[StageResult]:
+    """Reproduce RoBERTa sentiment accuracy + macro-F1 on the fixed labeled set.
+
+    Returns a ``pending`` row instead of raising when the checkpoint or the
+    labeled CSV is absent, so a partial install still reports.
+    """
+    import torch
+    from sklearn.metrics import accuracy_score, f1_score
+
+    loaded = _load_roberta_sentiment()
+    labeled = get_data_root() / "processed" / "radio_nlp" / "radio_labeled_data.csv"
+    if loaded is None or not labeled.exists():
+        return [
+            StageResult(
+                "sentiment",
+                "accuracy",
+                None,
+                _SENTIMENT_ACC,
+                "pending",
+                "roberta ckpt or radio_labeled_data.csv absent",
+            )
+        ]
+
+    import pandas as pd
+
+    model, tokenizer, device, names, max_len = loaded
+    df = pd.read_csv(labeled)
+    texts = df["radio_message"].astype(str).tolist()
+    y_true = df["sentiment"].tolist()
+
+    preds: list[str] = []
+    with torch.no_grad():
+        for start in range(0, len(texts), _SENTIMENT_BATCH):
+            batch = texts[start : start + _SENTIMENT_BATCH]
+            enc = tokenizer(
+                batch, truncation=True, padding=True, max_length=max_len, return_tensors="pt"
+            ).to(device)
+            idx = model(**enc).logits.argmax(dim=1).tolist()
+            preds.extend(names[j] for j in idx)
+
+    accuracy = float(accuracy_score(y_true, preds))
+    macro_f1 = float(f1_score(y_true, preds, average="macro"))
+    caveat = (
+        "full labeled set (train+test); optimistic vs the held-out 0.84 (split not pinned on disk)"
+    )
+    return [
+        StageResult(
+            "sentiment",
+            "accuracy",
+            round(accuracy, 4),
+            _SENTIMENT_ACC,
+            _status(accuracy, _SENTIMENT_ACC),
+            f"n={len(y_true)}; {caveat}",
+        ),
+        StageResult(
+            "sentiment",
+            "macro_f1",
+            round(macro_f1, 4),
+            _SENTIMENT_MACRO_F1,
+            _status(macro_f1, _SENTIMENT_MACRO_F1),
+            f"n={len(y_true)}; 3-class",
+        ),
+    ]
+
+
+def _status(value: float, reference: float) -> str:
+    """``reproduced`` when within tolerance of the thesis number, else ``delta``."""
+    return "reproduced" if abs(value - reference) <= _TOLERANCE else "delta"
+
+
+def _gated_stages() -> list[StageResult]:
+    """The stages that cannot run this phase, each with its exact blocker."""
+    return [
+        StageResult(
+            "intent",
+            "accuracy",
+            None,
+            None,
+            "blocked",
+            "setfit does not import under transformers 5.3.0 (#303); stage cannot run",
+        ),
+        StageResult(
+            "ner",
+            "entity_f1",
+            None,
+            None,
+            "pending",
+            "GLiNER/BERT reconstruction not wired this phase",
+        ),
+        StageResult(
+            "rcm",
+            "accuracy",
+            None,
+            None,
+            "pending",
+            "RCM classifier reconstruction not wired this phase",
+        ),
+        StageResult(
+            "alert_precision",
+            "precision",
+            None,
+            None,
+            "pending",
+            "no labeled alert ground-truth on disk (the MoE-routing metric #304 targets; data-collection task)",
+        ),
+    ]
+
+
+def collect_results() -> list[StageResult]:
+    """All NLP stage results: reproduced sentiment first, then gated stages."""
+    return [*reproduce_sentiment(), *_gated_stages()]
+
+
+def _render(results: list[StageResult]) -> str:
+    """Render the NLP eval as a markdown table, runnable stages first."""
+    order = {"delta": 0, "reproduced": 1, "blocked": 2, "pending": 3}
+    ordered = sorted(results, key=lambda r: order.get(r.status, 4))
+    header = "| stage | metric | value | reference | status | detail |"
+    rule = "|---|---|---|---|---|---|"
+    rows = []
+    for r in ordered:
+        value = "-" if r.value is None else f"{r.value:.4f}"
+        reference = "-" if r.reference is None else f"{r.reference:g}"
+        rows.append(f"| {r.stage} | {r.metric} | {value} | {reference} | {r.status} | {r.detail} |")
+    return "\n".join([header, rule, *rows])
+
+
+def build_nlp_report() -> dict[str, Any]:
+    """Regenerate the NLP eval report (the #304 deliverable)."""
+    results = collect_results()
+    ckpt = get_models_root() / "nlp" / "sentiment_classifier_v1" / "best_roberta_sentiment.ckpt"
+    header = build_header(
+        dataset="radio_labeled_data.csv (fixed set)", artifacts={"roberta_sentiment": ckpt}
+    )
+    payload = {"results": [asdict(r) for r in results]}
+    md_path, json_path = write_report(NLP_NAME, header, _render(results), payload)
+    return {
+        "header": asdict(header),
+        "md_path": str(md_path),
+        "json_path": str(json_path),
+        **payload,
+    }

--- a/src/strategy/eval/registry.py
+++ b/src/strategy/eval/registry.py
@@ -1,0 +1,300 @@
+"""E-08 consolidated metrics registry: the single citable source of truth.
+
+Today the headline numbers live scattered across ``model_config`` JSONs,
+notebook cells, thesis chapters and memory files, and at least one diverges
+(pace MAE 0.392 notebook-era vs 0.4104 thesis-final). Every downstream
+document (IEEE paper, AEPIA 5-pager, docs site, model cards) copies numbers by
+hand from that mess. This module regenerates ONE versioned table so the drift
+ends here.
+
+Two kinds of entry:
+
+- **config-sourced** - the model pins its own numbers in a ``model_config``
+  JSON (overtake, undercut, pit); the registry just surfaces them verbatim.
+  ``reproduce.py`` is what re-derives and checks they still reproduce.
+- **doc-pinned** - the number is NOT in any config (pace, tire-deg,
+  sentiment); it lives in the thesis (Tabla 6.1) / IEEE report. The
+  registry records the canonical (thesis-final) value AND the divergent
+  published/notebook-era value, so the reconciliation is documented in one
+  place forever. Docs reconciliation (#213) propagates the canonical from here;
+  provenance *verification* of these splits is Phase 2 (#207), not this phase.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from src.f1_strat_manager.data_cache import get_models_root
+from src.strategy.eval.report import build_header, write_report
+
+REGISTRY_NAME = "metrics_registry"
+
+
+@dataclass
+class MetricEntry:
+    """One headline metric consolidated into the registry.
+
+    Fields:
+    - ``model`` / ``family`` - which predictor and its problem type.
+    - ``metric`` / ``value`` / ``threshold`` - the number and its decision
+      threshold (``None`` for regressors).
+    - ``split`` - the train/test season split behind the number.
+    - ``source`` - where the number came from (config path or thesis).
+    - ``canonical`` - True for the citable authority value; a False entry is a
+      superseded/divergent value kept only to document the reconciliation.
+    - ``note`` - provenance / divergence commentary.
+    """
+
+    model: str
+    family: str
+    metric: str
+    value: float
+    threshold: float | None
+    split: str
+    source: str
+    canonical: bool
+    note: str
+
+
+def _config_entries() -> list[MetricEntry]:
+    """Read headline metrics straight from the ``model_config`` JSONs.
+
+    These models pin their own numbers, so the registry surfaces them without
+    re-deriving. The broken pit P05-P95 coverage (0.7047 vs 0.90 nominal) is
+    published inside its config too - the registry does not hide it; the
+    calibration report is what flags it as drift.
+    """
+    models = get_models_root()
+
+    overtake = json.loads(
+        (models / "overtake_probability" / "model_config.json").read_text(encoding="utf-8")
+    )
+    undercut = json.loads(
+        (models / "pit_prediction" / "model_config_undercut_v1.json").read_text(encoding="utf-8")
+    )
+    pit = json.loads((models / "pit_prediction" / "model_config.json").read_text(encoding="utf-8"))
+    sc = json.loads(
+        (models / "safety_car_probability" / "feature_list_v1.json").read_text(encoding="utf-8")
+    )
+
+    ov_split = f"train {overtake['train_seasons']} / test {overtake['test_season']}"
+    uc_split = f"train {undercut['train_years']} / test {undercut['test_year']}"
+    pit_split = f"train {pit['train_years']} / test {pit['test_year']}"
+    sc_split = f"train {sc['train_years']} / test {sc['test_year']}"
+
+    return [
+        MetricEntry(
+            "overtake",
+            "classification",
+            "auc_pr_test",
+            overtake["auc_pr_test"],
+            overtake["optimal_threshold"],
+            ov_split,
+            "config: overtake_probability/model_config.json",
+            True,
+            f"LightGBM + Platt(val 2024); auc_roc {overtake['auc_roc_test']}",
+        ),
+        MetricEntry(
+            "undercut",
+            "classification",
+            "auc_pr_test",
+            undercut["metrics"]["auc_pr_test"],
+            undercut["best_threshold"],
+            uc_split,
+            "config: pit_prediction/model_config_undercut_v1.json",
+            True,
+            f"LightGBM + Platt(val 2024); baseline_pr {undercut['metrics']['baseline_pr']}",
+        ),
+        MetricEntry(
+            "pit_duration",
+            "quantile",
+            "p50_mae_test_s",
+            pit["eval"]["p50_mae_test"],
+            None,
+            pit_split,
+            "config: pit_prediction/model_config.json",
+            True,
+            f"HistGBT P05/P50/P95; baseline_mae {pit['eval']['baseline_mae_test']}; "
+            f"P05-P95 coverage {pit['eval']['p05_p95_coverage_test']} vs 0.90 nominal (see calibration report)",
+        ),
+        MetricEntry(
+            "safety_car",
+            "classification",
+            "auc_pr_test",
+            sc["metrics"]["test_auc_pr"],
+            sc["best_threshold"],
+            sc_split,
+            "config: safety_car_probability/feature_list_v1.json",
+            True,
+            f"LightGBM + Platt(val 2024); baseline {sc['metrics']['baseline_auc_pr']}; "
+            f"3-lap lift {sc['target_comparison']['3-lap']['lift']}; target sc_within_3_laps",
+        ),
+    ]
+
+
+def _doc_pinned_entries() -> list[MetricEntry]:
+    """Encode the metrics that live in the thesis, not in any config.
+
+    Each divergent number produces two rows: the canonical (thesis-final) row
+    and the superseded row, so the reconciliation is self-documenting. Numbers
+    are sourced to the thesis Tabla 6.1 / IEEE report and issue #213; the
+    precise season splits for these are marked "verify in #207" rather than
+    asserted, because split provenance is exactly Phase 2's job.
+    """
+    verify = "split provenance pending (#207)"
+    entries: list[MetricEntry] = []
+
+    # Pace / lap-time delta (XGBoost, N06) - the canonical 0.392 -> 0.4104 case.
+    entries.append(
+        MetricEntry(
+            "pace",
+            "regression",
+            "mae_test_s",
+            0.4104,
+            None,
+            "test 2025",
+            "thesis Tabla 6.1 (final)",
+            True,
+            "XGBoost delta lap time; " + verify,
+        )
+    )
+    entries.append(
+        MetricEntry(
+            "pace",
+            "regression",
+            "mae_test_s",
+            0.392,
+            None,
+            "test 2025",
+            "notebook N06 (superseded)",
+            False,
+            "notebook-era value; superseded by thesis-final 0.4104",
+        )
+    )
+
+    # Tire degradation (TCN + MC Dropout, N07-10) - global MAE; best compound C2.
+    entries.append(
+        MetricEntry(
+            "tire_degradation",
+            "regression",
+            "mae_test_s",
+            0.7078,
+            None,
+            "test 2025",
+            "thesis Tabla 6.1 (global)",
+            True,
+            "TireDegTCN; per-compound best C2 0.5501s; missed R2 target; " + verify,
+        )
+    )
+
+    # Radio sentiment (RoBERTa, N20) - the 87.5% -> 0.84 case.
+    entries.append(
+        MetricEntry(
+            "sentiment",
+            "nlp",
+            "accuracy",
+            0.84,
+            None,
+            "held-out radio set",
+            "thesis Tabla 6.1 (final)",
+            True,
+            "RoBERTa; macro-F1 0.75; NLP harness in #304",
+        )
+    )
+    entries.append(
+        MetricEntry(
+            "sentiment",
+            "nlp",
+            "accuracy",
+            0.875,
+            None,
+            "held-out radio set",
+            "published-era (superseded)",
+            False,
+            "87.5% published; superseded by thesis-final 0.84",
+        )
+    )
+
+    return entries
+
+
+def collect_entries() -> list[MetricEntry]:
+    """All registry entries: config-sourced first, then doc-pinned."""
+    return _config_entries() + _doc_pinned_entries()
+
+
+def _render_table(entries: list[MetricEntry]) -> str:
+    """Render the registry as a markdown table + a divergences section."""
+    header = "| model | metric | value | thr | split | canonical | source |"
+    rule = "|---|---|---|---|---|---|---|"
+    rows = []
+    for entry in entries:
+        thr = "-" if entry.threshold is None else f"{entry.threshold:g}"
+        mark = "yes" if entry.canonical else "no"
+        rows.append(
+            f"| {entry.model} | {entry.metric} | {entry.value:g} | {thr} | "
+            f"{entry.split} | {mark} | {entry.source} |"
+        )
+
+    divergences = [e for e in entries if not e.canonical]
+    div_lines = ["", "## Divergences reconciled", ""]
+    if divergences:
+        for entry in divergences:
+            canonical = next(
+                c
+                for c in entries
+                if c.canonical and c.model == entry.model and c.metric == entry.metric
+            )
+            div_lines.append(
+                f"- **{entry.model} {entry.metric}**: {entry.value:g} "
+                f"({entry.source}) -> **{canonical.value:g}** ({canonical.source})"
+            )
+    else:
+        div_lines.append("- none")
+
+    return "\n".join([header, rule, *rows, *div_lines])
+
+
+def build_registry() -> dict[str, Any]:
+    """Regenerate the consolidated registry and write the versioned report.
+
+    Returns the payload dict (also written to
+    ``documents/eval_reports/metrics_registry.json``). This is the single
+    citable source that replaces the scattered numbers.
+    """
+    entries = collect_entries()
+    models = get_models_root()
+    artifacts = {
+        "overtake_cfg": models / "overtake_probability" / "model_config.json",
+        "undercut_cfg": models / "pit_prediction" / "model_config_undercut_v1.json",
+        "pit_cfg": models / "pit_prediction" / "model_config.json",
+        "sc_cfg": models / "safety_car_probability" / "feature_list_v1.json",
+    }
+    header = build_header(dataset="model_configs + thesis Tabla 6.1", artifacts=artifacts)
+    payload = {"entries": [asdict(e) for e in entries]}
+
+    md_path, json_path = write_report(REGISTRY_NAME, header, _render_table(entries), payload)
+    return {
+        "header": asdict(header),
+        "md_path": str(md_path),
+        "json_path": str(json_path),
+        **payload,
+    }
+
+
+def load_registry() -> dict[str, Any]:
+    """Read the committed registry JSON back (for #213 / #304 / tests).
+
+    Raises ``FileNotFoundError`` if the registry has never been generated, so
+    a stale consumer fails loudly instead of silently using no data.
+    """
+    from src.strategy.eval.report import eval_reports_dir
+
+    path = eval_reports_dir() / f"{REGISTRY_NAME}.json"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"registry not generated yet; run `f1-eval registry` (looked in {path})"
+        )
+    return json.loads(path.read_text(encoding="utf-8"))

--- a/src/strategy/eval/report.py
+++ b/src/strategy/eval/report.py
@@ -1,0 +1,167 @@
+"""E-15 provenance-header contract shared by every eval report.
+
+Every report the harness emits (metrics registry, calibration, regeneration)
+carries the same header so any number can be traced back to the exact
+artifacts, dataset snapshot, regulation era and harness version that produced
+it. Without this stamp a 2026 retraining makes every old report ambiguous
+(which model? which season? which code?).
+
+WHERE TO CHANGE IF THE PROVENANCE CONTRACT CHANGES:
+- add a field to ``ReportHeader`` + set it in ``build_header``; every report
+  writer downstream picks it up for free (registry.py, calibration.py, ...).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.f1_strat_manager.data_cache import _find_repo_root
+
+SCHEMA_VERSION = "1"
+ERA_TAG = "2022-2025"  # regulation era these numbers are valid for
+
+
+def _harness_sha() -> str:
+    """Short git SHA of the repo the harness runs from, or ``unknown``.
+
+    Returns ``unknown`` when running outside a checkout (e.g. an installed
+    tool venv) so a report is never blocked on git being available.
+    """
+    repo = _find_repo_root()
+    if repo is None:
+        return "unknown"
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        )
+        return out.stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        return "unknown"
+
+
+def artifact_hash(path: Path) -> str:
+    """First 12 hex chars of the SHA-256 of a model artifact.
+
+    Short enough to stay readable inside a committed markdown header, long
+    enough to pin an artifact version unambiguously in practice.
+    """
+    digest = hashlib.sha256(Path(path).read_bytes()).hexdigest()
+    return digest[:12]
+
+
+@dataclass
+class ReportHeader:
+    """Provenance stamp attached to every eval report (E-15).
+
+    Invariants:
+    - ``harness_sha`` pins the code; ``artifacts`` pins the model weights;
+      together they make a report reproducible.
+    - ``generated_at`` is provenance only and is NOT part of report equality
+      (two runs of the same code on the same data are "equal" bar the clock).
+    - ``llm`` is ``none`` for pure-ML reports; NLP/orchestrator reports that
+      call a model record ``provider/model/version`` (never Anthropic).
+    """
+
+    harness_sha: str
+    dataset: str
+    seed_policy: str
+    era_tag: str = ERA_TAG
+    llm: str = "none"
+    schema_version: str = SCHEMA_VERSION
+    generated_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat(timespec="seconds")
+    )
+    artifacts: dict[str, str] = field(default_factory=dict)
+
+
+def build_header(
+    *,
+    dataset: str,
+    seed_policy: str = "deterministic",
+    llm: str = "none",
+    artifacts: dict[str, Path] | None = None,
+) -> ReportHeader:
+    """Assemble a report header, hashing each artifact path that exists.
+
+    Missing artifact paths are skipped rather than raising, so a partial
+    install still produces a report (with a shorter artifact list) instead of
+    crashing the whole run.
+    """
+    hashed = {
+        name: artifact_hash(path) for name, path in (artifacts or {}).items() if Path(path).exists()
+    }
+    return ReportHeader(
+        harness_sha=_harness_sha(),
+        dataset=dataset,
+        seed_policy=seed_policy,
+        llm=llm,
+        artifacts=hashed,
+    )
+
+
+def eval_reports_dir() -> Path:
+    """``documents/eval_reports/`` (created on demand): committed, diffable.
+
+    Falls back to a user-cache directory when running outside a checkout so
+    the writer never fails; in that mode the reports simply are not version
+    controlled.
+    """
+    repo = _find_repo_root()
+    base = (
+        (repo / "documents" / "eval_reports")
+        if repo
+        else (Path.home() / ".f1-strat" / "eval_reports")
+    )
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def write_report(
+    name: str,
+    header: ReportHeader,
+    table_md: str,
+    payload: dict[str, Any],
+) -> tuple[Path, Path]:
+    """Write a report as a diffable markdown table + a machine-readable JSON.
+
+    The markdown is the human / paper-facing citable artifact; the JSON is
+    what downstream consumers (#213 docs reconciliation, #304 NLP harness,
+    the golden tests) read so they never have to re-parse prose.
+
+    Returns the ``(markdown_path, json_path)`` pair.
+    """
+    out = eval_reports_dir()
+    md_path = out / f"{name}.md"
+    json_path = out / f"{name}.json"
+    md_path.write_text(_render_md(name, header, table_md), encoding="utf-8")
+    json_path.write_text(
+        json.dumps({"header": asdict(header), **payload}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return md_path, json_path
+
+
+def _render_md(name: str, header: ReportHeader, table_md: str) -> str:
+    """Render a report: title, provenance header block, then the table body."""
+    artifacts = ", ".join(f"{k}=`{v}`" for k, v in header.artifacts.items()) or "—"
+    lines = [
+        f"# {name}",
+        "",
+        f"- harness `{header.harness_sha}` · schema v{header.schema_version} · generated {header.generated_at}",
+        f"- era {header.era_tag} · dataset {header.dataset} · seed {header.seed_policy} · llm {header.llm}",
+        f"- artifacts: {artifacts}",
+        "",
+        table_md,
+        "",
+    ]
+    return "\n".join(lines)

--- a/src/strategy/eval/reproduce.py
+++ b/src/strategy/eval/reproduce.py
@@ -1,0 +1,169 @@
+"""Headline-metric reproduction check (the ``f1-eval models`` deliverable).
+
+The registry consolidates the published numbers; this module re-derives them
+from the frozen model + holdout and reports reproduced-vs-config deltas. Where
+the on-disk data does not support a clean re-derivation, it documents the delta
+explicitly rather than inventing a number - which is the deliverable's own
+"reproduces every headline number within tolerance, or documents the delta".
+
+This phase only overtake AUC-PR reproduces cleanly (its holdout + derived
+features are fully reconstructable). The rest are blocked on the same on-disk
+gaps the calibration report names, and are handed to Phase 2 (#207).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from src.f1_strat_manager.data_cache import get_models_root
+from src.strategy.eval.calibration import load_overtake_predictions
+from src.strategy.eval.report import build_header, write_report
+
+REPRO_NAME = "reproduction"
+TOLERANCE = 0.01  # |reproduced - published| within this counts as reproduced
+
+
+@dataclass
+class ReproResult:
+    """One headline-metric reproduction check.
+
+    ``status`` is ``reproduced`` (within tolerance of the published value),
+    ``delta`` (re-derived but diverges), or ``pending`` (cannot re-derive
+    on-disk this phase).
+    """
+
+    model: str
+    metric: str
+    published: float
+    reproduced: float | None
+    status: str
+    detail: str
+
+
+def _overtake_auc_pr() -> ReproResult:
+    """Re-derive overtake AUC-PR on the 2025 holdout and compare to the config.
+
+    AUC-PR is threshold-free, so it is computed on the raw model scores (the
+    same quantity N12 reported). ``sklearn.average_precision_score`` is the
+    AUC-PR estimator.
+    """
+    cfg = json.loads(
+        (get_models_root() / "overtake_probability" / "model_config.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    published = float(cfg["auc_pr_test"])
+
+    loaded = load_overtake_predictions()
+    if loaded is None:
+        return ReproResult(
+            "overtake",
+            "auc_pr_test",
+            published,
+            None,
+            "pending",
+            "holdout or artifacts absent on disk",
+        )
+
+    from sklearn.metrics import average_precision_score
+
+    y, proba_raw, _ = loaded
+    reproduced = float(average_precision_score(y, proba_raw))
+    delta = abs(reproduced - published)
+    status = "reproduced" if delta <= TOLERANCE else "delta"
+    return ReproResult(
+        "overtake",
+        "auc_pr_test",
+        published,
+        reproduced,
+        status,
+        f"|delta| {delta:.4f} vs tol {TOLERANCE}",
+    )
+
+
+def _pending_metrics() -> list[ReproResult]:
+    """Document the headline numbers that cannot re-derive on-disk this phase.
+
+    Each carries the same blocker its calibration/registry entry names, so the
+    reproduction report and the calibration report agree on why.
+    """
+    return [
+        ReproResult(
+            "undercut",
+            "auc_pr_test",
+            0.6739,
+            None,
+            "pending",
+            "historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207)",
+        ),
+        ReproResult(
+            "pit_duration",
+            "p50_mae_test_s",
+            0.487,
+            None,
+            "pending",
+            "pit_labeled holdout empty on disk (#207)",
+        ),
+        ReproResult(
+            "safety_car",
+            "auc_pr_test",
+            0.0723,
+            None,
+            "pending",
+            "engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from holdout (#207)",
+        ),
+        ReproResult(
+            "pace",
+            "mae_test_s",
+            0.4104,
+            None,
+            "pending",
+            "laptime holdout feature build not wired this phase",
+        ),
+        ReproResult(
+            "tire_degradation",
+            "mae_test_s",
+            0.7078,
+            None,
+            "pending",
+            "TCN MC forward pass not run this phase (see calibration MC-sigma)",
+        ),
+    ]
+
+
+def collect_results() -> list[ReproResult]:
+    """All reproduction checks, reproduced/delta rows first."""
+    results = [_overtake_auc_pr(), *_pending_metrics()]
+    order = {"delta": 0, "reproduced": 1, "pending": 2}
+    return sorted(results, key=lambda r: order.get(r.status, 3))
+
+
+def _render_table(results: list[ReproResult]) -> str:
+    """Render reproduction results as a markdown table."""
+    header = "| model | metric | published | reproduced | status | detail |"
+    rule = "|---|---|---|---|---|---|"
+    rows = []
+    for r in results:
+        reproduced = "-" if r.reproduced is None else f"{r.reproduced:.4f}"
+        rows.append(
+            f"| {r.model} | {r.metric} | {r.published:g} | {reproduced} | {r.status} | {r.detail} |"
+        )
+    return "\n".join([header, rule, *rows])
+
+
+def build_reproduction_report() -> dict[str, Any]:
+    """Regenerate the reproduction report and write the versioned output."""
+    results = collect_results()
+    models = get_models_root()
+    artifacts = {"overtake_model": models / "overtake_probability" / "lgbm_overtake_v1.pkl"}
+    header = build_header(dataset="2025 holdout vs published model_configs", artifacts=artifacts)
+    payload = {"results": [asdict(r) for r in results]}
+    md_path, json_path = write_report(REPRO_NAME, header, _render_table(results), payload)
+    return {
+        "header": asdict(header),
+        "md_path": str(md_path),
+        "json_path": str(json_path),
+        **payload,
+    }

--- a/tests/eval/test_hygiene_golden.py
+++ b/tests/eval/test_hygiene_golden.py
@@ -1,0 +1,48 @@
+"""Golden tests for the #207 threshold-provenance / leakage report.
+
+The verdict assertions are hermetic (the audit findings are authored data).
+The overtake threshold-correction test is data-tier (it re-runs the model on
+the 2024/2025 holdout) and is skipped on CI without weights.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "overtake_probability" / "model_config.json").exists()
+
+
+def test_hygiene_verdicts_match_the_audit():
+    """Both contaminated thresholds, undercut clean, aggregates clean bar circuit_cluster."""
+    from src.strategy.eval.hygiene import CLEAN, CONTAMINATED, UNDERDOCUMENTED, audit_findings
+
+    findings = audit_findings()
+    thresholds = {f.model: f for f in findings if f.kind == "threshold"}
+
+    assert thresholds["overtake"].verdict == CONTAMINATED
+    assert thresholds["safety_car"].verdict == CONTAMINATED
+    assert thresholds["undercut"].verdict == CLEAN
+
+    aggregates = [f for f in findings if f.kind == "aggregate_feature"]
+    cluster = [f for f in aggregates if "circuit_cluster" in f.item]
+    assert cluster and cluster[0].verdict == UNDERDOCUMENTED
+    assert all(f.verdict == CLEAN for f in aggregates if "circuit_cluster" not in f.item)
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_MODELS, reason="data/models/ absent (CI runner without weights)")
+def test_overtake_threshold_correction_is_honest():
+    """Re-selecting on val-2024 yields a threshold whose test F1 <= the leaked (test-fit) one."""
+    from src.strategy.eval.hygiene import correct_overtake_threshold
+
+    correction = correct_overtake_threshold()
+    assert correction is not None
+    assert 0.0 < correction["corrected_threshold"] < 1.0
+    leaked_f1 = correction["leaked_test_operating_point"]["f1"]
+    corrected_f1 = correction["corrected_test_operating_point"]["f1"]
+    assert corrected_f1 <= leaked_f1 + 1e-9, (
+        "leaked threshold was fit on test, so its F1 is maximal there"
+    )

--- a/tests/eval/test_nlp_golden.py
+++ b/tests/eval/test_nlp_golden.py
@@ -1,0 +1,21 @@
+"""Golden tests for the #304 NLP eval harness.
+
+Hermetic: asserts the gated-stage contract (intent blocked on #303, alert
+precision pending a ground-truth set). The heavy RoBERTa sentiment reproduction
+is validated by running ``f1-eval nlp`` (it loads a 1.4 GB checkpoint), not in
+the routine test suite.
+"""
+
+from __future__ import annotations
+
+
+def test_nlp_gated_stages_carry_their_blockers():
+    """Intent is blocked on #303; alert precision + NER + RCM are pending."""
+    from src.strategy.eval.nlp import _gated_stages
+
+    by_stage = {r.stage: r for r in _gated_stages()}
+    assert by_stage["intent"].status == "blocked"
+    assert "303" in by_stage["intent"].detail
+    assert by_stage["alert_precision"].status == "pending"
+    assert by_stage["ner"].status == "pending"
+    assert by_stage["rcm"].status == "pending"

--- a/tests/eval/test_registry_golden.py
+++ b/tests/eval/test_registry_golden.py
@@ -1,0 +1,63 @@
+"""Golden acceptance tests for the eval harness (#206).
+
+Data-tier: these need ``data/models/`` + the labeled holdouts, so they are
+skipped on CI runners (marked ``data`` and guarded like the other model-backed
+tests) and run locally where the weights are present. They lock the harness's
+retro-validation contract - the three claims #206 must keep true:
+
+- the registry reconciles the pace 0.392 -> 0.4104 divergence to the canonical;
+- calibration "finds" the known-broken pit P05-P95 coverage (0.7047) as drift;
+- reproduction re-derives overtake AUC-PR back to its published 0.5491.
+
+They call the ``collect_*`` functions (pure, no report I/O) so the assertions
+test the harness logic, not the markdown writer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "overtake_probability" / "model_config.json").exists()
+
+pytestmark = [
+    pytest.mark.data,
+    pytest.mark.skipif(not _HAS_MODELS, reason="data/models/ absent (CI runner without weights)"),
+]
+
+
+def test_registry_reconciles_pace_divergence():
+    """The registry pins pace canonical = 0.4104 and keeps 0.392 as superseded."""
+    from src.strategy.eval.registry import collect_entries
+
+    pace = [e for e in collect_entries() if e.model == "pace" and e.metric == "mae_test_s"]
+    canonical = [e for e in pace if e.canonical]
+    superseded = [e for e in pace if not e.canonical]
+
+    assert len(canonical) == 1, "exactly one canonical pace entry"
+    assert canonical[0].value == pytest.approx(0.4104)
+    assert any(e.value == pytest.approx(0.392) for e in superseded), "0.392 kept for provenance"
+
+
+def test_calibration_flags_pit_coverage_drift():
+    """The pit P05-P95 coverage (0.7047) surfaces and is flagged as drift."""
+    from src.strategy.eval.calibration import collect_results
+
+    pit = [
+        r for r in collect_results() if r.model == "pit_duration" and r.metric == "p05_p95_coverage"
+    ]
+    assert len(pit) == 1
+    assert pit[0].value == pytest.approx(0.7047)
+    assert pit[0].status == "drift", "coverage below 0.90 nominal must flag drift"
+
+
+def test_reproduction_matches_overtake_auc_pr():
+    """Overtake AUC-PR re-derives to the published 0.5491 within tolerance."""
+    from src.strategy.eval.reproduce import collect_results
+
+    overtake = [r for r in collect_results() if r.model == "overtake" and r.metric == "auc_pr_test"]
+    assert len(overtake) == 1
+    assert overtake[0].status == "reproduced"
+    assert overtake[0].reproduced == pytest.approx(0.5491, abs=0.01)


### PR DESCRIPTION
Sprint 3 (paper-critical) promotion dev -> main. Four PRs landed on test -> dev:

- **#354 (#206)** feat(eval): metrics-registry + calibration harness (f1-eval). E-08 registry + E-03 calibration; overtake AUC-PR reproduces 0.5491 exactly, pit coverage 0.7047 flagged as drift.
- **#355 (#213)** docs(roadmap): reconcile published metrics to thesis/IEEE finals (pace 0.4104, sentiment 0.84, tire 0.7078).
- **#356 (#207)** feat(eval): threshold-provenance + leakage hygiene report (gates the paper freeze). Overtake/SC thresholds contaminated (test-selected); headline AUC-PR clears for overtake, SC AUC-PR optimistic (window selected on test).
- **#357 (#304)** feat(eval): NLP per-stage eval harness. Sentiment reproduced (0.9415/0.9153 on the fixed set); intent blocked on #303, alert precision pending a ground-truth set.

All four passed CI green on their PRs and were verified (two Fable verify-after adversarial passes for the #205-epic work). The new f1-eval console script and src/strategy/eval package are additive; no untouchable trees touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line evaluation workflow for generating reproducible model metrics, calibration, hygiene, NLP, and reproduction reports.
  - Added consolidated metric tracking with provenance, artifact verification, and machine-readable and human-readable report formats.
  - Added evaluation checks for data leakage, threshold selection, calibration drift, and headline metric reproduction.

- **Documentation**
  - Updated roadmap metrics to reflect revised lap-time, tire-degradation, and sentiment results.
  - Added evaluation reports documenting current findings, limitations, and pending assessments.

- **Tests**
  - Added acceptance tests covering metric reconciliation, calibration drift, hygiene findings, and gated NLP stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->