### PR TITLE
fix(N28): refuse to score an undercut against a car that is not racing

### DIFF
--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -622,6 +622,51 @@ class PitStrategyAgent:
         if not self._compounds_are_dry(comp_x, comp_y):
             return None
 
+        # A row with no Position cannot be scored. `pos_gap` is N16's single strongest
+        # feature (gain 0.690) and is built from both positions, so a NaN there is not a
+        # degraded prediction: LightGBM routes it down its missing branch and returns a
+        # confident-looking number computed from nothing.
+        #
+        # The defaults below cannot catch this: `Series.get(k, default)` returns the
+        # STORED value including NaN, and only falls back when the COLUMN is absent. So
+        # a crashed car whose Position is NaN sails straight through. That is the #428
+        # sentinel bug wearing a different column, and the rule is the same: refuse,
+        # never default to a number the model will read as a real reading (#462).
+        pos_x = x_row.get('Position')
+        pos_y = y_row.get('Position')
+        if pd.isna(pos_x) or pd.isna(pos_y):
+            logger.warning(
+                'Undercut features refused: %s or %s has no position at lap %s '
+                '(retired, or not classified on that lap)',
+                driver_x, driver_y, lap_number,
+            )
+            return None
+
+        # The position check above only catches a car whose last row happens to carry a
+        # NaN. It misses the worse case: BEA retired on lap 41 at Lusail, and at lap 50
+        # `_get_lap_row`'s unbounded prior-lap fallback returns his lap-41 row, complete,
+        # with Position 19.0. The features then build with no NaN and no warning: a
+        # confident undercut probability against a car in the garage, from 9-lap-stale
+        # telemetry.
+        #
+        # No staleness threshold can separate the two. Measured across 2025: a car that
+        # FINISHED can have its last known lap lag by 20 (RUS at Sakhir, because the
+        # featured frame drops SC/pit/out laps), while this bug fires at 9. The ranges
+        # overlap, so any bound that catches BEA also declares RUS retired.
+        #
+        # The only sound signal is presence: RaceStateManager builds `rivals` from the
+        # per-lap rows, so a car that is gone is simply absent. `_live_drivers` carries
+        # that set when we were run from a lap_state. When it is absent (direct calls,
+        # tests) we cannot know, and fall through rather than guess.
+        live = getattr(self, '_live_drivers', None)
+        if live is not None and driver_y not in live:
+            logger.warning(
+                'Undercut features refused: %s is not on track at lap %s '
+                '(absent from the lap_state rivals)',
+                driver_y, lap_number,
+            )
+            return None
+
         gp_name    = self.session_meta.get('gp_name', '')
         year       = self.session_meta.get('year', 2025)
         total_laps = self.session_meta.get('total_laps', 57)
