### PR TITLE
feat(eval): regenerate pit holdout from raw laps (closes #364)

### DIFF
--- a/documents/eval_reports/calibration.json
+++ b/documents/eval_reports/calibration.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "da1db0c",
+    "harness_sha": "e1ee603",
     "dataset": "2025 holdout + frozen calibration artifacts",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-11T16:52:47+00:00",
+    "generated_at": "2026-07-11T17:31:05+00:00",
     "artifacts": {
       "overtake_model": "cbb9d0eb0beb",
       "pit_cfg": "41dd673a93fb",
@@ -65,10 +65,10 @@
     {
       "model": "pit_duration",
       "metric": "p05_p95_coverage",
-      "value": 0.7047,
+      "value": 0.7023809523809523,
       "nominal": 0.9,
       "status": "drift",
-      "detail": "config-declared (recompute pending N15 holdout); 0.7047 vs 0.90 nominal"
+      "detail": "n=252; empirical P05-P95 coverage recomputed on the regenerated N15 holdout"
     },
     {
       "model": "tire_degradation[C2]",

--- a/documents/eval_reports/calibration.md
+++ b/documents/eval_reports/calibration.md
@@ -1,13 +1,13 @@
 # calibration
 
-- harness `da1db0c` · schema v1 · generated 2026-07-11T16:52:47+00:00
+- harness `e1ee603` · schema v1 · generated 2026-07-11T17:31:05+00:00
 - era 2022-2025 · dataset 2025 holdout + frozen calibration artifacts · seed deterministic · llm none
 - artifacts: overtake_model=`cbb9d0eb0beb`, pit_cfg=`41dd673a93fb`, tcn_mc_calib=`e03a170f6de4`
 
 | model | metric | value | nominal | status | detail |
 |---|---|---|---|---|---|
 | undercut | ece_calibrated | 0.1303 | 0.05 | drift | n=252; 10-bin equal-width |
-| pit_duration | p05_p95_coverage | 0.7047 | 0.9 | drift | config-declared (recompute pending N15 holdout); 0.7047 vs 0.90 nominal |
+| pit_duration | p05_p95_coverage | 0.7024 | 0.9 | drift | n=252; empirical P05-P95 coverage recomputed on the regenerated N15 holdout |
 | overtake | brier_calibrated | 0.0520 | - | ok | n=10217; brier raw 0.1304 -> cal 0.0520 (Platt val-2024) |
 | overtake | ece_calibrated | 0.0319 | 0.05 | ok | n=10217; 10-bin equal-width |
 | safety_car | brier_calibrated | 0.0426 | - | ok | n=995; recomputed on 2025 holdout |

--- a/documents/eval_reports/reproduction.json
+++ b/documents/eval_reports/reproduction.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "da1db0c",
+    "harness_sha": "e1ee603",
     "dataset": "2025 holdout vs published model_configs",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-11T16:52:50+00:00",
+    "generated_at": "2026-07-11T17:31:11+00:00",
     "artifacts": {
       "overtake_model": "cbb9d0eb0beb"
     }
@@ -40,9 +40,9 @@
       "model": "pit_duration",
       "metric": "p50_mae_test_s",
       "published": 0.487,
-      "reproduced": null,
-      "status": "pending",
-      "detail": "pit_labeled holdout empty on disk; regen from raw tracked in #364"
+      "reproduced": 0.48934217309932837,
+      "status": "reproduced",
+      "detail": "n=252; |delta| 0.0023 vs tol 0.01"
     },
     {
       "model": "pace",

--- a/documents/eval_reports/reproduction.md
+++ b/documents/eval_reports/reproduction.md
@@ -1,6 +1,6 @@
 # reproduction
 
-- harness `da1db0c` · schema v1 · generated 2026-07-11T16:52:50+00:00
+- harness `e1ee603` · schema v1 · generated 2026-07-11T17:31:11+00:00
 - era 2022-2025 · dataset 2025 holdout vs published model_configs · seed deterministic · llm none
 - artifacts: overtake_model=`cbb9d0eb0beb`
 
@@ -9,6 +9,6 @@
 | overtake | auc_pr_test | 0.5491 | 0.5491 | reproduced | |delta| 0.0000 vs tol 0.01 |
 | safety_car | auc_pr_test | 0.0723 | 0.0723 | reproduced | |delta| 0.0000 vs tol 0.01 |
 | undercut | auc_pr_test | 0.6739 | 0.6739 | reproduced | |delta| 0.0000 vs tol 0.01 |
-| pit_duration | p50_mae_test_s | 0.487 | - | pending | pit_labeled holdout empty on disk; regen from raw tracked in #364 |
+| pit_duration | p50_mae_test_s | 0.487 | 0.4893 | reproduced | n=252; |delta| 0.0023 vs tol 0.01 |
 | pace | mae_test_s | 0.4104 | - | pending | laptime holdout feature build not wired this phase |
 | tire_degradation | mae_test_s | 0.7078 | - | pending | TCN MC forward pass not run this phase (see calibration MC-sigma) |

--- a/src/strategy/eval/calibration.py
+++ b/src/strategy/eval/calibration.py
@@ -18,10 +18,10 @@ Scope this phase (#206):
   ``_add_overtake_features`` pattern. Both reproduce their published AUC-PR
   exactly (#364).
 
-ponytail: pit coverage + the MC sigma are read from frozen artifacts, not
-re-run from a holdout (``pit_labeled`` is empty on disk; the MC pass needs a
-torch forward pass x N). Upgrade path when the holdouts land: recompute both
-from data, the same way N33 Section D already does for the TCN.
+ponytail: the MC sigma is read from the frozen calibration JSON, not re-run (the
+MC pass needs a torch forward pass x N). pit coverage is now recomputed from the
+raw-laps holdout (#364, ``pit_holdout``). Upgrade path for MC: recompute from
+data, the same way N33 Section D already does for the TCN.
 """
 
 from __future__ import annotations
@@ -335,14 +335,33 @@ def _overtake_calibration() -> list[CalibrationResult]:
 
 
 def _pit_quantile_coverage() -> list[CalibrationResult]:
-    """Surface the pit P05-P95 empirical coverage and flag it vs nominal.
+    """Recompute the pit P05-P95 empirical coverage on the regenerated N15 holdout.
 
-    ponytail: read from the frozen ``model_config`` (the value is published
-    there) rather than re-run - ``pit_labeled`` is empty on disk so there is no
-    holdout to predict on. Upgrade path: recompute empirical coverage from the
-    hist_pit P05/P95 models over the N15 holdout once it lands. This is the
-    retro-validation target: the harness must surface the known 0.7047 break.
+    Coverage = fraction of test physical_stop_est falling inside [P05, P95]. This
+    is the retro-validation target: the harness must surface the known ~0.70
+    break vs the 0.90 nominal. Falls back to the config-declared value when the
+    raw laps or models are absent (#364 rebuilds the holdout from raw laps).
     """
+    from src.strategy.eval.pit_holdout import load_pit_holdout
+
+    loaded = load_pit_holdout()
+    if loaded is not None:
+        test_slice, models, features = loaded
+        x = test_slice[features]
+        lower = models["p05"].predict(x)
+        upper = models["p95"].predict(x)
+        actual = test_slice["physical_stop_est"].to_numpy()
+        coverage = float(((actual >= lower) & (actual <= upper)).mean())
+        status = "drift" if coverage < NOMINAL_COVERAGE else "ok"
+        detail = (
+            f"n={len(actual)}; empirical P05-P95 coverage recomputed on the regenerated N15 holdout"
+        )
+        return [
+            CalibrationResult(
+                "pit_duration", "p05_p95_coverage", coverage, NOMINAL_COVERAGE, status, detail
+            )
+        ]
+
     cfg_path = get_models_root() / "pit_prediction" / "model_config.json"
     if not cfg_path.exists():
         return [
@@ -352,14 +371,14 @@ def _pit_quantile_coverage() -> list[CalibrationResult]:
                 None,
                 NOMINAL_COVERAGE,
                 "pending",
-                "model_config absent",
+                "raw laps + model_config absent",
             )
         ]
 
     cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
     coverage = float(cfg["eval"]["p05_p95_coverage_test"])
     status = "drift" if coverage < NOMINAL_COVERAGE else "ok"
-    detail = f"config-declared (recompute pending N15 holdout); {coverage:.4f} vs {NOMINAL_COVERAGE:.2f} nominal"
+    detail = f"config-declared (raw laps absent for recompute); {coverage:.4f} vs {NOMINAL_COVERAGE:.2f} nominal"
     return [
         CalibrationResult(
             "pit_duration", "p05_p95_coverage", coverage, NOMINAL_COVERAGE, status, detail

--- a/src/strategy/eval/pit_holdout.py
+++ b/src/strategy/eval/pit_holdout.py
@@ -1,0 +1,174 @@
+"""Pit-duration holdout regeneration from raw laps (#364).
+
+``pit_labeled/`` is empty on disk, so unlike SC/undercut the pit holdout must be
+rebuilt from the raw FastF1 laps (``data/raw/<year>/<circuit>/laps.parquet``).
+This ports the N15 pipeline verbatim (pair pit-in lap N with pit-out lap N+1 ->
+pit_duration_s; filter drive-throughs + non-normal stops; per-circuit traversal
+from train; physical_stop_est; per-team-year median) and returns the deployed
+HistGBT P05/P50/P95 quantile models to score it.
+
+The raw circuit directory name is used as the ``circuit`` key: it is bijective
+with N15's ``GP_Name`` (one directory = one race = one GP), and the traversal is
+recomputed per key from train, so the physical_stop_est is identical to N15's.
+The only GP-name dependency (the 3 tight-pit-box circuits) is mapped explicitly.
+
+--- WHERE TO CHANGE IF THE PIT PIPELINE CHANGES ---
+notebooks/strategy/pit_prediction/N15_pit_duration.ipynb (cells 4/11/12/17) is
+the source of truth; mirror any edit here. Validated: P50 MAE 0.4893 vs the
+published 0.487 (delta 0.0023, within tolerance).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from src.f1_strat_manager.data_cache import get_data_root, get_models_root
+
+_PIT_DIR = "pit_prediction"
+_COMPOUND_ORDER = {"SOFT": 0, "MEDIUM": 1, "HARD": 2, "INTERMEDIATE": 3, "WET": 4}
+_SC_STATUSES = set("4567")  # TrackStatus digits meaning SC / VSC / red
+_TIGHT_DIRS = {"Monaco", "Marina_Bay", "Budapest"}  # Monaco / Singapore / Hungarian GP
+_STOP_MIN_S, _STOP_MAX_S = 2.0, 4.5  # normal physical stop window (N15)
+_RAW_MIN_S, _RAW_MAX_S = 15.0, 60.0  # raw pit_duration_s filter (N15 filter_pit_stops)
+_PHYSICAL_STOP_FLOOR = 1.5
+_TRAIN_YEARS = (2023, 2024)
+_TARGET = "physical_stop_est"
+
+
+def _collect_pit_stops(pd: Any) -> Any:
+    """Pair pit-in lap N with pit-out lap N+1 from raw laps -> one row per stop.
+
+    Reproduces N15 collect_pit_data over the on-disk laps instead of a FastF1
+    fetch. Filters drive-throughs (TyreLife_out <= 5) and keeps the raw
+    pit_duration_s in [15, 60] s.
+    """
+    raw_root = get_data_root() / "raw"
+    records = []
+    for laps_path in sorted(raw_root.glob("*/*/laps.parquet")):
+        circuit = laps_path.parent.name
+        year = int(laps_path.parent.parent.name)
+        laps = pd.read_parquet(laps_path)
+        needed = {
+            "Driver",
+            "Team",
+            "LapNumber",
+            "Compound",
+            "TyreLife",
+            "PitInTime",
+            "PitOutTime",
+            "TrackStatus",
+        }
+        if not needed <= set(laps.columns):
+            continue
+        pit_in = laps[laps["PitInTime"].notna()][
+            ["Driver", "Team", "LapNumber", "Compound", "TyreLife", "PitInTime", "TrackStatus"]
+        ].copy()
+        pit_out = laps[laps["PitOutTime"].notna()][
+            ["Driver", "LapNumber", "PitOutTime", "TyreLife"]
+        ].copy()
+        pit_in["LapNumber_out"] = pit_in["LapNumber"] + 1
+        merged = pit_in.merge(
+            pit_out.rename(columns={"LapNumber": "LapNumber_out", "TyreLife": "TyreLife_out"}),
+            on=["Driver", "LapNumber_out"],
+            how="inner",
+        )
+        merged["pit_duration_s"] = (merged["PitOutTime"] - merged["PitInTime"]).dt.total_seconds()
+        merged = merged[merged["TyreLife_out"] <= 5].copy()
+        merged["year"] = year
+        merged["circuit"] = circuit
+        records.append(merged)
+    if not records:
+        return pd.DataFrame()
+    stops = pd.concat(records, ignore_index=True)
+    return stops[(stops["pit_duration_s"] >= _RAW_MIN_S) & (stops["pit_duration_s"] <= _RAW_MAX_S)]
+
+
+def _engineer(stops: Any) -> Any:
+    """Add the N15 model features (compound_id, tyre_life_in, under_sc, compound_change, ...)."""
+    out = stops.copy()
+    out["Compound"] = out["Compound"].str.upper().str.strip()
+    out["compound_id"] = out["Compound"].map(_COMPOUND_ORDER).fillna(-1).astype(int)
+    out["tyre_life_in"] = out["TyreLife"].clip(upper=50).fillna(0).astype(float)
+    out["team"] = out["Team"].astype(str).str.strip()
+    out["lap_number"] = out["LapNumber"].fillna(0).astype(int)
+    out["under_sc"] = (
+        out["TrackStatus"].astype(str).apply(lambda s: int(any(c in _SC_STATUSES for c in s)))
+    ).astype(int)
+    out["tight_pit_box"] = out["circuit"].isin(_TIGHT_DIRS).astype(int)
+    out = out.sort_values(["year", "circuit", "Driver", "LapNumber"]).copy()
+    prev_compound = out.groupby(["year", "circuit", "Driver"])["compound_id"].shift(1)
+    out["compound_change"] = (
+        (prev_compound.notna()) & (out["compound_id"] != prev_compound)
+    ).astype(int)
+    return out
+
+
+def _add_team_year_median(train: Any, target_slice: Any) -> Any:
+    """Per-team prior: median physical_stop_est from the most recent training year (N15)."""
+    lookup = train.groupby(["team", "year"])[_TARGET].median()
+    global_median = train[_TARGET].median()
+    teams_seen = set(lookup.index.get_level_values("team"))
+
+    def most_recent(team: str, year: int) -> float:
+        if (team, year) in lookup.index:
+            return float(lookup[(team, year)])
+        if team in teams_seen:
+            return float(lookup.xs(team, level="team").iloc[-1])
+        return float(global_median)
+
+    target_slice = target_slice.copy()
+    target_slice["team_year_median"] = [
+        most_recent(t, y) for t, y in zip(target_slice["team"], target_slice["year"])
+    ]
+    return target_slice
+
+
+def load_pit_holdout(year: int = 2025) -> tuple[Any, dict[str, Any], list[str]] | None:
+    """Rebuild the pit holdout and return ``(test_slice, quantile_models, features)``.
+
+    ``test_slice`` carries the engineered features + ``physical_stop_est`` target
+    for the requested year; ``quantile_models`` maps ``p05/p50/p95`` to the loaded
+    HistGBT models. Returns ``None`` when the raw laps or models are absent.
+    """
+    import joblib
+    import pandas as pd
+
+    model_dir = get_models_root() / _PIT_DIR
+    cfg_path = model_dir / "model_config.json"
+    if not cfg_path.exists():
+        return None
+
+    stops = _collect_pit_stops(pd)
+    if stops.empty:
+        return None
+    df = _engineer(stops)
+    train = df[df["year"].isin(_TRAIN_YEARS)].copy()
+    target_slice = df[df["year"] == year].copy()
+
+    traversal = train.groupby("circuit")["pit_duration_s"].quantile(0.05) - _PHYSICAL_STOP_FLOOR
+    for part in (train, target_slice):
+        part["circuit_traversal"] = part["circuit"].map(traversal).fillna(traversal.mean())
+        part[_TARGET] = (part["pit_duration_s"] - part["circuit_traversal"]).clip(lower=0.5)
+    train = train[(train[_TARGET] >= _STOP_MIN_S) & (train[_TARGET] <= _STOP_MAX_S)]
+    target_slice = target_slice[
+        (target_slice[_TARGET] >= _STOP_MIN_S) & (target_slice[_TARGET] <= _STOP_MAX_S)
+    ].copy()
+    if target_slice.empty:
+        return None
+    target_slice = _add_team_year_median(train, target_slice)
+
+    cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+    features = cfg["features"]
+    team_classes = list(cfg["label_encoder_classes"]["team"])
+    target_slice["team"] = target_slice["team"].map(
+        lambda x: team_classes.index(x) if x in team_classes else 0
+    )
+
+    models = {}
+    for quantile in ("p05", "p50", "p95"):
+        path = model_dir / f"hist_pit_{quantile}_v1.pkl"
+        if not path.exists():
+            return None
+        models[quantile] = joblib.load(path)
+    return target_slice, models, features

--- a/src/strategy/eval/reproduce.py
+++ b/src/strategy/eval/reproduce.py
@@ -139,6 +139,47 @@ def _undercut_auc_pr() -> ReproResult:
     )
 
 
+_PIT_PUBLISHED_P50_MAE = 0.487  # registry headline (N15 P50 physical-stop MAE, s)
+
+
+def _pit_p50_mae() -> ReproResult:
+    """Re-derive the pit P50 MAE on the holdout rebuilt from raw laps (#364).
+
+    ``pit_labeled`` is empty on disk, so the holdout is regenerated from the raw
+    laps by ``pit_holdout.load_pit_holdout``. MAE of the P50 quantile prediction
+    vs physical_stop_est on the 2025 slice.
+    """
+    from src.strategy.eval.pit_holdout import load_pit_holdout
+
+    loaded = load_pit_holdout()
+    if loaded is None:
+        return ReproResult(
+            "pit_duration",
+            "p50_mae_test_s",
+            _PIT_PUBLISHED_P50_MAE,
+            None,
+            "pending",
+            "raw laps or pit models absent on disk",
+        )
+
+    import numpy as np
+
+    test_slice, models, features = loaded
+    predicted = models["p50"].predict(test_slice[features])
+    actual = test_slice["physical_stop_est"].to_numpy()
+    reproduced = float(np.mean(np.abs(predicted - actual)))
+    delta = abs(reproduced - _PIT_PUBLISHED_P50_MAE)
+    status = "reproduced" if delta <= TOLERANCE else "delta"
+    return ReproResult(
+        "pit_duration",
+        "p50_mae_test_s",
+        _PIT_PUBLISHED_P50_MAE,
+        reproduced,
+        status,
+        f"n={len(actual)}; |delta| {delta:.4f} vs tol {TOLERANCE}",
+    )
+
+
 def _pending_metrics() -> list[ReproResult]:
     """Headline numbers not yet re-derived on-disk (pit holdout regen + pace/tire).
 
@@ -146,14 +187,6 @@ def _pending_metrics() -> list[ReproResult]:
     reproduction report and the calibration report agree on why.
     """
     return [
-        ReproResult(
-            "pit_duration",
-            "p50_mae_test_s",
-            0.487,
-            None,
-            "pending",
-            "pit_labeled holdout empty on disk; regen from raw tracked in #364",
-        ),
         ReproResult(
             "pace",
             "mae_test_s",
@@ -175,7 +208,13 @@ def _pending_metrics() -> list[ReproResult]:
 
 def collect_results() -> list[ReproResult]:
     """All reproduction checks, reproduced/delta rows first."""
-    results = [_overtake_auc_pr(), _sc_auc_pr(), _undercut_auc_pr(), *_pending_metrics()]
+    results = [
+        _overtake_auc_pr(),
+        _sc_auc_pr(),
+        _undercut_auc_pr(),
+        _pit_p50_mae(),
+        *_pending_metrics(),
+    ]
     order = {"delta": 0, "reproduced": 1, "pending": 2}
     return sorted(results, key=lambda r: order.get(r.status, 3))
 

--- a/tests/eval/test_ml_recompute_golden.py
+++ b/tests/eval/test_ml_recompute_golden.py
@@ -13,6 +13,9 @@ import pytest
 ROOT = Path(__file__).parent.parent.parent
 _HAS_SC = (ROOT / "data" / "models" / "safety_car_probability" / "lgbm_sc_v1.pkl").exists()
 _HAS_UNDERCUT = (ROOT / "data" / "models" / "pit_prediction" / "lgbm_undercut_v1.pkl").exists()
+_HAS_PIT = (ROOT / "data" / "models" / "pit_prediction" / "hist_pit_p50_v1.pkl").exists() and bool(
+    list((ROOT / "data" / "raw").glob("*/*/laps.parquet"))
+)
 
 
 @pytest.mark.data
@@ -48,3 +51,14 @@ def test_undercut_auc_pr_reproduces_exactly():
     result = _undercut_auc_pr()
     assert result.status == "reproduced"
     assert result.reproduced is not None and abs(result.reproduced - 0.6739) < 0.01
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_PIT, reason="pit models or raw laps absent (CI runner without data)")
+def test_pit_p50_mae_reproduces_from_raw_laps():
+    """The pit holdout rebuilt from raw laps reproduces the 0.487 P50 MAE within tolerance."""
+    from src.strategy.eval.reproduce import _pit_p50_mae
+
+    result = _pit_p50_mae()
+    assert result.status == "reproduced"
+    assert result.reproduced is not None and abs(result.reproduced - 0.487) < 0.01


### PR DESCRIPTION
## What

Completes #364 (persist deferred holdouts) with the last and heaviest one: **pit**. Unlike SC/undercut, `pit_labeled/` is empty, so the holdout is rebuilt from the raw FastF1 laps.

- **`pit_holdout.py`** ports the N15 pipeline verbatim: pair pit-in lap N with pit-out lap N+1 -> `pit_duration_s`; drop drive-throughs (TyreLife_out <= 5) and keep raw duration in [15,60]s; recompute per-circuit traversal (P5 - floor) from train; `physical_stop_est = pit_duration_s - traversal`; filter to [2.0,4.5]s; per-team-year median.
- **Key insight**: the raw circuit directory is a bijective key for N15's `GP_Name` (one dir = one race = one GP), so the per-circuit traversal groups are identical to N15's - no GP-name map needed except the 3 tight-pit-box circuits (Monaco/Marina_Bay/Budapest).
- **calibration.py** now recomputes the empirical P05-P95 coverage; **reproduce.py** now recomputes the P50 MAE.

## Numbers

| metric | recomputed | published | status |
|---|---|---|---|
| pit P50 MAE (s) | **0.4893** | 0.487 | reproduced (delta 0.0023) |
| pit P05-P95 coverage | **0.7024** | ~0.7047 | drift vs 0.90 (the known break, retro-validated) |

## With #364 complete

The reproduction report now reproduces overtake / SC / undercut / pit; only pace + tire stay `pending` (separate follow-ups). Calibration surfaces the pit coverage break empirically instead of from config.

## Checks

- `pytest tests/eval/test_ml_recompute_golden.py -q` -> 4 passed (pit test is data-tier: needs raw laps + models, skips on CI)
- `uvx ruff check` / `format --check` clean
- `f1-eval calibration` / `f1-eval models` regenerate the reports

Closes #364