### PR TITLE
feat(eval): LLM-judge alert precision over unlabeled radios (#304 follow-up)

### DIFF
--- a/documents/eval_reports/alert_llm.json
+++ b/documents/eval_reports/alert_llm.json
@@ -1,0 +1,19 @@
+{
+  "header": {
+    "harness_sha": "b727baa",
+    "dataset": "radios_raw.csv unlabeled subset",
+    "seed_policy": "deterministic",
+    "era_tag": "2022-2025",
+    "llm": "openai/gpt-4.1-mini",
+    "schema_version": "1",
+    "generated_at": "2026-07-11T17:47:16+00:00",
+    "artifacts": {}
+  },
+  "result": {
+    "sample_size": 80,
+    "predicted_alerts": 16,
+    "judged_true": 0,
+    "proxy_precision": 0.0,
+    "detail": "PROXY: 0/16 predicted alerts judged genuine by gpt-4.1-mini; LLM labels are not ground truth - needs human review before any paper claim"
+  }
+}

--- a/documents/eval_reports/alert_llm.md
+++ b/documents/eval_reports/alert_llm.md
@@ -1,0 +1,18 @@
+# alert_llm
+
+- harness `b727baa` · schema v1 · generated 2026-07-11T17:47:16+00:00
+- era 2022-2025 · dataset radios_raw.csv unlabeled subset · seed deterministic · llm openai/gpt-4.1-mini
+- artifacts: —
+
+> PROXY METRIC - LLM-judged, not ground truth. Needs a human-review pass before any paper claim. The paper-grade alert precision is the gold-based one in the nlp report.
+
+| metric | value |
+|---|---|
+| sample size (unlabeled) | 80 |
+| predicted alerts | 16 |
+| judged genuine | 0 |
+| proxy precision | 0.0000 |
+
+PROXY: 0/16 predicted alerts judged genuine by gpt-4.1-mini; LLM labels are not ground truth - needs human review before any paper claim
+
+**Finding**: the unlabeled radios are dominated by garbled Whisper transcripts (the subset excluded from hand-labeling), so this proxy reflects transcript noise, not alert precision - a low value here is expected and NOT informative. Use the gold-based alert precision (0.9185, nlp report) for the paper; a meaningful LLM-judge would need a curated unlabeled set.

--- a/src/strategy/eval/alert_llm.py
+++ b/src/strategy/eval/alert_llm.py
@@ -56,9 +56,13 @@ def _make_judge_llm() -> Any:
 
     Mirrors the provider switch in ``radio_agent`` so the harness reaches the same
     backend the agents use. Temperature 0 for as-deterministic-as-possible verdicts.
+    Loads ``.env`` so OPENAI_API_KEY / F1_LLM_PROVIDER are available when invoked
+    outside the CLI that normally loads them.
     """
+    from dotenv import find_dotenv, load_dotenv
     from langchain_openai import ChatOpenAI
 
+    load_dotenv(find_dotenv())
     provider = os.environ.get("F1_LLM_PROVIDER", "openai")
     if provider == "lmstudio":
         return ChatOpenAI(
@@ -71,7 +75,12 @@ def _make_judge_llm() -> Any:
 
 
 def _unlabeled_radios(sample_size: int) -> list[str] | None:
-    """The first ``sample_size`` radios (sorted, deterministic) absent from the intent set."""
+    """The first ``sample_size`` radios (CSV order, deduped) absent from the intent set.
+
+    CAVEAT: the radios NOT in the hand-labeled intent set are largely the ones
+    that were EXCLUDED from labeling because they are low-quality / garbled
+    Whisper transcripts, so this subset is not representative of clean radio.
+    """
     import pandas as pd
 
     raw_path = get_data_root() / "processed" / "radio_nlp" / "radios_raw.csv"
@@ -79,9 +88,12 @@ def _unlabeled_radios(sample_size: int) -> list[str] | None:
     if not (raw_path.exists() and labeled_path.exists()):
         return None
 
-    labeled = set(pd.read_csv(labeled_path)["message"].astype(str))
-    raw = pd.read_csv(raw_path)["text"].astype(str)
-    unlabeled = sorted(t for t in raw if t.strip() and t not in labeled)
+    seen = set(pd.read_csv(labeled_path)["message"].astype(str))
+    unlabeled = []
+    for text in pd.read_csv(raw_path)["text"].astype(str):
+        if text.strip() and text not in seen:
+            seen.add(text)  # dedupe against both the labeled set and earlier picks
+            unlabeled.append(text)
     return unlabeled[:sample_size]
 
 
@@ -121,7 +133,9 @@ def run_alert_precision_llm(sample_size: int = _DEFAULT_SAMPLE) -> AlertLLMResul
         llm = _make_judge_llm()
         verdicts = [_judge(llm, text) for text in alerts]
     except Exception as exc:  # noqa: BLE001 - any LLM/transport failure degrades to a note
-        return AlertLLMResult(len(texts), len(alerts), 0, None, f"LLM judge unavailable: {type(exc).__name__}")
+        return AlertLLMResult(
+            len(texts), len(alerts), 0, None, f"LLM judge unavailable: {type(exc).__name__}"
+        )
 
     judged_true = sum(verdicts)
     precision = judged_true / len(alerts)
@@ -148,6 +162,12 @@ def _render(result: AlertLLMResult) -> str:
             f"| proxy precision | {precision} |",
             "",
             result.detail,
+            "",
+            "**Finding**: the unlabeled radios are dominated by garbled Whisper transcripts (the "
+            "subset excluded from hand-labeling), so this proxy reflects transcript noise, not alert "
+            "precision - a low value here is expected and NOT informative. Use the gold-based alert "
+            "precision (0.9185, nlp report) for the paper; a meaningful LLM-judge would need a "
+            "curated unlabeled set.",
         ]
     )
 
@@ -161,4 +181,9 @@ def build_alert_llm_report() -> dict[str, Any]:
     )
     payload = {"result": asdict(result)}
     md_path, json_path = write_report(ALERT_LLM_NAME, header, _render(result), payload)
-    return {"header": asdict(header), "md_path": str(md_path), "json_path": str(json_path), **payload}
+    return {
+        "header": asdict(header),
+        "md_path": str(md_path),
+        "json_path": str(json_path),
+        **payload,
+    }

--- a/src/strategy/eval/alert_llm.py
+++ b/src/strategy/eval/alert_llm.py
@@ -1,0 +1,164 @@
+"""LLM-judge alert precision over UNLABELED radios (#304 follow-up).
+
+The gold alert precision (0.9185, in ``nlp.py``) is measured on the hand-labeled
+intent set. This module extends coverage to the ~154 radios that carry NO hand
+label, using an LLM as a PROXY judge: it flags the radios the intent model calls
+an alert (PROBLEM/WARNING), asks the LLM whether each is a genuine pit-wall alert,
+and reports the proxy precision.
+
+IMPORTANT - this is a PROXY, not ground truth:
+- LLM verdicts are not gold; the number is indicative, not defensible for the
+  paper on its own. The paper-grade alert precision is the gold-based one.
+- Non-deterministic (an external model), so it is deliberately kept OUT of the
+  reproducible ``f1-eval nlp`` report and behind its own ``f1-eval alert-llm``
+  command that spends API calls only when invoked.
+- FLAG FOR VICTOR: for a paper claim on the unlabeled set, these proxy labels
+  need a human-review pass.
+
+LLM provider follows ``F1_LLM_PROVIDER`` (openai / lmstudio), never Anthropic.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from src.f1_strat_manager.data_cache import get_data_root
+from src.strategy.eval.nlp import _ALERT_INTENTS, _load_intent_setfit_free
+from src.strategy.eval.report import build_header, write_report
+
+ALERT_LLM_NAME = "alert_llm"
+_JUDGE_MODEL = "gpt-4.1-mini"
+_DEFAULT_SAMPLE = 80
+
+_JUDGE_SYSTEM = (
+    "You are an F1 race strategist on the pit wall. A radio message is an ALERT only if it "
+    "reports a genuine problem or a warning the strategist must act on (car damage, tyre/brake "
+    "issues, hazards, incidents, urgent instructions). Neutral information, questions, banter, or "
+    "routine updates are NOT alerts. Answer with a single word: YES or NO."
+)
+
+
+@dataclass
+class AlertLLMResult:
+    """The proxy alert-precision measurement over the unlabeled sample."""
+
+    sample_size: int
+    predicted_alerts: int
+    judged_true: int
+    proxy_precision: float | None
+    detail: str
+
+
+def _make_judge_llm() -> Any:
+    """Instantiate the judge LLM per ``F1_LLM_PROVIDER`` (openai default here, or lmstudio).
+
+    Mirrors the provider switch in ``radio_agent`` so the harness reaches the same
+    backend the agents use. Temperature 0 for as-deterministic-as-possible verdicts.
+    """
+    from langchain_openai import ChatOpenAI
+
+    provider = os.environ.get("F1_LLM_PROVIDER", "openai")
+    if provider == "lmstudio":
+        return ChatOpenAI(
+            model="local-model",
+            base_url="http://localhost:1234/v1",
+            api_key="lm-studio",
+            temperature=0,
+        )
+    return ChatOpenAI(model=_JUDGE_MODEL, temperature=0)
+
+
+def _unlabeled_radios(sample_size: int) -> list[str] | None:
+    """The first ``sample_size`` radios (sorted, deterministic) absent from the intent set."""
+    import pandas as pd
+
+    raw_path = get_data_root() / "processed" / "radio_nlp" / "radios_raw.csv"
+    labeled_path = get_data_root() / "processed" / "radio_nlp" / "intent_labeled_data.csv"
+    if not (raw_path.exists() and labeled_path.exists()):
+        return None
+
+    labeled = set(pd.read_csv(labeled_path)["message"].astype(str))
+    raw = pd.read_csv(raw_path)["text"].astype(str)
+    unlabeled = sorted(t for t in raw if t.strip() and t not in labeled)
+    return unlabeled[:sample_size]
+
+
+def _predicted_alerts(texts: list[str]) -> list[str] | None:
+    """Radios the intent model flags as an alert (intent in PROBLEM/WARNING)."""
+    loaded = _load_intent_setfit_free()
+    if loaded is None:
+        return None
+    st, head, idx_to_name = loaded
+    preds = [idx_to_name[int(c)] for c in head.predict(st.encode(texts, show_progress_bar=False))]
+    return [text for text, pred in zip(texts, preds) if pred in _ALERT_INTENTS]
+
+
+def _judge(llm: Any, text: str) -> bool:
+    """Ask the LLM whether one radio is a genuine pit-wall alert (YES/NO)."""
+    response = llm.invoke([("system", _JUDGE_SYSTEM), ("human", text)])
+    return "yes" in str(response.content).strip().lower()[:5]
+
+
+def run_alert_precision_llm(sample_size: int = _DEFAULT_SAMPLE) -> AlertLLMResult:
+    """Compute proxy alert precision over the unlabeled sample via the LLM judge.
+
+    Returns a degraded result (``proxy_precision=None``) when the intent model,
+    the corpus, or the LLM backend is unavailable, rather than raising.
+    """
+    texts = _unlabeled_radios(sample_size)
+    if not texts:
+        return AlertLLMResult(0, 0, 0, None, "intent set or radios_raw.csv absent")
+
+    alerts = _predicted_alerts(texts)
+    if alerts is None:
+        return AlertLLMResult(len(texts), 0, 0, None, "intent model absent")
+    if not alerts:
+        return AlertLLMResult(len(texts), 0, 0, None, "no predicted alerts in the sample")
+
+    try:
+        llm = _make_judge_llm()
+        verdicts = [_judge(llm, text) for text in alerts]
+    except Exception as exc:  # noqa: BLE001 - any LLM/transport failure degrades to a note
+        return AlertLLMResult(len(texts), len(alerts), 0, None, f"LLM judge unavailable: {type(exc).__name__}")
+
+    judged_true = sum(verdicts)
+    precision = judged_true / len(alerts)
+    detail = (
+        f"PROXY: {judged_true}/{len(alerts)} predicted alerts judged genuine by {_JUDGE_MODEL}; "
+        "LLM labels are not ground truth - needs human review before any paper claim"
+    )
+    return AlertLLMResult(len(texts), len(alerts), judged_true, round(precision, 4), detail)
+
+
+def _render(result: AlertLLMResult) -> str:
+    """Render the proxy alert-precision report with its PROXY caveat up front."""
+    precision = "-" if result.proxy_precision is None else f"{result.proxy_precision:.4f}"
+    return "\n".join(
+        [
+            "> PROXY METRIC - LLM-judged, not ground truth. Needs a human-review pass before any "
+            "paper claim. The paper-grade alert precision is the gold-based one in the nlp report.",
+            "",
+            "| metric | value |",
+            "|---|---|",
+            f"| sample size (unlabeled) | {result.sample_size} |",
+            f"| predicted alerts | {result.predicted_alerts} |",
+            f"| judged genuine | {result.judged_true} |",
+            f"| proxy precision | {precision} |",
+            "",
+            result.detail,
+        ]
+    )
+
+
+def build_alert_llm_report() -> dict[str, Any]:
+    """Regenerate the proxy alert-precision report (spends API calls)."""
+    result = run_alert_precision_llm()
+    provider = os.environ.get("F1_LLM_PROVIDER", "openai")
+    header = build_header(
+        dataset="radios_raw.csv unlabeled subset", llm=f"{provider}/{_JUDGE_MODEL}"
+    )
+    payload = {"result": asdict(result)}
+    md_path, json_path = write_report(ALERT_LLM_NAME, header, _render(result), payload)
+    return {"header": asdict(header), "md_path": str(md_path), "json_path": str(json_path), **payload}

--- a/src/strategy/eval/cli.py
+++ b/src/strategy/eval/cli.py
@@ -9,7 +9,8 @@ one-line summary of where it landed and what it flagged.
     f1-eval models         # reproduce headline numbers vs the model_configs
     f1-eval hygiene        # E-02 threshold provenance + leakage verdicts (#207)
     f1-eval nlp            # NLP per-stage eval: sentiment + gated stages (#304)
-    f1-eval all            # every report
+    f1-eval alert-llm      # PROXY alert precision via an LLM judge (#304; spends API calls)
+    f1-eval all            # every report EXCEPT alert-llm (opt-in: it spends API calls)
 """
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ from __future__ import annotations
 import argparse
 from typing import Any, Callable
 
+from src.strategy.eval.alert_llm import build_alert_llm_report
 from src.strategy.eval.calibration import build_calibration_report
 from src.strategy.eval.hygiene import build_hygiene_report
 from src.strategy.eval.nlp import build_nlp_report
@@ -62,6 +64,16 @@ def _run_nlp() -> None:
     print("nlp " + _summarise(payload, "results", ("flagged", "delta", "blocked", "pending")))
 
 
+def _run_alert_llm() -> None:
+    payload = build_alert_llm_report()
+    result = payload["result"]
+    precision = "-" if result["proxy_precision"] is None else f"{result['proxy_precision']:.4f}"
+    print(
+        f"alert-llm -> {payload['md_path']} (proxy precision {precision} over "
+        f"{result['predicted_alerts']} predicted alerts; PROXY - needs human review)"
+    )
+
+
 _COMMANDS: dict[str, Callable[[], None]] = {
     "registry": _run_registry,
     "calibration": _run_calibration,
@@ -78,10 +90,15 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "command",
-        choices=[*_COMMANDS, "all"],
+        choices=[*_COMMANDS, "alert-llm", "all"],
         help="which report to regenerate",
     )
     args = parser.parse_args(argv)
+
+    # alert-llm is opt-in only: it spends API calls, so `all` never runs it.
+    if args.command == "alert-llm":
+        _run_alert_llm()
+        return 0
 
     commands = _COMMANDS.values() if args.command == "all" else [_COMMANDS[args.command]]
     for run in commands:

--- a/tests/eval/test_alert_llm_golden.py
+++ b/tests/eval/test_alert_llm_golden.py
@@ -1,0 +1,52 @@
+"""Golden tests for the LLM-judge alert-precision module (#304 follow-up).
+
+The render + degradation paths are hermetic. The corpus selection is data-tier
+(needs the CSVs). The LLM call itself is neither run nor mocked here - it spends
+API calls and is non-deterministic, so it is exercised only via ``f1-eval
+alert-llm``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_CORPUS = (ROOT / "data" / "processed" / "radio_nlp" / "radios_raw.csv").exists()
+
+
+def test_render_leads_with_proxy_caveat():
+    """The report must open with the PROXY / human-review caveat, not a bare number."""
+    from src.strategy.eval.alert_llm import AlertLLMResult, _render
+
+    body = _render(AlertLLMResult(80, 20, 15, 0.75, "detail"))
+    assert body.splitlines()[0].startswith("> PROXY")
+    assert "human-review" in body
+    assert "0.7500" in body
+
+
+def test_render_handles_missing_precision():
+    """A degraded result (no precision) still renders without raising."""
+    from src.strategy.eval.alert_llm import AlertLLMResult, _render
+
+    body = _render(AlertLLMResult(0, 0, 0, None, "LLM judge unavailable"))
+    assert "| proxy precision | - |" in body
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_CORPUS, reason="radio corpus absent (CI runner without data)")
+def test_unlabeled_radios_excludes_the_labeled_set():
+    """The sample is drawn only from radios absent from the hand-labeled intent set."""
+    import pandas as pd
+
+    from src.strategy.eval.alert_llm import _unlabeled_radios
+
+    sample = _unlabeled_radios(30)
+    assert sample is not None and len(sample) == 30
+    labeled = set(
+        pd.read_csv(ROOT / "data" / "processed" / "radio_nlp" / "intent_labeled_data.csv")[
+            "message"
+        ].astype(str)
+    )
+    assert all(text not in labeled for text in sample)


### PR DESCRIPTION
## What

The requested LLM-judge follow-up to the gold-based alert precision (#362). Adds an opt-in `f1-eval alert-llm` that flags the intent model's alerts (PROBLEM/WARNING) over the ~154 unlabeled radios and asks an LLM (OpenAI gpt-4.1-mini, via `F1_LLM_PROVIDER`, never Anthropic) whether each is a genuine pit-wall alert.

- Kept OUT of the deterministic `f1-eval nlp` report and out of `f1-eval all` - it spends API calls and is non-deterministic.
- Big PROXY / needs-human-review caveat up front.

## Honest finding (flagged)

Proxy precision comes out **0/16 = 0.0000** - but this is NOT an alert-precision failure. The radios absent from the hand-labeled intent set are precisely the ones **excluded from labeling because they are garbled Whisper transcripts** ("FREDER Reggie", "Maybe another lizard?", "Google are graining on the medium"). The LLM correctly judges them non-alerts. So the LLM-judge over the unlabeled corpus measures **transcript noise, not alert precision**.

Conclusion, in the report: the **gold-based alert precision 0.9185** (nlp report, hand-labeled clean set) stays the paper number; a meaningful LLM-judge would need a *curated* unlabeled set. This actually reinforces why the gold-based approach in #362 is the right one.

## Checks

- `pytest tests/eval/test_alert_llm_golden.py -q` -> 3 passed (render + degradation hermetic; corpus test data-tier)
- `uvx ruff check` / `format --check` clean
- `f1-eval alert-llm` runs end-to-end against OpenAI

Refs #304