### PR TITLE
fix(data): validate the parquet read boundary + surface FastF1 quality flags (F-02)

### DIFF
--- a/src/simulation/data_validation.py
+++ b/src/simulation/data_validation.py
@@ -1,0 +1,109 @@
+"""Load-boundary validation for race data (F-02, #244).
+
+Turns silent failure modes at the parquet-read boundary into loud, sourced
+errors before they reach the agents:
+
+- A **missing required column** used to surface as a cryptic ``KeyError`` deep
+  inside ``RaceStateManager`` (or, worse, as a silent ``None`` in ``lap_state``
+  that flowed into an agent's feature vector). Now it fails at ingestion,
+  naming the artifact and the exact missing column.
+- The **FastF1 quality flags** (``IsAccurate`` / ``Deleted``) already ship in
+  every laps parquet but were never consulted. They are legitimate data, not
+  corruption, so they are surfaced as a *warning*, not a hard stop.
+
+Fail-loud vs warn split (per the P5 audit): structural breaks that make the
+data unusable raise :class:`DataValidationError`; quality-flag findings only
+warn.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pandas as pd
+
+# The columns the simulation pipeline needs to produce a correct lap_state.
+# Driver / LapNumber / Time / TrackStatus are indexed UNCONDITIONALLY by
+# RaceStateManager (the per-driver split + total laps, the session-time gaps in
+# _compute_session_times, and the weather/track-status snapshot), so a missing
+# one is a hard crash deep in construction. LapTime / Position / Compound /
+# TyreLife are read more defensively but a missing one would flow into lap_state
+# as a SILENT None on an agent's feature vector - exactly the failure mode #244
+# exists to catch - so they are required too.
+REQUIRED_LAPS_COLUMNS: tuple[str, ...] = (
+    "Driver",
+    "LapNumber",
+    "LapTime",
+    "Time",
+    "Position",
+    "Compound",
+    "TyreLife",
+    "TrackStatus",
+)
+
+
+class DataValidationError(ValueError):
+    """A loaded race artifact is structurally unusable.
+
+    Raised for a missing required column or an empty laps table - conditions
+    under which the simulation cannot produce a correct ``lap_state`` and must
+    stop loudly rather than emit silent ``None`` fields.
+    """
+
+
+def validate_laps_df(df: pd.DataFrame, source: str) -> None:
+    """Assert a laps DataFrame satisfies the RaceStateManager contract.
+
+    Args:
+        df:     The laps DataFrame just read from parquet.
+        source: A human-readable identifier for the error message (the parquet
+                path when known, else a ``"<gp> <year>"`` label).
+
+    Raises:
+        DataValidationError: if any :data:`REQUIRED_LAPS_COLUMNS` is absent or
+            the table has zero rows. The message names the source and the exact
+            missing columns so the fix is unambiguous.
+    """
+    missing = [c for c in REQUIRED_LAPS_COLUMNS if c not in df.columns]
+    if missing:
+        raise DataValidationError(
+            f"{source}: laps parquet is missing required column(s) {missing}. "
+            f"Present columns: {sorted(map(str, df.columns))}"
+        )
+    if len(df) == 0:
+        raise DataValidationError(f"{source}: laps parquet has zero rows.")
+    if not df["LapNumber"].notna().any():
+        raise DataValidationError(
+            f"{source}: laps parquet has no non-null LapNumber "
+            "(RaceStateManager cannot index laps or compute total_laps)."
+        )
+
+
+def warn_low_quality_laps(df: pd.DataFrame, source: str) -> None:
+    """Warn (never raise) when FastF1 flags some laps as inaccurate/deleted.
+
+    ``IsAccurate=False`` and ``Deleted=True`` are legitimate FastF1 annotations
+    (out-laps, track-limit deletions), not corruption - so this surfaces them
+    for the operator's awareness without blocking the run. Absent flag columns
+    make it a no-op.
+    """
+    notes: list[str] = []
+    try:
+        if "IsAccurate" in df.columns:
+            inaccurate = int((~df["IsAccurate"].astype("boolean").fillna(True)).sum())
+            if inaccurate:
+                notes.append(f"{inaccurate} lap(s) flagged IsAccurate=False")
+        if "Deleted" in df.columns:
+            deleted = int(df["Deleted"].astype("boolean").fillna(False).sum())
+            if deleted:
+                notes.append(f"{deleted} lap(s) flagged Deleted")
+    except (TypeError, ValueError):
+        # A quality-flag column with an unexpected dtype (e.g. "True"/"False"
+        # strings, mixed object) must never abort a load - this helper only ever
+        # advises, so swallow the coercion error rather than raise. (#244 D4)
+        return
+    if notes:
+        print(
+            f"[warn] {source}: {'; '.join(notes)} (FastF1 quality flags).",
+            file=sys.stderr,
+        )

--- a/src/simulation/race_state_manager.py
+++ b/src/simulation/race_state_manager.py
@@ -24,6 +24,8 @@ from typing import Any
 
 import pandas as pd
 
+from src.simulation.data_validation import validate_laps_df
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -112,6 +114,11 @@ class RaceStateManager:
         self.team = team
         self.gp_name = gp_name
         self.year = year
+
+        # Validate the schema contract here (not only in RaceReplayEngine) so a
+        # missing required column fails loudly at construction from ANY caller -
+        # the backend simulator and tests build RaceStateManager directly. (F-02)
+        validate_laps_df(laps_df, source=f"{gp_name or 'race'} {year} laps parquet")
 
         enriched = _compute_session_times(laps_df)
 

--- a/src/simulation/replay_engine.py
+++ b/src/simulation/replay_engine.py
@@ -19,6 +19,7 @@ all consume the same ``lap_state`` dict contract.
 from __future__ import annotations
 
 import json
+import sys
 import time
 from collections.abc import Iterator
 from pathlib import Path
@@ -26,6 +27,7 @@ from typing import Any
 
 import pandas as pd
 
+from src.simulation.data_validation import DataValidationError, warn_low_quality_laps
 from src.simulation.race_state_manager import RaceStateManager
 
 
@@ -65,12 +67,27 @@ class RaceReplayEngine:
         """
         race_dir = Path(race_dir)
 
