### PR TITLE
fix(nlp): DOUBLE YELLOW severity + time-penalty routing (#398 follow-up)

### DIFF
--- a/src/agents/radio_agent.py
+++ b/src/agents/radio_agent.py
@@ -96,6 +96,13 @@ _SAFETY_FLAGS = {
     "RED_FLAG",
     "YELLOW_FLAG",
     "YELLOW_FLAG_SECTOR",
+    # A time-penalty ruling is strategically relevant whether it lands on us (we
+    # serve it) or a rival (they lose track position, changing our undercut /
+    # overcut calculus), so it is forwarded as an alert and routed to N30's
+    # regulation lookup. NR-04's _RCM_PENALTY_EVENT_TYPES already includes it;
+    # this is the upstream half that lets it actually reach the alert list
+    # (#398 follow-up). Cost is bounded by the chat rate-limit + token cap.
+    "TIME_PENALTY",
 }
 
 _FLAG_MAP = {

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -604,6 +604,11 @@ _ALERT_SEVERITY: dict[str, int] = {
     "VIRTUAL_SAFETY_CAR": 2,
     "VSC": 2,
     "YELLOW_FLAG": 2,
+    # A sector yellow is the same danger tier as a full-track yellow, and it is
+    # the form DOUBLE YELLOW resolves to (radio_agent folds DOUBLE YELLOW into the
+    # YELLOW branch → YELLOW_FLAG_SECTOR). Without this key the banner fell back to
+    # severity 0 (dim), hiding the highest-danger local flag (#398 follow-up).
+    "YELLOW_FLAG_SECTOR": 2,
     "PROBLEM": 1,
     "WARNING": 1,
 }


### PR DESCRIPTION
Closes the two actionable INFO items the Fable audit raised on #398.

## What
- **Arcade banner** (`src/arcade/strategy.py`): add `YELLOW_FLAG_SECTOR: 2` to `_ALERT_SEVERITY`. NR-03 made DOUBLE YELLOW alertable (it folds into the YELLOW branch → `YELLOW_FLAG_SECTOR`), but the severity map only had `YELLOW_FLAG`, so the highest-danger local flag rendered **dim** (severity-0 fallback). Now at the same tier as `YELLOW_FLAG`.
- **Alert forwarding** (`src/agents/radio_agent.py`): add `TIME_PENALTY` to `_SAFETY_FLAGS`. NR-04 already routes `TIME_PENALTY` event types to N30, but it never reached the alert list (`_build_alerts` only forwards `_SAFETY_FLAGS` members), so that routing was inert. A time penalty is strategically relevant — ours (we serve it) or a rival's (they lose track position, changing our undercut/overcut calculus) — so it's now forwarded and routed to the regulation lookup. Cost stays bounded by the Phase-A rate-limit + token cap.

## Not included
- SESSION_* keyword validation is data-blocked (no red-flag race in the local 2025 corpus) — left as best-effort, as documented.

## Checks
33 tests green (`test_strategy_goldens`, `test_rcm_state`, `test_arcade_dashboard_imports`); ruff clean on `src/arcade`.

Refs #398.