### PR TITLE
fix(agents): force what the SC regulation makes certain, not a strategy opinion

### DIFF
--- a/docs/pages/agents-api.md
+++ b/docs/pages/agents-api.md
@@ -56,7 +56,7 @@ Each agent also exposes a `get_*_react_agent()` factory that returns a compiled 
 |---|---|---|
 | `overtake_prob` | float | Probability of being overtaken (0–1) |
 | `sc_prob_3lap` | float | Safety car probability within 3 laps (0–1) |
-| `sc_currently_active` | bool | A safety car is deployed **right now**. Not a prediction: it is read from the lap's RCM events, because N14 was trained to forecast a future SC and cannot recognise one already out. When true it forces `sc_prob_3lap = 1.0`, activates N28, and the final recommendation is held to `PIT_NOW`. See [Multi-agent system](#/multi-agent). |
+| `sc_currently_active` | bool | A safety car is deployed **right now**. Not a prediction: it is read from the lap's RCM events, because N14 was trained to forecast a future SC and cannot recognise one already out. When true it forces the regulatory facts (`sc_prob_3lap = 1.0`, `overtake_prob = 0` per Art. 55.8, `drs_window = 0` per Art. 22.1(c)) and activates N28. It does **not** force the action: whether to pit under an SC is race state, not a rule. See [Multi-agent system](#/multi-agent). |
 | `threat_level` | str | LOW, MEDIUM, HIGH, CRITICAL |
 | `gap_ahead_s` | float | Gap to car ahead in seconds |
 | `pace_delta_s` | float | Pace difference vs car ahead |

--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -130,11 +130,32 @@ Wraps N15 (physical pit stop duration P05/P50/P95 via HistGBT) and N16 (undercut
 
 #### Honoring an active Safety Car
 
-When the orchestrator sets `sc_currently_active = True` on the lap state, N28's prompt swaps the legacy "SC probability" line for an explicit `SC STATUS: SAFETY CAR DEPLOYED RIGHT NOW` banner and the system prompt waives the `MINIMUM STINT LENGTH` constraint (pitting under SC costs ~10 s vs ~22 s, inverting the cost/benefit). A code-level guard-rail then flips any residual `STAY_OUT` to `PIT_NOW` so a misbehaving LLM can't override the deterministic signal — replicating the McLaren Catar 2025 V7 fix where the chain of safeguards previously locked the recommendation into `STAY_OUT` despite a confirmed SC.
+**A rail encodes what the regulation makes certain. It never encodes a strategy opinion.** Facts are forced; the stop/stay call stays with the model, which is the only layer that sees the state the decision depends on.
 
-**The rail is enforced twice, and it has to be.** N28's guard produces the right `action`, but the orchestrator's final synthesis then writes its own: `_assemble_recommendation` took the LLM's answer verbatim, so N28's `PIT_NOW` only ever reached the synthesis *prompt* as a line of text the model could ignore. It did: the same Lusail lap 7 scenario returned `PIT_NOW` twice and `STAY_OUT` four times across six runs. `_assemble_recommendation` now applies the same flip to the synthesised action, tagged `[OVERRIDE: SC deployed — forcing PIT_NOW.]` in the reasoning.
+When `sc_currently_active = True`, N28's prompt swaps the "SC probability" line for an explicit `SC STATUS: SAFETY CAR DEPLOYED RIGHT NOW` banner and waives the `MINIMUM STINT LENGTH` constraint: a stop under an SC is far cheaper, because the field is delta-limited and queued, so your *relative* loss shrinks. That makes pitting cheaper. It does not make it correct, and nothing forces it.
 
-A deterministic rail is only deterministic at the layer that emits the final answer. A guard one layer down is a suggestion.
+What is forced are the rules:
+
+| Fact | Regulation | Value | Where |
+|---|---|---|---|
+| No overtaking on track | **Art. 55.8** (SC) / **56.6** (VSC) | `overtake_prob = 0` | N27 |
+| An SC is deployed | Art. 55.4 | `sc_prob_3lap = 1.0` | N27 |
+| DRS unavailable | **Art. 22.1(c)** | `drs_window = 0` | N27, feature build |
+| No green-flag lap-time target | **Art. 55.7** | `target_lap_time_s = None` | final assembly |
+
+`overtake_prob = 0` is not an approximation. N12 models a *racing* overtake; of the eight exceptions in Art. 55.8, only "a car slows with an obvious problem" yields a real position gain, and N12 has no feature for it. Every input it does use is regulation-corrupted: DRS is off, the gap compresses toward ten car lengths (55.7/55.10), and `pace_delta` collapses to the FIA ECU delta. Under an SC the model is not imprecise, it is **inapplicable**.
+
+`target_lap_time_s` is the subtle one. It is grounded in N06's **green-flag** pace, and Art. 55.7 requires drivers to stay **above** the FIA ECU minimum time: shipping it instructs the driver to earn a penalty. We cannot source the real delta, so the field has no valid value. `None` is forced by **absence of a source** — which is the test that separates a fact from an opinion.
+
+##### Why the old rail was removed
+
+This page used to document a rail that flipped any `STAY_OUT` to `PIT_NOW` under an SC, "replicating the McLaren Catar 2025 V7 fix". That is one race generalised into a universal law, and Art. 55.17 makes it provably wrong: if the SC is still out at the start of the last lap, the race **finishes behind it with no overtaking**, so track position surrendered to a late stop is unrecoverable by regulation. The pipeline could emit `action=PIT_NOW` carrying the reason *"too late to pit"*, because the rail overrode a correct guard-rail that already knew this.
+
+It also silenced the computation built to weigh it: with an SC deployed `sc_prob_3lap` is 1.0, so **every** Monte Carlo draw already receives the full `SC_PIT_BONUS`. A `STAY_OUT` argmax under those conditions *is* the model saying the cheap stop was outweighed.
+
+Staying out under an SC is right whenever you have already stopped, you lead a pack that must stop anyway, you would rejoin into traffic, or the race is ending. Boxing is right when you must stop anyway, the tyres are near the cliff, or the two-compound rule is unsatisfied and time is short. Not one of those is a rule. All of them are race state the model is given, and a rail sees none of it.
+
+See `tests/test_sc_regulatory_rails.py`.
 
 ### N29 — Radio Agent (`radio_agent.py`)
 

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -411,9 +411,17 @@ MINIMUM STINT LENGTH before a pit makes sense:
   set still has useful life; pitting now wastes a tyre allocation).
 
   EXCEPTION — SC ACTIVE: when the prompt states "SC STATUS: SAFETY CAR DEPLOYED
