### PR TITLE
fix(agents): resolve pit-agent circuit lookups by slug on the FastF1 path too

### DIFF
--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -40,7 +40,7 @@ try:
 except Exception:
     _DATA_ROOT = _REPO_ROOT / 'data'
 
-from src.f1_strat_manager.gp_slugs import rekey_by_slug  # noqa: E402
+from src.f1_strat_manager.gp_slugs import rekey_by_slug, slug_from_event_name  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -177,6 +177,28 @@ class PitAgentCFG:
         self.team_x_undercut_rate: dict = (
             _uc.groupby('Team_X')['undercut_success'].mean().to_dict()
         )
+
+    def traversal_for(self, gp_name: str) -> float:
+        """Pit-lane traversal (s) for a GP given in EITHER keyspace.
+
+        The two callers disagree, exactly as they do in race_situation_agent.sc_rate_for:
+        the FastF1 session path passes a full event name ('Qatar Grand Prix'), the replay
+        path passes the parquet slug ('Lusail'). circuit_traversal is keyed by slug (#448
+        rekeyed it), so the full name missed and every FastF1-path circuit fell back to
+        the 20.0 default. slug_from_event_name is reentrant and normalises both.
+        """
+        slug = slug_from_event_name(gp_name) or gp_name
+        return self.circuit_traversal.get(slug, 20.0)
+
+    def undercut_rate_for(self, gp_name: str) -> float:
+        """Circuit undercut base rate for a GP in either keyspace (an N16 feature).
+
+        Same dual-keyspace resolution as traversal_for. Without it the FastF1 path fed
+        N16 a constant 0.38 on every circuit, which is the #448 dead-feature bug moved to
+        the sibling path rather than fixed.
+        """
+        slug = slug_from_event_name(gp_name) or gp_name
+        return self.circuit_undercut_rate.get(slug, 0.38)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -761,10 +783,10 @@ class PitStrategyAgent:
             'compound_x_id':         comp_x_id,
             'compound_y_id':         comp_y_id,
             'compound_delta':        comp_x_id - comp_y_id,
-            'pit_delta_X':           self.cfg.circuit_traversal.get(gp_name, 20.0) + 4.5,
+            'pit_delta_X':           self.cfg.traversal_for(gp_name) + 4.5,
             'lap_race_pct':          lap_number / total_laps,
             'pos_X_before':          float(x_row.get('Position', 10)),
-            'circuit_undercut_rate': self.cfg.circuit_undercut_rate.get(gp_name, 0.38),
+            'circuit_undercut_rate': self.cfg.undercut_rate_for(gp_name),
             'team_x_undercut_rate':  self.cfg.team_x_undercut_rate.get(team_x, 0.38),
         }
         return pd.DataFrame([feat])[self.cfg.undercut_features]
@@ -843,7 +865,7 @@ class PitStrategyAgent:
             p50      = float(agent.cfg.pit_p50_model.predict(feat_df)[0])
             p95      = float(agent.cfg.pit_p95_model.predict(feat_df)[0])
             gp_name  = agent.session_meta.get('gp_name', '')
-            traversal = agent.cfg.circuit_traversal.get(gp_name, 20.0)
+            traversal = agent.cfg.traversal_for(gp_name)
             return (
                 f'physical_stop: P05={p05:.2f}s | P50={p50:.2f}s | P95={p95:.2f}s | '
                 f'total_pit_P50={p50 + traversal:.2f}s (traversal={traversal:.2f}s)'

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -334,11 +334,12 @@ CLIFF_THRESHOLD: dict[str, int] = {
 }
 
 # Longest race on the current calendar (Monaco, 78 laps; max observed across
-# 2023-2025 data). Used as the fallback ceiling for laps-to-cliff when
-# session_meta carries no total_laps: a cliff past this many laps is "not this
-# race" regardless of circuit. It must stay at or below the shortest real race so
-# a missing key can never lift the ceiling above an actual race and silently
-# disable the clamp — the earlier default of 100 exceeded every race and did.
+# 2023-2025 data). Fallback ceiling for laps-to-cliff when session_meta carries no
+# total_laps: a cliff beyond the longest possible race is "not this race" regardless
+# of circuit, so clamping there caps absurd values without touching any real one. The
+# earlier default of 100 sat above every race, so the clamp it belonged to never fired.
+# session_meta.total_laps is present on every shipping path, so this only guards
+# hand-built states.
 MAX_RACE_LAPS: int = 78
 
 
@@ -1173,7 +1174,7 @@ class TireAgent:
         compound    = d.get('compound', 'MEDIUM')
         tyre_life   = d.get('tyre_life', 1)
         gp_name     = meta.get('gp_name', '')
-        total_laps  = meta.get('total_laps', 60)
+        total_laps  = meta.get('total_laps', 57)
         year        = meta.get('year', 2025)
         team        = meta.get('team', 'Unknown')
 


### PR DESCRIPTION
Follow-up from the adversarial audit of the #485/#486 fixes. The audit's own success condition is finding what a fix broke or failed to reach, and it found a **sibling-path regression** from #448.

## The finding

#448 rekeyed `circuit_traversal` and `circuit_undercut_rate` to **slug** keys and routed `race_situation_agent` through `sc_rate_for` so both keyspaces resolve. `pit_strategy_agent` kept **three raw lookups**. `run()` (FastF1) feeds `gp_name = session.event['EventName']`, a full name like `'Qatar Grand Prix'`, so on that path every circuit missed:

| GP (FastF1 name) | traversal before | after | undercut_rate before | after |
|---|---|---|---|---|
| Qatar Grand Prix | **20.0** | 21.29 | **0.38** | 0.362 |
| Monaco Grand Prix | **20.0** | 22.54 | **0.38** | 0.514 |
| Hungarian Grand Prix | **20.0** | 19.66 | **0.38** | 0.386 |

`circuit_undercut_rate` is an N16 feature, so this is the #448 dead-feature bug (constant per circuit) **moved to the sibling path**, not eliminated. Primary surfaces (CLI/arcade/backend) use `..._from_state` (slug keys) and were unaffected; the FastF1 `run()` / `run_strategy_orchestrator` path was not.

## Fix

`cfg.traversal_for` / `cfg.undercut_rate_for`, mirroring `sc_rate_for`: normalise either keyspace via `slug_from_event_name`, keep the training default only for a genuinely unknown GP. The three call sites now use them. The slug form still resolves; an unknown GP still gets the default.

## Two more from the same audit
- `tire_agent.run_from_state` still defaulted `total_laps` to **60** while pit/race were aligned to 57 (a `laps_remaining` TCN feature off by 3 for hand-built states). Aligned.
- The `MAX_RACE_LAPS` comment claimed the value must stay at or below the *shortest* race, when 78 is the *longest*. Corrected to describe what the clamp does.

## Deferred (needs the LLM path)
The audit also noted `_live_drivers` is not reset on the bare react-agent entry point, so the interactive/chat path could validate against a stale roster after a prior `run_from_state`. That only manifests with a live LLM, so it is left for the LLM-driven audit.

## Checks
- Both keyspaces resolve (measured above); 25 tests pass; `ruff check .` + `format --check .` green.

Refs #448, #477