### PR TITLE
fix(agents): split Safety Car from Virtual Safety Car (#471)

### DIFF
--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -335,6 +335,7 @@ def _build_pit_prompt(
     sc_prob: float,
     laps_to_cliff_p10: float,
     sc_currently_active: bool = False,
+    vsc_active: bool = False,
 ) -> str:
     """Build the natural-language prompt for the Pit Strategy ReAct agent.
 
@@ -348,20 +349,29 @@ def _build_pit_prompt(
         rival_str: Description of the nearest rival ahead.
         sc_prob: Safety Car probability from N27.
         laps_to_cliff_p10: P10 laps-to-cliff from N26 TireOutput.
-        sc_currently_active: True when an RCM confirms a SC/VSC is deployed
-            right now.  Replaces the legacy "SC probability" line with an
-            unambiguous "SC STATUS: SAFETY CAR DEPLOYED RIGHT NOW" banner so
-            the model cannot mistake an active SC for a low future-SC
-            probability (the historical N28 failure mode at Catar 2025 V7).
+        sc_currently_active: True when an RCM confirms a neutralisation (SC OR VSC)
+            is deployed right now.  Replaces the legacy "SC probability" line with an
+            unambiguous "SC STATUS: ... DEPLOYED RIGHT NOW" banner so the model cannot
+            mistake an active neutralisation for a low future-SC probability (the
+            historical N28 failure mode at Catar 2025 V7).
+        vsc_active: True when that neutralisation is specifically a Virtual Safety Car
+            (Art. 56). The field is not queued and the restart is instant, so a stop
+            saves materially less than under a full SC; the banner says so, so the model
+            does not treat a VSC stop as the near-free stop a full SC offers (#471).
 
     Returns:
         Formatted prompt string for the ReAct agent.
     """
-    sc_line = (
-        "SC STATUS: SAFETY CAR DEPLOYED RIGHT NOW (confirmed by RCM).\n"
-        if sc_currently_active
-        else f"SC probability (next 3 laps): {sc_prob:.2f}\n"
-    )
+    if sc_currently_active and vsc_active:
+        sc_line = (
+            "SC STATUS: VIRTUAL SAFETY CAR DEPLOYED RIGHT NOW (confirmed by RCM). "
+            "Gaps are preserved and the restart is instant (Art. 56), so a stop saves "
+            "materially less time than under a full Safety Car.\n"
+        )
+    elif sc_currently_active:
+        sc_line = "SC STATUS: SAFETY CAR DEPLOYED RIGHT NOW (confirmed by RCM).\n"
+    else:
+        sc_line = f"SC probability (next 3 laps): {sc_prob:.2f}\n"
     return (
         f'Driver {driver} | Lap {lap_number} | P{position} | '
         f'Tyre: {compound} (life {tyre_life} laps)\n'
@@ -1101,9 +1111,11 @@ class PitStrategyAgent:
         }
 
         sc_currently_active = bool(lap_state.get('sc_currently_active', False))
+        vsc_active          = bool(lap_state.get('vsc_active', False))
         return self._run_core(
             driver, lap_number, compound, rival, sc_prob, laps_cliff,
             sc_currently_active=sc_currently_active,
+            vsc_active=vsc_active,
         )
 
     def run_from_state(self, lap_state: dict, laps_df: pd.DataFrame) -> PitStrategyOutput:
@@ -1178,10 +1190,12 @@ class PitStrategyAgent:
         sc_prob             = lap_state.get('sc_prob', 0.0)
         laps_cliff          = lap_state.get('laps_to_cliff')
         sc_currently_active = bool(lap_state.get('sc_currently_active', False))
+        vsc_active          = bool(lap_state.get('vsc_active', False))
 
         return self._run_core(
             driver, lap_number, compound, rival_ahead, sc_prob, laps_cliff,
             sc_currently_active=sc_currently_active,
+            vsc_active=vsc_active,
         )
 
     def _run_core(
@@ -1193,6 +1207,7 @@ class PitStrategyAgent:
         sc_prob: float,
         laps_cliff: Optional[float],
         sc_currently_active: bool = False,
+        vsc_active: bool = False,
     ) -> PitStrategyOutput:
         """Core invocation: self.laps_df / self.session_meta already set.
 
@@ -1205,6 +1220,10 @@ class PitStrategyAgent:
             rival: Abbreviation of the nearest rival ahead (or None).
             sc_prob: Safety Car probability from N27.
             laps_cliff: P10 laps-to-cliff from N26 (or None).
+            sc_currently_active: True when an RCM confirms a neutralisation now.
+            vsc_active: True when that neutralisation is a VSC (Art. 56); shapes the
+                prompt banner so the model does not treat a VSC stop as a near-free
+                full-SC stop (#471).
 
         Returns:
             Fully populated PitStrategyOutput.
@@ -1226,6 +1245,7 @@ class PitStrategyAgent:
             sc_prob=sc_prob,
             laps_to_cliff_p10=laps_cliff if laps_cliff is not None else 0.0,
             sc_currently_active=sc_currently_active,
+            vsc_active=vsc_active,
         )
 
         react_agent = self.get_react_agent()

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import Optional
 
@@ -67,19 +68,46 @@ _EXCLUDE_RE      = r'TRACK LIMITS|LAP TIME|PENALTY|PIT LANE|FORMATION|GRID|DRS|S
 
 
 # ── RCM context override (post-hoc fix for "SC active but model says low") ────
-# RCM event types that confirm a Safety Car is physically deployed RIGHT NOW.
-# Strings match exactly what radio_agent._classify_rcm_event() emits.
-_SC_ACTIVE_EVENT_TYPES: frozenset[str] = frozenset({
-    "SAFETY_CAR_DEPLOYED",
-    "VIRTUAL_SAFETY_CAR_DEPLOYED",
-})
+# A full Safety Car (FIA Sporting Regs Art. 55) and a Virtual Safety Car (Art. 56) are
+# different race situations, not one flag (#471): under a full SC the field queues behind
+# the car and gaps compress (55.7 / 55.10); under a VSC there is no queue, gaps are
+# broadly preserved and the delta binds throughout (56.5). Both ban overtaking
+# (55.8 / 56.6), so both force overtake_prob = 0, but the pit-time saving is much smaller
+# under a VSC, so the two are tracked apart from here on. Strings match exactly what
+# radio_agent._classify_rcm_event() emits. (src/nlp/rcm_state.py mirrors these sets for
+# its cross-lap tracker; keep them in sync.)
+_SC_DEPLOY_EVENT_TYPES:  frozenset[str] = frozenset({"SAFETY_CAR_DEPLOYED"})
+_VSC_DEPLOY_EVENT_TYPES: frozenset[str] = frozenset({"VIRTUAL_SAFETY_CAR_DEPLOYED"})
 
-# RCM event types that confirm the SC phase is ending and release the override.
-_SC_RELEASE_EVENT_TYPES: frozenset[str] = frozenset({
+# SC release. Art. 55.15's "SAFETY CAR IN THIS LAP" (the real message, which classifies
+# to SAFETY_CAR_ENDING — verified on Qatar 2025 L10 and Spain 2025 L60) means the car
+# enters the pits at the END of that lap, and Art. 55.8 forbids overtaking until the
+# driver passes the Line AFTER it has returned. So the announcement lap is still
+# neutralised: _neutralization_from_rcm keeps the flag active for it and it clears the
+# lap after. SAFETY_CAR_IN_PIT_LANE is the same case for the rarer "IN THE PIT LANE"
+# wording.
+_SC_RELEASE_EVENT_TYPES:  frozenset[str] = frozenset({
     "SAFETY_CAR_ENDING",
     "SAFETY_CAR_IN_PIT_LANE",
-    "VIRTUAL_SAFETY_CAR_ENDING",
 })
+
+# VSC release. Art. 56.7's restart is near-instant (green ~10-15 s after "VSC ENDING"),
+# so at lap granularity the neutralisation is over on the announcement lap: this releases
+# immediately, unlike the SC.
+_VSC_RELEASE_EVENT_TYPES: frozenset[str] = frozenset({"VIRTUAL_SAFETY_CAR_ENDING"})
+
+
+class Neutralization(str, Enum):
+    """Which on-track neutralisation the RCM feed confirms is in force this lap.
+
+    NONE — green-flag racing.
+    SC   — full Safety Car (FIA Sporting Regs Art. 55): field queued, large pit saving.
+    VSC  — Virtual Safety Car (Art. 56): no queue, gaps preserved, small pit saving.
+    """
+
+    NONE = "NONE"
+    SC = "SC"
+    VSC = "VSC"
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -209,6 +237,13 @@ class RaceSituationOutput:
         gap_ahead_s: Gap to the car directly ahead (seconds). < 1.0s = DRS range.
         pace_delta_s: 3-lap rolling pace delta vs car ahead (s/lap). Negative = faster.
         reasoning: LLM synthesis forwarded verbatim to N31 Orchestrator.
+        sc_currently_active: Any neutralisation (SC OR VSC) confirmed deployed this lap
+            by the RCM feed. Kept as the single back-compat flag every consumer already
+            reads; True under both a full SC and a VSC.
+        vsc_active: The active neutralisation is specifically a Virtual Safety Car
+            (Art. 56). Only meaningful when sc_currently_active is True. Lets consumers
+            that care about the pit-time saving (the Monte Carlo, the N28 prompt) tell a
+            VSC apart from a full SC, which the single flag could not (#471).
     """
 
     overtake_prob: float
@@ -217,7 +252,8 @@ class RaceSituationOutput:
     gap_ahead_s: float  = 0.0
     pace_delta_s: float = 0.0
     reasoning: str      = ''
-    sc_currently_active: bool = False  # True when an RCM confirms a SC/VSC is deployed AHORA
+    sc_currently_active: bool = False  # any neutralisation (SC OR VSC) confirmed by RCM this lap
+    vsc_active: bool          = False  # the active neutralisation is specifically a VSC (Art. 56)
 
     def __post_init__(self) -> None:
         if self.sc_currently_active or self.overtake_prob >= CFG.high_overtake or self.sc_prob_3lap >= CFG.high_sc:
@@ -226,6 +262,15 @@ class RaceSituationOutput:
             self.threat_level = 'MEDIUM'
         else:
             self.threat_level = 'LOW'
+
+    @property
+    def sc_active(self) -> bool:
+        """True only under a full Safety Car (Art. 55): a neutralisation that is not a VSC.
+
+        The complement of vsc_active within sc_currently_active, so the three read as a
+        clean split (green / SC / VSC) without storing a redundant third field.
+        """
+        return self.sc_currently_active and not self.vsc_active
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1234,33 +1279,40 @@ class RaceSituationAgent:
         parsed      = _parse_tool_outputs(response['messages'])
         reasoning   = response['messages'][-1].content
 
-        # Post-hoc override: when the lap's RCM events confirm a SC/VSC is
-        # currently deployed, force sc_prob_3lap to 1.0 and flag the output
-        # so downstream agents (N28 pit, N31 orchestrator) can react.  The
-        # legacy LightGBM model was trained to predict FUTURE SC, not to
-        # recognise a SC already in progress, hence the patch.
-        sc_active           = _sc_active_from_rcm(getattr(self, "_pending_rcm_events", None) or [])
-        raw_sc_prob         = round(parsed['sc_prob_3lap'], 3)
-        effective_sc_prob   = 1.0 if sc_active else raw_sc_prob
+        # Post-hoc override: when the lap's RCM events confirm a neutralisation is
+        # currently deployed, force sc_prob_3lap to 1.0 and flag the output so downstream
+        # agents (N28 pit, N31 orchestrator) can react. The legacy LightGBM model was
+        # trained to predict a FUTURE SC, not to recognise one already in progress, hence
+        # the patch. The SC/VSC split (#471) rides on the same signal: both are
+        # neutralisations (overtake_prob = 0, sc_prob_3lap = 1.0), but only the KIND
+        # changes the pit-time saving, carried downstream on vsc_active.
+        neutralization    = _neutralization_from_rcm(getattr(self, "_pending_rcm_events", None) or [])
+        is_neutralized    = neutralization is not Neutralization.NONE
+        is_vsc            = neutralization is Neutralization.VSC
+        raw_sc_prob       = round(parsed['sc_prob_3lap'], 3)
+        effective_sc_prob = 1.0 if is_neutralized else raw_sc_prob
 
         # Art. 55.8 (SC) / 56.6 (VSC): no overtaking on track. N12 predicts a RACING
-        # overtake, and under an SC the only exception that yields a real position gain
-        # is 55.8(h) ("a car slows with an obvious problem") — a mechanism N12 has no
-        # feature for. Meanwhile every input it does use is regulation-corrupted: DRS is
-        # disabled (Art. 22.1(c)), the gap compresses toward ten car lengths (55.7/55.10)
-        # and pace_delta collapses to the FIA ECU delta. So the model is not merely
-        # imprecise here, it is inapplicable: 0.0 is the correct value and the honest one.
+        # overtake, and under a neutralisation the only exception that yields a real
+        # position gain is 55.8(h) ("a car slows with an obvious problem") — a mechanism
+        # N12 has no feature for. Meanwhile every input it does use is regulation-
+        # corrupted: DRS is disabled (Art. 22.1(c)), the gap compresses toward ten car
+        # lengths (55.7/55.10) and pace_delta collapses to the FIA ECU delta. So the model
+        # is not merely imprecise here, it is inapplicable: 0.0 is the correct value and
+        # the honest one, and it holds identically under a VSC (56.6).
         raw_overtake_prob       = round(parsed['overtake_prob'], 3)
-        effective_overtake_prob = 0.0 if sc_active else raw_overtake_prob
+        effective_overtake_prob = 0.0 if is_neutralized else raw_overtake_prob
 
+        _kind_label       = "VIRTUAL_SAFETY_CAR_DEPLOYED" if is_vsc else "SAFETY_CAR_DEPLOYED"
+        _overtake_article = "56.6" if is_vsc else "55.8"
         effective_reasoning = (
             reasoning
-            if not sc_active
+            if not is_neutralized
             else (
-                f"[RCM OVERRIDE: SAFETY_CAR_DEPLOYED active — model output "
+                f"[RCM OVERRIDE: {_kind_label} active — model output "
                 f"sc_prob_3lap={raw_sc_prob:.2f} overridden to 1.00, "
                 f"overtake_prob={raw_overtake_prob:.2f} overridden to 0.00 "
-                f"(no overtaking under SC, Art. 55.8).] {reasoning}"
+                f"(no overtaking under a neutralisation, Art. {_overtake_article}).] {reasoning}"
             )
         )
 
@@ -1270,7 +1322,8 @@ class RaceSituationAgent:
             gap_ahead_s         = round(parsed['gap_ahead_s'],   2),
             pace_delta_s        = round(parsed['pace_delta_s'],  3),
             reasoning           = effective_reasoning,
-            sc_currently_active = sc_active,
+            sc_currently_active = is_neutralized,
+            vsc_active          = is_vsc,
         )
 
 
