### PR TITLE
Sprint 4: unblock the eval-harness backlog (NLP #303/#304 + ML-eval #363/#364)

### DIFF
--- a/documents/eval_reports/alert_llm.json
+++ b/documents/eval_reports/alert_llm.json
@@ -1,0 +1,19 @@
+{
+  "header": {
+    "harness_sha": "b727baa",
+    "dataset": "radios_raw.csv unlabeled subset",
+    "seed_policy": "deterministic",
+    "era_tag": "2022-2025",
+    "llm": "openai/gpt-4.1-mini",
+    "schema_version": "1",
+    "generated_at": "2026-07-11T17:47:16+00:00",
+    "artifacts": {}
+  },
+  "result": {
+    "sample_size": 80,
+    "predicted_alerts": 16,
+    "judged_true": 0,
+    "proxy_precision": 0.0,
+    "detail": "PROXY: 0/16 predicted alerts judged genuine by gpt-4.1-mini; LLM labels are not ground truth - needs human review before any paper claim"
+  }
+}

--- a/documents/eval_reports/alert_llm.md
+++ b/documents/eval_reports/alert_llm.md
@@ -1,0 +1,18 @@
+# alert_llm
+
+- harness `b727baa` · schema v1 · generated 2026-07-11T17:47:16+00:00
+- era 2022-2025 · dataset radios_raw.csv unlabeled subset · seed deterministic · llm openai/gpt-4.1-mini
+- artifacts: —
+
+> PROXY METRIC - LLM-judged, not ground truth. Needs a human-review pass before any paper claim. The paper-grade alert precision is the gold-based one in the nlp report.
+
+| metric | value |
+|---|---|
+| sample size (unlabeled) | 80 |
+| predicted alerts | 16 |
+| judged genuine | 0 |
+| proxy precision | 0.0000 |
+
+PROXY: 0/16 predicted alerts judged genuine by gpt-4.1-mini; LLM labels are not ground truth - needs human review before any paper claim
+
+**Finding**: the unlabeled radios are dominated by garbled Whisper transcripts (the subset excluded from hand-labeling), so this proxy reflects transcript noise, not alert precision - a low value here is expected and NOT informative. Use the gold-based alert precision (0.9185, nlp report) for the paper; a meaningful LLM-judge would need a curated unlabeled set.

--- a/documents/eval_reports/calibration.json
+++ b/documents/eval_reports/calibration.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "da1db0c",
+    "harness_sha": "e1ee603",
     "dataset": "2025 holdout + frozen calibration artifacts",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-11T16:52:47+00:00",
+    "generated_at": "2026-07-11T17:31:05+00:00",
     "artifacts": {
       "overtake_model": "cbb9d0eb0beb",
       "pit_cfg": "41dd673a93fb",
@@ -65,10 +65,10 @@
     {
       "model": "pit_duration",
       "metric": "p05_p95_coverage",
-      "value": 0.7047,
+      "value": 0.7023809523809523,
       "nominal": 0.9,
       "status": "drift",
-      "detail": "config-declared (recompute pending N15 holdout); 0.7047 vs 0.90 nominal"
+      "detail": "n=252; empirical P05-P95 coverage recomputed on the regenerated N15 holdout"
     },
     {
       "model": "tire_degradation[C2]",

--- a/documents/eval_reports/calibration.json
+++ b/documents/eval_reports/calibration.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "91b98d3",
+    "harness_sha": "da1db0c",
     "dataset": "2025 holdout + frozen calibration artifacts",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-11T15:07:21+00:00",
+    "generated_at": "2026-07-11T16:52:47+00:00",
     "artifacts": {
       "overtake_model": "cbb9d0eb0beb",
       "pit_cfg": "41dd673a93fb",
@@ -29,6 +29,38 @@
       "nominal": 0.05,
       "status": "ok",
       "detail": "n=10217; 10-bin equal-width"
+    },
+    {
+      "model": "safety_car",
+      "metric": "brier_calibrated",
+      "value": 0.04264973919444633,
+      "nominal": null,
+      "status": "ok",
+      "detail": "n=995; recomputed on 2025 holdout"
+    },
+    {
+      "model": "safety_car",
+      "metric": "ece_calibrated",
+      "value": 0.03471279476464329,
+      "nominal": 0.05,
+      "status": "ok",
+      "detail": "n=995; 10-bin equal-width"
+    },
+    {
+      "model": "undercut",
+      "metric": "brier_calibrated",
+      "value": 0.19295681891254568,
+      "nominal": null,
+      "status": "ok",
+      "detail": "n=252; recomputed on 2025 holdout"
+    },
+    {
+      "model": "undercut",
+      "metric": "ece_calibrated",
+      "value": 0.1303142864225645,
+      "nominal": 0.05,
+      "status": "drift",
+      "detail": "n=252; 10-bin equal-width"
     },
     {
       "model": "pit_duration",
@@ -69,22 +101,6 @@
       "nominal": null,
       "status": "ok",
       "detail": "deployed epistemic sigma; empirical coverage wired-pending (N33-D)"
-    },
-    {
-      "model": "safety_car",
-      "metric": "ece_calibrated",
-      "value": null,
-      "nominal": 0.05,
-      "status": "pending",
-      "detail": "engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from sc_labeled holdout (#207)"
-    },
-    {
-      "model": "undercut",
-      "metric": "ece_calibrated",
-      "value": null,
-      "nominal": 0.05,
-      "status": "pending",
-      "detail": "historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207)"
     }
   ]
 }

--- a/documents/eval_reports/calibration.md
+++ b/documents/eval_reports/calibration.md
@@ -1,16 +1,18 @@
 # calibration
 
-- harness `91b98d3` · schema v1 · generated 2026-07-11T15:07:21+00:00
+- harness `da1db0c` · schema v1 · generated 2026-07-11T16:52:47+00:00
 - era 2022-2025 · dataset 2025 holdout + frozen calibration artifacts · seed deterministic · llm none
 - artifacts: overtake_model=`cbb9d0eb0beb`, pit_cfg=`41dd673a93fb`, tcn_mc_calib=`e03a170f6de4`
 
 | model | metric | value | nominal | status | detail |
 |---|---|---|---|---|---|
+| undercut | ece_calibrated | 0.1303 | 0.05 | drift | n=252; 10-bin equal-width |
 | pit_duration | p05_p95_coverage | 0.7047 | 0.9 | drift | config-declared (recompute pending N15 holdout); 0.7047 vs 0.90 nominal |
-| safety_car | ece_calibrated | - | 0.05 | pending | engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from sc_labeled holdout (#207) |
-| undercut | ece_calibrated | - | 0.05 | pending | historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207) |
 | overtake | brier_calibrated | 0.0520 | - | ok | n=10217; brier raw 0.1304 -> cal 0.0520 (Platt val-2024) |
 | overtake | ece_calibrated | 0.0319 | 0.05 | ok | n=10217; 10-bin equal-width |
+| safety_car | brier_calibrated | 0.0426 | - | ok | n=995; recomputed on 2025 holdout |
+| safety_car | ece_calibrated | 0.0347 | 0.05 | ok | n=995; 10-bin equal-width |
+| undercut | brier_calibrated | 0.1930 | - | ok | n=252; recomputed on 2025 holdout |
 | tire_degradation[C2] | mc_mean_sigma_s | 0.1244 | - | ok | deployed epistemic sigma; empirical coverage wired-pending (N33-D) |
 | tire_degradation[C4] | mc_mean_sigma_s | 0.1504 | - | ok | deployed epistemic sigma; empirical coverage wired-pending (N33-D) |
 | tire_degradation[C5] | mc_mean_sigma_s | 0.1549 | - | ok | deployed epistemic sigma; empirical coverage wired-pending (N33-D) |

--- a/documents/eval_reports/calibration.md
+++ b/documents/eval_reports/calibration.md
@@ -1,13 +1,13 @@
 # calibration
 
-- harness `da1db0c` · schema v1 · generated 2026-07-11T16:52:47+00:00
+- harness `e1ee603` · schema v1 · generated 2026-07-11T17:31:05+00:00
 - era 2022-2025 · dataset 2025 holdout + frozen calibration artifacts · seed deterministic · llm none
 - artifacts: overtake_model=`cbb9d0eb0beb`, pit_cfg=`41dd673a93fb`, tcn_mc_calib=`e03a170f6de4`
 
 | model | metric | value | nominal | status | detail |
 |---|---|---|---|---|---|
 | undercut | ece_calibrated | 0.1303 | 0.05 | drift | n=252; 10-bin equal-width |
-| pit_duration | p05_p95_coverage | 0.7047 | 0.9 | drift | config-declared (recompute pending N15 holdout); 0.7047 vs 0.90 nominal |
+| pit_duration | p05_p95_coverage | 0.7024 | 0.9 | drift | n=252; empirical P05-P95 coverage recomputed on the regenerated N15 holdout |
 | overtake | brier_calibrated | 0.0520 | - | ok | n=10217; brier raw 0.1304 -> cal 0.0520 (Platt val-2024) |
 | overtake | ece_calibrated | 0.0319 | 0.05 | ok | n=10217; 10-bin equal-width |
 | safety_car | brier_calibrated | 0.0426 | - | ok | n=995; recomputed on 2025 holdout |

--- a/documents/eval_reports/hygiene.json
+++ b/documents/eval_reports/hygiene.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "c38c94e",
+    "harness_sha": "c1af9c1",
     "dataset": "notebooks/strategy audit + 2024/2025 overtake & SC holdouts",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-11T17:16:32+00:00",
+    "generated_at": "2026-07-11T17:25:07+00:00",
     "artifacts": {}
   },
   "findings": [
@@ -35,16 +35,16 @@
       "verdict": "underdocumented",
       "selection": "fit on 2024 probabilities, but 2024 is IN the train set (config fitted_on='val_2024' is misleading)",
       "evidence": "N14_sc_model.ipynb (calibration cell)",
-      "impact": "resubstitution fit; measured impact low (test ECE 0.0347 < 0.05, AUC-PR invariant under a monotone Platt map) but a provenance audit must record it"
+      "impact": "resubstitution fit; measured impact low (test ECE 0.0347 < 0.05, AUC-PR invariant under a monotone Platt map). Singled out because its config label fitted_on='val_2024' is misleading; overtake/undercut Platt are also 2024-in-train but not mislabeled"
     },
     {
       "item": "best_threshold=0.522",
       "kind": "threshold",
       "model": "undercut",
       "verdict": "clean",
-      "selection": "argmax-F1 on the calibrated val-2024 split (verified CLEAN in the #207 adversarial pass)",
+      "selection": "argmax-F1 on 2024 in-train (2024 is part of N16's 2023+2024 train set, same structure as overtake; mild, 143 positives / base 0.413) - but NEVER selected on test-2025",
       "evidence": "N16_undercut.ipynb (\"Threshold on calibrated val 2024\")",
-      "impact": "textbook-correct; the 2025 test set is only applied afterwards"
+      "impact": "CLEAN on the test-contamination axis this audit measures: the threshold never saw test (unlike overtake 0.7976 / SC 0.2335). 2024 is not a held-out val split, but with 143 positives it does not collapse (unlike SC); the headline 0.6739 is threshold-free anyway"
     },
     {
       "item": "circuit_sc_rate",

--- a/documents/eval_reports/hygiene.json
+++ b/documents/eval_reports/hygiene.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "50b7ecf",
-    "dataset": "notebooks/strategy audit + 2024/2025 overtake holdout",
+    "harness_sha": "5c97461",
+    "dataset": "notebooks/strategy audit + 2024/2025 overtake & SC holdouts",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-11T15:29:09+00:00",
+    "generated_at": "2026-07-11T17:00:40+00:00",
     "artifacts": {}
   },
   "findings": [
@@ -89,13 +89,53 @@
     "leaked_test_operating_point": {
       "precision": 0.5018,
       "recall": 0.5556,
-      "f1": 0.5273
+      "f1": 0.5273,
+      "f2": 0.5439
     },
     "corrected_test_operating_point": {
       "precision": 0.4583,
       "recall": 0.5827,
-      "f1": 0.5131
+      "f1": 0.5131,
+      "f2": 0.5527
     },
     "note": "threshold selected on val-2024; both operating points evaluated on the 2025 test set"
+  },
+  "sc_correction": {
+    "leaked_threshold": 0.2335,
+    "corrected_threshold": 0.6358,
+    "val_positive_count": 19,
+    "val_size": 1042,
+    "leaked_test_operating_point": {
+      "precision": 0.0797,
+      "recall": 0.5581,
+      "f1": 0.1395,
+      "f2": 0.2537
+    },
+    "corrected_test_operating_point": {
+      "precision": 0.0,
+      "recall": 0.0,
+      "f1": 0.0,
+      "f2": 0.0
+    },
+    "note": "F2 threshold selected on val-2024 raw scores; both operating points on 2025 test. val-2024 has few SC positives so the corrected point is high-variance - the collapse is the evidence that the leaked operating point was test-overfit"
+  },
+  "sc_window_sensitivity": {
+    "persisted_model_target": "sc_within_3_laps",
+    "per_window_auc_pr": {
+      "sc_within_3_laps": {
+        "val_2024_auc_pr": 0.8817,
+        "test_2025_auc_pr": 0.0723
+      },
+      "sc_within_5_laps": {
+        "val_2024_auc_pr": 0.6912,
+        "test_2025_auc_pr": 0.1054
+      },
+      "sc_within_7_laps": {
+        "val_2024_auc_pr": 0.6257,
+        "test_2025_auc_pr": 0.1323
+      }
+    },
+    "retro_selectable": false,
+    "note": "only the 3-lap model is persisted; the 5/7-lap models needed to re-select the window on val are not on disk (retraining out of scope). The reported SC AUC-PR 0.0723 keeps the caveat that its window was test-selected; the table is single-model sensitivity, not the original 3-model selection"
   }
 }

--- a/documents/eval_reports/hygiene.json
+++ b/documents/eval_reports/hygiene.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "5c97461",
+    "harness_sha": "c38c94e",
     "dataset": "notebooks/strategy audit + 2024/2025 overtake & SC holdouts",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-11T17:00:40+00:00",
+    "generated_at": "2026-07-11T17:16:32+00:00",
     "artifacts": {}
   },
   "findings": [
@@ -24,16 +24,25 @@
       "kind": "threshold",
       "model": "safety_car",
       "verdict": "contaminated",
-      "selection": "argmax-F2 threshold AND the best target-window both on the 2025 test set",
+      "selection": "argmax-F2 threshold AND the target-window both selected on the 2025 test set",
       "evidence": "N14_sc_model.ipynb (PR-curve + window-comparison cells)",
-      "impact": "threshold -> operating-point optimistic; window chosen by max-lift on test -> the headline AUC-PR 0.0723 is itself optimistic (a max over 3 candidates on test), NOT clean"
+      "impact": "threshold -> operating-point optimistic; the window was chosen by max-LIFT on test (3-lap lift 1.673x). The reported AUC-PR 0.0723 is in fact the LOWEST of the three windows (0.0723/0.0987/0.1165), not a max - the test-selection bias is on the lift, so the headline keeps a test-window-selected caveat, not an inflated-AUC claim"
+    },
+    {
+      "item": "sc Platt calibrator",
+      "kind": "calibrator",
+      "model": "safety_car",
+      "verdict": "underdocumented",
+      "selection": "fit on 2024 probabilities, but 2024 is IN the train set (config fitted_on='val_2024' is misleading)",
+      "evidence": "N14_sc_model.ipynb (calibration cell)",
+      "impact": "resubstitution fit; measured impact low (test ECE 0.0347 < 0.05, AUC-PR invariant under a monotone Platt map) but a provenance audit must record it"
     },
     {
       "item": "best_threshold=0.522",
       "kind": "threshold",
       "model": "undercut",
       "verdict": "clean",
-      "selection": "argmax-F1 on the calibrated val-2024 split",
+      "selection": "argmax-F1 on the calibrated val-2024 split (verified CLEAN in the #207 adversarial pass)",
       "evidence": "N16_undercut.ipynb (\"Threshold on calibrated val 2024\")",
       "impact": "textbook-correct; the 2025 test set is only applied afterwards"
     },
@@ -98,13 +107,13 @@
       "f1": 0.5131,
       "f2": 0.5527
     },
-    "note": "threshold selected on val-2024; both operating points evaluated on the 2025 test set"
+    "note": "threshold selected on 2024 (in-train; 2024 is part of N12's 2023+2024 train set, mild memorization at ~28k pairs); both operating points evaluated on the 2025 test set"
   },
   "sc_correction": {
     "leaked_threshold": 0.2335,
     "corrected_threshold": 0.6358,
-    "val_positive_count": 19,
-    "val_size": 1042,
+    "in_train_2024_positive_count": 19,
+    "in_train_2024_size": 1042,
     "leaked_test_operating_point": {
       "precision": 0.0797,
       "recall": 0.5581,
@@ -117,25 +126,25 @@
       "f1": 0.0,
       "f2": 0.0
     },
-    "note": "F2 threshold selected on val-2024 raw scores; both operating points on 2025 test. val-2024 has few SC positives so the corrected point is high-variance - the collapse is the evidence that the leaked operating point was test-overfit"
+    "note": "the F2 threshold 'selected on 2024' is IN-TRAIN (2024 is a subset of the 2023+2024 train set), NOT a held-out split; it lands on the train-memorization boundary and collapses on test. This shows N14 has no honest validation split for an operating threshold - the paper should report SC threshold-free, not re-select an operating point"
   },
   "sc_window_sensitivity": {
     "persisted_model_target": "sc_within_3_laps",
     "per_window_auc_pr": {
       "sc_within_3_laps": {
-        "val_2024_auc_pr": 0.8817,
+        "in_train_2024_auc_pr": 0.8817,
         "test_2025_auc_pr": 0.0723
       },
       "sc_within_5_laps": {
-        "val_2024_auc_pr": 0.6912,
+        "in_train_2024_auc_pr": 0.6912,
         "test_2025_auc_pr": 0.1054
       },
       "sc_within_7_laps": {
-        "val_2024_auc_pr": 0.6257,
+        "in_train_2024_auc_pr": 0.6257,
         "test_2025_auc_pr": 0.1323
       }
     },
     "retro_selectable": false,
-    "note": "only the 3-lap model is persisted; the 5/7-lap models needed to re-select the window on val are not on disk (retraining out of scope). The reported SC AUC-PR 0.0723 keeps the caveat that its window was test-selected; the table is single-model sensitivity, not the original 3-model selection"
+    "note": "only the 3-lap model is persisted; the 5/7-lap models needed to re-select the window are not on disk (retraining out of scope). The 2024 column is IN-TRAIN (2024 subset of train), so its high AUC-PR (0.88) is resubstitution, NOT validation - it only shows the metric is window-unstable. The reported SC AUC-PR 0.0723 keeps its test-window-selected caveat; this is single-model sensitivity, not the original 3-model selection"
   }
 }

--- a/documents/eval_reports/hygiene.md
+++ b/documents/eval_reports/hygiene.md
@@ -1,6 +1,6 @@
 # hygiene
 
-- harness `c38c94e` · schema v1 · generated 2026-07-11T17:16:32+00:00
+- harness `c1af9c1` · schema v1 · generated 2026-07-11T17:25:07+00:00
 - era 2022-2025 · dataset notebooks/strategy audit + 2024/2025 overtake & SC holdouts · seed deterministic · llm none
 - artifacts: —
 
@@ -10,7 +10,7 @@
 | best_threshold=0.2335 + 3/5/7-lap window | threshold | safety_car | **contaminated** | argmax-F2 threshold AND the target-window both selected on the 2025 test set | N14_sc_model.ipynb (PR-curve + window-comparison cells) |
 | sc Platt calibrator | calibrator | safety_car | **underdocumented** | fit on 2024 probabilities, but 2024 is IN the train set (config fitted_on='val_2024' is misleading) | N14_sc_model.ipynb (calibration cell) |
 | circuit_cluster (k-means) | aggregate_feature | overtake/safety_car/laptime | **underdocumented** | k-means fit window not year-restricted in code; 2025 holdout is intent-only | N03_circuit_clustering.ipynb (load_all_races / fit_kmeans_final) |
