### PR TITLE
fix(packaging): bundle the telemetry submodule in the release wheel (PK-01)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,7 +33,13 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
+      # `submodules: recursive` bakes src/telemetry (the Streamlit surface) into
+      # the wheel; without it f1-streamlit shipped dead (PK-01). fetch-depth: 0 so
+      # the build is identical regardless of checkout depth.
       - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -42,6 +48,30 @@ jobs:
 
       - name: Build wheel and sdist
         run: uv build
+
+      # Guard the exact failure PK-01 was: a wheel that installs but whose entry
+      # points don't resolve. Install (no deps) and assert every console script
+      # plus the bundled Streamlit app + audio-orb component are present.
+      - name: Smoke-test the wheel
+        run: |
+          python -m venv /tmp/smoke
+          /tmp/smoke/bin/python -m pip install --no-deps -q dist/*.whl
+          for s in f1-strat f1-sim f1-arcade f1-streamlit f1-eval; do
+            test -x /tmp/smoke/bin/$s || { echo "missing console script: $s"; exit 1; }
+          done
+          /tmp/smoke/bin/python - <<'PY'
+          import importlib.util, pathlib
+          root = pathlib.Path(importlib.util.find_spec("scripts.run_streamlit").origin).resolve().parent.parent
+          need = [
+              "scripts/f1_cli.py", "scripts/run_simulation_cli.py", "scripts/run_streamlit.py",
+              "src/arcade/main.py", "src/strategy/eval/cli.py",
+              "src/telemetry/frontend/app/main.py",
+              "src/telemetry/frontend/components/streamlit_audio_viz/frontend/build/index.html",
+          ]
+          missing = [r for r in need if not (root / r).exists()]
+          assert not missing, f"wheel is missing: {missing}"
+          print("wheel smoke OK: 5 entry points + Streamlit app + audio-orb assets present")
+          PY
 
       - name: Upload artefacts to release
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,13 @@ torchvision = [
 
 [tool.setuptools.package-data]
 "*" = ["*.yaml", "*.yml", "*.json"]
+# Compiled assets of the vendored Streamlit audio-orb component. Its `frontend/`
+# `.gitignore` ignores both `node_modules/` and `build/`, so a clean checkout
+# carries neither; the `build/` dir is force-committed for release (see the
+# submodule) and shipped here so `f1-streamlit` renders the orb from the wheel.
+# Scoped to `frontend/build/**` on purpose: a broad `*.js` glob would recursively
+# rake in the ~87 MB `node_modules` tree on a dev box that ran `npm install`.
+"src.telemetry.frontend.components.streamlit_audio_viz" = ["frontend/build/*", "frontend/build/**/*"]
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
## What
Fixes **PK-01** (`#289`): the released wheel omitted the entire `src/telemetry` submodule, so `f1-streamlit` was dead on any `uv tool install`.

- `release-please.yml` `publish-wheel`: checkout `submodules: recursive` + `fetch-depth: 0` so the Streamlit surface is baked into the wheel and the build is reproducible regardless of checkout depth.
- `pyproject.toml`: scoped `package-data` for the audio-orb component's compiled `build/` assets (force-committed in the submodule via F1_Telemetry_Manager#69), deliberately narrow so a dev box that ran `npm install` does not rake the ~87 MB `node_modules` tree into the wheel.
- Post-build **wheel smoke test**: installs the artifact (`--no-deps`) and asserts all 5 console scripts + the bundled Streamlit app + audio-orb assets resolve. This is the check that would have caught PK-01.

## Decision (OQ-1)
Per Víctor: the wheel carries **everything** so a clean download runs all entry points. `f1-streamlit` is kept and made to work from the wheel (not dropped in favour of Docker-only).

## Verification (local, clean-tree build = CI scenario)
Built the wheel from a git-tracked-only tree (emulating a clean CI checkout):
- 261 entries, **0 node_modules, 0 .venv**, 1.3 MB (vs a bloated 863-entry local build).
- All 4 audio-orb `build/` assets + `main.py` present; all 5 console scripts declared.
- `pip install --no-deps` into a fresh venv: all 5 scripts created, `f1-streamlit` resolves `main.py`, orb `build/index.html` resolves. **SMOKE PASS.**

## Depends on
F1_Telemetry_Manager#69 (merged) - pointer bumped `c283d94 -> 69bcc8a`.

Closes #289