### PR TITLE
fix(agents): Safety-Car rail on the final answer, MC sentinels, and un-freeze the circuit tables

### DIFF
--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -14,6 +14,7 @@ get_pit_strategy_react_agent(**kwargs)                 → CompiledGraph
 from __future__ import annotations
 
 import json
+import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -38,6 +39,10 @@ try:
     _DATA_ROOT = _get_data_root()
 except Exception:
     _DATA_ROOT = _REPO_ROOT / 'data'
+
+from src.f1_strat_manager.gp_slugs import rekey_by_slug  # noqa: E402
+
+logger = logging.getLogger(__name__)
 
 _MODELS    = _DATA_ROOT / 'models'
 _PROCESSED = _DATA_ROOT / 'processed'
@@ -136,7 +141,14 @@ class PitAgentCFG:
             pit_cfg = json.load(f)
 
         self.pit_features: list[str]   = pit_cfg['features']
-        self.circuit_traversal: dict   = pit_cfg['circuit_traversal_lookup']
+        # Re-key the circuit tables into the SLUG keyspace the agents actually query
+        # with (session_meta.gp_name / the featured parquet's GP_Name). They ship keyed
+        # by FastF1 full event names, whose overlap with the slugs is exactly zero — so
+        # every lookup missed and silently took its default, freezing traversal at
+        # 20.0 s and circuit_undercut_rate at 0.38 for every circuit (#448).
+        self.circuit_traversal: dict   = rekey_by_slug(
+            pit_cfg['circuit_traversal_lookup'], 'circuit_traversal_lookup',
+        )
 
         # Reconstruct LabelEncoder from saved class list
         le = LabelEncoder()
@@ -154,10 +166,13 @@ class PitAgentCFG:
         self.undercut_threshold: float    = uc_cfg['best_threshold']
         self.dry_compounds: list[str]     = uc_cfg['dry_compounds']
 
-        # Pre-aggregate circuit and team undercut rates from N16 training parquet
+        # Pre-aggregate circuit and team undercut rates from N16 training parquet.
+        # This parquet is keyed by full event name; re-key to slugs for the same
+        # reason as circuit_traversal above (#448).
         _uc = pd.read_parquet(_PROCESSED / 'undercut_labeled' / 'undercut_clean.parquet')
