### PR TITLE
Strategy engine correctness: epic #438

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,7 +21,7 @@ All three consume the same core:
 
 The Streamlit path also runs a FastAPI backend (`src/telemetry/backend/`).
 The Arcade path runs the strategy pipeline locally without the backend
-(see [`docs/arcade/strategy-pipeline.md`](docs/arcade/strategy-pipeline.md)).
+(see [`docs/pages/arcade-strategy-pipeline.md`](docs/pages/arcade-strategy-pipeline.md)).
 
 ## Multi-agent pipeline
 
@@ -29,9 +29,7 @@ N25 Pace · N26 Tire · N27 Situation · N29 Radio are always-on. N28 Pit
 Strategy and N30 RAG are conditional (routing decides per-lap). N31
 Orchestrator fuses all outputs through a Monte Carlo simulation and an
 LLM synthesis pass into a `StrategyRecommendation`. Full flow:
-[`docs/architecture.md`](docs/architecture.md) + the
-[`docs/diagrams/strategy_pipeline_flow.drawio`](docs/diagrams/strategy_pipeline_flow.drawio)
-diagram.
+[`docs/pages/architecture.md`](docs/pages/architecture.md).
 
 ## Arcade three-window topology
 
@@ -44,9 +42,7 @@ diagram.
 
 Both windows subscribe to the arcade's `TelemetryStreamServer` on
 `127.0.0.1:9998`. Details:
-[`docs/arcade/dashboard.md`](docs/arcade/dashboard.md) and the
-[`docs/diagrams/arcade_3window_architecture.drawio`](docs/diagrams/arcade_3window_architecture.drawio)
-diagram.
+[`docs/pages/arcade-dashboard.md`](docs/pages/arcade-dashboard.md).
 
 ## Data flow
 
@@ -58,16 +54,14 @@ diagram.
 - Featured laps parquets + per-race raw dirs + tire-compound-by-race
   map form the input to the multi-agent stack.
 
-See [`docs/diagrams/tcp_broadcast_dataflow.drawio`](docs/diagrams/tcp_broadcast_dataflow.drawio)
-and [`docs/diagrams/data_pipeline.drawio`](docs/diagrams/data_pipeline.drawio)
 for the wire-level view.
 
 ## Where to go next
 
 - **Install:** [`INSTALL.md`](INSTALL.md).
 - **Roadmap:** [`ROADMAP.md`](ROADMAP.md).
-- **Agents reference:** [`docs/agents-api-reference.md`](docs/agents-api-reference.md).
-- **Backend API:** [`docs/backend-api.md`](docs/backend-api.md).
-- **Streamlit frontend:** [`docs/streamlit-frontend.md`](docs/streamlit-frontend.md).
-- **Simulation engine:** [`docs/simulation/overview.md`](docs/simulation/overview.md).
+- **Agents reference:** [`docs/pages/agents-api.md`](docs/pages/agents-api.md).
+- **Backend API:** [`docs/pages/backend-api.md`](docs/pages/backend-api.md).
+- **Streamlit frontend:** [`docs/pages/streamlit.md`](docs/pages/streamlit.md).
+- **Simulation engine:** [`docs/pages/simulation.md`](docs/pages/simulation.md).
 - **All draw.io diagrams:** [`docs/diagrams/`](docs/diagrams/).

--- a/docs/app/nav.js
+++ b/docs/app/nav.js
@@ -125,9 +125,9 @@ window.PAGES = [
     title: "Strategy pipeline",
     section: "Arcade",
     file: "pages/arcade-strategy-pipeline.md",
-    description: "Why the arcade duplicates the N31 orchestrator body.",
+    description: "The shared run_lap engine behind all three surfaces, and its two profiles.",
     eyebrow: "Internals",
-    tags: ["arcade", "orchestrator", "agents", "pipeline", "monte-carlo", "threading"],
+    tags: ["arcade", "orchestrator", "agents", "pipeline", "engine", "monte-carlo", "threading"],
   },
 
   // ------- OPERATIONS -------

--- a/docs/pages/agents-api.md
+++ b/docs/pages/agents-api.md
@@ -10,13 +10,17 @@ Every agent has two entry points:
 
 | Agent | FastF1 Entry | RSM Adapter (no FastF1 session) |
 |---|---|---|
-| N25 Pace | `run_pace_agent(**kwargs)` | `run_pace_agent_from_state(lap_state, laps_df)` |
+| N25 Pace | `run_pace_agent(**kwargs)` | `run_pace_agent_from_state(lap_state)` |
 | N26 Tire | `run_tire_agent(stint_state)` | `run_tire_agent_from_state(lap_state, laps_df)` |
 | N27 Situation | `run_race_situation_agent(lap_state)` | `run_race_situation_agent_from_state(lap_state, laps_df)` |
 | N28 Pit | `run_pit_strategy_agent(lap_state)` | `run_pit_strategy_agent_from_state(lap_state, laps_df)` |
-| N29 Radio | `run_radio_agent(lap_state)` | `run_radio_agent_from_state(lap_state, laps_df)` |
-| N30 RAG | `run_rag_agent(question)` | `run_rag_agent_from_state(lap_state)` |
-| N31 Orchestrator | `run_strategy_orchestrator(race_state, lap_state)` | `run_strategy_orchestrator_from_state(race_state, laps_df)` |
+| N29 Radio | `run_radio_agent(lap_state, persist)` | `run_radio_agent_from_state(lap_state, laps_df, persist)` |
+| N30 RAG | `run_rag_agent(question)` | `run_rag_agent_from_state(lap_state, laps_df)` |
+| N31 Orchestrator | `run_strategy_orchestrator(race_state, lap_state)` | `run_strategy_orchestrator_from_state(race_state, laps_df, lap_state)` |
+
+**N25 is the odd one out: it takes no `laps_df`.** Everything it needs must already be in the
+`lap_state`, which is why the stint fuel baseline is carried there rather than derived from a
+frame. The adapters are not uniform, so check the signature before assuming.
 
 Each agent also exposes a `get_*_react_agent()` factory that returns a compiled LangGraph `CompiledGraph` for direct LangGraph usage.
 
@@ -52,6 +56,7 @@ Each agent also exposes a `get_*_react_agent()` factory that returns a compiled 
 |---|---|---|
 | `overtake_prob` | float | Probability of being overtaken (0–1) |
 | `sc_prob_3lap` | float | Safety car probability within 3 laps (0–1) |
+| `sc_currently_active` | bool | A safety car is deployed **right now**. Not a prediction: it is read from the lap's RCM events, because N14 was trained to forecast a future SC and cannot recognise one already out. When true it forces `sc_prob_3lap = 1.0`, activates N28, and the final recommendation is held to `PIT_NOW`. See [Multi-agent system](#/multi-agent). |
 | `threat_level` | str | LOW, MEDIUM, HIGH, CRITICAL |
 | `gap_ahead_s` | float | Gap to car ahead in seconds |
 | `pace_delta_s` | float | Pace difference vs car ahead |
