### PR TITLE
fix(N26): scope the TCN window to this stint, up to now, and zero-pad as trained

### DIFF
--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -790,7 +790,20 @@ class TireAgent:
         if len(scaled) >= window:
             seq = scaled[-window:]
         else:
-            pad = np.tile(scaled[0], (window - len(scaled), 1))
+            # Left-ZERO-pad, verbatim from N09's `_pad_or_truncate`:
+            #   pad = np.zeros((window - L, F)); seq = np.concatenate([pad, arr])
+            # This used to tile the stint's first lap instead. Windows are 28-31 laps and
+            # the median stint is 21-23, so the pad branch is the COMMON path, not the
+            # fallback: measured at Barcelona 2024, 97% of calls take it. The TCN's
+            # receptive field (61) exceeds the window, so the padding reaches the output.
+            #
+            # Repeating a real lap tells the model the car ran 20 identical laps before
+            # the stint began, which is a fiction it never saw in training; zeros are the
+            # scaled-space "no data" it did see. Measured: the tile-pad put 87% of
+            # predictions outside the training target's 5-95% band (mean -29.97 s of
+            # cumulative degradation against a band of [-5.80, +2.46]), and flipped
+            # `warning_level` on 10.5% of laps.
+            pad = np.zeros((window - len(scaled), scaled.shape[1]), dtype=scaled.dtype)
             seq = np.vstack([pad, scaled])
 
         return torch.tensor(seq, dtype=torch.float32).unsqueeze(0)  # (1, window, 42)
@@ -816,14 +829,35 @@ class TireAgent:
             f'{driver}_compound',
             driver_laps['Compound'].iloc[-1] if len(driver_laps) > 0 else 'MEDIUM',
         )
