### PR TITLE
docs(strategy): correct the pages the engine fixes made wrong

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,7 +21,7 @@ All three consume the same core:
 
 The Streamlit path also runs a FastAPI backend (`src/telemetry/backend/`).
 The Arcade path runs the strategy pipeline locally without the backend
-(see [`docs/arcade/strategy-pipeline.md`](docs/arcade/strategy-pipeline.md)).
+(see [`docs/pages/arcade-strategy-pipeline.md`](docs/pages/arcade-strategy-pipeline.md)).
 
 ## Multi-agent pipeline
 
@@ -29,9 +29,7 @@ N25 Pace · N26 Tire · N27 Situation · N29 Radio are always-on. N28 Pit
 Strategy and N30 RAG are conditional (routing decides per-lap). N31
 Orchestrator fuses all outputs through a Monte Carlo simulation and an
 LLM synthesis pass into a `StrategyRecommendation`. Full flow:
-[`docs/architecture.md`](docs/architecture.md) + the
-[`docs/diagrams/strategy_pipeline_flow.drawio`](docs/diagrams/strategy_pipeline_flow.drawio)
-diagram.
+[`docs/pages/architecture.md`](docs/pages/architecture.md).
 
 ## Arcade three-window topology
 
@@ -44,9 +42,7 @@ diagram.
 
 Both windows subscribe to the arcade's `TelemetryStreamServer` on
 `127.0.0.1:9998`. Details:
-[`docs/arcade/dashboard.md`](docs/arcade/dashboard.md) and the
-[`docs/diagrams/arcade_3window_architecture.drawio`](docs/diagrams/arcade_3window_architecture.drawio)
-diagram.
+[`docs/pages/arcade-dashboard.md`](docs/pages/arcade-dashboard.md).
 
 ## Data flow
 
@@ -58,16 +54,14 @@ diagram.
 - Featured laps parquets + per-race raw dirs + tire-compound-by-race
   map form the input to the multi-agent stack.
 
-See [`docs/diagrams/tcp_broadcast_dataflow.drawio`](docs/diagrams/tcp_broadcast_dataflow.drawio)
-and [`docs/diagrams/data_pipeline.drawio`](docs/diagrams/data_pipeline.drawio)
 for the wire-level view.
 
 ## Where to go next
 
 - **Install:** [`INSTALL.md`](INSTALL.md).
 - **Roadmap:** [`ROADMAP.md`](ROADMAP.md).
-- **Agents reference:** [`docs/agents-api-reference.md`](docs/agents-api-reference.md).
-- **Backend API:** [`docs/backend-api.md`](docs/backend-api.md).
-- **Streamlit frontend:** [`docs/streamlit-frontend.md`](docs/streamlit-frontend.md).
-- **Simulation engine:** [`docs/simulation/overview.md`](docs/simulation/overview.md).
+- **Agents reference:** [`docs/pages/agents-api.md`](docs/pages/agents-api.md).
+- **Backend API:** [`docs/pages/backend-api.md`](docs/pages/backend-api.md).
+- **Streamlit frontend:** [`docs/pages/streamlit.md`](docs/pages/streamlit.md).
+- **Simulation engine:** [`docs/pages/simulation.md`](docs/pages/simulation.md).
 - **All draw.io diagrams:** [`docs/diagrams/`](docs/diagrams/).

--- a/docs/app/nav.js
+++ b/docs/app/nav.js
@@ -125,9 +125,9 @@ window.PAGES = [
     title: "Strategy pipeline",
     section: "Arcade",
     file: "pages/arcade-strategy-pipeline.md",
-    description: "Why the arcade duplicates the N31 orchestrator body.",
+    description: "The shared run_lap engine behind all three surfaces, and its two profiles.",
     eyebrow: "Internals",
-    tags: ["arcade", "orchestrator", "agents", "pipeline", "monte-carlo", "threading"],
+    tags: ["arcade", "orchestrator", "agents", "pipeline", "engine", "monte-carlo", "threading"],
   },
 
   // ------- OPERATIONS -------

--- a/docs/pages/agents-api.md
+++ b/docs/pages/agents-api.md
@@ -10,13 +10,17 @@ Every agent has two entry points:
 
 | Agent | FastF1 Entry | RSM Adapter (no FastF1 session) |
 |---|---|---|
-| N25 Pace | `run_pace_agent(**kwargs)` | `run_pace_agent_from_state(lap_state, laps_df)` |
+| N25 Pace | `run_pace_agent(**kwargs)` | `run_pace_agent_from_state(lap_state)` |
 | N26 Tire | `run_tire_agent(stint_state)` | `run_tire_agent_from_state(lap_state, laps_df)` |
 | N27 Situation | `run_race_situation_agent(lap_state)` | `run_race_situation_agent_from_state(lap_state, laps_df)` |
 | N28 Pit | `run_pit_strategy_agent(lap_state)` | `run_pit_strategy_agent_from_state(lap_state, laps_df)` |
