### PR TITLE
feat(eval): recompute SC + undercut calibration + AUC-PR (part of #364)

### DIFF
--- a/documents/eval_reports/calibration.json
+++ b/documents/eval_reports/calibration.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "91b98d3",
+    "harness_sha": "da1db0c",
     "dataset": "2025 holdout + frozen calibration artifacts",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-11T15:07:21+00:00",
+    "generated_at": "2026-07-11T16:52:47+00:00",
     "artifacts": {
       "overtake_model": "cbb9d0eb0beb",
       "pit_cfg": "41dd673a93fb",
@@ -29,6 +29,38 @@
       "nominal": 0.05,
       "status": "ok",
       "detail": "n=10217; 10-bin equal-width"
+    },
+    {
+      "model": "safety_car",
+      "metric": "brier_calibrated",
+      "value": 0.04264973919444633,
+      "nominal": null,
+      "status": "ok",
+      "detail": "n=995; recomputed on 2025 holdout"
+    },
+    {
+      "model": "safety_car",
+      "metric": "ece_calibrated",
+      "value": 0.03471279476464329,
+      "nominal": 0.05,
+      "status": "ok",
+      "detail": "n=995; 10-bin equal-width"
+    },
+    {
+      "model": "undercut",
+      "metric": "brier_calibrated",
+      "value": 0.19295681891254568,
+      "nominal": null,
+      "status": "ok",
+      "detail": "n=252; recomputed on 2025 holdout"
+    },
+    {
+      "model": "undercut",
+      "metric": "ece_calibrated",
+      "value": 0.1303142864225645,
+      "nominal": 0.05,
+      "status": "drift",
+      "detail": "n=252; 10-bin equal-width"
     },
     {
       "model": "pit_duration",
@@ -69,22 +101,6 @@
       "nominal": null,
       "status": "ok",
       "detail": "deployed epistemic sigma; empirical coverage wired-pending (N33-D)"
-    },
-    {
-      "model": "safety_car",
-      "metric": "ece_calibrated",
-      "value": null,
-      "nominal": 0.05,
-      "status": "pending",
-      "detail": "engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from sc_labeled holdout (#207)"
-    },
-    {
-      "model": "undercut",
-      "metric": "ece_calibrated",
-      "value": null,
-      "nominal": 0.05,
-      "status": "pending",
-      "detail": "historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207)"
     }
   ]
 }

--- a/documents/eval_reports/calibration.md
+++ b/documents/eval_reports/calibration.md
@@ -1,16 +1,18 @@
 # calibration
 
-- harness `91b98d3` · schema v1 · generated 2026-07-11T15:07:21+00:00
+- harness `da1db0c` · schema v1 · generated 2026-07-11T16:52:47+00:00
 - era 2022-2025 · dataset 2025 holdout + frozen calibration artifacts · seed deterministic · llm none
 - artifacts: overtake_model=`cbb9d0eb0beb`, pit_cfg=`41dd673a93fb`, tcn_mc_calib=`e03a170f6de4`
 
 | model | metric | value | nominal | status | detail |
 |---|---|---|---|---|---|
+| undercut | ece_calibrated | 0.1303 | 0.05 | drift | n=252; 10-bin equal-width |
 | pit_duration | p05_p95_coverage | 0.7047 | 0.9 | drift | config-declared (recompute pending N15 holdout); 0.7047 vs 0.90 nominal |
-| safety_car | ece_calibrated | - | 0.05 | pending | engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from sc_labeled holdout (#207) |
-| undercut | ece_calibrated | - | 0.05 | pending | historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207) |
 | overtake | brier_calibrated | 0.0520 | - | ok | n=10217; brier raw 0.1304 -> cal 0.0520 (Platt val-2024) |
 | overtake | ece_calibrated | 0.0319 | 0.05 | ok | n=10217; 10-bin equal-width |
