### PR TITLE
fix(cli): feed the PMV the real overtake gap, and give the augmentation one home

### DIFF
--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -1334,9 +1334,18 @@ def run(args: argparse.Namespace) -> None:
 
     _load_tire_alloc(_REPO_ROOT)
 
+    from src.f1_strat_manager.laps_augment import augment_featured_laps
+
     # ── Load data ────────────────────────────────────────────────────────────
     with console.status("[dim]Loading parquets…[/dim]", spinner="dots"):
-        laps_df = pd.read_parquet(featured_path)
+        # Never read the featured parquet raw: N04 drops `Time` (session elapsed) and no
+        # published featured parquet carries a `Time_s`, while N11 trains its overtake
+        # gap on exactly that column. Without the merge the agent falls back to a single
+        # lap's LapTime delta, and at Lusail 2024 that fed the model a 0.453 s mean gap
+        # against a real 3.113 s, flagging 91.1% of pairs as "in the DRS window" where
+        # the truth is 20.5%. Worst pair: BOT vs LAW on lap 27, told 0.130 s, real gap
+        # 21.066 s. The backend's loader had this fix; this surface did not.
+        laps_df = augment_featured_laps(pd.read_parquet(featured_path), args.year)
         engine = RaceReplayEngine(race_dir, args.driver, args.team, interval_seconds=args.interval)
 
     # ── Static OpenF1 radio corpus (replaces --radio-every when available) ───

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -464,6 +464,12 @@ class PitStrategyAgent:
         self.cfg: PitAgentCFG      = PitAgentCFG()
         self.laps_df: pd.DataFrame = pd.DataFrame()
         self.session_meta: dict    = {}
+        # The cars on track this lap, or None when we do not know. This agent is a module
+        # singleton (`_get_default_pit_agent`), so it MUST be initialised here and reset
+        # on every entry point: left over from a previous call it would validate targets
+        # against another race's roster, refusing live cars or admitting dead ones. None
+        # means "unknown", which disables the guard rather than rejecting everything.
+        self._live_drivers: set | None = None
         self._react_agent          = None
         self._tools: list          = self._build_tools()
 
@@ -986,6 +992,15 @@ class PitStrategyAgent:
         laps               = session.laps.pick_accurate().copy()
         laps['LapNumber']  = laps['LapNumber'].astype(int)
         self.laps_df       = laps
