### PR TITLE
fix(agents): yellow laps read as green, empty-roster vs unknown, two raw parquet readers

### DIFF
--- a/scripts/bench_subagent_latency.py
+++ b/scripts/bench_subagent_latency.py
@@ -134,9 +134,15 @@ class SubAgentLatencyRunner:
         self.lap_state["question"] = "What is the minimum pit stop duration under Safety Car?"
 
         # Featured 2025 laps — required by Tire / RaceSituation / Pit / Radio
-        # agents because they pull historical context out of the laps frame.
-        self.laps_featured = pd.read_parquet(
-            _DATA_ROOT / "processed" / "laps_featured_2025.parquet"
+        # agents because they pull historical context out of the laps frame. Route through
+        # the shared augmenter so Time_s is present; a raw read collapses the overtake gap
+        # to a lap-time delta (#486), which would skew the very latencies this bench reports.
+        # Same fix as the CLI and arcade surfaces.
+        from src.f1_strat_manager.laps_augment import augment_featured_laps
+
+        self.laps_featured = augment_featured_laps(
+            pd.read_parquet(_DATA_ROOT / "processed" / "laps_featured_2025.parquet"),
+            2025,
         )
 
     @staticmethod

--- a/scripts/debug_agent.py
+++ b/scripts/debug_agent.py
@@ -398,7 +398,13 @@ def main() -> None:
     laps_df: pd.DataFrame | None = None
     if featured_path.exists():
         print(f"{_DIM}Loading featured parquet…{_RESET}", end=" ", flush=True)
-        laps_df = pd.read_parquet(featured_path)
+        # Route through the shared augmenter so this debug surface runs on the same frame
+        # the shipping paths do. A raw read leaves off Time_s, which collapses the overtake
+        # gap to a lap-time delta (#486); the debug harness is where you go to understand a
+        # bad number, so it is the worst possible place to run the degraded frame.
+        from src.f1_strat_manager.laps_augment import augment_featured_laps
+
+        laps_df = augment_featured_laps(pd.read_parquet(featured_path), args.year)
         print(f"done ({len(laps_df):,} rows)")
     else:
         print(

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -1097,7 +1097,9 @@ class PitStrategyAgent:
         lap_number = lap_state['lap_number']
         driver     = meta['driver']
         gp_name    = meta.get('gp_name', '')
-        total_laps = meta.get('total_laps', 60)
+        # 57 = median/mode race length across the 2022-2025 dataset; the same fallback the
+        # other strategy surfaces use, so a missing key resolves to one value everywhere.
+        total_laps = meta.get('total_laps', 57)
         year       = meta.get('year', 2025)
         team       = meta.get('team', 'Unknown')
         compound   = d.get('compound', 'MEDIUM')
@@ -1120,7 +1122,13 @@ class PitStrategyAgent:
         # Lusail lap 40 (he crashed on lap 7) scores happily, and worse: BEA retired on
         # lap 41, so at lap 50 the features come out complete, with no NaN and no
         # warning, describing a car sitting in the garage (#462).
-        self._live_drivers = {r['driver'] for r in rivals if r.get('driver')} | {driver}
+        #
+        # An empty rivals list means the roster is unknown, not "only our car is racing":
+        # keeping {driver} alone would reject every undercut target silently. None disables
+        # the guard instead, matching run() (`... if len(_at_lap) else None`) and
+        # _live_drivers_from (`return live or None`) in strategy_orchestrator.
+        on_track = {r['driver'] for r in rivals if r.get('driver')}
+        self._live_drivers = on_track | {driver} if on_track else None
 
         self.laps_df = laps_df.copy()
         if 'LapNumber' in self.laps_df.columns:

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -274,11 +274,23 @@ def _is_neutralised(track_status: object) -> bool:
 
 
 def _dominant_status(grp: pd.DataFrame) -> str:
-    """Return the single worst TrackStatus code seen in a lap group."""
+    """Return the single worst TrackStatus CODE (one character) seen in a lap group.
+
+    FastF1 packs several codes into one string per driver per lap, so a lap that crosses a
+    status boundary carries both (e.g. '12' is yellow then clear, '41' Safety Car then
+    green). The worst status of the lap therefore lives in an individual character, not in
+    a whole row string. Ranking the row strings and returning one intact yields values like
+    '12', which is a key neither STATUS_ENC nor STATUS_SEVERITY has, so downstream the lap
+    falls to the green default (encoding 0) and a real yellow reads as clear. Joining every
+    driver's codes and ranking the characters keeps the result inside the encoding domain.
+
+    Mirrors N13's most_severe_status (notebook N13_sc_eda.ipynb, Step 2 loader cell).
+    """
     codes = grp['TrackStatus'].dropna().astype(str).tolist()
-    if not codes:
+    chars = [c for c in ''.join(codes) if c in STATUS_SEVERITY]
+    if not chars:
         return '1'
-    return max(codes, key=lambda s: STATUS_SEVERITY.get(s[0], 1))
+    return max(chars, key=lambda c: STATUS_SEVERITY[c])
 
 
 def _compute_laptime_features(all_laps: pd.DataFrame, lap_number: int) -> dict:
@@ -865,6 +877,10 @@ class RaceSituationAgent:
         feat.update(_compute_rcm_features(all_laps, lap_number, session_meta, cur_code, prev_code))
         feat.update(_compute_weather_features(session_meta))
 
+        # RaceStateManager and the FastF1 session always supply total_laps, so this
+        # fallback only fires for hand-built states (tests, debug). 57 is the median and
+        # mode race length across the 2022-2025 dataset (71 races), so it is the least
+        # surprising stand-in and is kept identical across every strategy surface.
         total_laps = int(session_meta.get('total_laps', 57))
         is_lap1    = int(lap_number == 1)
         lap_pct    = float(lap_number) / max(total_laps, 1)
@@ -1134,7 +1150,9 @@ class RaceSituationAgent:
         lap_number = lap_state['lap_number']
         driver     = meta['driver']
         gp_name    = meta.get('gp_name', '')
-        total_laps = meta.get('total_laps', 60)
+        # 57 = median/mode race length across the dataset; matches _build_features above
+        # and the other strategy surfaces so the fallback is one value, not several.
+        total_laps = meta.get('total_laps', 57)
         year       = meta.get('year', 2025)
 
         driver_pos  = d.get('position', 20)

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -576,6 +576,7 @@ class SimConnector(threading.Thread):
         return RaceState(
             driver=driver_st.get("driver", "UNK"),
             lap=lap_num,
+            # 57 = median/mode race length across the dataset; the shared strategy fallback.
             total_laps=meta.get("total_laps", 57),
             position=driver_st.get("position", 10),
             compound=driver_st.get("compound", "MEDIUM"),


### PR DESCRIPTION
Four findings from #486, measured against real data. Split from #485 (which owns `tire_agent.py`) so the two run disjoint.

## 1. `_dominant_status` read 100% of yellow laps as green

It ranked whole TrackStatus **row strings** and returned one intact, so a multi-code lap like `'12'` fell out of `STATUS_ENC` and decoded to the green default. On 2024 (1357 IsAccurate race-laps) it read **64 of 64** true non-green laps as green.

Now mirrors N13's `most_severe_status` (N13_sc_eda.ipynb Step 2): join every driver's codes, rank the individual **characters** (which stay in the encoding domain). After the fix, **0 of 64** read as green. Verified: `[12,1,124]` resolves to `'4'` (Safety Car), a plain lap to `'1'`.

## 2. `run_from_state` confused "unknown" with "empty roster"

It set `_live_drivers` to `{driver}` when the rivals list was empty, silently rejecting every undercut target. Now returns `None` on an empty list (guard off = unknown), matching `run()` and `_live_drivers_from`. A populated roster still filters.

## 3. Two raw parquet readers on the developer surfaces

`scripts/debug_agent.py` and `scripts/bench_subagent_latency.py` read the featured parquet raw, so they ran on the un-augmented frame (no `Time_s`). Both now route through `augment_featured_laps` like the CLI and arcade. On Spa 2025 the degraded gap averaged **0.454s vs the true 4.029s**.

## 4. Inconsistent `total_laps` fallbacks

Aligned the scattered defaults to 57 (median and mode race length across 2022-2025) with a note at each site. These only fire for hand-built states.

## Checks

- `_dominant_status` verified against N13's helper and real multi-code laps.
- 34 tests pass (undercut, engine, engine-no-llm, SC rails, data-validation).
- `ruff check .` + `format --check .` green.

Refs #486
