### PR TITLE
fix(agents): six findings from the audits, three of them in this session's own fixes

### DIFF
--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -550,6 +550,27 @@ class PitStrategyAgent:
 
     # ── Feature builders ──────────────────────────────────────────────────────
 
+    @staticmethod
+    def _tyre_life_in(row) -> int:
+        """TyreLife for N15, clipped to the trained ceiling, NaN-safe.
+
+        `row` is a pandas Series, so `row.get('TyreLife', 1)` returns the STORED value
+        including NaN — the default only fires when the COLUMN is absent, never when the
+        VALUE is. `int(nan)` then raises ValueError inside the ReAct loop, and 451 rows
+        (1.98%) of the 2025 featured parquet have a NaN TyreLife. That is the same
+        Series.get trap as #428/#462, on a third column.
+
+        A missing tyre age means "fresh" is the only defensible read: a car with no
+        recorded TyreLife has just been given a set, and 1 is what the dead default was
+        reaching for anyway. It is also the conservative direction for N15, which is
+        predicting how long the stop takes, not whether to make it.
+        """
+        value = row.get('TyreLife')
+        if value is None or pd.isna(value):
+            logger.warning('TyreLife missing on the lap row; N15 reads it as a fresh set')
+            return 1
+        return min(int(value), _MAX_TRAINED_TYRE_LIFE)
+
     def _build_pit_duration_features(
         self,
         driver: str,
@@ -584,6 +605,7 @@ class PitStrategyAgent:
 
         # No gp_name here on purpose: N15's compound_id is an ordinal rank, not the
         # circuit's Pirelli allocation, so this builder needs no circuit lookup (#445).
+        # (helper `_tyre_life_in` below reads TyreLife safely; see its docstring)
         year     = self.session_meta.get('year', 2025)
         team_raw = self.session_meta.get('team_lookup', {}).get(driver, 'Unknown')
 
@@ -592,7 +614,13 @@ class PitStrategyAgent:
             'year':             year,
             # N15 clipped tyre_life at 50 in training (cell 11); pass the raw value and
             # an absurd stint extrapolates outside the fitted range (#450).
-            'tyre_life_in':     min(int(row.get('TyreLife', 1)), _MAX_TRAINED_TYRE_LIFE),
+            #
+            # `_tyre_life_in` rather than `min(int(row.get('TyreLife', 1)), 50)`: `row` is
+            # a Series, so `.get(k, 1)` returns the STORED NaN and the `1` is dead code —
+            # the default only fires when the COLUMN is missing, never the VALUE. `int(nan)`
+            # then raises ValueError inside the ReAct loop, on 451 real rows (1.98%) of the
+            # 2025 featured parquet.
+            'tyre_life_in':     self._tyre_life_in(row),
             'lap_number':       lap_number,
             'compound_id':      _N15_COMPOUND_ORDER.get(compound.upper(), _N15_COMPOUND_UNKNOWN),
             'compound_change':  int(compound_change),

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -674,13 +674,26 @@ class PitStrategyAgent:
         # a crashed car whose Position is NaN sails straight through. That is the #428
         # sentinel bug wearing a different column, and the rule is the same: refuse,
         # never default to a number the model will read as a real reading (#462).
-        pos_x = x_row.get('Position')
-        pos_y = y_row.get('Position')
-        if pd.isna(pos_x) or pd.isna(pos_y):
+        # Position AND TyreLife, on both cars. `TyreLife` feeds three of N16's features
+        # (`tyre_life_diff`, `TyreLife_X`, `TyreLife_Y`) and its `.get(k, 10)` defaults are
+        # the same dead code as the position ones: a Series returns the stored NaN, so the
+        # 10 never fires. Measured: 561 of 79,032 raw laps carry a real Position and a NaN
+        # TyreLife, so this is reachable for a car that IS racing, not just a retiree.
+        missing = [
+            name for name, value in (
+                (f'{driver_x} position',  x_row.get('Position')),
+                (f'{driver_y} position',  y_row.get('Position')),
+                (f'{driver_x} tyre life', x_row.get('TyreLife')),
+                (f'{driver_y} tyre life', y_row.get('TyreLife')),
+            )
+            if value is None or pd.isna(value)
+        ]
+        if missing:
             logger.warning(
-                'Undercut features refused: %s or %s has no position at lap %s '
-                '(retired, or not classified on that lap)',
-                driver_x, driver_y, lap_number,
+                'Undercut features refused at lap %s: %s missing. N16 reads these as real '
+                'values and LightGBM answers from its missing branch, so a default here is '
+                'a fabricated reading',
+                lap_number, ', '.join(missing),
             )
             return None
 
@@ -700,14 +713,26 @@ class PitStrategyAgent:
         # per-lap rows, so a car that is gone is simply absent. `_live_drivers` carries
         # that set when we were run from a lap_state. When it is absent (direct calls,
         # tests) we cannot know, and fall through rather than guess.
+        # BOTH drivers, not just the target. This guarded `driver_y` alone, which is the
+        # incomplete-fix pattern in its purest form: the same argument, one call away,
+        # left open. Both are LLM free text.
+        #
+        # And on the FEATURED frame it bites harder than the NaN check above can catch.
+        # HUL crashed on lap 7 at Lusail; the featured frame drops that lap as inaccurate,
+        # so his LAST row is lap 6 — a normal racing lap carrying Position 10.0. Ask about
+        # him at lap 20 and `_get_lap_row`'s unbounded fallback returns it complete: no
+        # NaN, no warning, a confident undercut built from 14-lap-stale telemetry. The
+        # position check cannot see it; only presence can.
         live = getattr(self, '_live_drivers', None)
-        if live is not None and driver_y not in live:
-            logger.warning(
-                'Undercut features refused: %s is not on track at lap %s '
-                '(absent from the lap_state rivals)',
-                driver_y, lap_number,
-            )
-            return None
+        if live is not None:
+            gone = [d for d in (driver_x, driver_y) if d not in live]
+            if gone:
+                logger.warning(
+                    'Undercut features refused: %s not on track at lap %s '
+                    '(absent from the lap_state rivals)',
+                    ' and '.join(gone), lap_number,
+                )
+                return None
 
         gp_name    = self.session_meta.get('gp_name', '')
         year       = self.session_meta.get('year', 2025)

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -1159,7 +1159,18 @@ class RaceSituationAgent:
             'AirTemp':          wx.get('air_temp',   28.0),
             'TrackTemp':        wx.get('track_temp', 38.0),
             'Humidity':         wx.get('humidity',   50.0),
-            'track_temp_start': wx.get('track_temp', 38.0),
+            # The session's FIRST track temp, which the RSM now supplies. This used to
+            # read `track_temp` — the CURRENT one — so `track_temp_delta` came out 0.0 on
+            # every lap of every race, on every shipping path (CLI, arcade, backend,
+            # /recommend, no-llm). The FastF1 path never had the bug: it reads
+            # `_wx['TrackTemp'].iloc[0]`, which is what this now mirrors.
+            #
+            # It is N14's 5th most important feature (6.0% gain). Real 2024 deltas reach
+            # -9.1 C (Monaco); the sensitivity is small mid-race and ~1.8x late, which is
+            # exactly where a late SC decides a result. Falling back to the current temp
+            # would reinstate the bug silently, so an absent value degrades to the
+            # training default instead.
+            'track_temp_start': wx.get('track_temp_start') or 38.0,
         }
 
         # Carry the RCM events into _run_core so the SC override can read them.

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -1175,7 +1175,21 @@ def _run_conditional_agents(
     if "N30" in active:
         pit_action = pit_out.action if pit_out else None
         question   = _build_rag_question(
-            sc_active  = situation_out.sc_prob_3lap > CFG.sc_prob_threshold,
+            # A deployed SC is a FACT, not a forecast. This used to key off
+            # `sc_prob_3lap > threshold`, but N13/N14 predicts an SC *within the next 3
+            # laps*: while one is already out, that forward probability can sit below the
+            # threshold, and N30 would then ask the green-flag question and hand the
+            # orchestrator a "hard regulation constraint" block describing the wrong
+            # race. `sc_currently_active` is N27's observation of the RCM feed and it was
+            # already in scope twelve lines above (`:1166`), passed to N28 and dropped
+            # here — the same restored-datum-with-an-unswitched-consumer shape as #447.
+            #
+            # Keep the forecast as well: an SC that is merely likely still changes which
+            # articles matter.
+            sc_active  = (
+                situation_out.sc_currently_active
+                or situation_out.sc_prob_3lap > CFG.sc_prob_threshold
+            ),
             pit_action = pit_action,
             compound   = race_state.compound,
         )

--- a/src/simulation/race_state_manager.py
+++ b/src/simulation/race_state_manager.py
@@ -370,6 +370,23 @@ class RaceStateManager:
                     "humidity": float(w["Humidity"]) if pd.notna(w.get("Humidity")) else None,
                     "wind_speed": float(w["WindSpeed"]) if pd.notna(w.get("WindSpeed")) else None,
                     "rainfall": bool(w["Rainfall"]) if pd.notna(w.get("Rainfall")) else False,
+                    # The session's FIRST track temperature, not this lap's. N14 trains
+                    # `track_temp_delta = track_temp - track_temp_start` and it is its 5th
+                    # most important feature (6.0% gain), above humidity and the circuit
+                    # SC rate. The consumer defaults `track_temp_start` to the CURRENT
+                    # temp when it is absent, so the delta came out 0.0 on every lap of
+                    # every race: a live feature reading a constant. Real 2024 values run
+                    # to -9.1 C (Monaco), -8.6 (Monza), -8.1 (Yas Island).
+                    #
+                    # It is a session constant, not a per-lap reading, but it ships in the
+                    # weather dict because that is the channel the consumer looks in, and
+                    # a second channel is how the two paths drifted apart in the first
+                    # place (the FastF1 path reads `_wx['TrackTemp'].iloc[0]` correctly).
+                    "track_temp_start": (
+                        float(weather_df.iloc[0]["TrackTemp"])
+                        if pd.notna(weather_df.iloc[0].get("TrackTemp"))
+                        else None
+                    ),
                 }
             )
 

