### PR TITLE
fix(agents): guard the pit prompt-build NaN crash + correct the calibration docstring

### DIFF
--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -1494,8 +1494,13 @@ class PitStrategyAgent:
         rival_str  = rival if rival else (candidates[0] if candidates else 'no rival in range')
 
         driver_row = self._get_lap_row(driver, lap_number)
-        tyre_life  = int(driver_row.get('TyreLife', 1)) if driver_row is not None else 1
-        position   = int(driver_row.get('Position', 0)) if driver_row is not None else 0
+        # Series.get returns a stored NaN, so int() would crash on the ~486 featured
+        # rows with NaN TyreLife/Position — guard with pd.notna, not a bare .get
+        # default (which only fires when the KEY is missing, never the VALUE) (#499).
+        _raw_tl    = driver_row.get('TyreLife') if driver_row is not None else None
+        tyre_life  = int(_raw_tl) if pd.notna(_raw_tl) else 1
+        _raw_pos   = driver_row.get('Position') if driver_row is not None else None
+        position   = int(_raw_pos) if pd.notna(_raw_pos) else 0
         team       = self.session_meta.get('team_lookup', {}).get(driver, 'Unknown')
 
         message = _build_pit_prompt(

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -219,7 +219,9 @@ class TireAgentConfig:
 
         mc_dropout_calibration.json stores per-compound mean_sigma_s values fitted
         in N10. The fallback sigma is the mean across all compounds — used when
-        compound_id is absent from the dict (e.g. C6 with sparse data).
+        compound_id is absent from the dict (currently C1 and C3, whose sigmas are
+        not yet fitted; C2/C4/C5/C6 are present). Regenerating them needs N09's MC
+        Dropout calibration cell, so the cross-compound mean stands in until then.
 
         Returns:
             Tuple (calibration_dict, sigma_fallback).


### PR DESCRIPTION
Follow-ups from the directed verification audit of the hardening sprint.

- **#499** `_run_core`'s prompt build did `int(driver_row.get('TyreLife'/'Position'))`, crashing on the ~486 featured rows with a stored NaN (Series.get's default only fires on a missing KEY, never a NaN VALUE). Guarded with `pd.notna`.
- **#477 follow-up** corrected the `mc_dropout_calibration` fallback docstring: the compounds absent from the file are C1/C3 (C2/C4/C5/C6 are present), not C6.

Verified: `ruff check .` clean; 18 pit/tire audit tests pass; no regression.

Closes #499. Refs #477.