### PR TITLE
fix(devex): unbreak the Docker/Streamlit quickstart + redirected-output crash (#388)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,6 +21,11 @@ prerequisites are on the machine.
   (recommended) or plain `pip`. `uv` resolves the CUDA-specific PyTorch
   wheel automatically via the `[tool.uv.sources]` table in
   `pyproject.toml`.
+- **First-run budget**: models and race data download lazily from Hugging
+  Face on first use (~7-8 GB over a session; keep ~15-20 GB free disk). The
+  first launch also spends ~30 s warming imports before the first panel
+  paints, and the first GP replay may fetch an extra ~1.5 GB Whisper
+  checkpoint. Subsequent runs read a warm cache and start fast.
 
 ---
 
@@ -78,10 +83,17 @@ controls legend, troubleshooting and window tour.
 ## Streamlit — post-race analysis UI (backend + frontend)
 
 ```bash
-git clone https://github.com/VforVitorio/F1_Strat_Manager.git
+git clone --recurse-submodules https://github.com/VforVitorio/F1_Strat_Manager.git
 cd F1_Strat_Manager
+cp .env.example .env          # add OPENAI_API_KEY, or set F1_LLM_PROVIDER=lmstudio
 docker compose up
 ```
+
+`--recurse-submodules` is required: both containers build from `src/telemetry`,
+which is empty without it. `cp .env.example .env` is required too — Compose
+aborts with "env file ./.env not found" otherwise. The backend also serves race
+data from a **read-only** `./data` mount, so seed `data/` on the host first (see
+[Data bootstrap](#data-bootstrap)) or the data endpoints return 404.
 
 Opens:
 
@@ -120,6 +132,15 @@ first run; a warm cache is zero-cost. For a production deploy without a
 repo clone the data tree would be downloaded from the TFG's Hugging Face
 mirror on first run (tracked under `project_cli_distribution_plan.md`,
 deferred past the first release).
+
+For the **Docker Streamlit stack**, `./data` is mounted read-only, so the
+container cannot populate it — seed it on the host before `docker compose up`,
+either by running the CLI path once (`uv run f1-sim Melbourne VER "Red Bull Racing" --year 2025 --no-llm --laps 1-1`)
+or directly:
+
+```bash
+uv run python -c "from src.f1_strat_manager.data_cache import ensure_setup; ensure_setup(show_progress=True)"
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ uv tool install "git+https://github.com/VforVitorio/F1-StratLab.git"
 f1-arcade
 ```
 
-**Streamlit**: clone and bring the stack up with Docker:
+**Streamlit**: clone **with the telemetry submodule**, add an env file, then bring the stack up with Docker:
 
 ```bash
-git clone https://github.com/VforVitorio/F1-StratLab.git && cd F1-StratLab
+git clone --recurse-submodules https://github.com/VforVitorio/F1-StratLab.git && cd F1-StratLab
+cp .env.example .env          # add OPENAI_API_KEY, or set F1_LLM_PROVIDER=lmstudio
 docker compose up
 ```
 

--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -42,6 +42,22 @@ import warnings
 from pathlib import Path
 from typing import Any, Optional
 
+# Ensure UTF-8 on Windows terminals when stdout/stderr are redirected (piped to a
+# file or another process). Without this, Rich's `→` glyphs raise
+# UnicodeEncodeError under the console's cp1252 fallback the moment output is not
+# a live terminal (issue #388). Must run before `console = Console()` below, which
+# caches the stream encoding at construction time.
+if hasattr(sys.stdout, "reconfigure"):
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+if hasattr(sys.stderr, "reconfigure"):
+    try:
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
 # Suppress stray SWIG DeprecationWarnings from C-extension imports.
 warnings.filterwarnings("ignore", message=".*builtin type.*__module__.*")
 


### PR DESCRIPTION
## What
Fixes **#252** (the 3 broken quickstarts) and **#388** (Windows cp1252 crash).

### Quickstart (docs)
The Streamlit Docker quickstart failed three ways on a fresh clone:
1. **No `--recurse-submodules`** → `src/telemetry` empty → empty Docker build context.
2. **No `.env`** → Compose aborts on the required `env_file: ./.env`.
3. **Unseeded read-only `./data` mount** → backend 404s on every data endpoint.

README.md + INSTALL.md now document `git clone --recurse-submodules`, `cp .env.example .env`, and a host-side data-bootstrap step. Added a **first-run budget** callout to INSTALL.md prerequisites (~7-8 GB HF pull, ~15-20 GB disk, ~30 s import warm-up) so the lazy download is not mistaken for a hang.

### #388 encoding crash (code)
`f1-sim` crashed with `UnicodeEncodeError` on Rich's `→` glyph the moment stdout was redirected on Windows (default cp1252). Added a `sys.stdout/stderr.reconfigure(encoding="utf-8", errors="replace")` guard at the top of `scripts/run_simulation_cli.py`, before the Rich `Console` is constructed - mirroring the guard already in `scripts/f1_cli.py:27-37`.

## Verification
Ran the exact #388 repro on Windows: `f1-sim Melbourne NOR McLaren --no-llm --laps 1-3 > log.txt 2>&1` → **exit 0, no traceback**, Rich output rendered cleanly into the redirected file.

Closes #252
Closes #388