### PR TITLE
fix(agents): compute FuelEffect from the stint baseline, not a hardcoded fuel_load factor

### DIFF
--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -21,6 +21,7 @@ existing public API is preserved without globals.
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -48,9 +49,18 @@ except Exception:
 _MODELS_DIR = _DATA_ROOT / 'models' / 'lap_time'
 _PROCESSED  = _DATA_ROOT / 'processed'
 
+logger = logging.getLogger(__name__)
+
 # ── Constants ─────────────────────────────────────────────────────────────────
 N_BOOTSTRAP: int   = 200
 _NOISE_PCT: float  = 0.02   # 2 % Gaussian noise on continuous features
+
+# Seconds of lap time recovered per lap as fuel burns off. N04 builds the training
+# feature as (TyreLife - min(TyreLife of the stint)) * 0.055 — verified exactly against
+# laps_featured_2025 (100% of laps reproduce, range 0..3.685 s). The same coefficient
+# lives in tire_agent._add_fuel_cols; deliberately duplicated rather than shared, since
+# unifying constants across agent modules is a wider refactor than this fix (#446).
+FUEL_GAIN_PER_LAP_S: float = 0.055
 
 # ── Artifact paths ────────────────────────────────────────────────────────────
 _CLUSTER_PARQUET  = _PROCESSED / 'circuit_clustering' / 'circuit_clusters_k4_2025.parquet'
@@ -242,6 +252,7 @@ class PaceAgent:
         total_laps: int,
         prev_speed_st: float,
         mean_sector_speed: Optional[float],
+        stint_baseline_tyre_life: Optional[int] = None,
     ) -> dict:
         """Compute features derived from raw inputs that are not in the source data.
 
@@ -264,9 +275,31 @@ class PaceAgent:
             Dict with keys FreshTyre, FuelEffect, laps_remaining,
             mean_sector_speed.
         """
+        # FuelEffect is the cumulative time recovered since the stint started, in
+        # SECONDS (training range 0..3.685 s). It was being computed as
+        # `fuel_load * 0.03` — a [0, 0.03] value, ~100x too small and semantically
+        # different — so the model always read "fresh-fuel stint start" and the learned
+        # fuel-burn pace gain was suppressed on every lap (#446).
+        #
+        # Absent baseline -> NaN, never a fabricated number. NaN is IN-DISTRIBUTION here:
+        # the training parquet itself carries 2.0% null FuelEffect, so XGBoost has a
+        # learned default direction for it, and `_build_feature_row`'s to_numeric(coerce)
+        # tail already routes None -> NaN -> the model's native missing handling. The old
+        # formula must NOT survive as the fallback: a producer we missed would silently
+        # reproduce the exact bug this kills, whereas a NaN plus a warning is impossible
+        # to mistake for a reading.
+        if stint_baseline_tyre_life is None:
+            logger.warning(
+                'stint_baseline_tyre_life absent from lap_state: FuelEffect=NaN for this '
+                'lap; the producer must supply it (#446)'
+            )
+            fuel_effect = float('nan')
+        else:
+            fuel_effect = (tyre_life - stint_baseline_tyre_life) * FUEL_GAIN_PER_LAP_S
+
         return {
             'FreshTyre':        int(tyre_life <= 1),
-            'FuelEffect':       fuel_load * 0.03,
+            'FuelEffect':       fuel_effect,
             'laps_remaining':   max(0, total_laps - lap_number),
             'mean_sector_speed': mean_sector_speed if mean_sector_speed is not None else prev_speed_st,
         }
@@ -296,6 +329,7 @@ class PaceAgent:
         prev_deg_rate: float = 0.0,
         prev_cum_deg: float = 0.0,
         prev_deg_accel: float = 0.0,