-  RIGHT NOW", the minimum stint constraint DOES NOT APPLY. Pitting under a
-  deployed SC costs ~10s instead of ~22s, so the cost/benefit inverts.  Recommend
-  PIT_NOW (action=PIT_NOW, not REACTIVE_SC) regardless of tyre_life.
+  RIGHT NOW", the minimum stint constraint DOES NOT APPLY: a stop under a deployed
+  SC is far cheaper because the field is delta-limited and queued behind the SC, so
+  your RELATIVE loss shrinks.
+  This makes pitting cheaper. It does NOT make it correct: weigh it against what a
+  stop surrenders. Stay out when you have already stopped (a second set buys you
+  nothing), when you lead a pack that still has to stop, when you would rejoin into
+  traffic, or when the race is ending — if the SC is still out on the last lap the
+  race finishes behind it with no overtaking (Art. 55.17), so track position given
+  away now cannot be won back. Box when you have yet to stop and must anyway, when
+  the tyres are near the cliff, or when the two-compound rule is still unsatisfied
+  and time is running out. Decide on the race state, not on the SC alone.
 
 COMPOUND vs REMAINING LAPS:
   SOFT: recommend only if remaining laps <= 15 (it won't last longer).
@@ -1049,14 +1057,12 @@ class PitStrategyAgent:
         parsed                          = _parse_tool_outputs(messages)
         action, compound_rec, reasoning = _parse_agent_summary(messages[-1].content)
 
-        # Code-level guard: if the SC is confirmed deployed but the LLM still
-        # returned STAY_OUT (e.g. it weighted MINIMUM STINT too heavily), force
-        # PIT_NOW.  Tag the reasoning so the override is auditable in the chat
-        # bubble / arcade dashboard.
-        if sc_currently_active and action == 'STAY_OUT':
-            action    = 'PIT_NOW'
-            reasoning = f"[OVERRIDE: SC deployed — forcing PIT_NOW.] {reasoning}"
-
+        # A deployed SC does NOT force a stop. There used to be a guard here flipping
+        # STAY_OUT to PIT_NOW, and it was a strategy opinion, not a rule: staying out
+        # is right whenever you have already stopped, you lead a pack that must stop
+        # anyway, or the race is ending (Art. 55.17 finishes it behind the SC, making
+        # the surrendered position unrecoverable). The regulatory facts an SC does
+        # force live in N27; see tests/test_sc_regulatory_rails.py.
         sc_reactive = sc_currently_active or (action == 'REACTIVE_SC') or (
             sc_prob >= 0.30 and action in ('PIT_NOW', 'UNDERCUT')
         )

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -255,6 +255,24 @@ def _zscore(series: pd.DataFrame, col: str, lap_number: int) -> float:
     return float((val.iloc[0] - mu) / sig) if not val.empty else 0.0
 
 
+def _is_neutralised(track_status: object) -> bool:
+    """True when the lap ran under a Safety Car or a Virtual Safety Car.
+
+    FastF1 packs several codes into one string per lap, so '41' means the lap saw both
+    green and SC. Code 4 is the Safety Car and 6 the VSC; a substring test is the right
+    read because any appearance means the lap was neutralised for part of its length.
+
+    Used to shut features the regulation shuts. It deliberately does NOT cover the lap
+    after the restart, where DRS is still disabled (one lap, two under the 2023 wording)
+    but the track status is already green: catching that needs restart-lap state this
+    function does not have. Tracked separately.
+    """
+    if track_status is None or pd.isna(track_status):
+        return False
+    codes = str(track_status)
+    return '4' in codes or '6' in codes
+
+
 def _dominant_status(grp: pd.DataFrame) -> str:
     """Return the single worst TrackStatus code seen in a lap group."""
     codes = grp['TrackStatus'].dropna().astype(str).tolist()
@@ -757,7 +775,13 @@ class RaceSituationAgent:
             float(driver_x_lap.get('SpeedST', 300.0)) - float(driver_y_lap.get('SpeedST', 300.0))
         )
         lap_number      = int(driver_x_lap['LapNumber'])