@@ -1278,41 +1331,37 @@ class RaceSituationAgent:
 # RCM context override helper
 # ─────────────────────────────────────────────────────────────────────────────
 
-def _sc_active_from_rcm(rcm_events: list | None) -> bool:
-    """True if the lap's RCM events confirm a Safety Car is deployed RIGHT NOW.
+def _classify_rcm_events(rcm_events: list | None) -> list[str]:
+    """Classify a lap's RCM events into canonical event-type strings.
 
     Accepts whatever shape the lap_state ships:
-      - dicts already pre-classified with an ``event_type`` key
-        (the cheap path used by RaceStateManager once a lap has been
-        classified upstream),
+      - dicts already pre-classified with an ``event_type`` key (the cheap path used by
+        RaceStateManager and the CLI's synthetic events once classified upstream),
       - ``RCMEvent`` dataclass instances from radio_agent,
-      - raw FastF1-shaped dicts (``message``, ``flag``, ``category``,
-        ``lap``...) which we promote to RCMEvent and classify.
+      - raw FastF1-shaped dicts (``message``, ``flag``, ``category``, ``lap``...), which
+        are promoted to RCMEvent and classified.
 
-    Resolution order (so a deploy + ending in the same window correctly
-    releases the override instead of pinning):
-      1. Any release event in the list  → False.
-      2. Any deploy event in the list   → True.
-      3. Anything else                  → False.
-
-    The radio_agent import is lazy to avoid the agents → orchestrator →
-    radio_agent → agents loop at module import time.
+    The radio_agent import is lazy AND only taken when a raw event actually needs
+    classifying: it avoids the agents -> orchestrator -> radio_agent -> agents loop at
+    module import time, and keeps a caller that passes only pre-classified dicts (the
+    CLI's synthetic events, the hermetic tests) from pulling in the heavy model stack.
     """
     if not rcm_events:
-        return False
-
-    from src.agents.radio_agent import RCMEvent, _classify_rcm_event
+        return []
 
     classified: list[str] = []
+    _radio = None
     for ev in rcm_events:
         if isinstance(ev, dict) and "event_type" in ev:
-            classified.append(ev["event_type"])
+            classified.append(str(ev["event_type"]))
             continue
-        if isinstance(ev, RCMEvent):
-            classified.append(_classify_rcm_event(ev))
+        if _radio is None:
+            from src.agents import radio_agent as _radio
+        if isinstance(ev, _radio.RCMEvent):
+            classified.append(_radio._classify_rcm_event(ev))
             continue
         if isinstance(ev, dict):
-            classified.append(_classify_rcm_event(RCMEvent(
+            classified.append(_radio._classify_rcm_event(_radio.RCMEvent(
                 message=str(ev.get("message", "")),
                 flag=str(ev.get("flag", "") or ""),
                 category=str(ev.get("category", "")),
@@ -1320,10 +1369,53 @@ def _sc_active_from_rcm(rcm_events: list | None) -> bool:
                 racing_number=ev.get("racing_number") or ev.get("RacingNumber"),
                 scope=str(ev.get("scope", "") or ""),
             )))
+    return classified
 
+
+def _neutralization_from_rcm(rcm_events: list | None) -> Neutralization:
+    """Which neutralisation the lap's RCM events confirm is in force RIGHT NOW.
+
+    Resolution order encodes two regulations that differ (#471):
+
+      1. VSC release (Art. 56.7)  -> NONE. The virtual SC restarts near-instantly, so at
+         lap granularity it is already over on the "VSC ENDING" lap.
+      2. SC release (Art. 55.15)  -> SC. "SAFETY CAR IN THIS LAP" means the car comes in
+         at the END of this lap and Art. 55.8 keeps overtaking banned until the driver
+         passes the Line after it has returned, so THIS lap is still neutralised. The
+         flag clears the next lap, when the cross-lap tracker stops re-asserting the
+         deploy and no release event remains in the window.
+      3. SC deploy                -> SC.
+      4. VSC deploy               -> VSC.
+      5. anything else            -> NONE.
+
+    Release beats deploy within one window (steps 1-2 before 3-4), matching the prior
+    "release wins" ordering. The only change from the old single-flag helper is that an
+    SC release no longer clears the override on its own announcement lap — that lap is
+    still neutralised by Art. 55.8, which is exactly the one-lap-early bug (#471).
+    """
+    classified = _classify_rcm_events(rcm_events)
+    if not classified:
+        return Neutralization.NONE
+
+    if any(t in _VSC_RELEASE_EVENT_TYPES for t in classified):
+        return Neutralization.NONE
     if any(t in _SC_RELEASE_EVENT_TYPES for t in classified):
-        return False
-    return any(t in _SC_ACTIVE_EVENT_TYPES for t in classified)
+        return Neutralization.SC
+    if any(t in _SC_DEPLOY_EVENT_TYPES for t in classified):
+        return Neutralization.SC
+    if any(t in _VSC_DEPLOY_EVENT_TYPES for t in classified):
+        return Neutralization.VSC
+    return Neutralization.NONE
+
+
+def _sc_active_from_rcm(rcm_events: list | None) -> bool:
+    """True if the lap's RCM events confirm any neutralisation (SC or VSC) right now.
+
+    Back-compat bool wrapper over :func:`_neutralization_from_rcm`; kept because the
+    override began life as a single flag. New code should read the finer distinction from
+    the enum, since SC and VSC differ on the pit-time saving (#471).
+    """
+    return _neutralization_from_rcm(rcm_events) is not Neutralization.NONE
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -589,14 +589,24 @@ CLIFF_LOSS   = 0.80  # s/lap lost when tyre passes the cliff.
                      # MEDIUM .059 / SOFT .072 s/lap), so it stands as a cliff parameter,
                      # not a Heilmeier citation.
 POS_GAP_S    = 1.50  # seconds per position gap (midfield approximation)
-SC_PIT_BONUS = 8.0   # seconds saved by pitting under SC (no delta-lap loss).
-                     # Measured on this repo's 71 races: 5.75 s, 95% CI [3.14, 8.25]
-                     # (n=124), so 8.0 sits inside the interval. Close to the mean of
-                     # Heilmeier's four published circuits (8.18 s, section 3.5 of
+SC_PIT_BONUS = 8.0   # seconds saved by pitting under a full Safety Car (Art. 55, no
+                     # delta-lap loss). Measured on this repo's 71 races: 5.75 s, 95% CI
+                     # [3.14, 8.25] (n=124), so 8.0 sits inside the interval. Close to the
+                     # mean of Heilmeier's four published circuits (8.18 s, section 3.5 of
                      # 10/4229). The N28 prompt's earlier "~12 s" is outside that CI.
                      # A per-circuit value would fit better: Heilmeier's spread runs
                      # 5.24 s (Melbourne) to 11.16 s (Catalunya), and #448 already builds
                      # the per-circuit table it could read from.
+VSC_PIT_BONUS = 3.0  # seconds saved by pitting under a Virtual Safety Car (Art. 56).
+                     # Materially less than a full SC: a VSC preserves gaps and restarts
+                     # near-instantly (56.5 / 56.7), so the field is NOT queued and the
+                     # relative saving is roughly half. NOT measured: the repo ships no
+                     # pit-stop dataset labelled by track status (data/processed/pit_labeled
+                     # is empty), so this is a conservative placeholder to calibrate once
+                     # such data exists (#470/#471). Roughly half the SC saving measured
+                     # elsewhere (~5.75 s) rounds to ~3.0; conservative (understates the VSC
+                     # benefit) so it biases against over-recommending a VSC stop until
+                     # measured.
 
 
 def simulate_lap_window(
@@ -606,6 +616,7 @@ def simulate_lap_window(
     pit_i:    float,
     ucut_i:   bool,
     window:   int = WINDOW_LAPS,
+    sc_pit_bonus: float = SC_PIT_BONUS,
 ) -> float:
     """Estimate position gain vs STAY_OUT baseline over a W-lap window.
 
@@ -619,12 +630,12 @@ def simulate_lap_window(
         beyond the cliff contribute CLIFF_LOSS s/lap of time loss, converted
         to position units using POS_GAP_S.
     sc_i:
-        Whether a Safety Car event occurs in the window (Bernoulli N27 draw).
-        Pitting under SC avoids the delta-lap penalty (SC_PIT_BONUS saved). Under SC,
-        OVERCUT scores the same as PIT_NOW (same stop, same bonus, same fresh-tyre
-        window), so the model is indifferent between them and the tie breaks elsewhere.
-        OVERCUT previously scored higher because its branch took the bonus without
-        subtracting the stop.
+        Whether a neutralisation (SC or VSC) occurs in the window (Bernoulli N27 draw).
+        Pitting under one avoids the delta-lap penalty (sc_pit_bonus saved). Under a
+        neutralisation, OVERCUT scores the same as PIT_NOW (same stop, same bonus, same
+        fresh-tyre window), so the model is indifferent between them and the tie breaks
+        elsewhere. OVERCUT previously scored higher because its branch took the bonus
+        without subtracting the stop.
     pit_i:
         Pit stop duration sample in seconds (Triangular N28 / prior draw). Physical stop
         only, not the pit-lane traversal. The two-compound rule makes a stop mandatory,
@@ -636,17 +647,23 @@ def simulate_lap_window(
         +POS_GAP_S bonus of UNDERCUT vs PIT_NOW.
     window:
         Lap horizon for the evaluation. Default is WINDOW_LAPS=5.
+    sc_pit_bonus:
+        Seconds a pit stop saves when sc_i is True. Defaults to SC_PIT_BONUS (a full
+        Safety Car). The caller passes VSC_PIT_BONUS under a Virtual Safety Car, which
+        saves materially less because the field is not queued (Art. 56, #471). Only the
+        magnitude of the neutralisation's pit benefit differs; every other term is
+        unchanged, so a green-flag call (default) is byte-identical to before.
     """
     if strategy == "STAY_OUT":
         cliff_laps = max(0.0, window - cliff_i)
         time_delta = -cliff_laps * CLIFF_LOSS
 
     elif strategy == "PIT_NOW":
-        sc_saving  = SC_PIT_BONUS if sc_i else 0.0
+        sc_saving  = sc_pit_bonus if sc_i else 0.0
         time_delta = -pit_i + sc_saving + FRESH_GAIN * window
 
     elif strategy == "UNDERCUT":
-        sc_saving  = SC_PIT_BONUS if sc_i else 0.0
+        sc_saving  = sc_pit_bonus if sc_i else 0.0
         ucut_bonus = POS_GAP_S if ucut_i else 0.0
         time_delta = -pit_i + sc_saving + FRESH_GAIN * window + ucut_bonus
 
@@ -666,7 +683,7 @@ def simulate_lap_window(
         # -14 positions against a worst-case STAY_OUT of about -2.7 and suppresses pitting.
         # See tests/test_mc_is_a_real_decision.py.
         if sc_i:
-            time_delta = -pit_i + SC_PIT_BONUS + FRESH_GAIN * window
+            time_delta = -pit_i + sc_pit_bonus + FRESH_GAIN * window
         else:
             cliff_laps = max(0.0, (window // 2) - cliff_i)
             time_delta = -pit_i + FRESH_GAIN * (window // 2) - cliff_laps * CLIFF_LOSS
@@ -738,6 +755,15 @@ def _run_mc_simulation(
 
     sc_prob = situation_out.sc_prob_3lap
 
+    # A VSC is a neutralisation too (N27 forces sc_prob_3lap to 1.0, so every draw sees
+    # it), but it does NOT bunch the field the way a full SC does: gaps are preserved and
+    # the restart is instant (Art. 56.5 / 56.7), so the relative pit-time saving is much
+    # smaller. Charge the VSC its own (smaller) bonus instead of the full SC one; every
+    # other draw is unchanged, so a green or full-SC state is byte-identical to before
+    # (#471, and the "same 8 s for a VSC" bug in #470). vsc_active is False on any
+    # RaceSituationOutput that predates the split, so old callers keep the SC bonus.
+    sc_pit_bonus = VSC_PIT_BONUS if getattr(situation_out, "vsc_active", False) else SC_PIT_BONUS
+
     # A tool-parse failure inside N28 leaves the durations at 0.0 (its `or 0.0`
     # defaults), and 0.0 is not a stop time — it means "unknown". Simulating it makes
     # a pit stop FREE, so PIT_NOW (~+1.25 s) wins essentially every draw: a silent
@@ -772,7 +798,8 @@ def _run_mc_simulation(
 
     for s in strategies:
         outcomes = np.array([
-            simulate_lap_window(s, cliff_s[i], sc_s[i], pit_s[i], ucut_s[i])
+            simulate_lap_window(s, cliff_s[i], sc_s[i], pit_s[i], ucut_s[i],
+                                sc_pit_bonus=sc_pit_bonus)
             for i in range(n)
         ])
         e_val   = float(np.mean(outcomes))
@@ -1213,6 +1240,9 @@ def _run_conditional_agents(
             # its prompt with the deploy banner, (b) bypass the minimum-stint
             # guard, and (c) trip the post-LLM STAY_OUT→PIT_NOW guard-rail.
             "sc_currently_active": situation_out.sc_currently_active,
+            # ...and this one so the banner names a VSC as a VSC: under Art. 56 the
+            # field is not queued, so a stop saves much less than under a full SC (#471).
+            "vsc_active":          situation_out.vsc_active,
         }
         if laps_df is not None:
             pit_out = run_pit_strategy_agent_from_state(pit_lap_state, laps_df)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -285,8 +285,10 @@ def test_race_situation_sc_override_pure():
     assert _sc_active_from_rcm([sc_ev]) is True
 
     end_ev = RCMEvent(message="SAFETY CAR ENDING", flag="", category="SafetyCar", lap=7)
-    # Release wins over deploy in the same RCM window.
-    assert _sc_active_from_rcm([sc_ev, end_ev]) is False
+    # A lap carrying the SC-ending message is still neutralised: the car returns at the
+    # end of that lap and overtaking stays banned until a driver passes the Line after it
+    # returns (Art. 55.15 + 55.8). The flag clears the next lap, not on the release lap.
+    assert _sc_active_from_rcm([sc_ev, end_ev]) is True
 
     # Raw FastF1-shaped dict is also accepted (auto-classified inside the helper).
     assert (


### PR DESCRIPTION
## What
The strategy engine treated a Virtual Safety Car exactly like a full Safety Car, and released a full SC one lap too early. This splits the two neutralisation types and holds the SC one extra lap on release.

## Why
- A VSC preserves gaps and restarts near-instantly (Art. 56), so a pit stop under it saves far less than under a full SC where the field queues at the delta. Scoring them the same over-recommended pitting under a VSC.
- On real FastF1 RCM data the SC 'coming in' message is **'SAFETY CAR IN THIS LAP'** (Qatar 2025 L10, Spain 2025 L60), which classifies to `SAFETY_CAR_ENDING`. The car returns at the *end* of that lap and overtaking stays banned until after (Art. 55.15 + 55.8), so clearing the flag on the announcement lap was one lap early.

## How
- `race_situation_agent`: `Neutralization(NONE/SC/VSC)` enum, split deploy/release event sets, new `vsc_active` output; `sc_currently_active` **retained unchanged** (True for both) so every existing consumer keeps working. `overtake_prob=0`/`sc_prob_3lap=1.0` forced for both.
- `strategy_orchestrator`: `VSC_PIT_BONUS=3.0`; `simulate_lap_window` gains `sc_pit_bonus` (default `SC_PIT_BONUS`); `_run_mc_simulation` picks the VSC bonus when `vsc_active`. The green-flag and full-SC MC paths are **byte-identical** (frozen goldens unchanged).
- `pit_strategy_agent`: `vsc_active` threaded into prompt + banner.
- SC held one extra lap on release; VSC release immediate.

## Verify (no LLM, real models loaded)
- `pytest` 50 passed / 1 xfailed: **goldens unchanged**, MC invariants hold, SC regulatory rails hold, SC/VSC classification tests pass.
- Behavioural proof: PIT_NOW under SC 4.500 vs under VSC 1.167 (VSC saves less); OVERCUT under SC 4.500 == PIT_NOW under SC (the #440/#485 `-pit_i` charge survived the merge).
- `ruff check .` clean.

## Note on the merge
The agent worked on a base predating the Monte Carlo `-pit_i` fix; the OVERCUT line was resolved by hand to keep **both** `-pit_i` (MC fix) and `sc_pit_bonus` (VSC): `-pit_i + sc_pit_bonus + FRESH_GAIN * window`.

## Out of scope
`VSC_PIT_BONUS=3.0` is a documented placeholder (no track-status-labelled pit dataset exists yet); `_build_rag_question` still uses SC wording under a VSC.

Closes #471