+        stint_baseline_tyre_life: Optional[int] = None,
     ) -> pd.DataFrame:
         """Pack raw race state into a single-row DataFrame ready for predict().
 
@@ -309,7 +343,7 @@ class PaceAgent:
         c_id, t_id, cluster = self._encode_categorical(compound, team, gp_name)
         derived = self._compute_derived(
             tyre_life, fuel_load, lap_number, total_laps,
-            prev_speed_st, mean_sector_speed,
+            prev_speed_st, mean_sector_speed, stint_baseline_tyre_life,
         )
 
         row = {
@@ -463,6 +497,7 @@ class PaceAgent:
         prev_deg_rate: float = 0.0,
         prev_cum_deg: float = 0.0,
         prev_deg_accel: float = 0.0,
+        stint_baseline_tyre_life: Optional[int] = None,
     ) -> PaceOutput:
         """Run pace prediction for a single lap and return a PaceOutput.
 
@@ -508,6 +543,7 @@ class PaceAgent:
             gp_name=gp_name, mean_sector_speed=mean_sector_speed,
             prev_deg_rate=prev_deg_rate, prev_cum_deg=prev_cum_deg,
             prev_deg_accel=prev_deg_accel,
+            stint_baseline_tyre_life=stint_baseline_tyre_life,
         )
 
         lap_time_pred   = self._predict(feature_df)
@@ -599,6 +635,11 @@ class PaceAgent:
             prev_deg_rate  = 0.0,
             prev_cum_deg   = 0.0,
             prev_deg_accel = 0.0,
