### PR TITLE
fix(arcade): stop reading the featured parquet raw

### DIFF
--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -33,6 +33,7 @@ from src.arcade.config import (
     TEXT_SECONDARY,
     WARNING,
 )
+from src.f1_strat_manager.laps_augment import augment_featured_laps
 
 logger = logging.getLogger(__name__)
 
@@ -494,11 +495,22 @@ class SimConnector(threading.Thread):
         )
 
     def _load_laps_df(self, year: int) -> pd.DataFrame | None:
+        """Load the featured laps for `year`, augmented, for the agents to consume.
+
+        Never `read_parquet` this file raw. N04 drops `Time` and no published featured
+        parquet carries a `Time_s`, which is the column N11 trains its overtake gap on,
+        so a direct read silently degrades that gap to a lap-time delta: at Lusail the
+        model reads a 0.49 s mean gap where the truth is 3.29 s, and 90% of pairs look
+        like they are in the DRS window when 20% are.
+
+        The backend's loader had this fix and the CLI did not; the arcade did not either.
+        `augment_featured_laps` is the one place that owns it now.
+        """
         path = REPO_ROOT / "data" / "processed" / f"laps_featured_{year}.parquet"
         if not path.exists():
             logger.error("Featured laps parquet missing: %s", path)
             return None
-        return pd.read_parquet(path)
+        return augment_featured_laps(pd.read_parquet(path), year)
 
     @staticmethod
     def _resolve_race_dir(year: int, gp: str):


### PR DESCRIPTION
## The same bug, a fourth time

The final verification audit found the **CLI** reading the featured parquet directly and therefore missing #447's gap fix. Sweeping for the class turned up **the arcade doing exactly the same thing** at `src/arcade/strategy.py:497`, and nobody had looked at it.

Without the merge there is no `Time_s`, so N11's overtake gap degrades to a single lap's LapTime delta. Measured at Lusail 2024: the model reads a **0.49 s** mean gap where the truth is **3.29 s**, and **90%** of position-adjacent pairs look like they are inside the DRS window when **20%** are.

## One line, and that is the point

The fix is a single call, because the augmentation now lives in `src/f1_strat_manager/laps_augment.py` instead of the telemetry backend's loader (#479). That is exactly why it was moved: while every consumer could read the file for itself, each new one was invisible until someone happened to look. Now there is one function, and the sweep that found this is repeatable:

```
grep -rn 'laps_featured_' src/ scripts/ --include=*.py
```

Everything else that matches is either already routed through `augment_featured_laps` / `get_laps_df`, or is offline evaluation that does not feed an agent.

## Checks

- `SimConnector._load_laps_df` now calls `augment_featured_laps` and no longer returns a raw read (asserted).
- `ruff check .` + `format --check .` green; 25 tests pass.

Refs #447