@@ -752,6 +797,18 @@ class PitStrategyAgent:
             Returns:
                 "P(undercut_success)={prob:.3f} | threshold={threshold} | pos_gap={gap:.0f} | tyre_life_diff={diff:+.0f} laps | verdict={YES/NO}"
             """
+            # The LLM picks driver_y as free text, so it can name any car on the grid,
+            # including one that is no longer in the race. Answer with an error rather
+            # than a probability: a number here reads as a finding, and the model has
+            # no way to tell an invented target from a real one.
+            live = getattr(agent, '_live_drivers', None)
+            if live is not None and driver_y not in live:
+                return (
+                    f'Undercut scoring REFUSED — {driver_y} is not on track at lap '
+                    f'{lap_number}. Cars in the race this lap: {", ".join(sorted(live))}. '
+                    f'Pick a target from that list.'
+                )
+
             feat_df = agent._build_undercut_features(driver_x, driver_y, lap_number)
             if feat_df is None:
                 return (
@@ -977,6 +1034,17 @@ class PitStrategyAgent:
 
         team_lookup = {r['driver']: r.get('team', 'Unknown') for r in rivals}
         team_lookup[driver] = team
+
+        # Who is actually on track this lap. RaceStateManager builds `rivals` from the
+        # per-lap rows, so a car that has retired simply is not in it; this is the same
+        # answer a timing screen gives, and the only one available without guessing.
+        #
+        # It matters because score_undercut_tool takes a free-text driver code from the
+        # LLM, which can name anyone on the grid. Without this, undercutting HUL at
+        # Lusail lap 40 (he crashed on lap 7) scores happily, and worse: BEA retired on
+        # lap 41, so at lap 50 the features come out complete, with no NaN and no
+        # warning, describing a car sitting in the garage (#462).
+        self._live_drivers = {r['driver'] for r in rivals if r.get('driver')} | {driver}
 
         self.laps_df = laps_df.copy()
         if 'LapNumber' in self.laps_df.columns:

--- a/tests/test_undercut_targets_are_on_track.py
+++ b/tests/test_undercut_targets_are_on_track.py
@@ -1,0 +1,89 @@
+"""N28 must not score an undercut against a car that is no longer racing.
+
+The bug that opened this epic: the pit wall recommended "undercut HUL" at Lusail lap 7,
+having watched HUL crash on lap 6 and cause the Safety Car it was reacting to. That was
+fixed in the rivals list, and N28 does not use the rivals list: it queries ``laps_df``
+directly, so it kept its own copy of the bug.
+
+Two distinct failures, and only one of them is loud:
+
+* **HUL at lap 40** — his last row carries a NaN position, and ``pos_gap`` (N16's single
+  strongest feature, gain 0.690) comes out NaN. LightGBM routes it down the missing
+  branch and answers anyway.
+* **BEA at lap 50** — he retired on lap 41, and ``_get_lap_row``'s unbounded prior-lap
+  fallback hands back that complete row, position 19.0 and all. **No NaN, no warning**:
+  a confident probability against a car in the garage, from 9-lap-stale telemetry.
+
+No staleness threshold separates them. Measured across 2025, a car that FINISHED can
+have its last known lap lag by 20 (RUS at Sakhir: the featured frame drops SC, pit and
+out laps), while this bug fires at 9. The ranges overlap. The only sound signal is
+presence: RaceStateManager builds ``rivals`` from the per-lap rows, so a car that is
+gone is simply absent, which is the same answer a timing screen gives.
+"""
+
+from __future__ import annotations
+
+from itertools import islice
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.agents.pit_strategy_agent import PitStrategyAgent
+
+RACE_DIR = Path("data/raw/2025/Lusail")
+
+pytestmark = pytest.mark.skipif(
+    not (RACE_DIR / "laps.parquet").exists(),
+    reason="needs the raw Lusail parquet (data/ is pulled from HF, not in git)",
+)
+
+
+@pytest.fixture(scope="module")
+def agent_at_lap_50():
+    """N28 wired exactly as ``run_from_state`` wires it, at Lusail lap 50."""
+    from src.simulation.replay_engine import RaceReplayEngine
+
+    replay = RaceReplayEngine(RACE_DIR, driver_code="NOR", team="McLaren")
+    lap_state = next(islice(replay.replay(), 49, 50))
+
+    agent = PitStrategyAgent()
+    agent.laps_df = pd.read_parquet(RACE_DIR / "laps.parquet")
+    agent.laps_df["LapNumber"] = agent.laps_df["LapNumber"].astype(int)
+    agent.session_meta = {"gp_name": "Lusail", "year": 2025, "total_laps": 57, "team_lookup": {}}
+    agent._live_drivers = {r["driver"] for r in lap_state["rivals"] if r.get("driver")} | {"NOR"}
+    return agent
+
+
+def test_a_car_that_retired_is_absent_from_the_lap_state(agent_at_lap_50):
+    """The premise: RSM already knows who is racing. HUL crashed L7, BEA retired L41."""
+    live = agent_at_lap_50._live_drivers
+    assert "HUL" not in live
+    assert "BEA" not in live
+    assert "PIA" in live, "the fixture is wrong if the leader is not on track"
+
+
+@pytest.mark.parametrize("target", ["HUL", "BEA"])
+def test_undercut_features_refuse_a_car_that_is_not_racing(agent_at_lap_50, target):
+    """Refuse, do not default. A number here reads as a finding."""
+    assert agent_at_lap_50._build_undercut_features("NOR", target, 50) is None
+
+
+def test_a_live_rival_still_scores(agent_at_lap_50):
+    """The guard must not buy safety by refusing everything."""
+    features = agent_at_lap_50._build_undercut_features("NOR", "PIA", 50)
+    assert features is not None
+    assert not pd.isna(features["pos_gap"].iloc[0])
+
+
+def test_the_position_default_cannot_mask_a_missing_value():
+    """``Series.get(k, default)`` returns the STORED value, including NaN.
+
+    The default only fires when the COLUMN is absent, never when the VALUE is. That is
+    why five call sites believed they had a safety net that could not fire, and it is
+    the #428 sentinel bug wearing a different column.
+    """
+    row = pd.Series({"Position": float("nan"), "Driver": "HUL"})
+    assert pd.isna(row.get("Position", 10)), (
+        "if this ever returns 10, pandas changed and the guards can be simplified"
+    )

--- a/tests/test_undercut_targets_are_on_track.py
+++ b/tests/test_undercut_targets_are_on_track.py
@@ -29,19 +29,22 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from src.agents.pit_strategy_agent import PitStrategyAgent
-
 RACE_DIR = Path("data/raw/2025/Lusail")
+ROOT = Path(__file__).parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
 
+# Importing N28 reads model configs at import time, and the fixture needs the raw
+# parquet. data/ is pulled from Hugging Face, so the CI runner has neither.
 pytestmark = pytest.mark.skipif(
-    not (RACE_DIR / "laps.parquet").exists(),
-    reason="needs the raw Lusail parquet (data/ is pulled from HF, not in git)",
+    not (_HAS_MODELS and (RACE_DIR / "laps.parquet").exists()),
+    reason="needs data/models/ and the raw Lusail parquet (data/ comes from HF, not git)",
 )
 
 
 @pytest.fixture(scope="module")
 def agent_at_lap_50():
     """N28 wired exactly as ``run_from_state`` wires it, at Lusail lap 50."""
+    from src.agents.pit_strategy_agent import PitStrategyAgent
     from src.simulation.replay_engine import RaceReplayEngine
 
     replay = RaceReplayEngine(RACE_DIR, driver_code="NOR", team="McLaren")


### PR DESCRIPTION
## The bug that opened this epic is not dead. It moved.

#428/#430 fixed the **rivals list**. N28 does not use the rivals list: it queries `laps_df` directly, so it kept its own copy of the bug. Found by the epic's final adversarial audit; verified here against the real Lusail 2025 parquet.

## Two failures, and only one of them is loud

| | what happens | |
|---|---|---|
| **HUL at lap 40** (crashed lap 7) | his last row carries a NaN position, so `pos_gap` comes out **NaN** | LightGBM routes it down the missing branch and answers anyway |
| **BEA at lap 50** (retired lap 41) | `_get_lap_row`'s unbounded prior-lap fallback returns his complete lap-41 row, **position 19.0** | **no NaN, no warning**: `pos_gap=-14.0`, a confident probability against a car in the garage, from 9-lap-stale telemetry |

`pos_gap` is N16's single strongest feature (gain 0.690).

## Why the existing defaults could never have caught it

```python
float(x_row.get('Position', 10))   # returns nan, not 10
```

**`Series.get(k, default)` returns the STORED value, including NaN.** The default only fires when the *column* is absent, never when the *value* is. Five call sites believed they had a safety net that cannot fire. Same shape as the #428 sentinel, different column.

## Why no staleness threshold works either

The obvious fix is "if the last known row is more than N laps old, the car is gone". Measured across all of 2025:

- a car that **finished** can have its last known lap lag by **20** (RUS at Sakhir, because the featured frame drops SC/pit/out laps),
- this bug fires at **9** (BEA).

**The ranges overlap.** Any bound that catches BEA declares RUS retired. There is no number.

## The fix: ask who is on track, don't infer who retired

`RaceStateManager` builds `rivals` from the per-lap rows, so a car that is gone is simply **absent** — the same answer a timing screen gives, and it needs no classification, no threshold and no new data source. It also handles the lapped-finisher edge case for free: at lap 50 a car a lap down is present; at lap 57 it is not, and it is indeed not racing lap 57.

`run_from_state` now records that set, and **both** consumers check it:

- **`_build_undercut_features`** refuses (with a warning) when the target is not on track, and separately when either position is NaN.
- **`score_undercut_tool`** needed it independently: it takes a **free-text driver code from the LLM**, so it could name anyone on the grid and route around the one `dropna()` gate that existed. It now returns an error naming the cars actually racing, because a probability reads as a finding and the model cannot tell an invented target from a real one.

When `_live_drivers` is absent (direct calls, tests) it falls through rather than guessing.

## Checks

Against the real parquet, at Lusail lap 50 (18 cars on track):

```
NOR vs HUL  -> REFUSED  ("has no position at lap 50")
NOR vs BEA  -> REFUSED  ("is not on track at lap 50")
NOR vs PIA  -> BUILT, pos_gap=3.0        <- the live case still works
```

`tests/test_undercut_targets_are_on_track.py` pins all of it, including a test that asserts `Series.get` still returns NaN (so the guards can be simplified if pandas ever changes). 11 tests pass; `ruff check .` + `format --check .` green.

Refs #462