+            # Plain .get, deliberately NOT the `or` pattern used above: `or` would
+            # collapse a legitimate baseline of 0 into None and re-introduce exactly
+            # the sentinel-vs-real-value confusion this epic is about. Absent stays
+            # absent, and _compute_derived turns that into a NaN plus a warning (#446).
+            stint_baseline_tyre_life = d.get('stint_baseline_tyre_life'),
         )
 
     # ── LangGraph ReAct agent ─────────────────────────────────────────────────

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -1403,6 +1403,12 @@ def run_strategy_orchestrator_from_state(
                 "compound":      race_state.compound,
                 "tyre_life":     race_state.tyre_life,
                 "stint":         stint,
+                # A RaceState carries no lap history, so the stint's opening TyreLife is
+                # genuinely unknowable here. None makes N06 emit NaN FuelEffect plus a
+                # warning, which is in-distribution (2% of the training parquet is null)
+                # and cannot be mistaken for a reading. Keep in lockstep with the same
+                # key in engine._build_default_lap_state (#446).
+                "stint_baseline_tyre_life": None,
                 "lap_time_s":    None,
                 "speed_st":      300.0,
                 "fuel_load":     1 - race_state.lap / max(race_state.total_laps, 1),

--- a/src/simulation/race_state_manager.py
+++ b/src/simulation/race_state_manager.py
@@ -132,6 +132,35 @@ class RaceStateManager:
         # calculations. Computed once to avoid repeated group operations.
         self._leader_cum: dict[int, float] = self._precompute_leader_times()
 
+        # TyreLife at the start of each of our driver's stints. Precomputed for the
+        # same reason as the leader times: get_lap_state must stay an O(1) lookup.
+        self._stint_baselines: dict[int, int] = self._precompute_stint_baselines()
+
+    def _precompute_stint_baselines(self) -> dict[int, int]:
+        """Return our driver's TyreLife at the first lap of each stint.
+
+        N06 trains ``FuelEffect`` as ``(TyreLife - min(TyreLife of the stint)) * 0.055``
+        — the seconds of lap time recovered since the stint began. The pace agent has no
+        laps frame of its own (``run_pace_agent_from_state`` takes only the lap_state),
+        so the baseline has to travel in the lap_state, and this is the producer that
+        actually has the stint history. Without it the agent fell back to
+        ``fuel_load * 0.03``, ~100x too small, and the model read every lap as a
+        fresh-fuel stint start (#446).
+
+        ``min`` rather than the first row's value so the result does not depend on row
+        order. Stints whose TyreLife is entirely NaN are omitted, and the consumer then
+        degrades to NaN rather than inventing a number.
+        """
+        baselines: dict[int, int] = {}
+        for stint, group in self._driver.groupby("Stint"):
+            if pd.isna(stint):
+                continue
+            tyre_life = group["TyreLife"].dropna()
+            if tyre_life.empty:
+                continue
+            baselines[int(stint)] = int(tyre_life.min())
+        return baselines
+
     def _precompute_leader_times(self) -> dict[int, float]:
         """Return the race leader's session elapsed time at the end of each lap.
 
@@ -209,6 +238,12 @@ class RaceStateManager:
             "compound_id": int(r["CompoundID"]) if pd.notna(r.get("CompoundID")) else None,
             "tyre_life": int(r["TyreLife"]) if pd.notna(r.get("TyreLife")) else None,
             "stint": int(r["Stint"]) if pd.notna(r.get("Stint")) else None,
+            # TyreLife when this stint began — N06's FuelEffect is measured from it.
+            # Driver-only on purpose: the pace model runs on our car, and rivals stay
+            # timing-screen-only per the single-driver boundary (#446).
+            "stint_baseline_tyre_life": (
+                self._stint_baselines.get(int(r["Stint"])) if pd.notna(r.get("Stint")) else None
+            ),
             "fresh_tyre": bool(r.get("FreshTyre", False)),
             # --- Speed traps (all four sensor points) ---
             "speed_i1": float(r["SpeedI1"]) if pd.notna(r.get("SpeedI1")) else None,

--- a/src/simulation/race_state_manager.py
+++ b/src/simulation/race_state_manager.py
@@ -150,7 +150,15 @@ class RaceStateManager:
         ``min`` rather than the first row's value so the result does not depend on row
         order. Stints whose TyreLife is entirely NaN are omitted, and the consumer then
         degrades to NaN rather than inventing a number.
+
+        ``Stint`` and ``TyreLife`` are not in ``REQUIRED_LAPS_COLUMNS``, so a frame may
+        legitimately arrive without them. That yields an empty map, which the consumer
+        reads as "no baseline" and turns into the same honest NaN.
         """
+        has_columns = {"Stint", "TyreLife"} <= set(self._driver.columns)
+        if not has_columns or self._driver.empty:
+            return {}
+
         baselines: dict[int, int] = {}
         for stint, group in self._driver.groupby("Stint"):
             if pd.isna(stint):
@@ -266,12 +274,18 @@ class RaceStateManager:
         compound and age, and the final speed trap reading. No sector times,
         no fuel data, no detailed speed readings beyond SpeedST.
 
-        ``interval_to_driver_s``: cumulative race time of rival minus our
-        driver's cumulative time. Positive → rival is ahead of us (they have
-        accumulated less race time). Negative → we are ahead of them.
+        ``interval_to_driver_s``: session elapsed time of the rival minus our
+        driver's. **Negative → the rival is ahead of us** (they reached the end
+        of this lap earlier, so less race time has elapsed for them). Positive
+        → we are ahead of them. Verified on Lusail 2025 lap 20: PIA leading,
+        every car behind reports a positive interval (NOR +3.578 s).
 
-        Returns a list sorted by Position (ascending). Rivals without a
-        position value sort to the back (position=99 placeholder).
+        Returns a list sorted by Position (ascending). A rival with no position
+        that lap keeps ``position=None`` and sorts to the back through a local
+        ``99`` placeholder. The placeholder is confined to the sort key on
+        purpose: it never enters the emitted dict, so no consumer can look up a
+        car "at position 99" and find one. Defaulting an unknown position to a
+        number the code also searches by is the #428 bug.
 
         Args:
             lap_number: 1-indexed lap number to retrieve.

--- a/src/strategy/inference/engine.py
+++ b/src/strategy/inference/engine.py
@@ -308,6 +308,12 @@ def _build_default_lap_state(race_state: RaceState, laps_df: pd.DataFrame) -> di
             "compound": race_state.compound,
             "tyre_life": race_state.tyre_life,
             "stint": stint,
