### PR TITLE
feat(eval): reproduce the pace MAE 0.4104 from the featured-laps holdout

### DIFF
--- a/documents/eval_reports/reproduction.json
+++ b/documents/eval_reports/reproduction.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "e1ee603",
+    "harness_sha": "1651c3b",
     "dataset": "2025 holdout vs published model_configs",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-11T17:31:11+00:00",
+    "generated_at": "2026-07-11T18:43:51+00:00",
     "artifacts": {
       "overtake_model": "cbb9d0eb0beb"
     }
@@ -48,9 +48,9 @@
       "model": "pace",
       "metric": "mae_test_s",
       "published": 0.4104,
-      "reproduced": null,
-      "status": "pending",
-      "detail": "laptime holdout feature build not wired this phase"
+      "reproduced": 0.4103626731730183,
+      "status": "reproduced",
+      "detail": "n=21247; |delta| 0.0000 vs tol 0.01"
     },
     {
       "model": "tire_degradation",

--- a/documents/eval_reports/reproduction.md
+++ b/documents/eval_reports/reproduction.md
@@ -1,6 +1,6 @@
 # reproduction
 
-- harness `e1ee603` · schema v1 · generated 2026-07-11T17:31:11+00:00
+- harness `1651c3b` · schema v1 · generated 2026-07-11T18:43:51+00:00
 - era 2022-2025 · dataset 2025 holdout vs published model_configs · seed deterministic · llm none
 - artifacts: overtake_model=`cbb9d0eb0beb`
 
@@ -10,5 +10,5 @@
 | safety_car | auc_pr_test | 0.0723 | 0.0723 | reproduced | |delta| 0.0000 vs tol 0.01 |
 | undercut | auc_pr_test | 0.6739 | 0.6739 | reproduced | |delta| 0.0000 vs tol 0.01 |
 | pit_duration | p50_mae_test_s | 0.487 | 0.4893 | reproduced | n=252; |delta| 0.0023 vs tol 0.01 |
-| pace | mae_test_s | 0.4104 | - | pending | laptime holdout feature build not wired this phase |
+| pace | mae_test_s | 0.4104 | 0.4104 | reproduced | n=21247; |delta| 0.0000 vs tol 0.01 |
 | tire_degradation | mae_test_s | 0.7078 | - | pending | TCN MC forward pass not run this phase (see calibration MC-sigma) |

--- a/src/strategy/eval/pace_holdout.py
+++ b/src/strategy/eval/pace_holdout.py
@@ -1,0 +1,118 @@
+"""Pace (lap-time delta) holdout reconstruction from the featured laps (#372).
+
+The N06 XGBoost model predicts ``LapTime_Delta`` (the change from the previous
+lap); the headline MAE 0.4104 s is on the RECONSTRUCTED absolute lap time
+(``Prev_LapTime + predicted_delta`` vs ``LapTime_s``) over the 2025 test slice,
+not on the delta directly.
+
+Unlike pit (which regenerates from raw laps), the pace holdout is derivable
+in-memory: the featured 2025 parquet already carries every base column, so this
+only re-applies the two N06 feature steps the delta model needs - the
+categorical encoding and the lag-1 degradation features - and loads the frozen
+model to score them.
+
+The model's saved ``xgb_laptime_delta_feature_names.json`` IS ``FEATURES_DELTA``:
+the session-leaky features (``year_circuit_median``, ``team_pace_rank``,
+``lap_time_pct_of_race_fastest``) and the same-lap degradation/speed columns were
+already excluded at train time (hygiene.py flags them LEAKY), so the 25
+prediction columns come straight from that list and no leaky feature enters.
+
+--- WHERE TO CHANGE IF THE PACE PIPELINE CHANGES ---
+notebooks/strategy/lap_time_prediction/N06_laptime_model.ipynb (cells 6 encode,
+25 load-2025, 29 lag features, 32 test reconstruction) is the source of truth;
+mirror any edit here. Validated: MAE 0.4104 on 2025, exact to the thesis-final
+headline.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from src.f1_strat_manager.data_cache import get_data_root, get_models_root
+
+_LAP_DIR = "lap_time"
+_MANIFEST = "feature_manifest_laptime.json"
+# groupby keys for the lag-1 shift: one stint of one driver in one race (N06 cell 29)
+_STINT_KEYS = ["GP_Name", "Year", "DriverNumber", "Stint"]
+_LAG_SOURCES = {
+    "Prev_DegradationRate": "DegradationRate",
+    "Prev_CumulativeDeg": "CumulativeDeg",
+    "Prev_DegAcceleration": "DegAcceleration",
+}
+_DROPNA = ["LapTime_Delta", "Prev_LapTime"]  # N06 drops first-lap-of-stint NaNs before scoring
+_PREV_LAP = "Prev_LapTime"
+
+
+def _encode_categoricals(df: Any, compound_map: dict, racephase_map: dict) -> Any:
+    """Map the string categoricals to the int codes the model was trained on (N06 encode_features).
+
+    Only ``FreshTyre`` feeds the delta model directly; ``Compound`` / ``race_phase``
+    are encoded for parity with the notebook (the model consumes the pre-numeric
+    ``CompoundID``), so the transform is applied verbatim.
+    """
+    out = df.copy()
+    out["Compound"] = out["Compound"].map(compound_map).fillna(-1).astype(int)
+    out["race_phase"] = out["race_phase"].astype(str).map(racephase_map).fillna(-1).astype(int)
+    out["FreshTyre"] = out["FreshTyre"].astype(int)
+    return out
+
+
+def _add_lag_deg_features(df: Any) -> Any:
+    """Add the lag-1 degradation features the delta model uses (N06 add_lag_deg_features).
+
+    The same-lap ``DegradationRate`` / ``CumulativeDeg`` / ``DegAcceleration`` are
+    leaky for a next-lap delta target, so the model consumes their previous-lap
+    value: a shift(1) within each (race, year, driver, stint) group. The first
+    lap of each stint becomes NaN and is dropped before scoring.
+    """
+    out = df.copy()
+    grp = out.groupby(_STINT_KEYS, sort=False)
+    for prev_col, source_col in _LAG_SOURCES.items():
+        out[prev_col] = grp[source_col].shift(1)
+    return out
+
+
+def load_pace_predictions(year: int = 2025) -> tuple[np.ndarray, np.ndarray] | None:
+    """Rebuild the pace holdout and return ``(y_true_abs, y_pred_abs)`` lap times in seconds.
+
+    Loads the featured ``year`` parquet, re-applies the two N06 feature steps,
+    scores the frozen delta model, and reconstructs the absolute lap time from
+    the predicted delta plus ``Prev_LapTime`` - the exact quantity the headline
+    MAE is measured on. Returns ``None`` when the model, feature list, manifest,
+    or holdout parquet is absent, so the caller degrades to a ``pending`` result.
+    """
+    import json
+
+    import pandas as pd
+    from xgboost import XGBRegressor
+
+    model_dir = get_models_root() / _LAP_DIR
+    model_path = model_dir / "xgb_laptime_delta_final.json"
+    features_path = model_dir / "xgb_laptime_delta_feature_names.json"
+    manifest_path = get_data_root() / "processed" / _MANIFEST
+    parquet = get_data_root() / "processed" / f"laps_featured_{year}.parquet"
+    if not all(p.exists() for p in (model_path, features_path, manifest_path, parquet)):
+        return None
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    compound_map = manifest["categorical_encoding"]["Compound"]
+    racephase_map = manifest["categorical_encoding"]["race_phase"]
+    target = manifest["target"]  # LapTime_s
+    features_delta = json.loads(features_path.read_text(encoding="utf-8"))
+
+    df = _add_lag_deg_features(
+        _encode_categoricals(pd.read_parquet(parquet), compound_map, racephase_map)
+    )
+    df = df.dropna(subset=_DROPNA).copy()
+    if df.empty:
+        return None
+
+    model = XGBRegressor()
+    model.load_model(str(model_path))
+
+    pred_delta = model.predict(df[features_delta])
+    y_pred_abs = df[_PREV_LAP].to_numpy() + pred_delta
+    y_true_abs = df[target].to_numpy()
+    return y_true_abs, y_pred_abs

--- a/src/strategy/eval/reproduce.py
+++ b/src/strategy/eval/reproduce.py
@@ -6,9 +6,10 @@ the on-disk data does not support a clean re-derivation, it documents the delta
 explicitly rather than inventing a number - which is the deliverable's own
 "reproduces every headline number within tolerance, or documents the delta".
 
-This phase only overtake AUC-PR reproduces cleanly (its holdout + derived
-features are fully reconstructable). The rest are blocked on the same on-disk
-gaps the calibration report names, and are handed to Phase 2 (#207).
+Reproduced on-disk: overtake / safety_car / undercut AUC-PR (in-memory feature
+rebuild), pit P50 MAE (raw-laps regen), and pace MAE (featured-laps in-memory
+rebuild of the N06 delta model). Still pending: tire MAE (needs the TCN MC
+forward pass).
 """
 
 from __future__ import annotations
@@ -180,21 +181,53 @@ def _pit_p50_mae() -> ReproResult:
     )
 
 
