### PR TITLE
feat(agents): give every sub-agent ChatOpenAI a finite provider timeout (L-1)

### DIFF
--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -641,9 +641,9 @@ class PaceAgent:
             provider = os.environ.get('F1_LLM_PROVIDER', 'lmstudio')
 
         if provider == 'lmstudio':
-            llm = ChatOpenAI(model=model_name, base_url=base_url, api_key=api_key, temperature=0)
+            llm = ChatOpenAI(model=model_name, base_url=base_url, api_key=api_key, temperature=0, timeout=120, max_retries=1)
         else:
-            llm = ChatOpenAI(model=model_name, temperature=0)
+            llm = ChatOpenAI(model=model_name, temperature=0, timeout=120, max_retries=1)
 
         self._react_agent = create_agent(
             model=llm,

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -830,9 +830,11 @@ class PitStrategyAgent:
                 temperature=0,
                 model_kwargs={'parallel_tool_calls': False},
                 disable_streaming=True,
+                timeout=120,
+                max_retries=1,
             )
         else:
-            llm = ChatOpenAI(model=model_name, temperature=0)
+            llm = ChatOpenAI(model=model_name, temperature=0, timeout=120, max_retries=1)
 
         self._react_agent = create_agent(
             llm, self._tools, system_prompt=_PIT_STRATEGY_SYSTEM_PROMPT

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -978,9 +978,9 @@ class RaceSituationAgent:
             provider = os.environ.get('F1_LLM_PROVIDER', 'lmstudio')
 
         if provider == 'lmstudio':
-            llm = ChatOpenAI(model=model_name, base_url=base_url, api_key=api_key, temperature=0)
+            llm = ChatOpenAI(model=model_name, base_url=base_url, api_key=api_key, temperature=0, timeout=120, max_retries=1)
         else:
-            llm = ChatOpenAI(model=model_name, temperature=0)
+            llm = ChatOpenAI(model=model_name, temperature=0, timeout=120, max_retries=1)
 
         self._react_agent = create_agent(
             model=llm,

--- a/src/agents/radio_agent.py
+++ b/src/agents/radio_agent.py
@@ -793,6 +793,8 @@ def _get_radio_llm():
             base_llm = ChatOpenAI(
                 model=CFG.model_name,
                 temperature=0.0,
+                timeout=120,
+                max_retries=1,
             )
         else:
             base_llm = ChatOpenAI(
@@ -801,6 +803,8 @@ def _get_radio_llm():
                 api_key="lm-studio",
                 temperature=0.0,
                 model_kwargs={"parallel_tool_calls": False},
+                timeout=120,
+                max_retries=1,
             )
         _structured_llm = base_llm.with_structured_output(RadioSynthesis)
     return _structured_llm

--- a/src/agents/rag_agent.py
+++ b/src/agents/rag_agent.py
@@ -148,7 +148,7 @@ def get_rag_react_agent():
         import os
         provider = os.environ.get("F1_LLM_PROVIDER", "lmstudio")
         if provider == "openai":
-            llm = ChatOpenAI(model="gpt-4.1-mini", temperature=0)
+            llm = ChatOpenAI(model="gpt-4.1-mini", temperature=0, timeout=120, max_retries=1)
         else:
             llm = ChatOpenAI(
                 model="gpt-4.1-mini",
@@ -156,6 +156,8 @@ def get_rag_react_agent():
                 api_key="lm-studio",
                 temperature=0,
                 model_kwargs={"parallel_tool_calls": False},
+                timeout=120,
+                max_retries=1,
             )
         _rag_agent = create_agent(
             model=llm,

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -135,7 +135,7 @@ def _get_orchestrator_llm():
         provider = os.environ.get("F1_LLM_PROVIDER", "lmstudio")
         if provider == "openai":
             # No parallel_tool_calls — OpenAI rejects it when no tools are specified
-            llm = ChatOpenAI(model=CFG.model_name, temperature=CFG.temperature)
+            llm = ChatOpenAI(model=CFG.model_name, temperature=CFG.temperature, timeout=120, max_retries=1)
         else:
             llm = ChatOpenAI(
                 model=CFG.model_name,
@@ -143,6 +143,8 @@ def _get_orchestrator_llm():
                 api_key="lm-studio",
                 temperature=CFG.temperature,
                 model_kwargs={"parallel_tool_calls": False},
+                timeout=120,
+                max_retries=1,
             )
         # _LLMSynthesis only has the 3 fields the LLM actually fills —
         # scenario_scores (dict) and regulation_context are attached in code after.

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -990,9 +990,11 @@ class TireAgent:
                 base_url=base_url,
                 api_key=api_key,
                 temperature=0,
+                timeout=120,
+                max_retries=1,
             )
         else:
-            llm = ChatOpenAI(model=model_name, temperature=0)
+            llm = ChatOpenAI(model=model_name, temperature=0, timeout=120, max_retries=1)
 
         self._react_agent = create_agent(
             model=llm,

--- a/tests/test_agent_llm_timeout.py
+++ b/tests/test_agent_llm_timeout.py
@@ -1,0 +1,59 @@
+"""Agent-side provider-timeout contract (LLM-cost L-1 / #263).
+
+The sub-agents construct their own ``ChatOpenAI`` clients; without a finite
+timeout a stalled provider (a hung LM Studio, a dead socket) can pin a lap for
+the SDK's full ~30-min retry budget. Every construction now passes
+``timeout=`` + ``max_retries=``. These hermetic tests pin both halves of the
+contract - the kwargs are still honored by langchain-openai, and no agent
+construction silently loses the timeout - without importing the agents (which
+would load the model configs) or hitting the network.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_AGENTS_DIR = Path(__file__).parent.parent / "src" / "agents"
+_AGENT_FILES = [
+    "pace_agent.py",
+    "tire_agent.py",
+    "pit_strategy_agent.py",
+    "race_situation_agent.py",
+    "radio_agent.py",
+    "rag_agent.py",
+    "strategy_orchestrator.py",
+]
+
+
+def test_chat_openai_still_accepts_timeout_and_retries():
+    """langchain-openai honors the two kwargs the agents rely on (lazy, no network)."""
+    ChatOpenAI = pytest.importorskip("langchain_openai").ChatOpenAI
+    client = ChatOpenAI(model="gpt-4.1-mini", api_key="test-key", timeout=120, max_retries=1)
+    assert client.request_timeout == 120.0
+    assert client.max_retries == 1
+
+
+@pytest.mark.parametrize("filename", _AGENT_FILES)
+def test_every_agent_chatopenai_has_a_timeout(filename: str):
+    """Each ``ChatOpenAI(`` construction in the agent carries a ``timeout=`` kwarg.
+
+    Source-level guard so a future edit that drops the timeout on any of the 14
+    construction sites fails here instead of shipping a hang-prone agent.
+    """
+    source = (_AGENTS_DIR / filename).read_text(encoding="utf-8")
+    # For each construction, scan from ``ChatOpenAI(`` to its balanced close paren.
+    for match in re.finditer(r"ChatOpenAI\(", source):
+        start = match.end()
+        depth = 1
+        i = start
+        while i < len(source) and depth > 0:
+            if source[i] == "(":
+                depth += 1
+            elif source[i] == ")":
+                depth -= 1
+            i += 1
+        construction = source[match.start() : i]
+        assert "timeout=" in construction, f"{filename}: a ChatOpenAI(...) has no timeout="


### PR DESCRIPTION
Refs #263 (epic #261, LLM Phase 1 - the agent side of L-1). Part of Sprint 2 hardening.

## What
The 7 sub-agents (pace/tire/pit/situation/radio/rag/orchestrator) each build their own `ChatOpenAI` client with **no timeout**, so a stalled provider (a hung LM Studio, a dead socket) could pin a simulated lap for the OpenAI SDK's full ~30-min retry budget. This adds `timeout=120, max_retries=1` to all **14 construction sites**.

## Why surgical / literal
Now that `src/agents` is editable post-TFG, this is done directly (the audit's intended fix) rather than via a global monkeypatch. Literal kwargs (not an env read) keep the change dependency-free and impossible to break from an import/scope issue - the only behaviour change is a finite timeout replacing the SDK's ~infinite one. 120 s mirrors the backend's LM Studio default (`F1_LLM_TIMEOUT`); the sub-agents run gpt-4.1-mini, so 120 s is generous headroom.

## Checks
- `tests/test_agent_llm_timeout.py` (hermetic): langchain-openai still honors `timeout`/`max_retries` (lazy construct, no network), and a source scan asserts **every** `ChatOpenAI(...)` in `src/agents` carries a `timeout=` - so a future edit that drops it fails here. 8/8 pass.
- All 7 agents `py_compile` clean; a constructed client reports `request_timeout=120.0`, `max_retries=1`.

## Not included
The submodule-side L-3 (async offload) + preflight land in a separate submodule PR that closes #263.