-        drs_window      = int(gap_ahead_s < 1.0)
+        # DRS is unavailable under SC/VSC (Art. 22.1(c): activation only resumes one lap
+        # after a safety car period, two in the 2023 regulation). The gap-based rule
+        # below cannot know that, so a neutralised lap used to report an open DRS window
+        # purely because the field had bunched to under a second: the feature was live
+        # and lying, on exactly the laps where it is regulated shut.
+        drs_allowed     = not _is_neutralised(driver_x_lap.get('TrackStatus'))
+        drs_window      = int(gap_ahead_s < 1.0) if drs_allowed else 0
         drs_ready_gap   = gap_ahead_s * drs_window
 
         compound_x = _abs_compound(str(driver_x_lap.get('Compound', 'MEDIUM')), gp_name, year)
@@ -1189,17 +1213,30 @@ class RaceSituationAgent:
         sc_active           = _sc_active_from_rcm(getattr(self, "_pending_rcm_events", None) or [])
         raw_sc_prob         = round(parsed['sc_prob_3lap'], 3)
         effective_sc_prob   = 1.0 if sc_active else raw_sc_prob
+
+        # Art. 55.8 (SC) / 56.6 (VSC): no overtaking on track. N12 predicts a RACING
+        # overtake, and under an SC the only exception that yields a real position gain
+        # is 55.8(h) ("a car slows with an obvious problem") — a mechanism N12 has no
+        # feature for. Meanwhile every input it does use is regulation-corrupted: DRS is
+        # disabled (Art. 22.1(c)), the gap compresses toward ten car lengths (55.7/55.10)
+        # and pace_delta collapses to the FIA ECU delta. So the model is not merely
+        # imprecise here, it is inapplicable: 0.0 is the correct value and the honest one.
+        raw_overtake_prob       = round(parsed['overtake_prob'], 3)
+        effective_overtake_prob = 0.0 if sc_active else raw_overtake_prob
+
         effective_reasoning = (
             reasoning
             if not sc_active
             else (
                 f"[RCM OVERRIDE: SAFETY_CAR_DEPLOYED active — model output "
-                f"sc_prob_3lap={raw_sc_prob:.2f} overridden to 1.00.] {reasoning}"
+                f"sc_prob_3lap={raw_sc_prob:.2f} overridden to 1.00, "
+                f"overtake_prob={raw_overtake_prob:.2f} overridden to 0.00 "
+                f"(no overtaking under SC, Art. 55.8).] {reasoning}"
             )
         )
 
         return RaceSituationOutput(
-            overtake_prob       = round(parsed['overtake_prob'], 3),
+            overtake_prob       = effective_overtake_prob,
             sc_prob_3lap        = effective_sc_prob,
             gap_ahead_s         = round(parsed['gap_ahead_s'],   2),
             pace_delta_s        = round(parsed['pace_delta_s'],  3),

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -1250,13 +1250,35 @@ def _assemble_recommendation(
     compound_next   = synth.compound_next   if synth.compound_next   is not None else fallback_cmpd
     undercut_target = synth.undercut_target if synth.undercut_target is not None else fallback_target
 
-    # Safety-Car guard-rail, mirroring N28's own (same condition, same tag) so the
-    # override stays auditable in the chat bubble / arcade dashboard / SSE stream.
+    # The action is the synthesis's, always. There used to be an SC rail here forcing
+    # STAY_OUT -> PIT_NOW, and it was an opinion wearing a rail's clothes: one race
+    # (Qatar 2025) generalised into a universal law. Under a real SC, staying out is
+    # often right (you just pitted; you lead and the pack must stop anyway; you would
+    # rejoin into traffic), and Art. 55.17 makes forcing the stop provably wrong in the
+    # closing laps, where the race finishes behind the SC and the surrendered track
+    # position is unrecoverable by regulation.
+    #
+    # It also silenced the very computation built to weigh it: with an SC deployed
+    # sc_prob_3lap is 1.0, so every Monte Carlo draw already receives the full
+    # SC_PIT_BONUS. A STAY_OUT argmax under those conditions IS the model saying the
+    # cheap stop was outweighed.
+    #
+    # What a deployed SC forces are the REGULATORY facts, and they live in N27 where
+    # every consumer inherits one consistent number: overtake_prob = 0 (Art. 55.8),
+    # sc_prob_3lap = 1.0, drs_window = 0 (Art. 22.1(c)).
+    #
+    # One is forced here instead, because it is this layer that emits it:
+    # `target_lap_time_s` is grounded in N06's PaceOutput CI, and N06 predicts
+    # GREEN-FLAG pace. Art. 55.7 requires drivers to stay ABOVE the FIA ECU minimum
+    # time while the SC is out, so a green-flag target is below the delta by
+    # construction: the system would be instructing the driver to earn a penalty. We
+    # cannot source the real delta (it is not in the telemetry), so the field has no
+    # valid value. None is forced by ABSENCE OF A SOURCE, not by a strategy view, and
+    # the schema already documents None as "the LLM prefers not to commit".
+    # Inventing a delta would only launder the breach into looking authoritative.
+    # See tests/test_sc_regulatory_rails.py.
     action    = synth.action
     reasoning = synth.reasoning
-    if sc_currently_active and action == 'STAY_OUT':
-        action    = 'PIT_NOW'
-        reasoning = f"[OVERRIDE: SC deployed — forcing PIT_NOW.] {reasoning}"
 
     return StrategyRecommendation(
         action             = action,
@@ -1266,7 +1288,7 @@ def _assemble_recommendation(
         compound_next      = compound_next,
         undercut_target    = undercut_target,
         pace_mode          = synth.pace_mode,
-        target_lap_time_s  = synth.target_lap_time_s,
+        target_lap_time_s  = None if sc_currently_active else synth.target_lap_time_s,
         risk_posture       = synth.risk_posture,
         contingencies      = synth.contingencies,
         key_risks          = synth.key_risks,

--- a/tests/test_sc_regulatory_rails.py
+++ b/tests/test_sc_regulatory_rails.py
@@ -1,0 +1,142 @@
+"""What a deployed Safety Car forces, and what it must not.
+
+The governing rule, set after the SC rail was found to be an opinion rather than a
+rule: **a deterministic rail may encode what the FIA Sporting Regulations make
+certain. It must never encode a strategy opinion.** Facts are forced; the pit/stay
+decision stays with the model, which is the only layer that sees the race state the
+decision actually depends on (stops made, laps remaining, gap behind, compounds used).
+
+The rail these tests replace forced ``STAY_OUT -> PIT_NOW`` on every SC lap. That was
+a single race (Qatar 2025) generalised into a universal law, and Art. 55.17 makes it
+provably wrong in the case it fired hardest on.
+
+Every assertion here runs without an LLM, against the real helpers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.agents.strategy_orchestrator import _assemble_recommendation
+from src.strategy.inference.no_llm import _deterministic_synthesis, apply_guard_rails
+
+
+def _recommend_under_sc(action: str, reason: str | None):
+    """Assemble a recommendation the way the no-LLM path does, with an SC deployed."""
+    synthesis = _deterministic_synthesis(action, reason)
+    mc_results = {"STAY_OUT": {"score": 0.4}, "PIT_NOW": {"score": -1.2}}
+    return _assemble_recommendation(synthesis, None, mc_results, "", sc_currently_active=True)
+
+
+def test_sc_in_the_last_laps_does_not_force_a_stop():
+    """Art. 55.17: an SC still out on the last lap ends the race behind it.
+
+    Laps under the SC count as race laps (Art. 55.16), and if the SC is still deployed
+    at the start of the last lap the cars take the flag behind it "without overtaking"
+    (Art. 55.17). So a stop in the closing laps surrenders track position that is not
+    merely hard to recover: it is unrecoverable by regulation.
+
+    The guard-rail already knows this and returns STAY_OUT. This asserts that nothing
+    downstream overrides it. Before the rail was removed, the pipeline shipped
+    ``action=PIT_NOW`` carrying the reason "too late to pit".
+    """
+    action, reason = apply_guard_rails(
+        action="PIT_NOW",
+        lap=55,
+        total_laps=57,
+        compound="MEDIUM",
+        tyre_life=30,
+        cliff_p10=99.0,
+    )
+    assert action == "STAY_OUT", "the guard-rail itself changed; this test's premise is gone"
+    assert "too late to pit" in (reason or "")
+
+    rec = _recommend_under_sc(action, reason)
+
+    assert rec.action == "STAY_OUT", (
+        "an SC in the closing laps must not force a stop: Art. 55.17 guarantees the race "
+        "finishes behind the SC, so pitting here is a certain loss"
+    )
+    assert "OVERRIDE" not in rec.reasoning
+
+
+def test_the_shipped_action_never_contradicts_its_own_reason():
+    """A recommendation may not carry a reason that argues against its action.
+
+    This is the shape the rail produced: it rewrote ``action`` at final assembly while
+    every field derived from it, ``guardrail_reason`` included, kept describing the
+    decision it had just overridden. A deterministic layer may only write a field it is
+    the authority for, and ``action`` is not a leaf.
+    """
+    action, reason = apply_guard_rails(
+        action="PIT_NOW",
+        lap=55,
+        total_laps=57,
+        compound="MEDIUM",
+        tyre_life=30,
+        cliff_p10=99.0,
+    )
+    rec = _recommend_under_sc(action, reason)
+
+    says_too_late = "too late to pit" in (rec.reasoning or "")
+    if says_too_late:
+        assert rec.action != "PIT_NOW", (
+            f"shipped action={rec.action!r} while its own reasoning says it is too late "
+            f"to pit: {rec.reasoning!r}"
+        )
+
+
+def test_no_green_flag_lap_time_target_under_a_safety_car():
+    """Art. 55.7 removes the field's only source, so it has no valid value.
+
+    ``target_lap_time_s`` is grounded in N06's PaceOutput CI, and N06 predicts
+    green-flag pace. While the SC is out, drivers must stay ABOVE the FIA ECU minimum
+    time, so a green-flag target sits below the delta by construction: shipping it
+    instructs the driver to earn a penalty. The delta itself is not in our telemetry,
+    so there is nothing to substitute. None is forced by absence of a source, which is
+    what separates this from a strategy opinion.
+    """
+    synthesis = _deterministic_synthesis("STAY_OUT", None)
+    synthesis.target_lap_time_s = 84.5  # a green-flag target
+    mc_results = {"STAY_OUT": {"score": 0.4}}
+
+    under_sc = _assemble_recommendation(synthesis, None, mc_results, "", sc_currently_active=True)
+    assert under_sc.target_lap_time_s is None, (
+        "a green-flag lap-time target under an SC tells the driver to break Art. 55.7"
+    )
+
+    green = _assemble_recommendation(synthesis, None, mc_results, "", sc_currently_active=False)
+    assert green.target_lap_time_s == 84.5, "the target must survive when the track is green"
+
+
+def test_drs_window_is_shut_on_neutralised_laps():
+    """Art. 22.1(c): no DRS under SC/VSC.
+
+    The feature is a plain ``gap < 1.0`` test, so a neutralised lap reported an open DRS
+    window purely because the field had bunched up: live and lying on exactly the laps
+    where the regulation shuts it.
+    """
+    from src.agents.race_situation_agent import _is_neutralised
+
+    assert _is_neutralised("4") is True, "code 4 is the Safety Car"
+    assert _is_neutralised("6") is True, "code 6 is the VSC"
+    assert _is_neutralised("41") is True, "FastF1 packs codes: a lap that saw the SC at all"
+    assert _is_neutralised("1") is False, "code 1 is green"
+    assert _is_neutralised(None) is False, "unknown status must not fake a neutralisation"
+
+
+@pytest.mark.parametrize("mc_favours_staying_out", [True, False])
+def test_the_model_keeps_the_pit_decision_under_a_safety_car(mc_favours_staying_out):
+    """The stop/stay call is race state, not regulation, so no rail may take it.
+
+    Under an SC the Monte Carlo already receives the full ``SC_PIT_BONUS`` on every
+    draw (``sc_prob_3lap`` is forced to 1.0, so every sample sees an SC). If it still
+    scores STAY_OUT highest, that is the model saying the cheap stop was outweighed.
+    Overriding it silences the exact computation built to weigh it.
+    """
+    chosen = "STAY_OUT" if mc_favours_staying_out else "PIT_NOW"
+    rec = _recommend_under_sc(chosen, None)
+    assert rec.action == chosen, (
+        "an active SC must not rewrite the chosen action; it is a strategy call that "
+        "depends on stops made, laps remaining and gap behind, none of which is a rule"
+    )

--- a/tests/test_sc_regulatory_rails.py
+++ b/tests/test_sc_regulatory_rails.py
@@ -15,14 +15,25 @@ Every assertion here runs without an LLM, against the real helpers.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from src.agents.strategy_orchestrator import _assemble_recommendation
-from src.strategy.inference.no_llm import _deterministic_synthesis, apply_guard_rails
+# Importing the orchestrator pulls the sub-agent modules, which read model configs at
+# import time, so this carries the same guard as the other agent-touching tests.
+ROOT = Path(__file__).parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+pytestmark = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="data/models/ not present (CI runner without model weights)",
+)
 
 
 def _recommend_under_sc(action: str, reason: str | None):
     """Assemble a recommendation the way the no-LLM path does, with an SC deployed."""
+    from src.agents.strategy_orchestrator import _assemble_recommendation
+    from src.strategy.inference.no_llm import _deterministic_synthesis
+
     synthesis = _deterministic_synthesis(action, reason)
     mc_results = {"STAY_OUT": {"score": 0.4}, "PIT_NOW": {"score": -1.2}}
     return _assemble_recommendation(synthesis, None, mc_results, "", sc_currently_active=True)
@@ -40,6 +51,8 @@ def test_sc_in_the_last_laps_does_not_force_a_stop():
     downstream overrides it. Before the rail was removed, the pipeline shipped
     ``action=PIT_NOW`` carrying the reason "too late to pit".
     """
+    from src.strategy.inference.no_llm import apply_guard_rails
+
     action, reason = apply_guard_rails(
         action="PIT_NOW",
         lap=55,
@@ -68,6 +81,8 @@ def test_the_shipped_action_never_contradicts_its_own_reason():
     decision it had just overridden. A deterministic layer may only write a field it is
     the authority for, and ``action`` is not a leaf.
     """
+    from src.strategy.inference.no_llm import apply_guard_rails
+
     action, reason = apply_guard_rails(
         action="PIT_NOW",
         lap=55,
@@ -96,6 +111,9 @@ def test_no_green_flag_lap_time_target_under_a_safety_car():
     so there is nothing to substitute. None is forced by absence of a source, which is
     what separates this from a strategy opinion.
     """
+    from src.agents.strategy_orchestrator import _assemble_recommendation
+    from src.strategy.inference.no_llm import _deterministic_synthesis
+
     synthesis = _deterministic_synthesis("STAY_OUT", None)
     synthesis.target_lap_time_s = 84.5  # a green-flag target
     mc_results = {"STAY_OUT": {"score": 0.4}}


### PR DESCRIPTION
## The rail was an opinion. The regulation says so.

The Safety-Car rail forced `STAY_OUT -> PIT_NOW` on every SC lap. The docs admitted its origin: *"replicating the McLaren Catar 2025 V7 fix"*. One race, generalised into a universal law.

**Art. 55.17 makes it provably wrong in the case it fired hardest on.** If the SC is still deployed at the start of the last lap, the race finishes behind it with no overtaking. Track position surrendered to a late stop is unrecoverable **by regulation**.

Reproduced with **no LLM**, against the real helpers:

```
guard-rail, 3 laps left:  action='STAY_OUT'
                          reason='guard-rail: too late to pit (<=3 laps left)'
after the SC rail:        action='PIT_NOW'          <- it overrode a correct guard-rail
reasoning it shipped:     '[OVERRIDE: SC deployed...] ...too late to pit...'
```

The pipeline emitted **"box now", justified by "too late to box"**, in the one scenario the rulebook certifies as a guaranteed loss. That is now `tests/test_sc_regulatory_rails.py`, written to fail first.

**It also silenced the computation built to weigh it.** With an SC deployed `sc_prob_3lap` is 1.0, so every Monte Carlo draw already receives the full `SC_PIT_BONUS`. A STAY_OUT argmax under those conditions **is the model saying the cheap stop was outweighed**. The rail overrode the answer to the question it claimed to be asking.

## What is deleted

All three sites: the orchestrator's final assembly, N28's own guard, and the N28 prompt. The prompt's *"recommend PIT_NOW regardless of tyre_life"* is replaced by the actual trade-off, because the decision is race state and none of it is a rule:

- **Stay out** when you have already stopped (a second set buys nothing), when you lead a pack that still has to stop, when you would rejoin into traffic, or when the race is ending (55.17).
- **Box** when you have yet to stop and must anyway, when the tyres are near the cliff, or when the two-compound rule is unsatisfied and time is running out.

## What is forced instead: the regulatory facts, in N27

| Fact | Basis | Value |
|---|---|---|
| No overtaking | **Art. 55.8** (SC) / **56.6** (VSC) | `overtake_prob = 0.0` |
| SC deployed | Art. 55.4 | `sc_prob_3lap = 1.0` (already there) |
| No DRS | **Art. 22.1(c)** | `drs_window = 0` on neutralised laps |
| No green-flag target | **Art. 55.7** | `target_lap_time_s = None` |

**`overtake_prob = 0` is not an approximation.** N12 models a *racing* overtake. Of the eight exceptions in 55.8, only "(h) a car slows with an obvious problem" yields a real classified position gain, and N12 has no feature for it. Meanwhile every input it does use is regulation-corrupted: DRS is disabled, the gap compresses toward ten car lengths (55.7/55.10), and `pace_delta` collapses to the FIA ECU delta. The model is not imprecise under an SC, it is **inapplicable**.

**`drs_window` was live and lying.** It is a bare `gap < 1.0` test, so a bunched field reported an open DRS window on exactly the laps where the regulation shuts it.

**`target_lap_time_s` is the subtle one**, and it is forced at the assembly because that is the layer emitting it. It is grounded in N06's **green-flag** pace, and Art. 55.7 requires drivers to stay **above** the FIA ECU minimum time. Shipping it **instructs the driver to earn a penalty**. The delta is not in our telemetry, so there is nothing to substitute: `None` is forced by **absence of a source**, not by a strategy view. That test is what separates a fact from an opinion, and it is why this one earns a rail while the action does not.

## Deliberately not done

- **`scenario_scores.best != action` is legal, not a bug.** The three-layer design exists so synthesis can disagree with the MC argmax. Forcing agreement would install a *new* opinion-rail, backed by a known-biased MC (see below).
- **`pace_mode`** cannot express "run to the delta" (`PUSH | NEUTRAL | MANAGE | LIFT_AND_COAST`). Forcing `NEUTRAL` would invent an opinion to paper over a schema gap. Logged, not forced.

## Checks

- `tests/test_sc_regulatory_rails.py`: **6 passed**, written to fail against the old code first (confirmed).
- Full suite: **187 passed**. One pre-existing failure (`test_cli_no_llm_smoke`, a Windows cp1252 stdout-capture issue) fails identically on `dev` with these changes stashed.
- `ruff check .` + `ruff format --check .` green repo-wide.

Refs #464