-        stint = (
-            self.laps_df[
-                (self.laps_df['Driver']   == driver) &
-                (self.laps_df['Compound'] == compound) &
-                (self.laps_df['TyreLife'] <= tyre_life)
-            ]
-            .sort_values('LapNumber')
+        mask = (
+            (self.laps_df['Driver']   == driver) &
+            (self.laps_df['Compound'] == compound) &
+            (self.laps_df['TyreLife'] <= tyre_life)
         )
+
+        # Scope to THIS stint and to laps that have already happened. N10 built its
+        # training windows grouped by ['Year','GP_Name','DriverNumber','Stint'] (cell 10),
+        # and matching on Compound alone does not reproduce that: a driver runs the same
+        # compound in more than one stint 26% of the time, so a later stint joined the
+        # window, and with no lap bound those laps had not happened yet.
+        #
+        # Measured on 2024 (26,606 decision points): 37.5% of windows mixed stints and
+        # 17.2% contained FUTURE laps. HAM at Barcelona lap 16 got [1..16, 44..59], and
+        # `deg_rate` is read as the window's last row, so the agent reported lap 59's
+        # degradation while the car was on lap 16. That flips `warning_level`, which is
+        # the orchestrator's routing key, so it also decides whether N28 runs at all.
+        #
+        # Both keys are optional: the FastF1 path does not supply them and keeps its old
+        # behaviour rather than breaking.
+        current_stint = self.session_meta.get(f'{driver}_stint')
+        if current_stint is not None and 'Stint' in self.laps_df.columns:
+            mask &= (self.laps_df['Stint'] == current_stint)
+
+        current_lap = self.session_meta.get('current_lap')
+        if current_lap is not None and 'LapNumber' in self.laps_df.columns:
+            mask &= (self.laps_df['LapNumber'] <= current_lap)
+
+        stint = self.laps_df[mask].sort_values('LapNumber')
         return stint if len(stint) > 0 else None
 
     # ── LangChain tool factory ────────────────────────────────────────────────
@@ -933,9 +967,21 @@ class TireAgent:
             threshold        = CLIFF_THRESHOLD.get(compound_id, 2.5)
             remaining_budget = max(0.0, threshold - mean_pred)
 
-            p50 = remaining_budget / deg_rate
-            p10 = max(0.0, (remaining_budget - total_std) / deg_rate)
-            p90 = (remaining_budget + total_std) / deg_rate
+            # Flooring the divisor without clamping the quotient produced cliffs beyond
+            # any possible race: HAM at Austin reported "P50: 27375.2 laps, OK". The floor
+            # fires by construction on a stint's first two laps (`_add_degradation_rate`
+            # shifts and fills 0), and measured over six 2024 GPs it fires on 10.5% of
+            # decision points, 11.8% of which yield >200 laps. The failure mode is "never
+            # pit", precisely when the model has no signal.
+            #
+            # A cliff past the chequered flag is operationally "not this race", so the
+            # race distance is the honest ceiling: it says the same thing without looking
+            # like a reading. Nothing is invented — the bound is the race itself.
+            cliff_ceiling = float(agent.session_meta.get('total_laps', 100) or 100)
+
+            p50 = min(remaining_budget / deg_rate, cliff_ceiling)
+            p10 = min(max(0.0, (remaining_budget - total_std) / deg_rate), cliff_ceiling)
+            p90 = min((remaining_budget + total_std) / deg_rate, cliff_ceiling)
 
             to = TireOutput(
                 compound=compound_id,
@@ -1123,6 +1169,16 @@ class TireAgent:
             'Humidity':  wx.get('humidity',   50.0),
             'Rainfall':  float(wx.get('rainfall', 0)),
             f'{driver}_compound': compound,
+            # The stint we are actually in, and the lap we are actually on. N10 trained
+            # on windows grouped by ['Year','GP_Name','DriverNumber','Stint'], and the
+            # slice below had neither: it matched on Compound alone, so a later stint on
+            # the same compound joined the window, and nothing bounded it to the past.
+            # At Barcelona 2024 lap 16, HAM's window ran [1..16, 44..59] and the TCN read
+            # LAP 59's degradation as current. Both keys travel here rather than through
+            # the signature so the FastF1 path, which has neither, degrades to the old
+            # behaviour instead of breaking (#449).
+            f'{driver}_stint': d.get('stint'),
+            'current_lap': lap_state.get('lap_number'),
         }
 
         return self._run_core(driver, compound_id, tyre_life, gp_name)


### PR DESCRIPTION
## The never-audited file disagreed with its own training notebook, twice

Found by the audit of the areas the previous adversarial pass admitted it left unswept. `tire_agent.py` had never been looked at. Its verdict on these two: *"the difference between the N26 tyre agent being a model and being noise"*.

## 1. The window was fed laps from the FUTURE

`_get_driver_stint` matched on `Driver` + `Compound` + `TyreLife <= tyre_life`. **No `Stint` filter. No lap bound.** N09/N10 build training windows grouped by `['Year','GP_Name','DriverNumber','Stint']`.

A driver runs the same compound in more than one stint **26% of the time**, so a later stint joined the window, and with nothing bounding it to the past those laps had not happened yet.

Reproduced against the real parquet, **HAM at Barcelona 2024, on lap 16**:

```
the slice fed to the TCN: 32 rows | stints [1.0, 3.0]
lap numbers: [1..16, 44..59]
the TCN's "most recent lap" = L59       <- the car is on L16
16 of the 32 rows had not happened yet
```

`deg_rate` is read as the window's **last** row, so the agent reported **lap 59's** degradation while the car was on lap 16. Season-wide on 2024 (26,606 decision points): **37.5% of windows mixed stints, 17.2% contained future laps**, worst race São Paulo at 48.1%.

`warning_level` is the orchestrator's routing key (`_decide_agents_to_call(tire_warning=...)`), so this also decided **whether N28 ran at all**.

**After:** 16 rows, stint 1 only, ending at lap 16.

## 2. The padding contradicted the training contract on 97% of calls

N09's `_pad_or_truncate`, verbatim:
```python
pad = np.zeros((window - L, F), dtype=np.float32)   # left-ZERO-pad
```
Inference tiled the stint's **first lap** instead. Windows are 28-31 laps and the median stint is 21-23, so **the pad branch is the common path, not the fallback** — measured at Barcelona, **1210/1248 = 97%** of calls take it. The TCN's receptive field (61) exceeds the window, so the padding reaches the output.

Repeating a real lap tells the model the car ran 20 identical laps before the stint began: a fiction it never saw. Zeros are the scaled-space "no data" it did. Measured:

```
predicted cumulative deg — training target 5-95% band = [-5.80, +2.46]
  tile-pad (shipped): mean -29.97  min -69.95  | 87% OFF-MANIFOLD
  zero-pad (trained): mean  -7.18  min -30.94  | 53% off-manifold
warning_level FLIPS: 127/1210 = 10.5%
```

At 94% padding the old path predicted **-52.7 s** of cumulative degradation where the trained contract gives -7.5 s, and `remaining_budget = max(0, 2 - (-52.7)) = 54.7 s` — **the tyre read as immortal**.

## 3. Also: the laps-to-cliff quotient had no ceiling

```python
deg_rate = max(abs(rate), 0.001)   # divisor floored
p50 = remaining_budget / deg_rate  # quotient not clamped
```

Real output: **"Laps to cliff — P50: 27375.2 | Warning level: OK"**. The floor fires by construction on a stint's first two laps (`_add_degradation_rate` shifts and fills 0) and on **10.5%** of decision points across six 2024 GPs, of which **11.8%** yield >200 laps. The failure mode is **"never pit"**, and it fires exactly when the model has no signal.

Clamped to the race distance: a cliff past the chequered flag is operationally "not this race", so it says the same thing without looking like a reading. Nothing is invented — the bound is the race itself.

## How the keys travel

`Stint` and the current lap go through `session_meta`, the same channel the compound already uses, **not** through the signature. The FastF1 path has neither and keeps its old behaviour rather than breaking (#449's lesson).

## Checks

- HAM Barcelona L16: 32 rows / stints [1,3] / last lap 59 → **16 rows / stint 1 / last lap 16**.
- The tensor builder zero-pads and no `np.tile` survives (asserted).
- Full suite: **192 passed**, 1 skipped. `ruff check .` + `format --check .` green.

Refs #449