-        self.circuit_undercut_rate: dict = (
-            _uc.groupby('GP_Name')['undercut_success'].mean().to_dict()
+        self.circuit_undercut_rate: dict = rekey_by_slug(
+            _uc.groupby('GP_Name')['undercut_success'].mean().to_dict(),
+            'circuit_undercut_rate',
         )
         self.team_x_undercut_rate: dict = (
             _uc.groupby('Team_X')['undercut_success'].mean().to_dict()

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -44,6 +44,8 @@ try:
 except Exception:
     _DATA_ROOT = _REPO_ROOT / 'data'
 
+from src.f1_strat_manager.gp_slugs import rekey_by_slug, slug_from_event_name  # noqa: E402
+
 _MODELS    = _DATA_ROOT / 'models'
 _PROCESSED = _DATA_ROOT / 'processed'
 _AGENTS    = _DATA_ROOT / 'models' / 'agents'
@@ -149,11 +151,32 @@ class RaceSituationConfig:
             _PROCESSED / 'sc_labeled' / 'sc_labeled_2023_2025.parquet',
             columns=['event_name', 'circuit_sc_rate'],
         )
-        self.circuit_sc_rate_map: dict = (
+        # Re-key to the SLUG keyspace the replay path queries with. This table ships
+        # keyed by FastF1 event names, which the FastF1 session path supplies but the
+        # replay path (CLI / arcade / webapp, all fed by RaceStateManager) does not —
+        # it passes session_meta.gp_name, a slug. The keyspaces do not overlap, so on
+        # every replay lap this lookup missed and returned the 0.10 default: a trained
+        # per-circuit feature frozen to a constant for every race (#448). Lookups go
+        # through `sc_rate_for`, which resolves EITHER keyspace, so the FastF1 path
+        # keeps working too.
+        self.circuit_sc_rate_map: dict = rekey_by_slug(
             _sc_df.drop_duplicates('event_name')
                   .set_index('event_name')['circuit_sc_rate']
-                  .to_dict()
+                  .to_dict(),
+            'circuit_sc_rate_map',
         )
+
+    def sc_rate_for(self, event_name: str) -> float:
+        """Circuit SC base rate for a GP given in EITHER keyspace.
+
+        The two callers disagree: the FastF1 session path passes a full event name
+        ('Qatar Grand Prix'), the replay path passes the parquet slug ('Lusail').
+        `slug_from_event_name` is reentrant, so it normalises both. Falls back to the
+        0.10 training-set mean when a GP is genuinely unknown — the same default as
+        before, but now only for real misses instead of on every replay lap.
+        """
+        slug = slug_from_event_name(event_name) or event_name
+        return self.circuit_sc_rate_map.get(slug, 0.10)
 
 
 # ── Module-level config singleton ─────────────────────────────────────────────
@@ -1029,7 +1052,7 @@ class RaceSituationAgent:
             'event_name':       event_name,
             'year':             lap_state.get('year', 2025),
             'circuit_cluster':  self.cfg.circuit_cluster_map.get(gp_name, 0),
-            'circuit_sc_rate':  self.cfg.circuit_sc_rate_map.get(event_name, 0.10),
+            'circuit_sc_rate':  self.cfg.sc_rate_for(event_name),
             'total_laps':       int(session.total_laps),
             'fastest_lap_s':    _clean['LapTime'].min().total_seconds(),
             'AirTemp':          float(_wx['AirTemp'].mean())    if 'AirTemp'   in _wx else 28.0,
@@ -1093,7 +1116,7 @@ class RaceSituationAgent:
             'event_name':       event_name,
             'year':             year,
             'circuit_cluster':  self.cfg.circuit_cluster_map.get(gp_name, 0),
-            'circuit_sc_rate':  self.cfg.circuit_sc_rate_map.get(event_name, 0.10),
+            'circuit_sc_rate':  self.cfg.sc_rate_for(event_name),
             'total_laps':       total_laps,
             'fastest_lap_s':    float(self.laps_df['LapTime'].dt.total_seconds().min())
                                 if len(self.laps_df) > 0 else 90.0,

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -692,20 +692,28 @@ def _run_mc_simulation(
 
     sc_prob = situation_out.sc_prob_3lap
 
-    if pit_out is not None:
+    # A tool-parse failure inside N28 leaves the durations at 0.0 (its `or 0.0`
+    # defaults), and 0.0 is not a stop time — it means "unknown". Simulating it makes
+    # a pit stop FREE, so PIT_NOW (~+1.25 s) wins essentially every draw: a silent
+    # parse miss becomes a confident recommendation to box. Treat a non-positive P50
+    # as unavailable and fall through to the same prior the pit_out-is-None branch
+    # already uses (#436). Durations and undercut_prob degrade INDEPENDENTLY: a
+    # failed duration parse says nothing about the undercut probability.
+    _durations_known = pit_out is not None and (pit_out.stop_duration_p50 or 0.0) > 0.0
+    if _durations_known:
         pit_p05, pit_p50, pit_p95 = _clamp_triangular(
             pit_out.stop_duration_p05,
             pit_out.stop_duration_p50,
             pit_out.stop_duration_p95,
         )
-        ucut_prob = (
-            pit_out.undercut_prob
-            if pit_out.undercut_prob is not None
-            else 0.5
-        )
     else:
         pit_p05, pit_p50, pit_p95 = 2.2, 2.8, 3.8
-        ucut_prob = 0.5
+
+    ucut_prob = (
+        pit_out.undercut_prob
+        if pit_out is not None and pit_out.undercut_prob is not None
+        else 0.5
+    )
 
     pace_s  = rng.normal(pace_out.lap_time_pred, sigma_pace, n)  # noqa: F841
     cliff_s = rng.triangular(p10_cliff, p50_cliff, p90_cliff, n)
@@ -1199,6 +1207,7 @@ def _assemble_recommendation(
     pit_out,
     mc_results:         dict,
     regulation_context: str,
+    sc_currently_active: bool = False,
 ) -> "StrategyRecommendation":
     """Merge the LLM synthesis with N28 pit data and attach grounding fields.
 
@@ -1217,6 +1226,19 @@ def _assemble_recommendation(
     * regulation_context — attached verbatim from N30 so the UI can surface
       the regulatory basis for the action without re-querying N30.
 
+    --- WHERE TO CHANGE IF THE SC POLICY CHANGES ---
+    sc_currently_active carries N27's verdict so the Safety-Car guard-rail can
+    be enforced HERE, on the final answer. N28 already refuses to stay out under
+    a deployed SC (pit_strategy_agent.py, same condition and tag), but its action
+    only ever reached the LLM as prompt TEXT — the orchestrator returned
+    synth.action verbatim, so a synthesis that ignored the deterministic signal
+    silently won. That is exactly the STAY_OUT-under-SC failure the Qatar 2025
+    case (thesis 6.3) exists to prevent, and docs/pages/multi-agent.md already
+    promises this rail "so a misbehaving LLM can't override the deterministic
+    signal". This makes the code honour the rule the project already adopted one
+    layer down. Defaults to False so any caller that does not thread N27's output
+    keeps the previous behaviour rather than silently changing it.
+
     Returns a fully-populated StrategyRecommendation ready for the UI layer.
     """
     # N28 fallbacks — only used when the LLM did not commit to a value
@@ -1228,9 +1250,17 @@ def _assemble_recommendation(
     compound_next   = synth.compound_next   if synth.compound_next   is not None else fallback_cmpd
     undercut_target = synth.undercut_target if synth.undercut_target is not None else fallback_target
 
+    # Safety-Car guard-rail, mirroring N28's own (same condition, same tag) so the
+    # override stays auditable in the chat bubble / arcade dashboard / SSE stream.
+    action    = synth.action
+    reasoning = synth.reasoning
+    if sc_currently_active and action == 'STAY_OUT':
+        action    = 'PIT_NOW'
+        reasoning = f"[OVERRIDE: SC deployed — forcing PIT_NOW.] {reasoning}"
+
     return StrategyRecommendation(
-        action             = synth.action,
-        reasoning          = synth.reasoning,
+        action             = action,
+        reasoning          = reasoning,
         confidence         = synth.confidence,
         pit_lap_target     = pit_lap_target,
         compound_next      = compound_next,
@@ -1322,7 +1352,10 @@ def run_strategy_orchestrator(
     )
 
     synth: _LLMSynthesis = _get_orchestrator_llm().invoke(prompt)
-    return _assemble_recommendation(synth, pit_out, mc_results, regulation_context)
+    return _assemble_recommendation(
+        synth, pit_out, mc_results, regulation_context,
+        sc_currently_active = situation_out.sc_currently_active,
+    )
 
 
 def run_strategy_orchestrator_from_state(
@@ -1440,4 +1473,7 @@ def run_strategy_orchestrator_from_state(
     )
 
     synth: _LLMSynthesis = _get_orchestrator_llm().invoke(prompt)
-    return _assemble_recommendation(synth, pit_out, mc_results, regulation_context)
+    return _assemble_recommendation(
+        synth, pit_out, mc_results, regulation_context,
+        sc_currently_active = situation_out.sc_currently_active,
+    )

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -21,6 +21,7 @@ CFG — TireAgentConfig: loads routing, calibration, encoding maps, cliff thresh
 from __future__ import annotations
 
 import json
+import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -49,6 +50,8 @@ try:
     _DATA_ROOT = _get_data_root()
 except Exception:
     _DATA_ROOT = _REPO_ROOT / 'data'
+
+logger = logging.getLogger(__name__)
 
 _MODEL_DIR  = _DATA_ROOT / 'models' / 'tire_degradation'
 _PROCESSED  = _DATA_ROOT / 'processed'
@@ -1178,12 +1181,40 @@ class TireAgent:
                     reasoning = m.content.strip()
                     break
 
+        # A parse miss must NOT become 0.0 laps-to-cliff. `_parse_tool_outputs` only
+        # writes a key when its regex matched, so an absent 'p10' means "the tool was
+        # skipped or its output did not parse" — whereas a PRESENT 0.0 legitimately
+        # means "the cliff is now". Defaulting the miss to 0.0 collapsed those two into
+        # the alarming one: the MC read "cliff NOW" (penalising STAY_OUT by ~4 s) and
+        # the warning level flipped to PIT_SOON, so a silent regex miss became a
+        # confident call to box. Fall back to the same conservative stub the
+        # wet/intermediate branch above already uses, and say so in the reasoning so the
+        # degradation is visible instead of masquerading as a reading (#436).
+        if 'p10' not in parsed:
+            logger.warning(
+                'Tire tool output did not parse for %s (tyre_life=%s) — using conservative '
+                'defaults instead of a 0.0 cliff', compound_id, tyre_life,
+            )
+            return TireOutput(
+                compound          = compound_id,
+                current_tyre_life = tyre_life,
+                gp_name           = gp_name,
+                deg_rate          = 0.03,
+                laps_to_cliff_p10 = 20.0,
+                laps_to_cliff_p50 = 30.0,
+                laps_to_cliff_p90 = 40.0,
+                reasoning         = (
+                    f"[{compound_id} — tire tool output could not be parsed; conservative "
+                    f"defaults used] {reasoning}"
+                ),
+            )
+
         return TireOutput(
             compound          = compound_id,
             current_tyre_life = tyre_life,
             gp_name           = gp_name,
             deg_rate          = round(parsed.get('deg_rate', 0.0), 4),
-            laps_to_cliff_p10 = round(parsed.get('p10', 0.0), 1),
+            laps_to_cliff_p10 = round(parsed['p10'], 1),
             laps_to_cliff_p50 = round(parsed.get('p50', 0.0), 1),
             laps_to_cliff_p90 = round(parsed.get('p90', 0.0), 1),
             reasoning         = reasoning,

--- a/src/f1_strat_manager/gp_slugs.py
+++ b/src/f1_strat_manager/gp_slugs.py
@@ -24,6 +24,11 @@ path on first run.
 
 from __future__ import annotations
 
+import logging
+from typing import Final, Optional
+
+logger = logging.getLogger(__name__)
+
 # Map from the friendly GP names used by the CLI / featured-laps parquet to
 # the on-disk slug produced by ``RadioDatasetBuilder._compute_slug``. Single
 # entries for single-race countries, distinct entries per circuit for the
@@ -100,6 +105,107 @@ def canonical_gp_name(name: str) -> str:
     if spaced in COUNTRY_SLUG_BY_GP:
         return spaced
     return name
+
+
+# ── Featured-parquet slug ⇄ FastF1 event name ────────────────────────────────
+# A THIRD GP keyspace, distinct from the radio-corpus slugs above. The featured
+# laps parquet (and therefore RaceStateManager's session_meta.gp_name, and every
+# agent lookup key) uses circuit slugs — 'Budapest', 'Lusail'. But the circuit
+# lookup TABLES the agents index into use FastF1 full event names —
+# 'Hungarian Grand Prix', 'Qatar Grand Prix': circuit_traversal_lookup in N15's
+# model_config.json, undercut_clean.parquet's GP_Name (which feeds
+# circuit_undercut_rate), and the SC-labelled frame.
+#
+# The overlap between the two keyspaces is EXACTLY ZERO, so every circuit lookup
+# missed and silently took its default: pit-lane traversal was permanently 20.0 s,
+# circuit_undercut_rate 0.38, circuit_sc_rate 0.10 — Monaco and Monza given
+# identical pit-lane physics, three trained per-circuit features frozen (#448).
+#
+# No mechanical derivation works: the full names are adjectival ('Hungarian', not
+# 'Hungary'), so the mapping has to be explicit. Verified 1:1 against both sources
+# on disk (24 slugs, 24 event names).
+EVENT_NAME_BY_SLUG: Final[dict[str, str]] = {
+    "Sakhir":            "Bahrain Grand Prix",
+    "Jeddah":            "Saudi Arabian Grand Prix",
+    "Melbourne":         "Australian Grand Prix",
+    "Suzuka":            "Japanese Grand Prix",
+    "Shanghai":          "Chinese Grand Prix",
+    "Miami":             "Miami Grand Prix",
+    "Imola":             "Emilia Romagna Grand Prix",
+    "Monaco":            "Monaco Grand Prix",
+    "Barcelona":         "Spanish Grand Prix",
+    "Montréal":          "Canadian Grand Prix",
+    "Spielberg":         "Austrian Grand Prix",
+    "Silverstone":       "British Grand Prix",
+    "Spa-Francorchamps": "Belgian Grand Prix",
+    "Budapest":          "Hungarian Grand Prix",
+    "Zandvoort":         "Dutch Grand Prix",
+    "Monza":             "Italian Grand Prix",
+    "Baku":              "Azerbaijan Grand Prix",
+    "Marina Bay":        "Singapore Grand Prix",
+    "Austin":            "United States Grand Prix",
+    "Mexico City":       "Mexico City Grand Prix",
+    "São Paulo":         "São Paulo Grand Prix",
+    "Las Vegas":         "Las Vegas Grand Prix",
+    "Lusail":            "Qatar Grand Prix",
+    "Yas Island":        "Abu Dhabi Grand Prix",
+}
+
+SLUG_BY_EVENT_NAME: Final[dict[str, str]] = {
+    event: slug for slug, event in EVENT_NAME_BY_SLUG.items()
+}
+
+
+def slug_from_event_name(event_name: str) -> Optional[str]:
+    """Translate a FastF1 full event name into the featured-parquet slug.
+
+    Used to NORMALISE the circuit lookup tables at load time, so they end up
+    keyed the way the agents actually query them (by the parquet's ``GP_Name``)
+    instead of failing every lookup and silently returning a default. Normalising
+    once at the boundary beats translating at each call site: there is one place
+    to keep correct, and the tables then speak the agents' native keyspace.
+
+    Returns ``None`` for an unknown name — callers should log it rather than drop
+    the row silently, since a miss means the keyspaces have drifted again (#448).
+    Already-slugged input passes through, keeping the call reentrant.
+    """
+    if event_name in EVENT_NAME_BY_SLUG:
+        return event_name  # already a slug
+    return SLUG_BY_EVENT_NAME.get(event_name)
+
+
+def rekey_by_slug(table: dict, table_name: str) -> dict:
+    """Re-key a circuit lookup table from FastF1 event names to parquet slugs.
+
+    The agents query these tables with ``session_meta.gp_name`` — a circuit slug —
+    but the tables ship keyed by full event names, and the two keyspaces do not
+    overlap at all, so every lookup missed and quietly returned its default (#448).
+    Normalising once at load is why the call sites need almost no change: the tables
+    end up speaking the agents' native keyspace.
+
+    Pair it with :func:`slug_from_event_name` at any call site whose key may arrive
+    in EITHER keyspace (the FastF1 session path passes a full event name, the replay
+    path passes a slug); that function is reentrant, so resolving twice is a no-op.
+
+    Entries whose name does not resolve are kept under their original key and logged.
+    Dropping them silently is what let this hide for months; a warning is the signal
+    that the keyspaces have drifted again.
+    """
+    rekeyed: dict = {}
+    unresolved: list[str] = []
+    for key, value in table.items():
+        slug = slug_from_event_name(str(key))
+        if slug is None:
+            unresolved.append(str(key))
+            rekeyed[key] = value
+            continue
+        rekeyed[slug] = value
+    if unresolved:
+        logger.warning(
+            '%s: %d key(s) did not resolve to a circuit slug and stay unreachable '
+            'from the agents: %s (#448)', table_name, len(unresolved), sorted(unresolved),
+        )
+    return rekeyed
 
 
 def resolve_gp_slug(gp_name: str) -> str:

--- a/src/f1_strat_manager/gp_slugs.py
+++ b/src/f1_strat_manager/gp_slugs.py
@@ -125,30 +125,30 @@ def canonical_gp_name(name: str) -> str:
 # 'Hungary'), so the mapping has to be explicit. Verified 1:1 against both sources
 # on disk (24 slugs, 24 event names).
 EVENT_NAME_BY_SLUG: Final[dict[str, str]] = {
-    "Sakhir":            "Bahrain Grand Prix",
-    "Jeddah":            "Saudi Arabian Grand Prix",
-    "Melbourne":         "Australian Grand Prix",
-    "Suzuka":            "Japanese Grand Prix",
-    "Shanghai":          "Chinese Grand Prix",
-    "Miami":             "Miami Grand Prix",
-    "Imola":             "Emilia Romagna Grand Prix",
-    "Monaco":            "Monaco Grand Prix",
-    "Barcelona":         "Spanish Grand Prix",
-    "Montréal":          "Canadian Grand Prix",
-    "Spielberg":         "Austrian Grand Prix",
-    "Silverstone":       "British Grand Prix",
+    "Sakhir": "Bahrain Grand Prix",
+    "Jeddah": "Saudi Arabian Grand Prix",
+    "Melbourne": "Australian Grand Prix",
+    "Suzuka": "Japanese Grand Prix",
+    "Shanghai": "Chinese Grand Prix",
+    "Miami": "Miami Grand Prix",
+    "Imola": "Emilia Romagna Grand Prix",
+    "Monaco": "Monaco Grand Prix",
+    "Barcelona": "Spanish Grand Prix",
+    "Montréal": "Canadian Grand Prix",
+    "Spielberg": "Austrian Grand Prix",
+    "Silverstone": "British Grand Prix",
     "Spa-Francorchamps": "Belgian Grand Prix",
-    "Budapest":          "Hungarian Grand Prix",
-    "Zandvoort":         "Dutch Grand Prix",
-    "Monza":             "Italian Grand Prix",
-    "Baku":              "Azerbaijan Grand Prix",
-    "Marina Bay":        "Singapore Grand Prix",
-    "Austin":            "United States Grand Prix",
-    "Mexico City":       "Mexico City Grand Prix",
-    "São Paulo":         "São Paulo Grand Prix",
-    "Las Vegas":         "Las Vegas Grand Prix",
-    "Lusail":            "Qatar Grand Prix",
-    "Yas Island":        "Abu Dhabi Grand Prix",
+    "Budapest": "Hungarian Grand Prix",
+    "Zandvoort": "Dutch Grand Prix",
+    "Monza": "Italian Grand Prix",
+    "Baku": "Azerbaijan Grand Prix",
+    "Marina Bay": "Singapore Grand Prix",
+    "Austin": "United States Grand Prix",
+    "Mexico City": "Mexico City Grand Prix",
+    "São Paulo": "São Paulo Grand Prix",
+    "Las Vegas": "Las Vegas Grand Prix",
+    "Lusail": "Qatar Grand Prix",
+    "Yas Island": "Abu Dhabi Grand Prix",
 }
 
 SLUG_BY_EVENT_NAME: Final[dict[str, str]] = {
@@ -202,8 +202,11 @@ def rekey_by_slug(table: dict, table_name: str) -> dict:
         rekeyed[slug] = value
     if unresolved:
         logger.warning(
-            '%s: %d key(s) did not resolve to a circuit slug and stay unreachable '
-            'from the agents: %s (#448)', table_name, len(unresolved), sorted(unresolved),
+            "%s: %d key(s) did not resolve to a circuit slug and stay unreachable "
+            "from the agents: %s (#448)",
+            table_name,
+            len(unresolved),
+            sorted(unresolved),
         )
     return rekeyed
 

--- a/src/strategy/inference/engine.py
+++ b/src/strategy/inference/engine.py
@@ -225,7 +225,13 @@ def _run_rich(
             regulation_context=regulation_context,
         )
         synth = _get_orchestrator_llm().invoke(prompt)
-        rec = _assemble_recommendation(synth, pit_out, mc_results, regulation_context)
+        rec = _assemble_recommendation(
+            synth,
+            pit_out,
+            mc_results,
+            regulation_context,
+            sc_currently_active=situation_out.sc_currently_active,
+        )
 
     timings["total"] = sum(timings.values())
 

--- a/src/strategy/inference/no_llm.py
+++ b/src/strategy/inference/no_llm.py
@@ -313,7 +313,13 @@ def run_no_llm_lap(
             tire_out.laps_to_cliff_p10,
         )
         synth = _deterministic_synthesis(action, guardrail_reason)
-        rec = _assemble_recommendation(synth, pit_out, mc_results, regulation_context)
+        rec = _assemble_recommendation(
+            synth,
+            pit_out,
+            mc_results,
+            regulation_context,
+            sc_currently_active=situation_out.sc_currently_active,
+        )
 
     timings["total"] = sum(timings.values())
 


### PR DESCRIPTION
Two defects that both made the orchestrator **confidently wrong**, in opposite directions.

## 1. The Safety-Car rail was documented, implemented one layer down, and then discarded

N28 already refuses to stay out under a deployed SC (`pit_strategy_agent.py`): it flips `STAY_OUT` to `PIT_NOW` and tags the reasoning. But its action only ever reached the LLM as **prompt text**, and the orchestrator returned `synth.action` **verbatim** — so a synthesis that ignored the deterministic signal silently won. Six runs of the same Lusail lap-7 scenario gave **2 PIT_NOW / 4 STAY_OUT**.

That is the exact STAY_OUT-under-SC failure the Qatar 2025 case (thesis 6.3) exists to prevent. And `docs/pages/multi-agent.md:131-133` **already promises this rail**:

> "A code-level guard-rail then flips any residual `STAY_OUT` to `PIT_NOW` **so a misbehaving LLM can't override the deterministic signal**"

So this is not a new design decision — it makes the **code honour the rule the project already adopted**, and already documented. `_assemble_recommendation` now enforces it on the final answer, mirroring N28's own condition and tag so the override stays auditable in the chat bubble / arcade dashboard / SSE stream.

`sc_currently_active` defaults to `False`: any caller not threading N27's output keeps its previous behaviour rather than changing silently. All four call sites (both orchestrator entry points, `engine.py`, `no_llm.py`) now thread it.

## 2. A parse miss made pit stops free

`0.0` is not a stop time — it means **unknown**. But a tool-parse failure left N28's durations at `0.0` and the MC simulated it, so a pit stop cost ~0 s and `PIT_NOW` (+1.25 s) won essentially every draw. **A silent regex miss became a confident call to box.** The sane prior existed but only on the `pit_out is None` branch; the `0.0` path bypassed it.

Now non-positive durations fall through to that same prior, and `undercut_prob` degrades **independently** (a failed duration parse says nothing about the undercut probability).

The tire agent had the mirror image: an unparsed cliff defaulted to `0.0` = "cliff NOW", penalising STAY_OUT by ~4 s and flipping the warning to PIT_SOON. Crucially its parser **only writes a key when the regex matched**, so an absent key is distinguishable from a genuine `0.0` — a miss now returns the same conservative stub the wet-compound branch already uses, with the degradation stated in the reasoning instead of masquerading as a reading.

## Verification (no LLM runs)

SC rail:
```
SC active + LLM STAY_OUT  -> PIT_NOW + tagged      OK
SC active + LLM PIT_NOW   -> untouched, no double-tag  OK
no SC     + LLM STAY_OUT  -> STAY_OUT (green flag safe) OK
kwarg omitted             -> unchanged (back-compat)    OK
SC active + LLM UNDERCUT  -> not hijacked               OK
```

Monte Carlo:
```
parse-miss (0.0 durations) PIT_NOW: -1.18
sane prior (pit_out None)  PIT_NOW: -1.18   <- now identical
real SLOW stop 9/11/14s    PIT_NOW: -7.12   <- real readings still drive the sim
```

The last line is the important one: the guard is not over-eager — a genuine reading is not swallowed by the prior.

Ruff: 10 findings on the touched files, **10 identical on `dev`** — all pre-existing, none introduced.

Refs #436
---

### Added: #448 — the circuit lookup tables were keyed in a language the agents don't speak

Three trained per-circuit features were **frozen at their defaults for every race**. The agents look up with `session_meta.gp_name` — a slug (`Budapest`, `Lusail`) — while the tables ship keyed by FastF1 full event names (`Hungarian Grand Prix`, `Qatar Grand Prix`). **The overlap is exactly zero**, so every lookup missed and silently took its default.

No mechanical derivation works (the names are adjectival: `Hungarian`, not `Hungary`), so it is an explicit 24-entry table, verified 1:1 against both sources on disk. It lives in `gp_slugs.py` — already *the* module that translates GP names — beside the radio-corpus slugs it must not be confused with.

Tables are re-keyed **once at load** instead of translated at each call site, so they end up speaking the agents' native keyspace. The SC table needs both directions: its FastF1 caller passes an event name while the replay caller passes a slug, so `sc_rate_for` resolves either (`slug_from_event_name` is reentrant by design — that is why the FastF1 path does not break). Unresolvable names are kept and **logged**, never dropped: the silent `.get(gp, default)` is exactly what hid this for months.

**Measured effect** (real tables, no LLM run) — pit-lane traversal, previously **20.0 s everywhere**:

| circuit | traversal | undercut rate (was 0.38 everywhere) |
|---|---|---|
| Marina Bay | **27.51 s** | — |
| Monaco | 22.54 s | **0.514** |
| Monza | 22.37 s | 0.457 |
| Lusail | 21.29 s | 0.362 |
| Budapest | **19.66 s** | — |

A **7.9 s spread** in pit-lane traversal the system could not see.

**Honest caveat:** `circuit_sc_rate` now reads its real `0.15` instead of defaulting to `0.10`, but that table only holds `{0.0, 0.15}` in the data — so there the win is correctness, not discrimination. Worth knowing before anyone expects the SC feature to sharpen.

Closes #448