-| N29 Radio | `run_radio_agent(lap_state)` | `run_radio_agent_from_state(lap_state, laps_df)` |
-| N30 RAG | `run_rag_agent(question)` | `run_rag_agent_from_state(lap_state)` |
-| N31 Orchestrator | `run_strategy_orchestrator(race_state, lap_state)` | `run_strategy_orchestrator_from_state(race_state, laps_df)` |
+| N29 Radio | `run_radio_agent(lap_state, persist)` | `run_radio_agent_from_state(lap_state, laps_df, persist)` |
+| N30 RAG | `run_rag_agent(question)` | `run_rag_agent_from_state(lap_state, laps_df)` |
+| N31 Orchestrator | `run_strategy_orchestrator(race_state, lap_state)` | `run_strategy_orchestrator_from_state(race_state, laps_df, lap_state)` |
+
+**N25 is the odd one out: it takes no `laps_df`.** Everything it needs must already be in the
+`lap_state`, which is why the stint fuel baseline is carried there rather than derived from a
+frame. The adapters are not uniform, so check the signature before assuming.
 
 Each agent also exposes a `get_*_react_agent()` factory that returns a compiled LangGraph `CompiledGraph` for direct LangGraph usage.
 
@@ -52,6 +56,7 @@ Each agent also exposes a `get_*_react_agent()` factory that returns a compiled 
 |---|---|---|
 | `overtake_prob` | float | Probability of being overtaken (0–1) |
 | `sc_prob_3lap` | float | Safety car probability within 3 laps (0–1) |
+| `sc_currently_active` | bool | A safety car is deployed **right now**. Not a prediction: it is read from the lap's RCM events, because N14 was trained to forecast a future SC and cannot recognise one already out. When true it forces `sc_prob_3lap = 1.0`, activates N28, and the final recommendation is held to `PIT_NOW`. See [Multi-agent system](#/multi-agent). |
 | `threat_level` | str | LOW, MEDIUM, HIGH, CRITICAL |
 | `gap_ahead_s` | float | Gap to car ahead in seconds |
 | `pace_delta_s` | float | Pace difference vs car ahead |