+_PACE_PUBLISHED_MAE = 0.4104  # thesis-final N06 delta-model absolute-lap MAE (s)
+
+
+def _pace_mae() -> ReproResult:
+    """Re-derive the pace MAE on the 2025 holdout rebuilt in-memory from the featured laps.
+
+    The N06 delta model predicts ``LapTime_Delta``; the reported MAE is on the
+    reconstructed absolute lap time (``Prev_LapTime + delta`` vs ``LapTime_s``).
+    ``pace_holdout.load_pace_predictions`` re-applies the two N06 feature steps
+    and scores the frozen model, so no leaky session feature enters.
+    """
+    from src.strategy.eval.pace_holdout import load_pace_predictions
+
+    loaded = load_pace_predictions()
+    if loaded is None:
+        return ReproResult(
+            "pace",
+            "mae_test_s",
+            _PACE_PUBLISHED_MAE,
+            None,
+            "pending",
+            "featured laptime holdout or delta model absent on disk",
+        )
+
+    import numpy as np
+
+    y_true, y_pred = loaded
+    reproduced = float(np.mean(np.abs(y_pred - y_true)))
+    delta = abs(reproduced - _PACE_PUBLISHED_MAE)
+    status = "reproduced" if delta <= TOLERANCE else "delta"
+    return ReproResult(
+        "pace",
+        "mae_test_s",
+        _PACE_PUBLISHED_MAE,
+        reproduced,
+        status,
+        f"n={len(y_true)}; |delta| {delta:.4f} vs tol {TOLERANCE}",
+    )
+
+
 def _pending_metrics() -> list[ReproResult]:
-    """Headline numbers not yet re-derived on-disk (pit holdout regen + pace/tire).
+    """Headline numbers not yet re-derived on-disk (tire TCN MC forward pass).
 
     Each carries the same blocker its calibration/registry entry names, so the
     reproduction report and the calibration report agree on why.
     """
     return [
-        ReproResult(
-            "pace",
-            "mae_test_s",
-            0.4104,
-            None,
-            "pending",
-            "laptime holdout feature build not wired this phase",
-        ),
         ReproResult(
             "tire_degradation",
             "mae_test_s",
@@ -213,6 +246,7 @@ def collect_results() -> list[ReproResult]:
         _sc_auc_pr(),
         _undercut_auc_pr(),
         _pit_p50_mae(),
+        _pace_mae(),
         *_pending_metrics(),
     ]
     order = {"delta": 0, "reproduced": 1, "pending": 2}

--- a/tests/eval/test_ml_recompute_golden.py
+++ b/tests/eval/test_ml_recompute_golden.py
@@ -16,6 +16,9 @@ _HAS_UNDERCUT = (ROOT / "data" / "models" / "pit_prediction" / "lgbm_undercut_v1
 _HAS_PIT = (ROOT / "data" / "models" / "pit_prediction" / "hist_pit_p50_v1.pkl").exists() and bool(
     list((ROOT / "data" / "raw").glob("*/*/laps.parquet"))
 )
+_HAS_PACE = (ROOT / "data" / "models" / "lap_time" / "xgb_laptime_delta_final.json").exists() and (
+    ROOT / "data" / "processed" / "laps_featured_2025.parquet"
+).exists()
 
 
 @pytest.mark.data
@@ -62,3 +65,16 @@ def test_pit_p50_mae_reproduces_from_raw_laps():
     result = _pit_p50_mae()
     assert result.status == "reproduced"
     assert result.reproduced is not None and abs(result.reproduced - 0.487) < 0.01
+
+
+@pytest.mark.data
+@pytest.mark.skipif(
+    not _HAS_PACE, reason="pace model or featured laps absent (CI runner without data)"
+)
+def test_pace_mae_reproduces_from_featured_laps():
+    """The pace holdout rebuilt in-memory reproduces the 0.4104 delta-model MAE within tolerance."""
+    from src.strategy.eval.reproduce import _pace_mae
+
+    result = _pace_mae()
+    assert result.status == "reproduced"
+    assert result.reproduced is not None and abs(result.reproduced - 0.4104) < 0.01


### PR DESCRIPTION
Closes #370. Sub of epic #205; follow-up to the closed #206/#207.

## What
Wires the last-but-one `pending` row in the reproduction report: **pace** (`mae_test_s`) now reproduces the thesis-final 0.4104 from disk. Only tire remains pending (its own PR).

## Why
The ML-eval deliverable is "reproduces every headline number within tolerance, or documents the delta". Pace was the one regression headline left unwired.

## How
- New `src/strategy/eval/pace_holdout.py`: `load_pace_predictions` rebuilds the 2025 holdout in-memory from `laps_featured_2025.parquet`, re-applying the two N06 feature steps the delta model consumes (categorical encoding + the lag-1 degradation features), then scores the frozen `xgb_laptime_delta_final.json` and reconstructs the absolute lap time (`Prev_LapTime + predicted_delta`) - the exact quantity the headline MAE is on.
- FEATURES_DELTA is sourced from the model own `feature_names.json`, so no session-leaky feature (`year_circuit_median`, `team_pace_rank`) enters (hygiene.py flagged them LEAKY and out of the reported model).
- `_pace_mae` wired into `reproduce.py`; report regenerated.

## Result
```
| pace | mae_test_s | 0.4104 | 0.4104 | reproduced | n=21247; |delta| 0.0000 vs tol 0.01 |
```

## Checks
- Data-tier golden test `test_pace_mae_reproduces_from_featured_laps` (skips on CI without weights; passes locally).
- `uvx ruff check/format` clean. The N06 notebook is untouchable and was not modified - only its logic was extracted.

## Out of scope
Tire MAE 0.7078 (TCN MC forward pass) - separate PR.