-        laps_df = pd.read_parquet(race_dir / "laps.parquet")
+        # Guard the read so a missing/corrupt parquet fails with a sourced error
+        # instead of a raw pyarrow/OS traceback; the required-column contract is
+        # then enforced in RaceStateManager. (F-02)
+        laps_path = race_dir / "laps.parquet"
+        try:
+            laps_df = pd.read_parquet(laps_path)
+        except Exception as exc:  # noqa: BLE001 - any read failure is a load-boundary error
+            raise DataValidationError(f"{laps_path}: cannot read laps parquet ({exc}).") from exc
+        warn_low_quality_laps(laps_df, source=str(laps_path))
 
         self._weather_df: pd.DataFrame | None = None
         weather_path = race_dir / "weather.parquet"
         if weather_path.exists():
-            self._weather_df = pd.read_parquet(weather_path)
+            try:
+                self._weather_df = pd.read_parquet(weather_path)
+            except Exception as exc:  # noqa: BLE001 - weather is optional; degrade, don't abort
+                print(
+                    f"[warn] {weather_path}: cannot read weather parquet ({exc}); "
+                    "continuing without weather.",
+                    file=sys.stderr,
+                )
 
         gp_name, year = self._parse_meta(race_dir)
 
@@ -96,6 +113,13 @@ class RaceReplayEngine:
             with open(meta_path) as f:
                 meta = json.load(f)
             return meta.get("gp_name", race_dir.name), int(meta.get("year", 2025))
+        # No metadata.json: warn loudly instead of silently assuming 2025 - a
+        # wrong year mis-selects circuit-aware thresholds and season config. (F-02)
+        print(
+            f"[warn] {meta_path} absent; falling back to gp_name={race_dir.name!r}, "
+            "year=2025 (circuit thresholds + season may be wrong).",
+            file=sys.stderr,
+        )
         return race_dir.name, 2025
 
     def replay(self) -> Iterator[dict[str, Any]]:

--- a/tests/test_data_validation.py
+++ b/tests/test_data_validation.py
@@ -1,0 +1,111 @@
+"""Hermetic tests for the load-boundary data validation (F-02, #244).
+
+Pins that a missing required column fails loudly at ingestion (naming the
+artifact + column) instead of surfacing as a silent ``None`` in ``lap_state``,
+and that the FastF1 quality flags only warn.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from src.simulation.data_validation import (
+    REQUIRED_LAPS_COLUMNS,
+    DataValidationError,
+    validate_laps_df,
+    warn_low_quality_laps,
+)
+
+
+def _valid_laps() -> pd.DataFrame:
+    """A minimal 2-driver x 2-lap frame carrying every required column."""
+    return pd.DataFrame(
+        {
+            "Driver": ["NOR", "VER", "NOR", "VER"],
+            "LapNumber": [1, 1, 2, 2],
+            "LapTime": [90.1, 90.3, 89.9, 90.0],
+            "Time": [90.1, 90.3, 180.0, 180.3],
+            "Position": [1, 2, 1, 2],
+            "Compound": ["SOFT", "SOFT", "MEDIUM", "MEDIUM"],
+            "TyreLife": [1, 1, 2, 2],
+            "TrackStatus": ["1", "1", "1", "1"],
+        }
+    )
+
+
+def test_valid_laps_pass():
+    validate_laps_df(_valid_laps(), source="test")  # must not raise
+
+
+@pytest.mark.parametrize("col", REQUIRED_LAPS_COLUMNS)
+def test_missing_column_raises_and_names_it(col):
+    df = _valid_laps().drop(columns=[col])
+    with pytest.raises(DataValidationError) as exc:
+        validate_laps_df(df, source="Melbourne 2025 laps.parquet")
+    assert col in str(exc.value)
+    assert "Melbourne 2025 laps.parquet" in str(exc.value)
+
+
+def test_empty_laps_raises():
+    with pytest.raises(DataValidationError):
+        validate_laps_df(_valid_laps().iloc[0:0], source="test")
+
+
+def test_quality_flags_warn(capsys):
+    df = _valid_laps()
+    df["IsAccurate"] = [True, False, True, True]
+    df["Deleted"] = [False, True, False, False]
+    warn_low_quality_laps(df, source="race")
+    err = capsys.readouterr().err
+    assert "IsAccurate=False" in err
+    assert "Deleted" in err
+
+
+def test_quality_flags_silent_when_clean(capsys):
+    df = _valid_laps()
+    df["IsAccurate"] = [True, True, True, True]
+    df["Deleted"] = [False, False, False, False]
+    warn_low_quality_laps(df, source="race")
+    assert capsys.readouterr().err == ""
+
+
+def test_rsm_rejects_missing_required_column():
+    """RaceStateManager enforces the schema from any construction path."""
+    from src.simulation.race_state_manager import RaceStateManager
+
+    df = _valid_laps().drop(columns=["Compound"])
+    with pytest.raises(DataValidationError):
+        RaceStateManager(laps_df=df, driver_code="NOR", team="McLaren", gp_name="Test", year=2025)
+
+
+def test_valid_frame_constructs_race_state_manager():
+    """A frame that passes validation actually builds a RaceStateManager.
+
+    Guards the gap Fable found: the required-column list must be a SUPERSET of
+    what RSM indexes unconditionally (Time/TrackStatus included), so a "valid"
+    frame never passes validation only to crash in construction.
+    """
+    from src.simulation.race_state_manager import RaceStateManager
+
+    rsm = RaceStateManager(
+        laps_df=_valid_laps(), driver_code="NOR", team="McLaren", gp_name="Test", year=2025
+    )
+    assert rsm.total_laps == 2
+
+
+def test_all_nan_lapnumber_raises():
+    """A present-but-all-NaN LapNumber is caught, not left to crash int(max())."""
+    import numpy as np
+
+    df = _valid_laps()
+    df["LapNumber"] = np.nan
+    with pytest.raises(DataValidationError):
+        validate_laps_df(df, source="test")
+
+
+def test_quality_flags_never_raise_on_bad_dtype():
+    """A hostile quality-flag dtype (strings) must be swallowed, never raised."""
+    df = _valid_laps()
+    df["IsAccurate"] = ["True", "False", "True", "False"]  # strings, not bools
+    warn_low_quality_laps(df, source="race")  # must return without raising


### PR DESCRIPTION
## What
Fixes **F-02** (`#244`, P0): the laps parquet was read with **zero checks**.

- A missing required column surfaced as a cryptic `KeyError` deep inside `RaceStateManager` - or worse, a silent `None` in `lap_state` that flowed into an agent feature vector.
- A missing `metadata.json` silently defaulted the season to **2025** (wrong year → wrong circuit thresholds).
- The FastF1 quality flags (`IsAccurate`, `Deleted`) that ship in every laps parquet were never consulted.

## Fix
New `src/simulation/data_validation.py`:
- `validate_laps_df(df, source)` → raises a **sourced** `DataValidationError` on a missing required column (naming it) or an empty table. **Fail-loud** on structural breaks.
- `warn_low_quality_laps(df, source)` → **warns** (never raises) on `IsAccurate=False` / `Deleted` laps; no-op when the flag columns are absent.

Wired in:
- `RaceStateManager.__init__` validates its schema contract - catches **every** construction path (backend, arcade, tests), not just the replay engine.
- `RaceReplayEngine.__init__` guards the `pd.read_parquet` (any failure → sourced error) and `_parse_meta` now **warns** when `metadata.json` is absent instead of silently assuming 2025.

## Verification
- `tests/test_data_validation.py` (new) + the RSM/replay/smoke suite: **23 passed, 1 skipped** (pre-existing data-gated Qatar test).
- The `mini_race.parquet` fixture carries all 6 required columns + the quality flags → no regression.
- 🟡 Fable VERIFY-AFTER gate running on the validation logic.

Closes #244