### PR TITLE
fix(agents): un-invert the undercut model's top feature and stop feeding it the race lap

### DIFF
--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -60,6 +60,15 @@ _COMPOUND_FALLBACK: dict[str, int] = {'HARD': 1, 'MEDIUM': 3, 'SOFT': 5}
 # Pirelli average stint capacities — Heilmeier et al. (2020, SAE 2020-01-1413)
 _STINT_CAPACITY_LAPS: dict[str, int] = {'SOFT': 18, 'MEDIUM': 30, 'HARD': 38}
 
+# N16 trained Lap_gap as the offset between the two stops (lap_y - lap_x), never the
+# race lap. At inference we always score the canonical undercut: we box on this lap and
+# the rival responds on the next one, so the offset is 1 (#444).
+_ASSUMED_UNDERCUT_LAP_GAP: int = 1
+
+# N15 clipped tyre_life_in at 50 laps in training (cell 11); mirror that ceiling here so
+# an absurd stint cannot extrapolate outside the fitted range (#450).
+_MAX_TRAINED_TYRE_LIFE: int = 50
+
 CLIFF_IMMINENT_LAPS = 3    # laps_to_cliff_p10 below this → PIT_NOW
 CLIFF_SOON_LAPS     = 10   # laps_to_cliff_p10 below this → prefer harder compound
 