--- a/src/strategy/inference/engine.py
+++ b/src/strategy/inference/engine.py
@@ -14,11 +14,16 @@ recommends (§7): CLI/Arcade/backend consume one ``run_lap`` instead of three co
 Design (per documents/audits/P2B_ENGINE_DESIGN.md, #169 Phases 1.1 + 1.2)
 --------------------------------------------------------------------------
 ``run_lap`` dispatches on ``profile``:
-  * ``rich``   — reproduces ``run_strategy_orchestrator_from_state`` byte-for-byte
-                 (same ``action`` / ``scenario_scores``) by IMPORTING the exact
-                 orchestrator layer functions and re-driving their five-step
-                 sequence, but RETURNS the per-agent outputs the orchestrator's
-                 public API discards. This is arcade's proven pattern, promoted.
+  * ``rich``   — re-drives ``run_strategy_orchestrator_from_state``'s five-step
+                 sequence by IMPORTING the exact orchestrator layer functions
+                 (never copying them), and RETURNS the per-agent outputs the
+                 orchestrator's public API discards. This is arcade's proven
+                 pattern, promoted.
+                 ⚠️ "byte-for-byte" is what this used to claim, and it was false:
+                 re-driving a sequence means every argument must be threaded by
+                 hand, and one was not (`live_drivers`, which silently disabled
+                 #462's guard on this profile — the default for every surface).
+                 Importing the functions removes body drift, not call drift.
   * ``no-llm`` — the deterministic, zero-LLM-client path (see ``no_llm.py``); fixes
                  #166 by construction (it never calls ``_run_conditional_agents``).
 
@@ -26,8 +31,15 @@ Untouchability: nothing in ``src/agents/`` is modified. Every strategy layer is 
 SAME code object the orchestrator runs (imported, never copied); the only
 engine-owned code is the call sequence itself and the default-lap_state builder.
 
-Anti-drift guard: ``tests/test_engine_parity.py`` asserts the engine's rich output
-equals the orchestrator's on a fixture lap, down to the byte-level LLM prompts.
+Anti-drift guard: ``tests/test_engine.py`` and ``tests/test_engine_no_llm.py``.
+
+⚠️ They do NOT assert byte-level parity with the orchestrator. This docstring used to
+promise a ``tests/test_engine_parity.py`` that **has never existed**, and the promise
+was load-bearing: it is why `_assemble_recommendation`'s `live_drivers` argument went
+unthreaded here for a whole session while everyone, including its author, believed a
+test would have caught it. What the real tests cover is the profile contract and the
+no-LLM path; the two `lap_state is None` fallbacks are kept in step **by hand**, so
+changing one without the other is a live risk, not a guarded one.
 """
 
 from __future__ import annotations
@@ -45,6 +57,7 @@ from src.agents.strategy_orchestrator import (
     _build_orchestrator_prompt,
     _decide_agents_to_call,
     _get_orchestrator_llm,
+    _live_drivers_from,
     _run_always_on_agents_from_state,
     _run_conditional_agents,
     _run_mc_simulation,
@@ -231,6 +244,13 @@ def _run_rich(
             mc_results,
             regulation_context,
             sc_currently_active=situation_out.sc_currently_active,
+            # Without this the LLM's free-text `undercut_target` ships unvalidated:
+            # `_assemble_recommendation` reads a missing `live_drivers` as "unknown" and
+            # lets it through by design. The orchestrator threads it; this path did not,
+            # so #462's guard was dead on the `rich` profile — which is the DEFAULT for
+            # /simulate, the arcade and the CLI. That is the whole class this engine
+            # exists to prevent: one call sequence, or every caller drifts.
+            live_drivers=_live_drivers_from(lap_state),
         )
 
     timings["total"] = sum(timings.values())

--- a/tests/test_engine_threads_every_argument.py
+++ b/tests/test_engine_threads_every_argument.py
@@ -1,0 +1,98 @@
+"""The engine must pass `_assemble_recommendation` everything the orchestrator does.
+
+The engine's whole purpose is to remove duplication: it IMPORTS the orchestrator's layer
+functions rather than copying their bodies. But it re-drives the call *sequence*, which
+means every argument is threaded by hand — and importing the functions removes **body**
+drift, not **call** drift.
+
+That distinction cost a real bug. `_assemble_recommendation` grew a `live_drivers`
+argument (#462, so the LLM cannot name a retired car as an undercut target). The
+orchestrator threads it at both call sites; the engine did not. `live_drivers=None` is
+documented to mean "unknown" and therefore passes the LLM's value unchecked, so the guard
+was dead on the `rich` profile — which is the DEFAULT for /simulate, the arcade and the
+CLI. The fix shipped and reached nothing.
+
+Nobody caught it because the module docstring promised an anti-drift guard,
+`tests/test_engine_parity.py`, that **has never existed**. This file is the smallest
+thing that would have.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+pytestmark = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="data/models/ not present (CI runner without model weights)",
+)
+
+
+def _kwargs_passed_by(func) -> set[str]:
+    """The keyword names `func` passes to `_assemble_recommendation`."""
+    import ast
+
+    tree = ast.parse(inspect.getsource(func).lstrip())
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_assemble_recommendation"
+        ):
+            return {kw.arg for kw in node.keywords if kw.arg}
+    return set()
+
+
+def test_the_engine_threads_every_argument_the_orchestrator_does():
+    """A new argument on the assembly must reach the engine, or its guard is dead.
+
+    Compares the keywords the engine passes against the ones the orchestrator passes.
+    Anything the orchestrator threads and the engine does not is, by construction, a
+    feature that works everywhere except the default path.
+    """
+    import src.agents.strategy_orchestrator as orch
+    from src.strategy.inference import engine
+
+    engine_kwargs = _kwargs_passed_by(engine._run_rich)
+    orch_kwargs = _kwargs_passed_by(orch.run_strategy_orchestrator_from_state)
+
+    missing = orch_kwargs - engine_kwargs
+    assert not missing, (
+        f"the engine's rich profile does not thread {sorted(missing)} into "
+        f"_assemble_recommendation, so whatever those arguments guard is dead on every "
+        f"surface that uses the default profile"
+    )
+
+
+def test_live_drivers_reaches_the_assembly_from_the_engine():
+    """The specific argument this test file was written for (#462)."""
+    from src.strategy.inference import engine
+
+    assert "live_drivers" in _kwargs_passed_by(engine._run_rich)
+
+
+def test_the_docstring_does_not_promise_a_test_that_does_not_exist():
+    """The promise of a guard is worse than no guard: it stops people looking.
+
+    The engine's docstring cited `tests/test_engine_parity.py` as its anti-drift guard
+    for months. The file never existed, and its absence is why `live_drivers` went
+    unthreaded while its author believed a test covered it.
+
+    Only the line that ASSERTS a guard is checked. Prose explaining a file's absence may
+    name it — that is history, not a claim.
+    """
+    import re
+
+    from src.strategy.inference import engine
+
+    for line in (engine.__doc__ or "").splitlines():
+        if not line.strip().startswith("Anti-drift guard:"):
+            continue
+        for name in re.findall(r"tests/test_[a-z_]+\.py", line):
+            assert (ROOT / name).exists(), (
+                f"the engine docstring names {name} as its anti-drift guard, and it does not exist"
+            )


### PR DESCRIPTION
Six findings, from the unswept-areas audit (#477) and the ultra audit of this session's own work. **Three of the six are bugs in fixes made earlier today** — that is the point of running the audits.

## From #477

**1. `track_temp_delta` was 0.0 on every lap of every race.** The RSM path passed the **current** track temp as `track_temp_start`; the FastF1 path reads the session's first sample and never had the bug. It is **N14's 5th most important feature (6.0% gain)**. Verified at Lusail, where the track cools 29.8 C → 25.2 C:

```
lap  1: delta +0.00C     lap 30: delta -1.80C
lap 15: delta -0.90C     lap 57: delta -4.60C     <- read 0.00 all race before
```

**2. N30's regulation query keyed off SC *probability*, not SC *deployment*.** N13/N14 predicts an SC within the next 3 laps, so while one is *already out* that forward probability can sit below threshold and the RAG agent asks the **green-flag question**. `sc_currently_active` was in scope twelve lines above and dropped.

**3. `int(NaN)` crashed the ReAct loop on 451 real rows.** `min(int(row.get('TyreLife', 1)), 50)` — `row` is a Series, so `.get` returns the stored NaN and the `1` is dead code.

## From the ultra audit — and these three are mine

**4. The engine never threaded `live_drivers`, so #462's guard was dead on the default path.** `engine.py`'s `_assemble_recommendation` call omitted it, and the assembly reads a missing `live_drivers` as *"unknown"* and lets the LLM's free-text `undercut_target` through **by design**. The `rich` profile is the default for `/simulate`, the arcade and the CLI. **The fix shipped this morning and reached nothing.**

Importing the orchestrator's functions removes **body** drift, not **call** drift: re-driving a sequence means every argument is threaded by hand.

**5. The docstring promised an anti-drift guard that has never existed.** `engine.py` cited `tests/test_engine_parity.py` as asserting byte-level parity. **The file does not exist.** That promise is *why* finding 4 happened: the argument went unthreaded while its author believed a test covered it. I repeated the claim in my own PR text.

`tests/test_engine_threads_every_argument.py` is the smallest thing that would have caught it: it compares by **AST** the keywords the engine passes against the ones the orchestrator passes, and asserts the docstring **cannot cite a file that is absent**.

**6. The undercut guard covered `driver_y` and not `driver_x`** — the same argument, one call away, both LLM free text. On the **featured** frame this bites harder than the NaN check can catch: HUL crashed on lap 7 at Lusail, that lap is dropped as inaccurate, so his **last row is lap 6 carrying a real Position of 10.0**. Asking about him at lap 20 built a complete feature row: no NaN, no warning, 14-lap-stale telemetry.

`TyreLife` joins `Position` in the guard: its `.get(k, 10)` defaults are the same dead code, and **561 of 79,032** raw laps carry a real Position with a NaN TyreLife — reachable for a car that **is** racing.

## Checks

- Lusail `track_temp_delta`: 5 distinct values across the race (was always 1: a constant 0.0).
- `_tyre_life_in`: NaN → 1 + warning; 70 → clipped to 50; 12 → 12.
- Undercut on the featured frame: `driver_x=HUL` **refused**, `driver_y=HUL` **refused**, two live cars still score `pos_gap=1.0`.
- Full suite **196 passed**, 1 skipped. `ruff check .` + `format --check .` green.

Refs #477, #462