@@ -151,27 +156,71 @@ result = process_radio_tool.invoke({
 
 **Agent-level (no LLM needed):**
 
-```python
-from src.agents.pace_agent import run_pace_agent_from_state
-import pandas as pd
+The `*_from_state` entry points take **only** a `lap_state`, and it must be the real
+nested dict (`driver` / `rivals` / `weather` / `session_meta`), not a flat one. Build it
+with `RaceStateManager` rather than by hand: it is the component that owns the contract,
+and hand-rolling one is how the second, buggy implementation of this got written.
 
-laps_df = pd.read_parquet("data/processed/laps_featured_2025.parquet")
-lap_state = {"driver": "VER", "lap_number": 20}
-output = run_pace_agent_from_state(lap_state, laps_df)
+```python
+from pathlib import Path
+from itertools import islice
+from src.simulation.replay_engine import RaceReplayEngine
+from src.agents.pace_agent import run_pace_agent_from_state
+
+replay = RaceReplayEngine(Path("data/raw/2025/Lusail"), driver_code="PIA", team="McLaren")
+lap_state = next(islice(replay.replay(), 19, 20))   # lap 20
+output = run_pace_agent_from_state(lap_state)
+
+print(output.lap_time_pred, output.ci_p10, output.ci_p90)
 ```
+
+**Take the `lap_state` from `replay()`, not from `rsm.get_lap_state(lap)` directly.**
+`get_lap_state`'s `weather_df` argument is optional, and `replay()` is what passes it. Call
+the RSM bare and the weather dict comes back with only `track_status`, so consumers fall
+through to their hardcoded defaults (the arcade's are 25.0 C air / 35.0 C track) and never
+say so. At Lusail the real values are 23.7 C and 29.8 C, and track temperature is a live
+input to tire degradation.
+
+See [Race replay engine](#/simulation) for the full `lap_state` schema.
 
 **Full orchestrator (requires LM Studio or OpenAI):**
 
 ```python
-from src.agents.strategy_orchestrator import RaceState, run_strategy_orchestrator_from_state
+from pathlib import Path
+from itertools import islice
 import pandas as pd
+from src.simulation.replay_engine import RaceReplayEngine
+from src.agents.strategy_orchestrator import RaceState
+from src.strategy.inference.engine import run_lap
 
-laps_df = pd.read_parquet("data/processed/laps_featured_2025.parquet")
+race_dir = Path("data/raw/2025/Lusail")
+laps_df = pd.read_parquet(race_dir / "laps.parquet")
+replay = RaceReplayEngine(race_dir, driver_code="PIA", team="McLaren")
+lap_state = next(islice(replay.replay(), 19, 20))   # lap 20
+
+driver = lap_state["driver"]
+ahead = [r for r in lap_state["rivals"] if r["position"] == driver["position"] - 1]
 race_state = RaceState(
-    driver="NOR", lap=18, total_laps=57, position=3,
-    compound="C2", tyre_life=20, gap_ahead_s=1.2, pace_delta_s=-0.3,
-    air_temp=32.0, track_temp=48.0,
+    driver=driver["driver"], lap=20, total_laps=replay.total_laps,
+    position=driver["position"], compound=driver["compound"],
+    tyre_life=driver["tyre_life"],
+    # rivals ahead report a NEGATIVE interval; RaceState wants a magnitude
+    gap_ahead_s=abs(ahead[0]["interval_to_driver_s"]) if ahead else 0.0,
+    pace_delta_s=0.0,
+    air_temp=lap_state["weather"]["air_temp"],
+    track_temp=lap_state["weather"]["track_temp"],
 )
-rec = run_strategy_orchestrator_from_state(race_state, laps_df)
+
+rec, agent_outputs, timings = run_lap(race_state, laps_df, lap_state, profile="no-llm")
 print(rec.action, rec.confidence, rec.reasoning)
 ```
+
+Prefer `run_lap` over calling `run_strategy_orchestrator_from_state` directly: it is the
+same pipeline (parity-tested), and it also hands back the per-agent outputs and stage
+timings. Pass `profile="no-llm"` to run the deterministic path with no provider at all.
+
+**Pass the `lap_state`, and make sure it carries `session_meta`.** The `laps_df` is scoped
+to the Grand Prix named there. Without it, the engine falls back to the whole frame and
+logs a warning, and the agents then look up rivals by driver and lap number across the
+entire season: the Zandvoort grid can end up deciding a race at Lusail. The fallback is
+loud on purpose, but the fix is to supply the `session_meta`, not to ignore the warning.

--- a/docs/pages/arcade-strategy-pipeline.md
+++ b/docs/pages/arcade-strategy-pipeline.md
@@ -1,104 +1,78 @@
-# Strategy Pipeline — Arcade Duplicate
+# Strategy Pipeline — the shared engine
 
-Why `src/arcade/strategy_pipeline.py` exists as a near-copy of `src/agents/strategy_orchestrator.py::run_strategy_orchestrator_from_state`, what gets duplicated, what does not, and how to keep the two bodies in sync.
+`src/strategy/inference/engine.py::run_lap` is the single implementation of the N31 lap pipeline. The CLI, the arcade and the backend all route through it. This page covers what it returns, the two profiles, and why the arcade is now a nine-line delegate instead of a copy.
 
-## Why the arcade duplicates
+## One engine, three surfaces
 
-The CLI (`scripts/run_simulation_cli.py`) and the Streamlit frontend both call `run_strategy_orchestrator_from_state(race_state, laps_df)` and consume its single return value: a `StrategyRecommendation` dataclass with `action`, `reasoning`, `confidence`, `scenario_scores`, and `regulation_context`. The public contract is narrow on purpose — the orchestrator hides the six sub-agent dataclasses behind a single synthesised decision.
-
-The arcade dashboard needs the opposite. To render the six sub-agent cards, the pace and tire charts, the scenario bars, and the reasoning tabs, the dashboard must see the **raw per-agent outputs**:
-
-- `PaceOutput.lap_time_pred`, `ci_p10`, `ci_p90`, `delta_vs_prev`
-- `TireOutput.laps_to_cliff_p10 / p50 / p90`, `warning_level`, `deg_rate`
-- `RaceSituationOutput.overtake_prob`, `sc_prob_3lap`, `threat_level`
-- `RadioOutput.alerts`, `radio_events`, `rcm_events`, `corrections`
-- `PitStrategyOutput.action`, `compound_recommendation`, `stop_duration_p05 / p50 / p95`, `undercut_prob`
-- `RegulationContext.answer`, `articles`
-- The Monte Carlo scenario scores before they collapse into the recommendation
-- The set of conditional agents that fired this lap (the `active` list)
-
-None of this is available from `StrategyRecommendation` alone.
-
-Two obvious alternatives, both rejected:
-
-1. **Extend the public orchestrator to return more fields.** Would force the CLI and Streamlit to depend on a wider return type and break the documented contract. The CLI is also the TFG's PMV and is flagged untouchable.
-2. **Call each sub-agent from the arcade directly and skip the orchestrator.** Would duplicate the MoE routing logic, the Monte Carlo simulation, the LLM synthesis step, and the guardrail logic — four distinct concerns instead of one.
-
-The chosen approach: duplicate the orchestrator body inside `src/arcade/strategy_pipeline.py::run_strategy_pipeline` and return a tuple `(StrategyRecommendation, raw_outputs_dict)`. The public orchestrator is untouched, the CLI/Streamlit keep their narrow return type, and the arcade sees everything.
-
-## What gets duplicated
-
-The full body of `run_strategy_orchestrator_from_state`, from the always-on layer through the MC simulation and the LLM synthesis. The duplicate lives in:
+Every surface needs the same six sub-agents, the same MoE routing, the same Monte Carlo pass and the same synthesis. They differ only in what they render. So the pipeline lives in one place and the surfaces choose how much of its output to consume:
 
 ```
-src/arcade/strategy_pipeline.py
-    run_strategy_pipeline(race_state, laps_df, lap_state=None)
-        -> tuple[StrategyRecommendation, dict]
+src/strategy/inference/engine.py
+    run_lap(race_state, laps_df, lap_state=None, *, profile="rich",
+            return_agent_outputs=True)
+        -> tuple[StrategyRecommendation, dict | None, dict[str, float]]
 ```
 
-The body mirrors the orchestrator's call sequence exactly:
+- **`StrategyRecommendation`** — the synthesised decision (14 fields). What the CLI and Streamlit consume.
+- **`agent_outputs`** — the raw per-sub-agent dataclasses, keyed `pace_out`, `tire_out`, `situation_out`, `radio_out`, `pit_out`, `regulation_context`, `rag`, `active`, `guardrail_reason`. What the arcade dashboard renders its cards and charts from.
+- **stage timings** — per-stage seconds, for the surfaces that show them.
 
-1. `_run_always_on_agents_from_state(race_state, laps_df, lap_state)` — returns `(pace_out, tire_out, situation_out, radio_out)`.
-2. `_decide_agents_to_call(tire_warning=..., sc_prob_3lap=..., radio_alerts=...)` — returns the `active` list.
-3. `_run_conditional_agents(active=..., lap_state=..., tire_out=..., situation_out=..., race_state=..., laps_df=...)` — returns `(pit_out, regulation_context)`.
-4. `_run_mc_simulation(pace_out, tire_out, situation_out, pit_out, race_state)` — returns the scenario score dict.
-5. `_build_orchestrator_prompt(...)` and `_get_orchestrator_llm()`.
-6. `_assemble_recommendation(...)` — builds the final `StrategyRecommendation`.
+The sub-agents are imported through their public `*_from_state` entry points; the output dataclasses come from `src/agents/strategy_orchestrator.py`. Nothing about them is engine-specific.
 
-The arcade pipeline packages every intermediate value into the second element of its return tuple — a dict under the keys `pace_out`, `tire_out`, `situation_out`, `radio_out`, `pit_out`, `regulation_context`, `active`, `scenario_scores`.
+## Profiles
 
-## What does NOT get duplicated
+| profile | what runs | use it for |
+|---|---|---|
+| `rich` | the full pipeline, including the LLM synthesis step | the default; reproduces `run_strategy_orchestrator_from_state` byte for byte |
+| `no-llm` | everything except the LLM; the deterministic guardrails produce the decision | fast, offline, reproducible runs, and any path that must not spend tokens |
 
-The six sub-agent modules are imported as-is via their public `*_from_state` entry points:
+`rich` is guarded by parity tests against the orchestrator, so the two cannot drift apart silently.
 
-- `src/agents/pace_agent.py` — `run_pace_agent_from_state`
-- `src/agents/tire_agent.py` — `run_tire_agent_from_state`
-- `src/agents/race_situation_agent.py` — `run_race_situation_agent_from_state`
-- `src/agents/radio_agent.py` — `run_radio_agent_from_state`
-- `src/agents/pit_strategy_agent.py` — `run_pit_strategy_agent_from_state`
-- `src/agents/rag_agent.py` — `run_rag_agent_from_state`
+## The arcade delegates
 
-Output dataclasses (`PaceOutput`, `TireOutput`, `RaceSituationOutput`, `RadioOutput`, `PitStrategyOutput`, `RegulationContext`, `StrategyRecommendation`) are also shared, imported from `src/agents/strategy_orchestrator.py`.
+`src/arcade/strategy_pipeline.py::run_strategy_pipeline` keeps its old public signature so `src/arcade/strategy.py` and the dashboard formatters are untouched. Its body is one call:
 
-In short: sub-agent logic and data types are shared; only the orchestration sequence is duplicated.
+```python
+rec, agent_outputs, _timings = run_lap(race_state, laps_df, lap_state, profile="rich")
+return rec, agent_outputs
+```
 
-## How to stay in sync
+The arcade needs the raw outputs and the CLI does not, but that is a difference in **consumption**, not in pipeline. `run_lap` returns both and each surface takes what it renders.
 
-Any edit to `run_strategy_orchestrator_from_state` in `src/agents/strategy_orchestrator.py` must be mirrored in `run_strategy_pipeline` in `src/arcade/strategy_pipeline.py`. The checklist:
+## Why this replaced a duplicate
 
-1. Open both files side by side.
-2. Transcribe the edit. If a new private helper was added, import it. If a call argument changed, update the arcade caller.
-3. If the orchestrator grew a new intermediate value that the dashboard might want to render, add it to the `raw_outputs_dict` second return value.
-4. Run the smoke test below before committing.
+This module used to be a body-copy of the orchestrator, and this page used to document a "how to stay in sync" ritual: open both files side by side and transcribe every edit by hand. That ritual was the bug. A copy kept in sync by discipline drifts the first time someone edits one file and not the other, and it did: the audit flagged it (`AUDIT_P2B_CORE_COMPUTE` F10) and the #166 crash proved it.
 
-### Smoke test
+The lesson generalises beyond the arcade, and the strategy engine relearned it the hard way. `src/simulation/race_state_manager.py` had already solved a pile of race-data problems correctly (NaN never becomes a searchable number, gaps come from the elapsed-time column, retired cars fall out on their own). A second implementation was later written alongside it for the API path, and it reproduced every one of those bugs from scratch, silently, for months. Two implementations of the same idea do not stay equal because someone intends them to.
+
+So: **before writing a second path that shapes race data, check whether a clean one already exists.** If it does, call it.
+
+## SimConnector threading
+
+The arcade strategy driver is `src/arcade/strategy.py::SimConnector`. It is a plain Python class, not a Qt object, spawned as a `threading.Thread` from `F1ArcadeView._init_strategy_layer`.
+
+- Owns a `StrategyState` dataclass caching the latest `LapDecision`, the per-agent outputs and playback metadata, behind a `threading.Lock`.
+- Owns the background thread that iterates `RaceReplayEngine.replay()` and calls `run_strategy_pipeline(race_state, laps_df)` per lap.
+- Emits `StartEventDTO` once on the first frame, then `LapDecisionDTO` per lap.
+
+## Why not SSE from the backend
+
+The arcade used to subscribe to `GET /api/v1/strategy/simulate/stream`. Phase 3.5 replaced it with the direct in-process loop:
+
+- **No extra process.** Strategy mode no longer needs `uvicorn` running first.
+- **No SSE client.** The arcade's consumer was a hand-rolled parser over `httpx.stream` with its own reconnect logic. A thread is simpler.
+- **Standalone.** The arcade ships without a FastAPI dependency.
+
+The backend SSE endpoint is still live and smoke-tested; the arcade just does not consume it.
+
+## Smoke test
 
 ```bash
-# CLI path — exercises run_strategy_orchestrator_from_state
-python scripts/run_simulation_cli.py Melbourne VER McLaren --no-llm
+# CLI path
+python scripts/run_simulation_cli.py Melbourne VER "Red Bull Racing" --no-llm
 
-# Arcade path — exercises run_strategy_pipeline
+# Arcade path
 python -m src.arcade.main --viewer --year 2025 --round 3 --driver VER --team "Red Bull Racing" --strategy
 ```
 
 Both should reach lap 2 without tracebacks.
-
-## SimConnector threading
-
-The arcade strategy driver lives in `src/arcade/strategy.py::SimConnector`. It is not a Qt object — it is a plain Python class that spawns a `threading.Thread` inside `F1ArcadeView._init_strategy_layer`.
-
-Responsibilities:
-
-- Own a `StrategyState` — a dataclass that caches the latest `LapDecision`, the per-agent outputs, and playback metadata. Protected by a `threading.Lock`.
-- Own a background thread that iterates `RaceReplayEngine.replay()` and calls `run_strategy_pipeline(race_state, laps_df)` per lap.
-- Emit `StartEventDTO` once on first frame and `LapDecisionDTO` per lap.
-
-## Why not SSE from the FastAPI backend
-
-The arcade used to subscribe to `GET /api/v1/strategy/simulate/stream`. Phase 3.5 Proceso B replaced that path with the direct local loop for three reasons:
-
-- **Extra process**: running the arcade with strategy mode required starting `uvicorn` first. The local loop eliminates the dependency.
-- **SSE consumer complexity**: the arcade's SSE client was a roll-your-own parser on top of `httpx.stream` with manual reconnect logic. Running the loop directly inside a thread is simpler.
-- **Isolation**: the arcade can now ship as a standalone entry point without any FastAPI dependency.
-
-The backend SSE endpoint is still live and covered by TestClient smoke tests — the arcade simply does not consume it any more.

--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -88,9 +88,9 @@ Four properties are load-bearing:
 1. **The arcade owns the `TelemetryStreamServer`.** `src/arcade/stream.py` exposes the merged arcade + strategy snapshot; every other window is a subscriber, never the source of truth.
 2. **One subprocess hosts both Qt windows.** The arcade spawns a single `subprocess.Popen` that boots one `QApplication`. Two windows inside one event loop is cheaper than two OS processes and avoids duplicated imports of PySide6 + pyqtgraph.
 3. **Each window has its own `TelemetryStreamClient(QThread)`.** Subscribers do not share sockets; each window reconnects independently when the arcade restarts.
-4. **Arcade runs a local strategy pipeline.** `src/arcade/strategy_pipeline.py` carries a copy of the N31 orchestrator body so the arcade does not depend on the FastAPI backend at runtime.
+4. **Arcade runs the strategy pipeline in-process.** `src/arcade/strategy_pipeline.py` delegates to the shared engine (`src/strategy/inference/engine.py::run_lap`), so the arcade does not depend on the FastAPI backend at runtime and does not carry its own copy of the orchestrator. It used to; that copy drifted and crashed (#166), which is why the engine exists.
 
-See [Arcade strategy pipeline](#/arcade-strategy-pipeline) for the rationale and [Arcade dashboard](#/arcade-dashboard) for the Qt-side architecture.
+See [Arcade strategy pipeline](#/arcade-strategy-pipeline) for the shared engine and its profiles, and [Arcade dashboard](#/arcade-dashboard) for the Qt-side architecture.
 
 ## Agent details
 
@@ -131,6 +131,10 @@ Wraps N15 (physical pit stop duration P05/P50/P95 via HistGBT) and N16 (undercut
 #### Honoring an active Safety Car
 
 When the orchestrator sets `sc_currently_active = True` on the lap state, N28's prompt swaps the legacy "SC probability" line for an explicit `SC STATUS: SAFETY CAR DEPLOYED RIGHT NOW` banner and the system prompt waives the `MINIMUM STINT LENGTH` constraint (pitting under SC costs ~10 s vs ~22 s, inverting the cost/benefit). A code-level guard-rail then flips any residual `STAY_OUT` to `PIT_NOW` so a misbehaving LLM can't override the deterministic signal — replicating the McLaren Catar 2025 V7 fix where the chain of safeguards previously locked the recommendation into `STAY_OUT` despite a confirmed SC.
+
+**The rail is enforced twice, and it has to be.** N28's guard produces the right `action`, but the orchestrator's final synthesis then writes its own: `_assemble_recommendation` took the LLM's answer verbatim, so N28's `PIT_NOW` only ever reached the synthesis *prompt* as a line of text the model could ignore. It did: the same Lusail lap 7 scenario returned `PIT_NOW` twice and `STAY_OUT` four times across six runs. `_assemble_recommendation` now applies the same flip to the synthesised action, tagged `[OVERRIDE: SC deployed — forcing PIT_NOW.]` in the reasoning.
+
+A deterministic rail is only deterministic at the layer that emits the final answer. A guard one layer down is a suggestion.
 
 ### N29 — Radio Agent (`radio_agent.py`)
 

--- a/docs/pages/simulation.md
+++ b/docs/pages/simulation.md
@@ -45,19 +45,35 @@ The single most important design decision in this module.
 
 Rivals get only what appears on the FIA live timing screen. This mirrors the real information asymmetry a strategy engineer faces on the pit wall.
 
+### Who counts as a rival
+
+The boundary above says *what* a rival's row contains. This says *which cars get a row at all*, and it is just as load-bearing:
+
+**A car appears in `rivals` for a lap only if it was classified on that lap.** Retired, crashed, or not yet across the line means no row, so the car is absent from the list entirely. It is never present with an invented position, a placeholder gap or a default lap time.
+
+This is the rule that a real timing screen follows, and skipping it produces decisions that look reasonable and are absurd. The pit wall once recommended undercutting HUL at Lusail lap 7. HUL had just crashed on lap 6, which is what brought out the safety car the same recommendation was reacting to. The car was gone; only a filled-in default kept it on the list.
+
+Two habits follow from it, and both are worth copying into any new code that shapes race data:
+
+- **Absence beats a default.** If a value is unknown, leave it `None` and let the consumer filter. A number is a claim, and an invented one is a false claim that nothing downstream can distinguish from a reading.
+- **Never default to a value the code also searches by.** `Position` defaulting to `0` is how the leader found "the car ahead at position `pos - 1 == 0`" and got handed the car that had just crashed. Placeholders belong in sort keys, never in emitted data.
+
 ## Gap computation
 
-Gaps are derived from cumulative `LapTime` differences rather than from the intervals OpenF1 API feed. This is the standard F1 analytics approach (see TUMFTM race-simulation methodology).
+Gaps come from `session_time_s`, the session elapsed time at the end of each lap, read from FastF1's `Time` column. This is the same value FastF1 uses internally for gaps in `session.laps`.
 
 ```
-gap_to_leader[driver, lap] = cum_time[driver, lap] - cum_time[leader, lap]
-interval_to_driver[rival, lap] = cum_time[rival, lap] - cum_time[our_driver, lap]
+gap_to_leader[driver, lap]      = session_time[driver, lap] - session_time[leader, lap]
+interval_to_driver[rival, lap]  = session_time[rival, lap]  - session_time[our_driver, lap]
 ```
 
-Known limitations (acceptable for thesis demo):
+**Not** cumulative `LapTime` sums, which is the tempting alternative. Summed lap times drift away from the real on-track gap wherever timing corrections or safety-car bunching apply, which is exactly where a strategy call matters most. `_compute_session_times` in `src/simulation/race_state_manager.py` takes elapsed time for that reason.
 
-- Safety car bunching is not reflected accurately.
-- Lapped cars show large positive gaps, not "lapped" flag.
+This is worth stating loudly because the feature-engineering step drops the `Time` column, so any consumer reading the featured parquet directly used to fall back to lap-time deltas without noticing. Measured on Lusail 2025 lap 20, that fallback fed the model a **0.10 s** gap between PIA and NOR when the real one was **3.58 s**: the difference between "inside the DRS window" and "not close". The loader now restores `Time_s` from the raw per-race parquet at load time, so both paths agree.
+
+Known limitations:
+
+- Lapped cars show a large positive gap rather than a "lapped" flag.
 
 ## Files
 
@@ -142,10 +158,17 @@ python -m src.simulation Silverstone VER "Red Bull Racing" --data-dir data/raw/2
         "is_in_lap": bool,
         "is_out_lap": bool,
     },
+    # Only cars classified on this lap. A car that has retired, crashed or has
+    # not yet completed the lap has no row for it, so it is simply ABSENT from
+    # `rivals` — never present with a filled-in default. See "Who counts as a
+    # rival" below.
     "rivals": [
         {
             "driver": str,
             "team": str,
+            # None when the car has no position that lap. It sorts to the back
+            # through a placeholder confined to the sort key, so no consumer can
+            # look up a car at that position and find one.
             "position": int | None,
             "lap_time_s": float | None,
             "compound": str,

--- a/src/arcade/README.md
+++ b/src/arcade/README.md
@@ -21,10 +21,9 @@ f1-arcade --viewer --year 2025 --round 3 --driver VER --team "Red Bull Racing"
 
 ## Public docs
 
-- **End-user quick start:** [`docs/arcade/quick-start.md`](../../docs/arcade/quick-start.md)
-- **Dashboard architecture (developer deep dive):** [`docs/arcade/dashboard.md`](../../docs/arcade/dashboard.md)
-- **Why the arcade duplicates the N31 orchestrator body:** [`docs/arcade/strategy-pipeline.md`](../../docs/arcade/strategy-pipeline.md)
-- **Visual overview:** [`docs/diagrams/arcade_3window_architecture.drawio`](../../docs/diagrams/arcade_3window_architecture.drawio)
+- **End-user quick start:** [`docs/pages/arcade-quick-start.md`](../../docs/pages/arcade-quick-start.md)
+- **Dashboard architecture (developer deep dive):** [`docs/pages/arcade-dashboard.md`](../../docs/pages/arcade-dashboard.md)
+- **The shared `run_lap` engine the arcade delegates to:** [`docs/pages/arcade-strategy-pipeline.md`](../../docs/pages/arcade-strategy-pipeline.md)
 
 ## Layout
 
@@ -35,7 +34,7 @@ src/arcade/
 ├── data.py              # SessionLoader + SessionData + FrameData
 ├── config.py            # Palette, GP calendars, constants
 ├── strategy.py          # SimConnector + StrategyState + DTOs
-├── strategy_pipeline.py # Arcade-local duplicate of the N31 orchestrator body
+├── strategy_pipeline.py # Thin delegate over the shared engine (run_lap)
 ├── stream.py            # TelemetryStreamServer (stdlib TCP)
 ├── overlays.py          # WeatherPanel, LeaderboardPanel, DriverInfoPanel, …
 ├── track.py             # Track polyline renderer (DRS zones, cars)
@@ -47,5 +46,5 @@ The arcade **does not depend on the FastAPI backend at runtime**. The
 strategy pipeline runs in a background thread inside this process using
 `RaceReplayEngine` + the featured-laps parquet + the local
 `strategy_pipeline.run_strategy_pipeline` wrapper. See
-[`docs/arcade/strategy-pipeline.md`](../../docs/arcade/strategy-pipeline.md)
-for why the N31 body is duplicated here rather than extended upstream.
+[`docs/pages/arcade-strategy-pipeline.md`](../../docs/pages/arcade-strategy-pipeline.md)
+for the shared engine, its two profiles, and why the old duplicate is gone.

--- a/src/simulation/README.md
+++ b/src/simulation/README.md
@@ -1,6 +1,6 @@
 # src/simulation — Race replay engine
 
-> **Canonical narrative doc:** [`docs/simulation/overview.md`](../../docs/simulation/overview.md)
+> **Canonical narrative doc:** [`docs/pages/simulation.md`](../../docs/pages/simulation.md)
 > covers the `lap_state` contract and the data boundary with the agents.
 > This README is the package-level API pointer.
 

--- a/src/strategy/README.md
+++ b/src/strategy/README.md
@@ -1,6 +1,15 @@
-# src/strategy — Strategy Model Modules (Jupytext exports)
+# src/strategy — Strategy Model Modules
 
-**Status: Jupytext export / reference** — not imported by current agent notebooks.
+**Read this first:** this package holds two different things with opposite statuses.
+
+- **`inference/` is production.** `inference/engine.py::run_lap` is the single
+  implementation of the N31 lap pipeline, and the CLI, the arcade and the backend
+  all route through it. See
+  [Strategy pipeline](https://docs.f1stratlab.com/#/arcade-strategy-pipeline).
+- **`training/` and the Jupytext exports are reference**, and the status note below
+  applies only to them.
+
+## Status of the Jupytext exports: reference only
 
 These are Jupytext `.py` exports from early strategy notebooks. They contain the
 model architectures and prediction utilities developed before the LightGBM-based
@@ -35,8 +44,9 @@ The current production tire degradation model is the per-compound fine-tuned TCN
 from N10, exported to `data/models/tire_degradation/`. The lap time model is the
 XGBoost delta predictor from N06 (`data/models/lap_time/`).
 
-These `src/strategy/` files pre-date those exports and use different model
-architectures or APIs. Do not rely on them for inference in agent code.
+The **Jupytext export** files pre-date those exports and use different model
+architectures or APIs. Do not rely on them for inference in agent code. This does
+not apply to `inference/`, which is the production path.
 
 ---
 


### PR DESCRIPTION
## What

Corrects the documentation the strategy-engine fixes turned false, plus the parts that were already false and nobody had run.

## Why

The docs describe the pre-fix system. Left alone they would not merely be stale: several pages actively teach the bugs this epic just removed.

## The pages

**`arcade-strategy-pipeline.md` — the whole premise was false.** It documented a duplicate of the orchestrator body and a "how to stay in sync" ritual: *open both files side by side and transcribe the edit*. The arcade has been a nine-line `run_lap` delegate since the engine landed, and that ritual is precisely the drift the engine abolished (the audit flagged it, the #166 crash proved it). Rewritten around the shared engine, which **nothing documented until now**: `run_lap`, its three return values, and the `rich` / `no-llm` profiles. That was one of the two structural gaps.

**`simulation.md` — it described the rejected design as if shipped.** The gap section claimed gaps come from cumulative `LapTime` sums and listed "safety car bunching is not reflected accurately" as a known limitation. The code reads session elapsed time *precisely so that it is* reflected. The page now says what `_compute_session_times` does and cites the measured cost of the fallback (Lusail L20: real gap 3.58 s, the fallback fed 0.10 s).

It also gains **"Who counts as a rival"**, the other structural gap. The rival-selection rule was undocumented, so the undercut-HUL bug had no sentence to correct. It now carries the rule (a car appears only if classified that lap) and the two habits behind it: absence beats a default, and never default to a value the code also searches by.

**`multi-agent.md`** — the arcade no longer carries an orchestrator copy, and the SC guard-rail is documented as enforced at **both** N28 and the final synthesis. The page already promised the rail; the orchestrator was walking around it.

**`agents-api.md` — both "runnable" examples raised `TypeError`.** `run_pace_agent_from_state` was documented as `(lap_state, laps_df)` when it takes only `(lap_state)`, and the `lap_state` shown was flat rather than the real nested dict. The entry-point table was regenerated from `inspect.signature`: **4 of 7 rows were wrong**. Both examples now come from `replay()` rather than a bare `rsm.get_lap_state(lap)`, whose optional `weather_df` silently degrades the weather dict to `track_status` alone and drops consumers onto hardcoded temperatures. Adds `sc_currently_active`, undocumented despite being what the entire SC path turns on.

**`race_state_manager.py`** — the `get_rival_states` docstring had the interval **sign inverted**: it claimed positive means the rival is ahead, while the code returns rival-minus-driver elapsed time, so ahead is negative. Verified on Lusail L20 (PIA leading, NOR behind at **+3.578 s**). The code was right and the prose was wrong, which is exactly how a correct sign gets "fixed" into a bug six months later.

**READMEs + `ARCHITECTURE.md`** — `src/strategy/README.md` declared the shared engine's own package dead code (*"Do not rely on them for inference"*) while `inference/engine.py` serves all three surfaces. Also repoints 12 dead mkdocs-era links and drops bullets for diagrams that no longer exist.

## Checks

- Both `agents-api.md` examples run verbatim: agent-level returns `85.869 / 83.372 / 88.166`; the orchestrator one returns a decision on the `no-llm` profile.
- Entry-point table generated from `inspect.signature`, not written by hand.
- Every rewritten page rendered in a browser and read (`arcade-strategy-pipeline`, `simulation`, `agents-api`): tables, code blocks and TOC correct, no console errors beyond local Cloudflare-analytics CORS noise.
- Dead-link sweep re-run: all 12 resolve.

Refs #438
