### PR TITLE
Promote Sprint 2 hardening to main: CI gate, security throttle/time-box, provider timeouts + async offload

### DIFF
--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -641,9 +641,9 @@ class PaceAgent:
             provider = os.environ.get('F1_LLM_PROVIDER', 'lmstudio')
 
         if provider == 'lmstudio':
-            llm = ChatOpenAI(model=model_name, base_url=base_url, api_key=api_key, temperature=0)
+            llm = ChatOpenAI(model=model_name, base_url=base_url, api_key=api_key, temperature=0, timeout=120, max_retries=1)
         else:
-            llm = ChatOpenAI(model=model_name, temperature=0)
+            llm = ChatOpenAI(model=model_name, temperature=0, timeout=120, max_retries=1)
 
         self._react_agent = create_agent(
             model=llm,

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -830,9 +830,11 @@ class PitStrategyAgent:
                 temperature=0,
                 model_kwargs={'parallel_tool_calls': False},
                 disable_streaming=True,
+                timeout=120,
+                max_retries=1,
             )
         else:
-            llm = ChatOpenAI(model=model_name, temperature=0)
+            llm = ChatOpenAI(model=model_name, temperature=0, timeout=120, max_retries=1)
 
         self._react_agent = create_agent(
             llm, self._tools, system_prompt=_PIT_STRATEGY_SYSTEM_PROMPT

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -978,9 +978,9 @@ class RaceSituationAgent:
             provider = os.environ.get('F1_LLM_PROVIDER', 'lmstudio')
 
         if provider == 'lmstudio':
-            llm = ChatOpenAI(model=model_name, base_url=base_url, api_key=api_key, temperature=0)
+            llm = ChatOpenAI(model=model_name, base_url=base_url, api_key=api_key, temperature=0, timeout=120, max_retries=1)
         else:
-            llm = ChatOpenAI(model=model_name, temperature=0)
+            llm = ChatOpenAI(model=model_name, temperature=0, timeout=120, max_retries=1)
 
         self._react_agent = create_agent(
             model=llm,

--- a/src/agents/radio_agent.py
+++ b/src/agents/radio_agent.py
@@ -793,6 +793,8 @@ def _get_radio_llm():
             base_llm = ChatOpenAI(
                 model=CFG.model_name,
                 temperature=0.0,
+                timeout=120,
+                max_retries=1,
             )
         else:
             base_llm = ChatOpenAI(
@@ -801,6 +803,8 @@ def _get_radio_llm():
                 api_key="lm-studio",
                 temperature=0.0,
                 model_kwargs={"parallel_tool_calls": False},
+                timeout=120,
+                max_retries=1,
             )
         _structured_llm = base_llm.with_structured_output(RadioSynthesis)
     return _structured_llm

--- a/src/agents/rag_agent.py
+++ b/src/agents/rag_agent.py
@@ -148,7 +148,7 @@ def get_rag_react_agent():
         import os
         provider = os.environ.get("F1_LLM_PROVIDER", "lmstudio")
         if provider == "openai":
-            llm = ChatOpenAI(model="gpt-4.1-mini", temperature=0)
+            llm = ChatOpenAI(model="gpt-4.1-mini", temperature=0, timeout=120, max_retries=1)
         else:
             llm = ChatOpenAI(
                 model="gpt-4.1-mini",
@@ -156,6 +156,8 @@ def get_rag_react_agent():
                 api_key="lm-studio",
                 temperature=0,
                 model_kwargs={"parallel_tool_calls": False},
+                timeout=120,
+                max_retries=1,
             )
         _rag_agent = create_agent(
             model=llm,

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -135,7 +135,7 @@ def _get_orchestrator_llm():
         provider = os.environ.get("F1_LLM_PROVIDER", "lmstudio")
         if provider == "openai":
             # No parallel_tool_calls — OpenAI rejects it when no tools are specified
-            llm = ChatOpenAI(model=CFG.model_name, temperature=CFG.temperature)
+            llm = ChatOpenAI(model=CFG.model_name, temperature=CFG.temperature, timeout=120, max_retries=1)
         else:
             llm = ChatOpenAI(
                 model=CFG.model_name,
@@ -143,6 +143,8 @@ def _get_orchestrator_llm():
                 api_key="lm-studio",
                 temperature=CFG.temperature,
                 model_kwargs={"parallel_tool_calls": False},
+                timeout=120,
+                max_retries=1,
             )
         # _LLMSynthesis only has the 3 fields the LLM actually fills —
         # scenario_scores (dict) and regulation_context are attached in code after.

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -990,9 +990,11 @@ class TireAgent:
                 base_url=base_url,
                 api_key=api_key,
                 temperature=0,
+                timeout=120,
+                max_retries=1,
             )
         else:
-            llm = ChatOpenAI(model=model_name, temperature=0)
+            llm = ChatOpenAI(model=model_name, temperature=0, timeout=120, max_retries=1)
 
         self._react_agent = create_agent(
             model=llm,

--- a/tests/test_agent_llm_timeout.py
+++ b/tests/test_agent_llm_timeout.py
@@ -1,0 +1,59 @@
+"""Agent-side provider-timeout contract (LLM-cost L-1 / #263).
+
+The sub-agents construct their own ``ChatOpenAI`` clients; without a finite
+timeout a stalled provider (a hung LM Studio, a dead socket) can pin a lap for
+the SDK's full ~30-min retry budget. Every construction now passes
+``timeout=`` + ``max_retries=``. These hermetic tests pin both halves of the
+contract - the kwargs are still honored by langchain-openai, and no agent
+construction silently loses the timeout - without importing the agents (which
+would load the model configs) or hitting the network.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_AGENTS_DIR = Path(__file__).parent.parent / "src" / "agents"
+_AGENT_FILES = [
+    "pace_agent.py",
+    "tire_agent.py",
+    "pit_strategy_agent.py",
+    "race_situation_agent.py",
+    "radio_agent.py",
+    "rag_agent.py",
+    "strategy_orchestrator.py",
+]
+
+
+def test_chat_openai_still_accepts_timeout_and_retries():
+    """langchain-openai honors the two kwargs the agents rely on (lazy, no network)."""
+    ChatOpenAI = pytest.importorskip("langchain_openai").ChatOpenAI
+    client = ChatOpenAI(model="gpt-4.1-mini", api_key="test-key", timeout=120, max_retries=1)
+    assert client.request_timeout == 120.0
+    assert client.max_retries == 1
+
+
+@pytest.mark.parametrize("filename", _AGENT_FILES)
+def test_every_agent_chatopenai_has_a_timeout(filename: str):
+    """Each ``ChatOpenAI(`` construction in the agent carries a ``timeout=`` kwarg.
+
+    Source-level guard so a future edit that drops the timeout on any of the 14
+    construction sites fails here instead of shipping a hang-prone agent.
+    """
+    source = (_AGENTS_DIR / filename).read_text(encoding="utf-8")
+    # For each construction, scan from ``ChatOpenAI(`` to its balanced close paren.
+    for match in re.finditer(r"ChatOpenAI\(", source):
+        start = match.end()
+        depth = 1
+        i = start
+        while i < len(source) and depth > 0:
+            if source[i] == "(":
+                depth += 1
+            elif source[i] == ")":
+                depth -= 1
+            i += 1
+        construction = source[match.start() : i]
+        assert "timeout=" in construction, f"{filename}: a ChatOpenAI(...) has no timeout="

--- a/tests/test_dep_imports.py
+++ b/tests/test_dep_imports.py
@@ -224,11 +224,22 @@ def test_tiktoken_encoding_roundtrip():
 
     Used by the chat token-budget guard; a bump that drops the encoding
     name or changes the encode signature would silently break trimming.
+
+    ``get_encoding`` fetches the vocab over HTTP on a cold cache, so an
+    upstream outage (openaipublic 503) must skip - not fail - the branch
+    (PK-09 #296). A genuine contract break (unknown encoding name ->
+    ValueError) still fails; only network errors are skipped.
     """
     pytest.importorskip("tiktoken")
     import tiktoken
 
-    enc = tiktoken.get_encoding("cl100k_base")
+    try:
+        enc = tiktoken.get_encoding("cl100k_base")
+    except ValueError:
+        raise  # unknown encoding name = a real contract regression; must fail
+    except Exception as exc:  # noqa: BLE001 - cold-cache vocab fetch is network-bound; an upstream outage must skip, not red the branch
+        pytest.skip(f"tiktoken vocab fetch failed (environment/network): {exc}")
+
     tokens = enc.encode("hello world")
     assert len(tokens) >= 1
     assert enc.decode(tokens) == "hello world"


### PR DESCRIPTION
Promotion of the Sprint 2 remainder (foundation hardening) from `dev` to `main`. 3 of the 4 Sprint-2 items land here; **#236 (CLI on the shared engine) is deferred** to a focused pass (see below).

## What lands
- **#296 (PR #380)** - CI reliability: the tiktoken vocab roundtrip skips on an upstream network outage instead of red-lighting the branch.
- **#263 (PRs #381 + telemetry #67/#68)** - LLM provider hardening: a finite `timeout`+`max_retries` on all 7 sub-agent `ChatOpenAI` sites (L-1, now that `src/agents` is editable post-TFG), plus the backend async offload of blocking provider calls off the event loop (L-3). The backend provider timeout (C1/S-5) was already in place.
- **#226 (telemetry #67)** - Security throttle/time-box: a stdlib per-IP token-bucket rate limiter on the expensive endpoints, CORS tightening (drop credentials, enumerate methods/headers), and prompt-input validation (chat_history/context bounds + pruning, TTS/audio caps). Zero new dependencies.
- **Submodule pointer** bumped to `c283d94` (#382).

## Deferred
- **#236 (CLI Phase D)** - wiring an additive `run_simulation_cli_v2` to the shared engine is a ~2400-line duplicate whose verification needs a full sim boot (models + LM Studio); it is zero-risk to defer (the PMV stays byte-intact) and has a complete Fable design ready. Next-sprint item.
- The chat graceful-degradation circuit breaker (a preflight short-circuit was tried but coupled the SSE grammar to a live health check and broke CI, so it was removed; the offload + finite timeout already bound the damage).

## Checks
- Parent: agent-timeout contract + source-scan test (8/8); tiktoken gate. Submodule: security + offload hermetic suites green (84 passed / 1 xfailed). All data-tier eval tests unaffected.
- No untouchable tree harmed; `src/agents` edits are surgical + tested per the relaxed post-TFG policy.

release-please will bump minor (2 `feat`, 1 `fix`); merge kept with its default non-conventional subject.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of AI-powered features by adding consistent request timeouts and limited automatic retries.
  * Reduced test failures caused by temporary network or environment issues during encoding checks.

* **Tests**
  * Added coverage to verify timeout and retry settings across AI agents.

* **Chores**
  * Updated the telemetry component to a newer pinned version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->