### PR TITLE
fix(nlp): RCM parser superset + penalty/red-flag routing + arcade SC persistence (#398)

### DIFF
--- a/src/agents/radio_agent.py
+++ b/src/agents/radio_agent.py
@@ -106,6 +106,29 @@ _FLAG_MAP = {
     "CHEQUERED": "CHEQUERED_FLAG",
 }
 
+# NR-03 (#398) — flag values that resolve through the same scope-aware branch as
+# a plain YELLOW. DOUBLE YELLOW is the highest-danger *local* flag (an incident
+# sits directly on the racing line; cars must slow far more than for a single
+# yellow) and is a frequent precursor to a full Safety Car. Before this fix it
+# matched neither `_FLAG_MAP` nor the old exact `flag == "YELLOW"` check, so it
+# fell all the way through to OTHER — invisible to `_SAFETY_FLAGS` and to N31.
+# Folding it into the YELLOW branch below means it inherits YELLOW_FLAG /
+# YELLOW_FLAG_SECTOR's existing alert status for free, with no edit needed to
+# `_SAFETY_FLAGS` itself and no change to how a plain YELLOW is handled.
+_YELLOW_FLAG_VALUES = {"YELLOW", "DOUBLE YELLOW"}
+
+# NR-03 (#398) — message-keyword families that fell through to OTHER. Verified
+# against the real 2025 rcm.parquet corpus (data/processed/race_radios/2025/**)
+# except _SESSION_* (see _classify_rcm_event docstring for the caveat: no race
+# in that corpus contains a red-flag suspension, so this family is unverified).
+_TRACK_LIMITS_KEYWORDS      = ("TRACK LIMITS", "TIME DELETED", "LAP DELETED", "DELETED")
+_INVESTIGATION_KEYWORDS     = ("UNDER INVESTIGATION", "NOTED")
+_SESSION_SUSPENDED_KEYWORDS = ("SESSION SUSPENDED", "RACE SUSPENDED")
+_SESSION_RESUMED_KEYWORDS   = (
+    "SESSION RESUMED", "RACE RESUMED", "RACE WILL RESUME", "SESSION WILL RESUME",
+)
+_SESSION_STARTED_KEYWORDS   = ("SESSION WILL START", "RACE WILL START")
+
 
 # ==============================================================================
 # Input/output dataclasses
@@ -563,12 +586,31 @@ def run_pipeline(text: str, rcm_result: Optional[dict] = None) -> dict:
 def _classify_rcm_event(event: "RCMEvent") -> str:
     """Map a raw RCMEvent to a canonical event type string.
 
-    Priority: SafetyCar category → flag keyword → incident keyword → OTHER.
-    Mirrors the N23 rule-based classifier used in N24's run_rcm_pipeline.
+    Priority: SafetyCar category -> flag keyword -> incident keyword ->
+    NR-03 (#398) coverage additions -> OTHER. Mirrors the N23 rule-based
+    classifier used in N24's run_rcm_pipeline.
+
+    NR-03 (#398) note on placement: every new branch below sits AFTER the
+    pre-existing DRS/collision/retired/penalty checks so no message that
+    already resolves to a specific event type changes classification — the
+    additions only catch what used to fall through to OTHER. One consequence,
+    verified against the real 2025 rcm.parquet corpus: nearly every real
+    "UNDER INVESTIGATION" / "NOTED" message also contains the word "INCIDENT"
+    (e.g. "TURN 1 INCIDENT INVOLVING CAR 7 (DOO) NOTED - MOVING UNDER
+    BRAKING"), so it is already caught by the COLLISION/CONTACT/INCIDENT
+    branch above and never reaches the new INVESTIGATION branch. That overlap
+    is pre-existing behaviour (unrelated to this fix, and out of scope to
+    narrow here since doing so would reclassify messages that already resolve
+    today) — the INVESTIGATION branch is genuine coverage only for messages
+    that use "NOTED"/"UNDER INVESTIGATION" wording without those keywords.
     """
-    cat  = event.category.strip()
-    flag = event.flag.strip().upper()
-    msg  = event.message.upper()
+    cat   = event.category.strip()
+    flag  = event.flag.strip().upper()
+    msg   = event.message.upper()
+    # NR-03 (#398): scope casing is not guaranteed by the data source (FastF1
+    # vs OpenF1-sourced corpora disagree on "Sector" vs "SECTOR"), so normalise
+    # before comparing rather than relying on the exact-case match used before.
+    scope = event.scope.strip().upper()
 
     if cat == "SafetyCar":
         # "SAFETY CAR IN THIS LAP" is the FIA end-of-neutralisation message (the
@@ -587,8 +629,8 @@ def _classify_rcm_event(event: "RCMEvent") -> str:
 
     if flag in _FLAG_MAP:
         return _FLAG_MAP[flag]
-    if flag == "YELLOW":
-        return "YELLOW_FLAG_SECTOR" if event.scope == "Sector" else "YELLOW_FLAG"
+    if flag in _YELLOW_FLAG_VALUES:
+        return "YELLOW_FLAG_SECTOR" if scope == "SECTOR" else "YELLOW_FLAG"
 
     if "DRS ENABLED"  in msg:
         return "DRS_ENABLED"
@@ -600,6 +642,39 @@ def _classify_rcm_event(event: "RCMEvent") -> str:
         return "CAR_RETIRED"
     if "PENALTY" in msg:
         return "TIME_PENALTY"
+
+    # ── NR-03 (#398) additive coverage ──────────────────────────────────────
+    # Track-limit / lap-time deletions ("CAR 1 (VER) LAP DELETED - TRACK
+    # LIMITS AT TURN 14 ..."): a penalty-risk signal for us or a rival that
+    # was previously indistinguishable from any other unclassified message.
+    if any(k in msg for k in _TRACK_LIMITS_KEYWORDS):
+        return "LAP_DELETED"
+    # Stewards reviewing an incident ("... UNDER INVESTIGATION" / "... NOTED"):
+    # penalty anticipation, worth surfacing even though (see docstring) the
+    # broader COLLISION/CONTACT/INCIDENT check above already intercepts the
+    # large majority of real-world instances of this phrasing.
+    if any(k in msg for k in _INVESTIGATION_KEYWORDS):
+        return "INVESTIGATION"
+    # Pit lane entry/exit status ("PIT LANE ENTRY CLOSED" / "... OPEN"): a hard
+    # veto or permission on PIT_NOW, so CLOSED and OPEN are kept as distinct
+    # event types rather than a single generic "pit lane event" bucket.
+    if "PIT" in msg and "CLOSED" in msg:
+        return "PIT_LANE_CLOSED"
+    if "PIT" in msg and "OPEN" in msg:
+        return "PIT_LANE_OPEN"
+    # Session suspend/resume/start announcements. Unlike the families above,
+    # no race in the local 2025 rcm.parquet corpus contains a red-flag
+    # suspension, so these keyword sets are best-effort FIA phrasing and are
+    # NOT corpus-verified — flagged in the PR/issue for validation against a
+    # real red-flag race before being relied on for the restart-procedure logic
+    # the audit describes (AUDIT_NLP_RADIO_PIPELINE.md section 5.2 item 4).
+    if any(k in msg for k in _SESSION_SUSPENDED_KEYWORDS):
+        return "SESSION_SUSPENDED"
+    if any(k in msg for k in _SESSION_RESUMED_KEYWORDS):
+        return "SESSION_RESUMED"
+    if any(k in msg for k in _SESSION_STARTED_KEYWORDS):
+        return "SESSION_STARTED"
+
     return "OTHER"
 
 

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -474,6 +474,18 @@ class StrategyRecommendation(BaseModel):
 # Layer 1 — MoE routing
 # ==============================================================================
 
+# RCM event_type values (radio_agent._classify_rcm_event naming) that count as
+# a FIA-facing penalty or red-flag ruling for N30 routing purposes. RED_FLAG is
+# reachable today: it is one of radio_agent._SAFETY_FLAGS, so radio_agent
+# ._build_alerts forwards it into RadioOutput.alerts as {'source': 'rcm',
+# 'event_type': 'RED_FLAG', ...}. TIME_PENALTY is listed for when an RCM event
+# actually reaches this set; as of writing, radio_agent._build_alerts only
+# forwards RCM events whose event_type is in _SAFETY_FLAGS, which excludes
+# TIME_PENALTY — so it currently never arrives in radio_alerts. That is a
+# separate, upstream gap in src/agents/radio_agent.py, not fixed here.
+_RCM_PENALTY_EVENT_TYPES = {"RED_FLAG", "TIME_PENALTY"}
+
+
 def _decide_agents_to_call(
     tire_warning:  str,
     sc_prob_3lap:  float,
@@ -504,8 +516,10 @@ def _decide_agents_to_call(
       and pit-lane rules (mandatory dry compound, unsafe release, pit window).
     * sc_prob_3lap > threshold → SC deployment likely → query SC procedure
       (delta lap time, pit-lane closure, double-yellow restart).
-    * Radio carries a FIA-facing alert (PENALTY / WARNING intent) → regulation
-      lookup for the infringement the steward is flagging.
+    * Radio carries a FIA-facing alert — an RCM alert whose event_type is in
+      _RCM_PENALTY_EVENT_TYPES (e.g. RED_FLAG), or a radio-transcript alert
+      with a WARNING intent → regulation lookup for the infringement the
+      steward is flagging.
 
     Any of the three conditions independently activates N30. The orchestrator
     LLM then sees the retrieved regulation snippet in its prompt and must
@@ -523,7 +537,16 @@ def _decide_agents_to_call(
     if sc_prob_3lap > CFG.sc_prob_threshold:
         activate.add("N30")
 
-    if alert_intents & {"PENALTY", "WARNING"}:
+    # RCM-sourced alerts (source='rcm') carry no 'intent' key at all — only
+    # radio-transcript alerts (source='radio') do, and radio_agent.CFG
+    # .alert_intents is ("PROBLEM", "WARNING"); no producer ever emits
+    # intent == "PENALTY". `alert_intents & {"PENALTY", "WARNING"}` was
+    # therefore unreachable on its PENALTY half. Route penalty/red-flag RCM
+    # alerts on their real 'event_type' field instead, unioned with the
+    # still-valid WARNING intent check so nothing that used to fire stops
+    # firing (NR-04, #398).
+    alert_event_types = {a.get("event_type", "") for a in radio_alerts}
+    if (alert_intents & {"WARNING"}) or (alert_event_types & _RCM_PENALTY_EVENT_TYPES):
         activate.add("N30")
 
     if "N28" in activate:

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -221,6 +221,15 @@ class SimConnector(threading.Thread):
         # degrade path — the agents run with empty radio_msgs if the
         # corpus cannot be loaded).
         self._radio_runner: Any = None
+        # One Safety-Car tracker for the whole replay: a "SAFETY CAR DEPLOYED"
+        # corpus message is announced once (at the deploy lap), so without this
+        # the per-lap RCM window is empty on laps 8-10 of the same neutralisation
+        # and the SC override drops mid-stint. Persists the state across laps and
+        # re-asserts it in _build_race_state (NR-02, #305 → #398; same wiring the
+        # CLI uses).
+        from src.nlp.rcm_state import RaceControlStateTracker
+
+        self._sc_tracker = RaceControlStateTracker()
 
     def stop(self) -> None:
         self._stop_event.set()
@@ -542,6 +551,15 @@ class SimConnector(threading.Thread):
                 radio_msgs, rcm_events = self._radio_runner.radios_for_lap(lap_num)
             except Exception as exc:
                 logger.debug("radios_for_lap(%d) failed: %s", lap_num, exc)
+
+        # Re-assert an active Safety Car on the laps whose RCM window carries no
+        # fresh deploy message. Ingest only the laps actually processed here; a
+        # release landing on a skipped (stale) lap is bounded by the tracker's
+        # safety valve rather than pinning the override (NR-02, #398 — mirrors
+        # the CLI wiring in run_simulation_cli).
+        self._sc_tracker.ingest(lap_num, rcm_events)
+        if self._sc_tracker.should_inject(lap_num):
+            rcm_events = list(rcm_events) + [self._sc_tracker.synthetic_event()]
 
         return RaceState(
             driver=driver_st.get("driver", "UNK"),

--- a/tests/test_strategy_goldens.py
+++ b/tests/test_strategy_goldens.py
@@ -169,8 +169,11 @@ def test_mc_pit_out_none_falls_back_to_conservative_prior():
         ("OK", 0.90, [], False, {"N30"}),
         # radio PROBLEM → unplanned-stop risk → pit + regulation
         ("OK", 0.05, [{"intent": "PROBLEM"}], False, {"N28", "N30"}),
-        # radio PENALTY → FIA-facing → regulation only
-        ("OK", 0.05, [{"intent": "PENALTY"}], False, {"N30"}),
+        # RCM red-flag ruling (event_type) → FIA-facing → regulation only. Radio
+        # transcripts only ever carry PROBLEM/WARNING intents (never a PENALTY
+        # intent), so penalty/red-flag rulings reach the orchestrator as RCM
+        # alerts with an event_type — the routing now keys on that (NR-04, #398).
+        ("OK", 0.05, [{"event_type": "RED_FLAG"}], False, {"N30"}),
         # SC physically deployed (RCM-confirmed) → force pit + regulation
         ("OK", 0.05, [], True, {"N28", "N30"}),
     ],


### PR DESCRIPTION
Closes #398. Follow-ups from the NR-02 Safety-Car tracker (#305).

## NR-03 — parser superset (`radio_agent._classify_rcm_event`)
Events that fell through to `OTHER` are now classified, all **appended after** the existing checks so nothing that already resolves changes type:
- **DOUBLE YELLOW** — highest-danger local flag, was invisible. Folded into the YELLOW branch → inherits `_SAFETY_FLAGS` alert status for free (no `_SAFETY_FLAGS` edit).
- Case-insensitive `scope` (FastF1 vs OpenF1 corpora disagree on `Sector`/`SECTOR`).
- New families: `LAP_DELETED`, `INVESTIGATION`, `PIT_LANE_OPEN|CLOSED`, `SESSION_SUSPENDED|RESUMED|STARTED`.
- **#305 `SAFETY CAR IN THIS LAP → ENDING` intact.**

## NR-04 — dead PENALTY routing (`strategy_orchestrator._decide_agents_to_call`)
`alert_intents & {PENALTY, WARNING}` was unreachable on its PENALTY half (RCM alerts carry no `intent`; no producer emits `intent==PENALTY`). Now routes penalty/red-flag RCM alerts on their real `event_type` (`RED_FLAG`/`TIME_PENALTY`), unioned with the still-valid `WARNING` intent. The routing golden now feeds a real `event_type=RED_FLAG` alert.

## Arcade wiring
One `RaceControlStateTracker` per replay, ingested in `SimConnector._build_race_state` (mirrors the CLI), so a deploy-once corpus SC message keeps the override active on the persisted laps mid-stint.

## Scope notes
- **Submodule simulator wiring dropped**: the telemetry submodule is the offline analysis screen, not the live agent strategy path — the SC-persistence bug doesn't apply there.
- `SESSION_*` keyword families are best-effort FIA phrasing (no red-flag race in the local 2025 corpus to verify against).
- `TIME_PENALTY` routing is future-proofed but currently inert upstream (`radio_agent._SAFETY_FLAGS` excludes it) — separate follow-up.

## Checks
Full parent suite green locally (`test_strategy_goldens`, `test_rcm_state`, `test_agents`, `test_engine_no_llm`, `test_arcade_dashboard_imports`); tracker behaviour re-verified (deploy→active→inject on persisted laps).