+            # A RaceState carries no lap history, so the stint's opening TyreLife is
+            # genuinely unknowable here. None makes N06 emit NaN FuelEffect plus a
+            # warning, which is in-distribution (2% of the training parquet is null)
+            # and cannot be mistaken for a reading. Keep in lockstep with the same
+            # key in strategy_orchestrator's lap_state fallback (#446).
+            "stint_baseline_tyre_life": None,
             "lap_time_s": None,
             "speed_st": 300.0,
             "fuel_load": 1 - race_state.lap / max(race_state.total_laps, 1),


### PR DESCRIPTION
## What

Fixes `FuelEffect`, the pace model's fuel-burn feature, which was being computed from a formula the model was never trained on.

## Why

N06 trains `FuelEffect` as `(TyreLife - min(TyreLife of the stint)) * 0.055`. Verified against the training parquet before writing a line:

```
FuelEffect in the TRAINING parquet: range 0.000..3.685 | null 2.0%
recomputed vs stored: exact on 100.0% of laps (tol 1e-6)
FORMULA CONFIRMED: (TyreLife - min(TyreLife per Driver/GP/Stint)) * 0.055
```

The agent was sending `fuel_load * 0.03`, bounded at 0.03 s. Measured on real data, Lusail 2025:

| lap | stint | tyre_life | baseline | real FuelEffect | what the agent fed |
|---|---|---|---|---|---|
| 20 | 1 | 20 | 1 | **1.045 s** | 0.015 s |
| 40 | 2 | 16 | 1 | **0.825 s** | 0.015 s |

Roughly **55x too small**, on a feature the model reads in seconds. It is the same shape as the rest of this epic: a plausible-looking default standing in for a real reading, silently, for months.

## How

`run_pace_agent_from_state` receives only the `lap_state` and has no laps frame, so "pass it the frame" is impossible without a signature change. The baseline travels inside the `lap_state` instead, computed by the producers that already hold the frame.

Five producers, all wired:

- `RaceStateManager` precomputes it per stint (it already groups by stint), so **the CLI and arcade inherit the fix** for free. Driver-only: rivals do not carry it, keeping the single-driver boundary intact.
- `/lap-state` and `_build_lap_state_from_row` in the backend (submodule PR #121; `_build_lap_state_from_row` gains a use for its previously dead `gp_df` param).
- `engine._build_default_lap_state` and the orchestrator's `lap_state is None` fallback carry an explicit `None` and a comment binding them together: a `RaceState` has no lap history, so the baseline is genuinely unknowable there. These two must move in lockstep or the engine parity tests break.

When the baseline is absent the agent emits **NaN plus a warning**, not a default. NaN is in-distribution (2% of the training parquet is null), XGBoost handles it natively, and it cannot be mistaken for a reading. That is the rule `race_state_manager.py` already applied, and the opposite of the sentinel bugs #436/#428 were about.

## Out of scope

The featured frame drops a stint's out-laps (N04's `IsAccurate` gate), so the minimum can sit 1-2 laps late and understate `FuelEffect` by <= ~0.11 s. Bounded, conservative, documented at the producer, and 40x smaller than the bug it replaces. The raw-parquet fallback path sees the full stint and is exact.

## Checks

- `uvx ruff check .` and `uvx ruff format --check .` green repo-wide (both CI gates, run as CI runs them).
- `tests/test_engine.py` + `tests/test_engine_no_llm.py`: 6 passed (the parity guard on the two lockstep fallbacks).
- Formula asserted against the real training parquet: exact on 100% of laps.
- Agent-level: `baseline=3, tyre_life=18` gives `FuelEffect=0.8250s` (= `15*0.055`); kwarg omitted gives NaN plus the warning.
- Producer-level: the RSM baseline matches an independently computed `min(TyreLife)` per stint on Lusail laps 20 and 40, lands inside the trained 0..3.685 s range, and is absent from `rivals`.

Note: `tests/eval/test_registry_golden.py::test_calibration_flags_pit_coverage_drift` fails locally (0.7024 vs the 0.7047 golden). Pre-existing, unrelated: it fails identically on `dev` with this branch stashed, `collect_results()` recomputes from `data/processed/` rather than going through the augmented loader, and CI is green because `data/**` is not in git. Worth a separate look, not this PR's business.

Refs #446
