### PR TITLE
ci(security): add CodeQL, OSV-Scanner, gitleaks and pip-audit to the parent (PK-03)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,3 +166,25 @@ jobs:
       - name: Mypy
         if: steps.changes.outputs.backend == 'true'
         run: uv run mypy src/rag/
+
+  # Same-day CVE alerts on the locked Python deps (OSV/PyPA), independent of
+  # whether the diff touches uv.lock. Always-on (no path filter) per
+  # PROJECT_BOOTSTRAP.md §6; advisory (continue-on-error) while baselining,
+  # promote to a required check after a clean week.
+  pip-audit:
+    name: pip-audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Audit locked dependencies (advisory)
+        continue-on-error: true
+        run: |
+          uv export --frozen --no-emit-project --all-extras --no-hashes \
+            --format requirements-txt -o requirements.audit.txt
+          uvx pip-audit -r requirements.audit.txt

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+# Static analysis (SAST) on the parent repo. The src/telemetry submodule has
+# its own scanner coverage owned by Security epic #223; this workflow scans the
+# parent's Python + the docs/ React SPA only (submodule left unchecked out).
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    - cron: "0 6 * * 1" # weekly, Monday 06:00 UTC
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, javascript-typescript]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,29 @@
+name: gitleaks
+
+# Secret scanning of the repo history + PR diffs. Complements GitHub-native
+# secret scanning / push protection (which are already on) with an explicit,
+# reproducible check. GITLEAKS_LICENSE is only required for GitHub orgs; this
+# is a personal public repo, so no license secret is needed.
+on:
+  push:
+    branches: [main, dev, test]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    - cron: "0 6 * * 1" # weekly, Monday 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # full history so the scan sees every commit
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,26 @@
+name: OSV-Scanner
+
+# Cross-ecosystem vulnerability scan against OSV.dev (Python via uv.lock, plus
+# any npm/JS manifests). Uploads SARIF to the Security tab. The submodule's own
+# manifests are owned by Security epic #223; this covers the parent.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    - cron: "30 6 * * 1" # weekly, Monday 06:30 UTC
+
+permissions:
+  actions: read
+  security-events: write
+  contents: read
+
+jobs:
+  scan-scheduled:
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.8"
+
+  scan-pr:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.8"


### PR DESCRIPTION
## What
Fixes **PK-03** (`#291`): the parent repo lacked almost the entire `PROJECT_BOOTSTRAP.md` §6 scanner stack. Adds:

- **CodeQL** (`codeql.yml`) - `python` + `javascript-typescript`, `security-extended`, on push/PR to main+dev + weekly.
- **OSV-Scanner** (`osv-scanner.yml`) - reusable PR + scheduled workflows `@v2.3.8`, SARIF to the Security tab.
- **gitleaks** (`gitleaks.yml`) - secret scan of history + PR diffs (no license needed on a personal public repo).
- **pip-audit** - new job in `ci.yml`, always-on (no path filter), `continue-on-error` while baselining.

## Scope
Parent only. Extending scanners to the `src/telemetry` submodule stays owned by Security epic #223 (#224). None are wired into branch-protection required contexts yet - promote after a clean week per the bootstrap.

## Notes
- pip-audit exports the locked deps (`uv export --frozen --no-emit-project --all-extras --no-hashes`) and audits them without installing.
- Dependabot `gitsubmodule`/`npm` ecosystems (PK-05) are a separate issue (#292), not this one.

Closes #291