### PR TITLE
fix(agents): validate LLM tool inputs and fix model-fidelity defects across the strategy engine

### DIFF
--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -207,18 +207,20 @@ class PaceAgent:
     def _load_reference_laps(self, processed_dir: Path) -> pd.DataFrame:
         """Load the reference laps parquet used for session median computation.
 
-        Only four columns are loaded to keep the in-memory footprint small.
-        The median baseline is used by N31 to contextualise absolute predictions.
+        Five columns are loaded to keep the in-memory footprint small. The median
+        baseline is used by N31 to contextualise absolute predictions. DriverNumber
+        is also kept so predict_pace_tool can refuse an LLM-invented car number for
+        a real GP/year instead of predicting from data that does not exist (#476).
 
         Args:
             processed_dir: Root of the processed data directory.
 
         Returns:
-            DataFrame with columns GP_Name, Year, Compound, LapTime_s.
+            DataFrame with columns GP_Name, Year, Compound, LapTime_s, DriverNumber.
         """
         return pd.read_parquet(
             processed_dir / 'laps_featured_2025.parquet',
-            columns=['GP_Name', 'Year', 'Compound', 'LapTime_s'],
+            columns=['GP_Name', 'Year', 'Compound', 'LapTime_s', 'DriverNumber'],
         )
 
     # ── Encoding helpers ──────────────────────────────────────────────────────
@@ -470,6 +472,56 @@ class PaceAgent:
         subset = self.laps_ref.loc[mask, 'LapTime_s'].dropna()
         return float(subset.median()) if len(subset) > 0 else None
 
