### PR TITLE
fix(data): resolve every GP's radio + compound labels via a canonical name (F-01)

### DIFF
--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -361,8 +361,14 @@ def _load_tire_alloc(repo_root: Path) -> None:
 
 def _compound_text(compound: str, gp_name: str, year: int) -> Text:
     """Return a coloured Rich Text showing compound + Cx (e.g. 'SOF/C4')."""
+    from src.f1_strat_manager.gp_slugs import canonical_gp_name
+
     cu = compound.upper()
-    cx = _TIRE_ALLOC.get(str(year), {}).get(gp_name, {}).get(cu)
+    # tire_compounds_by_race.json is keyed by the friendly GP name; normalise the
+    # raw folder name (e.g. "Miami_Gardens" -> "Miami", "Las_Vegas" -> "Las Vegas")
+    # so the Cx label resolves for every GP, not just the ~18 whose folder name
+    # already matched the friendly key (#243).
+    cx = _TIRE_ALLOC.get(str(year), {}).get(canonical_gp_name(gp_name), {}).get(cu)
     if cx:
         label = f"{cu[:3]}/{cx}"  # SOF/C4, MED/C3, HAR/C2
     else:

--- a/src/f1_strat_manager/data_cache.py
+++ b/src/f1_strat_manager/data_cache.py
@@ -38,6 +38,7 @@ F1_STRAT_NO_FIRST_RUN
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 from typing import Iterable
 
@@ -467,9 +468,16 @@ def ensure_radio_corpus(
     try:
         slug = resolve_gp_slug(gp_name)
     except ValueError:
-        # Unknown friendly name — let the caller handle it. We do NOT raise
-        # here because the runner may itself accept the raw gp_name path
-        # and the user gets a clearer error from the runner constructor.
+        # Unknown name even after canonical normalisation — a genuine typo or an
+        # as-yet-unmapped GP. We do NOT raise here (the runner may accept the raw
+        # gp_name path and gives a clearer error), but warn so the miss is not
+        # fully silent: a zero-radio simulation used to look identical to a
+        # healthy one (#243).
+        print(
+            f"[warn] ensure_radio_corpus: no radio-corpus mapping for {gp_name!r} "
+            f"({year}); simulating with no team radio.",
+            file=sys.stderr,
+        )
         return get_data_root() / "raw" / "radio_audio" / str(year) / gp_name
 
     data_root = get_data_root()

--- a/src/f1_strat_manager/gp_slugs.py
+++ b/src/f1_strat_manager/gp_slugs.py
@@ -63,11 +63,52 @@ COUNTRY_SLUG_BY_GP: dict[str, str] = {
 }
 
 
+# On-disk raw folder names that differ from the friendly key by more than the
+# underscore substitution — a mid-season circuit rename. Keyed by the folder
+# name under ``data/raw/{year}/``, value is the canonical friendly name used by
+# both :data:`COUNTRY_SLUG_BY_GP` and ``data/tire_compounds_by_race.json``. The
+# space-vs-underscore forms (``Las_Vegas`` → ``Las Vegas``) are handled generically
+# by :func:`canonical_gp_name` and do NOT belong here.
+FOLDER_ALIASES: dict[str, str] = {
+    "Miami_Gardens": "Miami",  # 2025 raw folder; 2023/2024 used "Miami"
+}
+
+
+def canonical_gp_name(name: str) -> str:
+    """Normalise any GP identifier form to the canonical friendly name.
+
+    A single GP is referred to by several strings across the project: the
+    friendly name the featured-laps parquet uses (``"Las Vegas"``), the raw
+    on-disk folder name with underscores (``"Las_Vegas"``, ``"Marina_Bay"``),
+    and the occasional renamed folder (``"Miami_Gardens"`` for what the tables
+    call ``"Miami"``). Both :data:`COUNTRY_SLUG_BY_GP` and
+    ``data/tire_compounds_by_race.json`` are keyed by the *friendly* name, so
+    every caller that starts from a folder name must funnel through here first
+    or it silently misses the lookup (~6 GPs/season had no radio and no
+    compound labels before this existed).
+
+    Resolution order: exact friendly name, then an explicit folder alias, then
+    the generic underscore→space form. Unknown inputs are returned unchanged so
+    the caller keeps control of the miss (the radio resolver raises; the
+    compound lookup degrades to a short label).
+    """
+    if name in COUNTRY_SLUG_BY_GP:
+        return name
+    if name in FOLDER_ALIASES:
+        return FOLDER_ALIASES[name]
+    spaced = name.replace("_", " ")
+    if spaced in COUNTRY_SLUG_BY_GP:
+        return spaced
+    return name
+
+
 def resolve_gp_slug(gp_name: str) -> str:
-    """Translate a friendly GP name into the on-disk corpus slug.
+    """Translate a friendly or on-disk GP name into the corpus slug.
 
     Accepts the names the CLI passes (``"Sakhir"``, ``"Imola"``,
-    ``"Marina Bay"``, ...) and returns the slug used by the static
+    ``"Marina Bay"``, ...) *and* the raw folder names with underscores
+    (``"Las_Vegas"``, ``"Miami_Gardens"``, ...) via
+    :func:`canonical_gp_name`, and returns the slug used by the static
     builder for the corpus directories under
     ``data/processed/race_radios/{year}/`` and
     ``data/raw/radio_audio/{year}/``. Falls through silently when the
