### PR TITLE
Promote: RCM alert follow-ups (DOUBLE YELLOW severity + time-penalty routing)

### DIFF
--- a/src/agents/radio_agent.py
+++ b/src/agents/radio_agent.py
@@ -96,6 +96,13 @@ _SAFETY_FLAGS = {
     "RED_FLAG",
     "YELLOW_FLAG",
     "YELLOW_FLAG_SECTOR",
+    # A time-penalty ruling is strategically relevant whether it lands on us (we
+    # serve it) or a rival (they lose track position, changing our undercut /
+    # overcut calculus), so it is forwarded as an alert and routed to N30's
+    # regulation lookup. NR-04's _RCM_PENALTY_EVENT_TYPES already includes it;
+    # this is the upstream half that lets it actually reach the alert list
+    # (#398 follow-up). Cost is bounded by the chat rate-limit + token cap.
+    "TIME_PENALTY",
 }
 
 _FLAG_MAP = {

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -604,6 +604,11 @@ _ALERT_SEVERITY: dict[str, int] = {
     "VIRTUAL_SAFETY_CAR": 2,
     "VSC": 2,
     "YELLOW_FLAG": 2,
+    # A sector yellow is the same danger tier as a full-track yellow, and it is
+    # the form DOUBLE YELLOW resolves to (radio_agent folds DOUBLE YELLOW into the
+    # YELLOW branch → YELLOW_FLAG_SECTOR). Without this key the banner fell back to
+    # severity 0 (dim), hiding the highest-danger local flag (#398 follow-up).
+    "YELLOW_FLAG_SECTOR": 2,
     "PROBLEM": 1,
     "WARNING": 1,
 }


### PR DESCRIPTION
Promotion of the two actionable Fable-audit follow-ups on #398 (PR #414) from `dev` to `main`.

- Arcade `_ALERT_SEVERITY` renders DOUBLE YELLOW (`YELLOW_FLAG_SECTOR`) at yellow severity instead of dim.
- `radio_agent._SAFETY_FLAGS` forwards `TIME_PENALTY`, so NR-04's routing of time-penalty rulings to N30 is no longer inert.

33 tests green; ruff clean. Refs #398.