### PR TITLE
chore(packaging): clean local wheel builds + ship dashboard PNG icons (#392)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,11 @@ voice = [
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["src*", "scripts*"]
+# A dev box that ran `npm install` leaves node_modules dirs that setuptools would
+# otherwise auto-discover as namespace packages, dragging ~600 of their files into
+# the wheel via the "*" package-data glob. Exclude them from discovery so a local
+# build stays clean and fast (CI is already immune — clean checkout has none) (#392 D1).
+exclude = ["*node_modules*"]
 
 [tool.uv]
 # experta 1.9.4 hard-pins frozendict==1.2, which cannot import on Python 3.10+
@@ -191,6 +196,17 @@ torchvision = [
 # Scoped to `frontend/build/**` on purpose: a broad `*.js` glob would recursively
 # rake in the ~87 MB `node_modules` tree on a dev box that ran `npm install`.
 "src.telemetry.frontend.components.streamlit_audio_viz" = ["frontend/build/*", "frontend/build/**/*"]
+# Tyre-compound icons the Streamlit dashboard lap-graph reads from
+# frontend/shared/img/*.png (lap_graph.py). No .png was in package-data, so they
+# never shipped in any wheel and the table rendered iconless (#392 D2).
+"src.telemetry.frontend" = ["shared/img/*.png"]
+
+[tool.setuptools.exclude-package-data]
+# node_modules is pruned at the packages.find level above (excluded from
+# discovery). This drops the stray ~1.4 MB `bundle.js.map` the frontend/build
+# glob rakes in on a dev-box build; CI is immune (clean checkout has no map) (#392 D1).
+"src.telemetry.frontend.components.streamlit_audio_viz" = ["frontend/build/*.map", "frontend/build/**/*.map"]
+"*" = ["**/*.map"]
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
Closes #392. From the Fable verify-after gate on #289 — all **non-blocking** (the CI release wheel is already correct; these affect manual/local builds or are cosmetic).

## D2 — dashboard tyre icons now ship (user-facing)
Added package-data key `"src.telemetry.frontend" = ["shared/img/*.png"]`. No `.png` was in package-data, so the 5 tyre-compound icons (`hard/inter/medium/soft/wet`) never shipped and the dashboard lap-graph table rendered iconless. Now included.

## D1 — local builds stop bloating
- **node_modules**: excluded from `packages.find` discovery (`exclude = ["*node_modules*"]`), so a `uv build` on a dev box that ran `npm install` stops raking ~605 `node_modules` files (mostly `package.json`) into the wheel via the broad `"*"` glob.
- **`*.map`**: `exclude-package-data` prunes the stray 1.4 MB `bundle.js.map` the `frontend/build/**` glob rakes in.
- CI is immune (clean checkout has neither), so the released wheel was always fine — this is dev-build QoL.

## Verified
A clean local build (`rm -rf build dist *.egg-info && uv build --wheel`) goes from **879 → 273** wheel entries: **node_modules 0, .map 0, dashboard PNGs 5**. (Note: a stale `./build/` cache masks pyproject changes — clean it before re-checking.)