### PR TITLE
fix(agents): let the overtake model see the elapsed-time gap it was trained on

### DIFF
--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -560,6 +560,18 @@ def _ensure_timedelta_laps(laps_df: pd.DataFrame) -> pd.DataFrame:
     elif not hasattr(df['LapTime'].iloc[0], 'total_seconds'):
         df['LapTime'] = pd.to_timedelta(pd.to_numeric(df['LapTime'], errors='coerce'), unit='s')
 
+    # Same normalisation for the session elapsed time, and it is load-bearing:
+    # _build_overtake_features reads `Time` to compute the gap the way N11 was
+    # trained (N11 cell 13: gap = abs(row_x["Time_s"] - row_y["Time_s"])), and
+    # falls back to a single lap's LapTime delta when it is absent. The featured
+    # parquet carries `Time_s`, never `Time`, so without this the fallback fired on
+    # 100% of calls: at Lusail lap 20 the model was told OCO sat 1.645 s from the
+    # leader when the real gap was 33.950 s, which is the difference between "in the
+    # DRS window" and "half a minute away". #447 restored the column; this is what
+    # lets the agent actually see it.
+    if 'Time' not in df.columns and 'Time_s' in df.columns:
+        df['Time'] = pd.to_timedelta(df['Time_s'], unit='s')
+
     for col in ('Sector1Time', 'Sector2Time', 'Sector3Time'):
         if col not in df.columns:
             df[col] = pd.NaT


### PR DESCRIPTION
Two findings from the epic's **final adversarial audit**, both of the same shape: a datum was restored and its consumer was never switched over.

## 1. N11 never saw #447's restored column

N11 trains its gap as `abs(row_x["Time_s"] - row_y["Time_s"])` (N11 cell 13). `_build_overtake_features` reads a `Time` column and falls back to a **single lap's LapTime delta** when it is absent.

`_ensure_timedelta_laps` normalises `LapTime_s` into `LapTime` but never did the same for `Time_s`, and the featured parquet carries `Time_s` and never `Time`. So the fallback fired on **100% of calls**:

| vs PIA, Lusail L20 | real gap | what N11 was fed |
|---|---|---|
| OCO | **+33.950 s** | 1.645 s |
| GAS | **+35.593 s** | 1.886 s |

That is the difference between "inside the DRS window, overtake imminent" and "half a minute away, irrelevant", on the model's own gap feature.

#447 restored the column; this is what lets the agent actually see it. **Restoring a datum and using it are two changes, and the first silently looks like a fix.** (#437 was the same lesson on `/lap-state`.)

## 2. Submodule bump: the raw fallback frame had no Time_s either

Picks up [F1_Telemetry_Manager#125](https://github.com/VforVitorio/F1_Telemetry_Manager/pull/125). **A fix breaking a fix**: #437 made `/lap-state` read `Time_s`, #447 restores it onto the *featured* frame, but `/lap-state` rebinds to the **raw** frame on SC/pit/out laps — the very laps that fallback exists for — where `Time_s` was never derived. It then summed lap times, which silently skips NaN-`LapTime` laps, and those live on exactly those incidents:

| OCO gap vs PIA at lap 20 | |
|---|---|
| truth | **+33.950 s** (behind) |
| served | **−126.751 s** (ahead) |
| error | **160.701 s, sign flipped** |

Lusail's NaN-`LapTime` laps: HUL L7, **OCO L9**, HAD L55.

## Checks

- `_ensure_timedelta_laps` now yields `Time`; N11 receives OCO **+33.950 s** (was 1.645 s).
- Raw fallback returns OCO **+33.950 s** (was −126.751 s).
- `uvx ruff check .` + `ruff format --check .` green repo-wide; submodule gate green; 22 tests pass.

Refs #437, #447