@@ -77,12 +118,13 @@ def resolve_gp_slug(gp_name: str) -> str:
     download.
 
     Raises :class:`ValueError` listing the known GP names whenever the
-    input matches neither a friendly name nor an existing slug, so a
-    typo at the CLI surfaces immediately instead of producing a silent
+    input matches neither a friendly/folder name nor an existing slug, so
+    a typo at the CLI surfaces immediately instead of producing a silent
     zero-radio simulation.
     """
-    if gp_name in COUNTRY_SLUG_BY_GP:
-        return COUNTRY_SLUG_BY_GP[gp_name]
+    canonical = canonical_gp_name(gp_name)
+    if canonical in COUNTRY_SLUG_BY_GP:
+        return COUNTRY_SLUG_BY_GP[canonical]
     if gp_name in set(COUNTRY_SLUG_BY_GP.values()):
         return gp_name
     raise ValueError(f"Unknown GP {gp_name!r}. Known: {sorted(COUNTRY_SLUG_BY_GP)}")

--- a/tests/test_gp_slugs.py
+++ b/tests/test_gp_slugs.py
@@ -1,0 +1,61 @@
+"""Hermetic unit tests for the GP name/slug resolver (#243).
+
+Before #243, ~6 GPs/season silently ran with **no radio and no compound
+labels**: the resolver keyed on the friendly space-separated name
+(``"Las Vegas"``) while callers passed the raw on-disk folder name with
+underscores (``"Las_Vegas"``) or a renamed folder (``"Miami_Gardens"``).
+These pin that every on-disk folder form now maps to the right slug, and
+that the reentrant / raise-on-typo contract is preserved.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.f1_strat_manager.gp_slugs import (
+    COUNTRY_SLUG_BY_GP,
+    canonical_gp_name,
+    resolve_gp_slug,
+)
+
+# The 6 GPs whose raw 2025 folder name did NOT match the friendly key before
+# #243: (folder_name, expected_friendly_name, expected_slug).
+_PREVIOUSLY_FAILING = [
+    ("Las_Vegas", "Las Vegas", "united_states_las_vegas"),
+    ("Marina_Bay", "Marina Bay", "singapore"),
+    ("Mexico_City", "Mexico City", "mexico"),
+    ("Miami_Gardens", "Miami", "united_states_miami"),
+    ("São_Paulo", "São Paulo", "brazil"),
+    ("Yas_Island", "Yas Island", "united_arab_emirates"),
+]
+
+
+@pytest.mark.parametrize("folder, friendly, slug", _PREVIOUSLY_FAILING)
+def test_folder_names_resolve(folder, friendly, slug):
+    """Underscore folder names (and the Miami_Gardens rename) now resolve."""
+    assert canonical_gp_name(folder) == friendly
+    assert resolve_gp_slug(folder) == slug
+
+
+def test_friendly_names_still_resolve():
+    """Every friendly key still maps to its slug — no regression."""
+    for friendly, slug in COUNTRY_SLUG_BY_GP.items():
+        assert resolve_gp_slug(friendly) == slug
+
+
+def test_resolve_is_reentrant_on_slugs():
+    """Passing an already-resolved slug is a no-op, not an error."""
+    for slug in set(COUNTRY_SLUG_BY_GP.values()):
+        assert resolve_gp_slug(slug) == slug
+
+
+def test_unknown_gp_raises():
+    """A genuine typo still raises so it does not silently drop radios."""
+    with pytest.raises(ValueError):
+        resolve_gp_slug("Nordschleife")
+
+
+def test_canonical_returns_unknown_unchanged():
+    """canonical_gp_name hands unknown input back verbatim (caller decides)."""
+    assert canonical_gp_name("Nordschleife") == "Nordschleife"
+    assert canonical_gp_name("Totally_Unknown") == "Totally_Unknown"


### PR DESCRIPTION
## What
Fixes **F-01** (`#243`): ~6 GPs/season silently ran with **no team radio and no Cx compound labels**.

`resolve_gp_slug()` and `data/tire_compounds_by_race.json` are both keyed by the *friendly* space-separated name (`Las Vegas`, `Miami`), but callers pass the raw on-disk folder name (`Las_Vegas`, `Miami_Gardens`). The resolver's `ValueError` was swallowed in `ensure_radio_corpus` and the compound lookup missed - a broken race looked identical to a healthy one.

## Fix
- New `canonical_gp_name()` in `gp_slugs.py`: exact key → folder alias (`Miami_Gardens`→`Miami`) → generic underscore→space. One normalizer, so `resolve_gp_slug` (radio, all callers incl. the backend) **and** the CLI compound lookup (`_compound_text`) both funnel through it.
- `ensure_radio_corpus` now **warns** instead of silently swallowing a genuinely unmapped GP.

## Verification
- `tests/test_gp_slugs.py` (new): **10 passed** - all 6 previously-failing folders resolve to the right slug, friendly names unchanged, reentrant on slugs, raises on a real typo.
- Resolver sweep over the on-disk 2025 folders: **24/24 resolve** (was 18).
- `f1-sim Miami_Gardens NOR McLaren --no-llm` → exit 0, no radio-mapping warning; `canonical_gp_name("Miami_Gardens")="Miami"` → compound resolves to `SOF/C5 / MED/C4 / HAR/C3` (before: bare `SOFT`).

The 6 folders fixed: `Las_Vegas`, `Marina_Bay`, `Mexico_City`, `Miami_Gardens`, `São_Paulo`, `Yas_Island`.

Closes #243