-| best_threshold=0.522 | threshold | undercut | **clean** | argmax-F1 on the calibrated val-2024 split (verified CLEAN in the #207 adversarial pass) | N16_undercut.ipynb ("Threshold on calibrated val 2024") |
+| best_threshold=0.522 | threshold | undercut | **clean** | argmax-F1 on 2024 in-train (2024 is part of N16's 2023+2024 train set, same structure as overtake; mild, 143 positives / base 0.413) - but NEVER selected on test-2025 | N16_undercut.ipynb ("Threshold on calibrated val 2024") |
 | circuit_sc_rate | aggregate_feature | safety_car | **clean** | past-season only (year < yr); 2023 rows get a fixed SC_PRIOR=0.15 | N13_sc_eda.ipynb (compute_circuit_sc_rate) |
 | team_year_median | aggregate_feature | pit_duration | **clean** | lookup fit on train only, applied to test with recent-year fallback | N15_pit_duration.ipynb (add_team_year_median) |
 | circuit_undercut_rate + team_x_undercut_rate | aggregate_feature | undercut | **clean** | target encoding fit on train only, train-mean fallback on test | N16_undercut.ipynb (compute_target_encoding) |

--- a/documents/eval_reports/hygiene.md
+++ b/documents/eval_reports/hygiene.md
@@ -1,15 +1,16 @@
 # hygiene
 
-- harness `5c97461` · schema v1 · generated 2026-07-11T17:00:40+00:00
+- harness `c38c94e` · schema v1 · generated 2026-07-11T17:16:32+00:00
 - era 2022-2025 · dataset notebooks/strategy audit + 2024/2025 overtake & SC holdouts · seed deterministic · llm none
 - artifacts: —
 
 | item | kind | model | verdict | selection | evidence |
 |---|---|---|---|---|---|
 | optimal_threshold=0.7976 | threshold | overtake | **contaminated** | argmax-F1 on the 2025 test set | N12_overtake_model.ipynb (threshold-analysis / step-5 cell) |
-| best_threshold=0.2335 + 3/5/7-lap window | threshold | safety_car | **contaminated** | argmax-F2 threshold AND the best target-window both on the 2025 test set | N14_sc_model.ipynb (PR-curve + window-comparison cells) |
+| best_threshold=0.2335 + 3/5/7-lap window | threshold | safety_car | **contaminated** | argmax-F2 threshold AND the target-window both selected on the 2025 test set | N14_sc_model.ipynb (PR-curve + window-comparison cells) |
+| sc Platt calibrator | calibrator | safety_car | **underdocumented** | fit on 2024 probabilities, but 2024 is IN the train set (config fitted_on='val_2024' is misleading) | N14_sc_model.ipynb (calibration cell) |
 | circuit_cluster (k-means) | aggregate_feature | overtake/safety_car/laptime | **underdocumented** | k-means fit window not year-restricted in code; 2025 holdout is intent-only | N03_circuit_clustering.ipynb (load_all_races / fit_kmeans_final) |
-| best_threshold=0.522 | threshold | undercut | **clean** | argmax-F1 on the calibrated val-2024 split | N16_undercut.ipynb ("Threshold on calibrated val 2024") |
+| best_threshold=0.522 | threshold | undercut | **clean** | argmax-F1 on the calibrated val-2024 split (verified CLEAN in the #207 adversarial pass) | N16_undercut.ipynb ("Threshold on calibrated val 2024") |
 | circuit_sc_rate | aggregate_feature | safety_car | **clean** | past-season only (year < yr); 2023 rows get a fixed SC_PRIOR=0.15 | N13_sc_eda.ipynb (compute_circuit_sc_rate) |
 | team_year_median | aggregate_feature | pit_duration | **clean** | lookup fit on train only, applied to test with recent-year fallback | N15_pit_duration.ipynb (add_team_year_median) |
 | circuit_undercut_rate + team_x_undercut_rate | aggregate_feature | undercut | **clean** | target encoding fit on train only, train-mean fallback on test | N16_undercut.ipynb (compute_target_encoding) |
@@ -18,30 +19,30 @@
 ## Correction (overtake threshold)
 
 - leaked threshold 0.7976 (selected on test): P 0.5018 / R 0.5556 / F1 0.5273 on 2025 test
-- corrected threshold 0.7626 (selected on val-2024): P 0.4583 / R 0.5827 / F1 0.5131 on 2025 test
-- threshold selected on val-2024; both operating points evaluated on the 2025 test set
+- corrected threshold 0.7626 (selected on 2024, in-train): P 0.4583 / R 0.5827 / F1 0.5131 on 2025 test
+- threshold selected on 2024 (in-train; 2024 is part of N12's 2023+2024 train set, mild memorization at ~28k pairs); both operating points evaluated on the 2025 test set
 
 ## Correction (safety-car threshold)
 
 - leaked threshold 0.2335 (F2 on test): P 0.0797 / R 0.5581 / F2 0.2537 on 2025 test
-- corrected threshold 0.6358 (F2 on val-2024, 19/1042 positive): P 0.0 / R 0.0 / F2 0.0 on 2025 test
-- F2 threshold selected on val-2024 raw scores; both operating points on 2025 test. val-2024 has few SC positives so the corrected point is high-variance - the collapse is the evidence that the leaked operating point was test-overfit
+- 'corrected' threshold 0.6358 (F2 on 2024, IN-TRAIN, 19/1042 positive): P 0.0 / R 0.0 / F2 0.0 on 2025 test
+- the F2 threshold 'selected on 2024' is IN-TRAIN (2024 is a subset of the 2023+2024 train set), NOT a held-out split; it lands on the train-memorization boundary and collapses on test. This shows N14 has no honest validation split for an operating threshold - the paper should report SC threshold-free, not re-select an operating point
 
 ## Correction (safety-car target window)
 
-| window | val-2024 AUC-PR | test-2025 AUC-PR |
+| window | 2024 AUC-PR (in-train) | test-2025 AUC-PR |
 |---|---|---|
 | sc_within_3_laps | 0.8817 | 0.0723 |
 | sc_within_5_laps | 0.6912 | 0.1054 |
 | sc_within_7_laps | 0.6257 | 0.1323 |
 
-- only the 3-lap model is persisted; the 5/7-lap models needed to re-select the window on val are not on disk (retraining out of scope). The reported SC AUC-PR 0.0723 keeps the caveat that its window was test-selected; the table is single-model sensitivity, not the original 3-model selection
+- only the 3-lap model is persisted; the 5/7-lap models needed to re-select the window are not on disk (retraining out of scope). The 2024 column is IN-TRAIN (2024 subset of train), so its high AUC-PR (0.88) is resubstitution, NOT validation - it only shows the metric is window-unstable. The reported SC AUC-PR 0.0723 keeps its test-window-selected caveat; this is single-model sensitivity, not the original 3-model selection
 
 ## Conclusion for the paper freeze
 
 - 2 contaminated items (overtake threshold; safety-car threshold + window). All other thresholds and aggregate features are clean or non-target.
-- **Overtake headline clears**: AUC-PR 0.5491 / AUC-ROC 0.8758 are threshold-free and involve no window selection; the threshold leakage touches only their operating point, corrected above.
-- **Safety-car operating threshold is NOT robustly recoverable**: re-selecting on val-2024 collapses the operating point (val-2024 has too few SC positives), which is itself the evidence that the leaked 0.2335 was test-overfit. The paper should report SC threshold-free and not claim a fixed operating threshold.
-- **Safety-car window cannot be retro-selected**: only the 3-lap model is persisted, so the {3,5,7}-lap window selected on test-2025 cannot be honestly re-chosen without retraining the 5/7-lap models. The reported SC AUC-PR 0.0723 therefore keeps an explicit test-window-selected caveat.
-- **Remaining action before freeze**: pin a year filter in N03 `load_all_races` to close the circuit_cluster underdocumentation.
+- **Overtake headline clears**: AUC-PR 0.5491 / AUC-ROC 0.8758 are threshold-free and involve no window selection; the threshold leakage touches only their operating point. NOTE the overtake 'correction' below is also in-train (N12 trains final on 2023+2024, 2024 was only Optuna inner-val), but with 28k pairs the memorization is mild, so its re-selected threshold is a reasonable operating point rather than a collapse.
+- **Safety-car has NO honest validation split**: N14 trains on 2023+2024 and tests on 2025, so there is no held-out split to re-select an operating threshold on. Re-selecting on 2024 is in-train (resubstitution) and collapses on test - evidence that an honest SC operating threshold does not exist without a fresh val split or retraining, NOT that 0.2335 was specifically test-overfit. The paper should report SC threshold-free.
+- **Safety-car window cannot be retro-selected**: only the 3-lap model is persisted, and the window was originally chosen by max-lift on test-2025, so it cannot be honestly re-chosen without retraining the 5/7-lap models. The reported SC AUC-PR 0.0723 (the lowest of the three windows) keeps an explicit test-window-selected caveat.
+- **Remaining action before freeze**: pin a year filter in N03 `load_all_races` to close the circuit_cluster underdocumentation; and give SC/overtake a real held-out val split (or nested CV) if a defensible operating threshold is ever needed.
 - Every other headline (undercut 0.6739, pit 0.487, pace 0.4104, tire 0.7078, sentiment 0.84) is unaffected by these findings.

--- a/documents/eval_reports/hygiene.md
+++ b/documents/eval_reports/hygiene.md
@@ -1,7 +1,7 @@
 # hygiene
 
-- harness `50b7ecf` · schema v1 · generated 2026-07-11T15:29:09+00:00
-- era 2022-2025 · dataset notebooks/strategy audit + 2024/2025 overtake holdout · seed deterministic · llm none
+- harness `5c97461` · schema v1 · generated 2026-07-11T17:00:40+00:00
+- era 2022-2025 · dataset notebooks/strategy audit + 2024/2025 overtake & SC holdouts · seed deterministic · llm none
 - artifacts: —
 
 | item | kind | model | verdict | selection | evidence |
@@ -21,10 +21,27 @@
 - corrected threshold 0.7626 (selected on val-2024): P 0.4583 / R 0.5827 / F1 0.5131 on 2025 test
 - threshold selected on val-2024; both operating points evaluated on the 2025 test set
 
+## Correction (safety-car threshold)
+
+- leaked threshold 0.2335 (F2 on test): P 0.0797 / R 0.5581 / F2 0.2537 on 2025 test
+- corrected threshold 0.6358 (F2 on val-2024, 19/1042 positive): P 0.0 / R 0.0 / F2 0.0 on 2025 test
+- F2 threshold selected on val-2024 raw scores; both operating points on 2025 test. val-2024 has few SC positives so the corrected point is high-variance - the collapse is the evidence that the leaked operating point was test-overfit
+
+## Correction (safety-car target window)
+
+| window | val-2024 AUC-PR | test-2025 AUC-PR |
+|---|---|---|
+| sc_within_3_laps | 0.8817 | 0.0723 |
+| sc_within_5_laps | 0.6912 | 0.1054 |
+| sc_within_7_laps | 0.6257 | 0.1323 |
+
+- only the 3-lap model is persisted; the 5/7-lap models needed to re-select the window on val are not on disk (retraining out of scope). The reported SC AUC-PR 0.0723 keeps the caveat that its window was test-selected; the table is single-model sensitivity, not the original 3-model selection
+
 ## Conclusion for the paper freeze
 
 - 2 contaminated items (overtake threshold; safety-car threshold + window). All other thresholds and aggregate features are clean or non-target.
-- **Overtake headline clears**: AUC-PR 0.5491 / AUC-ROC 0.8758 are threshold-free and involve no window selection; the threshold leakage touches only their operating point.
-- **Safety-car headline is optimistic, NOT clean**: AUC-PR 0.0723 is the max-lift window among {3,5,7} laps selected on test-2025, so the reported number is itself selection-biased (a max over 3 candidates on test), on top of the operating-point threshold leakage.
-- **Action before freeze**: (1) re-select the overtake + SC operating thresholds on val-2024 (the undercut N16 pattern) - the overtake correction above shows the honest operating point; (2) re-select the SC target window on the CV/val split (not test) and re-report SC AUC-PR, or caveat it as test-selected; (3) pin a year filter in N03 `load_all_races` to close the circuit_cluster underdocumentation.
+- **Overtake headline clears**: AUC-PR 0.5491 / AUC-ROC 0.8758 are threshold-free and involve no window selection; the threshold leakage touches only their operating point, corrected above.
+- **Safety-car operating threshold is NOT robustly recoverable**: re-selecting on val-2024 collapses the operating point (val-2024 has too few SC positives), which is itself the evidence that the leaked 0.2335 was test-overfit. The paper should report SC threshold-free and not claim a fixed operating threshold.
+- **Safety-car window cannot be retro-selected**: only the 3-lap model is persisted, so the {3,5,7}-lap window selected on test-2025 cannot be honestly re-chosen without retraining the 5/7-lap models. The reported SC AUC-PR 0.0723 therefore keeps an explicit test-window-selected caveat.
+- **Remaining action before freeze**: pin a year filter in N03 `load_all_races` to close the circuit_cluster underdocumentation.
 - Every other headline (undercut 0.6739, pit 0.487, pace 0.4104, tire 0.7078, sentiment 0.84) is unaffected by these findings.

--- a/documents/eval_reports/nlp.json
+++ b/documents/eval_reports/nlp.json
@@ -1,14 +1,15 @@
 {
   "header": {
-    "harness_sha": "5f1f29d",
-    "dataset": "radio_labeled_data.csv (fixed set)",
+    "harness_sha": "1c8ff7c",
+    "dataset": "radio_labeled_data.csv + intent_labeled_data.csv (fixed sets)",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-11T15:38:36+00:00",
+    "generated_at": "2026-07-11T16:13:28+00:00",
     "artifacts": {
-      "roberta_sentiment": "d7d0ada739c6"
+      "roberta_sentiment": "d7d0ada739c6",
+      "intent_head": "7c995ba21bc0"
     }
   },
   "results": [
@@ -31,10 +32,42 @@
     {
       "stage": "intent",
       "metric": "accuracy",
-      "value": null,
+      "value": 0.8885,
       "reference": null,
-      "status": "blocked",
-      "detail": "setfit does not import under transformers 5.3.0 (#303); stage cannot run"
+      "status": "reproduced",
+      "detail": "n=529; full labeled set (train+test); optimistic vs the published 0.5934 test weighted-F1"
+    },
+    {
+      "stage": "intent",
+      "metric": "macro_f1",
+      "value": 0.8922,
+      "reference": null,
+      "status": "reproduced",
+      "detail": "n=529; 5-class, no anchor"
+    },
+    {
+      "stage": "intent",
+      "metric": "weighted_f1",
+      "value": 0.8881,
+      "reference": 0.5934,
+      "status": "delta",
+      "detail": "n=529; vs deployed test weighted-F1 (full-set optimistic)"
+    },
+    {
+      "stage": "intent",
+      "metric": "predict_proba_order",
+      "value": 1.0,
+      "reference": 1.0,
+      "status": "reproduced",
+      "detail": "head.classes_=[0, 1, 2, 3, 4] map to intent_names via intent_mapping; 5/5 columns aligned (no swap)"
+    },
+    {
+      "stage": "ner",
+      "metric": "dead_classes",
+      "value": 4.0,
+      "reference": 0.0,
+      "status": "flagged",
+      "detail": "4 entity types with frozen-eval B-F1 < 0.15 (situation, incident, strategy instruction, track condition); suppressed as untrustworthy, re-measured in #304"
     },
     {
       "stage": "ner",
@@ -42,7 +75,7 @@
       "value": null,
       "reference": null,
       "status": "pending",
-      "detail": "GLiNER/BERT reconstruction not wired this phase"
+      "detail": "BERT-bio entity-level F1 reproduction not wired this phase (#304)"
     },
     {
       "stage": "rcm",
@@ -50,7 +83,7 @@
       "value": null,
       "reference": null,
       "status": "pending",
-      "detail": "RCM classifier reconstruction not wired this phase"
+      "detail": "RCM parser reproduction not wired this phase (#304)"
     },
     {
       "stage": "alert_precision",
@@ -58,7 +91,7 @@
       "value": null,
       "reference": null,
       "status": "pending",
-      "detail": "no labeled alert ground-truth on disk (the MoE-routing metric #304 targets; data-collection task)"
+      "detail": "no labeled alert ground-truth on disk (the MoE-routing metric #304 targets; data task)"
     }
   ]
 }

--- a/documents/eval_reports/nlp.json
+++ b/documents/eval_reports/nlp.json
@@ -1,15 +1,16 @@
 {
   "header": {
-    "harness_sha": "1c8ff7c",
-    "dataset": "radio_labeled_data.csv + intent_labeled_data.csv (fixed sets)",
+    "harness_sha": "6bc5413",
+    "dataset": "radio + intent labeled CSVs, entity annotations, 2025 RCM corpus",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-11T16:13:28+00:00",
+    "generated_at": "2026-07-11T16:31:09+00:00",
     "artifacts": {
       "roberta_sentiment": "d7d0ada739c6",
-      "intent_head": "7c995ba21bc0"
+      "intent_head": "7c995ba21bc0",
+      "ner_bert_bio": "9e60de9bf538"
     }
   },
   "results": [
@@ -63,27 +64,27 @@
     },
     {
       "stage": "ner",
+      "metric": "entity_f1",
+      "value": 0.4248,
+      "reference": 0.4151,
+      "status": "reproduced",
+      "detail": "n=529; micro entity-F1 (P 0.304/R 0.704); full-set optimistic; 4 dead classes flagged separately"
+    },
+    {
+      "stage": "rcm",
+      "metric": "coverage",
+      "value": 0.9868,
+      "reference": null,
+      "status": "reproduced",
+      "detail": "n=1515 across 24 2025 races; per-category [Drs 1.000, Flag 1.000, Other 0.971, SafetyCar 1.000]; vs config Flag 1.0/Other 0.928/Drs 1.0/SafetyCar 1.0 (N23 sample differs)"
+    },
+    {
+      "stage": "ner",
       "metric": "dead_classes",
       "value": 4.0,
       "reference": 0.0,
       "status": "flagged",
       "detail": "4 entity types with frozen-eval B-F1 < 0.15 (situation, incident, strategy instruction, track condition); suppressed as untrustworthy, re-measured in #304"
-    },
-    {
-      "stage": "ner",
-      "metric": "entity_f1",
-      "value": null,
-      "reference": null,
-      "status": "pending",
-      "detail": "BERT-bio entity-level F1 reproduction not wired this phase (#304)"
-    },
-    {
-      "stage": "rcm",
-      "metric": "accuracy",
-      "value": null,
-      "reference": null,
-      "status": "pending",
-      "detail": "RCM parser reproduction not wired this phase (#304)"
     },
     {
       "stage": "alert_precision",

--- a/documents/eval_reports/nlp.json
+++ b/documents/eval_reports/nlp.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "6bc5413",
+    "harness_sha": "bc0350d",
     "dataset": "radio + intent labeled CSVs, entity annotations, 2025 RCM corpus",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-11T16:31:09+00:00",
+    "generated_at": "2026-07-11T16:38:31+00:00",
     "artifacts": {
       "roberta_sentiment": "d7d0ada739c6",
       "intent_head": "7c995ba21bc0",
@@ -55,6 +55,14 @@
       "detail": "n=529; vs deployed test weighted-F1 (full-set optimistic)"
     },
     {
+      "stage": "alert_precision",
+      "metric": "precision",
+      "value": 0.9185,
+      "reference": null,
+      "status": "reproduced",
+      "detail": "n=529 (145 gold alerts); radio PROBLEM/WARNING channel from hand-labeled gold intent; R 0.855/F1 0.886; full-set optimistic"
+    },
+    {
       "stage": "intent",
       "metric": "predict_proba_order",
       "value": 1.0,
@@ -85,14 +93,6 @@
       "reference": 0.0,
       "status": "flagged",
       "detail": "4 entity types with frozen-eval B-F1 < 0.15 (situation, incident, strategy instruction, track condition); suppressed as untrustworthy, re-measured in #304"
-    },
-    {
-      "stage": "alert_precision",
-      "metric": "precision",
-      "value": null,
-      "reference": null,
-      "status": "pending",
-      "detail": "no labeled alert ground-truth on disk (the MoE-routing metric #304 targets; data task)"
     }
   ]
 }

--- a/documents/eval_reports/nlp.md
+++ b/documents/eval_reports/nlp.md
@@ -1,6 +1,6 @@
 # nlp
 
-- harness `6bc5413` · schema v1 · generated 2026-07-11T16:31:09+00:00
+- harness `bc0350d` · schema v1 · generated 2026-07-11T16:38:31+00:00
 - era 2022-2025 · dataset radio + intent labeled CSVs, entity annotations, 2025 RCM corpus · seed deterministic · llm none
 - artifacts: roberta_sentiment=`d7d0ada739c6`, intent_head=`7c995ba21bc0`, ner_bert_bio=`9e60de9bf538`
 
@@ -12,7 +12,7 @@
 | intent | weighted_f1 | 0.8881 | 0.5934 | delta | n=529; vs deployed test weighted-F1 (full-set optimistic) |
 | intent | accuracy | 0.8885 | - | reproduced | n=529; full labeled set (train+test); optimistic vs the published 0.5934 test weighted-F1 |
 | intent | macro_f1 | 0.8922 | - | reproduced | n=529; 5-class, no anchor |
+| alert_precision | precision | 0.9185 | - | reproduced | n=529 (145 gold alerts); radio PROBLEM/WARNING channel from hand-labeled gold intent; R 0.855/F1 0.886; full-set optimistic |
 | intent | predict_proba_order | 1.0000 | 1 | reproduced | head.classes_=[0, 1, 2, 3, 4] map to intent_names via intent_mapping; 5/5 columns aligned (no swap) |
 | ner | entity_f1 | 0.4248 | 0.4151 | reproduced | n=529; micro entity-F1 (P 0.304/R 0.704); full-set optimistic; 4 dead classes flagged separately |
 | rcm | coverage | 0.9868 | - | reproduced | n=1515 across 24 2025 races; per-category [Drs 1.000, Flag 1.000, Other 0.971, SafetyCar 1.000]; vs config Flag 1.0/Other 0.928/Drs 1.0/SafetyCar 1.0 (N23 sample differs) |
-| alert_precision | precision | - | - | pending | no labeled alert ground-truth on disk (the MoE-routing metric #304 targets; data task) |

--- a/documents/eval_reports/nlp.md
+++ b/documents/eval_reports/nlp.md
@@ -1,8 +1,8 @@
 # nlp
 
-- harness `1c8ff7c` · schema v1 · generated 2026-07-11T16:13:28+00:00
-- era 2022-2025 · dataset radio_labeled_data.csv + intent_labeled_data.csv (fixed sets) · seed deterministic · llm none
-- artifacts: roberta_sentiment=`d7d0ada739c6`, intent_head=`7c995ba21bc0`
+- harness `6bc5413` · schema v1 · generated 2026-07-11T16:31:09+00:00
+- era 2022-2025 · dataset radio + intent labeled CSVs, entity annotations, 2025 RCM corpus · seed deterministic · llm none
+- artifacts: roberta_sentiment=`d7d0ada739c6`, intent_head=`7c995ba21bc0`, ner_bert_bio=`9e60de9bf538`
 
 | stage | metric | value | reference | status | detail |
 |---|---|---|---|---|---|
@@ -13,6 +13,6 @@
 | intent | accuracy | 0.8885 | - | reproduced | n=529; full labeled set (train+test); optimistic vs the published 0.5934 test weighted-F1 |
 | intent | macro_f1 | 0.8922 | - | reproduced | n=529; 5-class, no anchor |
 | intent | predict_proba_order | 1.0000 | 1 | reproduced | head.classes_=[0, 1, 2, 3, 4] map to intent_names via intent_mapping; 5/5 columns aligned (no swap) |
-| ner | entity_f1 | - | - | pending | BERT-bio entity-level F1 reproduction not wired this phase (#304) |
-| rcm | accuracy | - | - | pending | RCM parser reproduction not wired this phase (#304) |
+| ner | entity_f1 | 0.4248 | 0.4151 | reproduced | n=529; micro entity-F1 (P 0.304/R 0.704); full-set optimistic; 4 dead classes flagged separately |
+| rcm | coverage | 0.9868 | - | reproduced | n=1515 across 24 2025 races; per-category [Drs 1.000, Flag 1.000, Other 0.971, SafetyCar 1.000]; vs config Flag 1.0/Other 0.928/Drs 1.0/SafetyCar 1.0 (N23 sample differs) |
 | alert_precision | precision | - | - | pending | no labeled alert ground-truth on disk (the MoE-routing metric #304 targets; data task) |

--- a/documents/eval_reports/nlp.md
+++ b/documents/eval_reports/nlp.md
@@ -1,14 +1,18 @@
 # nlp
 
-- harness `5f1f29d` · schema v1 · generated 2026-07-11T15:38:36+00:00
-- era 2022-2025 · dataset radio_labeled_data.csv (fixed set) · seed deterministic · llm none
-- artifacts: roberta_sentiment=`d7d0ada739c6`
+- harness `1c8ff7c` · schema v1 · generated 2026-07-11T16:13:28+00:00
+- era 2022-2025 · dataset radio_labeled_data.csv + intent_labeled_data.csv (fixed sets) · seed deterministic · llm none
+- artifacts: roberta_sentiment=`d7d0ada739c6`, intent_head=`7c995ba21bc0`
 
 | stage | metric | value | reference | status | detail |
 |---|---|---|---|---|---|
+| ner | dead_classes | 4.0000 | 0 | flagged | 4 entity types with frozen-eval B-F1 < 0.15 (situation, incident, strategy instruction, track condition); suppressed as untrustworthy, re-measured in #304 |
 | sentiment | accuracy | 0.9415 | 0.84 | delta | n=530; full labeled set (train+test); optimistic vs the held-out 0.84 (split not pinned on disk) |
 | sentiment | macro_f1 | 0.9153 | 0.75 | delta | n=530; 3-class |
-| intent | accuracy | - | - | blocked | setfit does not import under transformers 5.3.0 (#303); stage cannot run |
-| ner | entity_f1 | - | - | pending | GLiNER/BERT reconstruction not wired this phase |
-| rcm | accuracy | - | - | pending | RCM classifier reconstruction not wired this phase |
-| alert_precision | precision | - | - | pending | no labeled alert ground-truth on disk (the MoE-routing metric #304 targets; data-collection task) |
+| intent | weighted_f1 | 0.8881 | 0.5934 | delta | n=529; vs deployed test weighted-F1 (full-set optimistic) |
+| intent | accuracy | 0.8885 | - | reproduced | n=529; full labeled set (train+test); optimistic vs the published 0.5934 test weighted-F1 |
+| intent | macro_f1 | 0.8922 | - | reproduced | n=529; 5-class, no anchor |
+| intent | predict_proba_order | 1.0000 | 1 | reproduced | head.classes_=[0, 1, 2, 3, 4] map to intent_names via intent_mapping; 5/5 columns aligned (no swap) |
+| ner | entity_f1 | - | - | pending | BERT-bio entity-level F1 reproduction not wired this phase (#304) |
+| rcm | accuracy | - | - | pending | RCM parser reproduction not wired this phase (#304) |
+| alert_precision | precision | - | - | pending | no labeled alert ground-truth on disk (the MoE-routing metric #304 targets; data task) |

--- a/documents/eval_reports/reproduction.json
+++ b/documents/eval_reports/reproduction.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "91b98d3",
+    "harness_sha": "da1db0c",
     "dataset": "2025 holdout vs published model_configs",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-11T15:07:22+00:00",
+    "generated_at": "2026-07-11T16:52:50+00:00",
     "artifacts": {
       "overtake_model": "cbb9d0eb0beb"
     }
@@ -21,12 +21,20 @@
       "detail": "|delta| 0.0000 vs tol 0.01"
     },
     {
+      "model": "safety_car",
+      "metric": "auc_pr_test",
+      "published": 0.0723,
+      "reproduced": 0.07228992613666717,
+      "status": "reproduced",
+      "detail": "|delta| 0.0000 vs tol 0.01"
+    },
+    {
       "model": "undercut",
       "metric": "auc_pr_test",
       "published": 0.6739,
-      "reproduced": null,
-      "status": "pending",
-      "detail": "historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207)"
+      "reproduced": 0.6738805047752813,
+      "status": "reproduced",
+      "detail": "|delta| 0.0000 vs tol 0.01"
     },
     {
       "model": "pit_duration",
@@ -34,15 +42,7 @@
       "published": 0.487,
       "reproduced": null,
       "status": "pending",
-      "detail": "pit_labeled holdout empty on disk (#207)"
-    },
-    {
-      "model": "safety_car",
-      "metric": "auc_pr_test",
-      "published": 0.0723,
-      "reproduced": null,
-      "status": "pending",
-      "detail": "engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from holdout (#207)"
+      "detail": "pit_labeled holdout empty on disk; regen from raw tracked in #364"
     },
     {
       "model": "pace",

--- a/documents/eval_reports/reproduction.json
+++ b/documents/eval_reports/reproduction.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "da1db0c",
+    "harness_sha": "e1ee603",
     "dataset": "2025 holdout vs published model_configs",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-11T16:52:50+00:00",
+    "generated_at": "2026-07-11T17:31:11+00:00",
     "artifacts": {
       "overtake_model": "cbb9d0eb0beb"
     }
@@ -40,9 +40,9 @@
       "model": "pit_duration",
       "metric": "p50_mae_test_s",
       "published": 0.487,
-      "reproduced": null,
-      "status": "pending",
-      "detail": "pit_labeled holdout empty on disk; regen from raw tracked in #364"
+      "reproduced": 0.48934217309932837,
+      "status": "reproduced",
+      "detail": "n=252; |delta| 0.0023 vs tol 0.01"
     },
     {
       "model": "pace",

--- a/documents/eval_reports/reproduction.md
+++ b/documents/eval_reports/reproduction.md
@@ -1,14 +1,14 @@
 # reproduction
 
-- harness `91b98d3` · schema v1 · generated 2026-07-11T15:07:22+00:00
+- harness `da1db0c` · schema v1 · generated 2026-07-11T16:52:50+00:00
 - era 2022-2025 · dataset 2025 holdout vs published model_configs · seed deterministic · llm none
 - artifacts: overtake_model=`cbb9d0eb0beb`
 
 | model | metric | published | reproduced | status | detail |
 |---|---|---|---|---|---|
 | overtake | auc_pr_test | 0.5491 | 0.5491 | reproduced | |delta| 0.0000 vs tol 0.01 |
-| undercut | auc_pr_test | 0.6739 | - | pending | historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207) |
-| pit_duration | p50_mae_test_s | 0.487 | - | pending | pit_labeled holdout empty on disk (#207) |
-| safety_car | auc_pr_test | 0.0723 | - | pending | engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from holdout (#207) |
+| safety_car | auc_pr_test | 0.0723 | 0.0723 | reproduced | |delta| 0.0000 vs tol 0.01 |
+| undercut | auc_pr_test | 0.6739 | 0.6739 | reproduced | |delta| 0.0000 vs tol 0.01 |
+| pit_duration | p50_mae_test_s | 0.487 | - | pending | pit_labeled holdout empty on disk; regen from raw tracked in #364 |
 | pace | mae_test_s | 0.4104 | - | pending | laptime holdout feature build not wired this phase |
 | tire_degradation | mae_test_s | 0.7078 | - | pending | TCN MC forward pass not run this phase (see calibration MC-sigma) |

--- a/documents/eval_reports/reproduction.md
+++ b/documents/eval_reports/reproduction.md
@@ -1,6 +1,6 @@
 # reproduction
 
-- harness `da1db0c` · schema v1 · generated 2026-07-11T16:52:50+00:00
+- harness `e1ee603` · schema v1 · generated 2026-07-11T17:31:11+00:00
 - era 2022-2025 · dataset 2025 holdout vs published model_configs · seed deterministic · llm none
 - artifacts: overtake_model=`cbb9d0eb0beb`
 
@@ -9,6 +9,6 @@
 | overtake | auc_pr_test | 0.5491 | 0.5491 | reproduced | |delta| 0.0000 vs tol 0.01 |
 | safety_car | auc_pr_test | 0.0723 | 0.0723 | reproduced | |delta| 0.0000 vs tol 0.01 |
 | undercut | auc_pr_test | 0.6739 | 0.6739 | reproduced | |delta| 0.0000 vs tol 0.01 |
-| pit_duration | p50_mae_test_s | 0.487 | - | pending | pit_labeled holdout empty on disk; regen from raw tracked in #364 |
+| pit_duration | p50_mae_test_s | 0.487 | 0.4893 | reproduced | n=252; |delta| 0.0023 vs tol 0.01 |
 | pace | mae_test_s | 0.4104 | - | pending | laptime holdout feature build not wired this phase |
 | tire_degradation | mae_test_s | 0.7078 | - | pending | TCN MC forward pass not run this phase (see calibration MC-sigma) |

--- a/src/strategy/eval/alert_llm.py
+++ b/src/strategy/eval/alert_llm.py
@@ -56,9 +56,13 @@ def _make_judge_llm() -> Any:
 
     Mirrors the provider switch in ``radio_agent`` so the harness reaches the same
     backend the agents use. Temperature 0 for as-deterministic-as-possible verdicts.
+    Loads ``.env`` so OPENAI_API_KEY / F1_LLM_PROVIDER are available when invoked
+    outside the CLI that normally loads them.
     """
+    from dotenv import find_dotenv, load_dotenv
     from langchain_openai import ChatOpenAI
 
+    load_dotenv(find_dotenv())
     provider = os.environ.get("F1_LLM_PROVIDER", "openai")
     if provider == "lmstudio":
         return ChatOpenAI(
@@ -71,7 +75,12 @@ def _make_judge_llm() -> Any:
 
 
 def _unlabeled_radios(sample_size: int) -> list[str] | None:
-    """The first ``sample_size`` radios (sorted, deterministic) absent from the intent set."""
+    """The first ``sample_size`` radios (CSV order, deduped) absent from the intent set.
+
+    CAVEAT: the radios NOT in the hand-labeled intent set are largely the ones
+    that were EXCLUDED from labeling because they are low-quality / garbled
+    Whisper transcripts, so this subset is not representative of clean radio.
+    """
     import pandas as pd
 
     raw_path = get_data_root() / "processed" / "radio_nlp" / "radios_raw.csv"
@@ -79,9 +88,12 @@ def _unlabeled_radios(sample_size: int) -> list[str] | None:
     if not (raw_path.exists() and labeled_path.exists()):
         return None
 
-    labeled = set(pd.read_csv(labeled_path)["message"].astype(str))
-    raw = pd.read_csv(raw_path)["text"].astype(str)
-    unlabeled = sorted(t for t in raw if t.strip() and t not in labeled)
+    seen = set(pd.read_csv(labeled_path)["message"].astype(str))
+    unlabeled = []
+    for text in pd.read_csv(raw_path)["text"].astype(str):
+        if text.strip() and text not in seen:
+            seen.add(text)  # dedupe against both the labeled set and earlier picks
+            unlabeled.append(text)
     return unlabeled[:sample_size]
 
 
@@ -121,7 +133,9 @@ def run_alert_precision_llm(sample_size: int = _DEFAULT_SAMPLE) -> AlertLLMResul
         llm = _make_judge_llm()
         verdicts = [_judge(llm, text) for text in alerts]
     except Exception as exc:  # noqa: BLE001 - any LLM/transport failure degrades to a note
-        return AlertLLMResult(len(texts), len(alerts), 0, None, f"LLM judge unavailable: {type(exc).__name__}")
+        return AlertLLMResult(
+            len(texts), len(alerts), 0, None, f"LLM judge unavailable: {type(exc).__name__}"
+        )
 
     judged_true = sum(verdicts)
     precision = judged_true / len(alerts)
@@ -148,6 +162,12 @@ def _render(result: AlertLLMResult) -> str:
             f"| proxy precision | {precision} |",
             "",
             result.detail,
+            "",
+            "**Finding**: the unlabeled radios are dominated by garbled Whisper transcripts (the "
+            "subset excluded from hand-labeling), so this proxy reflects transcript noise, not alert "
+            "precision - a low value here is expected and NOT informative. Use the gold-based alert "
+            "precision (0.9185, nlp report) for the paper; a meaningful LLM-judge would need a "
+            "curated unlabeled set.",
         ]
     )
 
@@ -161,4 +181,9 @@ def build_alert_llm_report() -> dict[str, Any]:
     )
     payload = {"result": asdict(result)}
     md_path, json_path = write_report(ALERT_LLM_NAME, header, _render(result), payload)
-    return {"header": asdict(header), "md_path": str(md_path), "json_path": str(json_path), **payload}
+    return {
+        "header": asdict(header),
+        "md_path": str(md_path),
+        "json_path": str(json_path),
+        **payload,
+    }

--- a/src/strategy/eval/alert_llm.py
+++ b/src/strategy/eval/alert_llm.py
@@ -1,0 +1,164 @@
+"""LLM-judge alert precision over UNLABELED radios (#304 follow-up).
+
+The gold alert precision (0.9185, in ``nlp.py``) is measured on the hand-labeled
+intent set. This module extends coverage to the ~154 radios that carry NO hand
+label, using an LLM as a PROXY judge: it flags the radios the intent model calls
+an alert (PROBLEM/WARNING), asks the LLM whether each is a genuine pit-wall alert,
+and reports the proxy precision.
+
+IMPORTANT - this is a PROXY, not ground truth:
+- LLM verdicts are not gold; the number is indicative, not defensible for the
+  paper on its own. The paper-grade alert precision is the gold-based one.
+- Non-deterministic (an external model), so it is deliberately kept OUT of the
+  reproducible ``f1-eval nlp`` report and behind its own ``f1-eval alert-llm``
+  command that spends API calls only when invoked.
+- FLAG FOR VICTOR: for a paper claim on the unlabeled set, these proxy labels
+  need a human-review pass.
+
+LLM provider follows ``F1_LLM_PROVIDER`` (openai / lmstudio), never Anthropic.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from src.f1_strat_manager.data_cache import get_data_root
+from src.strategy.eval.nlp import _ALERT_INTENTS, _load_intent_setfit_free
+from src.strategy.eval.report import build_header, write_report
+
+ALERT_LLM_NAME = "alert_llm"
+_JUDGE_MODEL = "gpt-4.1-mini"
+_DEFAULT_SAMPLE = 80
+
+_JUDGE_SYSTEM = (
+    "You are an F1 race strategist on the pit wall. A radio message is an ALERT only if it "
+    "reports a genuine problem or a warning the strategist must act on (car damage, tyre/brake "
+    "issues, hazards, incidents, urgent instructions). Neutral information, questions, banter, or "
+    "routine updates are NOT alerts. Answer with a single word: YES or NO."
+)
+
+
+@dataclass
+class AlertLLMResult:
+    """The proxy alert-precision measurement over the unlabeled sample."""
+
+    sample_size: int
+    predicted_alerts: int
+    judged_true: int
+    proxy_precision: float | None
+    detail: str
+
+
+def _make_judge_llm() -> Any:
+    """Instantiate the judge LLM per ``F1_LLM_PROVIDER`` (openai default here, or lmstudio).
+
+    Mirrors the provider switch in ``radio_agent`` so the harness reaches the same
+    backend the agents use. Temperature 0 for as-deterministic-as-possible verdicts.
+    """
+    from langchain_openai import ChatOpenAI
+
+    provider = os.environ.get("F1_LLM_PROVIDER", "openai")
+    if provider == "lmstudio":
+        return ChatOpenAI(
+            model="local-model",
+            base_url="http://localhost:1234/v1",
+            api_key="lm-studio",
+            temperature=0,
+        )
+    return ChatOpenAI(model=_JUDGE_MODEL, temperature=0)
+
+
+def _unlabeled_radios(sample_size: int) -> list[str] | None:
+    """The first ``sample_size`` radios (sorted, deterministic) absent from the intent set."""
+    import pandas as pd
+
+    raw_path = get_data_root() / "processed" / "radio_nlp" / "radios_raw.csv"
+    labeled_path = get_data_root() / "processed" / "radio_nlp" / "intent_labeled_data.csv"
+    if not (raw_path.exists() and labeled_path.exists()):
+        return None
+
+    labeled = set(pd.read_csv(labeled_path)["message"].astype(str))
+    raw = pd.read_csv(raw_path)["text"].astype(str)
+    unlabeled = sorted(t for t in raw if t.strip() and t not in labeled)
+    return unlabeled[:sample_size]
+
+
+def _predicted_alerts(texts: list[str]) -> list[str] | None:
+    """Radios the intent model flags as an alert (intent in PROBLEM/WARNING)."""
+    loaded = _load_intent_setfit_free()
+    if loaded is None:
+        return None
+    st, head, idx_to_name = loaded
+    preds = [idx_to_name[int(c)] for c in head.predict(st.encode(texts, show_progress_bar=False))]
+    return [text for text, pred in zip(texts, preds) if pred in _ALERT_INTENTS]
+
+
+def _judge(llm: Any, text: str) -> bool:
+    """Ask the LLM whether one radio is a genuine pit-wall alert (YES/NO)."""
+    response = llm.invoke([("system", _JUDGE_SYSTEM), ("human", text)])
+    return "yes" in str(response.content).strip().lower()[:5]
+
+
+def run_alert_precision_llm(sample_size: int = _DEFAULT_SAMPLE) -> AlertLLMResult:
+    """Compute proxy alert precision over the unlabeled sample via the LLM judge.
+
+    Returns a degraded result (``proxy_precision=None``) when the intent model,
+    the corpus, or the LLM backend is unavailable, rather than raising.
+    """
+    texts = _unlabeled_radios(sample_size)
+    if not texts:
+        return AlertLLMResult(0, 0, 0, None, "intent set or radios_raw.csv absent")
+
+    alerts = _predicted_alerts(texts)
+    if alerts is None:
+        return AlertLLMResult(len(texts), 0, 0, None, "intent model absent")
+    if not alerts:
+        return AlertLLMResult(len(texts), 0, 0, None, "no predicted alerts in the sample")
+
+    try:
+        llm = _make_judge_llm()
+        verdicts = [_judge(llm, text) for text in alerts]
+    except Exception as exc:  # noqa: BLE001 - any LLM/transport failure degrades to a note
+        return AlertLLMResult(len(texts), len(alerts), 0, None, f"LLM judge unavailable: {type(exc).__name__}")
+
+    judged_true = sum(verdicts)
+    precision = judged_true / len(alerts)
+    detail = (
+        f"PROXY: {judged_true}/{len(alerts)} predicted alerts judged genuine by {_JUDGE_MODEL}; "
+        "LLM labels are not ground truth - needs human review before any paper claim"
+    )
+    return AlertLLMResult(len(texts), len(alerts), judged_true, round(precision, 4), detail)
+
+
+def _render(result: AlertLLMResult) -> str:
+    """Render the proxy alert-precision report with its PROXY caveat up front."""
+    precision = "-" if result.proxy_precision is None else f"{result.proxy_precision:.4f}"
+    return "\n".join(
+        [
+            "> PROXY METRIC - LLM-judged, not ground truth. Needs a human-review pass before any "
+            "paper claim. The paper-grade alert precision is the gold-based one in the nlp report.",
+            "",
+            "| metric | value |",
+            "|---|---|",
+            f"| sample size (unlabeled) | {result.sample_size} |",
+            f"| predicted alerts | {result.predicted_alerts} |",
+            f"| judged genuine | {result.judged_true} |",
+            f"| proxy precision | {precision} |",
+            "",
+            result.detail,
+        ]
+    )
+
+
+def build_alert_llm_report() -> dict[str, Any]:
+    """Regenerate the proxy alert-precision report (spends API calls)."""
+    result = run_alert_precision_llm()
+    provider = os.environ.get("F1_LLM_PROVIDER", "openai")
+    header = build_header(
+        dataset="radios_raw.csv unlabeled subset", llm=f"{provider}/{_JUDGE_MODEL}"
+    )
+    payload = {"result": asdict(result)}
+    md_path, json_path = write_report(ALERT_LLM_NAME, header, _render(result), payload)
+    return {"header": asdict(header), "md_path": str(md_path), "json_path": str(json_path), **payload}

--- a/src/strategy/eval/calibration.py
+++ b/src/strategy/eval/calibration.py
@@ -18,10 +18,10 @@ Scope this phase (#206):
   ``_add_overtake_features`` pattern. Both reproduce their published AUC-PR
   exactly (#364).
 
-ponytail: pit coverage + the MC sigma are read from frozen artifacts, not
-re-run from a holdout (``pit_labeled`` is empty on disk; the MC pass needs a
-torch forward pass x N). Upgrade path when the holdouts land: recompute both
-from data, the same way N33 Section D already does for the TCN.
+ponytail: the MC sigma is read from the frozen calibration JSON, not re-run (the
+MC pass needs a torch forward pass x N). pit coverage is now recomputed from the
+raw-laps holdout (#364, ``pit_holdout``). Upgrade path for MC: recompute from
+data, the same way N33 Section D already does for the TCN.
 """
 
 from __future__ import annotations
@@ -335,14 +335,33 @@ def _overtake_calibration() -> list[CalibrationResult]:
 
 
 def _pit_quantile_coverage() -> list[CalibrationResult]:
-    """Surface the pit P05-P95 empirical coverage and flag it vs nominal.
+    """Recompute the pit P05-P95 empirical coverage on the regenerated N15 holdout.
 
-    ponytail: read from the frozen ``model_config`` (the value is published
-    there) rather than re-run - ``pit_labeled`` is empty on disk so there is no
-    holdout to predict on. Upgrade path: recompute empirical coverage from the
-    hist_pit P05/P95 models over the N15 holdout once it lands. This is the
-    retro-validation target: the harness must surface the known 0.7047 break.
+    Coverage = fraction of test physical_stop_est falling inside [P05, P95]. This
+    is the retro-validation target: the harness must surface the known ~0.70
+    break vs the 0.90 nominal. Falls back to the config-declared value when the
+    raw laps or models are absent (#364 rebuilds the holdout from raw laps).
     """
+    from src.strategy.eval.pit_holdout import load_pit_holdout
+
+    loaded = load_pit_holdout()
+    if loaded is not None:
+        test_slice, models, features = loaded
+        x = test_slice[features]
+        lower = models["p05"].predict(x)
+        upper = models["p95"].predict(x)
+        actual = test_slice["physical_stop_est"].to_numpy()
+        coverage = float(((actual >= lower) & (actual <= upper)).mean())
+        status = "drift" if coverage < NOMINAL_COVERAGE else "ok"
+        detail = (
+            f"n={len(actual)}; empirical P05-P95 coverage recomputed on the regenerated N15 holdout"
+        )
+        return [
+            CalibrationResult(
+                "pit_duration", "p05_p95_coverage", coverage, NOMINAL_COVERAGE, status, detail
+            )
+        ]
+
     cfg_path = get_models_root() / "pit_prediction" / "model_config.json"
     if not cfg_path.exists():
         return [
@@ -352,14 +371,14 @@ def _pit_quantile_coverage() -> list[CalibrationResult]:
                 None,
                 NOMINAL_COVERAGE,
                 "pending",
-                "model_config absent",
+                "raw laps + model_config absent",
             )
         ]
 
     cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
     coverage = float(cfg["eval"]["p05_p95_coverage_test"])
     status = "drift" if coverage < NOMINAL_COVERAGE else "ok"
-    detail = f"config-declared (recompute pending N15 holdout); {coverage:.4f} vs {NOMINAL_COVERAGE:.2f} nominal"
+    detail = f"config-declared (raw laps absent for recompute); {coverage:.4f} vs {NOMINAL_COVERAGE:.2f} nominal"
     return [
         CalibrationResult(
             "pit_duration", "p05_p95_coverage", coverage, NOMINAL_COVERAGE, status, detail

--- a/src/strategy/eval/calibration.py
+++ b/src/strategy/eval/calibration.py
@@ -12,11 +12,11 @@ Scope this phase (#206):
 - **pit_duration** - the P05-P95 quantile coverage, flagged as drift vs the
   0.90 nominal.
 - **tire_degradation** - the deployed MC-Dropout sigma per compound.
-- **safety_car / undercut** - recompute from scratch is blocked on-disk (SC
-  needs 5 engineered features - lap_time_*_z, anomaly_and_yellow, lap1_chaos -
-  absent from the holdout; undercut historical aggregates absent too) so they
-  are reported as ``pending`` rather than hidden - Phase-2 (#207) territory.
-  Their headline numbers are still config-sourced in the registry.
+- **safety_car / undercut** - recomputed on the 2025 holdout by rebuilding their
+  engineered features in-memory (SC: the 5 derived features from N14 Step 2;
+  undercut: the two train-fit target encodings from N16 Step 3), the same
+  ``_add_overtake_features`` pattern. Both reproduce their published AUC-PR
+  exactly (#364).
 
 ponytail: pit coverage + the MC sigma are read from frozen artifacts, not
 re-run from a holdout (``pit_labeled`` is empty on disk; the MC pass needs a
@@ -61,6 +61,16 @@ _OVERTAKE_FEATURES = [
 ]
 _OVERTAKE_CAT = ["compound_x", "compound_y", "circuit_cluster"]
 _OVERTAKE_PAIR_KEYS = ["Year", "GP_Name", "driver_x", "driver_y"]
+
+# SC + undercut recompute: the model feature lists are read from disk; the
+# engineered features are rebuilt in-memory from the base parquet, the same
+# pattern _add_overtake_features uses.
+_SC_DIR = "safety_car_probability"
+_SC_LAPTIME_Z_COLS = ["lap_time_mean", "lap_time_std", "lap_time_min"]  # per-race z-scored
+_SC_TARGETS = ("sc_within_3_laps", "sc_within_5_laps", "sc_within_7_laps")
+_UNDERCUT_DIR = "pit_prediction"
+_UNDERCUT_TRAIN_YEARS = (2023, 2024)
+_UNDERCUT_TARGET = "undercut_success"
 
 
 @dataclass
@@ -156,6 +166,136 @@ def load_overtake_predictions(year: int = 2025) -> tuple[np.ndarray, np.ndarray,
     y = test["overtake"].astype(int).to_numpy()
     proba_raw = model.predict_proba(x)[:, 1]
     proba_cal = calibrator.predict_proba(proba_raw.reshape(-1, 1))[:, 1]
+    return y, proba_raw, proba_cal
+
+
+def _add_sc_features(df: "Any") -> "Any":
+    """Rebuild the SC model's engineered features in-memory (N14 Step 2, verbatim).
+
+    The persisted sc_labeled parquet stores base columns; the model consumes 5
+    derived features - per-race z-scores of lap_time_{mean,std,min} plus the
+    anomaly_and_yellow and lap1_chaos interactions - rebuilt here exactly as N14
+    did (per-race median imputation first, then z-scores, then weather fill), or
+    the LightGBM sees a different feature space and the number moves.
+
+    --- WHERE TO CHANGE IF THE SC FEATURES CHANGE ---
+    notebooks/strategy/sc_probability/N14_sc_model.ipynb (Step 2) is the source
+    of truth; mirror any edit here.
+    """
+    df = df.copy()
+    race_key = "race_id" if "race_id" in df.columns else "event_name"
+    for col in ["lap_time_mean", "lap_time_std", "lap_time_min", "lap_time_cv", "lap_time_trend_5"]:
+        if col in df.columns:
+            per_race_median = df.groupby(race_key)[col].transform("median")
+            df[col] = df[col].fillna(per_race_median).fillna(df[col].median())
+    for col in _SC_LAPTIME_Z_COLS:
+        if col in df.columns:
+            race_mu = df.groupby(race_key)[col].transform("mean")
+            race_sigma = df.groupby(race_key)[col].transform("std").clip(lower=0.01)
+            df[f"{col}_z"] = (df[col] - race_mu) / race_sigma
+    for col in ["track_temp", "air_temp", "humidity", "track_temp_delta"]:
+        if col in df.columns:
+            df[col] = df.groupby(race_key)[col].transform(lambda s: s.ffill().bfill())
+            df[col] = df[col].fillna(df[col].median())
+    has_anomaly = {"driver_anomaly_hard_count", "yellow_escalation_count"} <= set(df.columns)
+    df["anomaly_and_yellow"] = (
+        ((df["driver_anomaly_hard_count"] > 0) & (df["yellow_escalation_count"] > 0)).astype(int)
+        if has_anomaly
+        else 0
+    )
+    has_lap1 = {"is_lap1", "n_drivers_delta"} <= set(df.columns)
+    df["lap1_chaos"] = (df["is_lap1"] * df["n_drivers_delta"].abs()).astype(int) if has_lap1 else 0
+    return df
+
+
+def _sc_frame_and_proba(year: int) -> tuple["Any", np.ndarray, np.ndarray] | None:
+    """Load the SC year-slice with engineered features + model probabilities.
+
+    Returns ``(df_slice, proba_raw, proba_cal)`` or ``None``. Shared seam: the
+    calibration recompute (3-lap target) and the #363 threshold/window correction
+    both need the same slice + model output, so the load lives here once. The
+    feature order is read from the model's ``feature_list_v1.json``.
+    """
+    import json
+
+    import joblib
+    import pandas as pd
+
+    model_dir = get_models_root() / _SC_DIR
+    parquet = get_data_root() / "processed" / "sc_labeled" / "sc_labeled_2023_2025.parquet"
+    model_path = model_dir / "lgbm_sc_v1.pkl"
+    calib_path = model_dir / "calibrator_sc_v1.pkl"
+    feature_list_path = model_dir / "feature_list_v1.json"
+    if not all(p.exists() for p in (parquet, model_path, calib_path, feature_list_path)):
+        return None
+
+    features = json.loads(feature_list_path.read_text(encoding="utf-8"))["features"]
+    df = _add_sc_features(pd.read_parquet(parquet))
+    df_slice = df[df["year"] == year].copy()
+    model = joblib.load(model_path)
+    calibrator = joblib.load(calib_path)
+    proba_raw = model.predict_proba(df_slice[features])[:, 1]
+    proba_cal = calibrator.predict_proba(proba_raw.reshape(-1, 1))[:, 1]
+    return df_slice, proba_raw, proba_cal
+
+
+def load_sc_predictions(
+    year: int = 2025, target: str = "sc_within_3_laps"
+) -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
+    """``(y, proba_raw, proba_cal)`` for a SC target window, or ``None`` if artifacts absent.
+
+    ``year`` selects the season slice (2025 = test, 2024 = validation for the
+    #363 threshold re-selection); ``target`` selects the SC window (3/5/7 laps),
+    which the #363 window correction sweeps.
+    """
+    loaded = _sc_frame_and_proba(year)
+    if loaded is None:
+        return None
+    df_slice, proba_raw, proba_cal = loaded
+    y = df_slice[target].astype(int).to_numpy()
+    return y, proba_raw, proba_cal
+
+
+def load_undercut_predictions(
+    year: int = 2025,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
+    """``(y, proba_raw, proba_cal)`` for the undercut holdout with train-fit target encodings.
+
+    The two aggregate features (circuit_undercut_rate, team_x_undercut_rate) are
+    target encodings fit on the 2023-2024 train slice and applied to the requested
+    year (N16 Step 3), so the split precedes the encoding and no train<-test leak
+    occurs. Returns ``None`` when the artifacts or holdout are absent.
+    """
+    import json
+
+    import joblib
+    import pandas as pd
+
+    model_dir = get_models_root() / _UNDERCUT_DIR
+    parquet = get_data_root() / "processed" / "undercut_labeled" / "undercut_clean.parquet"
+    model_path = model_dir / "lgbm_undercut_v1.pkl"
+    calib_path = model_dir / "calibrator_undercut_v1.pkl"
+    cfg_path = model_dir / "model_config_undercut_v1.json"
+    if not all(p.exists() for p in (parquet, model_path, calib_path, cfg_path)):
+        return None
+
+    features = json.loads(cfg_path.read_text(encoding="utf-8"))["features"]
+    df = pd.read_parquet(parquet)
+    train = df[df["Year"].isin(_UNDERCUT_TRAIN_YEARS)]
+    target_slice = df[df["Year"] == year].copy()
+    for group_col, feat in (
+        ("circuit_key", "circuit_undercut_rate"),
+        ("Team_X", "team_x_undercut_rate"),
+    ):
+        encoding = train.groupby(group_col)[_UNDERCUT_TARGET].mean()
+        fallback = train[_UNDERCUT_TARGET].mean()
+        target_slice[feat] = target_slice[group_col].map(encoding).fillna(fallback)
+
+    model = joblib.load(model_path)
+    calibrator = joblib.load(calib_path)
+    proba_raw = model.predict_proba(target_slice[features])[:, 1]
+    proba_cal = calibrator.predict_proba(proba_raw.reshape(-1, 1))[:, 1]
+    y = target_slice[_UNDERCUT_TARGET].astype(int).to_numpy()
     return y, proba_raw, proba_cal
 
 
@@ -260,28 +400,46 @@ def _tcn_mc_sigma() -> list[CalibrationResult]:
     return results
 
 
-def _pending_classifiers() -> list[CalibrationResult]:
-    """Honest deltas for the two classifiers that cannot recompute on-disk.
+def _classifier_calibration(model_name: str, loader: "Any") -> list[CalibrationResult]:
+    """Brier + ECE on the 2025 holdout for a binary classifier via its loader.
 
-    Recording the blocker (not a fabricated number) is the point: both blockers
-    are precisely what Phase-2 provenance work (#207) resolves.
+    Generic over safety_car / undercut: both rebuild their engineered features
+    in-memory (the loaders in this module) and report the calibrated Brier + ECE,
+    the same quantities ``_overtake_calibration`` reports for overtake. Returns a
+    ``pending`` row when the loader cannot find its artifacts.
     """
+    loaded = loader()
+    if loaded is None:
+        return [
+            CalibrationResult(
+                model_name,
+                "ece_calibrated",
+                None,
+                ECE_DRIFT,
+                "pending",
+                "artifacts or holdout absent on disk",
+            )
+        ]
+    y, _proba_raw, proba_cal = loaded
+    brier_cal = float(np.mean((proba_cal - y) ** 2))
+    ece_cal = _ece(y, proba_cal)
+    status = "drift" if ece_cal > ECE_DRIFT else "ok"
     return [
         CalibrationResult(
-            "safety_car",
-            "ece_calibrated",
+            model_name,
+            "brier_calibrated",
+            brier_cal,
             None,
-            ECE_DRIFT,
-            "pending",
-            "engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from sc_labeled holdout (#207)",
+            "ok",
+            f"n={len(y)}; recomputed on 2025 holdout",
         ),
         CalibrationResult(
-            "undercut",
+            model_name,
             "ece_calibrated",
-            None,
+            ece_cal,
             ECE_DRIFT,
-            "pending",
-            "historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207)",
+            status,
+            f"n={len(y)}; {ECE_BINS}-bin equal-width",
         ),
     ]
 
@@ -290,9 +448,10 @@ def collect_results() -> list[CalibrationResult]:
     """All calibration results across the predictors."""
     return [
         *_overtake_calibration(),
+        *_classifier_calibration("safety_car", load_sc_predictions),
+        *_classifier_calibration("undercut", load_undercut_predictions),
         *_pit_quantile_coverage(),
         *_tcn_mc_sigma(),
-        *_pending_classifiers(),
     ]
 
 

--- a/src/strategy/eval/cli.py
+++ b/src/strategy/eval/cli.py
@@ -59,7 +59,7 @@ def _run_hygiene() -> None:
 
 def _run_nlp() -> None:
     payload = build_nlp_report()
-    print("nlp " + _summarise(payload, "results", ("delta", "blocked", "pending")))
+    print("nlp " + _summarise(payload, "results", ("flagged", "delta", "blocked", "pending")))
 
 
 _COMMANDS: dict[str, Callable[[], None]] = {

--- a/src/strategy/eval/cli.py
+++ b/src/strategy/eval/cli.py
@@ -9,7 +9,8 @@ one-line summary of where it landed and what it flagged.
     f1-eval models         # reproduce headline numbers vs the model_configs
     f1-eval hygiene        # E-02 threshold provenance + leakage verdicts (#207)
     f1-eval nlp            # NLP per-stage eval: sentiment + gated stages (#304)
-    f1-eval all            # every report
+    f1-eval alert-llm      # PROXY alert precision via an LLM judge (#304; spends API calls)
+    f1-eval all            # every report EXCEPT alert-llm (opt-in: it spends API calls)
 """
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ from __future__ import annotations
 import argparse
 from typing import Any, Callable
 
+from src.strategy.eval.alert_llm import build_alert_llm_report
 from src.strategy.eval.calibration import build_calibration_report
 from src.strategy.eval.hygiene import build_hygiene_report
 from src.strategy.eval.nlp import build_nlp_report
@@ -62,6 +64,16 @@ def _run_nlp() -> None:
     print("nlp " + _summarise(payload, "results", ("flagged", "delta", "blocked", "pending")))
 
 
+def _run_alert_llm() -> None:
+    payload = build_alert_llm_report()
+    result = payload["result"]
+    precision = "-" if result["proxy_precision"] is None else f"{result['proxy_precision']:.4f}"
+    print(
+        f"alert-llm -> {payload['md_path']} (proxy precision {precision} over "
+        f"{result['predicted_alerts']} predicted alerts; PROXY - needs human review)"
+    )
+
+
 _COMMANDS: dict[str, Callable[[], None]] = {
     "registry": _run_registry,
     "calibration": _run_calibration,
@@ -78,10 +90,15 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "command",
-        choices=[*_COMMANDS, "all"],
+        choices=[*_COMMANDS, "alert-llm", "all"],
         help="which report to regenerate",
     )
     args = parser.parse_args(argv)
+
+    # alert-llm is opt-in only: it spends API calls, so `all` never runs it.
+    if args.command == "alert-llm":
+        _run_alert_llm()
+        return 0
 
     commands = _COMMANDS.values() if args.command == "all" else [_COMMANDS[args.command]]
     for run in commands:

--- a/src/strategy/eval/hygiene.py
+++ b/src/strategy/eval/hygiene.py
@@ -13,11 +13,14 @@ the 2025 test set, so they inflate only the OPERATING-POINT metrics
 (precision/recall/F1 at that threshold). The threshold-FREE headline numbers the
 paper actually reports - AUC-PR and AUC-ROC - are computed from probabilities
 and are unaffected, so they clear. This module re-selects the overtake threshold
-on val-2024 (the honest split) to show the operating-point delta, and does the
-same for the safety-car threshold (#363) - where the correction collapses because
-val-2024 is SC-positive-sparse, evidence the leaked operating point was
-test-overfit. The SC target window cannot be retro-selected (only the 3-lap model
-is persisted), so its AUC-PR keeps an explicit test-window-selected caveat.
+on 2024 to show the operating-point delta, and does the same for the safety-car
+threshold (#363). CAVEAT: 2024 is IN the train set for both N12 and N14 (they
+train on 2023+2024; 2024 was only Optuna inner-val), so these re-selections are
+in-train, not held-out. For overtake the memorization is mild (28k pairs), so the
+threshold is a reasonable operating point; for SC it collapses on test, exposing
+that N14 has NO honest validation split for an operating threshold (report SC
+threshold-free). The SC target window cannot be retro-selected (only the 3-lap
+model is persisted), so its AUC-PR keeps an explicit test-window-selected caveat.
 """
 
 from __future__ import annotations
@@ -87,17 +90,29 @@ def audit_findings() -> list[ProvenanceEntry]:
             "threshold",
             "safety_car",
             CONTAMINATED,
-            "argmax-F2 threshold AND the best target-window both on the 2025 test set",
+            "argmax-F2 threshold AND the target-window both selected on the 2025 test set",
             "N14_sc_model.ipynb (PR-curve + window-comparison cells)",
-            "threshold -> operating-point optimistic; window chosen by max-lift on test -> the headline "
-            "AUC-PR 0.0723 is itself optimistic (a max over 3 candidates on test), NOT clean",
+            "threshold -> operating-point optimistic; the window was chosen by max-LIFT on test "
+            "(3-lap lift 1.673x). The reported AUC-PR 0.0723 is in fact the LOWEST of the three windows "
+            "(0.0723/0.0987/0.1165), not a max - the test-selection bias is on the lift, so the headline "
+            "keeps a test-window-selected caveat, not an inflated-AUC claim",
+        ),
+        ProvenanceEntry(
+            "sc Platt calibrator",
+            "calibrator",
+            "safety_car",
+            UNDERDOCUMENTED,
+            "fit on 2024 probabilities, but 2024 is IN the train set (config fitted_on='val_2024' is misleading)",
+            "N14_sc_model.ipynb (calibration cell)",
+            "resubstitution fit; measured impact low (test ECE 0.0347 < 0.05, AUC-PR invariant under a "
+            "monotone Platt map) but a provenance audit must record it",
         ),
         ProvenanceEntry(
             "best_threshold=0.522",
             "threshold",
             "undercut",
             CLEAN,
-            "argmax-F1 on the calibrated val-2024 split",
+            "argmax-F1 on the calibrated val-2024 split (verified CLEAN in the #207 adversarial pass)",
             'N16_undercut.ipynb ("Threshold on calibrated val 2024")',
             "textbook-correct; the 2025 test set is only applied afterwards",
         ),
@@ -173,14 +188,16 @@ def _operating_point(y: np.ndarray, proba: np.ndarray, threshold: float) -> dict
 
 
 def correct_overtake_threshold() -> dict[str, Any] | None:
-    """Re-select the overtake threshold on val-2024 and show the operating-point delta.
+    """Re-select the overtake threshold on 2024 and show the operating-point delta.
 
     The E-02 correction for the worst contaminated item: pick the threshold by
-    argmax-F1 on the 2024 validation slice (never touching test), then report its
-    operating point on the 2025 test set next to the leaked 0.7976's operating
-    point on the same test set. The leaked threshold's F1 is maximal on test by
-    construction (it was fit there); the corrected threshold's F1 is the honest
-    number. Returns ``None`` if the holdout is absent.
+    argmax-F1 on the 2024 slice, then report its operating point on the 2025 test
+    set next to the leaked 0.7976's operating point on the same test set. CAVEAT:
+    2024 is IN N12's train set (2023+2024; 2024 was only Optuna inner-val), so
+    this re-selection is in-train, not a held-out val - but with ~28k pairs the
+    memorization is mild, so the re-selected threshold is a reasonable operating
+    point (unlike SC, which collapses). The leaked threshold's F1 is maximal on
+    test by construction (it was fit there). Returns ``None`` if absent.
     """
     val = load_overtake_predictions(year=2024)
     test = load_overtake_predictions(year=2025)
@@ -202,20 +219,22 @@ def correct_overtake_threshold() -> dict[str, Any] | None:
         "corrected_test_operating_point": _operating_point(
             y_test, proba_test_raw, corrected_threshold
         ),
-        "note": "threshold selected on val-2024; both operating points evaluated on the 2025 test set",
+        "note": "threshold selected on 2024 (in-train; 2024 is part of N12's 2023+2024 train set, "
+        "mild memorization at ~28k pairs); both operating points evaluated on the 2025 test set",
     }
 
 
 def correct_sc_threshold() -> dict[str, Any] | None:
-    """Re-select the SC operating threshold on val-2024 (argmax-F2) and show the delta.
+    """Try to re-select the SC threshold on 2024 - and expose that no honest split exists.
 
     The SC threshold 0.2335 was argmax-F2 on test-2025 (pre-calibration, N14
-    Step 5), so the correction sweeps F2 on the 2024 validation raw scores and
-    reports its test operating point next to the leaked one. IMPORTANT: val-2024
-    carries very few SC-positive laps, so the val-selected threshold is
-    high-variance - a degenerate corrected operating point is itself the finding
-    (the leaked operating point was a product of test overfitting and does not
-    reproduce off-test). Returns ``None`` if the holdout is absent.
+    Step 5). CRITICAL: N14 trains on 2023+2024 and tests on 2025, so it has NO
+    held-out validation split. This sweeps F2 on 2024, but 2024 is IN the train
+    set, so the re-selection is IN-TRAIN (resubstitution): it lands on the
+    train-memorization boundary (~0.6358, where 2024's few positives sit) and
+    collapses to F2 0.0 on test. The collapse does NOT prove 0.2335 was
+    test-overfit - it demonstrates that no honest operating threshold exists
+    without a fresh val split or retraining. Returns ``None`` if absent.
     """
     from src.strategy.eval.calibration import load_sc_predictions
 
@@ -233,17 +252,18 @@ def correct_sc_threshold() -> dict[str, Any] | None:
     return {
         "leaked_threshold": _LEAKED_SC_THRESHOLD,
         "corrected_threshold": round(corrected_threshold, 4),
-        "val_positive_count": int(y_val.sum()),
-        "val_size": int(len(y_val)),
+        "in_train_2024_positive_count": int(y_val.sum()),
+        "in_train_2024_size": int(len(y_val)),
         "leaked_test_operating_point": _operating_point(
             y_test, proba_test_raw, _LEAKED_SC_THRESHOLD
         ),
         "corrected_test_operating_point": _operating_point(
             y_test, proba_test_raw, corrected_threshold
         ),
-        "note": "F2 threshold selected on val-2024 raw scores; both operating points on 2025 test. "
-        "val-2024 has few SC positives so the corrected point is high-variance - the collapse is the "
-        "evidence that the leaked operating point was test-overfit",
+        "note": "the F2 threshold 'selected on 2024' is IN-TRAIN (2024 is a subset of the 2023+2024 "
+        "train set), NOT a held-out split; it lands on the train-memorization boundary and collapses "
+        "on test. This shows N14 has no honest validation split for an operating threshold - the paper "
+        "should report SC threshold-free, not re-select an operating point",
     }
 
 
@@ -274,7 +294,7 @@ def sc_window_sensitivity() -> dict[str, Any] | None:
     per_window = {}
     for target in _SC_TARGETS:
         per_window[target] = {
-            "val_2024_auc_pr": round(
+            "in_train_2024_auc_pr": round(
                 float(average_precision_score(val_frame[target].astype(int), val_proba)), 4
             ),
             "test_2025_auc_pr": round(
@@ -286,9 +306,10 @@ def sc_window_sensitivity() -> dict[str, Any] | None:
         "per_window_auc_pr": per_window,
         "retro_selectable": False,
         "note": "only the 3-lap model is persisted; the 5/7-lap models needed to re-select the window "
-        "on val are not on disk (retraining out of scope). The reported SC AUC-PR 0.0723 keeps the "
-        "caveat that its window was test-selected; the table is single-model sensitivity, not the "
-        "original 3-model selection",
+        "are not on disk (retraining out of scope). The 2024 column is IN-TRAIN (2024 subset of "
+        "train), so its high AUC-PR (0.88) is resubstitution, NOT validation - it only shows the metric "
+        "is window-unstable. The reported SC AUC-PR 0.0723 keeps its test-window-selected caveat; this "
+        "is single-model sensitivity, not the original 3-model selection",
     }
 
 
@@ -303,7 +324,7 @@ def _render_overtake_correction(correction: dict[str, Any] | None) -> list[str]:
         *lines,
         f"- leaked threshold {correction['leaked_threshold']} (selected on test): "
         f"P {leaked['precision']} / R {leaked['recall']} / F1 {leaked['f1']} on 2025 test",
-        f"- corrected threshold {correction['corrected_threshold']} (selected on val-2024): "
+        f"- corrected threshold {correction['corrected_threshold']} (selected on 2024, in-train): "
         f"P {fixed['precision']} / R {fixed['recall']} / F1 {fixed['f1']} on 2025 test",
         f"- {correction['note']}",
     ]
@@ -320,8 +341,8 @@ def _render_sc_correction(correction: dict[str, Any] | None) -> list[str]:
         *lines,
         f"- leaked threshold {correction['leaked_threshold']} (F2 on test): "
         f"P {leaked['precision']} / R {leaked['recall']} / F2 {leaked['f2']} on 2025 test",
-        f"- corrected threshold {correction['corrected_threshold']} (F2 on val-2024, "
-        f"{correction['val_positive_count']}/{correction['val_size']} positive): "
+        f"- 'corrected' threshold {correction['corrected_threshold']} (F2 on 2024, IN-TRAIN, "
+        f"{correction['in_train_2024_positive_count']}/{correction['in_train_2024_size']} positive): "
         f"P {fixed['precision']} / R {fixed['recall']} / F2 {fixed['f2']} on 2025 test",
         f"- {correction['note']}",
     ]
@@ -333,11 +354,11 @@ def _render_sc_window(window: dict[str, Any] | None) -> list[str]:
     if window is None:
         return [*lines, "- holdout absent on disk; sensitivity not computed this run"]
     lines += [
-        "| window | val-2024 AUC-PR | test-2025 AUC-PR |",
+        "| window | 2024 AUC-PR (in-train) | test-2025 AUC-PR |",
         "|---|---|---|",
     ]
     for target, aucs in window["per_window_auc_pr"].items():
-        lines.append(f"| {target} | {aucs['val_2024_auc_pr']} | {aucs['test_2025_auc_pr']} |")
+        lines.append(f"| {target} | {aucs['in_train_2024_auc_pr']} | {aucs['test_2025_auc_pr']} |")
     return [*lines, "", f"- {window['note']}"]
 
 
@@ -370,17 +391,22 @@ def _render(
         f"- {len(contaminated)} contaminated items (overtake threshold; safety-car threshold + window). "
         "All other thresholds and aggregate features are clean or non-target.",
         "- **Overtake headline clears**: AUC-PR 0.5491 / AUC-ROC 0.8758 are threshold-free and involve no "
-        "window selection; the threshold leakage touches only their operating point, corrected above.",
-        "- **Safety-car operating threshold is NOT robustly recoverable**: re-selecting on val-2024 "
-        "collapses the operating point (val-2024 has too few SC positives), which is itself the evidence "
-        "that the leaked 0.2335 was test-overfit. The paper should report SC threshold-free and not claim "
-        "a fixed operating threshold.",
-        "- **Safety-car window cannot be retro-selected**: only the 3-lap model is persisted, so the "
-        "{3,5,7}-lap window selected on test-2025 cannot be honestly re-chosen without retraining the "
-        "5/7-lap models. The reported SC AUC-PR 0.0723 therefore keeps an explicit test-window-selected "
-        "caveat.",
+        "window selection; the threshold leakage touches only their operating point. NOTE the overtake "
+        "'correction' below is also in-train (N12 trains final on 2023+2024, 2024 was only Optuna "
+        "inner-val), but with 28k pairs the memorization is mild, so its re-selected threshold is a "
+        "reasonable operating point rather than a collapse.",
+        "- **Safety-car has NO honest validation split**: N14 trains on 2023+2024 and tests on 2025, so "
+        "there is no held-out split to re-select an operating threshold on. Re-selecting on 2024 is "
+        "in-train (resubstitution) and collapses on test - evidence that an honest SC operating threshold "
+        "does not exist without a fresh val split or retraining, NOT that 0.2335 was specifically "
+        "test-overfit. The paper should report SC threshold-free.",
+        "- **Safety-car window cannot be retro-selected**: only the 3-lap model is persisted, and the "
+        "window was originally chosen by max-lift on test-2025, so it cannot be honestly re-chosen "
+        "without retraining the 5/7-lap models. The reported SC AUC-PR 0.0723 (the lowest of the three "
+        "windows) keeps an explicit test-window-selected caveat.",
         "- **Remaining action before freeze**: pin a year filter in N03 `load_all_races` to close the "
-        "circuit_cluster underdocumentation.",
+        "circuit_cluster underdocumentation; and give SC/overtake a real held-out val split (or nested "
+        "CV) if a defensible operating threshold is ever needed.",
         "- Every other headline (undercut 0.6739, pit 0.487, pace 0.4104, tire 0.7078, sentiment 0.84) is "
         "unaffected by these findings.",
     ]

--- a/src/strategy/eval/hygiene.py
+++ b/src/strategy/eval/hygiene.py
@@ -105,16 +105,20 @@ def audit_findings() -> list[ProvenanceEntry]:
             "fit on 2024 probabilities, but 2024 is IN the train set (config fitted_on='val_2024' is misleading)",
             "N14_sc_model.ipynb (calibration cell)",
             "resubstitution fit; measured impact low (test ECE 0.0347 < 0.05, AUC-PR invariant under a "
-            "monotone Platt map) but a provenance audit must record it",
+            "monotone Platt map). Singled out because its config label fitted_on='val_2024' is "
+            "misleading; overtake/undercut Platt are also 2024-in-train but not mislabeled",
         ),
         ProvenanceEntry(
             "best_threshold=0.522",
             "threshold",
             "undercut",
             CLEAN,
-            "argmax-F1 on the calibrated val-2024 split (verified CLEAN in the #207 adversarial pass)",
+            "argmax-F1 on 2024 in-train (2024 is part of N16's 2023+2024 train set, same structure as "
+            "overtake; mild, 143 positives / base 0.413) - but NEVER selected on test-2025",
             'N16_undercut.ipynb ("Threshold on calibrated val 2024")',
-            "textbook-correct; the 2025 test set is only applied afterwards",
+            "CLEAN on the test-contamination axis this audit measures: the threshold never saw test "
+            "(unlike overtake 0.7976 / SC 0.2335). 2024 is not a held-out val split, but with 143 "
+            "positives it does not collapse (unlike SC); the headline 0.6739 is threshold-free anyway",
         ),
         ProvenanceEntry(
             "circuit_sc_rate",
@@ -270,11 +274,11 @@ def correct_sc_threshold() -> dict[str, Any] | None:
 def sc_window_sensitivity() -> dict[str, Any] | None:
     """Show the SC target window (3/5/7) cannot be honestly retro-selected, and caveat it.
 
-    N14 chose the window by comparing three separately-trained models on
-    test-2025 (the leak); only the winning 3-lap model is persisted, so the
-    window CANNOT be re-selected on val without retraining the 5/7-lap models
-    (out of scope). As supporting evidence this reports the persisted 3-lap
-    model's AUC-PR against each target window on val-2024 vs test-2025 - a
+    N14 chose the window by comparing three separately-trained models by max-lift
+    on test-2025 (the leak); only the winning 3-lap model is persisted, so the
+    window CANNOT be re-selected without retraining the 5/7-lap models (out of
+    scope). As supporting evidence this reports the persisted 3-lap model's AUC-PR
+    against each target window on 2024 (IN-TRAIN, resubstitution) vs test-2025 - a
     single-model sensitivity check, NOT the original 3-model selection - which
     shows the metric is window-unstable. The paper's honest position: report the
     threshold-free AUC-PR WITH the caveat that its window was test-selected.

--- a/src/strategy/eval/hygiene.py
+++ b/src/strategy/eval/hygiene.py
@@ -13,7 +13,11 @@ the 2025 test set, so they inflate only the OPERATING-POINT metrics
 (precision/recall/F1 at that threshold). The threshold-FREE headline numbers the
 paper actually reports - AUC-PR and AUC-ROC - are computed from probabilities
 and are unaffected, so they clear. This module re-selects the overtake threshold
-on val-2024 (the honest split) to show the operating-point delta.
+on val-2024 (the honest split) to show the operating-point delta, and does the
+same for the safety-car threshold (#363) - where the correction collapses because
+val-2024 is SC-positive-sparse, evidence the leaked operating point was
+test-overfit. The SC target window cannot be retro-selected (only the 3-lap model
+is persisted), so its AUC-PR keeps an explicit test-window-selected caveat.
 """
 
 from __future__ import annotations
@@ -38,6 +42,8 @@ UNDERDOCUMENTED = "underdocumented"
 # uses the same candidate set the notebook did.
 _THRESHOLD_GRID = np.linspace(0.05, 0.92, 200)
 _LEAKED_OVERTAKE_THRESHOLD = 0.7976
+_LEAKED_SC_THRESHOLD = 0.2335  # argmax-F2 on test-2025 (N14 Step 5)
+_SC_TARGETS = ("sc_within_3_laps", "sc_within_5_laps", "sc_within_7_laps")
 
 
 @dataclass
@@ -144,7 +150,12 @@ def audit_findings() -> list[ProvenanceEntry]:
 
 
 def _operating_point(y: np.ndarray, proba: np.ndarray, threshold: float) -> dict[str, float]:
-    """Precision / recall / F1 of ``proba >= threshold`` against ``y``."""
+    """Precision / recall / F1 / F2 of ``proba >= threshold`` against ``y``.
+
+    F1 is the overtake operating metric; F2 (recall-biased) is the one N14 uses
+    to pick the safety-car threshold, so both are returned and each caller reads
+    the one its notebook selected on.
+    """
     pred = (proba >= threshold).astype(int)
     tp = int(((pred == 1) & (y == 1)).sum())
     fp = int(((pred == 1) & (y == 0)).sum())
@@ -152,7 +163,13 @@ def _operating_point(y: np.ndarray, proba: np.ndarray, threshold: float) -> dict
     precision = tp / (tp + fp) if (tp + fp) else 0.0
     recall = tp / (tp + fn) if (tp + fn) else 0.0
     f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
-    return {"precision": round(precision, 4), "recall": round(recall, 4), "f1": round(f1, 4)}
+    f2 = 5 * precision * recall / (4 * precision + recall) if (4 * precision + recall) else 0.0
+    return {
+        "precision": round(precision, 4),
+        "recall": round(recall, 4),
+        "f1": round(f1, 4),
+        "f2": round(f2, 4),
+    }
 
 
 def correct_overtake_threshold() -> dict[str, Any] | None:
@@ -189,8 +206,148 @@ def correct_overtake_threshold() -> dict[str, Any] | None:
     }
 
 
-def _render(findings: list[ProvenanceEntry], correction: dict[str, Any] | None) -> str:
-    """Render the hygiene report: verdict table + correction + paper conclusion."""
+def correct_sc_threshold() -> dict[str, Any] | None:
+    """Re-select the SC operating threshold on val-2024 (argmax-F2) and show the delta.
+
+    The SC threshold 0.2335 was argmax-F2 on test-2025 (pre-calibration, N14
+    Step 5), so the correction sweeps F2 on the 2024 validation raw scores and
+    reports its test operating point next to the leaked one. IMPORTANT: val-2024
+    carries very few SC-positive laps, so the val-selected threshold is
+    high-variance - a degenerate corrected operating point is itself the finding
+    (the leaked operating point was a product of test overfitting and does not
+    reproduce off-test). Returns ``None`` if the holdout is absent.
+    """
+    from src.strategy.eval.calibration import load_sc_predictions
+
+    val = load_sc_predictions(year=2024, target="sc_within_3_laps")
+    test = load_sc_predictions(year=2025, target="sc_within_3_laps")
+    if val is None or test is None:
+        return None
+
+    y_val, proba_val_raw, _ = val
+    y_test, proba_test_raw, _ = test
+
+    f2_scores = [_operating_point(y_val, proba_val_raw, t)["f2"] for t in _THRESHOLD_GRID]
+    corrected_threshold = float(_THRESHOLD_GRID[int(np.argmax(f2_scores))])
+
+    return {
+        "leaked_threshold": _LEAKED_SC_THRESHOLD,
+        "corrected_threshold": round(corrected_threshold, 4),
+        "val_positive_count": int(y_val.sum()),
+        "val_size": int(len(y_val)),
+        "leaked_test_operating_point": _operating_point(
+            y_test, proba_test_raw, _LEAKED_SC_THRESHOLD
+        ),
+        "corrected_test_operating_point": _operating_point(
+            y_test, proba_test_raw, corrected_threshold
+        ),
+        "note": "F2 threshold selected on val-2024 raw scores; both operating points on 2025 test. "
+        "val-2024 has few SC positives so the corrected point is high-variance - the collapse is the "
+        "evidence that the leaked operating point was test-overfit",
+    }
+
+
+def sc_window_sensitivity() -> dict[str, Any] | None:
+    """Show the SC target window (3/5/7) cannot be honestly retro-selected, and caveat it.
+
+    N14 chose the window by comparing three separately-trained models on
+    test-2025 (the leak); only the winning 3-lap model is persisted, so the
+    window CANNOT be re-selected on val without retraining the 5/7-lap models
+    (out of scope). As supporting evidence this reports the persisted 3-lap
+    model's AUC-PR against each target window on val-2024 vs test-2025 - a
+    single-model sensitivity check, NOT the original 3-model selection - which
+    shows the metric is window-unstable. The paper's honest position: report the
+    threshold-free AUC-PR WITH the caveat that its window was test-selected.
+    Returns ``None`` if the holdout is absent.
+    """
+    from sklearn.metrics import average_precision_score
+
+    from src.strategy.eval.calibration import _sc_frame_and_proba
+
+    val = _sc_frame_and_proba(2024)
+    test = _sc_frame_and_proba(2025)
+    if val is None or test is None:
+        return None
+
+    val_frame, val_proba, _ = val
+    test_frame, test_proba, _ = test
+    per_window = {}
+    for target in _SC_TARGETS:
+        per_window[target] = {
+            "val_2024_auc_pr": round(
+                float(average_precision_score(val_frame[target].astype(int), val_proba)), 4
+            ),
+            "test_2025_auc_pr": round(
+                float(average_precision_score(test_frame[target].astype(int), test_proba)), 4
+            ),
+        }
+    return {
+        "persisted_model_target": "sc_within_3_laps",
+        "per_window_auc_pr": per_window,
+        "retro_selectable": False,
+        "note": "only the 3-lap model is persisted; the 5/7-lap models needed to re-select the window "
+        "on val are not on disk (retraining out of scope). The reported SC AUC-PR 0.0723 keeps the "
+        "caveat that its window was test-selected; the table is single-model sensitivity, not the "
+        "original 3-model selection",
+    }
+
+
+def _render_overtake_correction(correction: dict[str, Any] | None) -> list[str]:
+    """Markdown block for the overtake threshold correction (F1-selected)."""
+    lines = ["## Correction (overtake threshold)", ""]
+    if correction is None:
+        return [*lines, "- holdout absent on disk; correction not computed this run"]
+    leaked = correction["leaked_test_operating_point"]
+    fixed = correction["corrected_test_operating_point"]
+    return [
+        *lines,
+        f"- leaked threshold {correction['leaked_threshold']} (selected on test): "
+        f"P {leaked['precision']} / R {leaked['recall']} / F1 {leaked['f1']} on 2025 test",
+        f"- corrected threshold {correction['corrected_threshold']} (selected on val-2024): "
+        f"P {fixed['precision']} / R {fixed['recall']} / F1 {fixed['f1']} on 2025 test",
+        f"- {correction['note']}",
+    ]
+
+
+def _render_sc_correction(correction: dict[str, Any] | None) -> list[str]:
+    """Markdown block for the SC threshold correction (F2-selected, sparse-val caveat)."""
+    lines = ["## Correction (safety-car threshold)", ""]
+    if correction is None:
+        return [*lines, "- holdout absent on disk; correction not computed this run"]
+    leaked = correction["leaked_test_operating_point"]
+    fixed = correction["corrected_test_operating_point"]
+    return [
+        *lines,
+        f"- leaked threshold {correction['leaked_threshold']} (F2 on test): "
+        f"P {leaked['precision']} / R {leaked['recall']} / F2 {leaked['f2']} on 2025 test",
+        f"- corrected threshold {correction['corrected_threshold']} (F2 on val-2024, "
+        f"{correction['val_positive_count']}/{correction['val_size']} positive): "
+        f"P {fixed['precision']} / R {fixed['recall']} / F2 {fixed['f2']} on 2025 test",
+        f"- {correction['note']}",
+    ]
+
+
+def _render_sc_window(window: dict[str, Any] | None) -> list[str]:
+    """Markdown block for the SC target-window sensitivity + retro-selection caveat."""
+    lines = ["## Correction (safety-car target window)", ""]
+    if window is None:
+        return [*lines, "- holdout absent on disk; sensitivity not computed this run"]
+    lines += [
+        "| window | val-2024 AUC-PR | test-2025 AUC-PR |",
+        "|---|---|---|",
+    ]
+    for target, aucs in window["per_window_auc_pr"].items():
+        lines.append(f"| {target} | {aucs['val_2024_auc_pr']} | {aucs['test_2025_auc_pr']} |")
+    return [*lines, "", f"- {window['note']}"]
+
+
+def _render(
+    findings: list[ProvenanceEntry],
+    correction: dict[str, Any] | None,
+    sc_correction: dict[str, Any] | None,
+    sc_window: dict[str, Any] | None,
+) -> str:
+    """Render the hygiene report: verdict table + corrections + paper conclusion."""
     header = "| item | kind | model | verdict | selection | evidence |"
     rule = "|---|---|---|---|---|---|"
     order = {CONTAMINATED: 0, UNDERDOCUMENTED: 1, CLEAN: 2}
@@ -200,19 +357,10 @@ def _render(findings: list[ProvenanceEntry], correction: dict[str, Any] | None) 
         for f in ordered
     ]
 
-    lines = [header, rule, *rows, "", "## Correction (overtake threshold)", ""]
-    if correction is None:
-        lines.append("- holdout absent on disk; correction not computed this run")
-    else:
-        leaked = correction["leaked_test_operating_point"]
-        fixed = correction["corrected_test_operating_point"]
-        lines += [
-            f"- leaked threshold {correction['leaked_threshold']} (selected on test): "
-            f"P {leaked['precision']} / R {leaked['recall']} / F1 {leaked['f1']} on 2025 test",
-            f"- corrected threshold {correction['corrected_threshold']} (selected on val-2024): "
-            f"P {fixed['precision']} / R {fixed['recall']} / F1 {fixed['f1']} on 2025 test",
-            f"- {correction['note']}",
-        ]
+    lines = [header, rule, *rows, ""]
+    lines += _render_overtake_correction(correction)
+    lines += ["", *_render_sc_correction(sc_correction)]
+    lines += ["", *_render_sc_window(sc_window)]
 
     contaminated = [f for f in findings if f.verdict == CONTAMINATED]
     lines += [
@@ -222,14 +370,16 @@ def _render(findings: list[ProvenanceEntry], correction: dict[str, Any] | None) 
         f"- {len(contaminated)} contaminated items (overtake threshold; safety-car threshold + window). "
         "All other thresholds and aggregate features are clean or non-target.",
         "- **Overtake headline clears**: AUC-PR 0.5491 / AUC-ROC 0.8758 are threshold-free and involve no "
-        "window selection; the threshold leakage touches only their operating point.",
-        "- **Safety-car headline is optimistic, NOT clean**: AUC-PR 0.0723 is the max-lift window among "
-        "{3,5,7} laps selected on test-2025, so the reported number is itself selection-biased (a max over "
-        "3 candidates on test), on top of the operating-point threshold leakage.",
-        "- **Action before freeze**: (1) re-select the overtake + SC operating thresholds on val-2024 "
-        "(the undercut N16 pattern) - the overtake correction above shows the honest operating point; "
-        "(2) re-select the SC target window on the CV/val split (not test) and re-report SC AUC-PR, or "
-        "caveat it as test-selected; (3) pin a year filter in N03 `load_all_races` to close the "
+        "window selection; the threshold leakage touches only their operating point, corrected above.",
+        "- **Safety-car operating threshold is NOT robustly recoverable**: re-selecting on val-2024 "
+        "collapses the operating point (val-2024 has too few SC positives), which is itself the evidence "
+        "that the leaked 0.2335 was test-overfit. The paper should report SC threshold-free and not claim "
+        "a fixed operating threshold.",
+        "- **Safety-car window cannot be retro-selected**: only the 3-lap model is persisted, so the "
+        "{3,5,7}-lap window selected on test-2025 cannot be honestly re-chosen without retraining the "
+        "5/7-lap models. The reported SC AUC-PR 0.0723 therefore keeps an explicit test-window-selected "
+        "caveat.",
+        "- **Remaining action before freeze**: pin a year filter in N03 `load_all_races` to close the "
         "circuit_cluster underdocumentation.",
         "- Every other headline (undercut 0.6739, pit 0.487, pace 0.4104, tire 0.7078, sentiment 0.84) is "
         "unaffected by these findings.",
@@ -238,12 +388,21 @@ def _render(findings: list[ProvenanceEntry], correction: dict[str, Any] | None) 
 
 
 def build_hygiene_report() -> dict[str, Any]:
-    """Regenerate the signed hygiene report (the #207 deliverable)."""
+    """Regenerate the signed hygiene report (the #207 / #363 deliverable)."""
     findings = audit_findings()
     correction = correct_overtake_threshold()
-    header = build_header(dataset="notebooks/strategy audit + 2024/2025 overtake holdout")
-    payload = {"findings": [asdict(f) for f in findings], "overtake_correction": correction}
-    md_path, json_path = write_report(HYGIENE_NAME, header, _render(findings, correction), payload)
+    sc_correction = correct_sc_threshold()
+    sc_window = sc_window_sensitivity()
+    header = build_header(dataset="notebooks/strategy audit + 2024/2025 overtake & SC holdouts")
+    payload = {
+        "findings": [asdict(f) for f in findings],
+        "overtake_correction": correction,
+        "sc_correction": sc_correction,
+        "sc_window_sensitivity": sc_window,
+    }
+    md_path, json_path = write_report(
+        HYGIENE_NAME, header, _render(findings, correction, sc_correction, sc_window), payload
+    )
     return {
         "header": asdict(header),
         "md_path": str(md_path),

--- a/src/strategy/eval/nlp.py
+++ b/src/strategy/eval/nlp.py
@@ -22,8 +22,13 @@ Stage status this phase:
   would mean a live bug). ``src/agents`` is untouchable; the harness only records
   the verdict.
 - **NR-07** (dead NER classes) - entity types the frozen NER eval predicts at
-  ~0 B-F1 are flagged untrustworthy; the #304 NER stage re-measures them.
-- **NER F1 / RCM / alert precision** - pending (#304 phases).
+  ~0 B-F1 are flagged untrustworthy, separately from the NER score below.
+- **ner** (BERT-bio) - entity-level micro-F1 reproduced with seqeval over the
+  annotation set, vs the frozen 0.4151 headline (#304).
+- **rcm** - the N23 rule-based classifier is ported into the harness and run
+  over the persisted 2025 RCM corpus; coverage (1 - OTHER-rate) per category vs
+  the frozen config (#304).
+- **alert precision** - pending a labeled alert ground-truth set (#304 phase 3).
 """
 
 from __future__ import annotations
@@ -43,7 +48,11 @@ _TOLERANCE = 0.03
 _SENTIMENT_BATCH = 32
 _INTENT_DIR = "intent_setfit_modernbert_v1"
 _NER_DIR = "ner_v1"
+_NER_PROD_MODEL = "bert_bio_v1"  # production NER model under ner_v1/
+_NER_HEADLINE_F1 = 0.4151  # frozen bert_large_conll03_bio entity-F1 (model_config)
+_NER_MAX_LEN = 128  # must match the N22 training config
 _DEAD_NER_F1 = 0.15  # entity types with frozen-eval B-F1 below this are flagged dead (NR-07)
+_RCM_CORPUS_GLOB = "race_radios/2025/*/rcm.parquet"  # persisted FastF1 RCM corpus
 
 
 @dataclass
@@ -336,6 +345,327 @@ def dead_ner_classes() -> tuple[list[str], StageResult]:
     return dead, StageResult("ner", "dead_classes", float(len(dead)), 0.0, "flagged", detail)
 
 
+def _load_ner_model() -> tuple[Any, Any, dict[int, str], str] | None:
+    """Load the production BERT-bio NER model (additive replica of radio_agent).
+
+    Mirrors ``radio_agent._load_ner_model`` but stays in the harness because
+    importing ``src.agents`` loads every NLP model at import time. The
+    checkpoint's classifier head is 19-label BIO; ``from_pretrained`` warns about
+    the base model's 9-label head, then ``load_state_dict`` overwrites it with
+    the trained weights. Returns ``(tokenizer, model, id2label, device)`` or
+    ``None`` when the artifacts are absent.
+    """
+    import torch
+    from transformers import AutoTokenizer, BertForTokenClassification
+
+    ner_dir = get_models_root() / "nlp" / _NER_DIR / _NER_PROD_MODEL
+    cfg_path = ner_dir / "model_config.json"
+    state_path = ner_dir / "bert_bio_state_dict.pt"
+    if not (cfg_path.exists() and state_path.exists()):
+        return None
+
+    cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+    label2id = cfg["label2id"]
+    id2label = {int(k): v for k, v in cfg["id2label"].items()}
+    base = cfg.get("model_name", "dbmdz/bert-large-cased-finetuned-conll03-english")
+    tokenizer = AutoTokenizer.from_pretrained(str(ner_dir), use_fast=True)
+    model = BertForTokenClassification.from_pretrained(
+        base, num_labels=len(label2id), ignore_mismatched_sizes=True
+    )
+    model.load_state_dict(torch.load(state_path, map_location="cpu", weights_only=False))
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model.to(device).eval()
+    return tokenizer, model, id2label, device
+
+
+def _ner_predicted_tags(
+    words: list[str], tokenizer: Any, model: Any, id2label: dict[int, str], device: str
+) -> list[str]:
+    """Word-level BIO tags for a pre-split word list (replica of the radio_agent decode).
+
+    Keeps only the first subword tag per word, mirroring
+    ``radio_agent._decode_word_tags`` so the harness scores the exact tags the
+    production pipeline would emit.
+    """
+    import torch
+
+    enc = tokenizer(
+        words,
+        is_split_into_words=True,
+        add_special_tokens=True,
+        max_length=_NER_MAX_LEN,
+        padding="max_length",
+        truncation=True,
+        return_tensors="pt",
+    )
+    word_ids = enc.word_ids(batch_index=0)
+    with torch.no_grad():
+        logits = (
+            model(
+                input_ids=enc["input_ids"].to(device),
+                attention_mask=enc["attention_mask"].to(device),
+            )
+            .logits[0]
+            .cpu()
+        )
+    predicted_ids = logits.argmax(dim=-1).tolist()
+    first_tag_per_word: dict[int, str] = {}
+    for token_i, word_i in enumerate(word_ids):
+        if word_i is not None and word_i not in first_tag_per_word:
+            first_tag_per_word[word_i] = id2label.get(predicted_ids[token_i], "O")
+    return [first_tag_per_word.get(i, "O") for i in range(len(words))]
+
+
+def _gold_bio_tags(text: str, entities: list) -> tuple[list[str], list[str]]:
+    """Convert char-offset gold entities to word-level BIO over ``text.split()``.
+
+    ``predict_entities`` splits on whitespace, so the gold tags must use the same
+    word boundaries to line up with the model's per-word predictions. A word is
+    tagged with an entity when its character span overlaps the gold span (B- on
+    the first overlapping word, I- after). Returns ``(words, gold_tags)``.
+    """
+    words = text.split()
+    offsets = []
+    cursor = 0
+    for word in words:
+        start = text.index(word, cursor)
+        offsets.append((start, start + len(word)))
+        cursor = start + len(word)
+
+    tags = ["O"] * len(words)
+    for entity in entities:
+        if not (isinstance(entity, (list, tuple)) and len(entity) == 3):
+            continue
+        char_start, char_end, label = entity
+        opening = True
+        for word_i, (word_start, word_end) in enumerate(offsets):
+            if word_start < char_end and word_end > char_start:
+                tags[word_i] = ("B-" if opening else "I-") + str(label)
+                opening = False
+    return words, tags
+
+
+def _iter_ner_annotations() -> list[tuple[str, list]]:
+    """``(text, gold_entities)`` pairs from the annotation set (radio_message as text).
+
+    Records whose ``annotations`` payload is malformed keep their text with an
+    empty gold set, so they still contribute to precision (a spurious prediction
+    on a no-entity message is a false positive).
+    """
+    path = get_data_root() / "processed" / "radio_nlp" / "f1_radio_entity_annotations.json"
+    if not path.exists():
+        return []
+    records = json.loads(path.read_text(encoding="utf-8"))
+    pairs = []
+    for record in records:
+        text = str(record.get("radio_message", ""))
+        annotation = record.get("annotations")
+        well_formed = (
+            isinstance(annotation, list)
+            and len(annotation) == 2
+            and isinstance(annotation[1], dict)
+        )
+        entities = annotation[1].get("entities", []) if well_formed else []
+        if text.strip():
+            pairs.append((text, entities))
+    return pairs
+
+
+def reproduce_ner() -> list[StageResult]:
+    """Reproduce BERT-bio entity-level micro-F1 on the annotation set (seqeval).
+
+    Full-set score (train+test), so it runs slightly optimistic vs the frozen
+    0.4151 headline; the 4 NR-07 dead classes stay in the score but are flagged
+    separately. Returns a ``pending`` row when the model or annotations are
+    absent.
+    """
+    from seqeval.metrics import f1_score, precision_score, recall_score
+
+    loaded = _load_ner_model()
+    pairs = _iter_ner_annotations()
+    if loaded is None or not pairs:
+        return [
+            StageResult(
+                "ner",
+                "entity_f1",
+                None,
+                _NER_HEADLINE_F1,
+                "pending",
+                "ner model or annotations absent",
+            )
+        ]
+
+    tokenizer, model, id2label, device = loaded
+    gold_seqs, pred_seqs = [], []
+    for text, entities in pairs:
+        words, gold = _gold_bio_tags(text, entities)
+        if not words:
+            continue
+        gold_seqs.append(gold)
+        pred_seqs.append(_ner_predicted_tags(words, tokenizer, model, id2label, device))
+
+    micro_f1 = float(f1_score(gold_seqs, pred_seqs))
+    precision = float(precision_score(gold_seqs, pred_seqs))
+    recall = float(recall_score(gold_seqs, pred_seqs))
+    dead, _ = dead_ner_classes()
+    detail = (
+        f"n={len(gold_seqs)}; micro entity-F1 (P {precision:.3f}/R {recall:.3f}); full-set optimistic; "
+        f"{len(dead)} dead classes flagged separately"
+    )
+    return [
+        StageResult(
+            "ner",
+            "entity_f1",
+            round(micro_f1, 4),
+            _NER_HEADLINE_F1,
+            _status(micro_f1, _NER_HEADLINE_F1),
+            detail,
+        )
+    ]
+
+
+def _classify_rcm_event(category: str, flag: Any, scope: Any, sector: Any, message: str) -> str:
+    """Rule-based RCM event classifier ported from N23 (``_classify_event``).
+
+    Reads the persisted lowercase RCM schema (category/flag/scope/sector/
+    message). The branch logic is identical to the N23 notebook parser and the
+    inlined ``radio_agent`` copy; only the field access is adapted to the
+    on-disk column names. Kept in the harness because importing ``radio_agent``
+    loads every NLP model.
+
+    --- WHERE TO CHANGE IF THE PARSER CHANGES ---
+    ``notebooks/nlp/N23_rcm_parser.ipynb`` (_classify_event) is the source of
+    truth; mirror any edit there into this port and the radio_agent copy.
+    """
+    import pandas as pd
+
+    cat = str(category).strip()
+    flag_up = str(flag).strip().upper()
+    msg = str(message).upper()
+
+    if cat == "SafetyCar":
+        if "VIRTUAL" in msg:
+            return (
+                "VIRTUAL_SAFETY_CAR_DEPLOYED" if "DEPLOYED" in msg else "VIRTUAL_SAFETY_CAR_ENDING"
+            )
+        if "DEPLOYED" in msg:
+            return "SAFETY_CAR_DEPLOYED"
+        if "PIT LANE" in msg or "IN THIS LAP" in msg:
+            return "SAFETY_CAR_IN_PIT_LANE"
+        if "ENDING" in msg or "WITHDRAWN" in msg:
+            return "SAFETY_CAR_ENDING"
+        return "OTHER"
+
+    if cat == "Flag":
+        if flag_up == "CHEQUERED" or "CHEQUERED" in msg:
+            return "CHEQUERED_FLAG"
+        if flag_up == "BLUE":
+            return "BLUE_FLAG"
+        if flag_up == "BLACK AND WHITE":
+            return "BLACK_AND_WHITE_FLAG"
+        if flag_up in ("VIRTUAL_SAFETY_CAR", "VSC"):
+            return "VIRTUAL_SAFETY_CAR_DEPLOYED"
+        if flag_up == "SAFETY_CAR":
+            return "SAFETY_CAR_DEPLOYED"
+        if flag_up == "RED" or "RED FLAG" in msg:
+            return "RED_FLAG"
+        if flag_up == "GREEN" or "GREEN FLAG" in msg:
+            return "GREEN_FLAG"
+        if flag_up == "CLEAR":
+            return "CLEAR_FLAG"
+        if flag_up in ("YELLOW", "DOUBLE YELLOW"):
+            if str(scope).strip() == "Sector" or pd.notna(sector):
+                return "YELLOW_FLAG_SECTOR"
+            return "YELLOW_FLAG"
+        return "OTHER"
+
+    if cat == "Drs":
+        return "DRS_ENABLED" if "ENABLED" in msg else "DRS_DISABLED"
+
+    if cat == "CarEvent":
+        if "RETIRED" in msg or "ABANDON" in msg:
+            return "CAR_RETIRED"
+        if "COLLISION" in msg or "CONTACT" in msg:
+            return "CAR_COLLISION"
+        if "MECHANICAL" in msg or "ENGINE" in msg or "GEARBOX" in msg:
+            return "CAR_MECHANICAL"
+        return "OTHER"
+
+    if cat == "Other":
+        if "DRS ENABLED" in msg:
+            return "DRS_ENABLED"
+        if "DRS DISABLED" in msg:
+            return "DRS_DISABLED"
+        if (
+            "TRACK LIMITS" in msg
+            or "TIME DELETED" in msg
+            or "LAP DELETED" in msg
+            or "DELETED" in msg
+        ):
+            return "LAP_DELETED"
+        if "UNDER INVESTIGATION" in msg or "FIA STEWARDS" in msg or "NOTED" in msg:
+            return "INVESTIGATION"
+        if "PENALTY" in msg or ("TIME" in msg and "SECOND" in msg):
+            return "TIME_PENALTY"
+        if "PIT EXIT" in msg or "PIT LANE" in msg:
+            return "PIT_EXIT"
+        track_surface = "TRACK" in msg and (
+            "CONDITION" in msg or "SLIPPERY" in msg or "SURFACE" in msg
+        )
+        other_surface = any(k in msg for k in ("DEBRIS", "FLUID", "LOW GRIP", "RAIN", "AWNING"))
+        if track_surface or other_surface:
+            return "TRACK_CONDITION"
+        if "LAPPED" in msg and "OVERTAKE" in msg:
+            return "LAPPED_CARS_OVERTAKE"
+        if "ALL CARS MAY OVERTAKE" in msg:
+            return "SAFETY_CAR_ENDING"
+        return "OTHER"
+
+    return "OTHER"
+
+
+def reproduce_rcm() -> list[StageResult]:
+    """Reproduce the RCM parser coverage (1 - OTHER-rate) per FastF1 category.
+
+    Runs the ported rule-based classifier over the persisted 2025 RCM corpus and
+    reports overall + per-category coverage against the frozen config
+    (Flag 1.0 / Other 0.928 / Drs 1.0 / SafetyCar 1.0). The corpus (all 2025
+    races) differs from the N23 sample, so the numbers are close but not
+    identical. Returns a ``pending`` row when the corpus is absent.
+    """
+    from collections import Counter
+
+    import pandas as pd
+
+    corpus = sorted((get_data_root() / "processed").glob(_RCM_CORPUS_GLOB))
+    if not corpus:
+        return [
+            StageResult("rcm", "coverage", None, None, "pending", "2025 rcm corpus absent on disk")
+        ]
+
+    total: Counter = Counter()
+    other: Counter = Counter()
+    for path in corpus:
+        df = pd.read_parquet(path)
+        for _, row in df.iterrows():
+            category = str(row["category"]).strip()
+            event = _classify_rcm_event(
+                row["category"], row["flag"], row["scope"], row["sector"], row["message"]
+            )
+            total[category] += 1
+            if event == "OTHER":
+                other[category] += 1
+
+    n = sum(total.values())
+    coverage = 1 - sum(other.values()) / n
+    per_category = ", ".join(f"{cat} {1 - other[cat] / total[cat]:.3f}" for cat in sorted(total))
+    detail = (
+        f"n={n} across {len(corpus)} 2025 races; per-category [{per_category}]; "
+        "vs config Flag 1.0/Other 0.928/Drs 1.0/SafetyCar 1.0 (N23 sample differs)"
+    )
+    return [StageResult("rcm", "coverage", round(coverage, 4), None, "reproduced", detail)]
+
+
 def _status(value: float, reference: float) -> str:
     """``reproduced`` when within tolerance of the reference number, else ``delta``."""
     return "reproduced" if abs(value - reference) <= _TOLERANCE else "delta"
@@ -344,22 +674,6 @@ def _status(value: float, reference: float) -> str:
 def _gated_stages() -> list[StageResult]:
     """The stages that cannot run this phase, each with its exact blocker (#304)."""
     return [
-        StageResult(
-            "ner",
-            "entity_f1",
-            None,
-            None,
-            "pending",
-            "BERT-bio entity-level F1 reproduction not wired this phase (#304)",
-        ),
-        StageResult(
-            "rcm",
-            "accuracy",
-            None,
-            None,
-            "pending",
-            "RCM parser reproduction not wired this phase (#304)",
-        ),
         StageResult(
             "alert_precision",
             "precision",
@@ -378,6 +692,8 @@ def collect_results() -> list[StageResult]:
         *reproduce_sentiment(),
         *reproduce_intent(),
         verify_intent_column_order(),
+        *reproduce_ner(),
+        *reproduce_rcm(),
         dead_row,
         *_gated_stages(),
     ]
@@ -407,9 +723,11 @@ def build_nlp_report() -> dict[str, Any]:
         / "sentiment_classifier_v1"
         / "best_roberta_sentiment.ckpt",
         "intent_head": models / "nlp" / _INTENT_DIR / "model_head.pkl",
+        "ner_bert_bio": models / "nlp" / _NER_DIR / _NER_PROD_MODEL / "bert_bio_state_dict.pt",
     }
     header = build_header(
-        dataset="radio_labeled_data.csv + intent_labeled_data.csv (fixed sets)", artifacts=artifacts
+        dataset="radio + intent labeled CSVs, entity annotations, 2025 RCM corpus",
+        artifacts=artifacts,
     )
     payload = {"results": [asdict(r) for r in results]}
     md_path, json_path = write_report(NLP_NAME, header, _render(results), payload)

--- a/src/strategy/eval/nlp.py
+++ b/src/strategy/eval/nlp.py
@@ -1,22 +1,29 @@
-"""NLP evaluation harness on the shared eval package (issue #304).
+"""NLP evaluation harness on the shared eval package (issues #303, #304).
 
 Per-stage evaluation of the radio NLP pipeline, built ON ``src/strategy/eval``
 (NOT a parallel harness - it reuses report.py's header + writer). This phase
-reproduces the RoBERTa sentiment stage on a fixed labeled set; the other stages
-are gated with their exact blocker, the same honest-delta convention the ML-eval
-harness (#206) uses.
+reproduces the sentiment and intent stages on fixed labeled sets, records the
+two #303 hygiene verdicts, and gates the stages not yet wired.
 
 Stage status this phase:
 - **sentiment** (RoBERTa) - reproduced over the fixed 530-row labeled radio set
   (accuracy + macro-F1), compared to the thesis-final 0.84 / macro-F1 0.75. The
-  labeled CSV is the full set (train+test), so the number is expected to run
-  optimistic vs the held-out 0.84; the held-out split is not pinned on disk.
-- **intent** (SetFit) - BLOCKED: setfit does not import under transformers 5.3.0
-  (#303), so the intent stage cannot be reproduced until that is fixed.
-- **NER / RCM** - pending: their model reconstruction is not wired this phase.
-- **alert precision** (the MoE-routing signal the orchestrator depends on) -
-  pending a labeled alert ground-truth set; none exists on disk today. This is
-  the metric #304 most wants and it is a data-collection task, not a code one.
+  labeled CSV is the full set (train+test), so the number runs optimistic vs the
+  held-out 0.84; the held-out split is not pinned on disk.
+- **intent** (SetFit ModernBERT) - reproduced SETFIT-FREE (#303). The deployed
+  model is a SentenceTransformer body + a pickled sklearn head; ``import setfit``
+  fails under transformers 5.3.0 (it imports ``default_logdir``, removed in 5.x),
+  so the harness classifies with the two pieces directly. accuracy + macro/
+  weighted-F1 on the full labeled set (optimistic vs the published 0.5934 test
+  weighted-F1).
+- **NR-08** (intent predict_proba order) - the production ``radio_agent`` decodes
+  ``predict_proba`` with the hardcoded ``intent_names`` tuple; verified aligned
+  with the head's class order, so there is no confidence swap (a ``flagged`` row
+  would mean a live bug). ``src/agents`` is untouchable; the harness only records
+  the verdict.
+- **NR-07** (dead NER classes) - entity types the frozen NER eval predicts at
+  ~0 B-F1 are flagged untrustworthy; the #304 NER stage re-measures them.
+- **NER F1 / RCM / alert precision** - pending (#304 phases).
 """
 
 from __future__ import annotations
@@ -31,18 +38,24 @@ from src.strategy.eval.report import build_header, write_report
 NLP_NAME = "nlp"
 _SENTIMENT_ACC = 0.84  # thesis-final RoBERTa accuracy
 _SENTIMENT_MACRO_F1 = 0.75  # thesis-final macro-F1
+_INTENT_PUBLISHED_WEIGHTED_F1 = 0.5934  # deployed SetFit ModernBERT test weighted-F1 (model_config)
 _TOLERANCE = 0.03
 _SENTIMENT_BATCH = 32
+_INTENT_DIR = "intent_setfit_modernbert_v1"
+_NER_DIR = "ner_v1"
+_DEAD_NER_F1 = 0.15  # entity types with frozen-eval B-F1 below this are flagged dead (NR-07)
 
 
 @dataclass
 class StageResult:
-    """One NLP stage measurement.
+    """One NLP stage measurement or hygiene verdict.
 
-    ``status`` is ``reproduced`` (within tolerance of the thesis number),
-    ``delta`` (measured but diverges - e.g. full-set vs held-out), ``blocked``
-    (a dependency prevents the stage from running at all), or ``pending`` (not
-    wired / no ground-truth this phase).
+    ``status`` is ``reproduced`` (a metric within tolerance of the reference, or
+    a hygiene verdict that clears), ``delta`` (measured but diverges - e.g.
+    full-set vs held-out), ``flagged`` (a hygiene finding the paper must
+    surface - NR-07 dead classes, an NR-08 swap), ``blocked`` (a dependency
+    prevents the stage from running at all), or ``pending`` (not wired / no
+    ground-truth this phase).
     """
 
     stage: str
@@ -155,29 +168,189 @@ def reproduce_sentiment() -> list[StageResult]:
     ]
 
 
+def _load_intent_setfit_free() -> tuple[Any, Any, dict[int, str]] | None:
+    """Load the intent classifier WITHOUT importing setfit (#303 blocker).
+
+    The deployed intent model is a SentenceTransformer body + a pickled sklearn
+    ``LogisticRegression`` head. ``import setfit`` fails under transformers 5.3.0
+    (it imports ``default_logdir``, removed in 5.x), so the harness reconstructs
+    the two pieces directly: encode with the SentenceTransformer, classify with
+    the head. Returns ``(sentence_transformer, head, idx_to_name)`` or ``None``
+    when the artifacts are absent.
+    """
+    import joblib
+    from sentence_transformers import SentenceTransformer
+
+    model_dir = get_models_root() / "nlp" / _INTENT_DIR
+    head_path = model_dir / "model_head.pkl"
+    cfg_path = model_dir / "model_config.json"
+    if not (head_path.exists() and cfg_path.exists() and (model_dir / "config.json").exists()):
+        return None
+
+    mapping = json.loads(cfg_path.read_text(encoding="utf-8"))["intent_mapping"]
+    idx_to_name = {v: k for k, v in mapping.items()}
+    st = SentenceTransformer(str(model_dir))
+    head = joblib.load(head_path)
+    return st, head, idx_to_name
+
+
+def reproduce_intent() -> list[StageResult]:
+    """Reproduce intent accuracy + macro/weighted-F1 on the fixed labeled set.
+
+    Setfit-free (see ``_load_intent_setfit_free``). The labeled CSV is the full
+    train+test set, so the numbers run optimistic vs the deployed model's
+    published test weighted-F1 (0.5934); the held-out split is not pinned on
+    disk. Only ``weighted_f1`` has a published anchor; accuracy + macro-F1 are
+    new measurements with no thesis reference. Returns a ``pending`` row when the
+    artifacts or CSV are absent.
+    """
+    from sklearn.metrics import accuracy_score, f1_score
+
+    loaded = _load_intent_setfit_free()
+    labeled = get_data_root() / "processed" / "radio_nlp" / "intent_labeled_data.csv"
+    if loaded is None or not labeled.exists():
+        return [
+            StageResult(
+                "intent",
+                "accuracy",
+                None,
+                None,
+                "pending",
+                "intent model or intent_labeled_data.csv absent",
+            )
+        ]
+
+    import pandas as pd
+
+    st, head, idx_to_name = loaded
+    df = pd.read_csv(labeled)
+    texts = df["message"].astype(str).tolist()
+    y_true = df["intent"].tolist()
+    embeddings = st.encode(texts, show_progress_bar=False)
+    preds = [idx_to_name[int(c)] for c in head.predict(embeddings)]
+
+    accuracy = float(accuracy_score(y_true, preds))
+    macro_f1 = float(f1_score(y_true, preds, average="macro"))
+    weighted_f1 = float(f1_score(y_true, preds, average="weighted"))
+    n = len(y_true)
+    caveat = "full labeled set (train+test); optimistic vs the published 0.5934 test weighted-F1"
+    return [
+        StageResult(
+            "intent", "accuracy", round(accuracy, 4), None, "reproduced", f"n={n}; {caveat}"
+        ),
+        StageResult(
+            "intent",
+            "macro_f1",
+            round(macro_f1, 4),
+            None,
+            "reproduced",
+            f"n={n}; 5-class, no anchor",
+        ),
+        StageResult(
+            "intent",
+            "weighted_f1",
+            round(weighted_f1, 4),
+            _INTENT_PUBLISHED_WEIGHTED_F1,
+            _status(weighted_f1, _INTENT_PUBLISHED_WEIGHTED_F1),
+            f"n={n}; vs deployed test weighted-F1 (full-set optimistic)",
+        ),
+    ]
+
+
+def verify_intent_column_order() -> StageResult:
+    """NR-08: verify the production ``predict_proba`` decode reads the right class.
+
+    ``radio_agent.predict_intent`` decodes ``predict_proba(...)[label_idx]`` with
+    ``label_idx`` from the hardcoded ``intent_names`` order. That is correct only
+    if the head's ``classes_`` columns line up with ``intent_names`` via
+    ``intent_mapping``. This loads ONLY the 30 KB head + config (not the 568 MB
+    encoder) and checks the alignment column-by-column. ``reproduced`` = fully
+    aligned (no confidence swap); ``flagged`` = a live confidence-swap bug.
+    """
+    import joblib
+
+    model_dir = get_models_root() / "nlp" / _INTENT_DIR
+    head_path = model_dir / "model_head.pkl"
+    cfg_path = model_dir / "model_config.json"
+    if not (head_path.exists() and cfg_path.exists()):
+        return StageResult(
+            "intent", "predict_proba_order", None, 1.0, "pending", "intent head/config absent"
+        )
+
+    cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+    intent_names = cfg["intent_names"]
+    inverse = {v: k for k, v in cfg["intent_mapping"].items()}
+    classes = [int(c) for c in joblib.load(head_path).classes_]
+
+    if len(classes) != len(intent_names):
+        return StageResult(
+            "intent",
+            "predict_proba_order",
+            0.0,
+            1.0,
+            "flagged",
+            f"head has {len(classes)} classes vs {len(intent_names)} intent_names",
+        )
+
+    aligned = sum(1 for pos, name in enumerate(intent_names) if inverse.get(classes[pos]) == name)
+    fraction = aligned / len(intent_names)
+    swap_note = "no swap" if aligned == len(intent_names) else "CONFIDENCE SWAP - live bug"
+    return StageResult(
+        "intent",
+        "predict_proba_order",
+        round(fraction, 4),
+        1.0,
+        "reproduced" if aligned == len(intent_names) else "flagged",
+        f"head.classes_={classes} map to intent_names via intent_mapping; "
+        f"{aligned}/{len(intent_names)} columns aligned ({swap_note})",
+    )
+
+
+def dead_ner_classes() -> tuple[list[str], StageResult]:
+    """NR-07: flag NER entity types the frozen model predicts at ~0 B-F1.
+
+    Annotation support is balanced, so "dead" is a MODEL failure, not a data
+    gap: the production NER model_config's per-class B-F1 (from the training
+    eval) exposes types the model never gets right. Those must not be surfaced
+    as reliable; the #304 NER stage re-measures them. Returns
+    ``(dead_type_names, flag_row)``.
+    """
+    cfg_path = get_models_root() / "nlp" / _NER_DIR / "model_config.json"
+    if not cfg_path.exists():
+        return [], StageResult(
+            "ner", "dead_classes", None, None, "pending", "ner model_config absent"
+        )
+
+    cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+    per_class = cfg["results"]["bert_large_conll03_bio"]["per_class_f1"]
+    dead = []
+    for etype in cfg["entity_types"]:
+        b_f1 = per_class.get("B-" + etype.upper().replace(" ", "_"))
+        if b_f1 is not None and b_f1 < _DEAD_NER_F1:
+            dead.append(etype)
+
+    detail = (
+        f"{len(dead)} entity types with frozen-eval B-F1 < {_DEAD_NER_F1} "
+        f"({', '.join(dead) or 'none'}); suppressed as untrustworthy, re-measured in #304"
+    )
+    return dead, StageResult("ner", "dead_classes", float(len(dead)), 0.0, "flagged", detail)
+
+
 def _status(value: float, reference: float) -> str:
-    """``reproduced`` when within tolerance of the thesis number, else ``delta``."""
+    """``reproduced`` when within tolerance of the reference number, else ``delta``."""
     return "reproduced" if abs(value - reference) <= _TOLERANCE else "delta"
 
 
 def _gated_stages() -> list[StageResult]:
-    """The stages that cannot run this phase, each with its exact blocker."""
+    """The stages that cannot run this phase, each with its exact blocker (#304)."""
     return [
-        StageResult(
-            "intent",
-            "accuracy",
-            None,
-            None,
-            "blocked",
-            "setfit does not import under transformers 5.3.0 (#303); stage cannot run",
-        ),
         StageResult(
             "ner",
             "entity_f1",
             None,
             None,
             "pending",
-            "GLiNER/BERT reconstruction not wired this phase",
+            "BERT-bio entity-level F1 reproduction not wired this phase (#304)",
         ),
         StageResult(
             "rcm",
@@ -185,7 +358,7 @@ def _gated_stages() -> list[StageResult]:
             None,
             None,
             "pending",
-            "RCM classifier reconstruction not wired this phase",
+            "RCM parser reproduction not wired this phase (#304)",
         ),
         StageResult(
             "alert_precision",
@@ -193,20 +366,27 @@ def _gated_stages() -> list[StageResult]:
             None,
             None,
             "pending",
-            "no labeled alert ground-truth on disk (the MoE-routing metric #304 targets; data-collection task)",
+            "no labeled alert ground-truth on disk (the MoE-routing metric #304 targets; data task)",
         ),
     ]
 
 
 def collect_results() -> list[StageResult]:
-    """All NLP stage results: reproduced sentiment first, then gated stages."""
-    return [*reproduce_sentiment(), *_gated_stages()]
+    """All NLP stage results: reproduced stages, the #303 hygiene verdicts, then gated stages."""
+    _dead, dead_row = dead_ner_classes()
+    return [
+        *reproduce_sentiment(),
+        *reproduce_intent(),
+        verify_intent_column_order(),
+        dead_row,
+        *_gated_stages(),
+    ]
 
 
 def _render(results: list[StageResult]) -> str:
-    """Render the NLP eval as a markdown table, runnable stages first."""
-    order = {"delta": 0, "reproduced": 1, "blocked": 2, "pending": 3}
-    ordered = sorted(results, key=lambda r: order.get(r.status, 4))
+    """Render the NLP eval as a markdown table, findings + runnable stages first."""
+    order = {"flagged": 0, "delta": 1, "reproduced": 2, "blocked": 3, "pending": 4}
+    ordered = sorted(results, key=lambda r: order.get(r.status, 5))
     header = "| stage | metric | value | reference | status | detail |"
     rule = "|---|---|---|---|---|---|"
     rows = []
@@ -218,11 +398,18 @@ def _render(results: list[StageResult]) -> str:
 
 
 def build_nlp_report() -> dict[str, Any]:
-    """Regenerate the NLP eval report (the #304 deliverable)."""
+    """Regenerate the NLP eval report (the #303/#304 deliverable)."""
     results = collect_results()
-    ckpt = get_models_root() / "nlp" / "sentiment_classifier_v1" / "best_roberta_sentiment.ckpt"
+    models = get_models_root()
+    artifacts = {
+        "roberta_sentiment": models
+        / "nlp"
+        / "sentiment_classifier_v1"
+        / "best_roberta_sentiment.ckpt",
+        "intent_head": models / "nlp" / _INTENT_DIR / "model_head.pkl",
+    }
     header = build_header(
-        dataset="radio_labeled_data.csv (fixed set)", artifacts={"roberta_sentiment": ckpt}
+        dataset="radio_labeled_data.csv + intent_labeled_data.csv (fixed sets)", artifacts=artifacts
     )
     payload = {"results": [asdict(r) for r in results]}
     md_path, json_path = write_report(NLP_NAME, header, _render(results), payload)

--- a/src/strategy/eval/nlp.py
+++ b/src/strategy/eval/nlp.py
@@ -28,7 +28,10 @@ Stage status this phase:
 - **rcm** - the N23 rule-based classifier is ported into the harness and run
   over the persisted 2025 RCM corpus; coverage (1 - OTHER-rate) per category vs
   the frozen config (#304).
-- **alert precision** - pending a labeled alert ground-truth set (#304 phase 3).
+- **alert precision** - the MoE-routing signal the audit names: a radio alert is
+  raised when the predicted intent is PROBLEM/WARNING. The intent set is
+  hand-labeled, so the alert ground truth already exists; precision is real, not
+  an LLM proxy (#304).
 """
 
 from __future__ import annotations
@@ -53,6 +56,7 @@ _NER_HEADLINE_F1 = 0.4151  # frozen bert_large_conll03_bio entity-F1 (model_conf
 _NER_MAX_LEN = 128  # must match the N22 training config
 _DEAD_NER_F1 = 0.15  # entity types with frozen-eval B-F1 below this are flagged dead (NR-07)
 _RCM_CORPUS_GLOB = "race_radios/2025/*/rcm.parquet"  # persisted FastF1 RCM corpus
+_ALERT_INTENTS = ("PROBLEM", "WARNING")  # radio_agent.CFG.alert_intents (the alert channel)
 
 
 @dataclass
@@ -203,21 +207,43 @@ def _load_intent_setfit_free() -> tuple[Any, Any, dict[int, str]] | None:
     return st, head, idx_to_name
 
 
-def reproduce_intent() -> list[StageResult]:
+def _intent_predictions() -> tuple[list[str], list[str]] | None:
+    """``(y_true, preds)`` for the intent labeled set, computed once (setfit-free).
+
+    Shared by ``reproduce_intent`` and ``reproduce_alert_precision`` so the
+    568 MB encoder loads and encodes the 529 messages a single time per report.
+    Returns ``None`` when the model or CSV is absent.
+    """
+    import pandas as pd
+
+    loaded = _load_intent_setfit_free()
+    labeled = get_data_root() / "processed" / "radio_nlp" / "intent_labeled_data.csv"
+    if loaded is None or not labeled.exists():
+        return None
+
+    st, head, idx_to_name = loaded
+    df = pd.read_csv(labeled)
+    texts = df["message"].astype(str).tolist()
+    y_true = df["intent"].tolist()
+    preds = [idx_to_name[int(c)] for c in head.predict(st.encode(texts, show_progress_bar=False))]
+    return y_true, preds
+
+
+def reproduce_intent(predictions: tuple[list[str], list[str]] | None = None) -> list[StageResult]:
     """Reproduce intent accuracy + macro/weighted-F1 on the fixed labeled set.
 
     Setfit-free (see ``_load_intent_setfit_free``). The labeled CSV is the full
     train+test set, so the numbers run optimistic vs the deployed model's
     published test weighted-F1 (0.5934); the held-out split is not pinned on
     disk. Only ``weighted_f1`` has a published anchor; accuracy + macro-F1 are
-    new measurements with no thesis reference. Returns a ``pending`` row when the
-    artifacts or CSV are absent.
+    new measurements with no thesis reference. ``predictions`` may be supplied to
+    reuse a shared inference pass; otherwise it is computed. Returns a
+    ``pending`` row when the artifacts or CSV are absent.
     """
     from sklearn.metrics import accuracy_score, f1_score
 
-    loaded = _load_intent_setfit_free()
-    labeled = get_data_root() / "processed" / "radio_nlp" / "intent_labeled_data.csv"
-    if loaded is None or not labeled.exists():
+    data = predictions if predictions is not None else _intent_predictions()
+    if data is None:
         return [
             StageResult(
                 "intent",
@@ -229,15 +255,7 @@ def reproduce_intent() -> list[StageResult]:
             )
         ]
 
-    import pandas as pd
-
-    st, head, idx_to_name = loaded
-    df = pd.read_csv(labeled)
-    texts = df["message"].astype(str).tolist()
-    y_true = df["intent"].tolist()
-    embeddings = st.encode(texts, show_progress_bar=False)
-    preds = [idx_to_name[int(c)] for c in head.predict(embeddings)]
-
+    y_true, preds = data
     accuracy = float(accuracy_score(y_true, preds))
     macro_f1 = float(f1_score(y_true, preds, average="macro"))
     weighted_f1 = float(f1_score(y_true, preds, average="weighted"))
@@ -263,6 +281,50 @@ def reproduce_intent() -> list[StageResult]:
             _status(weighted_f1, _INTENT_PUBLISHED_WEIGHTED_F1),
             f"n={n}; vs deployed test weighted-F1 (full-set optimistic)",
         ),
+    ]
+
+
+def reproduce_alert_precision(
+    predictions: tuple[list[str], list[str]] | None = None,
+) -> list[StageResult]:
+    """Precision of the radio alert channel (intent in PROBLEM/WARNING), from gold labels.
+
+    This is the MoE-routing signal the audit (#304) names as "never measured":
+    ``radio_agent`` raises a radio alert exactly when the predicted intent is in
+    ``CFG.alert_intents`` (PROBLEM, WARNING). The intent CSV is hand-labeled, so
+    the alert ground truth already exists - a real precision, not an LLM proxy.
+    Full-set (train+test), so it runs optimistic vs a held-out split (not pinned
+    on disk), the same caveat as the other stages. Returns a ``pending`` row when
+    the model or CSV is absent.
+    """
+    from sklearn.metrics import f1_score, precision_score, recall_score
+
+    data = predictions if predictions is not None else _intent_predictions()
+    if data is None:
+        return [
+            StageResult(
+                "alert_precision",
+                "precision",
+                None,
+                None,
+                "pending",
+                "intent model or intent_labeled_data.csv absent",
+            )
+        ]
+
+    y_true, preds = data
+    gold_alert = [1 if label in _ALERT_INTENTS else 0 for label in y_true]
+    pred_alert = [1 if label in _ALERT_INTENTS else 0 for label in preds]
+    precision = float(precision_score(gold_alert, pred_alert, zero_division=0))
+    recall = float(recall_score(gold_alert, pred_alert, zero_division=0))
+    f1 = float(f1_score(gold_alert, pred_alert, zero_division=0))
+    n_alerts = sum(gold_alert)
+    detail = (
+        f"n={len(y_true)} ({n_alerts} gold alerts); radio PROBLEM/WARNING channel from hand-labeled "
+        f"gold intent; R {recall:.3f}/F1 {f1:.3f}; full-set optimistic"
+    )
+    return [
+        StageResult("alert_precision", "precision", round(precision, 4), None, "reproduced", detail)
     ]
 
 
@@ -672,25 +734,21 @@ def _status(value: float, reference: float) -> str:
 
 
 def _gated_stages() -> list[StageResult]:
-    """The stages that cannot run this phase, each with its exact blocker (#304)."""
-    return [
-        StageResult(
-            "alert_precision",
-            "precision",
-            None,
-            None,
-            "pending",
-            "no labeled alert ground-truth on disk (the MoE-routing metric #304 targets; data task)",
-        ),
-    ]
+    """Stages that cannot run this phase. Empty after #304: every NLP stage now reproduces.
+
+    Kept as the documented extension point for a future gated NLP metric.
+    """
+    return []
 
 
 def collect_results() -> list[StageResult]:
     """All NLP stage results: reproduced stages, the #303 hygiene verdicts, then gated stages."""
+    intent_predictions = _intent_predictions()
     _dead, dead_row = dead_ner_classes()
     return [
         *reproduce_sentiment(),
-        *reproduce_intent(),
+        *reproduce_intent(intent_predictions),
+        *reproduce_alert_precision(intent_predictions),
         verify_intent_column_order(),
         *reproduce_ner(),
         *reproduce_rcm(),

--- a/src/strategy/eval/pit_holdout.py
+++ b/src/strategy/eval/pit_holdout.py
@@ -1,0 +1,174 @@
+"""Pit-duration holdout regeneration from raw laps (#364).
+
+``pit_labeled/`` is empty on disk, so unlike SC/undercut the pit holdout must be
+rebuilt from the raw FastF1 laps (``data/raw/<year>/<circuit>/laps.parquet``).
+This ports the N15 pipeline verbatim (pair pit-in lap N with pit-out lap N+1 ->
+pit_duration_s; filter drive-throughs + non-normal stops; per-circuit traversal
+from train; physical_stop_est; per-team-year median) and returns the deployed
+HistGBT P05/P50/P95 quantile models to score it.
+
+The raw circuit directory name is used as the ``circuit`` key: it is bijective
+with N15's ``GP_Name`` (one directory = one race = one GP), and the traversal is
+recomputed per key from train, so the physical_stop_est is identical to N15's.
+The only GP-name dependency (the 3 tight-pit-box circuits) is mapped explicitly.
+
+--- WHERE TO CHANGE IF THE PIT PIPELINE CHANGES ---
+notebooks/strategy/pit_prediction/N15_pit_duration.ipynb (cells 4/11/12/17) is
+the source of truth; mirror any edit here. Validated: P50 MAE 0.4893 vs the
+published 0.487 (delta 0.0023, within tolerance).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from src.f1_strat_manager.data_cache import get_data_root, get_models_root
+
+_PIT_DIR = "pit_prediction"
+_COMPOUND_ORDER = {"SOFT": 0, "MEDIUM": 1, "HARD": 2, "INTERMEDIATE": 3, "WET": 4}
+_SC_STATUSES = set("4567")  # TrackStatus digits meaning SC / VSC / red
+_TIGHT_DIRS = {"Monaco", "Marina_Bay", "Budapest"}  # Monaco / Singapore / Hungarian GP
+_STOP_MIN_S, _STOP_MAX_S = 2.0, 4.5  # normal physical stop window (N15)
+_RAW_MIN_S, _RAW_MAX_S = 15.0, 60.0  # raw pit_duration_s filter (N15 filter_pit_stops)
+_PHYSICAL_STOP_FLOOR = 1.5
+_TRAIN_YEARS = (2023, 2024)
+_TARGET = "physical_stop_est"
+
+
+def _collect_pit_stops(pd: Any) -> Any:
+    """Pair pit-in lap N with pit-out lap N+1 from raw laps -> one row per stop.
+
+    Reproduces N15 collect_pit_data over the on-disk laps instead of a FastF1
+    fetch. Filters drive-throughs (TyreLife_out <= 5) and keeps the raw
+    pit_duration_s in [15, 60] s.
+    """
+    raw_root = get_data_root() / "raw"
+    records = []
+    for laps_path in sorted(raw_root.glob("*/*/laps.parquet")):
+        circuit = laps_path.parent.name
+        year = int(laps_path.parent.parent.name)
+        laps = pd.read_parquet(laps_path)
+        needed = {
+            "Driver",
+            "Team",
+            "LapNumber",
+            "Compound",
+            "TyreLife",
+            "PitInTime",
+            "PitOutTime",
+            "TrackStatus",
+        }
+        if not needed <= set(laps.columns):
+            continue
+        pit_in = laps[laps["PitInTime"].notna()][
+            ["Driver", "Team", "LapNumber", "Compound", "TyreLife", "PitInTime", "TrackStatus"]
+        ].copy()
+        pit_out = laps[laps["PitOutTime"].notna()][
+            ["Driver", "LapNumber", "PitOutTime", "TyreLife"]
+        ].copy()
+        pit_in["LapNumber_out"] = pit_in["LapNumber"] + 1
+        merged = pit_in.merge(
+            pit_out.rename(columns={"LapNumber": "LapNumber_out", "TyreLife": "TyreLife_out"}),
+            on=["Driver", "LapNumber_out"],
+            how="inner",
+        )
+        merged["pit_duration_s"] = (merged["PitOutTime"] - merged["PitInTime"]).dt.total_seconds()
+        merged = merged[merged["TyreLife_out"] <= 5].copy()
+        merged["year"] = year
+        merged["circuit"] = circuit
+        records.append(merged)
+    if not records:
+        return pd.DataFrame()
+    stops = pd.concat(records, ignore_index=True)
+    return stops[(stops["pit_duration_s"] >= _RAW_MIN_S) & (stops["pit_duration_s"] <= _RAW_MAX_S)]
+
+
+def _engineer(stops: Any) -> Any:
+    """Add the N15 model features (compound_id, tyre_life_in, under_sc, compound_change, ...)."""
+    out = stops.copy()
+    out["Compound"] = out["Compound"].str.upper().str.strip()
+    out["compound_id"] = out["Compound"].map(_COMPOUND_ORDER).fillna(-1).astype(int)
+    out["tyre_life_in"] = out["TyreLife"].clip(upper=50).fillna(0).astype(float)
+    out["team"] = out["Team"].astype(str).str.strip()
+    out["lap_number"] = out["LapNumber"].fillna(0).astype(int)
+    out["under_sc"] = (
+        out["TrackStatus"].astype(str).apply(lambda s: int(any(c in _SC_STATUSES for c in s)))
+    ).astype(int)
+    out["tight_pit_box"] = out["circuit"].isin(_TIGHT_DIRS).astype(int)
+    out = out.sort_values(["year", "circuit", "Driver", "LapNumber"]).copy()
+    prev_compound = out.groupby(["year", "circuit", "Driver"])["compound_id"].shift(1)
+    out["compound_change"] = (
+        (prev_compound.notna()) & (out["compound_id"] != prev_compound)
+    ).astype(int)
+    return out
+
+
+def _add_team_year_median(train: Any, target_slice: Any) -> Any:
+    """Per-team prior: median physical_stop_est from the most recent training year (N15)."""
+    lookup = train.groupby(["team", "year"])[_TARGET].median()
+    global_median = train[_TARGET].median()
+    teams_seen = set(lookup.index.get_level_values("team"))
+
+    def most_recent(team: str, year: int) -> float:
+        if (team, year) in lookup.index:
+            return float(lookup[(team, year)])
+        if team in teams_seen:
+            return float(lookup.xs(team, level="team").iloc[-1])
+        return float(global_median)
+
+    target_slice = target_slice.copy()
+    target_slice["team_year_median"] = [
+        most_recent(t, y) for t, y in zip(target_slice["team"], target_slice["year"])
+    ]
+    return target_slice
+
+
+def load_pit_holdout(year: int = 2025) -> tuple[Any, dict[str, Any], list[str]] | None:
+    """Rebuild the pit holdout and return ``(test_slice, quantile_models, features)``.
+
+    ``test_slice`` carries the engineered features + ``physical_stop_est`` target
+    for the requested year; ``quantile_models`` maps ``p05/p50/p95`` to the loaded
+    HistGBT models. Returns ``None`` when the raw laps or models are absent.
+    """
+    import joblib
+    import pandas as pd
+
+    model_dir = get_models_root() / _PIT_DIR
+    cfg_path = model_dir / "model_config.json"
+    if not cfg_path.exists():
+        return None
+
+    stops = _collect_pit_stops(pd)
+    if stops.empty:
+        return None
+    df = _engineer(stops)
+    train = df[df["year"].isin(_TRAIN_YEARS)].copy()
+    target_slice = df[df["year"] == year].copy()
+
+    traversal = train.groupby("circuit")["pit_duration_s"].quantile(0.05) - _PHYSICAL_STOP_FLOOR
+    for part in (train, target_slice):
+        part["circuit_traversal"] = part["circuit"].map(traversal).fillna(traversal.mean())
+        part[_TARGET] = (part["pit_duration_s"] - part["circuit_traversal"]).clip(lower=0.5)
+    train = train[(train[_TARGET] >= _STOP_MIN_S) & (train[_TARGET] <= _STOP_MAX_S)]
+    target_slice = target_slice[
+        (target_slice[_TARGET] >= _STOP_MIN_S) & (target_slice[_TARGET] <= _STOP_MAX_S)
+    ].copy()
+    if target_slice.empty:
+        return None
+    target_slice = _add_team_year_median(train, target_slice)
+
+    cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+    features = cfg["features"]
+    team_classes = list(cfg["label_encoder_classes"]["team"])
+    target_slice["team"] = target_slice["team"].map(
+        lambda x: team_classes.index(x) if x in team_classes else 0
+    )
+
+    models = {}
+    for quantile in ("p05", "p50", "p95"):
+        path = model_dir / f"hist_pit_{quantile}_v1.pkl"
+        if not path.exists():
+            return None
+        models[quantile] = joblib.load(path)
+    return target_slice, models, features

--- a/src/strategy/eval/reproduce.py
+++ b/src/strategy/eval/reproduce.py
@@ -18,7 +18,11 @@ from dataclasses import asdict, dataclass
 from typing import Any
 
 from src.f1_strat_manager.data_cache import get_models_root
-from src.strategy.eval.calibration import load_overtake_predictions
+from src.strategy.eval.calibration import (
+    load_overtake_predictions,
+    load_sc_predictions,
+    load_undercut_predictions,
+)
 from src.strategy.eval.report import build_header, write_report
 
 REPRO_NAME = "reproduction"
@@ -83,36 +87,72 @@ def _overtake_auc_pr() -> ReproResult:
     )
 
 
+def _classifier_auc_pr(model: str, published: float, loader: "Any") -> ReproResult:
+    """Re-derive a classifier's AUC-PR on the 2025 holdout via a shared loader.
+
+    AUC-PR is threshold-free, so it is computed on the raw model scores. Generic
+    over safety_car / undercut, mirroring ``_overtake_auc_pr``.
+    """
+    loaded = loader()
+    if loaded is None:
+        return ReproResult(
+            model, "auc_pr_test", published, None, "pending", "holdout or artifacts absent on disk"
+        )
+
+    from sklearn.metrics import average_precision_score
+
+    y, proba_raw, _ = loaded
+    reproduced = float(average_precision_score(y, proba_raw))
+    delta = abs(reproduced - published)
+    status = "reproduced" if delta <= TOLERANCE else "delta"
+    return ReproResult(
+        model,
+        "auc_pr_test",
+        published,
+        reproduced,
+        status,
+        f"|delta| {delta:.4f} vs tol {TOLERANCE}",
+    )
+
+
+def _sc_auc_pr() -> ReproResult:
+    """SC AUC-PR reproduction against its published test number (feature_list_v1)."""
+    cfg = json.loads(
+        (get_models_root() / "safety_car_probability" / "feature_list_v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    return _classifier_auc_pr(
+        "safety_car", float(cfg["metrics"]["test_auc_pr"]), load_sc_predictions
+    )
+
+
+def _undercut_auc_pr() -> ReproResult:
+    """Undercut AUC-PR reproduction against its published test number (model_config)."""
+    cfg = json.loads(
+        (get_models_root() / "pit_prediction" / "model_config_undercut_v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    return _classifier_auc_pr(
+        "undercut", float(cfg["metrics"]["auc_pr_test"]), load_undercut_predictions
+    )
+
+
 def _pending_metrics() -> list[ReproResult]:
-    """Document the headline numbers that cannot re-derive on-disk this phase.
+    """Headline numbers not yet re-derived on-disk (pit holdout regen + pace/tire).
 
     Each carries the same blocker its calibration/registry entry names, so the
     reproduction report and the calibration report agree on why.
     """
     return [
         ReproResult(
-            "undercut",
-            "auc_pr_test",
-            0.6739,
-            None,
-            "pending",
-            "historical aggregates circuit_undercut_rate/team_x_undercut_rate absent from holdout (#207)",
-        ),
-        ReproResult(
             "pit_duration",
             "p50_mae_test_s",
             0.487,
             None,
             "pending",
-            "pit_labeled holdout empty on disk (#207)",
-        ),
-        ReproResult(
-            "safety_car",
-            "auc_pr_test",
-            0.0723,
-            None,
-            "pending",
-            "engineered features (lap_time_*_z, anomaly_and_yellow, lap1_chaos) absent from holdout (#207)",
+            "pit_labeled holdout empty on disk; regen from raw tracked in #364",
         ),
         ReproResult(
             "pace",
@@ -135,7 +175,7 @@ def _pending_metrics() -> list[ReproResult]:
 
 def collect_results() -> list[ReproResult]:
     """All reproduction checks, reproduced/delta rows first."""
-    results = [_overtake_auc_pr(), *_pending_metrics()]
+    results = [_overtake_auc_pr(), _sc_auc_pr(), _undercut_auc_pr(), *_pending_metrics()]
     order = {"delta": 0, "reproduced": 1, "pending": 2}
     return sorted(results, key=lambda r: order.get(r.status, 3))
 

--- a/src/strategy/eval/reproduce.py
+++ b/src/strategy/eval/reproduce.py
@@ -139,6 +139,47 @@ def _undercut_auc_pr() -> ReproResult:
     )
 
 
+_PIT_PUBLISHED_P50_MAE = 0.487  # registry headline (N15 P50 physical-stop MAE, s)
+
+
+def _pit_p50_mae() -> ReproResult:
+    """Re-derive the pit P50 MAE on the holdout rebuilt from raw laps (#364).
+
+    ``pit_labeled`` is empty on disk, so the holdout is regenerated from the raw
+    laps by ``pit_holdout.load_pit_holdout``. MAE of the P50 quantile prediction
+    vs physical_stop_est on the 2025 slice.
+    """
+    from src.strategy.eval.pit_holdout import load_pit_holdout
+
+    loaded = load_pit_holdout()
+    if loaded is None:
+        return ReproResult(
+            "pit_duration",
+            "p50_mae_test_s",
+            _PIT_PUBLISHED_P50_MAE,
+            None,
+            "pending",
+            "raw laps or pit models absent on disk",
+        )
+
+    import numpy as np
+
+    test_slice, models, features = loaded
+    predicted = models["p50"].predict(test_slice[features])
+    actual = test_slice["physical_stop_est"].to_numpy()
+    reproduced = float(np.mean(np.abs(predicted - actual)))
+    delta = abs(reproduced - _PIT_PUBLISHED_P50_MAE)
+    status = "reproduced" if delta <= TOLERANCE else "delta"
+    return ReproResult(
+        "pit_duration",
+        "p50_mae_test_s",
+        _PIT_PUBLISHED_P50_MAE,
+        reproduced,
+        status,
+        f"n={len(actual)}; |delta| {delta:.4f} vs tol {TOLERANCE}",
+    )
+
+
 def _pending_metrics() -> list[ReproResult]:
     """Headline numbers not yet re-derived on-disk (pit holdout regen + pace/tire).
 
@@ -146,14 +187,6 @@ def _pending_metrics() -> list[ReproResult]:
     reproduction report and the calibration report agree on why.
     """
     return [
-        ReproResult(
-            "pit_duration",
-            "p50_mae_test_s",
-            0.487,
-            None,
-            "pending",
-            "pit_labeled holdout empty on disk; regen from raw tracked in #364",
-        ),
         ReproResult(
             "pace",
             "mae_test_s",
@@ -175,7 +208,13 @@ def _pending_metrics() -> list[ReproResult]:
 
 def collect_results() -> list[ReproResult]:
     """All reproduction checks, reproduced/delta rows first."""
-    results = [_overtake_auc_pr(), _sc_auc_pr(), _undercut_auc_pr(), *_pending_metrics()]
+    results = [
+        _overtake_auc_pr(),
+        _sc_auc_pr(),
+        _undercut_auc_pr(),
+        _pit_p50_mae(),
+        *_pending_metrics(),
+    ]
     order = {"delta": 0, "reproduced": 1, "pending": 2}
     return sorted(results, key=lambda r: order.get(r.status, 3))
 

--- a/tests/eval/test_alert_llm_golden.py
+++ b/tests/eval/test_alert_llm_golden.py
@@ -1,0 +1,52 @@
+"""Golden tests for the LLM-judge alert-precision module (#304 follow-up).
+
+The render + degradation paths are hermetic. The corpus selection is data-tier
+(needs the CSVs). The LLM call itself is neither run nor mocked here - it spends
+API calls and is non-deterministic, so it is exercised only via ``f1-eval
+alert-llm``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_CORPUS = (ROOT / "data" / "processed" / "radio_nlp" / "radios_raw.csv").exists()
+
+
+def test_render_leads_with_proxy_caveat():
+    """The report must open with the PROXY / human-review caveat, not a bare number."""
+    from src.strategy.eval.alert_llm import AlertLLMResult, _render
+
+    body = _render(AlertLLMResult(80, 20, 15, 0.75, "detail"))
+    assert body.splitlines()[0].startswith("> PROXY")
+    assert "human-review" in body
+    assert "0.7500" in body
+
+
+def test_render_handles_missing_precision():
+    """A degraded result (no precision) still renders without raising."""
+    from src.strategy.eval.alert_llm import AlertLLMResult, _render
+
+    body = _render(AlertLLMResult(0, 0, 0, None, "LLM judge unavailable"))
+    assert "| proxy precision | - |" in body
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_CORPUS, reason="radio corpus absent (CI runner without data)")
+def test_unlabeled_radios_excludes_the_labeled_set():
+    """The sample is drawn only from radios absent from the hand-labeled intent set."""
+    import pandas as pd
+
+    from src.strategy.eval.alert_llm import _unlabeled_radios
+
+    sample = _unlabeled_radios(30)
+    assert sample is not None and len(sample) == 30
+    labeled = set(
+        pd.read_csv(ROOT / "data" / "processed" / "radio_nlp" / "intent_labeled_data.csv")[
+            "message"
+        ].astype(str)
+    )
+    assert all(text not in labeled for text in sample)

--- a/tests/eval/test_hygiene_golden.py
+++ b/tests/eval/test_hygiene_golden.py
@@ -59,7 +59,7 @@ def test_sc_threshold_correction_does_not_beat_test_fit():
 
     correction = correct_sc_threshold()
     assert correction is not None
-    assert correction["val_positive_count"] >= 0
+    assert correction["in_train_2024_positive_count"] >= 0
     leaked_f2 = correction["leaked_test_operating_point"]["f2"]
     corrected_f2 = correction["corrected_test_operating_point"]["f2"]
     assert corrected_f2 <= leaked_f2 + 1e-9

--- a/tests/eval/test_hygiene_golden.py
+++ b/tests/eval/test_hygiene_golden.py
@@ -46,3 +46,39 @@ def test_overtake_threshold_correction_is_honest():
     assert corrected_f1 <= leaked_f1 + 1e-9, (
         "leaked threshold was fit on test, so its F1 is maximal there"
     )
+
+
+@pytest.mark.data
+@pytest.mark.skipif(
+    not (ROOT / "data" / "models" / "safety_car_probability" / "lgbm_sc_v1.pkl").exists(),
+    reason="SC model absent (CI runner without weights)",
+)
+def test_sc_threshold_correction_does_not_beat_test_fit():
+    """The val-selected SC F2 cannot exceed the leaked (test-fit) F2 on test."""
+    from src.strategy.eval.hygiene import correct_sc_threshold
+
+    correction = correct_sc_threshold()
+    assert correction is not None
+    assert correction["val_positive_count"] >= 0
+    leaked_f2 = correction["leaked_test_operating_point"]["f2"]
+    corrected_f2 = correction["corrected_test_operating_point"]["f2"]
+    assert corrected_f2 <= leaked_f2 + 1e-9
+
+
+@pytest.mark.data
+@pytest.mark.skipif(
+    not (ROOT / "data" / "models" / "safety_car_probability" / "lgbm_sc_v1.pkl").exists(),
+    reason="SC model absent (CI runner without weights)",
+)
+def test_sc_window_is_not_retro_selectable():
+    """Only the 3-lap SC model is persisted, so the window cannot be re-selected."""
+    from src.strategy.eval.hygiene import sc_window_sensitivity
+
+    window = sc_window_sensitivity()
+    assert window is not None
+    assert window["retro_selectable"] is False
+    assert set(window["per_window_auc_pr"]) == {
+        "sc_within_3_laps",
+        "sc_within_5_laps",
+        "sc_within_7_laps",
+    }

--- a/tests/eval/test_ml_recompute_golden.py
+++ b/tests/eval/test_ml_recompute_golden.py
@@ -13,6 +13,9 @@ import pytest
 ROOT = Path(__file__).parent.parent.parent
 _HAS_SC = (ROOT / "data" / "models" / "safety_car_probability" / "lgbm_sc_v1.pkl").exists()
 _HAS_UNDERCUT = (ROOT / "data" / "models" / "pit_prediction" / "lgbm_undercut_v1.pkl").exists()
+_HAS_PIT = (ROOT / "data" / "models" / "pit_prediction" / "hist_pit_p50_v1.pkl").exists() and bool(
+    list((ROOT / "data" / "raw").glob("*/*/laps.parquet"))
+)
 
 
 @pytest.mark.data
@@ -48,3 +51,14 @@ def test_undercut_auc_pr_reproduces_exactly():
     result = _undercut_auc_pr()
     assert result.status == "reproduced"
     assert result.reproduced is not None and abs(result.reproduced - 0.6739) < 0.01
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_PIT, reason="pit models or raw laps absent (CI runner without data)")
+def test_pit_p50_mae_reproduces_from_raw_laps():
+    """The pit holdout rebuilt from raw laps reproduces the 0.487 P50 MAE within tolerance."""
+    from src.strategy.eval.reproduce import _pit_p50_mae
+
+    result = _pit_p50_mae()
+    assert result.status == "reproduced"
+    assert result.reproduced is not None and abs(result.reproduced - 0.487) < 0.01

--- a/tests/eval/test_ml_recompute_golden.py
+++ b/tests/eval/test_ml_recompute_golden.py
@@ -1,0 +1,50 @@
+"""Golden tests for the SC + undercut recomputes (#364).
+
+Data-tier: the loaders rebuild the engineered features in-memory and run the
+LightGBM, so they need the models + holdouts on disk and skip on CI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_SC = (ROOT / "data" / "models" / "safety_car_probability" / "lgbm_sc_v1.pkl").exists()
+_HAS_UNDERCUT = (ROOT / "data" / "models" / "pit_prediction" / "lgbm_undercut_v1.pkl").exists()
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_SC, reason="SC model absent (CI runner without weights)")
+def test_sc_auc_pr_reproduces_exactly():
+    """SC AUC-PR reproduces its 0.0723 headline via the in-memory feature rebuild."""
+    from src.strategy.eval.reproduce import _sc_auc_pr
+
+    result = _sc_auc_pr()
+    assert result.status == "reproduced"
+    assert result.reproduced is not None and abs(result.reproduced - 0.0723) < 0.01
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_SC, reason="SC model absent (CI runner without weights)")
+def test_sc_loader_supports_windows_and_years():
+    """The SC loader slices any year and any of the 3 target windows (for #363)."""
+    from src.strategy.eval.calibration import load_sc_predictions
+
+    for target in ("sc_within_3_laps", "sc_within_5_laps", "sc_within_7_laps"):
+        loaded = load_sc_predictions(year=2024, target=target)
+        assert loaded is not None
+        y, proba_raw, proba_cal = loaded
+        assert len(y) == len(proba_raw) == len(proba_cal) > 0
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_UNDERCUT, reason="undercut model absent (CI runner without weights)")
+def test_undercut_auc_pr_reproduces_exactly():
+    """Undercut AUC-PR reproduces its 0.6739 headline with train-fit target encodings."""
+    from src.strategy.eval.reproduce import _undercut_auc_pr
+
+    result = _undercut_auc_pr()
+    assert result.status == "reproduced"
+    assert result.reproduced is not None and abs(result.reproduced - 0.6739) < 0.01

--- a/tests/eval/test_nlp_golden.py
+++ b/tests/eval/test_nlp_golden.py
@@ -1,21 +1,62 @@
-"""Golden tests for the #304 NLP eval harness.
+"""Golden tests for the #303/#304 NLP eval harness.
 
-Hermetic: asserts the gated-stage contract (intent blocked on #303, alert
-precision pending a ground-truth set). The heavy RoBERTa sentiment reproduction
-is validated by running ``f1-eval nlp`` (it loads a 1.4 GB checkpoint), not in
-the routine test suite.
+The gated-stage contract is hermetic (authored data). The intent reproduction +
+NR-08 column-order verdict are data-tier: they load pickled weights, so they run
+locally and skip on CI without ``data/models/``.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
 
-def test_nlp_gated_stages_carry_their_blockers():
-    """Intent is blocked on #303; alert precision + NER + RCM are pending."""
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_INTENT_DIR = ROOT / "data" / "models" / "nlp" / "intent_setfit_modernbert_v1"
+_HAS_INTENT_HEAD = (_INTENT_DIR / "model_head.pkl").exists()
+_HAS_NER_CFG = (ROOT / "data" / "models" / "nlp" / "ner_v1" / "model_config.json").exists()
+
+
+def test_nlp_gated_stages_are_pending_after_303():
+    """After #303 only NER F1, RCM and alert precision stay gated; intent is not."""
     from src.strategy.eval.nlp import _gated_stages
 
     by_stage = {r.stage: r for r in _gated_stages()}
-    assert by_stage["intent"].status == "blocked"
-    assert "303" in by_stage["intent"].detail
-    assert by_stage["alert_precision"].status == "pending"
-    assert by_stage["ner"].status == "pending"
-    assert by_stage["rcm"].status == "pending"
+    assert set(by_stage) == {"ner", "rcm", "alert_precision"}
+    assert all(r.status == "pending" for r in by_stage.values())
+    assert "303" in by_stage["ner"].detail or "#304" in by_stage["ner"].detail
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_INTENT_HEAD, reason="intent head absent (CI runner without weights)")
+def test_intent_predict_proba_order_is_aligned():
+    """NR-08: the production predict_proba decode reads the correct class (no swap)."""
+    from src.strategy.eval.nlp import verify_intent_column_order
+
+    verdict = verify_intent_column_order()
+    assert verdict.status == "reproduced"
+    assert verdict.value == 1.0
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_INTENT_HEAD, reason="intent model absent (CI runner without weights)")
+def test_intent_reproduction_is_sane():
+    """Setfit-free reproduction runs and beats chance on the labeled set."""
+    from src.strategy.eval.nlp import reproduce_intent
+
+    rows = {r.metric: r for r in reproduce_intent()}
+    assert rows["accuracy"].status != "pending"
+    assert rows["accuracy"].value is not None and rows["accuracy"].value > 0.5
+    assert "weighted_f1" in rows
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_NER_CFG, reason="ner model_config absent (CI runner without weights)")
+def test_dead_ner_classes_flags_zero_f1_types():
+    """NR-07: entity types with ~0 frozen-eval B-F1 are flagged untrustworthy."""
+    from src.strategy.eval.nlp import dead_ner_classes
+
+    dead, row = dead_ner_classes()
+    assert row.status == "flagged"
+    assert row.value == float(len(dead))
+    assert len(dead) >= 1

--- a/tests/eval/test_nlp_golden.py
+++ b/tests/eval/test_nlp_golden.py
@@ -21,13 +21,11 @@ _HAS_NER_MODEL = (
 _HAS_RCM_CORPUS = bool(list((ROOT / "data" / "processed").glob("race_radios/2025/*/rcm.parquet")))
 
 
-def test_nlp_gated_stages_are_pending_after_304():
-    """After #304 only alert precision stays gated (NER, RCM, intent all run)."""
+def test_no_nlp_stage_is_gated_after_304():
+    """After #304 every NLP stage reproduces; nothing stays gated."""
     from src.strategy.eval.nlp import _gated_stages
 
-    by_stage = {r.stage: r for r in _gated_stages()}
-    assert set(by_stage) == {"alert_precision"}
-    assert by_stage["alert_precision"].status == "pending"
+    assert _gated_stages() == []
 
 
 def test_rcm_classifier_maps_known_events():
@@ -79,6 +77,17 @@ def test_intent_reproduction_is_sane():
     assert rows["accuracy"].status != "pending"
     assert rows["accuracy"].value is not None and rows["accuracy"].value > 0.5
     assert "weighted_f1" in rows
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_INTENT_HEAD, reason="intent model absent (CI runner without weights)")
+def test_alert_precision_from_gold_is_high():
+    """Alert precision (intent PROBLEM/WARNING) is real (gold-derived) and clears 0.8."""
+    from src.strategy.eval.nlp import reproduce_alert_precision
+
+    rows = {r.metric: r for r in reproduce_alert_precision()}
+    assert rows["precision"].status == "reproduced"
+    assert rows["precision"].value is not None and rows["precision"].value > 0.8
 
 
 @pytest.mark.data

--- a/tests/eval/test_nlp_golden.py
+++ b/tests/eval/test_nlp_golden.py
@@ -15,16 +15,47 @@ ROOT = Path(__file__).parent.parent.parent
 _INTENT_DIR = ROOT / "data" / "models" / "nlp" / "intent_setfit_modernbert_v1"
 _HAS_INTENT_HEAD = (_INTENT_DIR / "model_head.pkl").exists()
 _HAS_NER_CFG = (ROOT / "data" / "models" / "nlp" / "ner_v1" / "model_config.json").exists()
+_HAS_NER_MODEL = (
+    ROOT / "data" / "models" / "nlp" / "ner_v1" / "bert_bio_v1" / "bert_bio_state_dict.pt"
+).exists()
+_HAS_RCM_CORPUS = bool(list((ROOT / "data" / "processed").glob("race_radios/2025/*/rcm.parquet")))
 
 
-def test_nlp_gated_stages_are_pending_after_303():
-    """After #303 only NER F1, RCM and alert precision stay gated; intent is not."""
+def test_nlp_gated_stages_are_pending_after_304():
+    """After #304 only alert precision stays gated (NER, RCM, intent all run)."""
     from src.strategy.eval.nlp import _gated_stages
 
     by_stage = {r.stage: r for r in _gated_stages()}
-    assert set(by_stage) == {"ner", "rcm", "alert_precision"}
-    assert all(r.status == "pending" for r in by_stage.values())
-    assert "303" in by_stage["ner"].detail or "#304" in by_stage["ner"].detail
+    assert set(by_stage) == {"alert_precision"}
+    assert by_stage["alert_precision"].status == "pending"
+
+
+def test_rcm_classifier_maps_known_events():
+    """Hermetic: the ported N23 rule-based classifier maps representative rows."""
+    from src.strategy.eval.nlp import _classify_rcm_event
+
+    assert (
+        _classify_rcm_event("SafetyCar", "", None, None, "SAFETY CAR DEPLOYED")
+        == "SAFETY_CAR_DEPLOYED"
+    )
+    assert _classify_rcm_event("Flag", "BLUE", None, None, "WAVED BLUE FLAG") == "BLUE_FLAG"
+    assert _classify_rcm_event("Drs", "", None, None, "DRS ENABLED") == "DRS_ENABLED"
+    yellow_sector = _classify_rcm_event(
+        "Flag", "DOUBLE YELLOW", "Sector", 20, "DOUBLE YELLOW SECTOR 20"
+    )
+    assert yellow_sector == "YELLOW_FLAG_SECTOR"
+    assert _classify_rcm_event("Other", "", None, None, "SOMETHING UNMAPPED") == "OTHER"
+
+
+def test_gold_bio_tags_align_to_split_words():
+    """Hermetic: char-offset gold entities become word-level BIO over text.split()."""
+    from src.strategy.eval.nlp import _gold_bio_tags
+
+    text = "Box now Hamilton"
+    # "Hamilton" starts at char 8
+    words, tags = _gold_bio_tags(text, [[8, 16, "ACTION"]])
+    assert words == ["Box", "now", "Hamilton"]
+    assert tags == ["O", "O", "B-ACTION"]
 
 
 @pytest.mark.data
@@ -60,3 +91,25 @@ def test_dead_ner_classes_flags_zero_f1_types():
     assert row.status == "flagged"
     assert row.value == float(len(dead))
     assert len(dead) >= 1
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_NER_MODEL, reason="ner weights absent (CI runner without weights)")
+def test_ner_entity_f1_reproduces_headline():
+    """Entity micro-F1 reproduces the frozen 0.4151 headline within tolerance (full-set optimistic)."""
+    from src.strategy.eval.nlp import reproduce_ner
+
+    rows = {r.metric: r for r in reproduce_ner()}
+    assert rows["entity_f1"].status == "reproduced"
+    assert rows["entity_f1"].value is not None and 0.3 < rows["entity_f1"].value < 0.6
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_RCM_CORPUS, reason="2025 rcm corpus absent (CI runner without data)")
+def test_rcm_coverage_is_high():
+    """The ported parser leaves few OTHER events; overall coverage clears 0.9."""
+    from src.strategy.eval.nlp import reproduce_rcm
+
+    rows = {r.metric: r for r in reproduce_rcm()}
+    assert rows["coverage"].status == "reproduced"
+    assert rows["coverage"].value is not None and rows["coverage"].value > 0.9


### PR DESCRIPTION
Promotion of Sprint 4 (eval-harness unblock) from dev to main. Eight PRs, all additive to `src/strategy/eval/`; no untouchable tree touched.

## NLP harness (#303 closed, #304 closed)
- **#360** #303: intent reproduced setfit-free (acc 0.8885); NR-08 predict_proba order verified aligned (no confidence swap); NR-07 flags 4 dead NER classes.
- **#361** #304: NER entity-F1 0.4248 (vs 0.4151) via seqeval; RCM coverage 0.9868 via the ported N23 classifier.
- **#362** #304: alert precision 0.9185 from the hand-labeled gold intent (real, not a proxy) - closes #304.
- **#368** #304 follow-up: opt-in `f1-eval alert-llm` LLM-judge; finding: the unlabeled radios are garbled Whisper transcripts, so that proxy is uninformative (gold-based 0.9185 stands).

## ML-eval harness (#363 closed, #364 closed)
- **#365** SC + undercut recompute in-memory: AUC-PR 0.0723 / 0.6739 reproduced exactly; undercut ECE 0.13 flagged drift.
- **#366** #363: SC threshold/window correction on honest splits. **Fable verify-after gate caught a real flaw** (2024 is train, not validation) - relabeled as in-train; conclusion is now 'SC has no honest val split, report threshold-free', which is defensible. Fable re-verify: GO.
- **#367** #364: pit holdout regenerated from raw laps (P50 MAE 0.4893 vs 0.487; coverage 0.7024 drift) - closes #364.

## New issues filed
- #363 (SC corrections, closed by #366), #364 (holdouts, closed by #367).

## Notes
- New: `pit_holdout.py`, `alert_llm.py`; extended `nlp.py`/`calibration.py`/`reproduce.py`/`hygiene.py`.
- All eval tests are data-tier (skip on CI, run locally); ruff + typecheck green on every PR.
- release-please will open a version PR on main after merge (Victor releases).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional LLM-assisted alert-precision evaluation, clearly labeled as a proxy requiring human review.
  - Expanded evaluation coverage for intent classification, named-entity recognition, race-control event coverage, safety-car, undercut, and pit-duration metrics.
  - Added safety-car threshold and target-window sensitivity analysis.

- **Documentation**
  - Refreshed evaluation reports with reproduced metrics, calibration results, provenance findings, limitations, and correction guidance.
  - Clarified contamination risks and which results are suitable for publication.

- **Tests**
  - Added regression coverage for evaluation, calibration, NLP, alert precision, and hygiene checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->