### PR TITLE
fix(orchestrator): stop the LLM overriding the validated undercut target

### DIFF
--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -33,6 +33,7 @@ Liu et al. (2024) arXiv:2402.02392 — DeLLMa decision under uncertainty with LL
 """
 
 import json
+import logging
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
@@ -43,6 +44,8 @@ from typing import Literal, Optional
 import numpy as np
 import pandas as pd
 from pydantic import BaseModel, ConfigDict, Field
+
+logger = logging.getLogger(__name__)
 
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve()
@@ -1202,12 +1205,35 @@ def _run_conditional_agents(
 # Post-LLM assembly helper
 # ==============================================================================
 
+def _live_drivers_from(lap_state: dict | None) -> set | None:
+    """The cars on track this lap, or None when we cannot tell.
+
+    RaceStateManager builds ``rivals`` from the per-lap rows, so a car that has retired
+    is simply absent: the same answer a timing screen gives, and the only sound one.
+    No staleness threshold works, because the featured frame drops SC, pit and out laps,
+    so a car that FINISHED can have its last known lap lag by 20 while a retirement shows
+    up at 9 — the ranges overlap (#462).
+
+    Returns None rather than an empty set when there is no lap_state, so callers can tell
+    "nobody is racing" from "we do not know" and fall through instead of rejecting all.
+    """
+    if not lap_state:
+        return None
+    rivals = lap_state.get('rivals') or []
+    live = {r['driver'] for r in rivals if r.get('driver')}
+    own = (lap_state.get('session_meta') or {}).get('driver')
+    if own:
+        live.add(own)
+    return live or None
+
+
 def _assemble_recommendation(
     synth:              "_LLMSynthesis",
     pit_out,
     mc_results:         dict,
     regulation_context: str,
     sc_currently_active: bool = False,
+    live_drivers:       set | None = None,
 ) -> "StrategyRecommendation":
     """Merge the LLM synthesis with N28 pit data and attach grounding fields.
 
@@ -1248,7 +1274,24 @@ def _assemble_recommendation(
 
     pit_lap_target  = synth.pit_lap_target  if synth.pit_lap_target  is not None else fallback_lap
     compound_next   = synth.compound_next   if synth.compound_next   is not None else fallback_cmpd
-    undercut_target = synth.undercut_target if synth.undercut_target is not None else fallback_target
+    # N28's target wins, always. It is the one that went through score_undercut_tool's
+    # `_live_drivers` check; the synthesis field is free text the orchestrator LLM typed,
+    # and the prompt even seeds it with a literal example ("e.g. SAI"). Letting the LLM
+    # win made that check dead code: #462's fix never reached the output. The LLM may
+    # only fill the field when N28 produced nothing, and only if it names a car that is
+    # actually racing — an unvalidated code ends up rendered on the pit wall as
+    # "UCUT: SAI".
+    if fallback_target is not None:
+        undercut_target = fallback_target
+    elif synth.undercut_target is not None and synth.undercut_target in (live_drivers or ()):
+        undercut_target = synth.undercut_target
+    else:
+        if synth.undercut_target is not None:
+            logger.warning(
+                "Discarding LLM undercut_target %r: not on track this lap (live: %s)",
+                synth.undercut_target, sorted(live_drivers or ()),
+            )
+        undercut_target = None
 
     # The action is the synthesis's, always. There used to be an SC rail here forcing
     # STAY_OUT -> PIT_NOW, and it was an opinion wearing a rail's clothes: one race
@@ -1377,6 +1420,7 @@ def run_strategy_orchestrator(
     return _assemble_recommendation(
         synth, pit_out, mc_results, regulation_context,
         sc_currently_active = situation_out.sc_currently_active,
+        live_drivers        = _live_drivers_from(lap_state),
     )
 
 
@@ -1504,4 +1548,5 @@ def run_strategy_orchestrator_from_state(
     return _assemble_recommendation(
         synth, pit_out, mc_results, regulation_context,
         sc_currently_active = situation_out.sc_currently_active,
+        live_drivers        = _live_drivers_from(lap_state),
     )

--- a/tests/test_undercut_targets_are_on_track.py
+++ b/tests/test_undercut_targets_are_on_track.py
@@ -90,3 +90,35 @@ def test_the_position_default_cannot_mask_a_missing_value():
     assert pd.isna(row.get("Position", 10)), (
         "if this ever returns 10, pandas changed and the guards can be simplified"
     )
+
+
+def test_the_orchestrator_llm_cannot_ship_a_retired_undercut_target():
+    """N28's validated target wins; the LLM's free text only fills a gap, and only if live.
+
+    `score_undercut_tool` checks its target against the cars on track. The orchestrator
+    LLM then writes the SAME field from free text, and the prompt seeds it with a literal
+    example ("e.g. SAI"). Preferring the LLM's value made that check dead code: the
+    validated answer was computed and then overwritten by an unchecked string, which the
+    arcade renders as "UCUT: <name>".
+    """
+    from itertools import islice
+
+    from src.agents.strategy_orchestrator import _assemble_recommendation, _live_drivers_from
+    from src.simulation.replay_engine import RaceReplayEngine
+    from src.strategy.inference.no_llm import _deterministic_synthesis
+
+    replay = RaceReplayEngine(RACE_DIR, driver_code="NOR", team="McLaren")
+    live = _live_drivers_from(next(islice(replay.replay(), 49, 50)))
+    mc_results = {"UNDERCUT": {"score": 0.4}}
+
+    # HUL crashed on lap 7. The LLM names him anyway.
+    synthesis = _deterministic_synthesis("UNDERCUT", None)
+    synthesis.undercut_target = "HUL"
+    rec = _assemble_recommendation(synthesis, None, mc_results, "", live_drivers=live)
+    assert rec.undercut_target is None, "a car that crashed 43 laps ago reached the pit wall"
+
+    # A car that is racing survives.
+    synthesis_live = _deterministic_synthesis("UNDERCUT", None)
+    synthesis_live.undercut_target = "PIA"
+    rec_live = _assemble_recommendation(synthesis_live, None, mc_results, "", live_drivers=live)
+    assert rec_live.undercut_target == "PIA"


### PR DESCRIPTION
## The #462 fix was dead on arrival

Found by the audit of the unswept areas, and it is the most valuable finding per line changed: it **re-arms a fix that shipped this morning and never did anything**.

`score_undercut_tool` checks its target against the cars actually on track. Then the orchestrator LLM writes the **same field** from free text, and the assembly preferred the LLM's value:

```python
fallback_target = pit_out.undercut_target if pit_out else None
undercut_target = synth.undercut_target if synth.undercut_target is not None else fallback_target
```

So the validated answer was computed and immediately **overwritten by an unchecked string**.

The prompt makes it worse. It tells the LLM to emit a rival code, **seeds it with a literal example** (`e.g. SAI`), and says to prefer N28's *"when available"* — which reads as *invent one otherwise*. And `grep -rn "field_validator|model_validator|@validator" src/agents/` returns **zero hits**, so nothing downstream checks it either. It lands in `StrategyRecommendation.undercut_target` and the arcade renders it as **"UCUT: SAI"**.

Concrete scenario: N28 is not activated that lap (`pit_block = "[N28 Pit] not activated"`), the LLM picks UNDERCUT and echoes the prompt's own example → the pit wall is told to undercut **SAI**, who may not be in the race.

## The fix

**N28's target wins whenever it exists.** The LLM may only fill the field when N28 produced nothing, and only if it names a car in `live_drivers` — the same presence signal N28 uses (RaceStateManager's `rivals`, which omits cars that are gone), threaded in via `_live_drivers_from`.

`_live_drivers_from` returns `None` rather than an empty set when there is no `lap_state`, so a caller that genuinely cannot know falls through instead of rejecting everything.

## Checks

Real parquet, Lusail lap 50 (18 cars on track):

```
LLM says 'undercut HUL' (crashed on lap 7) -> shipped None, with a warning
LLM says 'undercut PIA' (racing)          -> shipped 'PIA'
```

Pinned in `tests/test_undercut_targets_are_on_track.py`; 6 passed. `ruff check .` + `format --check .` green.

Refs #462