@@ -539,7 +548,9 @@ class PitStrategyAgent:
         feat = {
             'team':             self._encode_team(team_raw),
             'year':             year,
-            'tyre_life_in':     int(row.get('TyreLife', 1)),
+            # N15 clipped tyre_life at 50 in training (cell 11); pass the raw value and
+            # an absurd stint extrapolates outside the fitted range (#450).
+            'tyre_life_in':     min(int(row.get('TyreLife', 1)), _MAX_TRAINED_TYRE_LIFE),
             'lap_number':       lap_number,
             'compound_id':      _compound_to_id(compound, gp_name, year),
             'compound_change':  int(compound_change),
@@ -593,8 +604,17 @@ class PitStrategyAgent:
         comp_y_id = _compound_to_id(comp_y, gp_name, year)
 
         feat = {
-            'pos_gap':               float(y_row.get('Position', 9)) - float(x_row.get('Position', 10)),
-            'Lap_gap':               lap_number,
+            # N16 trained pos_gap as pos_X_before - pos_Y_before, so X (us, the
+            # undercutter) being BEHIND Y is positive — that is the model's single
+            # strongest feature (gain 0.690). The operands were reversed here, which
+            # handed every X-behind-Y pair a negative value the model never saw for
+            # that case. Keep this order aligned with N16 cell 41 (#444).
+            'pos_gap':               float(x_row.get('Position', 10)) - float(y_row.get('Position', 9)),
+            # Trained as the OFFSET between the two stops (lap_y - lap_x, 1..max_lap_gap),
+            # not the race lap. Feeding lap_number put it 10-70x out of range, so LightGBM
+            # clamped to the deepest bin on every call. We score the canonical undercut:
+            # we box now, the rival responds on the next lap (#444).
+            'Lap_gap':               _ASSUMED_UNDERCUT_LAP_GAP,
             'tyre_life_diff':        float(x_row.get('TyreLife', 10)) - float(y_row.get('TyreLife', 10)),
             'TyreLife_X':            float(x_row.get('TyreLife', 10)),
             'TyreLife_Y':            float(y_row.get('TyreLife', 10)),

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -65,6 +65,18 @@ _STINT_CAPACITY_LAPS: dict[str, int] = {'SOFT': 18, 'MEDIUM': 30, 'HARD': 38}
 # the rival responds on the next one, so the offset is 1 (#444).
 _ASSUMED_UNDERCUT_LAP_GAP: int = 1
 
+# N15 (pit duration) encoded compound_id with an ORDINAL rank, NOT the Pirelli number:
+# verbatim from N15_pit_duration.ipynb cell 11, where it is applied as
+# `.map(COMPOUND_ORDER).fillna(-1)`. Feeding `_compound_to_id` here (the absolute C1-C6)
+# made the model read a SOFT as WET and a MEDIUM as INTERMEDIATE on essentially every
+# call. N16 is different and DOES want the absolute Cx, so the two must not share a
+# helper (#445).
+# ponytail: duplicated from the notebook; load it from model_config.json once N15 exports it.
+_N15_COMPOUND_ORDER: dict[str, int] = {
+    'SOFT': 0, 'MEDIUM': 1, 'HARD': 2, 'INTERMEDIATE': 3, 'WET': 4,
+}
+_N15_COMPOUND_UNKNOWN: int = -1  # matches the notebook's .fillna(-1)
+
 # N15 clipped tyre_life_in at 50 laps in training (cell 11); mirror that ceiling here so
 # an absurd stint cannot extrapolate outside the fitted range (#450).
 _MAX_TRAINED_TYRE_LIFE: int = 50
@@ -541,7 +553,8 @@ class PitStrategyAgent:
         if row is None:
             raise ValueError(f'No lap data for {driver} at lap {lap_number}')
 
-        gp_name  = self.session_meta.get('gp_name', '')
+        # No gp_name here on purpose: N15's compound_id is an ordinal rank, not the
+        # circuit's Pirelli allocation, so this builder needs no circuit lookup (#445).
         year     = self.session_meta.get('year', 2025)
         team_raw = self.session_meta.get('team_lookup', {}).get(driver, 'Unknown')
 
@@ -552,7 +565,7 @@ class PitStrategyAgent:
             # an absurd stint extrapolates outside the fitted range (#450).
             'tyre_life_in':     min(int(row.get('TyreLife', 1)), _MAX_TRAINED_TYRE_LIFE),
             'lap_number':       lap_number,
-            'compound_id':      _compound_to_id(compound, gp_name, year),
+            'compound_id':      _N15_COMPOUND_ORDER.get(compound.upper(), _N15_COMPOUND_UNKNOWN),
             'compound_change':  int(compound_change),
             'under_sc':         int(under_sc),
             'tight_pit_box':    0,

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -904,9 +904,16 @@ class TireAgent:
             model.train()  # keep dropout active for MC
 
             preds = []
-            with torch.no_grad():
-                for _ in range(agent.cfg.n_mc):
-                    preds.append(model(tensor).item())
+            try:
+                with torch.no_grad():
+                    for _ in range(agent.cfg.n_mc):
+                        preds.append(model(tensor).item())
+            finally:
+                # Never leave the shared bundle in train mode: any later consumer of
+                # bundles[cid]['model'] would silently get stochastic "deterministic"
+                # predictions. Today only predict_tire_deg_tool saves us, by defensively
+                # calling eval() itself (#449).
+                model.eval()
 
             mean_pred = float(np.mean(preds))
             mc_std    = float(np.std(preds))


### PR DESCRIPTION
The smallest, highest-leverage slice of the epic #438 audit: four one-liners, each corrected directly against its training definition.

## What changed

| Fix | Was | Now | Issue |
|---|---|---|---|
| **`pos_gap` un-inverted** | `Y - X` | `X - Y`, as N16 cell 41 trained it | #444 |
| **`Lap_gap`** | the race lap (up to ~70) | the stop offset (1), as trained (1..max_lap_gap) | #444 |
| **`tyre_life_in`** | raw | clipped at 50, N15's training ceiling | #450 (partial) |
| **TCN train-mode leak** | left in `train()` after the MC loop | `eval()` in a `finally` | #449 (partial) |

## Why `pos_gap` matters most

It is the undercut model's **single strongest feature** (gain 0.690). Being **one place behind the rival** is the most decisive undercut case and was trained as `+1`; the agent handed the model `-1`, a value it never saw for X-behind-Y pairs. Every undercut probability the system has ever reported was computed with its top feature on the wrong side of every split point.

## Verification (no LLM run needed, deliberately)

The corrected expressions are asserted directly:

```
>>> X=P3 behind Y=P2 -> pos_gap=+1 (training: X behind Y must be POSITIVE)
>>> Lap_gap now the stop offset, not the race lap: 1 (was lap_number, up to ~70)
>>> tyre_life clip: 50 (raw 70 -> clipped to training ceiling)
>>> ALL ASSERTIONS PASSED
```

Ruff clean on both files apart from two pre-existing import-sort warnings.

## Scope

Deliberately small. The rest of #438 (data hygiene, GP scoping, compound encodings, the parquet's missing `Time` column, the rival contract) is untouched here and stays open. `Lap_gap` uses a named constant `_ASSUMED_UNDERCUT_LAP_GAP = 1` rather than a magic literal, so the assumption ("we box now, the rival responds next lap") is stated and easy to revisit.

Closes #444

---

### Added after review: N15 compound encoding (#445)

N15 (pit duration) trained `compound_id` as an **ordinal rank**, verbatim from `N15_pit_duration.ipynb` cell 11: `{SOFT: 0, MEDIUM: 1, HARD: 2, INTERMEDIATE: 3, WET: 4}`, applied as `.map(COMPOUND_ORDER).fillna(-1)`. Inference fed it the **absolute Pirelli number** instead, so **every compound landed on the wrong class**:

| | was | training read it as | now |
|---|---|---|---|
| SOFT | 5 | *(outside the trained range)* | 0 = SOFT |
| MEDIUM | 3 | **INTERMEDIATE** | 1 = MEDIUM |
| HARD | 1 | **MEDIUM** | 2 = HARD |

N16 is deliberately untouched: it genuinely wants the absolute Cx, so the two models must not share the helper. Verified against the notebook itself, no LLM run.

Also closes #445