+    def _validate_pace_inputs(
+        self, driver_number: int, lap_number: int, total_laps: int,
+        gp_name: str, year: int,
+    ) -> Optional[str]:
+        """Refuse an LLM-supplied pace query when the lap or driver cannot be real.
+
+        predict_pace_tool takes 19 raw scalar params straight from the LLM with no
+        closure over a live-drivers roster or a lap_state at all (#476) — unlike
+        score_undercut_tool in pit_strategy_agent.py, which checks its free-text
+        driver_y against self._live_drivers before scoring. This is the pace-side
+        equivalent: an out-of-range lap or an invented car number would otherwise
+        produce a confident-looking lap-time prediction from data that does not
+        exist.
+
+        laps_ref only carries the 2025 season (see _load_reference_laps), so a
+        legitimate 2023/2024 call, or a GP name outside the 2025 calendar, yields
+        an empty ``known`` set here. That means "the roster is unknown", not "no
+        cars are racing", so the driver check is skipped rather than rejecting
+        every call outside 2025 — the same unknown-disables-the-guard rule
+        score_undercut_tool follows for its own live_drivers=None case.
+
+        Args:
+            driver_number: Car number as supplied by the LLM caller.
+            lap_number: Lap number as supplied by the LLM caller.
+            total_laps: Total scheduled race laps, also LLM-supplied.
+            gp_name: GP name matching the laps_ref GP_Name column.
+            year: Race year integer.
+
+        Returns:
+            An error string when the query should be refused, None when it is
+            safe to run inference.
+        """
+        if not (1 <= lap_number <= total_laps):
+            return (
+                f'Pace prediction REFUSED — lap {lap_number} is out of range for a '
+                f'{total_laps}-lap race (valid range: 1-{total_laps}).'
+            )
+
+        known = self.laps_ref.loc[
+            (self.laps_ref['GP_Name'] == gp_name) & (self.laps_ref['Year'] == year),
+            'DriverNumber',
+        ].dropna().astype(int)
+        known_set = set(known)
+        if known_set and driver_number not in known_set:
+            return (
+                f'Pace prediction REFUSED — car number {driver_number} is not on '
+                f'track at {gp_name} {year}. Known car numbers: {sorted(known_set)}.'
+            )
+        return None
+
     # ── Main inference entrypoint ─────────────────────────────────────────────
 
     def run(
@@ -623,7 +675,23 @@ class PaceAgent:
             laps_since_pit = d.get('tyre_life') or 1,
             fuel_load      = laps_remaining / max(total_laps, 1),
             year           = meta.get('year') or 2025,
-            prev_lap_time  = d.get('lap_time_s') or 90.0,
+            # ``d.get('prev_lap_time') or 90.0``, NOT ``d.get('lap_time_s')``: the
+            # latter fed this LAP's own time back in as the PREVIOUS lap's time, so
+            # the model chased its own most recent prediction instead of the real
+            # preceding lap (#435). RaceStateManager.get_driver_state now emits the
+            # real 'prev_lap_time' sourced from the parquet's Prev_LapTime column.
+            # ``or``, not the two-arg get(key, default) form: Prev_LapTime is NaN
+            # on the first lap of a stint/race (no earlier lap exists), which
+            # get_driver_state turns into an explicit ``None`` — present key, None
+            # value — and the two-arg form only substitutes when the KEY is
+            # absent, never when the VALUE is (the same Series.get trap #428/#446/
+            # #462 keep finding). Unlike stint_baseline_tyre_life below, None
+            # cannot be allowed through here: _predict() reads Prev_LapTime
+            # straight into ``prev + delta`` with no NaN branch, so a bare None
+            # would turn lap_time_pred itself into NaN. 90.0 is the same
+            # order-of-magnitude placeholder the old (wrong) code used, now only
+            # reached on a genuinely missing previous lap.
+            prev_lap_time  = d.get('prev_lap_time') or 90.0,
             prev_tyre_life = max(0, (d.get('tyre_life') or 1) - 1),
             prev_speed_st  = float(_speed_st),
             air_temp       = float(_air_temp),
@@ -814,8 +882,19 @@ if _LANGGRAPH_AVAILABLE:
 
         Returns:
             Dict with keys: lap_time_pred, delta_vs_prev, delta_vs_median,
-            ci_p10, ci_p90 (all floats in seconds).
+            ci_p10, ci_p90 (all floats in seconds). Returns {'error': str}
+            instead, without running inference, when the driver is not on
+            track for the given GP/year or the lap is outside [1, total_laps]
+            (#476) — the LLM supplies every one of these 19 params as free
+            text with no server-side roster or range check otherwise.
         """
+        agent = _get_default_pace_agent()
+        validation_error = agent._validate_pace_inputs(
+            driver_number, lap_number, total_laps, gp_name, year,
+        )
+        if validation_error is not None:
+            return {'error': validation_error}
+
         out = run_pace_agent(
             driver_number=driver_number, lap_number=lap_number, stint=stint,
             tyre_life=tyre_life, compound=compound, position=position, team=team,

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -40,7 +40,11 @@ try:
 except Exception:
     _DATA_ROOT = _REPO_ROOT / 'data'
 
-from src.f1_strat_manager.gp_slugs import rekey_by_slug, slug_from_event_name  # noqa: E402
+from src.f1_strat_manager.gp_slugs import (  # noqa: E402
+    canonical_gp_name,
+    rekey_by_slug,
+    slug_from_event_name,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +90,22 @@ _N15_COMPOUND_UNKNOWN: int = -1  # matches the notebook's .fillna(-1)
 # an absurd stint cannot extrapolate outside the fitted range (#450).
 _MAX_TRAINED_TYRE_LIFE: int = 50
 
+# N15's tight_pit_box feature (notebook cell 4): {"Monaco Grand Prix", "Singapore Grand
+# Prix", "Hungarian Grand Prix"} — circuits with narrow/short pit boxes that cause minor
+# stop delays. Keyed here by the CANONICAL SLUG ('Monaco', 'Marina Bay', 'Budapest'), not
+# the full event name, because gp_name at inference can arrive in EITHER keyspace exactly
+# like circuit_traversal/circuit_undercut_rate above; resolve through slug_from_event_name
+# before checking membership (#450, the same dual-keyspace fix as #448).
+_TIGHT_PIT_BOX_SLUGS: frozenset[str] = frozenset({'Monaco', 'Marina Bay', 'Budapest'})
+
+# N15 only trained on "normal" stops (N15_pit_duration.ipynb Step 2): physical_stop_est
+# in [2.0, 4.5] s. Penalties, jack failures and unsafe releases fall outside this and are
+# handled by race-control messages elsewhere, not this model. Apply the same scope when
+# aggregating team_year_median from raw data (#450) so the medians reflect the same
+# stops N15 was actually trained on.
+_NORMAL_STOP_MIN_S: float = 2.0
+_NORMAL_STOP_MAX_S: float = 4.5
+
 CLIFF_IMMINENT_LAPS = 3    # laps_to_cliff_p10 below this → PIT_NOW
 CLIFF_SOON_LAPS     = 10   # laps_to_cliff_p10 below this → prefer harder compound
 
@@ -108,9 +128,12 @@ class PitAgentCFG:
     team_encoder is a sklearn LabelEncoder reconstructed from the class list in
     model_config.json — no separate .pkl needed.
 
-    team_year_median_fallback (2.8 s): per-team×year medians were not exported from
-    N15. This constant is the centre of the [2.0, 4.5 s] training range; the feature
-    ranks low in permutation importance so the approximation is adequate.
+    team_year_median_fallback (2.8 s): N15 never exported its per-team×year medians, so
+    this constant used to stand in for EVERY call regardless of team or year (#450).
+    __post_init__ now aggregates the real medians from raw pit data
+    (_load_team_year_medians); this constant only backstops a (team, year) combo with
+    no raw data (e.g. a team's rookie season). It is the centre of the [2.0, 4.5 s]
+    training range, chosen so an unseen combo still lands in-distribution.
 
     circuit_undercut_rate and team_x_undercut_rate are pre-aggregated at startup
     from undercut_clean.parquet so tool calls are stateless.
@@ -155,6 +178,12 @@ class PitAgentCFG:
         le.classes_ = np.array(pit_cfg['label_encoder_classes']['team'])
         self.team_encoder: LabelEncoder = le
 
+        # Real per-(team, year) physical-stop medians, aggregated from raw pit data now
+        # that circuit_traversal is available (needed to isolate the physical-stop
+        # component from total pit-lane time, same decomposition N15 was trained on).
+        # See team_year_median_fallback's docstring above and #450.
+        self.team_year_median: dict[tuple[str, int], float] = self._load_team_year_medians()
+
         # N16: undercut classifier + calibrator
         self.undercut_model      = joblib.load(_pit / 'lgbm_undercut_v1.pkl')
         self.undercut_calibrator = joblib.load(_pit / 'calibrator_undercut_v1.pkl')
@@ -178,6 +207,57 @@ class PitAgentCFG:
             _uc.groupby('Team_X')['undercut_success'].mean().to_dict()
         )
 
+    def _load_team_year_medians(self) -> dict[tuple[str, int], float]:
+        """Aggregate real per-(team, year) physical-stop medians from raw pit data.
+
+        Mirrors N15's own team_year_median feature (N15_pit_duration.ipynb Step 2,
+        add_team_year_median): physical_stop_est = pit_duration_s - circuit_traversal,
+        grouped by (team, year) and reduced to the median. That table was never
+        exported from the notebook, so inference fed every call the SAME 2.8s
+        constant no matter which team or year was asked about (#450) — this rebuilds
+        it from data/raw/<year>/<GP>/pitstops.parquet instead of guessing.
+
+        Requires self.circuit_traversal to already be populated (called after that
+        assignment in __post_init__): each GP's traversal is needed to isolate the
+        physical-stop component from the raw pit-lane time, the same decomposition
+        N15 was trained on.
+
+        Returns:
+            Dict keyed by (team name normalised through _TEAM_ALIASES, year) → median
+            physical_stop_est in seconds. A combo absent here falls back to
+            team_year_median_fallback at read time (team_year_median_for).
+        """
+        records: list[dict] = []
+        for gp_dir in sorted((_DATA_ROOT / 'raw').glob('*/*')):
+            pit_path = gp_dir / 'pitstops.parquet'
+            if not pit_path.exists():
+                continue
+            try:
+                year = int(gp_dir.parent.name)
+            except ValueError:
+                continue
+
+            gp_slug   = canonical_gp_name(gp_dir.name)
+            traversal = self.circuit_traversal.get(gp_slug, 20.0)
+            try:
+                stops = _extract_physical_stops(pit_path, traversal)
+            except Exception:
+                logger.warning('team_year_median: failed to parse %s; skipping this GP', pit_path)
+                continue
+
+            for team_raw, physical_stop_est in stops:
+                team = _TEAM_ALIASES.get(team_raw, team_raw)
+                records.append({'team': team, 'year': year, 'physical_stop_est': physical_stop_est})
+
+        if not records:
+            return {}
+        medians = (
+            pd.DataFrame.from_records(records)
+            .groupby(['team', 'year'])['physical_stop_est']
+            .median()
+        )
+        return {key: float(value) for key, value in medians.items()}
+
     def traversal_for(self, gp_name: str) -> float:
         """Pit-lane traversal (s) for a GP given in EITHER keyspace.
 
@@ -189,6 +269,21 @@ class PitAgentCFG:
         """
         slug = slug_from_event_name(gp_name) or gp_name
         return self.circuit_traversal.get(slug, 20.0)
+
+    def team_year_median_for(self, team: str, year: int) -> float:
+        """Per-(team, year) physical-stop median (s), or the global fallback if unseen.
+
+        Args:
+            team: Team name already normalised through _TEAM_ALIASES — callers must
+                apply that alias BEFORE this lookup so a 2025 'Racing Bulls' row
+                lands on the same key as the '2023/2024 'RB' rows it aggregated with.
+            year: Race year.
+
+        Returns:
+            Median physical_stop_est (s) for that team/year, or
+            team_year_median_fallback (2.8 s) when the combo has no raw pit data.
+        """
+        return self.team_year_median.get((team, year), self.team_year_median_fallback)
 
     def undercut_rate_for(self, gp_name: str) -> float:
         """Circuit undercut base rate for a GP in either keyspace (an N16 feature).
@@ -263,18 +358,77 @@ def _compound_to_id(compound: str, gp_name: str, year: int) -> int:
     return _COMPOUND_FALLBACK.get(compound.upper(), 3)
 
 
+def _extract_physical_stops(pit_path: Path, traversal_s: float) -> list[tuple[str, float]]:
+    """Reconstruct (team, physical_stop_est) pairs from one raw pitstops.parquet.
+
+    Mirrors N15_pit_duration.ipynb's collect_pit_data: the raw file holds one row per
+    stop with PitInTime set (the in-lap) and a second row on the NEXT lap with
+    PitOutTime set (the out-lap) for the same driver. Matching them by
+    (Driver, LapNumber + 1) and subtracting timestamps gives total pit-lane time;
+    subtracting traversal_s (this circuit's fixed traversal component) isolates the
+    physical-stop component the same way N15's target was built. The TyreLife_out <= 5
+    filter drops drive-through penalties and jack failures where no tyre was actually
+    changed — those carry no team-quality signal and were excluded from training too.
+
+    Args:
+        pit_path: Path to one GP's raw pitstops.parquet.
+        traversal_s: This circuit's pit-lane traversal time (s), already resolved from
+            PitAgentCFG.circuit_traversal.
+
+    Returns:
+        List of (team_name, physical_stop_est_seconds) tuples, one per genuine,
+        in-training-scope stop ([_NORMAL_STOP_MIN_S, _NORMAL_STOP_MAX_S]).
+    """
+    cols = ['Driver', 'Team', 'LapNumber', 'PitInTime', 'PitOutTime', 'TyreLife']
+    laps = pd.read_parquet(pit_path, columns=cols)
+
+    pit_in  = laps.loc[laps['PitInTime'].notna(), ['Driver', 'Team', 'LapNumber', 'PitInTime']].copy()
+    pit_out = laps.loc[laps['PitOutTime'].notna(), ['Driver', 'LapNumber', 'PitOutTime', 'TyreLife']].copy()
+    pit_in['LapNumber_out'] = pit_in['LapNumber'] + 1
+
+    merged = pit_in.merge(
+        pit_out.rename(columns={'LapNumber': 'LapNumber_out', 'TyreLife': 'TyreLife_out'}),
+        on=['Driver', 'LapNumber_out'], how='inner',
+    )
+    if merged.empty:
+        return []
+
+    merged = merged[merged['TyreLife_out'] <= 5]
+    if merged.empty:
+        return []
+
+    pit_duration_s    = (merged['PitOutTime'] - merged['PitInTime']).dt.total_seconds()
+    physical_stop_est = (pit_duration_s - traversal_s).clip(lower=0.5)
+    in_scope          = physical_stop_est.between(_NORMAL_STOP_MIN_S, _NORMAL_STOP_MAX_S)
+
+    return list(zip(merged.loc[in_scope, 'Team'], physical_stop_est[in_scope]))
+
+
 def _parse_tool_outputs(messages: list) -> dict:
     """Extract numeric values from tool call results in the agent message history.
 
     Scans ToolMessage content for structured strings from each tool. Values
     default to None when the corresponding tool was not called.
 
+    The ReAct agent calls score_undercut_tool once PER candidate rival (system prompt
+    rule 2: "for each rival within 5 positions ahead"), so several undercut results can
+    appear across the message history. Only latching onto the FIRST P(undercut_success)
+    match — and never onto WHICH driver it was scored against — meant undercut_target
+    was assembled from the positional rival_ahead candidate instead of the driver N16
+    actually scored highest, silently mismatching prob and target on every multi-rival
+    call (#432). Tracking the argmax (driver, prob) pair across ALL score_undercut_tool
+    calls fixes this; score_undercut_tool embeds the driver_y it scored (`candidate=...`)
+    precisely so this function has something to key the argmax on.
+
     Args:
         messages: LangChain message objects from the agent's invoke result.
 
     Returns:
         Dict with: stop_duration_p05/p50/p95, undercut_prob, undercut_target,
-        compound_recommendation. Missing keys default to None.
+        compound_recommendation. Missing keys default to None. undercut_target is
+        the driver whose call produced the highest undercut_prob seen, NOT yet
+        validated against the live-drivers roster — callers must validate before
+        using it (see PitStrategyAgent._validate_undercut_target).
     """
     result: dict = {
         'stop_duration_p05':       None,
@@ -293,9 +447,13 @@ def _parse_tool_outputs(messages: list) -> dict:
             result['stop_duration_p05'] = float(m.group(1))
             result['stop_duration_p50'] = float(m.group(2))
             result['stop_duration_p95'] = float(m.group(3))
-        m = re.search(r'P\(undercut_success\)=(\d+(?:\.\d+)?)', content)
-        if m and result['undercut_prob'] is None:
-            result['undercut_prob'] = float(m.group(1))
+        m = re.search(r'candidate=(\w+)\s*\|\s*P\(undercut_success\)=(\d+(?:\.\d+)?)', content)
+        if m:
+            candidate_driver = m.group(1)
+            candidate_prob   = float(m.group(2))
+            if result['undercut_prob'] is None or candidate_prob > result['undercut_prob']:
+                result['undercut_prob']   = candidate_prob
+                result['undercut_target'] = candidate_driver
         m = re.search(r'Recommended:\s*(SOFT|MEDIUM|HARD)', content)
         if m:
             result['compound_recommendation'] = m.group(1)
@@ -626,9 +784,10 @@ class PitStrategyAgent:
         """Build the 9-feature input row for the N15 quantile regressors.
 
         Assembles features from self.laps_df, self.session_meta, and self.cfg lookups.
-        team_year_median uses cfg.team_year_median_fallback (2.8 s) because
-        per-team×year medians were not exported from N15.
-        tight_pit_box is hardcoded False — near-zero permutation importance in N15.
+        tight_pit_box checks the circuit against N15's trained tight-pit-box set
+        (Monaco/Singapore/Hungary); team_year_median looks up the real aggregated
+        per-(team, year) median, falling back to cfg.team_year_median_fallback (2.8s)
+        only for a combo with no raw pit data (#450 — both used to be frozen constants).
 
         Args:
             driver: FastF1 driver abbreviation.
@@ -647,11 +806,24 @@ class PitStrategyAgent:
         if row is None:
             raise ValueError(f'No lap data for {driver} at lap {lap_number}')
 
-        # No gp_name here on purpose: N15's compound_id is an ordinal rank, not the
-        # circuit's Pirelli allocation, so this builder needs no circuit lookup (#445).
+        # gp_name IS needed here now, unlike #445's note about compound_id: tight_pit_box
+        # is a circuit-membership check, not a Pirelli compound lookup, so it does not
+        # share that concern.
         # (helper `_tyre_life_in` below reads TyreLife safely; see its docstring)
         year     = self.session_meta.get('year', 2025)
         team_raw = self.session_meta.get('team_lookup', {}).get(driver, 'Unknown')
+        gp_name  = self.session_meta.get('gp_name', '')
+
+        # gp_name can arrive as either a FastF1 full event name or a replay-parquet
+        # slug (same dual-keyspace situation as circuit_traversal/circuit_undercut_rate);
+        # resolve to the slug before checking membership (#450).
+        gp_slug       = slug_from_event_name(gp_name) or gp_name
+        tight_pit_box = gp_slug in _TIGHT_PIT_BOX_SLUGS
+
+        # team_year_median_for needs the SAME normalised team string _encode_team uses
+        # internally, so the lookup and the encoding never disagree on which team a
+        # 2025 'Racing Bulls' row aggregated with (#450).
+        team_str = _TEAM_ALIASES.get(team_raw, team_raw)
 
         feat = {
             'team':             self._encode_team(team_raw),
@@ -669,8 +841,8 @@ class PitStrategyAgent:
             'compound_id':      _N15_COMPOUND_ORDER.get(compound.upper(), _N15_COMPOUND_UNKNOWN),
             'compound_change':  int(compound_change),
             'under_sc':         int(under_sc),
-            'tight_pit_box':    0,
-            'team_year_median': self.cfg.team_year_median_fallback,
+            'tight_pit_box':    int(tight_pit_box),
+            'team_year_median': self.cfg.team_year_median_for(team_str, year),
         }
         return pd.DataFrame([feat])[self.cfg.pit_features]
 
@@ -877,11 +1049,40 @@ class PitStrategyAgent:
                 lap_number: Lap on which the stop would occur.
                 compound: Compound being fitted ('SOFT', 'MEDIUM', 'HARD').
                 compound_change: True if switching from current compound.
-                under_sc: True if Safety Car is active during the stop.
+                under_sc: True if Safety Car is active during the stop. Cross-checked
+                    against the RCM-confirmed ground truth when a real run set it
+                    (see PitStrategyAgent._run_core); an LLM guess never overrides a
+                    known fact (#476).
 
             Returns:
                 "physical_stop: P05={p05:.2f}s | P50={p50:.2f}s | P95={p95:.2f}s | total_pit_P50={total:.2f}s (traversal={traversal:.2f}s)"
             """
+            # driver is LLM free text, exactly like score_undercut_tool's driver_y —
+            # replicate that tool's REFUSED shape instead of computing on a car that
+            # is not (or no longer) on track (#476).
+            live = getattr(agent, '_live_drivers', None)
+            if live is not None and driver not in live:
+                return (
+                    f'Pit duration prediction REFUSED — {driver} is not on track at lap '
+                    f'{lap_number}. Cars in the race this lap: {", ".join(sorted(live))}. '
+                    f'Pick a driver from that list.'
+                )
+
+            # under_sc is also LLM free text. self.sc_currently_active (set only inside
+            # _run_core, for the duration of one real invocation) is the RCM-confirmed
+            # ground truth for THIS lap; when it disagrees with what the LLM supplied,
+            # trust the confirmed state rather than the guess. getattr(..., None) keeps
+            # direct/test calls of this tool (outside _run_core) unaffected — the
+            # cross-check only fires when the ground truth is actually reachable.
+            known_sc = getattr(agent, 'sc_currently_active', None)
+            if known_sc is not None and bool(under_sc) != known_sc:
+                logger.warning(
+                    'predict_pit_duration_tool: LLM-supplied under_sc=%s contradicts the '
+                    'RCM-confirmed sc_currently_active=%s at lap %s; using the RCM value (#476)',
+                    under_sc, known_sc, lap_number,
+                )
+                under_sc = known_sc
+
             feat_df  = agent._build_pit_duration_features(driver, lap_number, compound, compound_change, under_sc)
             p05      = float(agent.cfg.pit_p05_model.predict(feat_df)[0])
             p50      = float(agent.cfg.pit_p50_model.predict(feat_df)[0])
@@ -906,7 +1107,10 @@ class PitStrategyAgent:
                 lap_number: Current lap number.
 
             Returns:
-                "P(undercut_success)={prob:.3f} | threshold={threshold} | pos_gap={gap:.0f} | tyre_life_diff={diff:+.0f} laps | verdict={YES/NO}"
+                "candidate={driver_y} | P(undercut_success)={prob:.3f} | threshold={threshold} | pos_gap={gap:.0f} | tyre_life_diff={diff:+.0f} laps | verdict={YES/NO}"
+                The leading candidate=<driver_y> is what lets _parse_tool_outputs track
+                the argmax across multiple rivals scored in one run (#432) — every
+                other tool output format is unaffected.
             """
             # The LLM picks driver_y as free text, so it can name any car on the grid,
             # including one that is no longer in the race. Answer with an error rather
@@ -935,8 +1139,9 @@ class PitStrategyAgent:
             tyre_diff = feat_df['tyre_life_diff'].iloc[0]
 
             return (
-                f'P(undercut_success)={calib_proba:.3f} | threshold={agent.cfg.undercut_threshold} | '
-                f'pos_gap={pos_gap:.0f} | tyre_life_diff={tyre_diff:+.0f} laps | verdict={verdict}'
+                f'candidate={driver_y} | P(undercut_success)={calib_proba:.3f} | '
+                f'threshold={agent.cfg.undercut_threshold} | pos_gap={pos_gap:.0f} | '
+                f'tyre_life_diff={tyre_diff:+.0f} laps | verdict={verdict}'
             )
 
         @lc_tool
@@ -962,6 +1167,18 @@ class PitStrategyAgent:
             Returns:
                 "Recommended: {compound} | {strategy} | {urgency} | laps_remaining={n} | current={current} | source={source}"
             """
+            # driver is LLM free text here too, exactly like the other two tools; guard
+            # it the same way even though the computation below is driver-agnostic
+            # today (only lap_number/current_compound/laps_to_cliff feed it) — a caller
+            # that later wires in per-driver state must not inherit an unguarded arg (#476).
+            live = getattr(agent, '_live_drivers', None)
+            if live is not None and driver not in live:
+                return (
+                    f'Compound recommendation REFUSED — {driver} is not on track at lap '
+                    f'{lap_number}. Cars in the race this lap: {", ".join(sorted(live))}. '
+                    f'Pick a driver from that list.'
+                )
+
             total_laps       = agent.session_meta.get('total_laps', 57)
             laps_remaining   = total_laps - lap_number
             current_compound = current_compound.upper()
@@ -1150,10 +1367,17 @@ class PitStrategyAgent:
         team       = meta.get('team', 'Unknown')
         compound   = d.get('compound', 'MEDIUM')
 
-        driver_pos  = d.get('position', 20)
-        rival_ahead = next(
-            (r['driver'] for r in rivals if r.get('position') == driver_pos - 1),
-            None,
+        # A missing position must not resolve to a searchable value: defaulting to 20
+        # lets `driver_pos - 1 == 19` accidentally match a REAL P19 rival, inventing a
+        # rival-ahead relationship for a car whose position we don't actually know. This
+        # is the same Series.get(k, default)-only-fires-on-missing-COLUMN sentinel
+        # pattern documented elsewhere in this file (#428/#444/#462) — here the default
+        # is dict.get, but the failure mode is identical: an explicit unknown must
+        # propagate as None, not as a plausible-looking P20 (#465/F6).
+        driver_pos  = d.get('position')
+        rival_ahead = (
+            next((r['driver'] for r in rivals if r.get('position') == driver_pos - 1), None)
+            if driver_pos is not None else None
         )
 
         team_lookup = {r['driver']: r.get('team', 'Unknown') for r in rivals}
@@ -1198,6 +1422,33 @@ class PitStrategyAgent:
             vsc_active=vsc_active,
         )
 
+    def _validate_undercut_target(self, candidate: Optional[str]) -> Optional[str]:
+        """Return candidate only when it is a currently-live driver (or liveness unknown).
+
+        score_undercut_tool already refuses to score a driver_y absent from
+        _live_drivers, so its P(undercut_success) never reaches _parse_tool_outputs'
+        regex for an invalid target — but that guard and this one must not depend on
+        each other to be correct: assembly re-checks independently before the parsed
+        argmax driver becomes PitStrategyOutput.undercut_target (#432).
+
+        Args:
+            candidate: Driver abbreviation parsed as the argmax undercut target from
+                _parse_tool_outputs, or None when no score_undercut_tool call matched.
+
+        Returns:
+            candidate unchanged when liveness can't be determined (_live_drivers is
+            None) or candidate is live; otherwise None.
+        """
+        if candidate is None:
+            return None
+        if self._live_drivers is not None and candidate not in self._live_drivers:
+            logger.warning(
+                'undercut_target %s parsed from tool output but not on track; dropping',
+                candidate,
+            )
+            return None
+        return candidate
+
     def _run_core(
         self,
         driver: str,
@@ -1230,6 +1481,14 @@ class PitStrategyAgent:
         """
         if not _LANGGRAPH_AVAILABLE:
             raise ImportError('LangGraph / LangChain not installed.')
+
+        # RCM-confirmed ground truth for this lap, stored so predict_pit_duration_tool
+        # can cross-check the LLM-supplied under_sc argument against it instead of
+        # trusting free text alone (#476). Set only here, not in __init__: a direct
+        # tool call outside a real run leaves it absent (getattr returns None), which
+        # skips the cross-check rather than asserting a False ground truth against an
+        # intentional test input.
+        self.sc_currently_active = sc_currently_active
 
         candidates = self._get_undercut_candidates(driver, lap_number)
         rival_str  = rival if rival else (candidates[0] if candidates else 'no rival in range')
@@ -1273,7 +1532,10 @@ class PitStrategyAgent:
             stop_duration_p50       = parsed['stop_duration_p50'] or 0.0,
             stop_duration_p95       = parsed['stop_duration_p95'] or 0.0,
             undercut_prob           = parsed['undercut_prob'],
-            undercut_target         = rival_str if parsed['undercut_prob'] else None,
+            # The driver score_undercut_tool actually scored highest, not the
+            # POSITIONAL rival_str candidate used to build the prompt — those two
+            # silently disagreed whenever the agent scored more than one rival (#432).
+            undercut_target         = self._validate_undercut_target(parsed['undercut_target']),
             sc_reactive             = sc_reactive,
             reasoning               = reasoning,
         )

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -124,14 +124,18 @@ class RaceSituationConfig:
     save_model on Windows.
 
     Threat-level boundaries map raw calibrated probabilities to LOW/MEDIUM/HIGH
-    categorical signals for N31. Thresholds match the Optuna/F2-score tuning
-    from N12 (overtake) and N14 (SC).
+    categorical signals for N31. high_overtake/high_sc are overwritten in
+    __post_init__ from the tuned optimal_threshold/best_threshold in each model's
+    on-disk config (#450) — the literals below are only a construction-time
+    placeholder, never the value actually used once the config has loaded.
 
     Attributes:
         model_name: LM Studio model identifier for the ReAct agent LLM.
         high_overtake: Probability above which threat_level is HIGH via overtake.
+            Overwritten from overtake_threshold (N12's model_config.json).
         medium_overtake: Probability above which threat_level is MEDIUM via overtake.
         high_sc: Probability above which threat_level is HIGH via SC risk.
+            Overwritten from sc_threshold (N14's feature_list_v1.json).
         medium_sc: Probability above which threat_level is MEDIUM via SC risk.
     """
 
@@ -167,6 +171,18 @@ class RaceSituationConfig:
             sc_cfg = json.load(f)
         self.sc_features: list[str] = sc_cfg['features']
         self.sc_threshold: float    = sc_cfg['best_threshold']
+
+        # #450: high_overtake/high_sc were dataclass literals (0.80/0.30) that this
+        # __post_init__ never touched, so the genuinely tuned thresholds loaded just
+        # above (overtake_threshold, sc_threshold) sat unused — every threat_level ever
+        # computed by RaceSituationOutput.__post_init__ was thresholded against the
+        # untuned placeholder, most visibly for SC (0.30 hardcoded vs 0.2335 tuned:
+        # a real SC risk between those two values was silently reported as MEDIUM
+        # instead of HIGH). Overwriting here means every downstream reader of
+        # CFG.high_overtake / CFG.high_sc (RaceSituationOutput, the system prompt
+        # string below) gets the value the model was actually tuned against.
+        self.high_overtake = self.overtake_threshold
+        self.high_sc       = self.sc_threshold
 
         # Circuit cluster map (k=4 parquet from N05)
         _cl = pd.read_parquet(_PROCESSED / 'circuit_clustering' / 'circuit_clusters_k4.parquet')
@@ -230,9 +246,12 @@ class RaceSituationOutput:
 
     Attributes:
         overtake_prob: Calibrated P(overtake in next few laps) from N12 LightGBM
-            + Platt calibration. Above CFG.high_overtake (0.80) = strong opportunity.
+            + Platt calibration. Above CFG.high_overtake (N12's tuned
+            optimal_threshold, ~0.80 — see RaceSituationConfig.__post_init__) =
+            strong opportunity.
         sc_prob_3lap: Calibrated P(SC within 3 laps) from N14 LightGBM + Platt
-            calibration. Above CFG.high_sc (0.30) = imminent SC risk.
+            calibration. Above CFG.high_sc (N14's tuned best_threshold, ~0.23 —
+            see RaceSituationConfig.__post_init__) = imminent SC risk.
         threat_level: LOW / MEDIUM / HIGH derived from both probabilities in __post_init__.
         gap_ahead_s: Gap to the car directly ahead (seconds). < 1.0s = DRS range.
         pace_delta_s: 3-lap rolling pace delta vs car ahead (s/lap). Negative = faster.
@@ -341,8 +360,14 @@ def _dominant_status(grp: pd.DataFrame) -> str:
 def _compute_laptime_features(all_laps: pd.DataFrame, lap_number: int) -> dict:
     """Compute lap-time aggregate and z-score features for the current lap window.
 
-    Replicates the N13 aggregate_laps logic. Z-scores are causal — only laps up
-    to lap_number are used, matching the N14 training pipeline.
+    Replicates the N13 aggregate_laps logic, but NOT the N14 training pipeline's
+    normalisation: N14 was trained on z-scores computed non-causally over the WHOLE
+    race (mean/std of lap_time drawn from every lap, past and future relative to the
+    labeled row). This function is deliberately causal instead — it z-scores only
+    against laps up to lap_number, because a live agent has no future laps to read.
+    That is a genuine train/serve skew (#450); retraining N14 causally is out of
+    scope here, so this docstring names the mismatch rather than the previous
+    (incorrect) claim that the two "match".
 
     Args:
         all_laps: Accurate FastF1 laps from race start to current lap.
@@ -713,10 +738,15 @@ except ImportError:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# System prompt (module-level constant — unchanged from N27)
+# System prompt (module-level constant — interpolates CFG's loaded thresholds)
 # ─────────────────────────────────────────────────────────────────────────────
 
-_RACE_SITUATION_SYSTEM_PROMPT = """You are a Formula 1 race situation analyst embedded in a multi-agent strategy system.
+# f-string, not a plain triple-quoted constant: it must read the SAME thresholds
+# RaceSituationOutput.__post_init__ actually classifies against (CFG.high_overtake /
+# CFG.high_sc, loaded from each model's tuned config in RaceSituationConfig.__post_init__),
+# not the untuned dataclass literals. CFG is fully built by the time this module-level
+# constant is evaluated (CFG is constructed above, at import time). #450.
+_RACE_SITUATION_SYSTEM_PROMPT = f"""You are a Formula 1 race situation analyst embedded in a multi-agent strategy system.
 
 Your job is to assess two dimensions of strategic threat per lap:
 
@@ -728,8 +758,8 @@ Your job is to assess two dimensions of strategic threat per lap:
 1. If the gap to the car ahead is less than 2.5 seconds, call `predict_overtake_tool` with the chasing driver (driver_x) and the car ahead (driver_y) at the current lap number.
 2. Always call `predict_sc_tool` with the current lap number to assess SC deployment risk.
 3. Synthesize a **threat level** based on the two probabilities:
-   - **HIGH**: Either P(overtake) >= 0.80 OR P(SC 3-lap) >= 0.30
-   - **MEDIUM**: Either P(overtake) >= 0.40 OR P(SC 3-lap) >= 0.15
+   - **HIGH**: Either P(overtake) >= {CFG.high_overtake:.3f} OR P(SC 3-lap) >= {CFG.high_sc:.3f}
+   - **MEDIUM**: Either P(overtake) >= {CFG.medium_overtake:.3f} OR P(SC 3-lap) >= {CFG.medium_sc:.3f}
    - **LOW**: Both probabilities below medium thresholds
 
 ## Rules
@@ -951,6 +981,62 @@ class RaceSituationAgent:
 
         return pd.DataFrame([feat])[self.cfg.sc_features]
 
+    # ── LLM-input validation (shared by both LangChain tools) ────────────────
+
+    def _lap_range_error(self, lap_number: int) -> Optional[str]:
+        """Reject a lap_number outside the causal range the agent was loaded with.
+
+        run() loads the WHOLE FastF1 session into self.laps_df (session.laps.pick_
+        accurate()), so nothing on its own stops a hallucinated future lap number
+        from reaching the feature builders and returning a confident-looking
+        prediction built from data the race hasn't reached yet (#476). self.
+        _current_lap is set once per call in run()/run_from_state() to the lap
+        actually being assessed; anything beyond it is a future lookahead.
+
+        Args:
+            lap_number: The lap_number argument as supplied by the LLM tool call.
+
+        Returns:
+            An error string naming the problem, or None when lap_number is valid.
+        """
+        if lap_number < 1:
+            return f'invalid lap_number {lap_number} — laps start at 1'
+        current = getattr(self, '_current_lap', None)
+        if current is not None and lap_number > current:
+            return (
+                f'invalid lap_number {lap_number} — the race is currently at lap '
+                f'{current}; cannot query a future lap'
+            )
+        return None
+
+    def _unknown_driver_error(self, drivers: tuple[str, ...], lap_number: int) -> Optional[str]:
+        """Reject driver codes that are not racing at lap_number.
+
+        Both LangChain tools take driver abbreviations as free LLM text, so a
+        hallucinated or retired driver code would otherwise reach the feature
+        builders unchecked (#476) — mirrors pit_strategy_agent's score_undercut_tool
+        guard, same error shape (names the valid options instead of just failing).
+
+        Args:
+            drivers: One or more driver abbreviations to check.
+            lap_number: Lap number, only used to phrase the error message.
+
+        Returns:
+            An error string naming the offending driver(s) and the valid roster,
+            or None when every driver is live (or presence is unknown, in which
+            case the guard disables rather than rejecting every target).
+        """
+        live = getattr(self, '_live_drivers', None)
+        if live is None:
+            return None
+        unknown = [d for d in drivers if d not in live]
+        if not unknown:
+            return None
+        return (
+            f'{" and ".join(unknown)} not on track at lap {lap_number}. '
+            f'Drivers racing this lap: {", ".join(sorted(live))}. Pick from that list.'
+        )
+
     # ── LangChain tool factory ────────────────────────────────────────────────
 
     def _build_tools(self) -> list:
@@ -983,6 +1069,13 @@ class RaceSituationAgent:
             Returns:
                 "P(overtake) = 0.XXX | gap=X.XXs | pace_delta=X.XXXs/lap | DRS: active/inactive"
             """
+            lap_err = agent._lap_range_error(lap_number)
+            if lap_err:
+                return f'Overtake scoring REFUSED — {lap_err}'
+            drv_err = agent._unknown_driver_error((driver_x, driver_y), lap_number)
+            if drv_err:
+                return f'Overtake scoring REFUSED — {drv_err}'
+
             x_rows = agent.laps_df[
                 (agent.laps_df['Driver'] == driver_x) & (agent.laps_df['LapNumber'] == lap_number)
             ]
@@ -1037,6 +1130,9 @@ class RaceSituationAgent:
             Returns:
                 "P(SC 3-lap) = 0.XXX | lap_time_std_z=X.XX | circuit_sc_rate=X.XX | status: {status} | {incident}"
             """
+            lap_err = agent._lap_range_error(lap_number)
+            if lap_err:
+                return f'SC scoring REFUSED — {lap_err}'
             if len(agent.laps_df) < 10:
                 return f'Insufficient lap data at lap {lap_number}'
 
@@ -1143,6 +1239,17 @@ class RaceSituationAgent:
         _clean       = self.laps_df[self.laps_df['TrackStatus'] == '1']
         _wx          = session.weather_data
 
+        # Who is actually on track at this lap. session.laps carries the WHOLE race
+        # (not just laps up to lap_number), so without this a free-text driver_x/
+        # driver_y from the LLM can name a car that already retired, or a lap the
+        # driver never reached, and still get a confident-looking prediction back
+        # (#476) — mirrors pit_strategy_agent's `_live_drivers` (#462). Empty means
+        # we could not tell (e.g. lap_number outside the session), so the guard
+        # disables (None) rather than rejecting every target.
+        _at_lap = self.laps_df.loc[self.laps_df['LapNumber'] == lap_number, 'Driver'].dropna()
+        self._live_drivers = set(_at_lap) | {driver} if len(_at_lap) else None
+        self._current_lap  = lap_number
+
         self.session_meta = {
             'session':          session,
             'gp_name':          gp_name,
@@ -1175,7 +1282,11 @@ class RaceSituationAgent:
         estimates using track status and lap-time variance signals.
 
         The rival_ahead is derived from lap_state['rivals'] by looking for the car
-        with position = driver_position - 1.
+        with position = driver_position - 1. When the driver's own position is
+        unknown (missing from the telemetry dict), rival_ahead is None rather than
+        guessing a position — a guessed default is a searchable grid slot, so it
+        would otherwise silently pair the driver with whoever is one place ahead of
+        the DEFAULT, not the truth (#465).
 
         Args:
             lap_state: Dict from RaceStateManager.get_lap_state(). Expected keys:
@@ -1200,14 +1311,30 @@ class RaceSituationAgent:
         total_laps = meta.get('total_laps', 57)
         year       = meta.get('year', 2025)
 
-        driver_pos  = d.get('position', 20)
-        rival_ahead = next(
-            (r['driver'] for r in rivals if r.get('position') == driver_pos - 1),
-            None,
+        # #465 (F6): a defaulted position (previously `.get('position', 20)`) is a
+        # SEARCHABLE value, not a safe placeholder — if the real grid has a car at
+        # P19, "unknown position" and "genuinely P20" silently produce the same
+        # rival_ahead lookup. An unknown position must propagate as "no rival
+        # computable", not guess P20.
+        driver_pos  = d.get('position')
+        rival_ahead = (
+            next((r['driver'] for r in rivals if r.get('position') == driver_pos - 1), None)
+            if driver_pos is not None else None
         )
 
         self.laps_df = _ensure_timedelta_laps(laps_df)
         event_name   = meta.get('event_name', gp_name)
+
+        # Who is actually on track this lap, from the RSM's `rivals` list (a car that
+        # retired simply is not in it — the same answer a timing screen gives). Used
+        # to refuse predict_overtake_tool/predict_sc_tool calls naming a driver who
+        # isn't racing this lap (#476), mirroring pit_strategy_agent's `_live_drivers`
+        # (#462). An empty rivals list means the roster is unknown, not "only our car
+        # is racing", so it disables the guard (None) rather than rejecting every
+        # target — same convention as pit_strategy_agent.run_from_state.
+        on_track = {r['driver'] for r in rivals if r.get('driver')}
+        self._live_drivers = on_track | {driver} if on_track else None
+        self._current_lap  = lap_number
 
         self.session_meta = {
             'session':          None,

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -74,6 +74,7 @@ from src.agents.race_situation_agent import (
 from src.agents.pit_strategy_agent import (
     run_pit_strategy_agent,
     run_pit_strategy_agent_from_state,
+    _STINT_CAPACITY_LAPS,
 )
 from src.agents.radio_agent        import (
     run_radio_agent,
@@ -1327,6 +1328,8 @@ def _assemble_recommendation(
     regulation_context: str,
     sc_currently_active: bool = False,
     live_drivers:       set | None = None,
+    cliff_p50:          Optional[float] = None,
+    total_laps:         Optional[int] = None,
 ) -> "StrategyRecommendation":
     """Merge the LLM synthesis with N28 pit data and attach grounding fields.
 
@@ -1372,6 +1375,11 @@ def _assemble_recommendation(
     `live_drivers` carries the cars on track so the LLM's free-text undercut_target can
     be checked. **None means "unknown", not "nobody"** — a caller without a lap_state
     cannot know, so its target passes rather than being silently discarded.
+
+    `cliff_p50` (N26 TireOutput.laps_to_cliff_p50) and `total_laps` (RaceState.total_laps)
+    ground `expected_stint_end` — see the clamp below (#433). Both default to None so a
+    caller that has not been updated to pass them keeps the previous unclamped behaviour
+    rather than crashing.
 
     Returns a fully-populated StrategyRecommendation ready for the UI layer.
     """
@@ -1436,6 +1444,39 @@ def _assemble_recommendation(
     action    = synth.action
     reasoning = synth.reasoning
 
+    # #433 — expected_stint_end is unvalidated LLM free text: nothing in the schema
+    # stops the LLM naming a lap far beyond what this stint can physically reach.
+    # Ground it against pit_lap_target (already resolved above) plus the shorter of
+    # the N26 cliff P50 and the Pirelli stint capacity for the NEXT compound — the
+    # same capacity table recommend_compound_tool uses in pit_strategy_agent.py, not
+    # duplicated here. Accept the LLM's number only when it lands within +/-3 laps of
+    # that anchor; otherwise use the anchor itself. cliff_p50 measures the CURRENT
+    # compound's cliff from now, reused here as a stint-length proxy for the NEXT
+    # compound — a deliberate simplification, not a physically exact re-derivation.
+    # When pit_lap_target, compound_next, or cliff_p50 is unavailable there is no
+    # anchor to ground against, so the LLM value passes through unclamped rather
+    # than inventing one.
+    if pit_lap_target is not None and compound_next is not None and cliff_p50 is not None:
+        capacity = _STINT_CAPACITY_LAPS.get(compound_next, _STINT_CAPACITY_LAPS['MEDIUM'])
+        anchor = pit_lap_target + min(cliff_p50, capacity)
+        if total_laps is not None:
+            anchor = min(anchor, total_laps)
+        anchor = int(round(anchor))
+
+        llm_stint_end = synth.expected_stint_end
+        if llm_stint_end is not None and abs(llm_stint_end - anchor) <= 3:
+            expected_stint_end = llm_stint_end
+        else:
+            if llm_stint_end is not None:
+                logger.warning(
+                    "Clamping LLM expected_stint_end %r to anchor %d "
+                    "(pit_lap_target=%s, compound_next=%s, cliff_p50=%.1f) — #433",
+                    llm_stint_end, anchor, pit_lap_target, compound_next, cliff_p50,
+                )
+            expected_stint_end = anchor
+    else:
+        expected_stint_end = synth.expected_stint_end
+
     return StrategyRecommendation(
         action             = action,
         reasoning          = reasoning,
@@ -1448,7 +1489,7 @@ def _assemble_recommendation(
         risk_posture       = synth.risk_posture,
         contingencies      = synth.contingencies,
         key_risks          = synth.key_risks,
-        expected_stint_end = synth.expected_stint_end,
+        expected_stint_end = expected_stint_end,
         scenario_scores    = mc_results,
         regulation_context = regulation_context,
     )
@@ -1534,7 +1575,29 @@ def run_strategy_orchestrator(
         synth, pit_out, mc_results, regulation_context,
         sc_currently_active = situation_out.sc_currently_active,
         live_drivers        = _live_drivers_from(lap_state),
+        cliff_p50           = tire_out.laps_to_cliff_p50,
+        total_laps          = race_state.total_laps,
     )
+
+
+def _scope_laps_to_gp(
+    laps_df: pd.DataFrame,
+    lap_state: dict | None,
+    race_state: "RaceState | None" = None,
+) -> pd.DataFrame:
+    """Narrow a season-wide laps frame to the Grand Prix being analysed (#429/#465).
+
+    Thin delegator to the canonical implementation in
+    ``src/strategy/inference/engine.py``. That module imports FROM this one, so a
+    top-level ``import`` would be circular — the deferred import inside the body
+    breaks the cycle while keeping ONE source of truth. A hand-kept duplicate is
+    exactly the kind of drift the #429/#465 family of bugs came from, so we do not
+    keep two copies; the engine version also derives the GP from ``race_state`` when
+    ``lap_state`` carries no ``gp_name`` yet.
+    """
+    from src.strategy.inference.engine import _scope_laps_to_gp as _engine_scope
+
+    return _engine_scope(laps_df, lap_state, race_state)
 
 
 def run_strategy_orchestrator_from_state(
@@ -1565,8 +1628,14 @@ def run_strategy_orchestrator_from_state(
         driver_rows = laps_df[laps_df["Driver"] == race_state.driver]
         lap_row     = driver_rows[driver_rows["LapNumber"] == race_state.lap]
         year        = int(laps_df["Year"].iloc[0]) if "Year" in laps_df.columns else 2025
+        # Derive the GP from the (driver, lap) row match, NOT laps_df.iloc[0] (the
+        # first row of the whole-season frame): the latter blends one race's GP with
+        # another race's stint/team — the #465 wrong-GP bug engine._build_default_lap_state
+        # also has to avoid. Fall back to iloc[0] only when the row is absent.
         gp_name     = (
-            str(laps_df["GP_Name"].iloc[0]) if "GP_Name" in laps_df.columns else ""
+            str(lap_row["GP_Name"].iloc[0])
+            if not lap_row.empty and "GP_Name" in lap_row
+            else (str(laps_df["GP_Name"].iloc[0]) if "GP_Name" in laps_df.columns else "")
         )
         stint = int(lap_row["Stint"].iloc[0]) if not lap_row.empty else 1
         team  = (
@@ -1608,6 +1677,13 @@ def run_strategy_orchestrator_from_state(
             },
             "rivals": [],
         }
+
+    # Scope AFTER lap_state is resolved (built above or supplied by the caller),
+    # never before — see _scope_laps_to_gp's docstring for the #465 ordering bug
+    # this avoids. Passing race_state lets the canonical engine helper derive the GP
+    # even when a caller supplies a lap_state without a gp_name. Every downstream use
+    # of laps_df in this function (both agent calls below) sees the scoped frame.
+    laps_df = _scope_laps_to_gp(laps_df, lap_state, race_state)
 
     # Layer 1a — always-on agents (RSM variants)
     pace_out, tire_out, situation_out, radio_out = _run_always_on_agents_from_state(
@@ -1662,4 +1738,6 @@ def run_strategy_orchestrator_from_state(
         synth, pit_out, mc_results, regulation_context,
         sc_currently_active = situation_out.sc_currently_active,
         live_drivers        = _live_drivers_from(lap_state),
+        cliff_p50           = tire_out.laps_to_cliff_p50,
+        total_laps          = race_state.total_laps,
     )

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -1321,6 +1321,45 @@ def _live_drivers_from(lap_state: dict | None) -> set | None:
     return live or None
 
 
+def _clamp_expected_stint_end(
+    llm_stint_end:  int | None,
+    pit_lap_target: int | None,
+    compound_next:  str | None,
+    cliff_p50:      float | None,
+    total_laps:     int | None,
+) -> int | None:
+    """Ground the LLM's ``expected_stint_end`` against a physical anchor (#433).
+
+    ``expected_stint_end`` is unvalidated LLM free text: nothing in the schema stops
+    the LLM naming a lap far beyond what this stint can physically reach. Anchor it to
+    ``pit_lap_target`` plus the shorter of the N26 cliff P50 and the Pirelli stint
+    capacity for the NEXT compound (the same ``_STINT_CAPACITY_LAPS`` table
+    ``recommend_compound_tool`` uses, not duplicated), bounded by ``total_laps``. Accept
+    the LLM value only within +/-3 laps of the anchor; otherwise use the anchor. When
+    ``pit_lap_target``, ``compound_next`` or ``cliff_p50`` is missing there is no anchor
+    to ground against, so the LLM value passes through unclamped rather than inventing
+    one. Pure (no I/O) so it is unit-testable without loading any model.
+    """
+    if pit_lap_target is None or compound_next is None or cliff_p50 is None:
+        return llm_stint_end
+
+    capacity = _STINT_CAPACITY_LAPS.get(compound_next, _STINT_CAPACITY_LAPS['MEDIUM'])
+    anchor = pit_lap_target + min(cliff_p50, capacity)
+    if total_laps is not None:
+        anchor = min(anchor, total_laps)
+    anchor = int(round(anchor))
+
+    if llm_stint_end is not None and abs(llm_stint_end - anchor) <= 3:
+        return llm_stint_end
+    if llm_stint_end is not None:
+        logger.warning(
+            "Clamping LLM expected_stint_end %r to anchor %d "
+            "(pit_lap_target=%s, compound_next=%s, cliff_p50=%.1f) — #433",
+            llm_stint_end, anchor, pit_lap_target, compound_next, cliff_p50,
+        )
+    return anchor
+
+
 def _assemble_recommendation(
     synth:              "_LLMSynthesis",
     pit_out,
@@ -1444,38 +1483,12 @@ def _assemble_recommendation(
     action    = synth.action
     reasoning = synth.reasoning
 
-    # #433 — expected_stint_end is unvalidated LLM free text: nothing in the schema
-    # stops the LLM naming a lap far beyond what this stint can physically reach.
-    # Ground it against pit_lap_target (already resolved above) plus the shorter of
-    # the N26 cliff P50 and the Pirelli stint capacity for the NEXT compound — the
-    # same capacity table recommend_compound_tool uses in pit_strategy_agent.py, not
-    # duplicated here. Accept the LLM's number only when it lands within +/-3 laps of
-    # that anchor; otherwise use the anchor itself. cliff_p50 measures the CURRENT
-    # compound's cliff from now, reused here as a stint-length proxy for the NEXT
-    # compound — a deliberate simplification, not a physically exact re-derivation.
-    # When pit_lap_target, compound_next, or cliff_p50 is unavailable there is no
-    # anchor to ground against, so the LLM value passes through unclamped rather
-    # than inventing one.
-    if pit_lap_target is not None and compound_next is not None and cliff_p50 is not None:
-        capacity = _STINT_CAPACITY_LAPS.get(compound_next, _STINT_CAPACITY_LAPS['MEDIUM'])
-        anchor = pit_lap_target + min(cliff_p50, capacity)
-        if total_laps is not None:
-            anchor = min(anchor, total_laps)
-        anchor = int(round(anchor))
-
-        llm_stint_end = synth.expected_stint_end
-        if llm_stint_end is not None and abs(llm_stint_end - anchor) <= 3:
-            expected_stint_end = llm_stint_end
-        else:
-            if llm_stint_end is not None:
-                logger.warning(
-                    "Clamping LLM expected_stint_end %r to anchor %d "
-                    "(pit_lap_target=%s, compound_next=%s, cliff_p50=%.1f) — #433",
-                    llm_stint_end, anchor, pit_lap_target, compound_next, cliff_p50,
-                )
-            expected_stint_end = anchor
-    else:
-        expected_stint_end = synth.expected_stint_end
+    # #433 — expected_stint_end is unvalidated LLM free text; clamp it against the
+    # physical pit_lap + cliff/capacity anchor via the pure _clamp_expected_stint_end
+    # helper (extracted so the clamp is CI-testable without loading any model).
+    expected_stint_end = _clamp_expected_stint_end(
+        synth.expected_stint_end, pit_lap_target, compound_next, cliff_p50, total_laps
+    )
 
     return StrategyRecommendation(
         action             = action,

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -638,10 +638,14 @@ def _parse_tool_outputs(messages: list) -> dict:
         if not isinstance(content, str):
             continue
         for pattern, key in [
-            (r'Degradation rate:\s*([\d.]+)', 'deg_rate'),
-            (r'P10:\s*([\d.]+)',              'p10'),
-            (r'P50:\s*([\d.]+)',              'p50'),
-            (r'P90:\s*([\d.]+)',              'p90'),
+            # -?[\d.]+ (was [\d.]+, #477): the bare digit class can't match a
+            # leading minus, so a negative degradation rate — real and expected
+            # per the system prompt ("track evolution or fuel load reduction")
+            # — silently failed to parse and fell through to the 0.0 default.
+            (r'Degradation rate:\s*(-?[\d.]+)', 'deg_rate'),
+            (r'P10:\s*(-?[\d.]+)',              'p10'),
+            (r'P50:\s*(-?[\d.]+)',              'p50'),
+            (r'P90:\s*(-?[\d.]+)',              'p90'),
         ]:
             m = re.search(pattern, content)
             if m and key not in result:
@@ -759,6 +763,11 @@ class TireAgent:
         self.bundles: dict        = self.cfg.load_all_bundles()
         self.laps_df: pd.DataFrame = pd.DataFrame()
         self.session_meta: dict    = {}
+        # Driver codes actually on track for the CURRENT loaded state (#476). Reset
+        # on every run()/run_from_state() call — this instance is a process-level
+        # singleton reused across many laps/drivers, so a stale set from a previous
+        # call must never leak into the next one's tool-arg validation.
+        self._live_drivers: Optional[set] = None
         self._react_agent          = None
         self._tools: list          = self._build_tools()
 
@@ -916,6 +925,65 @@ class TireAgent:
         stint = self.laps_df[mask].sort_values('LapNumber')
         return stint if len(stint) > 0 else None
 
+    # ── Live-driver guard (#476) ───────────────────────────────────────────────
+
+    def _live_drivers_at_current_lap(self) -> Optional[set]:
+        """Return driver codes on track for the currently loaded state, or None.
+
+        run_from_state() sets self._live_drivers from the RSM's rivals list plus
+        our own driver — both are PRESENCE-based (a row exists for this lap), the
+        same signal race_state_manager.py and pit_strategy_agent.py rely on for
+        their own retired-car guards (#470/#462): an age/lap-count cutoff cannot
+        separate a retiree from a finisher because the ranges overlap (a finisher
+        can go 20 laps without a row, a retirement can show up in 9). The FastF1
+        run() path has no per-lap rivals list, so it falls back to every driver
+        present anywhere in laps_df.
+
+        Returns:
+            Set of driver codes, or None when there is nothing to validate against
+            (callers treat None as "cannot tell" and skip the guard rather than
+            block every driver on missing data — the same convention
+            pit_strategy_agent.py uses for its own `_live_drivers`, #470/#462).
+        """
+        if self._live_drivers is not None:
+            return self._live_drivers
+        if len(self.laps_df) > 0 and 'Driver' in self.laps_df.columns:
+            drivers = set(self.laps_df['Driver'].dropna().unique())
+            return drivers or None
+        return None
+
+    def _validate_driver_on_track(self, driver: str) -> Optional[str]:
+        """Return an error string if `driver` is not on track right now, else None.
+
+        Guards the two LLM-facing tools against a hallucinated or long-retired
+        driver code. Reachable in production: laps_df carries the WHOLE race's
+        history, so the stint filter in _get_driver_stint happily builds a
+        'stint' out of laps recorded before a car crashed — it never checks
+        whether the driver is still racing at the lap the agent is currently
+        analysing. Example (#476): Austin 2024, HAM crashed on lap 2 of 56;
+        asked about at a later lap, the tool used to return a confident
+        'P50: 21867.1' instead of erroring.
+
+        Args:
+            driver: FastF1 driver abbreviation as passed by the LLM tool call.
+
+        Returns:
+            An error string (do not compute) when the driver is not in the live
+            set, or when the loaded current_lap falls outside [1, total_laps].
+            None when the driver checks out and the tool should proceed.
+        """
+        live       = self._live_drivers_at_current_lap()
+        lap        = self.session_meta.get('current_lap')
+        total_laps = self.session_meta.get('total_laps')
+        lap_out_of_range = (
+            lap is not None and total_laps is not None and not (1 <= lap <= total_laps)
+        )
+        if (live is not None and driver not in live) or lap_out_of_range:
+            lap_display = lap if lap is not None else 'unknown'
+            valid = sorted(live) if live is not None else []
+            return f"error: '{driver}' is not on track at lap {lap_display}; valid: {valid}"
+        return None
+
     # ── LangChain tool factory ────────────────────────────────────────────────
 
     def _build_tools(self) -> list:
@@ -949,8 +1017,13 @@ class TireAgent:
 
             Returns:
                 Multi-line string: cumulative degradation (s) and degradation rate (s/lap).
-                Returns an error string if no laps are found.
+                Returns an error string if no laps are found, or if the driver is not
+                on track at the currently loaded lap (#476).
             """
+            guard_error = agent._validate_driver_on_track(driver)
+            if guard_error:
+                return guard_error
+
             stint = agent._get_driver_stint(driver, tyre_life)
             if stint is None:
                 return f'No laps found for driver {driver} with tyre_life <= {tyre_life}.'
@@ -987,7 +1060,13 @@ class TireAgent:
 
             Returns:
                 Multi-line string: P10/P50/P90 laps to cliff, deg rate, MC std, warning level.
+                Returns an error string if no laps are found, or if the driver is not
+                on track at the currently loaded lap (#476).
             """
+            guard_error = agent._validate_driver_on_track(driver)
+            if guard_error:
+                return guard_error
+
             stint = agent._get_driver_stint(driver, tyre_life)
             if stint is None:
                 return f'No laps found for driver {driver} with tyre_life <= {tyre_life}.'
@@ -1167,8 +1246,16 @@ class TireAgent:
             'AirTemp':   float(_weather.get('AirTemp',   28.0)),
             'TrackTemp': float(_weather.get('TrackTemp', 38.0)),
             'Humidity':  float(_weather.get('Humidity',  50.0)),
-            'Rainfall':  0.0,
+            # Was hardcoded 0.0 (#477) while run_from_state() correctly reads
+            # wx.get('rainfall', 0) from the RSM weather dict — mirror that here
+            # from the session's own weather data instead of silently telling
+            # every dry-model feature the race was rain-free regardless of what
+            # actually happened.
+            'Rainfall':  float(_weather.get('Rainfall', 0.0)),
         }
+        # No per-lap rivals list on this path (single-shot FastF1 query, not a live
+        # simulation lap) — _live_drivers_at_current_lap() falls back to laps_df.
+        self._live_drivers = None
 
         return self._run_core(driver, compound_id, tyre_life, gp_name)
 
@@ -1243,6 +1330,16 @@ class TireAgent:
             # behaviour instead of breaking (#449).
             f'{driver}_stint': d.get('stint'),
             'current_lap': lap_state.get('lap_number'),
+        }
+
+        # Presence-based on-track set for this lap (#476): our own driver plus
+        # every rival the RSM actually emitted a row for. A driver who crashed
+        # earlier in the race simply stops appearing in rivals from that lap on
+        # — the same signal race_state_manager.py itself relies on (#470) — so
+        # this catches an LLM tool call for a long-retired driver code without
+        # reimplementing any retirement/lap-count heuristic.
+        self._live_drivers = {driver} | {
+            str(r['driver']) for r in lap_state.get('rivals', []) or [] if r.get('driver')
         }
 
         return self._run_core(driver, compound_id, tyre_life, gp_name)

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -587,7 +587,19 @@ class SimConnector(threading.Thread):
         pace_delta = cur_lap_time - prev_lap_time if prev_lap_time else 0.0
 
         rivals = lap_state.get("rivals", [])
-        our_pos = driver_st.get("position", 99)
+        our_pos = driver_st.get("position")
+        # `_lap_skip_reason` (the DNF/incomplete-lap guard the driver loop runs before
+        # `_step_once` -> `_build_race_state`) already filters out laps where position
+        # is None, so reaching here with an unknown position means that invariant broke.
+        # Fail loudly instead of fabricating a searchable P99 car (the #428 bug shape:
+        # a sentinel that collides with a real rival's `position - 1`) — the caller's
+        # `except Exception` wraps this into a surfaced `state.error`, it does not crash
+        # the driver thread (#465).
+        if our_pos is None:
+            raise ValueError(
+                "_build_race_state: driver position is None; the incomplete-lap guard "
+                "should have skipped this lap before calling _build_race_state (#465)"
+            )
         car_ahead = next((r for r in rivals if r.get("position") == our_pos - 1), None)
         gap_ahead_s = abs(car_ahead.get("interval_to_driver_s") or 0.0) if car_ahead else 0.0
 
@@ -614,7 +626,7 @@ class SimConnector(threading.Thread):
             lap=lap_num,
             # 57 = median/mode race length across the dataset; the shared strategy fallback.
             total_laps=meta.get("total_laps", 57),
-            position=driver_st.get("position", 10),
+            position=our_pos,
             compound=driver_st.get("compound", "MEDIUM"),
             tyre_life=driver_st.get("tyre_life", 1),
             gap_ahead_s=float(gap_ahead_s),

--- a/src/simulation/race_state_manager.py
+++ b/src/simulation/race_state_manager.py
@@ -235,6 +235,17 @@ class RaceStateManager:
             "lap_number": int(lap_number),
             # --- Timing ---
             "lap_time_s": _to_seconds(r.get("LapTime")),
+            # The featured parquet's own previous-lap time (N04's Prev_LapTime
+            # column) — NOT this lap's lap_time_s reused as a stand-in. The pace
+            # agent used to default prev_lap_time to the CURRENT lap's time
+            # (`d.get('lap_time_s') or 90.0`), which fed its own most recent
+            # prediction back in as the "previous" lap and made pace
+            # self-fulfilling (#435). ``.get`` (not indexing) so a laps_df built
+            # without this optional column returns None here rather than raising,
+            # same as every other optional column read via ``r.get(...)`` below.
+            # NaN (no earlier lap, e.g. the first lap of a stint) -> None, same
+            # handling as every other timing field in this method.
+            "prev_lap_time": _to_seconds(r.get("Prev_LapTime")),
             "sector1_s": _to_seconds(r.get("Sector1Time")),
             "sector2_s": _to_seconds(r.get("Sector2Time")),
             "sector3_s": _to_seconds(r.get("Sector3Time")),

--- a/src/strategy/inference/engine.py
+++ b/src/strategy/inference/engine.py
@@ -71,7 +71,11 @@ Profile = Literal["rich", "no-llm"]
 logger = logging.getLogger(__name__)
 
 
-def _scope_laps_to_gp(laps_df: pd.DataFrame, lap_state: dict[str, Any] | None) -> pd.DataFrame:
+def _scope_laps_to_gp(
+    laps_df: pd.DataFrame,
+    lap_state: dict[str, Any] | None,
+    race_state: RaceState | None = None,
+) -> pd.DataFrame:
     """Narrow a season-wide laps frame to the Grand Prix being analysed (#429).
 
     Every caller loads ``laps_featured_<year>.parquet``, which holds the WHOLE season,
@@ -85,12 +89,38 @@ def _scope_laps_to_gp(laps_df: pd.DataFrame, lap_state: dict[str, Any] | None) -
 
     The GP name comes from ``lap_state['session_meta']['gp_name']``, which
     ``RaceStateManager`` emits in the same keyspace the parquet's ``GP_Name`` uses
-    (verified: 'Lusail'). Falls back to the full frame, loudly, when the name does not
-    resolve — handing the agents an EMPTY frame would be worse than the bug this fixes,
-    and a warning is how we find out the keyspaces have drifted apart (see #448).
+    (verified: 'Lusail'). When ``lap_state`` is ``None`` (the ``_build_default_lap_state``
+    path, #465), there is no ``session_meta`` yet to read a GP from — so, given a
+    ``race_state``, this derives the GP the same way ``_build_default_lap_state`` will
+    (the (driver, lap) row match) and scopes on THAT. This lets scoping happen BEFORE the
+    default lap_state is built instead of after: the previous order scoped on a still-None
+    ``lap_state`` (a no-op) and only built the default from the still-unscoped, season-wide
+    frame, so a GP's grid could be decided from another race's data.
+
+    Falls back to the full frame, loudly, when the name does not resolve — handing the
+    agents an EMPTY frame would be worse than the bug this fixes, and a warning is how we
+    find out the keyspaces have drifted apart (see #448).
     """
     gp_name = (lap_state or {}).get("session_meta", {}).get("gp_name")
-    if not gp_name or "GP_Name" not in laps_df.columns:
+
+    if (
+        not gp_name
+        and race_state is not None
+        and laps_df is not None
+        and "GP_Name" in laps_df.columns
+    ):
+        driver_rows = laps_df[laps_df["Driver"] == race_state.driver]
+        lap_row = driver_rows[driver_rows["LapNumber"] == race_state.lap]
+        if not lap_row.empty:
+            gp_name = str(lap_row["GP_Name"].iloc[0])
+
+    if not gp_name or laps_df is None or "GP_Name" not in laps_df.columns:
+        if laps_df is not None:
+            logger.warning(
+                "Could not resolve a GP to scope laps by (gp_name=%r) — falling back to "
+                "the unscoped frame; agent lookups may resolve to the wrong race (#429/#465)",
+                gp_name,
+            )
         return laps_df
 
     scoped = laps_df[laps_df["GP_Name"] == gp_name]
@@ -155,8 +185,11 @@ def run_lap(
         ValueError: on an unknown profile, or on the reserved ``"fast"`` profile.
     """
     # Scope BEFORE dispatch so both profiles, and therefore every surface that routes
-    # through this engine (CLI PMV, arcade), get the single-race frame (#429).
-    laps_df = _scope_laps_to_gp(laps_df, lap_state)
+    # through this engine (CLI PMV, arcade), get the single-race frame (#429). Passing
+    # `race_state` lets scoping resolve a GP even when `lap_state` is None (#465), so the
+    # `_build_default_lap_state` fallback below/inside `_run_rich`/`run_no_llm_lap` always
+    # runs against an already-scoped frame instead of the season-wide one.
+    laps_df = _scope_laps_to_gp(laps_df, lap_state, race_state)
 
     if profile == "rich":
         return _run_rich(race_state, laps_df, lap_state, return_agent_outputs)
@@ -309,6 +342,11 @@ def _build_default_lap_state(race_state: RaceState, laps_df: pd.DataFrame) -> di
     single non-orchestrator home for it; arcade's copy is deleted when it delegates.
     The parity test's ``lap_state=None`` case guards this against the orchestrator's
     inline block.
+
+    ``laps_df`` is expected to already be scoped to a single GP by the time this runs
+    (``run_lap`` calls ``_scope_laps_to_gp(..., race_state)`` BEFORE dispatching to
+    ``_run_rich``/``run_no_llm_lap``, #465) — otherwise ``gp_name``/``year`` below read
+    ``iloc[0]`` of a season-wide frame and can pick a GP unrelated to ``race_state``.
     """
     driver_rows = laps_df[laps_df["Driver"] == race_state.driver]
     lap_row = driver_rows[driver_rows["LapNumber"] == race_state.lap]

--- a/src/strategy/inference/no_llm.py
+++ b/src/strategy/inference/no_llm.py
@@ -186,8 +186,18 @@ def _situation_no_llm(sit_lap_state: dict[str, Any], laps_df: pd.DataFrame):
     driver = meta["driver"]
     lap_number = sit_lap_state["lap_number"]
     rivals = sit_lap_state.get("rivals", []) or []
-    driver_pos = d.get("position", 20)
-    rival = next((r["driver"] for r in rivals if r.get("position") == driver_pos - 1), None)
+    driver_pos = d.get("position")
+    # An incomplete lap (FastF1 NaN) or the bare-RaceState default builder leave
+    # `position` as `None` (RSM's own convention, see race_state_manager.py's
+    # get_rival_states docstring — #428). Defaulting it to 20 here would fabricate a
+    # position that could coincidentally collide with a real rival's `position - 1`
+    # and hand `predict_overtake_tool` the wrong "car ahead" (#465); skip the rival
+    # lookup instead when the position is genuinely unknown.
+    rival = (
+        next((r["driver"] for r in rivals if r.get("position") == driver_pos - 1), None)
+        if driver_pos is not None
+        else None
+    )
 
     tools = {tool.name: tool for tool in agent._tools}
     calls: list[tuple[Any, dict[str, Any]]] = [

--- a/tests/audit/test_engine_scope_defaults.py
+++ b/tests/audit/test_engine_scope_defaults.py
@@ -1,0 +1,191 @@
+"""Regression tests for the #465 scope-before-build + dead-position-default fixes.
+
+F7 (``src/strategy/inference/engine.py``): ``run_lap``'s ``_build_default_lap_state``
+fallback (``lap_state=None``) used to run against the still season-wide frame,
+because ``_scope_laps_to_gp`` had no ``gp_name`` to scope by until AFTER the default
+was built. A ``race_state``-driven fallback in ``_scope_laps_to_gp`` now derives the
+GP from the (driver, lap) row match BEFORE the default lap_state is built, so
+``session_meta['gp_name']`` and the frame handed to every agent both refer to the
+SAME race instead of two unrelated ones.
+
+F6 (``src/strategy/inference/no_llm.py``, ``src/arcade/strategy.py``): three call
+sites used to default a missing ``position`` to a fixed number (20 / 99 / 10) that
+the SAME code then searched for (``position - 1``) — a sentinel that can collide
+with a real rival's position (the #428 bug shape). All three now propagate the
+unknown position instead of inventing one.
+
+No LLM client is constructed by any test here. The scoping test asserts against the
+real featured parquet (``data/processed/laps_featured_2025.parquet``); the position
+tests use hand-built dicts, per the epic's no-LLM-assertion doctrine.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+_skip_no_models = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="data/models/ not present (CI runner without model weights)",
+)
+
+_PARQUET = ROOT / "data" / "processed" / "laps_featured_2025.parquet"
+_skip_no_parquet = pytest.mark.skipif(
+    not _PARQUET.exists(),
+    reason="laps_featured_2025.parquet not present (data/ not downloaded)",
+)
+
+
+def _pick_target_and_decoy_gp(df: pd.DataFrame) -> tuple[pd.Series, str, str]:
+    """Find a (driver, lap) row whose GP is genuinely NOT the frame's first GP.
+
+    Returns ``(candidate_row, target_gp, decoy_gp)``. ``decoy_gp`` is whatever GP
+    sorts first in ``df`` — what the pre-#465 code picked via ``laps_df.iloc[0]``,
+    regardless of which driver/lap was actually requested. ``target_gp`` is a
+    DIFFERENT GP holding a clean (no missing Position/Compound/TyreLife) row for
+    some driver+lap — the race the fix must resolve to instead. Skips the test
+    (rather than failing) when the parquet only has one GP, since the bug this
+    guards cannot be reproduced without a second one.
+    """
+    decoy_gp = str(df["GP_Name"].iloc[0])
+    required_cols = ["Position", "Compound", "TyreLife"]
+    for gp_name in df["GP_Name"].unique():
+        if gp_name == decoy_gp:
+            continue
+        clean = df[df["GP_Name"] == gp_name].dropna(subset=required_cols)
+        if not clean.empty:
+            return clean.iloc[0], str(gp_name), decoy_gp
+    pytest.skip("no second GP with a clean row found in the featured parquet")
+
+
+@_skip_no_models
+@_skip_no_parquet
+def test_scope_laps_to_gp_resolves_requested_gp_before_default_build():
+    """F7: scoping (via ``race_state``) must pick the driver's OWN GP, not whichever
+    GP happens to sort first in a multi-GP frame — and the default lap_state built
+    from the scoped frame must carry that same GP in ``session_meta``.
+
+    Builds a synthetic ``combined`` frame from two REAL GP slices (decoy rows
+    first, target rows second) so the "wrong GP picked first" scenario is
+    deterministic instead of hoping the raw parquet happens to exhibit it for
+    some guessed driver/lap.
+    """
+    from src.agents.strategy_orchestrator import RaceState
+    from src.strategy.inference.engine import _build_default_lap_state, _scope_laps_to_gp
+
+    df = pd.read_parquet(_PARQUET)
+    candidate, target_gp, decoy_gp = _pick_target_and_decoy_gp(df)
+    driver = str(candidate["Driver"])
+    lap = int(candidate["LapNumber"])
+
+    # Decoy rows: real rows from a DIFFERENT GP, with any accidental (driver, lap)
+    # match stripped out so the only match for (driver, lap) in `combined` is the
+    # target row below — otherwise the test would not discriminate between the
+    # two GPs (both would look like valid "first matches").
+    decoy_rows = df[
+        (df["GP_Name"] == decoy_gp) & ~((df["Driver"] == driver) & (df["LapNumber"] == lap))
+    ]
+    target_rows = df[df["GP_Name"] == target_gp]
+    # Decoy rows come FIRST, mirroring a season-wide frame where an unrelated GP
+    # sorts ahead of the driver's actual race.
+    combined = pd.concat([decoy_rows, target_rows], ignore_index=True)
+    assert str(combined["GP_Name"].iloc[0]) == decoy_gp  # sanity: decoy really is first
+
+    race_state = RaceState(
+        driver=driver,
+        lap=lap,
+        total_laps=int(target_rows["LapNumber"].max()),
+        position=int(candidate["Position"]),
+        compound=str(candidate["Compound"]),
+        tyre_life=int(candidate["TyreLife"]),
+        gap_ahead_s=1.0,
+        pace_delta_s=0.0,
+        air_temp=25.0,
+        track_temp=35.0,
+    )
+
+    scoped = _scope_laps_to_gp(combined, None, race_state)
+    assert scoped["GP_Name"].nunique() == 1
+    assert scoped["GP_Name"].iloc[0] == target_gp, (
+        f"scoping picked {scoped['GP_Name'].iloc[0]!r}, expected the driver's own "
+        f"GP {target_gp!r} (decoy was {decoy_gp!r})"
+    )
+
+    lap_state = _build_default_lap_state(race_state, scoped)
+    assert lap_state["session_meta"]["gp_name"] == target_gp
+
+    # Confirm this is a real fix, not a tautology: building the default straight
+    # from the UNSCOPED frame (the pre-#465 order) reproduces the bug — gp_name
+    # comes from the decoy GP's first row, unrelated to the driver's actual race.
+    buggy_lap_state = _build_default_lap_state(race_state, combined)
+    assert buggy_lap_state["session_meta"]["gp_name"] == decoy_gp
+    assert buggy_lap_state["session_meta"]["gp_name"] != target_gp
+
+
+@_skip_no_models
+def test_situation_no_llm_skips_rival_lookup_when_position_is_none(monkeypatch):
+    """F6: a missing ``position`` (RSM's ``None`` convention for an incomplete lap,
+    #428) must not default to 20 — a rival sitting at position 19 would otherwise
+    be wrongly picked as "the car ahead" purely because ``20 - 1 == 19``.
+
+    Stubs ``run_from_state`` so the test never needs a real ``laps_df`` or GPU/CPU
+    model inference — it only inspects which tools ``_situation_no_llm`` queued
+    into the null tool-runner BEFORE ``run_from_state`` would have executed them.
+    """
+    from src.strategy.inference import no_llm
+
+    agent = no_llm._get_situation_agent()
+    captured: dict[str, Any] = {}
+
+    def _fake_run_from_state(lap_state, laps_df):
+        captured["tool_names"] = {tool.name for tool, _ in agent._react_agent._tool_calls}
+        return None
+
+    monkeypatch.setattr(agent, "run_from_state", _fake_run_from_state)
+
+    sit_lap_state = {
+        "session_meta": {"driver": "VER", "gp_name": "Lusail", "year": 2025},
+        "driver": {"position": None, "compound": "MEDIUM", "tyre_life": 5},
+        "lap_number": 10,
+        "rivals": [{"driver": "HAM", "position": 19}],
+    }
+
+    no_llm._situation_no_llm(sit_lap_state, laps_df=None)
+
+    assert "predict_sc_tool" in captured["tool_names"]
+    assert "predict_overtake_tool" not in captured["tool_names"], (
+        "position=None must skip the rival lookup, not resolve it via a position=20 default"
+    )
+
+
+@_skip_no_models
+def test_build_race_state_fails_loudly_instead_of_defaulting_position():
+    """F6 (arcade): ``_build_race_state`` must not fabricate a searchable P10/P99
+    car when ``position`` is ``None``.
+
+    The DNF/incomplete-lap guard (``_lap_skip_reason``) is supposed to skip this
+    lap before ``_build_race_state`` ever runs; reaching this method with
+    ``position=None`` means that invariant broke, and #465 makes it fail loudly
+    (caught by the driver loop's ``except Exception``, surfaced as ``state.error``)
+    instead of silently building a fake P10 car.
+    """
+    from src.arcade.strategy import SimConnector, SimulateRequestDTO, StrategyState
+
+    request = SimulateRequestDTO(year=2025, gp="Lusail", driver="VER", team="Red Bull Racing")
+    connector = SimConnector(request, StrategyState())
+
+    lap_state = {
+        "driver": {"position": None, "lap_time_s": 90.0, "compound": "MEDIUM", "tyre_life": 5},
+        "weather": {},
+        "session_meta": {"total_laps": 57},
+        "rivals": [],
+        "lap_number": 10,
+    }
+
+    with pytest.raises(ValueError, match="position"):
+        connector._build_race_state(lap_state, prev_lap_time=89.0)

--- a/tests/audit/test_pace_orchestrator_hardening.py
+++ b/tests/audit/test_pace_orchestrator_hardening.py
@@ -11,9 +11,9 @@ Doctrine: no-LLM assertions only.
 - The #476 section calls ``PaceAgent.run()`` (the real N06 XGBoost model) through
   ``predict_pace_tool.invoke()`` directly — deterministic inference, never a
   LangGraph ReAct loop or a live LLM client.
-- The #433 section calls ``_clamp_expected_stint_end`` directly — the pure clamp
-  helper extracted from ``_assemble_recommendation`` — so it needs no model or data
-  and never runs a live orchestrator.
+- The #433 section calls the pure ``_clamp_expected_stint_end`` helper directly
+  (never a live orchestrator), but skips when ``data/`` is absent: importing
+  ``strategy_orchestrator`` instantiates the tire agent, which loads model files.
 """
 
 from __future__ import annotations
@@ -228,21 +228,41 @@ def test_predict_pace_tool_still_computes_for_a_real_driver_in_range(
 # =============================================================================
 # #433 — expected_stint_end must be grounded against pit_lap_target plus the
 # N26 cliff / Pirelli stint capacity, not passed through as raw LLM free text.
-# The clamp is the pure _clamp_expected_stint_end helper, so these tests need no
-# model and run on CI too (not just locally with data/).
+# The clamp is the pure _clamp_expected_stint_end helper; these tests call it
+# directly (no live orchestrator). They skip when data/ is absent because
+# importing strategy_orchestrator instantiates the tire agent, which loads
+# data/models/tire_degradation/ (fetched from HF Hub, not committed).
 # =============================================================================
 
 
-def test_expected_stint_end_is_clamped_to_the_pit_and_cliff_anchor():
+@pytest.fixture(scope="module")
+def clamp_fn():
+    """The pure _clamp_expected_stint_end helper, imported lazily.
+
+    Importing it pulls in strategy_orchestrator, whose import chain instantiates the
+    tire agent and loads data/models/tire_degradation/routing_config.json — absent in
+    a bare checkout (data/ comes from HF Hub). Skip rather than fail there, like every
+    other data-dependent test in this suite; the pure clamp still runs locally.
+    """
+    routing_cfg = ROOT / "data" / "models" / "tire_degradation" / "routing_config.json"
+    if not routing_cfg.exists():
+        pytest.skip(
+            "importing strategy_orchestrator instantiates the tire agent, which needs "
+            "data/models/tire_degradation/ (data/ comes from HF, not git)"
+        )
+    from src.agents.strategy_orchestrator import _clamp_expected_stint_end
+
+    return _clamp_expected_stint_end
+
+
+def test_expected_stint_end_is_clamped_to_the_pit_and_cliff_anchor(clamp_fn):
     """#433: an absurd 57 must be pulled back to the pit_lap + cliff/capacity anchor.
 
     pit_lap_target=7, HARD capacity=38 (pit_strategy_agent._STINT_CAPACITY_LAPS),
     cliff_p50=20.0 -> anchor = 7 + min(20.0, 38) = 27. |57 - 27| = 30 > 3, so the
     LLM's 57 must be discarded in favour of the anchor.
     """
-    from src.agents.strategy_orchestrator import _clamp_expected_stint_end
-
-    result = _clamp_expected_stint_end(
+    result = clamp_fn(
         llm_stint_end=57,
         pit_lap_target=7,
         compound_next="HARD",
@@ -254,12 +274,10 @@ def test_expected_stint_end_is_clamped_to_the_pit_and_cliff_anchor():
     assert result <= 45
 
 
-def test_expected_stint_end_within_band_is_kept_as_the_llm_reported_it():
+def test_expected_stint_end_within_band_is_kept_as_the_llm_reported_it(clamp_fn):
     """A plausible LLM value close to the anchor must survive unchanged."""
-    from src.agents.strategy_orchestrator import _clamp_expected_stint_end
-
     # anchor is 27; |29-27| = 2 <= 3
-    result = _clamp_expected_stint_end(
+    result = clamp_fn(
         llm_stint_end=29,
         pit_lap_target=7,
         compound_next="HARD",
@@ -270,12 +288,10 @@ def test_expected_stint_end_within_band_is_kept_as_the_llm_reported_it():
     assert result == 29
 
 
-def test_expected_stint_end_anchor_is_clamped_to_total_laps():
+def test_expected_stint_end_anchor_is_clamped_to_total_laps(clamp_fn):
     """The anchor itself must never exceed the race's actual lap count."""
-    from src.agents.strategy_orchestrator import _clamp_expected_stint_end
-
     # 50 + min(38, 38) = 88 would exceed a 57-lap race
-    result = _clamp_expected_stint_end(
+    result = clamp_fn(
         llm_stint_end=95,
         pit_lap_target=50,
         compound_next="HARD",
@@ -286,14 +302,12 @@ def test_expected_stint_end_anchor_is_clamped_to_total_laps():
     assert result == 57
 
 
-def test_expected_stint_end_passes_through_unclamped_when_no_anchor_is_available():
+def test_expected_stint_end_passes_through_unclamped_when_no_anchor_is_available(clamp_fn):
     """Without pit_lap_target/compound_next/cliff_p50 there is no anchor to
     ground against, so the LLM's raw value must pass through rather than
     inventing one.
     """
-    from src.agents.strategy_orchestrator import _clamp_expected_stint_end
-
-    result = _clamp_expected_stint_end(
+    result = clamp_fn(
         llm_stint_end=57,
         pit_lap_target=None,
         compound_next=None,

--- a/tests/audit/test_pace_orchestrator_hardening.py
+++ b/tests/audit/test_pace_orchestrator_hardening.py
@@ -1,0 +1,344 @@
+"""Hardening tests for the pace agent, RaceStateManager, and strategy orchestrator —
+#435 (pace self-fulfilling prev_lap_time), #476 (unvalidated predict_pace_tool LLM
+input), and #433 (unvalidated expected_stint_end LLM free text).
+
+Doctrine: no-LLM assertions only.
+
+- The #435 section builds a real ``RaceStateManager`` off the raw Lusail 2025 laps
+  parquet, merged with ``Prev_LapTime`` from the real featured parquet (the same
+  join ``src/f1_strat_manager/laps_augment.py`` performs in the opposite direction),
+  and reads the real dataclass method — no mocks, no LLM.
+- The #476 section calls ``PaceAgent.run()`` (the real N06 XGBoost model) through
+  ``predict_pace_tool.invoke()`` directly — deterministic inference, never a
+  LangGraph ReAct loop or a live LLM client.
+- The #433 section exercises ``_assemble_recommendation``, a pure post-LLM
+  assembly helper, with a hand-built ``_LLMSynthesis`` — never a live orchestrator
+  run end to end.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+RAW_LUSAIL = ROOT / "data" / "raw" / "2025" / "Lusail" / "laps.parquet"
+FEATURED_2025 = ROOT / "data" / "processed" / "laps_featured_2025.parquet"
+
+_HAS_RSM_DATA = RAW_LUSAIL.exists() and FEATURED_2025.exists()
+
+_HAS_PACE_MODEL = (
+    (ROOT / "data" / "models" / "lap_time" / "xgb_laptime_delta_final.json").exists()
+    and (ROOT / "data" / "processed" / "feature_manifest_laptime.json").exists()
+    and (
+        ROOT / "data" / "processed" / "circuit_clustering" / "circuit_clusters_k4_2025.parquet"
+    ).exists()
+    and FEATURED_2025.exists()
+)
+
+
+# =============================================================================
+# #435 — RaceStateManager.get_driver_state must emit the REAL previous-lap
+# time (Prev_LapTime from the featured parquet), not the current lap's time
+# reused as a stand-in.
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def lusail_rsm_and_reference_row():
+    """A real RaceStateManager for Lusail 2025, plus the row used to check it.
+
+    ``data/raw/2025/Lusail/laps.parquet`` satisfies RaceStateManager's raw-shape
+    contract (LapTime/Time/TrackStatus/... as REQUIRED_LAPS_COLUMNS expects) but
+    has no Prev_LapTime column — that is an N04-engineered feature that only
+    lives in the featured parquet. Merging it in on (Driver, LapNumber) mirrors
+    laps_augment.augment_featured_laps's own raw<->featured join, just in the
+    other direction, and produces the same laps_df shape the strategy pipeline
+    relies on in production.
+    """
+    if not _HAS_RSM_DATA:
+        pytest.skip(
+            "needs data/raw/2025/Lusail/laps.parquet and "
+            "data/processed/laps_featured_2025.parquet (data/ comes from HF, not git)"
+        )
+
+    from src.simulation.race_state_manager import RaceStateManager
+
+    raw = pd.read_parquet(RAW_LUSAIL)
+    raw["LapNumber"] = raw["LapNumber"].astype(int)
+
+    featured = pd.read_parquet(
+        FEATURED_2025, columns=["GP_Name", "Driver", "LapNumber", "Prev_LapTime"]
+    )
+    featured = featured[featured["GP_Name"] == "Lusail"].copy()
+    featured["LapNumber"] = featured["LapNumber"].astype(int)
+
+    merged = raw.merge(
+        featured[["Driver", "LapNumber", "Prev_LapTime"]],
+        on=["Driver", "LapNumber"],
+        how="left",
+    )
+
+    candidates = merged.dropna(subset=["Prev_LapTime"])
+    if candidates.empty:
+        pytest.skip("no Lusail 2025 lap has a non-NaN Prev_LapTime after the join")
+
+    # Prefer VER lap 10 (the task's suggested repro) when it survived the join;
+    # otherwise any non-NaN candidate demonstrates the same fix.
+    ver_lap10 = candidates[(candidates["Driver"] == "VER") & (candidates["LapNumber"] == 10)]
+    row = ver_lap10.iloc[0] if not ver_lap10.empty else candidates.iloc[0]
+
+    team = merged.loc[merged["Driver"] == row["Driver"], "Team"].iloc[0]
+    rsm = RaceStateManager(
+        merged, driver_code=row["Driver"], team=team, gp_name="Lusail", year=2025
+    )
+    return rsm, row
+
+
+def test_prev_lap_time_matches_the_real_prev_laptime_and_differs_from_current(
+    lusail_rsm_and_reference_row,
+):
+    """#435: prev_lap_time must be the row's real Prev_LapTime, not lap_time_s.
+
+    Before the fix, PaceAgent.run_from_state fed lap_time_s (this lap's own time)
+    back in as the "previous" lap, so the model chased its own last prediction.
+    get_driver_state must now expose the real preceding-lap value so the agent
+    can stop doing that.
+    """
+    rsm, row = lusail_rsm_and_reference_row
+    state = rsm.get_lap_state(int(row["LapNumber"]))
+    driver = state["driver"]
+
+    assert driver["prev_lap_time"] == pytest.approx(float(row["Prev_LapTime"]), abs=1e-6)
+    assert driver["prev_lap_time"] != driver["lap_time_s"]
+
+
+# =============================================================================
+# #476 — predict_pace_tool must refuse an off-roster driver number or an
+# out-of-range lap instead of predicting from data that cannot exist.
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def pace_agent_and_valid_driver():
+    """The real, singleton PaceAgent plus a genuinely-on-track Lusail 2025 car
+    number, discovered from the agent's own loaded reference data rather than
+    guessed — so the "still works for a real driver" control case cannot
+    accidentally be wrong about who was racing.
+    """
+    if not _HAS_PACE_MODEL:
+        pytest.skip(
+            "needs data/models/lap_time/, data/processed/feature_manifest_laptime.json, "
+            "data/processed/circuit_clustering/circuit_clusters_k4_2025.parquet and "
+            "data/processed/laps_featured_2025.parquet (data/ comes from HF, not git)"
+        )
+
+    from src.agents.pace_agent import _get_default_pace_agent
+
+    agent = _get_default_pace_agent()
+    ref = agent.laps_ref
+    lusail_2025 = ref[(ref["GP_Name"] == "Lusail") & (ref["Year"] == 2025)]
+    valid_numbers = lusail_2025["DriverNumber"].dropna().astype(int)
+    if valid_numbers.empty:
+        pytest.skip("no DriverNumber found for Lusail 2025 in laps_ref")
+    return agent, int(valid_numbers.iloc[0])
+
+
+def _pace_tool_kwargs(**overrides) -> dict:
+    """Base kwargs for predict_pace_tool.invoke() — all 19 params, overridable.
+
+    Values are plausible but not required to be exact: everything except
+    driver_number/lap_number/gp_name/year/total_laps degrades gracefully
+    (unknown team/compound fall back to encoding defaults), so the guard under
+    test is isolated from the rest of the feature row.
+    """
+    kwargs = dict(
+        driver_number=1,
+        lap_number=10,
+        stint=1,
+        tyre_life=5,
+        compound="MEDIUM",
+        position=5,
+        team="Red Bull Racing",
+        laps_since_pit=5,
+        fuel_load=0.8,
+        year=2025,
+        prev_lap_time=85.0,
+        prev_tyre_life=4,
+        prev_speed_st=320.0,
+        air_temp=28.0,
+        track_temp=38.0,
+        humidity=50.0,
+        rainfall=False,
+        total_laps=57,
+        gp_name="Lusail",
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+def test_predict_pace_tool_refuses_a_driver_not_on_track(pace_agent_and_valid_driver):
+    """#476: an invented car number for a real GP/year must error, not predict."""
+    from src.agents.pace_agent import predict_pace_tool
+
+    _agent, _valid_number = pace_agent_and_valid_driver
+    off_roster_number = -999  # no real car has ever carried this number
+
+    result = predict_pace_tool.invoke(_pace_tool_kwargs(driver_number=off_roster_number))
+
+    assert "error" in result, f"expected a refusal, got: {result}"
+    assert "REFUSED" in result["error"]
+    assert str(off_roster_number) in result["error"]
+
+
+def test_predict_pace_tool_refuses_an_out_of_range_lap(pace_agent_and_valid_driver):
+    """#476: a lap far beyond total_laps must error, not predict."""
+    from src.agents.pace_agent import predict_pace_tool
+
+    _agent, valid_number = pace_agent_and_valid_driver
+
+    result = predict_pace_tool.invoke(
+        _pace_tool_kwargs(driver_number=valid_number, lap_number=9999, total_laps=57)
+    )
+
+    assert "error" in result, f"expected a refusal, got: {result}"
+    assert "REFUSED" in result["error"]
+
+
+def test_predict_pace_tool_still_computes_for_a_real_driver_in_range(
+    pace_agent_and_valid_driver,
+):
+    """The guard must not buy safety by refusing everyone — a real, in-range
+    driver number must still run inference and return a prediction.
+    """
+    from src.agents.pace_agent import predict_pace_tool
+
+    _agent, valid_number = pace_agent_and_valid_driver
+
+    result = predict_pace_tool.invoke(
+        _pace_tool_kwargs(driver_number=valid_number, lap_number=10, total_laps=57)
+    )
+
+    assert "error" not in result, f"a live, in-range driver was refused: {result}"
+    assert "lap_time_pred" in result
+
+
+# =============================================================================
+# #433 — expected_stint_end must be grounded against pit_lap_target plus the
+# N26 cliff / Pirelli stint capacity, not passed through as raw LLM free text.
+# =============================================================================
+
+
+def _minimal_llm_synthesis(**overrides):
+    """Build a minimal, schema-valid _LLMSynthesis for clamp-logic tests.
+
+    Only the fields _assemble_recommendation actually reads for the clamp
+    (pit_lap_target, compound_next, expected_stint_end) vary per test; the rest
+    are fixed to the smallest valid value _LLMSynthesis's schema accepts.
+    """
+    from src.agents.strategy_orchestrator import _LLMSynthesis
+
+    base = dict(
+        action="STAY_OUT",
+        reasoning="test synthesis",
+        confidence=0.5,
+        pace_mode="NEUTRAL",
+        risk_posture="BALANCED",
+    )
+    base.update(overrides)
+    return _LLMSynthesis(**base)
+
+
+def test_expected_stint_end_is_clamped_to_the_pit_and_cliff_anchor():
+    """#433: an absurd 57 must be pulled back to the pit_lap + cliff/capacity anchor.
+
+    pit_lap_target=7, HARD capacity=38 (pit_strategy_agent._STINT_CAPACITY_LAPS),
+    cliff_p50=20.0 -> anchor = 7 + min(20.0, 38) = 27. |57 - 27| = 30 > 3, so the
+    LLM's 57 must be discarded in favour of the anchor.
+    """
+    from src.agents.strategy_orchestrator import _assemble_recommendation
+
+    synth = _minimal_llm_synthesis(
+        pit_lap_target=7,
+        compound_next="HARD",
+        expected_stint_end=57,
+    )
+
+    rec = _assemble_recommendation(
+        synth,
+        pit_out=None,
+        mc_results={},
+        regulation_context="",
+        cliff_p50=20.0,
+        total_laps=57,
+    )
+
+    assert rec.expected_stint_end == 27
+    assert rec.expected_stint_end <= 45
+
+
+def test_expected_stint_end_within_band_is_kept_as_the_llm_reported_it():
+    """A plausible LLM value close to the anchor must survive unchanged."""
+    from src.agents.strategy_orchestrator import _assemble_recommendation
+
+    synth = _minimal_llm_synthesis(
+        pit_lap_target=7,
+        compound_next="HARD",
+        expected_stint_end=29,  # anchor is 27; |29-27|=2 <= 3
+    )
+
+    rec = _assemble_recommendation(
+        synth,
+        pit_out=None,
+        mc_results={},
+        regulation_context="",
+        cliff_p50=20.0,
+        total_laps=57,
+    )
+
+    assert rec.expected_stint_end == 29
+
+
+def test_expected_stint_end_anchor_is_clamped_to_total_laps():
+    """The anchor itself must never exceed the race's actual lap count."""
+    from src.agents.strategy_orchestrator import _assemble_recommendation
+
+    synth = _minimal_llm_synthesis(
+        pit_lap_target=50,
+        compound_next="HARD",
+        expected_stint_end=95,  # 50 + min(38,38) = 88 would exceed a 57-lap race
+    )
+
+    rec = _assemble_recommendation(
+        synth,
+        pit_out=None,
+        mc_results={},
+        regulation_context="",
+        cliff_p50=38.0,
+        total_laps=57,
+    )
+
+    assert rec.expected_stint_end == 57
+
+
+def test_expected_stint_end_passes_through_unclamped_when_no_anchor_is_available():
+    """Without pit_lap_target/compound_next/cliff_p50 there is no anchor to
+    ground against, so the LLM's raw value must pass through rather than
+    inventing one.
+    """
+    from src.agents.strategy_orchestrator import _assemble_recommendation
+
+    synth = _minimal_llm_synthesis(expected_stint_end=57)  # no pit_lap_target set
+
+    rec = _assemble_recommendation(
+        synth,
+        pit_out=None,
+        mc_results={},
+        regulation_context="",
+        cliff_p50=None,
+        total_laps=57,
+    )
+
+    assert rec.expected_stint_end == 57

--- a/tests/audit/test_pace_orchestrator_hardening.py
+++ b/tests/audit/test_pace_orchestrator_hardening.py
@@ -11,9 +11,9 @@ Doctrine: no-LLM assertions only.
 - The #476 section calls ``PaceAgent.run()`` (the real N06 XGBoost model) through
   ``predict_pace_tool.invoke()`` directly — deterministic inference, never a
   LangGraph ReAct loop or a live LLM client.
-- The #433 section exercises ``_assemble_recommendation``, a pure post-LLM
-  assembly helper, with a hand-built ``_LLMSynthesis`` — never a live orchestrator
-  run end to end.
+- The #433 section calls ``_clamp_expected_stint_end`` directly — the pure clamp
+  helper extracted from ``_assemble_recommendation`` — so it needs no model or data
+  and never runs a live orchestrator.
 """
 
 from __future__ import annotations
@@ -228,27 +228,9 @@ def test_predict_pace_tool_still_computes_for_a_real_driver_in_range(
 # =============================================================================
 # #433 — expected_stint_end must be grounded against pit_lap_target plus the
 # N26 cliff / Pirelli stint capacity, not passed through as raw LLM free text.
+# The clamp is the pure _clamp_expected_stint_end helper, so these tests need no
+# model and run on CI too (not just locally with data/).
 # =============================================================================
-
-
-def _minimal_llm_synthesis(**overrides):
-    """Build a minimal, schema-valid _LLMSynthesis for clamp-logic tests.
-
-    Only the fields _assemble_recommendation actually reads for the clamp
-    (pit_lap_target, compound_next, expected_stint_end) vary per test; the rest
-    are fixed to the smallest valid value _LLMSynthesis's schema accepts.
-    """
-    from src.agents.strategy_orchestrator import _LLMSynthesis
-
-    base = dict(
-        action="STAY_OUT",
-        reasoning="test synthesis",
-        confidence=0.5,
-        pace_mode="NEUTRAL",
-        risk_posture="BALANCED",
-    )
-    base.update(overrides)
-    return _LLMSynthesis(**base)
 
 
 def test_expected_stint_end_is_clamped_to_the_pit_and_cliff_anchor():
@@ -258,69 +240,50 @@ def test_expected_stint_end_is_clamped_to_the_pit_and_cliff_anchor():
     cliff_p50=20.0 -> anchor = 7 + min(20.0, 38) = 27. |57 - 27| = 30 > 3, so the
     LLM's 57 must be discarded in favour of the anchor.
     """
-    from src.agents.strategy_orchestrator import _assemble_recommendation
+    from src.agents.strategy_orchestrator import _clamp_expected_stint_end
 
-    synth = _minimal_llm_synthesis(
+    result = _clamp_expected_stint_end(
+        llm_stint_end=57,
         pit_lap_target=7,
         compound_next="HARD",
-        expected_stint_end=57,
-    )
-
-    rec = _assemble_recommendation(
-        synth,
-        pit_out=None,
-        mc_results={},
-        regulation_context="",
         cliff_p50=20.0,
         total_laps=57,
     )
 
-    assert rec.expected_stint_end == 27
-    assert rec.expected_stint_end <= 45
+    assert result == 27
+    assert result <= 45
 
 
 def test_expected_stint_end_within_band_is_kept_as_the_llm_reported_it():
     """A plausible LLM value close to the anchor must survive unchanged."""
-    from src.agents.strategy_orchestrator import _assemble_recommendation
+    from src.agents.strategy_orchestrator import _clamp_expected_stint_end
 
-    synth = _minimal_llm_synthesis(
+    # anchor is 27; |29-27| = 2 <= 3
+    result = _clamp_expected_stint_end(
+        llm_stint_end=29,
         pit_lap_target=7,
         compound_next="HARD",
-        expected_stint_end=29,  # anchor is 27; |29-27|=2 <= 3
-    )
-
-    rec = _assemble_recommendation(
-        synth,
-        pit_out=None,
-        mc_results={},
-        regulation_context="",
         cliff_p50=20.0,
         total_laps=57,
     )
 
-    assert rec.expected_stint_end == 29
+    assert result == 29
 
 
 def test_expected_stint_end_anchor_is_clamped_to_total_laps():
     """The anchor itself must never exceed the race's actual lap count."""
-    from src.agents.strategy_orchestrator import _assemble_recommendation
+    from src.agents.strategy_orchestrator import _clamp_expected_stint_end
 
-    synth = _minimal_llm_synthesis(
+    # 50 + min(38, 38) = 88 would exceed a 57-lap race
+    result = _clamp_expected_stint_end(
+        llm_stint_end=95,
         pit_lap_target=50,
         compound_next="HARD",
-        expected_stint_end=95,  # 50 + min(38,38) = 88 would exceed a 57-lap race
-    )
-
-    rec = _assemble_recommendation(
-        synth,
-        pit_out=None,
-        mc_results={},
-        regulation_context="",
         cliff_p50=38.0,
         total_laps=57,
     )
 
-    assert rec.expected_stint_end == 57
+    assert result == 57
 
 
 def test_expected_stint_end_passes_through_unclamped_when_no_anchor_is_available():
@@ -328,17 +291,14 @@ def test_expected_stint_end_passes_through_unclamped_when_no_anchor_is_available
     ground against, so the LLM's raw value must pass through rather than
     inventing one.
     """
-    from src.agents.strategy_orchestrator import _assemble_recommendation
+    from src.agents.strategy_orchestrator import _clamp_expected_stint_end
 
-    synth = _minimal_llm_synthesis(expected_stint_end=57)  # no pit_lap_target set
-
-    rec = _assemble_recommendation(
-        synth,
-        pit_out=None,
-        mc_results={},
-        regulation_context="",
+    result = _clamp_expected_stint_end(
+        llm_stint_end=57,
+        pit_lap_target=None,
+        compound_next=None,
         cliff_p50=None,
         total_laps=57,
     )
 
-    assert rec.expected_stint_end == 57
+    assert result == 57

--- a/tests/audit/test_pit_agent_hardening.py
+++ b/tests/audit/test_pit_agent_hardening.py
@@ -1,0 +1,427 @@
+"""Hardening tests for the Pit Strategy Agent — #432, #450, #465 (F6), #476.
+
+No LLM calls, no ReAct invocation, no orchestrator run. Every test exercises a pure
+function or a private builder method directly:
+
+#432 — `_parse_tool_outputs` latched onto the FIRST `P(undercut_success)=` match and
+never tracked which driver it belonged to, so `undercut_target` was assembled from the
+POSITIONAL `rival_ahead` candidate instead of the rival N16 actually scored highest.
+`score_undercut_tool` now embeds `candidate=<driver_y>` in its return string so the
+parser can track the argmax (driver, prob) pair across every rival scored in one run.
+
+#476 — `predict_pit_duration_tool`, `score_undercut_tool` and `recommend_compound_tool`
+all accept free-text driver codes from the LLM with no guard against naming a car that
+is not (or no longer) on track. Applies the same `_live_drivers` refusal shape
+`score_undercut_tool` already used. `predict_pit_duration_tool`'s `under_sc` argument is
+also LLM free text; it is now cross-checked against `self.sc_currently_active`, the
+RCM-confirmed ground truth set for the duration of one real `_run_core` invocation.
+
+#450 — `_build_pit_duration_features` fed N15 two FROZEN constants: `tight_pit_box`
+was hardcoded 0 and `team_year_median` was always the 2.8s fallback, regardless of
+which circuit, team or year was actually asked about. Both are now real lookups:
+`tight_pit_box` checks the (slug-resolved) circuit against N15's trained Monaco/
+Singapore/Hungary set, and `team_year_median` is aggregated from the raw per-GP
+pitstops.parquet files at `PitAgentCFG.__post_init__` time.
+
+#465 (F6) — `run_from_state`'s `d.get('position', 20)` used a SEARCHABLE sentinel: a
+missing position silently became P20, and `driver_pos - 1 == 19` could then match a
+REAL P19 rival, inventing a rival-ahead relationship for a car whose position was
+actually unknown. The fix propagates `None` instead and skips the rival lookup.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "pit_prediction" / "model_config.json").exists()
+_HAS_UNDERCUT_DATA = (
+    ROOT / "data" / "processed" / "undercut_labeled" / "undercut_clean.parquet"
+).exists()
+_HAS_RAW_PITSTOPS = any((ROOT / "data" / "raw").glob("*/*/pitstops.parquet"))
+
+# PitAgentCFG.__post_init__ loads the N15/N16 model bundles, the undercut training
+# parquet, and now scans data/raw/<year>/<GP>/pitstops.parquet too. All of that comes
+# from Hugging Face Hub on first run, not from git, so a CI runner without data/ skips
+# this whole module rather than failing on missing fixtures.
+pytestmark = pytest.mark.skipif(
+    not (_HAS_MODELS and _HAS_UNDERCUT_DATA and _HAS_RAW_PITSTOPS),
+    reason=(
+        "needs data/models/pit_prediction/, data/processed/undercut_labeled/, and "
+        "data/raw/<year>/<GP>/pitstops.parquet (data/ comes from HF, not git)"
+    ),
+)
+
+
+class _FakeToolMessage:
+    """Minimal stand-in for a LangChain ToolMessage — only `.content` is read."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+def _one_row_laps_df(driver: str, lap_number: int) -> pd.DataFrame:
+    """A single-row laps_df just complete enough for _build_pit_duration_features."""
+    return pd.DataFrame(
+        [
+            {
+                "Driver": driver,
+                "LapNumber": lap_number,
+                "TyreLife": 10.0,
+                "Compound": "MEDIUM",
+            }
+        ]
+    )
+
+
+@pytest.fixture(scope="module")
+def pit_agent():
+    """A real PitStrategyAgent — real N15/N16 models, real aggregated lookups.
+
+    Module-scoped: constructing it loads several joblib model bundles and now also
+    scans every raw pitstops.parquet, so tests share one instance and only mutate the
+    per-call state (laps_df / session_meta / _live_drivers) each test needs.
+    """
+    from src.agents.pit_strategy_agent import PitStrategyAgent
+
+    return PitStrategyAgent()
+
+
+# ---------------------------------------------------------------------------
+# #432 — undercut_target must be the argmax-scored driver, not the first one seen
+# ---------------------------------------------------------------------------
+
+
+def test_parse_tool_outputs_tracks_the_argmax_undercut_driver():
+    """Two rivals scored in one run: the HIGHER-probability driver must win.
+
+    Before #432, only the FIRST P(undercut_success) match was kept and the driver it
+    belonged to was never recorded at all — undercut_target came from the positional
+    rival_ahead candidate built for the prompt, which can name either rival depending
+    on race state, independent of which one N16 actually favoured.
+    """
+    from src.agents.pit_strategy_agent import _parse_tool_outputs
+
+    messages = [
+        _FakeToolMessage(
+            "candidate=SAI | P(undercut_success)=0.310 | threshold=0.522 | "
+            "pos_gap=2 | tyre_life_diff=+3 laps | verdict=NO"
+        ),
+        _FakeToolMessage(
+            "candidate=HAM | P(undercut_success)=0.680 | threshold=0.522 | "
+            "pos_gap=1 | tyre_life_diff=-2 laps | verdict=YES"
+        ),
+    ]
+
+    parsed = _parse_tool_outputs(messages)
+
+    assert parsed["undercut_target"] == "HAM"
+    assert parsed["undercut_prob"] == pytest.approx(0.680)
+
+
+def test_parse_tool_outputs_argmax_is_order_independent():
+    """The SAME two candidates in reverse order must still pick the higher probability.
+
+    Guards against a regression that accidentally keeps "first seen" semantics instead
+    of a true argmax (e.g. `>` vs never updating after the first match).
+    """
+    from src.agents.pit_strategy_agent import _parse_tool_outputs
+
+    messages = [
+        _FakeToolMessage(
+            "candidate=HAM | P(undercut_success)=0.680 | threshold=0.522 | "
+            "pos_gap=1 | tyre_life_diff=-2 laps | verdict=YES"
+        ),
+        _FakeToolMessage(
+            "candidate=SAI | P(undercut_success)=0.310 | threshold=0.522 | "
+            "pos_gap=2 | tyre_life_diff=+3 laps | verdict=NO"
+        ),
+    ]
+
+    parsed = _parse_tool_outputs(messages)
+
+    assert parsed["undercut_target"] == "HAM"
+
+
+def test_validate_undercut_target_drops_a_car_not_on_track(pit_agent):
+    """Assembly must re-check liveness independently of score_undercut_tool's own guard.
+
+    The two guards must not depend on each other to be correct (#432): even if a
+    driver code slipped through parsing (a stale message format, a test double), the
+    final PitStrategyOutput.undercut_target must not name a car that is not racing.
+    """
+    pit_agent._live_drivers = {"NOR", "HAM"}
+    assert pit_agent._validate_undercut_target("HUL") is None
+    assert pit_agent._validate_undercut_target("HAM") == "HAM"
+    # Unknown liveness (None) must not reject everything either.
+    pit_agent._live_drivers = None
+    assert pit_agent._validate_undercut_target("HUL") == "HUL"
+
+
+# ---------------------------------------------------------------------------
+# #476 — the LLM-facing tools must refuse a driver who is not on track
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tool_name,extra_kwargs",
+    [
+        (
+            "predict_pit_duration_tool",
+            {"lap_number": 30, "compound": "MEDIUM", "compound_change": True, "under_sc": False},
+        ),
+        (
+            "recommend_compound_tool",
+            {"lap_number": 30, "current_compound": "MEDIUM"},
+        ),
+    ],
+)
+def test_tool_refuses_a_driver_not_on_track(pit_agent, tool_name, extra_kwargs):
+    """Asking either LLM-facing tool about a car absent from the roster must refuse.
+
+    Before #476 this would have gone straight into the feature builder and either
+    crashed on missing lap data or, worse, quietly answered from stale data.
+    """
+    pit_agent.session_meta = {
+        "gp_name": "Budapest",
+        "year": 2024,
+        "total_laps": 70,
+        "team_lookup": {},
+    }
+    pit_agent._live_drivers = {"NOR", "HAM"}
+
+    tool = next(t for t in pit_agent._tools if t.name == tool_name)
+    result = tool.invoke({"driver": "ZZZ", **extra_kwargs})
+
+    assert "REFUSED" in result
+    assert "ZZZ" in result
+    assert "NOR" in result or "HAM" in result  # the valid-drivers list names a real car
+
+
+def test_a_live_driver_is_not_refused_by_the_guard(pit_agent):
+    """The guard must not buy safety by refusing everyone — a real car must pass it."""
+    pit_agent.laps_df = _one_row_laps_df("NOR", 30)
+    pit_agent.session_meta = {
+        "gp_name": "Budapest",
+        "year": 2024,
+        "total_laps": 70,
+        "team_lookup": {"NOR": "McLaren"},
+    }
+    pit_agent._live_drivers = {"NOR", "HAM"}
+
+    tool = next(t for t in pit_agent._tools if t.name == "predict_pit_duration_tool")
+    result = tool.invoke(
+        {
+            "driver": "NOR",
+            "lap_number": 30,
+            "compound": "MEDIUM",
+            "compound_change": False,
+            "under_sc": False,
+        }
+    )
+
+    assert "REFUSED" not in result
+    assert "physical_stop" in result
+
+
+def test_predict_pit_duration_tool_trusts_the_rcm_over_the_llm(pit_agent, monkeypatch):
+    """An LLM-supplied under_sc that contradicts the confirmed RCM state is overridden.
+
+    sc_currently_active is only ever set by _run_core, for the duration of one real
+    invocation; setting it directly here stands in for that without needing an LLM
+    run. _build_pit_duration_features is stubbed to CAPTURE the under_sc value the
+    tool actually forwards, isolating the cross-check from the quantile models'
+    sensitivity to that one feature (which is not itself under test here).
+    """
+    pit_agent.session_meta = {
+        "gp_name": "Budapest",
+        "year": 2024,
+        "total_laps": 70,
+        "team_lookup": {"NOR": "McLaren"},
+    }
+    pit_agent._live_drivers = {"NOR"}
+    pit_agent.sc_currently_active = True  # RCM: the SC IS out right now
+
+    captured: dict = {}
+
+    def fake_build_features(driver, lap_number, compound, compound_change, under_sc):
+        captured["under_sc"] = under_sc
+        return pd.DataFrame([{col: 0 for col in pit_agent.cfg.pit_features}])
+
+    monkeypatch.setattr(pit_agent, "_build_pit_duration_features", fake_build_features)
+
+    tool = next(t for t in pit_agent._tools if t.name == "predict_pit_duration_tool")
+    tool.invoke(
+        # The LLM claims no SC (under_sc=False); the RCM's True must win instead.
+        {
+            "driver": "NOR",
+            "lap_number": 30,
+            "compound": "MEDIUM",
+            "compound_change": False,
+            "under_sc": False,
+        }
+    )
+
+    assert captured["under_sc"] is True, "the RCM-confirmed value must override the LLM's guess"
+
+    del pit_agent.sc_currently_active  # avoid leaking state into later tests
+
+
+# ---------------------------------------------------------------------------
+# #450 — tight_pit_box and team_year_median must be real lookups, not frozen constants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "gp_name,expected",
+    [
+        ("Monaco", 1),
+        ("Monaco Grand Prix", 1),  # the FastF1 full-event-name keyspace must resolve too
+        ("Silverstone", 0),
+    ],
+)
+def test_tight_pit_box_matches_n15s_trained_circuit_set(pit_agent, gp_name, expected):
+    """Monaco (either keyspace) must flag tight_pit_box=1; Silverstone must not.
+
+    N15 was trained with tight_pit_box = GP_Name.isin({"Monaco Grand Prix",
+    "Singapore Grand Prix", "Hungarian Grand Prix"}) (N15_pit_duration.ipynb cell 4).
+    Before #450 this feature was hardcoded to 0 for every circuit, every call.
+    """
+    pit_agent.laps_df = _one_row_laps_df("NOR", 20)
+    pit_agent.session_meta = {
+        "gp_name": gp_name,
+        "year": 2024,
+        "team_lookup": {"NOR": "McLaren"},
+    }
+
+    feat_df = pit_agent._build_pit_duration_features("NOR", 20, "MEDIUM", False, False)
+
+    assert feat_df["tight_pit_box"].iloc[0] == expected
+
+
+def test_team_year_median_is_aggregated_from_real_pit_data(pit_agent):
+    """A known (team, year) combo must differ from the 2.8s constant fallback.
+
+    Before #450, team_year_median was ALWAYS cfg.team_year_median_fallback (2.8s),
+    for every team and every year — the aggregation in _load_team_year_medians must
+    actually vary the feature with the input.
+    """
+    cfg = pit_agent.cfg
+    assert cfg.team_year_median, "aggregation must find at least one real (team, year) combo"
+
+    ferrari_2024 = cfg.team_year_median.get(("Ferrari", 2024))
+    assert ferrari_2024 is not None, "Ferrari raced in 2024; raw pit data must cover it"
+    assert ferrari_2024 != pytest.approx(cfg.team_year_median_fallback)
+
+    # The read-time helper must actually surface the aggregated value...
+    assert cfg.team_year_median_for("Ferrari", 2024) == pytest.approx(ferrari_2024)
+    # ...and still fall back cleanly for a combo with no raw data.
+    assert cfg.team_year_median_for("NoSuchTeam", 1999) == pytest.approx(
+        cfg.team_year_median_fallback
+    )
+
+
+# ---------------------------------------------------------------------------
+# #465 (F6) — a missing position must propagate as None, not the searchable P20
+# ---------------------------------------------------------------------------
+
+
+def _stub_run_core(monkeypatch, captured: dict) -> None:
+    """Replace PitStrategyAgent._run_core with a recorder, so run_from_state can be
+    exercised end-to-end up to (and including) the rival_ahead computation without
+    ever reaching the LangGraph ReAct agent or an LLM endpoint.
+
+    Args:
+        monkeypatch: The pytest monkeypatch fixture.
+        captured: Dict the fake _run_core writes its `rival` argument into.
+    """
+    from src.agents.pit_strategy_agent import PitStrategyAgent, PitStrategyOutput
+
+    def fake_run_core(
+        self,
+        driver,
+        lap_number,
+        compound,
+        rival,
+        sc_prob,
+        laps_cliff,
+        sc_currently_active=False,
+        vsc_active=False,
+    ):
+        captured["rival"] = rival
+        return PitStrategyOutput(
+            action="STAY_OUT",
+            recommended_lap=None,
+            compound_recommendation="MEDIUM",
+            stop_duration_p05=0.0,
+            stop_duration_p50=0.0,
+            stop_duration_p95=0.0,
+            undercut_prob=None,
+            undercut_target=None,
+            sc_reactive=False,
+            reasoning="",
+        )
+
+    monkeypatch.setattr(PitStrategyAgent, "_run_core", fake_run_core)
+
+
+def test_run_from_state_rival_ahead_is_none_when_position_is_missing(pit_agent, monkeypatch):
+    """A driver with no known position must not resolve rival_ahead via a fake P20.
+
+    Before the fix, `d.get('position', 20)` handed a REAL P19 rival a rival-ahead
+    relationship it never earned, purely because 20 - 1 happens to equal 19.
+    """
+    captured: dict = {}
+    _stub_run_core(monkeypatch, captured)
+
+    laps_df = pd.DataFrame([{"Driver": "NOR", "LapNumber": 30}])
+    lap_state = {
+        "driver": {"compound": "MEDIUM"},  # no 'position' key at all
+        "session_meta": {
+            "driver": "NOR",
+            "gp_name": "Budapest",
+            "total_laps": 70,
+            "year": 2024,
+            "team": "McLaren",
+        },
+        "lap_number": 30,
+        # A real rival at P19 — this must NOT be picked as "the car ahead" just
+        # because the dead default made driver_pos - 1 equal 19.
+        "rivals": [{"driver": "HAM", "position": 19, "team": "Mercedes"}],
+    }
+
+    pit_agent.run_from_state(lap_state, laps_df)
+
+    assert captured["rival"] is None, (
+        "a missing position must not invent a rival-ahead via the old fake P20 default"
+    )
+
+
+def test_run_from_state_rival_ahead_resolves_when_position_is_known(pit_agent, monkeypatch):
+    """Regression guard: a KNOWN position must still resolve the real rival ahead.
+
+    The #465/F6 fix must not overcorrect into never finding a rival at all.
+    """
+    captured: dict = {}
+    _stub_run_core(monkeypatch, captured)
+
+    laps_df = pd.DataFrame([{"Driver": "NOR", "LapNumber": 30}])
+    lap_state = {
+        "driver": {"compound": "MEDIUM", "position": 5},
+        "session_meta": {
+            "driver": "NOR",
+            "gp_name": "Budapest",
+            "total_laps": 70,
+            "year": 2024,
+            "team": "McLaren",
+        },
+        "lap_number": 30,
+        "rivals": [{"driver": "HAM", "position": 4, "team": "Mercedes"}],
+    }
+
+    pit_agent.run_from_state(lap_state, laps_df)
+
+    assert captured["rival"] == "HAM"

--- a/tests/audit/test_race_situation_hardening.py
+++ b/tests/audit/test_race_situation_hardening.py
@@ -1,0 +1,171 @@
+"""Race Situation Agent (N27) hardening — #450 tuned thresholds, #476 unvalidated LLM input.
+
+Two independent bugs closed here, both silent (no exception, just a wrong or
+unused number):
+
+- **#450**: ``RaceSituationConfig.high_overtake``/``high_sc`` were dataclass
+  literals (0.80 / 0.30) that ``__post_init__`` loaded the REAL tuned thresholds
+  (``overtake_threshold`` from N12's ``model_config.json``, ``sc_threshold`` from
+  N14's ``feature_list_v1.json``) right next to, and then never used. Every
+  ``threat_level`` ever computed by ``RaceSituationOutput.__post_init__`` was
+  thresholded against the untuned placeholder — most visibly for SC, where the
+  hardcoded 0.30 sat nowhere near the tuned 0.2335.
+- **#476**: ``predict_overtake_tool``/``predict_sc_tool`` take free-text driver
+  codes and a free-int lap number straight from the LLM. The only guard was an
+  empty-dataframe check, which does not catch a driver who is not racing THIS
+  lap but still has stale rows elsewhere in ``laps_df`` (the FastF1 path loads
+  the WHOLE session), nor a lap number beyond the one the agent was actually
+  loaded for.
+
+Doctrine: no-LLM assertions only — real Lusail 2025 parquet, the actual loaded
+model config, no LangGraph ReAct / live orchestrator run anywhere below.
+"""
+
+from __future__ import annotations
+
+import json
+from itertools import islice
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+RACE_DIR = Path("data/raw/2025/Lusail")
+ROOT = Path(__file__).parent.parent.parent
+
+_HAS_OVERTAKE_MODEL = (
+    ROOT / "data" / "models" / "overtake_probability" / "model_config.json"
+).exists()
+_HAS_SC_MODEL = (
+    ROOT / "data" / "models" / "safety_car_probability" / "feature_list_v1.json"
+).exists()
+_HAS_RACE_DATA = (RACE_DIR / "laps.parquet").exists()
+
+# Importing race_situation_agent builds the module-level CFG singleton at import
+# time (loads both LightGBM models + calibrators + the circuit parquets), and the
+# fixture below needs the raw Lusail parquet. data/ comes from Hugging Face, not
+# git, so CI runners without it must skip rather than fail on import.
+pytestmark = [
+    pytest.mark.data,
+    pytest.mark.skipif(
+        not (_HAS_OVERTAKE_MODEL and _HAS_SC_MODEL and _HAS_RACE_DATA),
+        reason="needs data/models/{overtake_probability,safety_car_probability}/ "
+        "and the raw Lusail parquet (data/ comes from HF, not git)",
+    ),
+]
+
+
+def test_thresholds_loaded_from_model_config_not_hardcoded():
+    """#450: CFG.high_overtake/high_sc must be the TUNED thresholds, not 0.80/0.30.
+
+    Reads the two on-disk configs independently of the agent module (so the test
+    does not just compare the singleton against itself) and checks CFG matches
+    what was actually written to disk by N12/N14 — and does NOT match the old
+    dataclass literals, which is exactly the bug: they were never overwritten.
+    """
+    from src.agents.race_situation_agent import CFG
+
+    with open(ROOT / "data" / "models" / "overtake_probability" / "model_config.json") as f:
+        ov_cfg = json.load(f)
+    with open(ROOT / "data" / "models" / "safety_car_probability" / "feature_list_v1.json") as f:
+        sc_cfg = json.load(f)
+
+    loaded_overtake_threshold = ov_cfg["optimal_threshold"]
+    loaded_sc_threshold = sc_cfg["best_threshold"]
+
+    assert CFG.high_overtake == pytest.approx(loaded_overtake_threshold)
+    assert CFG.high_sc == pytest.approx(loaded_sc_threshold)
+
+    # The pre-fix hardcoded literals. If CFG ever equals these again while the
+    # loaded config differs, #450 has regressed (the loaded value stopped being
+    # the one threat_level actually thresholds against).
+    if loaded_overtake_threshold != pytest.approx(0.80):
+        assert CFG.high_overtake != pytest.approx(0.80)
+    if loaded_sc_threshold != pytest.approx(0.30):
+        assert CFG.high_sc != pytest.approx(0.30)
+
+
+@pytest.fixture(scope="module")
+def agent_at_lap_50():
+    """RaceSituationAgent wired exactly as run_from_state wires it, Lusail lap 50.
+
+    Reuses the same real-bug scenario as tests/test_undercut_targets_are_on_track.py:
+    HUL crashed on lap 7, so he is absent from the RaceStateManager ``rivals`` this
+    replay actually produces at lap 50 — a real retired-driver case, not a made-up one.
+    """
+    from src.agents.race_situation_agent import RaceSituationAgent, _ensure_timedelta_laps
+    from src.simulation.replay_engine import RaceReplayEngine
+
+    replay = RaceReplayEngine(RACE_DIR, driver_code="NOR", team="McLaren")
+    lap_state = next(islice(replay.replay(), 49, 50))
+
+    agent = RaceSituationAgent()
+    agent.laps_df = _ensure_timedelta_laps(pd.read_parquet(RACE_DIR / "laps.parquet"))
+    agent.laps_df["LapNumber"] = agent.laps_df["LapNumber"].astype(int)
+    agent.session_meta = {
+        "session": None,
+        "gp_name": "Lusail",
+        "event_name": "Lusail",
+        "year": 2025,
+        "circuit_cluster": 0,
+        "circuit_sc_rate": 0.10,
+        "total_laps": 57,
+        "AirTemp": 28.0,
+        "TrackTemp": 38.0,
+        "Humidity": 50.0,
+        "track_temp_start": 38.0,
+    }
+    agent._live_drivers = {r["driver"] for r in lap_state["rivals"] if r.get("driver")} | {"NOR"}
+    agent._current_lap = 50
+    return agent
+
+
+def _tool(agent, name: str):
+    """Look up one of the agent's built LangChain tools by name."""
+    tools = {t.name: t for t in agent._tools}
+    if name not in tools:
+        pytest.skip("LangGraph/LangChain not installed — _build_tools() returned no tools")
+    return tools[name]
+
+
+def test_a_car_that_retired_is_absent_from_the_lap_state(agent_at_lap_50):
+    """The premise the guard relies on: HUL crashed on Lusail lap 7."""
+    assert "HUL" not in agent_at_lap_50._live_drivers
+    assert "PIA" in agent_at_lap_50._live_drivers, "fixture is wrong if the leader is not racing"
+
+
+def test_predict_overtake_tool_refuses_a_car_not_on_track(agent_at_lap_50):
+    """#476: an impossible pair (one driver retired 43 laps ago) must error, not score.
+
+    Mirrors the task's example (predict_overtake_tool('VER','HAM', lap=12) when they
+    are not racing each other) with the real retired-driver case this repo already
+    has a verified fixture for.
+    """
+    result = _tool(agent_at_lap_50, "predict_overtake_tool").invoke(
+        {"driver_x": "NOR", "driver_y": "HUL", "lap_number": 50}
+    )
+    assert "REFUSED" in result, f"expected a refusal, got: {result}"
+    assert "HUL" in result
+
+
+def test_predict_overtake_tool_refuses_a_future_lap(agent_at_lap_50):
+    """#476: a lap far beyond the one the agent was actually loaded for must error."""
+    result = _tool(agent_at_lap_50, "predict_overtake_tool").invoke(
+        {"driver_x": "NOR", "driver_y": "PIA", "lap_number": 9999}
+    )
+    assert "REFUSED" in result, f"expected a refusal, got: {result}"
+
+
+def test_predict_sc_tool_refuses_a_future_lap(agent_at_lap_50):
+    """#476: predict_sc_tool takes only a lap number — it needs the same lap-range guard."""
+    result = _tool(agent_at_lap_50, "predict_sc_tool").invoke({"lap_number": 9999})
+    assert "REFUSED" in result, f"expected a refusal, got: {result}"
+
+
+def test_a_live_pair_still_scores(agent_at_lap_50):
+    """The guard must not buy safety by refusing everything — a real pair still answers."""
+    result = _tool(agent_at_lap_50, "predict_overtake_tool").invoke(
+        {"driver_x": "NOR", "driver_y": "PIA", "lap_number": 50}
+    )
+    assert "REFUSED" not in result, f"a live, in-range pair was refused: {result}"
+    assert "P(overtake)" in result

--- a/tests/audit/test_tire_agent_hardening.py
+++ b/tests/audit/test_tire_agent_hardening.py
@@ -1,0 +1,127 @@
+"""Hardening tests for the Tire Agent — #476 (unvalidated LLM driver input) and
+#477 (Rainfall hardcode + negative degradation-rate regex).
+
+No LLM calls: `_parse_tool_outputs` is a pure string parser, and
+`_validate_driver_on_track` / the tool functions built by `_build_tools()`
+return before any TCN inference or ReAct invocation when the guard fires.
+Nothing here builds a react agent or talks to an LLM endpoint.
+
+#476 — `predict_tire_deg_tool` and `estimate_laps_to_cliff_tool` accepted any
+free-text driver code from the LLM. `laps_df` carries the WHOLE race's
+history, so a driver who crashed early still has rows the stint filter in
+`_get_driver_stint` can happily build a "stint" from — it never checked
+whether the driver was still racing at the lap the agent is currently
+analysing. Austin 2024 is the exact repro named in the issue: HAM's last
+real row is LapNumber=2 (confirmed against the raw parquet below), the race
+runs to lap 56, and asking about him at a later lap used to return a
+confident P50 instead of an error.
+
+#477 — `_parse_tool_outputs`'s regexes used a bare `[\\d.]+` digit class,
+which cannot match a leading minus. A negative degradation rate is real and
+expected per the tire agent's own system prompt ("a negative degradation
+rate means the driver is improving pace... this is real, not an error"), so
+the parse miss silently fell through to the 0.0 default instead of raising.
+"""
+
+from __future__ import annotations
+
+from itertools import islice
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+RACE_DIR = ROOT / "data" / "raw" / "2024" / "Austin"
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+_HAS_RACE_DATA = (RACE_DIR / "laps.parquet").exists()
+
+# TireAgent() loads the TCN bundles at __init__ time, and the fixture below
+# needs the real Austin 2024 raw parquet to derive a genuine rivals list.
+# Both come from Hugging Face, not git, so a CI runner without data/ skips
+# this whole module rather than failing on missing fixtures.
+pytestmark = pytest.mark.skipif(
+    not (_HAS_MODELS and _HAS_RACE_DATA),
+    reason="needs data/models/tire_degradation/ and data/raw/2024/Austin/ (data/ comes from HF, not git)",
+)
+
+
+class _FakeToolMessage:
+    """Minimal stand-in for a LangChain ToolMessage — only `.content` is read."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+# ---------------------------------------------------------------------------
+# #477 — negative degradation rate must parse, not silently drop
+# ---------------------------------------------------------------------------
+
+
+def test_parse_tool_outputs_matches_a_negative_degradation_rate():
+    """The regex must accept a leading minus, not just `[\\d.]+`."""
+    from src.agents.tire_agent import _parse_tool_outputs
+
+    message = _FakeToolMessage(
+        "Driver NOR | Compound C2 | TyreLife 12\n"
+        "Cumulative degradation: -1.200 s | Degradation rate: -0.05 s/lap"
+    )
+
+    parsed = _parse_tool_outputs([message])
+
+    assert parsed["deg_rate"] == -0.05
+
+
+# ---------------------------------------------------------------------------
+# #476 — the tools must refuse a driver who is not on track
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def tire_agent_at_austin_lap_30():
+    """A TireAgent wired exactly as run_from_state() wires it, Austin 2024 lap 30.
+
+    HAM crashed on lap 2 of this 56-lap race — his last raw-data row is
+    LapNumber=2 (real reference data, not a synthetic fixture). NOR ran the
+    full distance, so he is a legitimate "still on track" control case.
+    """
+    from src.agents.tire_agent import TireAgent
+    from src.simulation.replay_engine import RaceReplayEngine
+
+    replay = RaceReplayEngine(RACE_DIR, driver_code="NOR", team="McLaren", interval_seconds=0.0)
+    lap_state = next(islice(replay.replay(), 29, 30))  # 0-indexed 29 -> lap 30
+
+    agent = TireAgent()
+    agent.laps_df = pd.read_parquet(RACE_DIR / "laps.parquet")
+    agent.session_meta = {"current_lap": 30, "total_laps": 56}
+    agent._live_drivers = {"NOR"} | {r["driver"] for r in lap_state["rivals"] if r.get("driver")}
+    return agent
+
+
+def test_ham_is_absent_from_the_lap_30_rivals(tire_agent_at_austin_lap_30):
+    """The premise: HAM crashed on lap 2, so he cannot still be racing at lap 30."""
+    live = tire_agent_at_austin_lap_30._live_drivers
+    assert "HAM" not in live
+    assert "NOR" in live
+
+
+@pytest.mark.parametrize("tool_name", ["predict_tire_deg_tool", "estimate_laps_to_cliff_tool"])
+def test_tool_refuses_a_driver_not_on_track(tire_agent_at_austin_lap_30, tool_name):
+    """Asking either LLM-facing tool about HAM at lap 30 must error, not compute.
+
+    Before #476 this returned a confident-looking prediction (e.g.
+    'P50: 21867.1') built from HAM's stale pre-crash laps instead of refusing.
+    """
+    agent = tire_agent_at_austin_lap_30
+    tool = next(t for t in agent._tools if t.name == tool_name)
+
+    result = tool.invoke({"driver": "HAM", "compound_id": "C2", "tyre_life": 10})
+
+    assert result.startswith("error:")
+    assert "HAM" in result
+    assert "NOR" in result  # the valid-drivers list should still name a real car
+
+
+def test_a_live_driver_is_not_refused_by_the_guard(tire_agent_at_austin_lap_30):
+    """The guard must not buy safety by refusing everyone — NOR must pass it."""
+    assert tire_agent_at_austin_lap_30._validate_driver_on_track("NOR") is None


### PR DESCRIPTION
## What
Parallel Fable-audit hardening of the strategy engine: validate every LLM-facing sub-agent tool's inputs and correct a batch of model-fidelity defects. Built by parallel workers on disjoint files, verified centrally.

## Why
The adversarial audit found that LLM-facing tools accepted unvalidated free text (an off-track/crashed driver still got a fabricated prediction) and that several agent features were frozen or wrongly substituted, biasing the models.

## How
- **#476** reuse the existing `_live_drivers` guard across the pit, tire, situation and pace agents; an off-track driver or out-of-range lap is refused, not computed on. `predict_pit_duration` also cross-checks `under_sc` against the RCM-confirmed state.
- **#432** `undercut_target` reports the argmax-probability driver, re-validated for liveness at assembly.
- **#433** `expected_stint_end` clamped to `pit_lap + min(cliff_p50, tyre capacity)`, bounded by `total_laps`.
- **#435** emit + read the real `Prev_LapTime` instead of the current lap's own time.
- **#450** wire the loaded overtake/SC thresholds in (vs hardcoded 0.80/0.30); derive `tight_pit_box`/`team_year_median` from real pitstop data; fix the false causal-training docstring + stale SC inference note.
- **#465** scope laps to the requested GP before building the default lap_state (engine + orchestrator share one helper, no duplicate); stop coercing a missing position to a sentinel.
- **#477** real Rainfall on the FastF1 path; parse negative degradation rates.

## Checks
- 35 no-LLM assertions against the real featured parquet + model artifacts (`tests/audit/`), all passing locally.
- `ruff check .` clean; `ruff format --check .` clean.

Closes #432, #433, #450, #477. Advances #435, #465, #476 (telemetry-submodule parts follow in a separate PR).