+| safety_car | brier_calibrated | 0.0426 | - | ok | n=995; recomputed on 2025 holdout |
+| safety_car | ece_calibrated | 0.0347 | 0.05 | ok | n=995; 10-bin equal-width |
+| undercut | brier_calibrated | 0.1930 | - | ok | n=252; recomputed on 2025 holdout |
 | tire_degradation[C2] | mc_mean_sigma_s | 0.1244 | - | ok | deployed epistemic sigma; empirical coverage wired-pending (N33-D) |
 | tire_degradation[C4] | mc_mean_sigma_s | 0.1504 | - | ok | deployed epistemic sigma; empirical coverage wired-pending (N33-D) |
 | tire_degradation[C5] | mc_mean_sigma_s | 0.1549 | - | ok | deployed epistemic sigma; empirical coverage wired-pending (N33-D) |

--- a/documents/eval_reports/reproduction.json
+++ b/documents/eval_reports/reproduction.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "91b98d3",
+    "harness_sha": "da1db0c",
     "dataset": "2025 holdout vs published model_configs",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-11T15:07:22+00:00",
+    "generated_at": "2026-07-11T16:52:50+00:00",
     "artifacts": {
       "overtake_model": "cbb9d0eb0beb"
     }
@@ -21,12 +21,20 @@
       "detail": "|delta| 0.0000 vs tol 0.01"
     },
     {
+      "model": "safety_car",
+      "metric": "auc_pr_test",
+      "published": 0.0723,
+      "reproduced": 0.07228992613666717,
+      "status": "reproduced",
+      "detail": "|delta| 0.0000 vs tol 0.01"
+    },
+    {
       "model": "undercut",
       "metric": "auc_pr_test",
       "published": 0.6739,
-      "reproduced": null,
-      "status": "pending",
-      "detail": "historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207)"
+      "reproduced": 0.6738805047752813,
+      "status": "reproduced",
+      "detail": "|delta| 0.0000 vs tol 0.01"
     },
     {
       "model": "pit_duration",
@@ -34,15 +42,7 @@
       "published": 0.487,
       "reproduced": null,
       "status": "pending",
-      "detail": "pit_labeled holdout empty on disk (#207)"
-    },
-    {
-      "model": "safety_car",
-      "metric": "auc_pr_test",
-      "published": 0.0723,
-      "reproduced": null,
-      "status": "pending",
-      "detail": "engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from holdout (#207)"
+      "detail": "pit_labeled holdout empty on disk; regen from raw tracked in #364"
     },
     {
       "model": "pace",

--- a/documents/eval_reports/reproduction.md
+++ b/documents/eval_reports/reproduction.md
@@ -1,14 +1,14 @@
 # reproduction
 
-- harness `91b98d3` · schema v1 · generated 2026-07-11T15:07:22+00:00
+- harness `da1db0c` · schema v1 · generated 2026-07-11T16:52:50+00:00
 - era 2022-2025 · dataset 2025 holdout vs published model_configs · seed deterministic · llm none
 - artifacts: overtake_model=`cbb9d0eb0beb`
 
 | model | metric | published | reproduced | status | detail |
 |---|---|---|---|---|---|
 | overtake | auc_pr_test | 0.5491 | 0.5491 | reproduced | |delta| 0.0000 vs tol 0.01 |
-| undercut | auc_pr_test | 0.6739 | - | pending | historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207) |
-| pit_duration | p50_mae_test_s | 0.487 | - | pending | pit_labeled holdout empty on disk (#207) |
-| safety_car | auc_pr_test | 0.0723 | - | pending | engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from holdout (#207) |
+| safety_car | auc_pr_test | 0.0723 | 0.0723 | reproduced | |delta| 0.0000 vs tol 0.01 |
+| undercut | auc_pr_test | 0.6739 | 0.6739 | reproduced | |delta| 0.0000 vs tol 0.01 |
+| pit_duration | p50_mae_test_s | 0.487 | - | pending | pit_labeled holdout empty on disk; regen from raw tracked in #364 |
 | pace | mae_test_s | 0.4104 | - | pending | laptime holdout feature build not wired this phase |
 | tire_degradation | mae_test_s | 0.7078 | - | pending | TCN MC forward pass not run this phase (see calibration MC-sigma) |

--- a/src/strategy/eval/calibration.py
+++ b/src/strategy/eval/calibration.py
@@ -12,11 +12,11 @@ Scope this phase (#206):
 - **pit_duration** - the P05-P95 quantile coverage, flagged as drift vs the
   0.90 nominal.
 - **tire_degradation** - the deployed MC-Dropout sigma per compound.
-- **safety_car / undercut** - recompute from scratch is blocked on-disk (SC
-  needs 5 engineered features - lap_time_*_z, anomaly_and_yellow, lap1_chaos -
-  absent from the holdout; undercut historical aggregates absent too) so they
-  are reported as ``pending`` rather than hidden - Phase-2 (#207) territory.
-  Their headline numbers are still config-sourced in the registry.
+- **safety_car / undercut** - recomputed on the 2025 holdout by rebuilding their
+  engineered features in-memory (SC: the 5 derived features from N14 Step 2;
+  undercut: the two train-fit target encodings from N16 Step 3), the same
+  ``_add_overtake_features`` pattern. Both reproduce their published AUC-PR
+  exactly (#364).
 
 ponytail: pit coverage + the MC sigma are read from frozen artifacts, not
 re-run from a holdout (``pit_labeled`` is empty on disk; the MC pass needs a
@@ -61,6 +61,16 @@ _OVERTAKE_FEATURES = [
 ]
 _OVERTAKE_CAT = ["compound_x", "compound_y", "circuit_cluster"]
 _OVERTAKE_PAIR_KEYS = ["Year", "GP_Name", "driver_x", "driver_y"]
+
+# SC + undercut recompute: the model feature lists are read from disk; the
+# engineered features are rebuilt in-memory from the base parquet, the same
+# pattern _add_overtake_features uses.
+_SC_DIR = "safety_car_probability"
+_SC_LAPTIME_Z_COLS = ["lap_time_mean", "lap_time_std", "lap_time_min"]  # per-race z-scored
+_SC_TARGETS = ("sc_within_3_laps", "sc_within_5_laps", "sc_within_7_laps")
+_UNDERCUT_DIR = "pit_prediction"
+_UNDERCUT_TRAIN_YEARS = (2023, 2024)
+_UNDERCUT_TARGET = "undercut_success"
 
 
 @dataclass
@@ -156,6 +166,136 @@ def load_overtake_predictions(year: int = 2025) -> tuple[np.ndarray, np.ndarray,
     y = test["overtake"].astype(int).to_numpy()
     proba_raw = model.predict_proba(x)[:, 1]
     proba_cal = calibrator.predict_proba(proba_raw.reshape(-1, 1))[:, 1]
+    return y, proba_raw, proba_cal
+
+
+def _add_sc_features(df: "Any") -> "Any":
+    """Rebuild the SC model's engineered features in-memory (N14 Step 2, verbatim).
+
+    The persisted sc_labeled parquet stores base columns; the model consumes 5
+    derived features - per-race z-scores of lap_time_{mean,std,min} plus the
+    anomaly_and_yellow and lap1_chaos interactions - rebuilt here exactly as N14
+    did (per-race median imputation first, then z-scores, then weather fill), or
+    the LightGBM sees a different feature space and the number moves.
+
+    --- WHERE TO CHANGE IF THE SC FEATURES CHANGE ---
+    notebooks/strategy/sc_probability/N14_sc_model.ipynb (Step 2) is the source
+    of truth; mirror any edit here.
+    """
+    df = df.copy()
+    race_key = "race_id" if "race_id" in df.columns else "event_name"
+    for col in ["lap_time_mean", "lap_time_std", "lap_time_min", "lap_time_cv", "lap_time_trend_5"]:
+        if col in df.columns:
+            per_race_median = df.groupby(race_key)[col].transform("median")
+            df[col] = df[col].fillna(per_race_median).fillna(df[col].median())
+    for col in _SC_LAPTIME_Z_COLS:
+        if col in df.columns:
+            race_mu = df.groupby(race_key)[col].transform("mean")
+            race_sigma = df.groupby(race_key)[col].transform("std").clip(lower=0.01)
+            df[f"{col}_z"] = (df[col] - race_mu) / race_sigma
+    for col in ["track_temp", "air_temp", "humidity", "track_temp_delta"]:
+        if col in df.columns:
+            df[col] = df.groupby(race_key)[col].transform(lambda s: s.ffill().bfill())
+            df[col] = df[col].fillna(df[col].median())
+    has_anomaly = {"driver_anomaly_hard_count", "yellow_escalation_count"} <= set(df.columns)
+    df["anomaly_and_yellow"] = (
+        ((df["driver_anomaly_hard_count"] > 0) & (df["yellow_escalation_count"] > 0)).astype(int)
+        if has_anomaly
+        else 0
+    )
+    has_lap1 = {"is_lap1", "n_drivers_delta"} <= set(df.columns)
+    df["lap1_chaos"] = (df["is_lap1"] * df["n_drivers_delta"].abs()).astype(int) if has_lap1 else 0
+    return df
+
+
+def _sc_frame_and_proba(year: int) -> tuple["Any", np.ndarray, np.ndarray] | None:
+    """Load the SC year-slice with engineered features + model probabilities.
+
+    Returns ``(df_slice, proba_raw, proba_cal)`` or ``None``. Shared seam: the
+    calibration recompute (3-lap target) and the #363 threshold/window correction
+    both need the same slice + model output, so the load lives here once. The
+    feature order is read from the model's ``feature_list_v1.json``.
+    """
+    import json
+
+    import joblib
+    import pandas as pd
+
+    model_dir = get_models_root() / _SC_DIR
+    parquet = get_data_root() / "processed" / "sc_labeled" / "sc_labeled_2023_2025.parquet"
+    model_path = model_dir / "lgbm_sc_v1.pkl"
+    calib_path = model_dir / "calibrator_sc_v1.pkl"
+    feature_list_path = model_dir / "feature_list_v1.json"
+    if not all(p.exists() for p in (parquet, model_path, calib_path, feature_list_path)):
+        return None
+
+    features = json.loads(feature_list_path.read_text(encoding="utf-8"))["features"]
+    df = _add_sc_features(pd.read_parquet(parquet))
+    df_slice = df[df["year"] == year].copy()
+    model = joblib.load(model_path)
+    calibrator = joblib.load(calib_path)
+    proba_raw = model.predict_proba(df_slice[features])[:, 1]
+    proba_cal = calibrator.predict_proba(proba_raw.reshape(-1, 1))[:, 1]
+    return df_slice, proba_raw, proba_cal
+
+
+def load_sc_predictions(
+    year: int = 2025, target: str = "sc_within_3_laps"
+) -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
+    """``(y, proba_raw, proba_cal)`` for a SC target window, or ``None`` if artifacts absent.
+
+    ``year`` selects the season slice (2025 = test, 2024 = validation for the
+    #363 threshold re-selection); ``target`` selects the SC window (3/5/7 laps),
+    which the #363 window correction sweeps.
+    """
+    loaded = _sc_frame_and_proba(year)
+    if loaded is None:
+        return None
+    df_slice, proba_raw, proba_cal = loaded
+    y = df_slice[target].astype(int).to_numpy()
+    return y, proba_raw, proba_cal
+
+
+def load_undercut_predictions(
+    year: int = 2025,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
+    """``(y, proba_raw, proba_cal)`` for the undercut holdout with train-fit target encodings.
+
+    The two aggregate features (circuit_undercut_rate, team_x_undercut_rate) are
+    target encodings fit on the 2023-2024 train slice and applied to the requested
+    year (N16 Step 3), so the split precedes the encoding and no train<-test leak
+    occurs. Returns ``None`` when the artifacts or holdout are absent.
+    """
+    import json
+
+    import joblib
+    import pandas as pd
+
+    model_dir = get_models_root() / _UNDERCUT_DIR
+    parquet = get_data_root() / "processed" / "undercut_labeled" / "undercut_clean.parquet"
+    model_path = model_dir / "lgbm_undercut_v1.pkl"
+    calib_path = model_dir / "calibrator_undercut_v1.pkl"
+    cfg_path = model_dir / "model_config_undercut_v1.json"
+    if not all(p.exists() for p in (parquet, model_path, calib_path, cfg_path)):
+        return None
+
+    features = json.loads(cfg_path.read_text(encoding="utf-8"))["features"]
+    df = pd.read_parquet(parquet)
+    train = df[df["Year"].isin(_UNDERCUT_TRAIN_YEARS)]
+    target_slice = df[df["Year"] == year].copy()
+    for group_col, feat in (
+        ("circuit_key", "circuit_undercut_rate"),
+        ("Team_X", "team_x_undercut_rate"),
+    ):
+        encoding = train.groupby(group_col)[_UNDERCUT_TARGET].mean()
+        fallback = train[_UNDERCUT_TARGET].mean()
+        target_slice[feat] = target_slice[group_col].map(encoding).fillna(fallback)
+
+    model = joblib.load(model_path)
+    calibrator = joblib.load(calib_path)
+    proba_raw = model.predict_proba(target_slice[features])[:, 1]
+    proba_cal = calibrator.predict_proba(proba_raw.reshape(-1, 1))[:, 1]
+    y = target_slice[_UNDERCUT_TARGET].astype(int).to_numpy()
     return y, proba_raw, proba_cal
 
 
@@ -260,28 +400,46 @@ def _tcn_mc_sigma() -> list[CalibrationResult]:
     return results
 
 
-def _pending_classifiers() -> list[CalibrationResult]:
-    """Honest deltas for the two classifiers that cannot recompute on-disk.
+def _classifier_calibration(model_name: str, loader: "Any") -> list[CalibrationResult]:
+    """Brier + ECE on the 2025 holdout for a binary classifier via its loader.
 
-    Recording the blocker (not a fabricated number) is the point: both blockers
-    are precisely what Phase-2 provenance work (#207) resolves.
+    Generic over safety_car / undercut: both rebuild their engineered features
+    in-memory (the loaders in this module) and report the calibrated Brier + ECE,
+    the same quantities ``_overtake_calibration`` reports for overtake. Returns a
+    ``pending`` row when the loader cannot find its artifacts.
     """
+    loaded = loader()
+    if loaded is None:
+        return [
+            CalibrationResult(
+                model_name,
+                "ece_calibrated",
+                None,
+                ECE_DRIFT,
+                "pending",
+                "artifacts or holdout absent on disk",
+            )
+        ]
+    y, _proba_raw, proba_cal = loaded
+    brier_cal = float(np.mean((proba_cal - y) ** 2))
+    ece_cal = _ece(y, proba_cal)
+    status = "drift" if ece_cal > ECE_DRIFT else "ok"
     return [
         CalibrationResult(
-            "safety_car",
-            "ece_calibrated",
+            model_name,
+            "brier_calibrated",
+            brier_cal,
             None,
-            ECE_DRIFT,
-            "pending",
-            "engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from sc_labeled holdout (#207)",
+            "ok",
+            f"n={len(y)}; recomputed on 2025 holdout",
         ),
         CalibrationResult(
-            "undercut",
+            model_name,
             "ece_calibrated",
-            None,
+            ece_cal,
             ECE_DRIFT,
-            "pending",
-            "historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207)",
+            status,
+            f"n={len(y)}; {ECE_BINS}-bin equal-width",
         ),
     ]
 
@@ -290,9 +448,10 @@ def collect_results() -> list[CalibrationResult]:
     """All calibration results across the predictors."""
     return [
         *_overtake_calibration(),
+        *_classifier_calibration("safety_car", load_sc_predictions),
+        *_classifier_calibration("undercut", load_undercut_predictions),
         *_pit_quantile_coverage(),
         *_tcn_mc_sigma(),
-        *_pending_classifiers(),
     ]
 
 

--- a/src/strategy/eval/reproduce.py
+++ b/src/strategy/eval/reproduce.py
@@ -18,7 +18,11 @@ from dataclasses import asdict, dataclass
 from typing import Any
 
 from src.f1_strat_manager.data_cache import get_models_root
-from src.strategy.eval.calibration import load_overtake_predictions
+from src.strategy.eval.calibration import (
+    load_overtake_predictions,
+    load_sc_predictions,
+    load_undercut_predictions,
+)
 from src.strategy.eval.report import build_header, write_report
 
 REPRO_NAME = "reproduction"
@@ -83,36 +87,72 @@ def _overtake_auc_pr() -> ReproResult:
     )
 
 
+def _classifier_auc_pr(model: str, published: float, loader: "Any") -> ReproResult:
+    """Re-derive a classifier's AUC-PR on the 2025 holdout via a shared loader.
+
+    AUC-PR is threshold-free, so it is computed on the raw model scores. Generic
+    over safety_car / undercut, mirroring ``_overtake_auc_pr``.
+    """
+    loaded = loader()
+    if loaded is None:
+        return ReproResult(
+            model, "auc_pr_test", published, None, "pending", "holdout or artifacts absent on disk"
+        )
+
+    from sklearn.metrics import average_precision_score
+
+    y, proba_raw, _ = loaded
+    reproduced = float(average_precision_score(y, proba_raw))
+    delta = abs(reproduced - published)
+    status = "reproduced" if delta <= TOLERANCE else "delta"
+    return ReproResult(
+        model,
+        "auc_pr_test",
+        published,
+        reproduced,
+        status,
+        f"|delta| {delta:.4f} vs tol {TOLERANCE}",
+    )
+
+
+def _sc_auc_pr() -> ReproResult:
+    """SC AUC-PR reproduction against its published test number (feature_list_v1)."""
+    cfg = json.loads(
+        (get_models_root() / "safety_car_probability" / "feature_list_v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    return _classifier_auc_pr(
+        "safety_car", float(cfg["metrics"]["test_auc_pr"]), load_sc_predictions
+    )
+
+
+def _undercut_auc_pr() -> ReproResult:
+    """Undercut AUC-PR reproduction against its published test number (model_config)."""
+    cfg = json.loads(
+        (get_models_root() / "pit_prediction" / "model_config_undercut_v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    return _classifier_auc_pr(
+        "undercut", float(cfg["metrics"]["auc_pr_test"]), load_undercut_predictions
+    )
+
+
 def _pending_metrics() -> list[ReproResult]:
-    """Document the headline numbers that cannot re-derive on-disk this phase.
+    """Headline numbers not yet re-derived on-disk (pit holdout regen + pace/tire).
 
     Each carries the same blocker its calibration/registry entry names, so the
     reproduction report and the calibration report agree on why.
     """
     return [
         ReproResult(
-            "undercut",
-            "auc_pr_test",
-            0.6739,
-            None,
-            "pending",
-            "historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207)",
-        ),
-        ReproResult(
             "pit_duration",
             "p50_mae_test_s",
             0.487,
             None,
             "pending",
-            "pit_labeled holdout empty on disk (#207)",
-        ),
-        ReproResult(
-            "safety_car",
-            "auc_pr_test",
-            0.0723,
-            None,
-            "pending",
-            "engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from holdout (#207)",
+            "pit_labeled holdout empty on disk; regen from raw tracked in #364",
         ),
         ReproResult(
             "pace",
@@ -135,7 +175,7 @@ def _pending_metrics() -> list[ReproResult]:
 
 def collect_results() -> list[ReproResult]:
     """All reproduction checks, reproduced/delta rows first."""
-    results = [_overtake_auc_pr(), *_pending_metrics()]
+    results = [_overtake_auc_pr(), _sc_auc_pr(), _undercut_auc_pr(), *_pending_metrics()]
     order = {"delta": 0, "reproduced": 1, "pending": 2}
     return sorted(results, key=lambda r: order.get(r.status, 3))
 

--- a/tests/eval/test_ml_recompute_golden.py
+++ b/tests/eval/test_ml_recompute_golden.py
@@ -1,0 +1,50 @@
+"""Golden tests for the SC + undercut recomputes (#364).
+
+Data-tier: the loaders rebuild the engineered features in-memory and run the
+LightGBM, so they need the models + holdouts on disk and skip on CI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_SC = (ROOT / "data" / "models" / "safety_car_probability" / "lgbm_sc_v1.pkl").exists()
+_HAS_UNDERCUT = (ROOT / "data" / "models" / "pit_prediction" / "lgbm_undercut_v1.pkl").exists()
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_SC, reason="SC model absent (CI runner without weights)")
+def test_sc_auc_pr_reproduces_exactly():
+    """SC AUC-PR reproduces its 0.0723 headline via the in-memory feature rebuild."""
+    from src.strategy.eval.reproduce import _sc_auc_pr
+
+    result = _sc_auc_pr()
+    assert result.status == "reproduced"
+    assert result.reproduced is not None and abs(result.reproduced - 0.0723) < 0.01
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_SC, reason="SC model absent (CI runner without weights)")
+def test_sc_loader_supports_windows_and_years():
+    """The SC loader slices any year and any of the 3 target windows (for #363)."""
+    from src.strategy.eval.calibration import load_sc_predictions
+
+    for target in ("sc_within_3_laps", "sc_within_5_laps", "sc_within_7_laps"):
+        loaded = load_sc_predictions(year=2024, target=target)
+        assert loaded is not None
+        y, proba_raw, proba_cal = loaded
+        assert len(y) == len(proba_raw) == len(proba_cal) > 0
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_UNDERCUT, reason="undercut model absent (CI runner without weights)")
+def test_undercut_auc_pr_reproduces_exactly():
+    """Undercut AUC-PR reproduces its 0.6739 headline with train-fit target encodings."""
+    from src.strategy.eval.reproduce import _undercut_auc_pr
+
+    result = _undercut_auc_pr()
+    assert result.status == "reproduced"
+    assert result.reproduced is not None and abs(result.reproduced - 0.6739) < 0.01


### PR DESCRIPTION
## What

First half of #364 (persist deferred holdouts): the **SC** and **undercut** recomputes. Both were `pending` in the calibration + reproduction reports because their engineered features were not on disk; this rebuilds them **in-memory** at load, the same `_add_overtake_features` pattern the harness already uses (no new parquet to version).

- **`load_sc_predictions`**: rebuilds the 5 SC engineered features (per-race z-scores of lap_time_{mean,std,min} + anomaly_and_yellow + lap1_chaos) verbatim from N14 Step 2, selects the model's `feature_list_v1.json` features, predicts. Exposes `year` + `target` so #363 can re-select the threshold on val-2024 and sweep the 3/5/7 windows.
- **`load_undercut_predictions`**: fits the two target encodings (circuit_undercut_rate, team_x_undercut_rate) on the 2023-2024 train slice and applies them to the requested year (N16 Step 3, no leakage).
- both live in `calibration.py` as the shared seam (reproduce.py + the #363 hygiene correction import them), mirroring `load_overtake_predictions`.

## Numbers

| model | AUC-PR reproduced | published | calibration |
|---|---|---|---|
| safety_car | **0.0723** | 0.0723 | Brier 0.0426 / ECE 0.0347 (ok) |
| undercut | **0.6739** | 0.6739 | Brier 0.1930 / ECE **0.1303 (drift)** |

Both AUC-PR reproduce exactly (|delta| 0.0000). The undercut ECE 0.13 > 0.05 is a real, honest miscalibration finding on the 2025 test set.

## Checks

- `uv run python -m pytest tests/eval/test_ml_recompute_golden.py -q` -> 3 passed (data-tier; skip on CI without weights)
- `uvx ruff check` / `format --check` clean
- `f1-eval calibration` / `f1-eval models` regenerate the reports

## Scope / follow-up

Splitting #364 into this (SC + undercut, in-memory, de-risked) and a **pit** PR (the pit holdout must be regenerated from raw laps/pitstops via the N15 pipeline - heavier, separate concern). pace/tire recompute stay `pending`.

Refs #364