### PR TITLE
fix(agents): bound the retired-car lap fallback by presence; make searchable defaults loud

### DIFF
--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -545,6 +545,16 @@ class PitStrategyAgent:
         Returns:
             Pandas Series for that lap, the closest prior lap, or None.
         """
+        # A car that is not on track this lap has no valid row, however many stale ones
+        # it left behind. Without this, a driver who retired on lap 5 answers a lap-50
+        # query with his lap-5 row (the prior-lap fallback below has no staleness bound,
+        # and no bound works: a finisher's last featured lap can lag 20 while a retiree
+        # shows at 9, #462). `_live_drivers` is the presence signal RaceStateManager
+        # already supplies; None means we cannot tell, so the guard stays off then.
+        live = getattr(self, '_live_drivers', None)
+        if live is not None and driver not in live:
+            return None
+
         driver_rows = self.laps_df[self.laps_df['Driver'] == driver]
         if driver_rows.empty:
             return None
@@ -554,8 +564,10 @@ class PitStrategyAgent:
         prior = driver_rows[driver_rows['LapNumber'] < lap_number]
         if not prior.empty:
             return prior.sort_values('LapNumber').iloc[-1]
-        # No prior lap either — fall back to the earliest later lap so the
-        # feature builder still has something to work with.
+        # No prior lap: the query is for a lap before this driver's first recorded one
+        # (FastF1 sometimes omits lap 1). Return the earliest lap as a start-of-race
+        # stand-in. This is not the retired-car case, which the presence guard above and
+        # the prior-lap branch already handle.
         return driver_rows.sort_values('LapNumber').iloc[0]
 
     def _get_position_map(self, lap_number: int) -> dict[str, float]:

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -522,11 +522,34 @@ def _add_compound_cols(df: pd.DataFrame, compound_id: str) -> pd.DataFrame:
     All three encodings are constant within a stint. CompoundHardness is the
     inverse of AbsoluteCompoundID: C1=6 (hardest), C6=1 (softest), as encoded
     in the N10 training data.
+
+    The defaults (C3 / mid-hardness / SOFT) are real, in-range codes, so an unknown
+    compound is silently scored as a real one rather than flagged. That is only reached
+    with corrupt or out-of-scope compound data, but it is a sentinel by construction, so
+    it is logged loudly rather than left invisible.
     """
+    name = str(df['Compound'].iloc[0])
+    if compound_id not in CFG.abs_compound_id_map:
+        logger.warning("Unknown compound_id %r: encoding as C3 (AbsoluteCompoundID=3)", compound_id)
+    if name not in CFG.compound_id_map:
+        logger.warning("Unknown compound name %r: encoding as SOFT (CompoundID=1)", name)
     df['AbsoluteCompoundID'] = CFG.abs_compound_id_map.get(compound_id, 3)
     df['CompoundHardness']   = CFG.compound_hardness_map.get(compound_id, 4)
-    df['CompoundID']         = CFG.compound_id_map.get(df['Compound'].iloc[0], 1)
+    df['CompoundID']         = CFG.compound_id_map.get(name, 1)
     return df
+
+
+def _encode_team_id(team_id_map: dict, team: str) -> int:
+    """Team label encoding, with the McLaren default made loud.
+
+    `team_id_map.get(team, 4)` defaults to 4, which is a real team (McLaren), so an
+    unrecognised team is silently scored as one. This is reachable in normal operation:
+    engine.py sets team='Unknown' whenever a lap row is empty, and 'Unknown' is not in
+    the map. Log it rather than let a mislabelled team ride as McLaren unnoticed.
+    """
+    if team not in team_id_map:
+        logger.warning("Unknown team %r: encoding as team_id 4 (McLaren default)", team)
+    return team_id_map.get(team, 4)
 
 
 def _add_fuel_cols(df: pd.DataFrame, session_meta: dict) -> pd.DataFrame:
@@ -1139,7 +1162,7 @@ class TireAgent:
             'cluster_mean_lap_s': _clean['LapTime'].dt.total_seconds().mean(),
             'total_laps':         int(session.total_laps),
             'cluster_id':         self.cfg.circuit_cluster_map.get(gp_name, 0),
-            'team_id':            self.cfg.team_id_map.get(stint_state.get('team', 'Unknown'), 4),
+            'team_id':            _encode_team_id(self.cfg.team_id_map, stint_state.get('team', 'Unknown')),
             'year':               stint_state.get('year', 2025),
             'AirTemp':   float(_weather.get('AirTemp',   28.0)),
             'TrackTemp': float(_weather.get('TrackTemp', 38.0)),
@@ -1203,7 +1226,7 @@ class TireAgent:
             'cluster_mean_lap_s': float(clean_times.mean()) if len(clean_times) > 0 else 90.0,
             'total_laps':         total_laps,
             'cluster_id':         self.cfg.circuit_cluster_map.get(gp_name, 0),
-            'team_id':            self.cfg.team_id_map.get(team, 4),
+            'team_id':            _encode_team_id(self.cfg.team_id_map, team),
             'year':               year,
             'AirTemp':   wx.get('air_temp',   28.0),
             'TrackTemp': wx.get('track_temp', 38.0),


### PR DESCRIPTION
The four open findings of #477 (four of its eight were already fixed by #483/#485, documented on the issue). All class A/C survivors.

## _get_lap_row: unbounded prior-lap fallback (class C)

A driver who retired on lap 5 answered a lap-50 query with his lap-5 row. No staleness threshold works: a finisher's last featured lap can lag 20 while a retiree shows at 9 (#462). Now uses the same presence signal as the undercut guard: if `_live_drivers` is set and the driver is not on it, return None. `None` (no lap_state) leaves the guard off, consistent with `_live_drivers_from`. The start-of-race fallback for an omitted lap 1 is kept and documented as distinct.

Verified: `_get_lap_row('HUL', 50)` returns None when HUL is not on track; a live driver still returns his row.

## Searchable defaults made loud (class A)

- `_add_compound_cols` defaulted an unknown compound to real, in-range codes (C3 / mid-hardness / SOFT), so corrupt compound data was scored as a real compound silently. Values unchanged (the models only know real codes); the miss is now logged.
- `_encode_team_id`: `team_id_map.get(team, 4)` defaults to McLaren, reachable because `engine.py` sets `team='Unknown'` on an empty lap row. Both call sites route through the helper and log the miss.

These do not change any value a model receives; they turn a silent sentinel into a visible one, which is the #438 improvement where a real "unknown" category cannot be added without retraining.

## Checks

- Measured against real data (HUL retired at Lusail; unknown team/compound trigger the warnings).
- 25 tests pass; `ruff check .` + `format --check .` green.

Refs #477