@@ -151,27 +156,71 @@ result = process_radio_tool.invoke({
 
 **Agent-level (no LLM needed):**
 
-```python
-from src.agents.pace_agent import run_pace_agent_from_state
-import pandas as pd
+The `*_from_state` entry points take **only** a `lap_state`, and it must be the real
+nested dict (`driver` / `rivals` / `weather` / `session_meta`), not a flat one. Build it
+with `RaceStateManager` rather than by hand: it is the component that owns the contract,
+and hand-rolling one is how the second, buggy implementation of this got written.
 
-laps_df = pd.read_parquet("data/processed/laps_featured_2025.parquet")
-lap_state = {"driver": "VER", "lap_number": 20}
-output = run_pace_agent_from_state(lap_state, laps_df)
+```python
+from pathlib import Path
+from itertools import islice
+from src.simulation.replay_engine import RaceReplayEngine
+from src.agents.pace_agent import run_pace_agent_from_state
+
+replay = RaceReplayEngine(Path("data/raw/2025/Lusail"), driver_code="PIA", team="McLaren")
+lap_state = next(islice(replay.replay(), 19, 20))   # lap 20
+output = run_pace_agent_from_state(lap_state)
+
+print(output.lap_time_pred, output.ci_p10, output.ci_p90)
 ```
+
+**Take the `lap_state` from `replay()`, not from `rsm.get_lap_state(lap)` directly.**
+`get_lap_state`'s `weather_df` argument is optional, and `replay()` is what passes it. Call
+the RSM bare and the weather dict comes back with only `track_status`, so consumers fall
+through to their hardcoded defaults (the arcade's are 25.0 C air / 35.0 C track) and never
+say so. At Lusail the real values are 23.7 C and 29.8 C, and track temperature is a live
+input to tire degradation.
+
+See [Race replay engine](#/simulation) for the full `lap_state` schema.
 
 **Full orchestrator (requires LM Studio or OpenAI):**
 
 ```python
-from src.agents.strategy_orchestrator import RaceState, run_strategy_orchestrator_from_state
+from pathlib import Path
+from itertools import islice
 import pandas as pd
+from src.simulation.replay_engine import RaceReplayEngine
+from src.agents.strategy_orchestrator import RaceState
+from src.strategy.inference.engine import run_lap
 
-laps_df = pd.read_parquet("data/processed/laps_featured_2025.parquet")
+race_dir = Path("data/raw/2025/Lusail")
+laps_df = pd.read_parquet(race_dir / "laps.parquet")
+replay = RaceReplayEngine(race_dir, driver_code="PIA", team="McLaren")
+lap_state = next(islice(replay.replay(), 19, 20))   # lap 20
+
+driver = lap_state["driver"]
+ahead = [r for r in lap_state["rivals"] if r["position"] == driver["position"] - 1]
 race_state = RaceState(
-    driver="NOR", lap=18, total_laps=57, position=3,
-    compound="C2", tyre_life=20, gap_ahead_s=1.2, pace_delta_s=-0.3,
-    air_temp=32.0, track_temp=48.0,
+    driver=driver["driver"], lap=20, total_laps=replay.total_laps,
+    position=driver["position"], compound=driver["compound"],
+    tyre_life=driver["tyre_life"],
+    # rivals ahead report a NEGATIVE interval; RaceState wants a magnitude
+    gap_ahead_s=abs(ahead[0]["interval_to_driver_s"]) if ahead else 0.0,
+    pace_delta_s=0.0,
+    air_temp=lap_state["weather"]["air_temp"],
+    track_temp=lap_state["weather"]["track_temp"],
 )
-rec = run_strategy_orchestrator_from_state(race_state, laps_df)
+
+rec, agent_outputs, timings = run_lap(race_state, laps_df, lap_state, profile="no-llm")
 print(rec.action, rec.confidence, rec.reasoning)
 ```
+
+Prefer `run_lap` over calling `run_strategy_orchestrator_from_state` directly: it is the
+same pipeline (parity-tested), and it also hands back the per-agent outputs and stage
+timings. Pass `profile="no-llm"` to run the deterministic path with no provider at all.
+
+**Pass the `lap_state`, and make sure it carries `session_meta`.** The `laps_df` is scoped
+to the Grand Prix named there. Without it, the engine falls back to the whole frame and
+logs a warning, and the agents then look up rivals by driver and lap number across the
+entire season: the Zandvoort grid can end up deciding a race at Lusail. The fallback is
+loud on purpose, but the fix is to supply the `session_meta`, not to ignore the warning.

--- a/docs/pages/arcade-strategy-pipeline.md
+++ b/docs/pages/arcade-strategy-pipeline.md
@@ -1,104 +1,78 @@
-# Strategy Pipeline — Arcade Duplicate
+# Strategy Pipeline — the shared engine
 
-Why `src/arcade/strategy_pipeline.py` exists as a near-copy of `src/agents/strategy_orchestrator.py::run_strategy_orchestrator_from_state`, what gets duplicated, what does not, and how to keep the two bodies in sync.
+`src/strategy/inference/engine.py::run_lap` is the single implementation of the N31 lap pipeline. The CLI, the arcade and the backend all route through it. This page covers what it returns, the two profiles, and why the arcade is now a nine-line delegate instead of a copy.
 
-## Why the arcade duplicates
+## One engine, three surfaces
 
-The CLI (`scripts/run_simulation_cli.py`) and the Streamlit frontend both call `run_strategy_orchestrator_from_state(race_state, laps_df)` and consume its single return value: a `StrategyRecommendation` dataclass with `action`, `reasoning`, `confidence`, `scenario_scores`, and `regulation_context`. The public contract is narrow on purpose — the orchestrator hides the six sub-agent dataclasses behind a single synthesised decision.
-
-The arcade dashboard needs the opposite. To render the six sub-agent cards, the pace and tire charts, the scenario bars, and the reasoning tabs, the dashboard must see the **raw per-agent outputs**:
-
-- `PaceOutput.lap_time_pred`, `ci_p10`, `ci_p90`, `delta_vs_prev`
-- `TireOutput.laps_to_cliff_p10 / p50 / p90`, `warning_level`, `deg_rate`
-- `RaceSituationOutput.overtake_prob`, `sc_prob_3lap`, `threat_level`
-- `RadioOutput.alerts`, `radio_events`, `rcm_events`, `corrections`
-- `PitStrategyOutput.action`, `compound_recommendation`, `stop_duration_p05 / p50 / p95`, `undercut_prob`
-- `RegulationContext.answer`, `articles`
-- The Monte Carlo scenario scores before they collapse into the recommendation
-- The set of conditional agents that fired this lap (the `active` list)
-
-None of this is available from `StrategyRecommendation` alone.
-
-Two obvious alternatives, both rejected:
-
-1. **Extend the public orchestrator to return more fields.** Would force the CLI and Streamlit to depend on a wider return type and break the documented contract. The CLI is also the TFG's PMV and is flagged untouchable.
-2. **Call each sub-agent from the arcade directly and skip the orchestrator.** Would duplicate the MoE routing logic, the Monte Carlo simulation, the LLM synthesis step, and the guardrail logic — four distinct concerns instead of one.
-
-The chosen approach: duplicate the orchestrator body inside `src/arcade/strategy_pipeline.py::run_strategy_pipeline` and return a tuple `(StrategyRecommendation, raw_outputs_dict)`. The public orchestrator is untouched, the CLI/Streamlit keep their narrow return type, and the arcade sees everything.
-
-## What gets duplicated
-
-The full body of `run_strategy_orchestrator_from_state`, from the always-on layer through the MC simulation and the LLM synthesis. The duplicate lives in:
+Every surface needs the same six sub-agents, the same MoE routing, the same Monte Carlo pass and the same synthesis. They differ only in what they render. So the pipeline lives in one place and the surfaces choose how much of its output to consume:
 
 ```
-src/arcade/strategy_pipeline.py
-    run_strategy_pipeline(race_state, laps_df, lap_state=None)
-        -> tuple[StrategyRecommendation, dict]
+src/strategy/inference/engine.py
+    run_lap(race_state, laps_df, lap_state=None, *, profile="rich",
+            return_agent_outputs=True)
+        -> tuple[StrategyRecommendation, dict | None, dict[str, float]]
 ```
 
-The body mirrors the orchestrator's call sequence exactly:
+- **`StrategyRecommendation`** — the synthesised decision (14 fields). What the CLI and Streamlit consume.
+- **`agent_outputs`** — the raw per-sub-agent dataclasses, keyed `pace_out`, `tire_out`, `situation_out`, `radio_out`, `pit_out`, `regulation_context`, `rag`, `active`, `guardrail_reason`. What the arcade dashboard renders its cards and charts from.
+- **stage timings** — per-stage seconds, for the surfaces that show them.
 
-1. `_run_always_on_agents_from_state(race_state, laps_df, lap_state)` — returns `(pace_out, tire_out, situation_out, radio_out)`.
-2. `_decide_agents_to_call(tire_warning=..., sc_prob_3lap=..., radio_alerts=...)` — returns the `active` list.
-3. `_run_conditional_agents(active=..., lap_state=..., tire_out=..., situation_out=..., race_state=..., laps_df=...)` — returns `(pit_out, regulation_context)`.
-4. `_run_mc_simulation(pace_out, tire_out, situation_out, pit_out, race_state)` — returns the scenario score dict.
-5. `_build_orchestrator_prompt(...)` and `_get_orchestrator_llm()`.
-6. `_assemble_recommendation(...)` — builds the final `StrategyRecommendation`.
+The sub-agents are imported through their public `*_from_state` entry points; the output dataclasses come from `src/agents/strategy_orchestrator.py`. Nothing about them is engine-specific.
 
-The arcade pipeline packages every intermediate value into the second element of its return tuple — a dict under the keys `pace_out`, `tire_out`, `situation_out`, `radio_out`, `pit_out`, `regulation_context`, `active`, `scenario_scores`.
+## Profiles
 
-## What does NOT get duplicated
+| profile | what runs | use it for |
+|---|---|---|
+| `rich` | the full pipeline, including the LLM synthesis step | the default; reproduces `run_strategy_orchestrator_from_state` byte for byte |
+| `no-llm` | everything except the LLM; the deterministic guardrails produce the decision | fast, offline, reproducible runs, and any path that must not spend tokens |
 
-The six sub-agent modules are imported as-is via their public `*_from_state` entry points:
+`rich` is guarded by parity tests against the orchestrator, so the two cannot drift apart silently.
 
-- `src/agents/pace_agent.py` — `run_pace_agent_from_state`
-- `src/agents/tire_agent.py` — `run_tire_agent_from_state`
-- `src/agents/race_situation_agent.py` — `run_race_situation_agent_from_state`
-- `src/agents/radio_agent.py` — `run_radio_agent_from_state`
-- `src/agents/pit_strategy_agent.py` — `run_pit_strategy_agent_from_state`
-- `src/agents/rag_agent.py` — `run_rag_agent_from_state`
+## The arcade delegates
 
-Output dataclasses (`PaceOutput`, `TireOutput`, `RaceSituationOutput`, `RadioOutput`, `PitStrategyOutput`, `RegulationContext`, `StrategyRecommendation`) are also shared, imported from `src/agents/strategy_orchestrator.py`.
+`src/arcade/strategy_pipeline.py::run_strategy_pipeline` keeps its old public signature so `src/arcade/strategy.py` and the dashboard formatters are untouched. Its body is one call:
 
-In short: sub-agent logic and data types are shared; only the orchestration sequence is duplicated.
+```python
+rec, agent_outputs, _timings = run_lap(race_state, laps_df, lap_state, profile="rich")
+return rec, agent_outputs
+```
 
-## How to stay in sync
+The arcade needs the raw outputs and the CLI does not, but that is a difference in **consumption**, not in pipeline. `run_lap` returns both and each surface takes what it renders.
 
-Any edit to `run_strategy_orchestrator_from_state` in `src/agents/strategy_orchestrator.py` must be mirrored in `run_strategy_pipeline` in `src/arcade/strategy_pipeline.py`. The checklist:
+## Why this replaced a duplicate
 
-1. Open both files side by side.
-2. Transcribe the edit. If a new private helper was added, import it. If a call argument changed, update the arcade caller.
-3. If the orchestrator grew a new intermediate value that the dashboard might want to render, add it to the `raw_outputs_dict` second return value.
-4. Run the smoke test below before committing.
+This module used to be a body-copy of the orchestrator, and this page used to document a "how to stay in sync" ritual: open both files side by side and transcribe every edit by hand. That ritual was the bug. A copy kept in sync by discipline drifts the first time someone edits one file and not the other, and it did: the audit flagged it (`AUDIT_P2B_CORE_COMPUTE` F10) and the #166 crash proved it.
 
-### Smoke test
+The lesson generalises beyond the arcade, and the strategy engine relearned it the hard way. `src/simulation/race_state_manager.py` had already solved a pile of race-data problems correctly (NaN never becomes a searchable number, gaps come from the elapsed-time column, retired cars fall out on their own). A second implementation was later written alongside it for the API path, and it reproduced every one of those bugs from scratch, silently, for months. Two implementations of the same idea do not stay equal because someone intends them to.
+
+So: **before writing a second path that shapes race data, check whether a clean one already exists.** If it does, call it.
+
+## SimConnector threading
+
+The arcade strategy driver is `src/arcade/strategy.py::SimConnector`. It is a plain Python class, not a Qt object, spawned as a `threading.Thread` from `F1ArcadeView._init_strategy_layer`.
+
+- Owns a `StrategyState` dataclass caching the latest `LapDecision`, the per-agent outputs and playback metadata, behind a `threading.Lock`.
+- Owns the background thread that iterates `RaceReplayEngine.replay()` and calls `run_strategy_pipeline(race_state, laps_df)` per lap.
+- Emits `StartEventDTO` once on the first frame, then `LapDecisionDTO` per lap.
+
+## Why not SSE from the backend
+
+The arcade used to subscribe to `GET /api/v1/strategy/simulate/stream`. Phase 3.5 replaced it with the direct in-process loop:
+
+- **No extra process.** Strategy mode no longer needs `uvicorn` running first.
+- **No SSE client.** The arcade's consumer was a hand-rolled parser over `httpx.stream` with its own reconnect logic. A thread is simpler.
+- **Standalone.** The arcade ships without a FastAPI dependency.
+
+The backend SSE endpoint is still live and smoke-tested; the arcade just does not consume it.
+
+## Smoke test
 
 ```bash
-# CLI path — exercises run_strategy_orchestrator_from_state
-python scripts/run_simulation_cli.py Melbourne VER McLaren --no-llm
+# CLI path
+python scripts/run_simulation_cli.py Melbourne VER "Red Bull Racing" --no-llm
 
-# Arcade path — exercises run_strategy_pipeline
+# Arcade path
 python -m src.arcade.main --viewer --year 2025 --round 3 --driver VER --team "Red Bull Racing" --strategy
 ```
 
 Both should reach lap 2 without tracebacks.
-
-## SimConnector threading
-
-The arcade strategy driver lives in `src/arcade/strategy.py::SimConnector`. It is not a Qt object — it is a plain Python class that spawns a `threading.Thread` inside `F1ArcadeView._init_strategy_layer`.
-
-Responsibilities:
-
-- Own a `StrategyState` — a dataclass that caches the latest `LapDecision`, the per-agent outputs, and playback metadata. Protected by a `threading.Lock`.
-- Own a background thread that iterates `RaceReplayEngine.replay()` and calls `run_strategy_pipeline(race_state, laps_df)` per lap.
-- Emit `StartEventDTO` once on first frame and `LapDecisionDTO` per lap.
-
-## Why not SSE from the FastAPI backend
-
-The arcade used to subscribe to `GET /api/v1/strategy/simulate/stream`. Phase 3.5 Proceso B replaced that path with the direct local loop for three reasons:
-
-- **Extra process**: running the arcade with strategy mode required starting `uvicorn` first. The local loop eliminates the dependency.
-- **SSE consumer complexity**: the arcade's SSE client was a roll-your-own parser on top of `httpx.stream` with manual reconnect logic. Running the loop directly inside a thread is simpler.
-- **Isolation**: the arcade can now ship as a standalone entry point without any FastAPI dependency.
-
-The backend SSE endpoint is still live and covered by TestClient smoke tests — the arcade simply does not consume it any more.

--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -88,9 +88,9 @@ Four properties are load-bearing:
 1. **The arcade owns the `TelemetryStreamServer`.** `src/arcade/stream.py` exposes the merged arcade + strategy snapshot; every other window is a subscriber, never the source of truth.
 2. **One subprocess hosts both Qt windows.** The arcade spawns a single `subprocess.Popen` that boots one `QApplication`. Two windows inside one event loop is cheaper than two OS processes and avoids duplicated imports of PySide6 + pyqtgraph.
 3. **Each window has its own `TelemetryStreamClient(QThread)`.** Subscribers do not share sockets; each window reconnects independently when the arcade restarts.
-4. **Arcade runs a local strategy pipeline.** `src/arcade/strategy_pipeline.py` carries a copy of the N31 orchestrator body so the arcade does not depend on the FastAPI backend at runtime.
+4. **Arcade runs the strategy pipeline in-process.** `src/arcade/strategy_pipeline.py` delegates to the shared engine (`src/strategy/inference/engine.py::run_lap`), so the arcade does not depend on the FastAPI backend at runtime and does not carry its own copy of the orchestrator. It used to; that copy drifted and crashed (#166), which is why the engine exists.
 
-See [Arcade strategy pipeline](#/arcade-strategy-pipeline) for the rationale and [Arcade dashboard](#/arcade-dashboard) for the Qt-side architecture.
+See [Arcade strategy pipeline](#/arcade-strategy-pipeline) for the shared engine and its profiles, and [Arcade dashboard](#/arcade-dashboard) for the Qt-side architecture.
 
 ## Agent details
 
@@ -131,6 +131,10 @@ Wraps N15 (physical pit stop duration P05/P50/P95 via HistGBT) and N16 (undercut
 #### Honoring an active Safety Car
 
 When the orchestrator sets `sc_currently_active = True` on the lap state, N28's prompt swaps the legacy "SC probability" line for an explicit `SC STATUS: SAFETY CAR DEPLOYED RIGHT NOW` banner and the system prompt waives the `MINIMUM STINT LENGTH` constraint (pitting under SC costs ~10 s vs ~22 s, inverting the cost/benefit). A code-level guard-rail then flips any residual `STAY_OUT` to `PIT_NOW` so a misbehaving LLM can't override the deterministic signal — replicating the McLaren Catar 2025 V7 fix where the chain of safeguards previously locked the recommendation into `STAY_OUT` despite a confirmed SC.
+
+**The rail is enforced twice, and it has to be.** N28's guard produces the right `action`, but the orchestrator's final synthesis then writes its own: `_assemble_recommendation` took the LLM's answer verbatim, so N28's `PIT_NOW` only ever reached the synthesis *prompt* as a line of text the model could ignore. It did: the same Lusail lap 7 scenario returned `PIT_NOW` twice and `STAY_OUT` four times across six runs. `_assemble_recommendation` now applies the same flip to the synthesised action, tagged `[OVERRIDE: SC deployed — forcing PIT_NOW.]` in the reasoning.
+
+A deterministic rail is only deterministic at the layer that emits the final answer. A guard one layer down is a suggestion.
 
 ### N29 — Radio Agent (`radio_agent.py`)
 

--- a/docs/pages/simulation.md
+++ b/docs/pages/simulation.md
@@ -45,19 +45,35 @@ The single most important design decision in this module.
 
 Rivals get only what appears on the FIA live timing screen. This mirrors the real information asymmetry a strategy engineer faces on the pit wall.
 
+### Who counts as a rival
+
+The boundary above says *what* a rival's row contains. This says *which cars get a row at all*, and it is just as load-bearing:
+
+**A car appears in `rivals` for a lap only if it was classified on that lap.** Retired, crashed, or not yet across the line means no row, so the car is absent from the list entirely. It is never present with an invented position, a placeholder gap or a default lap time.
+
+This is the rule that a real timing screen follows, and skipping it produces decisions that look reasonable and are absurd. The pit wall once recommended undercutting HUL at Lusail lap 7. HUL had just crashed on lap 6, which is what brought out the safety car the same recommendation was reacting to. The car was gone; only a filled-in default kept it on the list.
+
+Two habits follow from it, and both are worth copying into any new code that shapes race data:
+
+- **Absence beats a default.** If a value is unknown, leave it `None` and let the consumer filter. A number is a claim, and an invented one is a false claim that nothing downstream can distinguish from a reading.
+- **Never default to a value the code also searches by.** `Position` defaulting to `0` is how the leader found "the car ahead at position `pos - 1 == 0`" and got handed the car that had just crashed. Placeholders belong in sort keys, never in emitted data.
+
 ## Gap computation
 
-Gaps are derived from cumulative `LapTime` differences rather than from the intervals OpenF1 API feed. This is the standard F1 analytics approach (see TUMFTM race-simulation methodology).
+Gaps come from `session_time_s`, the session elapsed time at the end of each lap, read from FastF1's `Time` column. This is the same value FastF1 uses internally for gaps in `session.laps`.
 
 ```
-gap_to_leader[driver, lap] = cum_time[driver, lap] - cum_time[leader, lap]
-interval_to_driver[rival, lap] = cum_time[rival, lap] - cum_time[our_driver, lap]
+gap_to_leader[driver, lap]      = session_time[driver, lap] - session_time[leader, lap]
+interval_to_driver[rival, lap]  = session_time[rival, lap]  - session_time[our_driver, lap]
 ```
 
-Known limitations (acceptable for thesis demo):
+**Not** cumulative `LapTime` sums, which is the tempting alternative. Summed lap times drift away from the real on-track gap wherever timing corrections or safety-car bunching apply, which is exactly where a strategy call matters most. `_compute_session_times` in `src/simulation/race_state_manager.py` takes elapsed time for that reason.
 
-- Safety car bunching is not reflected accurately.
-- Lapped cars show large positive gaps, not "lapped" flag.
+This is worth stating loudly because the feature-engineering step drops the `Time` column, so any consumer reading the featured parquet directly used to fall back to lap-time deltas without noticing. Measured on Lusail 2025 lap 20, that fallback fed the model a **0.10 s** gap between PIA and NOR when the real one was **3.58 s**: the difference between "inside the DRS window" and "not close". The loader now restores `Time_s` from the raw per-race parquet at load time, so both paths agree.
+
+Known limitations:
+
+- Lapped cars show a large positive gap rather than a "lapped" flag.
 
 ## Files
 
@@ -142,10 +158,17 @@ python -m src.simulation Silverstone VER "Red Bull Racing" --data-dir data/raw/2
         "is_in_lap": bool,
         "is_out_lap": bool,
     },
+    # Only cars classified on this lap. A car that has retired, crashed or has
+    # not yet completed the lap has no row for it, so it is simply ABSENT from
+    # `rivals` — never present with a filled-in default. See "Who counts as a
+    # rival" below.
     "rivals": [
         {
             "driver": str,
             "team": str,
+            # None when the car has no position that lap. It sorts to the back
+            # through a placeholder confined to the sort key, so no consumer can
+            # look up a car at that position and find one.
             "position": int | None,
             "lap_time_s": float | None,
             "compound": str,

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -21,6 +21,7 @@ existing public API is preserved without globals.
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -48,9 +49,18 @@ except Exception:
 _MODELS_DIR = _DATA_ROOT / 'models' / 'lap_time'
 _PROCESSED  = _DATA_ROOT / 'processed'
 
+logger = logging.getLogger(__name__)
+
 # ── Constants ─────────────────────────────────────────────────────────────────
 N_BOOTSTRAP: int   = 200
 _NOISE_PCT: float  = 0.02   # 2 % Gaussian noise on continuous features
+
+# Seconds of lap time recovered per lap as fuel burns off. N04 builds the training
+# feature as (TyreLife - min(TyreLife of the stint)) * 0.055 — verified exactly against
+# laps_featured_2025 (100% of laps reproduce, range 0..3.685 s). The same coefficient
+# lives in tire_agent._add_fuel_cols; deliberately duplicated rather than shared, since
+# unifying constants across agent modules is a wider refactor than this fix (#446).
+FUEL_GAIN_PER_LAP_S: float = 0.055
 
 # ── Artifact paths ────────────────────────────────────────────────────────────
 _CLUSTER_PARQUET  = _PROCESSED / 'circuit_clustering' / 'circuit_clusters_k4_2025.parquet'
@@ -242,6 +252,7 @@ class PaceAgent:
         total_laps: int,
         prev_speed_st: float,
         mean_sector_speed: Optional[float],
+        stint_baseline_tyre_life: Optional[int] = None,
     ) -> dict:
         """Compute features derived from raw inputs that are not in the source data.
 
@@ -264,9 +275,31 @@ class PaceAgent:
             Dict with keys FreshTyre, FuelEffect, laps_remaining,
             mean_sector_speed.
         """
+        # FuelEffect is the cumulative time recovered since the stint started, in
+        # SECONDS (training range 0..3.685 s). It was being computed as
+        # `fuel_load * 0.03` — a [0, 0.03] value, ~100x too small and semantically
+        # different — so the model always read "fresh-fuel stint start" and the learned
+        # fuel-burn pace gain was suppressed on every lap (#446).
+        #
+        # Absent baseline -> NaN, never a fabricated number. NaN is IN-DISTRIBUTION here:
+        # the training parquet itself carries 2.0% null FuelEffect, so XGBoost has a
+        # learned default direction for it, and `_build_feature_row`'s to_numeric(coerce)
+        # tail already routes None -> NaN -> the model's native missing handling. The old
+        # formula must NOT survive as the fallback: a producer we missed would silently
+        # reproduce the exact bug this kills, whereas a NaN plus a warning is impossible
+        # to mistake for a reading.
+        if stint_baseline_tyre_life is None:
+            logger.warning(
+                'stint_baseline_tyre_life absent from lap_state: FuelEffect=NaN for this '
+                'lap; the producer must supply it (#446)'
+            )
+            fuel_effect = float('nan')
+        else:
+            fuel_effect = (tyre_life - stint_baseline_tyre_life) * FUEL_GAIN_PER_LAP_S
+
         return {
             'FreshTyre':        int(tyre_life <= 1),
-            'FuelEffect':       fuel_load * 0.03,
+            'FuelEffect':       fuel_effect,
             'laps_remaining':   max(0, total_laps - lap_number),
             'mean_sector_speed': mean_sector_speed if mean_sector_speed is not None else prev_speed_st,
         }
@@ -296,6 +329,7 @@ class PaceAgent:
         prev_deg_rate: float = 0.0,
         prev_cum_deg: float = 0.0,
         prev_deg_accel: float = 0.0,
+        stint_baseline_tyre_life: Optional[int] = None,
     ) -> pd.DataFrame:
         """Pack raw race state into a single-row DataFrame ready for predict().
 
@@ -309,7 +343,7 @@ class PaceAgent:
         c_id, t_id, cluster = self._encode_categorical(compound, team, gp_name)
         derived = self._compute_derived(
             tyre_life, fuel_load, lap_number, total_laps,
-            prev_speed_st, mean_sector_speed,
+            prev_speed_st, mean_sector_speed, stint_baseline_tyre_life,
         )
 
         row = {
@@ -463,6 +497,7 @@ class PaceAgent:
         prev_deg_rate: float = 0.0,
         prev_cum_deg: float = 0.0,
         prev_deg_accel: float = 0.0,
+        stint_baseline_tyre_life: Optional[int] = None,
     ) -> PaceOutput:
         """Run pace prediction for a single lap and return a PaceOutput.
 
@@ -508,6 +543,7 @@ class PaceAgent:
             gp_name=gp_name, mean_sector_speed=mean_sector_speed,
             prev_deg_rate=prev_deg_rate, prev_cum_deg=prev_cum_deg,
             prev_deg_accel=prev_deg_accel,
+            stint_baseline_tyre_life=stint_baseline_tyre_life,
         )
 
         lap_time_pred   = self._predict(feature_df)
@@ -599,6 +635,11 @@ class PaceAgent:
             prev_deg_rate  = 0.0,
             prev_cum_deg   = 0.0,
             prev_deg_accel = 0.0,
+            # Plain .get, deliberately NOT the `or` pattern used above: `or` would
+            # collapse a legitimate baseline of 0 into None and re-introduce exactly
+            # the sentinel-vs-real-value confusion this epic is about. Absent stays
+            # absent, and _compute_derived turns that into a NaN plus a warning (#446).
+            stint_baseline_tyre_life = d.get('stint_baseline_tyre_life'),
         )
 
     # ── LangGraph ReAct agent ─────────────────────────────────────────────────

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -60,6 +60,15 @@ _COMPOUND_FALLBACK: dict[str, int] = {'HARD': 1, 'MEDIUM': 3, 'SOFT': 5}
 # Pirelli average stint capacities — Heilmeier et al. (2020, SAE 2020-01-1413)
 _STINT_CAPACITY_LAPS: dict[str, int] = {'SOFT': 18, 'MEDIUM': 30, 'HARD': 38}
 
+# N16 trained Lap_gap as the offset between the two stops (lap_y - lap_x), never the
+# race lap. At inference we always score the canonical undercut: we box on this lap and
+# the rival responds on the next one, so the offset is 1 (#444).
+_ASSUMED_UNDERCUT_LAP_GAP: int = 1
+
+# N15 clipped tyre_life_in at 50 laps in training (cell 11); mirror that ceiling here so
+# an absurd stint cannot extrapolate outside the fitted range (#450).
+_MAX_TRAINED_TYRE_LIFE: int = 50
+
 CLIFF_IMMINENT_LAPS = 3    # laps_to_cliff_p10 below this → PIT_NOW
 CLIFF_SOON_LAPS     = 10   # laps_to_cliff_p10 below this → prefer harder compound
 
@@ -539,7 +548,9 @@ class PitStrategyAgent:
         feat = {
             'team':             self._encode_team(team_raw),
             'year':             year,
-            'tyre_life_in':     int(row.get('TyreLife', 1)),
+            # N15 clipped tyre_life at 50 in training (cell 11); pass the raw value and
+            # an absurd stint extrapolates outside the fitted range (#450).
+            'tyre_life_in':     min(int(row.get('TyreLife', 1)), _MAX_TRAINED_TYRE_LIFE),
             'lap_number':       lap_number,
             'compound_id':      _compound_to_id(compound, gp_name, year),
             'compound_change':  int(compound_change),
@@ -593,8 +604,17 @@ class PitStrategyAgent:
         comp_y_id = _compound_to_id(comp_y, gp_name, year)
 
         feat = {
-            'pos_gap':               float(y_row.get('Position', 9)) - float(x_row.get('Position', 10)),
-            'Lap_gap':               lap_number,
+            # N16 trained pos_gap as pos_X_before - pos_Y_before, so X (us, the
+            # undercutter) being BEHIND Y is positive — that is the model's single
+            # strongest feature (gain 0.690). The operands were reversed here, which
+            # handed every X-behind-Y pair a negative value the model never saw for
+            # that case. Keep this order aligned with N16 cell 41 (#444).
+            'pos_gap':               float(x_row.get('Position', 10)) - float(y_row.get('Position', 9)),
+            # Trained as the OFFSET between the two stops (lap_y - lap_x, 1..max_lap_gap),
+            # not the race lap. Feeding lap_number put it 10-70x out of range, so LightGBM
+            # clamped to the deepest bin on every call. We score the canonical undercut:
+            # we box now, the rival responds on the next lap (#444).
+            'Lap_gap':               _ASSUMED_UNDERCUT_LAP_GAP,
             'tyre_life_diff':        float(x_row.get('TyreLife', 10)) - float(y_row.get('TyreLife', 10)),
             'TyreLife_X':            float(x_row.get('TyreLife', 10)),
             'TyreLife_Y':            float(y_row.get('TyreLife', 10)),

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -65,6 +65,18 @@ _STINT_CAPACITY_LAPS: dict[str, int] = {'SOFT': 18, 'MEDIUM': 30, 'HARD': 38}
 # the rival responds on the next one, so the offset is 1 (#444).
 _ASSUMED_UNDERCUT_LAP_GAP: int = 1
 
+# N15 (pit duration) encoded compound_id with an ORDINAL rank, NOT the Pirelli number:
+# verbatim from N15_pit_duration.ipynb cell 11, where it is applied as
+# `.map(COMPOUND_ORDER).fillna(-1)`. Feeding `_compound_to_id` here (the absolute C1-C6)
+# made the model read a SOFT as WET and a MEDIUM as INTERMEDIATE on essentially every
+# call. N16 is different and DOES want the absolute Cx, so the two must not share a
+# helper (#445).
+# ponytail: duplicated from the notebook; load it from model_config.json once N15 exports it.
+_N15_COMPOUND_ORDER: dict[str, int] = {
+    'SOFT': 0, 'MEDIUM': 1, 'HARD': 2, 'INTERMEDIATE': 3, 'WET': 4,
+}
+_N15_COMPOUND_UNKNOWN: int = -1  # matches the notebook's .fillna(-1)
+
 # N15 clipped tyre_life_in at 50 laps in training (cell 11); mirror that ceiling here so
 # an absurd stint cannot extrapolate outside the fitted range (#450).
 _MAX_TRAINED_TYRE_LIFE: int = 50
@@ -541,7 +553,8 @@ class PitStrategyAgent:
         if row is None:
             raise ValueError(f'No lap data for {driver} at lap {lap_number}')
 
-        gp_name  = self.session_meta.get('gp_name', '')
+        # No gp_name here on purpose: N15's compound_id is an ordinal rank, not the
+        # circuit's Pirelli allocation, so this builder needs no circuit lookup (#445).
         year     = self.session_meta.get('year', 2025)
         team_raw = self.session_meta.get('team_lookup', {}).get(driver, 'Unknown')
 
@@ -552,7 +565,7 @@ class PitStrategyAgent:
             # an absurd stint extrapolates outside the fitted range (#450).
             'tyre_life_in':     min(int(row.get('TyreLife', 1)), _MAX_TRAINED_TYRE_LIFE),
             'lap_number':       lap_number,
-            'compound_id':      _compound_to_id(compound, gp_name, year),
+            'compound_id':      _N15_COMPOUND_ORDER.get(compound.upper(), _N15_COMPOUND_UNKNOWN),
             'compound_change':  int(compound_change),
             'under_sc':         int(under_sc),
             'tight_pit_box':    0,

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -14,6 +14,7 @@ get_pit_strategy_react_agent(**kwargs)                 → CompiledGraph
 from __future__ import annotations
 
 import json
+import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -38,6 +39,10 @@ try:
     _DATA_ROOT = _get_data_root()
 except Exception:
     _DATA_ROOT = _REPO_ROOT / 'data'
+
+from src.f1_strat_manager.gp_slugs import rekey_by_slug  # noqa: E402
+
+logger = logging.getLogger(__name__)
 
 _MODELS    = _DATA_ROOT / 'models'
 _PROCESSED = _DATA_ROOT / 'processed'
@@ -136,7 +141,14 @@ class PitAgentCFG:
             pit_cfg = json.load(f)
 
         self.pit_features: list[str]   = pit_cfg['features']
-        self.circuit_traversal: dict   = pit_cfg['circuit_traversal_lookup']
+        # Re-key the circuit tables into the SLUG keyspace the agents actually query
+        # with (session_meta.gp_name / the featured parquet's GP_Name). They ship keyed
+        # by FastF1 full event names, whose overlap with the slugs is exactly zero — so
+        # every lookup missed and silently took its default, freezing traversal at
+        # 20.0 s and circuit_undercut_rate at 0.38 for every circuit (#448).
+        self.circuit_traversal: dict   = rekey_by_slug(
+            pit_cfg['circuit_traversal_lookup'], 'circuit_traversal_lookup',
+        )
 
         # Reconstruct LabelEncoder from saved class list
         le = LabelEncoder()
@@ -154,10 +166,13 @@ class PitAgentCFG:
         self.undercut_threshold: float    = uc_cfg['best_threshold']
         self.dry_compounds: list[str]     = uc_cfg['dry_compounds']
 
-        # Pre-aggregate circuit and team undercut rates from N16 training parquet
+        # Pre-aggregate circuit and team undercut rates from N16 training parquet.
+        # This parquet is keyed by full event name; re-key to slugs for the same
+        # reason as circuit_traversal above (#448).
         _uc = pd.read_parquet(_PROCESSED / 'undercut_labeled' / 'undercut_clean.parquet')
-        self.circuit_undercut_rate: dict = (
-            _uc.groupby('GP_Name')['undercut_success'].mean().to_dict()
+        self.circuit_undercut_rate: dict = rekey_by_slug(
+            _uc.groupby('GP_Name')['undercut_success'].mean().to_dict(),
+            'circuit_undercut_rate',
         )
         self.team_x_undercut_rate: dict = (
             _uc.groupby('Team_X')['undercut_success'].mean().to_dict()

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -560,6 +560,18 @@ def _ensure_timedelta_laps(laps_df: pd.DataFrame) -> pd.DataFrame:
     elif not hasattr(df['LapTime'].iloc[0], 'total_seconds'):
         df['LapTime'] = pd.to_timedelta(pd.to_numeric(df['LapTime'], errors='coerce'), unit='s')
 
+    # Same normalisation for the session elapsed time, and it is load-bearing:
+    # _build_overtake_features reads `Time` to compute the gap the way N11 was
+    # trained (N11 cell 13: gap = abs(row_x["Time_s"] - row_y["Time_s"])), and
+    # falls back to a single lap's LapTime delta when it is absent. The featured
+    # parquet carries `Time_s`, never `Time`, so without this the fallback fired on
+    # 100% of calls: at Lusail lap 20 the model was told OCO sat 1.645 s from the
+    # leader when the real gap was 33.950 s, which is the difference between "in the
+    # DRS window" and "half a minute away". #447 restored the column; this is what
+    # lets the agent actually see it.
+    if 'Time' not in df.columns and 'Time_s' in df.columns:
+        df['Time'] = pd.to_timedelta(df['Time_s'], unit='s')
+
     for col in ('Sector1Time', 'Sector2Time', 'Sector3Time'):
         if col not in df.columns:
             df[col] = pd.NaT

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -44,6 +44,8 @@ try:
 except Exception:
     _DATA_ROOT = _REPO_ROOT / 'data'
 
+from src.f1_strat_manager.gp_slugs import rekey_by_slug, slug_from_event_name  # noqa: E402
+
 _MODELS    = _DATA_ROOT / 'models'
 _PROCESSED = _DATA_ROOT / 'processed'
 _AGENTS    = _DATA_ROOT / 'models' / 'agents'
@@ -149,11 +151,32 @@ class RaceSituationConfig:
             _PROCESSED / 'sc_labeled' / 'sc_labeled_2023_2025.parquet',
             columns=['event_name', 'circuit_sc_rate'],
         )
-        self.circuit_sc_rate_map: dict = (
+        # Re-key to the SLUG keyspace the replay path queries with. This table ships
+        # keyed by FastF1 event names, which the FastF1 session path supplies but the
+        # replay path (CLI / arcade / webapp, all fed by RaceStateManager) does not —
+        # it passes session_meta.gp_name, a slug. The keyspaces do not overlap, so on
+        # every replay lap this lookup missed and returned the 0.10 default: a trained
+        # per-circuit feature frozen to a constant for every race (#448). Lookups go
+        # through `sc_rate_for`, which resolves EITHER keyspace, so the FastF1 path
+        # keeps working too.
+        self.circuit_sc_rate_map: dict = rekey_by_slug(
             _sc_df.drop_duplicates('event_name')
                   .set_index('event_name')['circuit_sc_rate']
-                  .to_dict()
+                  .to_dict(),
+            'circuit_sc_rate_map',
         )
+
+    def sc_rate_for(self, event_name: str) -> float:
+        """Circuit SC base rate for a GP given in EITHER keyspace.
+
+        The two callers disagree: the FastF1 session path passes a full event name
+        ('Qatar Grand Prix'), the replay path passes the parquet slug ('Lusail').
+        `slug_from_event_name` is reentrant, so it normalises both. Falls back to the
+        0.10 training-set mean when a GP is genuinely unknown — the same default as
+        before, but now only for real misses instead of on every replay lap.
+        """
+        slug = slug_from_event_name(event_name) or event_name
+        return self.circuit_sc_rate_map.get(slug, 0.10)
 
 
 # ── Module-level config singleton ─────────────────────────────────────────────
@@ -1029,7 +1052,7 @@ class RaceSituationAgent:
             'event_name':       event_name,
             'year':             lap_state.get('year', 2025),
             'circuit_cluster':  self.cfg.circuit_cluster_map.get(gp_name, 0),
-            'circuit_sc_rate':  self.cfg.circuit_sc_rate_map.get(event_name, 0.10),
+            'circuit_sc_rate':  self.cfg.sc_rate_for(event_name),
             'total_laps':       int(session.total_laps),
             'fastest_lap_s':    _clean['LapTime'].min().total_seconds(),
             'AirTemp':          float(_wx['AirTemp'].mean())    if 'AirTemp'   in _wx else 28.0,
@@ -1093,7 +1116,7 @@ class RaceSituationAgent:
             'event_name':       event_name,
             'year':             year,
             'circuit_cluster':  self.cfg.circuit_cluster_map.get(gp_name, 0),
-            'circuit_sc_rate':  self.cfg.circuit_sc_rate_map.get(event_name, 0.10),
+            'circuit_sc_rate':  self.cfg.sc_rate_for(event_name),
             'total_laps':       total_laps,
             'fastest_lap_s':    float(self.laps_df['LapTime'].dt.total_seconds().min())
                                 if len(self.laps_df) > 0 else 90.0,

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -1403,6 +1403,12 @@ def run_strategy_orchestrator_from_state(
                 "compound":      race_state.compound,
                 "tyre_life":     race_state.tyre_life,
                 "stint":         stint,
+                # A RaceState carries no lap history, so the stint's opening TyreLife is
+                # genuinely unknowable here. None makes N06 emit NaN FuelEffect plus a
+                # warning, which is in-distribution (2% of the training parquet is null)
+                # and cannot be mistaken for a reading. Keep in lockstep with the same
+                # key in engine._build_default_lap_state (#446).
+                "stint_baseline_tyre_life": None,
                 "lap_time_s":    None,
                 "speed_st":      300.0,
                 "fuel_load":     1 - race_state.lap / max(race_state.total_laps, 1),

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -692,20 +692,28 @@ def _run_mc_simulation(
 
     sc_prob = situation_out.sc_prob_3lap
 
-    if pit_out is not None:
+    # A tool-parse failure inside N28 leaves the durations at 0.0 (its `or 0.0`
+    # defaults), and 0.0 is not a stop time — it means "unknown". Simulating it makes
+    # a pit stop FREE, so PIT_NOW (~+1.25 s) wins essentially every draw: a silent
+    # parse miss becomes a confident recommendation to box. Treat a non-positive P50
+    # as unavailable and fall through to the same prior the pit_out-is-None branch
+    # already uses (#436). Durations and undercut_prob degrade INDEPENDENTLY: a
+    # failed duration parse says nothing about the undercut probability.
+    _durations_known = pit_out is not None and (pit_out.stop_duration_p50 or 0.0) > 0.0
+    if _durations_known:
         pit_p05, pit_p50, pit_p95 = _clamp_triangular(
             pit_out.stop_duration_p05,
             pit_out.stop_duration_p50,
             pit_out.stop_duration_p95,
         )
-        ucut_prob = (
-            pit_out.undercut_prob
-            if pit_out.undercut_prob is not None
-            else 0.5
-        )
     else:
         pit_p05, pit_p50, pit_p95 = 2.2, 2.8, 3.8
-        ucut_prob = 0.5
+
+    ucut_prob = (
+        pit_out.undercut_prob
+        if pit_out is not None and pit_out.undercut_prob is not None
+        else 0.5
+    )
 
     pace_s  = rng.normal(pace_out.lap_time_pred, sigma_pace, n)  # noqa: F841
     cliff_s = rng.triangular(p10_cliff, p50_cliff, p90_cliff, n)
@@ -1199,6 +1207,7 @@ def _assemble_recommendation(
     pit_out,
     mc_results:         dict,
     regulation_context: str,
+    sc_currently_active: bool = False,
 ) -> "StrategyRecommendation":
     """Merge the LLM synthesis with N28 pit data and attach grounding fields.
 
@@ -1217,6 +1226,19 @@ def _assemble_recommendation(
     * regulation_context — attached verbatim from N30 so the UI can surface
       the regulatory basis for the action without re-querying N30.
 
+    --- WHERE TO CHANGE IF THE SC POLICY CHANGES ---
+    sc_currently_active carries N27's verdict so the Safety-Car guard-rail can
+    be enforced HERE, on the final answer. N28 already refuses to stay out under
+    a deployed SC (pit_strategy_agent.py, same condition and tag), but its action
+    only ever reached the LLM as prompt TEXT — the orchestrator returned
+    synth.action verbatim, so a synthesis that ignored the deterministic signal
+    silently won. That is exactly the STAY_OUT-under-SC failure the Qatar 2025
+    case (thesis 6.3) exists to prevent, and docs/pages/multi-agent.md already
+    promises this rail "so a misbehaving LLM can't override the deterministic
+    signal". This makes the code honour the rule the project already adopted one
+    layer down. Defaults to False so any caller that does not thread N27's output
+    keeps the previous behaviour rather than silently changing it.
+
     Returns a fully-populated StrategyRecommendation ready for the UI layer.
     """
     # N28 fallbacks — only used when the LLM did not commit to a value
@@ -1228,9 +1250,17 @@ def _assemble_recommendation(
     compound_next   = synth.compound_next   if synth.compound_next   is not None else fallback_cmpd
     undercut_target = synth.undercut_target if synth.undercut_target is not None else fallback_target
 
+    # Safety-Car guard-rail, mirroring N28's own (same condition, same tag) so the
+    # override stays auditable in the chat bubble / arcade dashboard / SSE stream.
+    action    = synth.action
+    reasoning = synth.reasoning
+    if sc_currently_active and action == 'STAY_OUT':
+        action    = 'PIT_NOW'
+        reasoning = f"[OVERRIDE: SC deployed — forcing PIT_NOW.] {reasoning}"
+
     return StrategyRecommendation(
-        action             = synth.action,
-        reasoning          = synth.reasoning,
+        action             = action,
+        reasoning          = reasoning,
         confidence         = synth.confidence,
         pit_lap_target     = pit_lap_target,
         compound_next      = compound_next,
@@ -1322,7 +1352,10 @@ def run_strategy_orchestrator(
     )
 
     synth: _LLMSynthesis = _get_orchestrator_llm().invoke(prompt)
-    return _assemble_recommendation(synth, pit_out, mc_results, regulation_context)
+    return _assemble_recommendation(
+        synth, pit_out, mc_results, regulation_context,
+        sc_currently_active = situation_out.sc_currently_active,
+    )
 
 
 def run_strategy_orchestrator_from_state(
@@ -1440,4 +1473,7 @@ def run_strategy_orchestrator_from_state(
     )
 
     synth: _LLMSynthesis = _get_orchestrator_llm().invoke(prompt)
-    return _assemble_recommendation(synth, pit_out, mc_results, regulation_context)
+    return _assemble_recommendation(
+        synth, pit_out, mc_results, regulation_context,
+        sc_currently_active = situation_out.sc_currently_active,
+    )

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -21,6 +21,7 @@ CFG — TireAgentConfig: loads routing, calibration, encoding maps, cliff thresh
 from __future__ import annotations
 
 import json
+import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -49,6 +50,8 @@ try:
     _DATA_ROOT = _get_data_root()
 except Exception:
     _DATA_ROOT = _REPO_ROOT / 'data'
+
+logger = logging.getLogger(__name__)
 
 _MODEL_DIR  = _DATA_ROOT / 'models' / 'tire_degradation'
 _PROCESSED  = _DATA_ROOT / 'processed'
@@ -1178,12 +1181,40 @@ class TireAgent:
                     reasoning = m.content.strip()
                     break
 
+        # A parse miss must NOT become 0.0 laps-to-cliff. `_parse_tool_outputs` only
+        # writes a key when its regex matched, so an absent 'p10' means "the tool was
+        # skipped or its output did not parse" — whereas a PRESENT 0.0 legitimately
+        # means "the cliff is now". Defaulting the miss to 0.0 collapsed those two into
+        # the alarming one: the MC read "cliff NOW" (penalising STAY_OUT by ~4 s) and
+        # the warning level flipped to PIT_SOON, so a silent regex miss became a
+        # confident call to box. Fall back to the same conservative stub the
+        # wet/intermediate branch above already uses, and say so in the reasoning so the
+        # degradation is visible instead of masquerading as a reading (#436).
+        if 'p10' not in parsed:
+            logger.warning(
+                'Tire tool output did not parse for %s (tyre_life=%s) — using conservative '
+                'defaults instead of a 0.0 cliff', compound_id, tyre_life,
+            )
+            return TireOutput(
+                compound          = compound_id,
+                current_tyre_life = tyre_life,
+                gp_name           = gp_name,
+                deg_rate          = 0.03,
+                laps_to_cliff_p10 = 20.0,
+                laps_to_cliff_p50 = 30.0,
+                laps_to_cliff_p90 = 40.0,
+                reasoning         = (
+                    f"[{compound_id} — tire tool output could not be parsed; conservative "
+                    f"defaults used] {reasoning}"
+                ),
+            )
+
         return TireOutput(
             compound          = compound_id,
             current_tyre_life = tyre_life,
             gp_name           = gp_name,
             deg_rate          = round(parsed.get('deg_rate', 0.0), 4),
-            laps_to_cliff_p10 = round(parsed.get('p10', 0.0), 1),
+            laps_to_cliff_p10 = round(parsed['p10'], 1),
             laps_to_cliff_p50 = round(parsed.get('p50', 0.0), 1),
             laps_to_cliff_p90 = round(parsed.get('p90', 0.0), 1),
             reasoning         = reasoning,

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -904,9 +904,16 @@ class TireAgent:
             model.train()  # keep dropout active for MC
 
             preds = []
-            with torch.no_grad():
-                for _ in range(agent.cfg.n_mc):
-                    preds.append(model(tensor).item())
+            try:
+                with torch.no_grad():
+                    for _ in range(agent.cfg.n_mc):
+                        preds.append(model(tensor).item())
+            finally:
+                # Never leave the shared bundle in train mode: any later consumer of
+                # bundles[cid]['model'] would silently get stochastic "deterministic"
+                # predictions. Today only predict_tire_deg_tool saves us, by defensively
+                # calling eval() itself (#449).
+                model.eval()
 
             mean_pred = float(np.mean(preds))
             mc_std    = float(np.std(preds))

--- a/src/arcade/README.md
+++ b/src/arcade/README.md
@@ -21,10 +21,9 @@ f1-arcade --viewer --year 2025 --round 3 --driver VER --team "Red Bull Racing"
 
 ## Public docs
 
-- **End-user quick start:** [`docs/arcade/quick-start.md`](../../docs/arcade/quick-start.md)
-- **Dashboard architecture (developer deep dive):** [`docs/arcade/dashboard.md`](../../docs/arcade/dashboard.md)
-- **Why the arcade duplicates the N31 orchestrator body:** [`docs/arcade/strategy-pipeline.md`](../../docs/arcade/strategy-pipeline.md)
-- **Visual overview:** [`docs/diagrams/arcade_3window_architecture.drawio`](../../docs/diagrams/arcade_3window_architecture.drawio)
+- **End-user quick start:** [`docs/pages/arcade-quick-start.md`](../../docs/pages/arcade-quick-start.md)
+- **Dashboard architecture (developer deep dive):** [`docs/pages/arcade-dashboard.md`](../../docs/pages/arcade-dashboard.md)
+- **The shared `run_lap` engine the arcade delegates to:** [`docs/pages/arcade-strategy-pipeline.md`](../../docs/pages/arcade-strategy-pipeline.md)
 
 ## Layout
 
@@ -35,7 +34,7 @@ src/arcade/
 ├── data.py              # SessionLoader + SessionData + FrameData
 ├── config.py            # Palette, GP calendars, constants
 ├── strategy.py          # SimConnector + StrategyState + DTOs
-├── strategy_pipeline.py # Arcade-local duplicate of the N31 orchestrator body
+├── strategy_pipeline.py # Thin delegate over the shared engine (run_lap)
 ├── stream.py            # TelemetryStreamServer (stdlib TCP)
 ├── overlays.py          # WeatherPanel, LeaderboardPanel, DriverInfoPanel, …
 ├── track.py             # Track polyline renderer (DRS zones, cars)
@@ -47,5 +46,5 @@ The arcade **does not depend on the FastAPI backend at runtime**. The
 strategy pipeline runs in a background thread inside this process using
 `RaceReplayEngine` + the featured-laps parquet + the local
 `strategy_pipeline.run_strategy_pipeline` wrapper. See
-[`docs/arcade/strategy-pipeline.md`](../../docs/arcade/strategy-pipeline.md)
-for why the N31 body is duplicated here rather than extended upstream.
+[`docs/pages/arcade-strategy-pipeline.md`](../../docs/pages/arcade-strategy-pipeline.md)
+for the shared engine, its two profiles, and why the old duplicate is gone.

--- a/src/f1_strat_manager/gp_slugs.py
+++ b/src/f1_strat_manager/gp_slugs.py
@@ -24,6 +24,11 @@ path on first run.
 
 from __future__ import annotations
 
+import logging
+from typing import Final, Optional
+
+logger = logging.getLogger(__name__)
+
 # Map from the friendly GP names used by the CLI / featured-laps parquet to
 # the on-disk slug produced by ``RadioDatasetBuilder._compute_slug``. Single
 # entries for single-race countries, distinct entries per circuit for the
@@ -100,6 +105,107 @@ def canonical_gp_name(name: str) -> str:
     if spaced in COUNTRY_SLUG_BY_GP:
         return spaced
     return name
+
+
+# ── Featured-parquet slug ⇄ FastF1 event name ────────────────────────────────
+# A THIRD GP keyspace, distinct from the radio-corpus slugs above. The featured
+# laps parquet (and therefore RaceStateManager's session_meta.gp_name, and every
+# agent lookup key) uses circuit slugs — 'Budapest', 'Lusail'. But the circuit
+# lookup TABLES the agents index into use FastF1 full event names —
+# 'Hungarian Grand Prix', 'Qatar Grand Prix': circuit_traversal_lookup in N15's
+# model_config.json, undercut_clean.parquet's GP_Name (which feeds
+# circuit_undercut_rate), and the SC-labelled frame.
+#
+# The overlap between the two keyspaces is EXACTLY ZERO, so every circuit lookup
+# missed and silently took its default: pit-lane traversal was permanently 20.0 s,
+# circuit_undercut_rate 0.38, circuit_sc_rate 0.10 — Monaco and Monza given
+# identical pit-lane physics, three trained per-circuit features frozen (#448).
+#
+# No mechanical derivation works: the full names are adjectival ('Hungarian', not
+# 'Hungary'), so the mapping has to be explicit. Verified 1:1 against both sources
+# on disk (24 slugs, 24 event names).
+EVENT_NAME_BY_SLUG: Final[dict[str, str]] = {
+    "Sakhir":            "Bahrain Grand Prix",
+    "Jeddah":            "Saudi Arabian Grand Prix",
+    "Melbourne":         "Australian Grand Prix",
+    "Suzuka":            "Japanese Grand Prix",
+    "Shanghai":          "Chinese Grand Prix",
+    "Miami":             "Miami Grand Prix",
+    "Imola":             "Emilia Romagna Grand Prix",
+    "Monaco":            "Monaco Grand Prix",
+    "Barcelona":         "Spanish Grand Prix",
+    "Montréal":          "Canadian Grand Prix",
+    "Spielberg":         "Austrian Grand Prix",
+    "Silverstone":       "British Grand Prix",
+    "Spa-Francorchamps": "Belgian Grand Prix",
+    "Budapest":          "Hungarian Grand Prix",
+    "Zandvoort":         "Dutch Grand Prix",
+    "Monza":             "Italian Grand Prix",
+    "Baku":              "Azerbaijan Grand Prix",
+    "Marina Bay":        "Singapore Grand Prix",
+    "Austin":            "United States Grand Prix",
+    "Mexico City":       "Mexico City Grand Prix",
+    "São Paulo":         "São Paulo Grand Prix",
+    "Las Vegas":         "Las Vegas Grand Prix",
+    "Lusail":            "Qatar Grand Prix",
+    "Yas Island":        "Abu Dhabi Grand Prix",
+}
+
+SLUG_BY_EVENT_NAME: Final[dict[str, str]] = {
+    event: slug for slug, event in EVENT_NAME_BY_SLUG.items()
+}
+
+
+def slug_from_event_name(event_name: str) -> Optional[str]:
+    """Translate a FastF1 full event name into the featured-parquet slug.
+
+    Used to NORMALISE the circuit lookup tables at load time, so they end up
+    keyed the way the agents actually query them (by the parquet's ``GP_Name``)
+    instead of failing every lookup and silently returning a default. Normalising
+    once at the boundary beats translating at each call site: there is one place
+    to keep correct, and the tables then speak the agents' native keyspace.
+
+    Returns ``None`` for an unknown name — callers should log it rather than drop
+    the row silently, since a miss means the keyspaces have drifted again (#448).
+    Already-slugged input passes through, keeping the call reentrant.
+    """
+    if event_name in EVENT_NAME_BY_SLUG:
+        return event_name  # already a slug
+    return SLUG_BY_EVENT_NAME.get(event_name)
+
+
+def rekey_by_slug(table: dict, table_name: str) -> dict:
+    """Re-key a circuit lookup table from FastF1 event names to parquet slugs.
+
+    The agents query these tables with ``session_meta.gp_name`` — a circuit slug —
+    but the tables ship keyed by full event names, and the two keyspaces do not
+    overlap at all, so every lookup missed and quietly returned its default (#448).
+    Normalising once at load is why the call sites need almost no change: the tables
+    end up speaking the agents' native keyspace.
+
+    Pair it with :func:`slug_from_event_name` at any call site whose key may arrive
+    in EITHER keyspace (the FastF1 session path passes a full event name, the replay
+    path passes a slug); that function is reentrant, so resolving twice is a no-op.
+
+    Entries whose name does not resolve are kept under their original key and logged.
+    Dropping them silently is what let this hide for months; a warning is the signal
+    that the keyspaces have drifted again.
+    """
+    rekeyed: dict = {}
+    unresolved: list[str] = []
+    for key, value in table.items():
+        slug = slug_from_event_name(str(key))
+        if slug is None:
+            unresolved.append(str(key))
+            rekeyed[key] = value
+            continue
+        rekeyed[slug] = value
+    if unresolved:
+        logger.warning(
+            '%s: %d key(s) did not resolve to a circuit slug and stay unreachable '
+            'from the agents: %s (#448)', table_name, len(unresolved), sorted(unresolved),
+        )
+    return rekeyed
 
 
 def resolve_gp_slug(gp_name: str) -> str:

--- a/src/f1_strat_manager/gp_slugs.py
+++ b/src/f1_strat_manager/gp_slugs.py
@@ -125,30 +125,30 @@ def canonical_gp_name(name: str) -> str:
 # 'Hungary'), so the mapping has to be explicit. Verified 1:1 against both sources
 # on disk (24 slugs, 24 event names).
 EVENT_NAME_BY_SLUG: Final[dict[str, str]] = {
-    "Sakhir":            "Bahrain Grand Prix",
-    "Jeddah":            "Saudi Arabian Grand Prix",
-    "Melbourne":         "Australian Grand Prix",
-    "Suzuka":            "Japanese Grand Prix",
-    "Shanghai":          "Chinese Grand Prix",
-    "Miami":             "Miami Grand Prix",
-    "Imola":             "Emilia Romagna Grand Prix",
-    "Monaco":            "Monaco Grand Prix",
-    "Barcelona":         "Spanish Grand Prix",
-    "Montréal":          "Canadian Grand Prix",
-    "Spielberg":         "Austrian Grand Prix",
-    "Silverstone":       "British Grand Prix",
+    "Sakhir": "Bahrain Grand Prix",
+    "Jeddah": "Saudi Arabian Grand Prix",
+    "Melbourne": "Australian Grand Prix",
+    "Suzuka": "Japanese Grand Prix",
+    "Shanghai": "Chinese Grand Prix",
+    "Miami": "Miami Grand Prix",
+    "Imola": "Emilia Romagna Grand Prix",
+    "Monaco": "Monaco Grand Prix",
+    "Barcelona": "Spanish Grand Prix",
+    "Montréal": "Canadian Grand Prix",
+    "Spielberg": "Austrian Grand Prix",
+    "Silverstone": "British Grand Prix",
     "Spa-Francorchamps": "Belgian Grand Prix",
-    "Budapest":          "Hungarian Grand Prix",
-    "Zandvoort":         "Dutch Grand Prix",
-    "Monza":             "Italian Grand Prix",
-    "Baku":              "Azerbaijan Grand Prix",
-    "Marina Bay":        "Singapore Grand Prix",
-    "Austin":            "United States Grand Prix",
-    "Mexico City":       "Mexico City Grand Prix",
-    "São Paulo":         "São Paulo Grand Prix",
-    "Las Vegas":         "Las Vegas Grand Prix",
-    "Lusail":            "Qatar Grand Prix",
-    "Yas Island":        "Abu Dhabi Grand Prix",
+    "Budapest": "Hungarian Grand Prix",
+    "Zandvoort": "Dutch Grand Prix",
+    "Monza": "Italian Grand Prix",
+    "Baku": "Azerbaijan Grand Prix",
+    "Marina Bay": "Singapore Grand Prix",
+    "Austin": "United States Grand Prix",
+    "Mexico City": "Mexico City Grand Prix",
+    "São Paulo": "São Paulo Grand Prix",
+    "Las Vegas": "Las Vegas Grand Prix",
+    "Lusail": "Qatar Grand Prix",
+    "Yas Island": "Abu Dhabi Grand Prix",
 }
 
 SLUG_BY_EVENT_NAME: Final[dict[str, str]] = {
@@ -202,8 +202,11 @@ def rekey_by_slug(table: dict, table_name: str) -> dict:
         rekeyed[slug] = value
     if unresolved:
         logger.warning(
-            '%s: %d key(s) did not resolve to a circuit slug and stay unreachable '
-            'from the agents: %s (#448)', table_name, len(unresolved), sorted(unresolved),
+            "%s: %d key(s) did not resolve to a circuit slug and stay unreachable "
+            "from the agents: %s (#448)",
+            table_name,
+            len(unresolved),
+            sorted(unresolved),
         )
     return rekeyed
 

--- a/src/simulation/README.md
+++ b/src/simulation/README.md
@@ -1,6 +1,6 @@
 # src/simulation — Race replay engine
 
-> **Canonical narrative doc:** [`docs/simulation/overview.md`](../../docs/simulation/overview.md)
+> **Canonical narrative doc:** [`docs/pages/simulation.md`](../../docs/pages/simulation.md)
 > covers the `lap_state` contract and the data boundary with the agents.
 > This README is the package-level API pointer.
 

--- a/src/simulation/race_state_manager.py
+++ b/src/simulation/race_state_manager.py
@@ -132,6 +132,35 @@ class RaceStateManager:
         # calculations. Computed once to avoid repeated group operations.
         self._leader_cum: dict[int, float] = self._precompute_leader_times()
 
+        # TyreLife at the start of each of our driver's stints. Precomputed for the
+        # same reason as the leader times: get_lap_state must stay an O(1) lookup.
+        self._stint_baselines: dict[int, int] = self._precompute_stint_baselines()
+
+    def _precompute_stint_baselines(self) -> dict[int, int]:
+        """Return our driver's TyreLife at the first lap of each stint.
+
+        N06 trains ``FuelEffect`` as ``(TyreLife - min(TyreLife of the stint)) * 0.055``
+        — the seconds of lap time recovered since the stint began. The pace agent has no
+        laps frame of its own (``run_pace_agent_from_state`` takes only the lap_state),
+        so the baseline has to travel in the lap_state, and this is the producer that
+        actually has the stint history. Without it the agent fell back to
+        ``fuel_load * 0.03``, ~100x too small, and the model read every lap as a
+        fresh-fuel stint start (#446).
+
+        ``min`` rather than the first row's value so the result does not depend on row
+        order. Stints whose TyreLife is entirely NaN are omitted, and the consumer then
+        degrades to NaN rather than inventing a number.
+        """
+        baselines: dict[int, int] = {}
+        for stint, group in self._driver.groupby("Stint"):
+            if pd.isna(stint):
+                continue
+            tyre_life = group["TyreLife"].dropna()
+            if tyre_life.empty:
+                continue
+            baselines[int(stint)] = int(tyre_life.min())
+        return baselines
+
     def _precompute_leader_times(self) -> dict[int, float]:
         """Return the race leader's session elapsed time at the end of each lap.
 
@@ -209,6 +238,12 @@ class RaceStateManager:
             "compound_id": int(r["CompoundID"]) if pd.notna(r.get("CompoundID")) else None,
             "tyre_life": int(r["TyreLife"]) if pd.notna(r.get("TyreLife")) else None,
             "stint": int(r["Stint"]) if pd.notna(r.get("Stint")) else None,
+            # TyreLife when this stint began — N06's FuelEffect is measured from it.
+            # Driver-only on purpose: the pace model runs on our car, and rivals stay
+            # timing-screen-only per the single-driver boundary (#446).
+            "stint_baseline_tyre_life": (
+                self._stint_baselines.get(int(r["Stint"])) if pd.notna(r.get("Stint")) else None
+            ),
             "fresh_tyre": bool(r.get("FreshTyre", False)),
             # --- Speed traps (all four sensor points) ---
             "speed_i1": float(r["SpeedI1"]) if pd.notna(r.get("SpeedI1")) else None,

--- a/src/simulation/race_state_manager.py
+++ b/src/simulation/race_state_manager.py
@@ -150,7 +150,15 @@ class RaceStateManager:
         ``min`` rather than the first row's value so the result does not depend on row
         order. Stints whose TyreLife is entirely NaN are omitted, and the consumer then
         degrades to NaN rather than inventing a number.
+
+        ``Stint`` and ``TyreLife`` are not in ``REQUIRED_LAPS_COLUMNS``, so a frame may
+        legitimately arrive without them. That yields an empty map, which the consumer
+        reads as "no baseline" and turns into the same honest NaN.
         """
+        has_columns = {"Stint", "TyreLife"} <= set(self._driver.columns)
+        if not has_columns or self._driver.empty:
+            return {}
+
         baselines: dict[int, int] = {}
         for stint, group in self._driver.groupby("Stint"):
             if pd.isna(stint):
@@ -266,12 +274,18 @@ class RaceStateManager:
         compound and age, and the final speed trap reading. No sector times,
         no fuel data, no detailed speed readings beyond SpeedST.
 
-        ``interval_to_driver_s``: cumulative race time of rival minus our
-        driver's cumulative time. Positive → rival is ahead of us (they have
-        accumulated less race time). Negative → we are ahead of them.
+        ``interval_to_driver_s``: session elapsed time of the rival minus our
+        driver's. **Negative → the rival is ahead of us** (they reached the end
+        of this lap earlier, so less race time has elapsed for them). Positive
+        → we are ahead of them. Verified on Lusail 2025 lap 20: PIA leading,
+        every car behind reports a positive interval (NOR +3.578 s).
 
-        Returns a list sorted by Position (ascending). Rivals without a
-        position value sort to the back (position=99 placeholder).
+        Returns a list sorted by Position (ascending). A rival with no position
+        that lap keeps ``position=None`` and sorts to the back through a local
+        ``99`` placeholder. The placeholder is confined to the sort key on
+        purpose: it never enters the emitted dict, so no consumer can look up a
+        car "at position 99" and find one. Defaulting an unknown position to a
+        number the code also searches by is the #428 bug.
 
         Args:
             lap_number: 1-indexed lap number to retrieve.

--- a/src/strategy/README.md
+++ b/src/strategy/README.md
@@ -1,6 +1,15 @@
-# src/strategy — Strategy Model Modules (Jupytext exports)
+# src/strategy — Strategy Model Modules
 
-**Status: Jupytext export / reference** — not imported by current agent notebooks.
+**Read this first:** this package holds two different things with opposite statuses.
+
+- **`inference/` is production.** `inference/engine.py::run_lap` is the single
+  implementation of the N31 lap pipeline, and the CLI, the arcade and the backend
+  all route through it. See
+  [Strategy pipeline](https://docs.f1stratlab.com/#/arcade-strategy-pipeline).
+- **`training/` and the Jupytext exports are reference**, and the status note below
+  applies only to them.
+
+## Status of the Jupytext exports: reference only
 
 These are Jupytext `.py` exports from early strategy notebooks. They contain the
 model architectures and prediction utilities developed before the LightGBM-based
@@ -35,8 +44,9 @@ The current production tire degradation model is the per-compound fine-tuned TCN
 from N10, exported to `data/models/tire_degradation/`. The lap time model is the
 XGBoost delta predictor from N06 (`data/models/lap_time/`).
 
-These `src/strategy/` files pre-date those exports and use different model
-architectures or APIs. Do not rely on them for inference in agent code.
+The **Jupytext export** files pre-date those exports and use different model
+architectures or APIs. Do not rely on them for inference in agent code. This does
+not apply to `inference/`, which is the production path.
 
 ---
 

--- a/src/strategy/inference/engine.py
+++ b/src/strategy/inference/engine.py
@@ -225,7 +225,13 @@ def _run_rich(
             regulation_context=regulation_context,
         )
         synth = _get_orchestrator_llm().invoke(prompt)
-        rec = _assemble_recommendation(synth, pit_out, mc_results, regulation_context)
+        rec = _assemble_recommendation(
+            synth,
+            pit_out,
+            mc_results,
+            regulation_context,
+            sc_currently_active=situation_out.sc_currently_active,
+        )
 
     timings["total"] = sum(timings.values())
 

--- a/src/strategy/inference/engine.py
+++ b/src/strategy/inference/engine.py
@@ -32,6 +32,7 @@ equals the orchestrator's on a fixture lap, down to the byte-level LLM prompts.
 
 from __future__ import annotations
 
+import logging
 import time
 from typing import Any, Literal
 
@@ -55,6 +56,41 @@ from src.agents.strategy_orchestrator import (
 PROFILES: tuple[str, ...] = ("rich", "no-llm")
 
 Profile = Literal["rich", "no-llm"]
+
+logger = logging.getLogger(__name__)
+
+
+def _scope_laps_to_gp(laps_df: pd.DataFrame, lap_state: dict[str, Any] | None) -> pd.DataFrame:
+    """Narrow a season-wide laps frame to the Grand Prix being analysed (#429).
+
+    Every caller loads ``laps_featured_<year>.parquet``, which holds the WHOLE season,
+    and hands it straight to the agents. Their lookups (``_get_lap_row``,
+    ``_get_position_map``, ``_get_undercut_candidates``, ``_get_driver_stint``, the SC
+    feature builder) filter by Driver and LapNumber but never by GP, so each silently
+    resolved to whichever race sorted first or last in the file: measured while analysing
+    Lusail, the lap-7 position map came from Zandvoort and the driver's lap row from
+    Barcelona. Every one of those lookups wants the single race, so scoping once here
+    fixes them all without touching the agents.
+
+    The GP name comes from ``lap_state['session_meta']['gp_name']``, which
+    ``RaceStateManager`` emits in the same keyspace the parquet's ``GP_Name`` uses
+    (verified: 'Lusail'). Falls back to the full frame, loudly, when the name does not
+    resolve — handing the agents an EMPTY frame would be worse than the bug this fixes,
+    and a warning is how we find out the keyspaces have drifted apart (see #448).
+    """
+    gp_name = (lap_state or {}).get("session_meta", {}).get("gp_name")
+    if not gp_name or "GP_Name" not in laps_df.columns:
+        return laps_df
+
+    scoped = laps_df[laps_df["GP_Name"] == gp_name]
+    if scoped.empty:
+        logger.warning(
+            "GP %r not found in the laps frame (%d rows, %d GPs); falling back to the "
+            "unscoped season frame — agent lookups may resolve to the wrong race (#429/#448)",
+            gp_name, len(laps_df), laps_df["GP_Name"].nunique(),
+        )
+        return laps_df
+    return scoped
 
 
 class _StageTimer:
@@ -107,6 +143,10 @@ def run_lap(
     Raises:
         ValueError: on an unknown profile, or on the reserved ``"fast"`` profile.
     """
+    # Scope BEFORE dispatch so both profiles, and therefore every surface that routes
+    # through this engine (CLI PMV, arcade), get the single-race frame (#429).
+    laps_df = _scope_laps_to_gp(laps_df, lap_state)
+
     if profile == "rich":
         return _run_rich(race_state, laps_df, lap_state, return_agent_outputs)
     if profile == "no-llm":

--- a/src/strategy/inference/engine.py
+++ b/src/strategy/inference/engine.py
@@ -308,6 +308,12 @@ def _build_default_lap_state(race_state: RaceState, laps_df: pd.DataFrame) -> di
             "compound": race_state.compound,
             "tyre_life": race_state.tyre_life,
             "stint": stint,
+            # A RaceState carries no lap history, so the stint's opening TyreLife is
+            # genuinely unknowable here. None makes N06 emit NaN FuelEffect plus a
+            # warning, which is in-distribution (2% of the training parquet is null)
+            # and cannot be mistaken for a reading. Keep in lockstep with the same
+            # key in strategy_orchestrator's lap_state fallback (#446).
+            "stint_baseline_tyre_life": None,
             "lap_time_s": None,
             "speed_st": 300.0,
             "fuel_load": 1 - race_state.lap / max(race_state.total_laps, 1),

--- a/src/strategy/inference/no_llm.py
+++ b/src/strategy/inference/no_llm.py
@@ -313,7 +313,13 @@ def run_no_llm_lap(
             tire_out.laps_to_cliff_p10,
         )
         synth = _deterministic_synthesis(action, guardrail_reason)
-        rec = _assemble_recommendation(synth, pit_out, mc_results, regulation_context)
+        rec = _assemble_recommendation(
+            synth,
+            pit_out,
+            mc_results,
+            regulation_context,
+            sc_currently_active=situation_out.sc_currently_active,
+        )
 
     timings["total"] = sum(timings.values())
 


### PR DESCRIPTION
Promotes the strategy-engine correctness work from epic #438 to `main`.

## Where this started

The pit wall recommended **"undercut HUL"** at Lusail 2025 lap 7. HUL had crashed on lap 6, and that crash is what brought out the safety car the same recommendation was reacting to. Alongside it, a long-standing complaint that the system "sometimes picks fairly random rivals off the grid".

Four read-only audits turned those two symptoms into **~60 bugs in 6 recurring classes**: sentinel collisions, unscoped season data, dead cars treated as live, inputs dropped or hardcoded, unvalidated LLM free text, and silently-wrong defaults.

## What landed

Every fix below was verified against the real parquet with no-LLM assertions rather than by watching an orchestrator run. That doctrine is what made the numbers in this table possible to state.

| Fix | What it was doing | What it does now |
|---|---|---|
| **#428 + #430** | A crashed car had `Position=NaN`, a `_safe` helper turned it into `0`, and the leader looking for "the car ahead at `pos-1 == 0`" found the wreck | Cars without a position that lap are absent from `rivals`; the `99` placeholder is confined to the sort key where nothing can look it up |
| **#444** | N16's `pos_gap` was **inverted**, and it is that model's top feature (gain 0.690) | Correct sign |
| **#445** | N15 read the Pirelli compound number as the trained ordinal: **HARD as MEDIUM, MEDIUM as INTERMEDIATE, SOFT out of range** | Reads the ordinal from N15 cell 11 |
| **#429** | Agents received the whole-season frame and looked rivals up by driver and lap, so the **Zandvoort grid could decide a race at Lusail** | Scoped by GP at `run_lap`, so the CLI and arcade inherit it |
| **SC coherence** | N28 already forced `PIT_NOW` under a safety car, but the orchestrator took the LLM's answer verbatim, so the guard only reached it as prompt text. Lusail lap 7: **2 PIT_NOW / 4 STAY_OUT over six runs** | Enforced at the final assembly too. `docs/pages/multi-agent.md:131` already promised this rail; the code now matches its own documentation |
| **#436** | Tool-parse failures produced `0.0` durations, which made pit stops **free** in the Monte Carlo | Parse-miss falls through to the prior (-1.18) while a real 9/11/14 s stop still scores -7.12 |
| **#448** | The two GP keyspaces had **zero overlap**, so every circuit lookup missed, always. Monaco and Monza had identical pit-lane physics | Marina Bay 27.51 s · Monaco 22.54 s · Monza 22.37 s · Budapest 19.66 s (was 20.0 everywhere: a 7.9 s spread the system could not see) |
| **#447 Part A** | The featured parquet dropped `Time`, so the overtake gap degenerated into a lap-time delta. PIA vs NOR at Lusail L20: **real 3.58 s, model fed 0.10 s** (inside the DRS window) | `Time_s` restored from the raw per-race parquet at load time, 100% coverage |
| **#437** | `/lap-state` reconstructed gaps by summing lap times, but the parquet drops each driver's SC/pit/out laps. **NOR reported 80.868 s behind PIA where the truth is 3.578 s; TSU off by 173.7 s** | Reads the restored `Time_s`. The 173.7 s is exactly the `Δgap -174.6s` symptom this was filed on |
| **#446** | `FuelEffect` was `fuel_load * 0.03` (≤ 0.03 s) where the trained truth at Lusail L20 is **1.045 s: ~55x too small**, on a feature the model reads in seconds | Real stint baseline, threaded through 5 producers. Absent baseline emits NaN plus a warning, never a default |
| **#440** | The `/simulate` no-LLM path was a hand-synced duplicate that had drifted three ways at once | Delegates to `run_lap(profile="no-llm")`. **227 lines out** |

**#440 deserves its own line.** The copy unpacked two values from a three-value helper, so the `ValueError` fired on **every routed lap** and was swallowed by a bare `except`: N28 and N30 **ran**, paying for LLM and Qdrant calls, and their results were **discarded**. On the path whose entire purpose is not to use an LLM. It also dropped the `sc_currently_active` routing argument, and its fallback stubs invented readings (a 90.0 s lap, a 20-lap cliff) and served them as decisions.

## Documentation (#458)

The docs were not stale, they were **teaching the bugs**:

- `arcade-strategy-pipeline.md` documented a duplicate and a *"open both files side by side and transcribe the edit"* sync ritual. That ritual is precisely the drift the shared engine abolished. Rewritten as the shared-engine page, filling a real gap: **nothing documented `run_lap` or its profiles**.
- `simulation.md` described the **rejected** gap design as if shipped, *including its limitation* ("safety car bunching is not reflected accurately"), when the code reads elapsed time **precisely so that it is**. It also gained "Who counts as a rival", because that rule was undocumented and so the HUL bug had no sentence to correct.
- `agents-api.md`: both "runnable" examples raised `TypeError`, and the entry-point table was regenerated from `inspect.signature` after **4 of its 7 rows** turned out wrong.
- `race_state_manager.py`'s `get_rival_states` docstring had the interval **sign inverted**. The code was right and the prose was wrong, which is how a correct sign gets "fixed" into a bug later.

## The lesson worth keeping

`src/simulation/race_state_manager.py` had **already solved all of this correctly**: NaN never becomes a searchable number, gaps come from the elapsed-time column, retired cars fall out on their own. The API path was written separately, alongside it, and reproduced every one of those bugs from scratch, silently, for months.

Two implementations of the same idea do not stay equal because someone intends them to. Before writing a second path that shapes race data, check whether a clean one already exists.

## Not done, deliberately, and documented

- **#447 Part B rejected** — the SC-lap drop is an intentional, documented quality gate (`IsAccurate == True`). The models were fit without those laps on purpose. Restoring them would mean porting ~700 lines out of a read-only notebook and shifting the training distribution, to fix nothing: SC-lap state is already served by the raw fallback.
- **#450 thresholds not wired** — threat-level *bands* and classifier *operating points* are different concepts. Wiring them would route the SC agent ~28% more often for no stated reason.
- **#428's `?? 2.0` rejected** — it trades a phantom car 2 s ahead for a phantom car alongside. Making "no car ahead" representable (`Optional[float]`) is the real fix, tracked as the residual.

## The final adversarial audit earned its place

The epic's exit criterion was: never close on "all sub-issues merged", run a read-only adversarial pass whose success condition is **finding what is still broken**. It found a **fix breaking a fix**, plus three survivors. Two were fixed on the spot; the rest are filed.

**Fixed from its findings, in this promotion:**

- **`/lap-state`'s raw fallback had no `Time_s`.** #437 made it read `Time_s`; #447 restores `Time_s` onto the *featured* frame; but `/lap-state` rebinds to the **raw** frame on SC/pit/out laps, which is the entire reason that fallback exists. It then summed lap times, and a sum silently skips NaN-`LapTime` laps, which live on **exactly those incidents**. **OCO read as 126.751 s ahead of the leader when the truth is 33.950 s behind: a 160.7 s error that flips the sign.**
- **The overtake model never saw #447 at all.** `_ensure_timedelta_laps` normalises `LapTime_s` into `LapTime` but never did the same for `Time_s`, and the agent reads `Time`. The degenerate fallback fired on **100% of calls**: N11 was told OCO sat **1.645 s** from the leader when the real gap was **33.950 s**. I restored the column and never checked that the consumer read it, which is the same mistake #437 was, made an hour later.

**Filed, not buried** — and these are why the `Closes` list below is shorter than it would otherwise be:

- **#462 — the "undercut HUL" bug is alive at the N28 tool layer.** #428/#430 fixed the *rivals list*; N28 does not use it, it queries `laps_df` directly. `Series.get('Position', 10)` returns **NaN**, because a value-default only fires when the *column* is missing. BEA retired on lap 41; at lap 50 the system produces `pos_gap=-14.0` with **no NaN and no warning**: a confident undercut probability against a car in the garage.
- **#463 — #429 is alive on the default `/simulate`.** `no_llm` defaults to `False`, so the default path calls the orchestrator directly and bypasses `run_lap`'s scoping. #440 fixed the no-LLM half only.
- **#464 — the SC rail flips 2 of 14 fields.** `action=PIT_NOW` while `pit_lap_target=32` and the reasoning still argues to stay out. `pit_lap_target`'s own docs say *"prefer this field over parsing the reasoning string"*, so the rail is defeated for exactly the consumers we told to read it.
- **#465** — `_safe` NaN→0 survivors (`TyreLife` 1.98% → `0`, which reads as **brand-new tyres**, not "unknown"), five dead `.get('position', 20)` defaults, and `_scope_laps_to_gp` running before the lap_state exists.
- **#459** — `/simulate` never sees a safety car: `rcm_events` dropped at the `build_race_state` boundary. Proven on Lusail L5-L12: all `STAY_OUT` while the lap times show the bunching plainly.

**A correction the audit forced on our own summary:** #428/#430 do **not** "drop position-less cars from the rivals list". They emit them with `position: None` (HUL *is* among the 19 rivals at Lusail lap 7). That contract is sound, since `None` is unsearchable, but it means every consumer must filter, and five do not.

So **#428, #429 and #430 stay open**. Their symptom is fixed where it was diagnosed and alive where it was not, and closing them would bury exactly the kind of half-fix this epic exists to stop.

Closes #436
Closes #437
Closes #440
Closes #444
Closes #445
Closes #446
Closes #447
Closes #448