+
+        # Who is on track this lap. This agent is a module singleton, so leaving the
+        # previous call's roster in place would validate targets against another race.
+        # A car that is gone has no row for the lap, which is the same presence signal
+        # RaceStateManager's `rivals` gives the other entry point (#462). Empty means we
+        # could not tell, so it stays None and the guard disables rather than rejecting
+        # every target.
+        _at_lap = laps.loc[laps['LapNumber'] == lap_number, 'Driver'].dropna()
+        self._live_drivers = set(_at_lap) | {driver} if len(_at_lap) else None
 
         team_lookup = (
             laps[['Driver', 'Team']].drop_duplicates()

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -1253,17 +1253,32 @@ def _assemble_recommendation(
       the regulatory basis for the action without re-querying N30.
 
     --- WHERE TO CHANGE IF THE SC POLICY CHANGES ---
-    sc_currently_active carries N27's verdict so the Safety-Car guard-rail can
-    be enforced HERE, on the final answer. N28 already refuses to stay out under
-    a deployed SC (pit_strategy_agent.py, same condition and tag), but its action
-    only ever reached the LLM as prompt TEXT — the orchestrator returned
-    synth.action verbatim, so a synthesis that ignored the deterministic signal
-    silently won. That is exactly the STAY_OUT-under-SC failure the Qatar 2025
-    case (thesis 6.3) exists to prevent, and docs/pages/multi-agent.md already
-    promises this rail "so a misbehaving LLM can't override the deterministic
-    signal". This makes the code honour the rule the project already adopted one
-    layer down. Defaults to False so any caller that does not thread N27's output
-    keeps the previous behaviour rather than silently changing it.
+    **There is no action rail here, and there must not be one.** A rail may encode what
+    the FIA regulation makes certain; it may never encode a strategy opinion. Whether to
+    pit under a Safety Car depends on stops already made, laps remaining, gap behind and
+    compounds used — race state, none of it a rule — so it belongs to the model.
+
+    One forcing to a strategy opinion once lived here (STAY_OUT -> PIT_NOW on every SC
+    lap, from the Qatar 2025 case). It was wrong: Art. 55.17 finishes the race behind a
+    late SC with no overtaking, so the position a forced stop surrenders is unrecoverable
+    BY REGULATION, and the pipeline shipped PIT_NOW carrying the guard-rail's own reason
+    "too late to pit". It also silenced its evidence: with an SC deployed sc_prob is 1.0,
+    so every MC draw already receives the full SC_PIT_BONUS, and a STAY_OUT argmax IS the
+    model saying the cheap stop was outweighed.
+
+    What `sc_currently_active` is for, then: the regulatory FACTS. Most live in N27, so
+    every consumer inherits one number (overtake_prob = 0, Art. 55.8; drs_window = 0,
+    Art. 22.1(c)). Only `target_lap_time_s` is forced here, because this is the layer
+    that emits it — see the note at its assignment below. Add a new fact only if the
+    regulation removes the field's SOURCE; if it merely makes a choice usually smart,
+    it belongs in the prompt or the MC. See tests/test_sc_regulatory_rails.py.
+
+    Defaults to False so a caller that does not thread N27's output keeps the previous
+    behaviour rather than silently changing it.
+
+    `live_drivers` carries the cars on track so the LLM's free-text undercut_target can
+    be checked. **None means "unknown", not "nobody"** — a caller without a lap_state
+    cannot know, so its target passes rather than being silently discarded.
 
     Returns a fully-populated StrategyRecommendation ready for the UI layer.
     """
@@ -1283,14 +1298,21 @@ def _assemble_recommendation(
     # "UCUT: SAI".
     if fallback_target is not None:
         undercut_target = fallback_target
-    elif synth.undercut_target is not None and synth.undercut_target in (live_drivers or ()):
+    elif synth.undercut_target is None:
+        undercut_target = None
+    elif live_drivers is None:
+        # We cannot tell who is racing (no lap_state: the FastF1 path). Rejecting here
+        # would silently discard every LLM target on that path, which is not the same
+        # thing as knowing it is wrong. `None` means unknown; only a real roster may
+        # reject. Collapsing it to an empty set is how a "do not know" turns into a "no".
+        undercut_target = synth.undercut_target
+    elif synth.undercut_target in live_drivers:
         undercut_target = synth.undercut_target
     else:
-        if synth.undercut_target is not None:
-            logger.warning(
-                "Discarding LLM undercut_target %r: not on track this lap (live: %s)",
-                synth.undercut_target, sorted(live_drivers or ()),
-            )
+        logger.warning(
+            "Discarding LLM undercut_target %r: not on track this lap (live: %s)",
+            synth.undercut_target, sorted(live_drivers),
+        )
         undercut_target = None
 
     # The action is the synthesis's, always. There used to be an SC rail here forcing

--- a/src/f1_strat_manager/laps_augment.py
+++ b/src/f1_strat_manager/laps_augment.py
@@ -1,0 +1,162 @@
+"""Restore onto the featured laps frame the columns its producer drops.
+
+**Every consumer of `laps_featured_<year>.parquet` must call `augment_featured_laps`.**
+Reading the parquet directly is a bug, and it has been one three times now.
+
+N04 drops `Time` (session elapsed) with a comment saying it is "already converted to
+`*_s`". It is not: there is no `Time_s` in any published featured parquet. But N11 trains
+its overtake gap as `abs(row_x["Time_s"] - row_y["Time_s"])`, so without it the agent
+falls back to a single lap's LapTime delta, and two cars 20 s apart lapping within 0.5 s
+of each other read as "in the DRS window".
+
+Measured on Lusail 2024, 629 position-adjacent pairs:
+
+    mean gap fed to N12: 0.453 s   |  truth: 3.113 s
+    "in DRS window":     91.1%     |  truth: 20.5%
+    worst pair:  BOT vs LAW L27 -> model told 0.130 s, real gap 21.066 s
+
+This lives in the PARENT package on purpose. It used to live in the telemetry backend's
+loader, which meant the backend was fixed and every other consumer was not: the CLI
+(`f1-sim`, the TFG's PMV) read the parquet straight from disk and shipped the degraded
+gap on 100% of calls. The data layer belongs to whoever owns the data, and the submodule
+consumes it — not the other way round.
+
+`PitInTime` is deliberately NOT restored, though raw has it: a car only carries one on
+the lap it actually pits, and those are precisely the laps N04's `IsAccurate` filter
+drops. Measured: 44/1067 raw Lusail laps have one and 0% survive into featured, so a
+merge could only ever restore nulls. Deriving `active_pitstop_count` from `Stint` /
+`TyreLife` resets is the real answer; faking it with a structurally-empty column is not.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Callable, Dict, Optional
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# Raw column -> the name the models were trained on.
+RAW_COLUMNS_TO_RESTORE: Dict[str, str] = {
+    "Time": "Time_s",  # timedelta -> seconds, matching the trained feature
+    "TrackStatus": "TrackStatus",
+}
+
+_JOIN_KEYS = ["GP_Name", "Driver", "LapNumber"]
+
+# Inverted from gp_slugs.FOLDER_ALIASES (keyed folder -> friendly) so the one place that
+# owns circuit renames stays the one place. Reversing at import keeps this from becoming
+# a second, drifting copy.
+try:
+    from src.f1_strat_manager.gp_slugs import FOLDER_ALIASES as _FOLDER_ALIASES
+
+    _FRIENDLY_TO_FOLDER: Dict[str, str] = {v: k for k, v in _FOLDER_ALIASES.items()}
+except Exception:  # pragma: no cover
+    _FRIENDLY_TO_FOLDER = {"Miami": "Miami_Gardens"}
+
+
+def _default_data_root() -> Path:
+    """The repo's data root, resolved the way the rest of the parent package does."""
+    from src.f1_strat_manager.data_cache import get_data_root
+
+    return get_data_root()
+
+
+def _raw_race_dir(data_root: Path, year: int, gp_name: str) -> Path:
+    """Raw per-race directory for a featured `GP_Name`.
+
+    Three forms have to be tried, and the third is not optional: the raw dirs mostly
+    match `GP_Name` exactly, the underscore variant covers the space-vs-underscore forms
+    FastF1 emits (`Marina Bay` -> `Marina_Bay`), and a small number of circuits were
+    simply renamed on disk (`Miami` -> `Miami_Gardens`). Skipping the rename cost Miami
+    its whole augmentation on the first pass, 3.8% of the season silently unfixed, which
+    is exactly the silent-miss class this work is about.
+    """
+    base = data_root / "raw" / str(year)
+    for candidate in (
+        base / gp_name,
+        base / gp_name.replace(" ", "_"),
+        base / _FRIENDLY_TO_FOLDER.get(gp_name, gp_name),
+    ):
+        if candidate.exists():
+            return candidate
+    return base / gp_name
+
+
+def augment_featured_laps(
+    df: pd.DataFrame,
+    year: int,
+    data_root: Optional[Path] = None,
+    root_resolver: Optional[Callable[[], Path]] = None,
+) -> pd.DataFrame:
+    """Merge `Time_s` / `TrackStatus` onto a featured laps frame, from the raw parquets.
+
+    --- WHERE TO CHANGE IF THE ARTEFACT CHANGES ---
+    This runs at LOAD time on purpose, not as a rewrite of the parquet. The featured
+    parquet is published on Hugging Face and pulled by `scripts/download_data.py`, so a
+    locally-patched file would be silently reverted by the next download; and its only
+    producer is a read-only notebook (N04). Merging here is immune to both: nothing to
+    re-upload, no divergence from the published dataset, no fork of the pipeline.
+
+    The join is safe: `(GP_Name, Driver, LapNumber)` is unique in the featured frame and
+    every featured row is a subset of raw. A race whose raw parquet is absent is skipped
+    with a warning rather than failing — the agents' existing fallbacks then behave as
+    they did before, which is the old status quo rather than a new failure.
+
+    Args:
+        df: A featured laps frame, as read from `laps_featured_<year>.parquet`.
+        year: The season, used to locate the raw per-race directories.
+        data_root: Data root override. The telemetry backend passes its own resolver's
+            answer, since it honours `$F1_STRAT_DATA_ROOT` and a different `.git` walk.
+        root_resolver: Callable form of the same, resolved lazily.
+
+    Returns:
+        The frame with `Time_s` and `TrackStatus` merged on, or unchanged when the raw
+        parquets are unavailable.
+    """
+    if "GP_Name" not in df.columns:
+        return df
+    if "Time_s" in df.columns:
+        return df  # already augmented; do not merge twice
+
+    root = data_root or (root_resolver() if root_resolver else _default_data_root())
+
+    frames = []
+    missing: list[str] = []
+    for gp_name in df["GP_Name"].dropna().unique():
+        path = _raw_race_dir(root, year, str(gp_name)) / "laps.parquet"
+        if not path.exists():
+            missing.append(str(gp_name))
+            continue
+        raw = pd.read_parquet(path)
+        if not set(RAW_COLUMNS_TO_RESTORE).issubset(raw.columns):
+            missing.append(str(gp_name))
+            continue
+        slice_ = raw[["Driver", "LapNumber", *RAW_COLUMNS_TO_RESTORE]].copy()
+        slice_["GP_Name"] = gp_name
+        # `Time` is a session-elapsed timedelta; the models were trained on seconds.
+        slice_["Time"] = pd.to_timedelta(slice_["Time"]).dt.total_seconds()
+        frames.append(slice_.rename(columns=RAW_COLUMNS_TO_RESTORE))
+
+    if missing:
+        logger.warning(
+            "Raw laps unavailable for %d GP(s) in %d: %s — their laps keep the "
+            "degraded behaviour (the overtake gap falls back to a lap-time delta)",
+            len(missing),
+            year,
+            sorted(missing),
+        )
+    if not frames:
+        return df
+
+    augmented = df.merge(pd.concat(frames, ignore_index=True), on=_JOIN_KEYS, how="left")
+    restored = int(augmented["Time_s"].notna().sum())
+    logger.info(
+        "Restored Time_s/TrackStatus onto %d/%d laps of %d from the raw parquets",
+        restored,
+        len(augmented),
+        year,
+    )
+    return augmented


### PR DESCRIPTION
## The PMV was being fed a 0.13 s gap where the real one is 21 s

Found by the **final verification audit**, and it is the epic's key insight for the third time: a fix landed on one path while a sibling kept reading the unaugmented frame.

`#447` restored `Time_s` in the telemetry backend's loader. `scripts/run_simulation_cli.py:1339` does a plain `pd.read_parquet`, and **no published featured parquet carries `Time_s`** — verified across all three years:

```
laps_featured_2023.parquet | Time: False | Time_s: False | TrackStatus: False
laps_featured_2024.parquet | Time: False | Time_s: False | TrackStatus: False
laps_featured_2025.parquet | Time: False | Time_s: False | TrackStatus: False
```

`Time_s` is *created* by the loader. So on the CLI, N11's overtake gap fell back to a lap-time delta on **100% of calls**. Measured, Lusail 2024, 656 position-adjacent pairs:

| | what the CLI fed N12 | truth |
|---|---|---|
| mean gap | **0.488 s** | **3.290 s** |
| "in DRS window" | **89.9%** of pairs | **20.3%** |

The audit's worst pair: **BOT vs LAW, lap 27 — model told 0.130 s, real gap 21.066 s.** `gap_ahead_s`, `drs_window`, `drs_ready_gap` and `gap_pace_product` are all N12 inputs, and `f1-sim` is the TFG's PMV: the demo surface was the one running blind.

## The fix, and why it is not just a call site

The augmentation moves to **`src/f1_strat_manager/laps_augment.py`** in the parent, and the submodule consumes it ([F1_Telemetry_Manager#127](https://github.com/VforVitorio/F1_Telemetry_Manager/pull/127), which deletes 108 lines). The parent owns the data layer; the submodule is a consumer, not the owner.

Putting it behind one function is the point. This bug has now appeared three times — `/lap-state` summing lap times (#437), `_ensure_timedelta_laps` not normalising `Time_s` (#466), and now the CLI — every one of them *"someone read the parquet directly"*. The module docstring says so in the first line: **every consumer must call `augment_featured_laps`; reading the parquet directly is a bug.**

## Also from the same audit

- **`_live_drivers` on a singleton (F4).** `PitStrategyAgent` is a module singleton, and `_live_drivers` was set only in `run_from_state`, never initialised and never set in `run()`. So the FastF1 path either disabled the guard or — after any prior call — validated targets against **a previous race's roster**. Now initialised in `__init__` and set in `run()` from the lap's own rows.
- **`live_drivers=None` meant "unknown" but behaved as "empty" (F5).** My own docstring promised callers could *"fall through instead of rejecting all"*; the code did `synth.undercut_target in (live_drivers or ())`, collapsing `None` to `()` and rejecting everything. A caller that cannot know is not the same as a roster that excludes you.
- **The `WHERE TO CHANGE IF THE SC POLICY CHANGES` block still described the deleted rail as live (F6)**, telling a future maintainer that "N28 already refuses to stay out under a deployed SC". `grep 'sc_currently_active and action'` → 0 hits. Rewritten around what is actually true, including the test that distinguishes a fact from an opinion.

## Checks

- The CLI's frame now carries `Time_s`; mean gap **3.290 s** (was 0.488 s).
- `get_laps_df` still augments: 22,760 rows.
- `live_drivers=None` keeps the LLM's target; a real roster without it still rejects.
- `_live_drivers` is `None` on a fresh agent.
- Full suite **193 passed**; `ruff check .` + `format --check .` green; submodule gate green.

Refs #447, #462
