### PR TITLE
docs: fact-check and refresh the project + site documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,13 +15,18 @@ All three consume the same core:
 
 - `src/agents/` — N25-N31 multi-agent stack (pace, tire, race situation,
   pit strategy, radio NLP, RAG regulations, orchestrator).
+- `src/strategy/inference/engine.py::run_lap` — the single shared per-lap
+  pipeline call that the CLI, Arcade, and backend all route through
+  (profiles: `rich` for the full LLM-synthesis path, `no-llm` for the
+  deterministic zero-LLM-client path). Replaces three hand-mirrored
+  copies of the orchestrator sequence that used to drift out of sync.
 - `src/simulation/` — `RaceReplayEngine` + `RaceStateManager`.
 - `data/processed/laps_featured_<year>.parquet` + `data/raw/<year>/<Location>/` +
   `data/tire_compounds_by_race.json`.
 
 The Streamlit path also runs a FastAPI backend (`src/telemetry/backend/`).
-The Arcade path runs the strategy pipeline locally without the backend
-(see [`docs/pages/arcade-strategy-pipeline.md`](docs/pages/arcade-strategy-pipeline.md)).
+The Arcade path calls `run_lap` in-process without going through the
+backend (see [`docs/pages/arcade-strategy-pipeline.md`](docs/pages/arcade-strategy-pipeline.md)).
 
 ## Multi-agent pipeline
 
@@ -54,7 +59,7 @@ Both windows subscribe to the arcade's `TelemetryStreamServer` on
 - Featured laps parquets + per-race raw dirs + tire-compound-by-race
   map form the input to the multi-agent stack.
 
-for the wire-level view.
+See [`docs/pages/simulation.md`](docs/pages/simulation.md) for the wire-level view.
 
 ## Where to go next
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,8 @@ after merge.
 ## Development setup
 
 ```bash
-git clone https://github.com/VforVitorio/F1_Strat_Manager.git
-cd F1_Strat_Manager
+git clone https://github.com/VforVitorio/F1-StratLab.git
+cd F1-StratLab
 git submodule update --init --recursive     # src/telemetry/ is a submodule
 uv sync                                      # installs every dependency
 cp .env.example .env                         # add OPENAI_API_KEY here
@@ -34,13 +34,15 @@ Run once to pre-populate the data cache on first launch:
 python -c "from src.f1_strat_manager.data_cache import ensure_setup; ensure_setup(show_progress=True)"
 ```
 
-Three entry points after install (`pyproject.toml::[project.scripts]`):
+Five entry points after install (`pyproject.toml::[project.scripts]`):
 
 | Command | What it runs |
 |---|---|
-| `f1-sim` | CLI strategy simulation with Rich live panel |
+| `f1-strat` | Interactive CLI wizard (arrow-key pickers for race / driver / provider); shells out to `f1-sim` |
+| `f1-sim` | Headless CLI strategy simulation with Rich live panel (the scripted form) |
 | `f1-arcade --strategy` | 2D replay + PySide6 dashboard + telemetry |
 | `f1-streamlit` | Post-race analysis + chat UI |
+| `f1-eval` | Regenerates the model evaluation reports (`registry`, `calibration`, `hygiene`, `nlp`, `models`, `alert-llm` subcommands) under `documents/eval_reports/` |
 
 ## Code style
 
@@ -71,9 +73,10 @@ Some code carries hard rules set by the TFG author:
 - **`scripts/run_simulation_cli.py`** — the TFG's PMV (first working
   CLI). Duplicate before modifying; do not refactor in-place.
 - **`src/agents/` internals** — stable contract for the CLI + Streamlit
-  + Arcade paths. Additive entry points are welcome (see the verbose
-  variant in `src/arcade/strategy_pipeline.py`), but do not refactor
-  existing ones.
+  + Arcade paths. Additive entry points are welcome (see
+  `src/strategy/inference/engine.py::run_lap`, the shared per-lap pipeline
+  call all three surfaces route through), but do not refactor existing
+  agent modules in place.
 - **`notebooks/**`** and **`legacy/**`** — exploration / historical
   archive, different conventions.
 
@@ -127,13 +130,20 @@ these safeguards trigger there. They are no-ops on POSIX.
 
 ## CI pipeline
 
-Three parallel jobs run on every push and PR (`.github/workflows/ci.yml`):
+Four jobs run on every push and PR (`.github/workflows/ci.yml`):
 
 | Job | Installs | Runs |
 |---|---|---|
 | `lint` | nothing — ruff via `uvx` | `ruff check .` + `ruff format --check .` |
 | `typecheck` | `uv sync --extra dev` (mypy + project deps, no voice extras) | `mypy src/rag/` |
-| `test` | `uv sync --all-extras` (full ML/voice/arcade stack) | `pytest -v` |
+| `test` | `uv sync --all-extras` (full ML/voice/arcade stack) | `pytest -v --cov=src` + a collected-test-count floor (guards against a refactor silently dropping the suite) |
+| `pip-audit` | `uv export` to a requirements file | `pip-audit` against the locked deps (advisory, `continue-on-error: true` while baselining) |
+
+`test` and `typecheck` are additionally gated by `dorny/paths-filter`:
+they skip their real work (still reporting green) when the diff touches
+neither `src/`, `tests/`, `pyproject.toml`, `uv.lock`, nor the workflow
+file itself — a docs-only or CI-only PR does not pay for a full ML-stack
+install. `lint` and `pip-audit` stay always-on.
 
 All jobs share uv's wheel cache (`enable-cache: true`, keyed off
 `uv.lock`), so the cache only invalidates when the resolved graph
@@ -159,7 +169,7 @@ at once and stranded them for 20+ minutes.
 ### PR labels
 
 Every pull request gets auto-tagged with one or more `area:` labels by
-`.github/workflows/labeler.yml` (path-based via `actions/labeler@v5`).
+`.github/workflows/labeler.yml` (path-based via `actions/labeler@v6`).
 Dependabot PRs additionally get their label set by `dependabot.yml` so
 the tag is in place the moment the PR opens — no need to wait for the
 labeler workflow to run.
@@ -219,11 +229,28 @@ accepting a bump that breaks something:
      import paths, `np.bool_` alias). Grows whenever a new upstream
      incident reveals a fragile call site.
 
+### Security workflows
+
+Three additional workflows run independently of `ci.yml`, all scoped to
+the parent repo (the `src/telemetry` submodule has its own scanner
+coverage, tracked separately):
+
+- **CodeQL** (`.github/workflows/codeql.yml`) — SAST on Python and the
+  `docs/` React SPA, `security-extended` query suite, on push/PR to
+  `main`/`dev` plus a weekly schedule.
+- **gitleaks** (`.github/workflows/gitleaks.yml`) — secret scanning over
+  full history on push/PR plus a weekly schedule, complementing GitHub's
+  native secret scanning.
+- **OSV-Scanner** (`.github/workflows/osv-scanner.yml`) — cross-ecosystem
+  vulnerability scan against OSV.dev on `uv.lock`; blocking (any new,
+  un-waived CVE fails the build). Known unfixable CVEs (Pillow, torch,
+  ecdsa) are waived with documented reasons in `osv-scanner.toml`.
+
 ## Issue templates
 
-File an issue via the GitHub UI. Three templates are available under
+File an issue via the GitHub UI. Four templates are available under
 [.github/ISSUE_TEMPLATE/](.github/ISSUE_TEMPLATE): bug report, feature
-request, data issue.
+request, data issue, epic.
 
 ## Related reading
 

--- a/INDEX.md
+++ b/INDEX.md
@@ -6,7 +6,7 @@ The project integrates several ML stacks — XGBoost/LightGBM for race strategy 
 
 The current development phase (N25–N31) replaces the legacy Experta rule engine with a **LangGraph multi-agent architecture**: specialised sub-agents (pace, tyre, overtake, safety car, pit strategy, radio NLP, regulation RAG) coordinate under a Supervisor Orchestrator.
 
-> For full documentation see the [README](README.md) and the [DeepWiki](https://deepwiki.com/VforVitorio/F1_Strat_Manager). For the deep reference (methodology, metrics, design rationale): the **TFG thesis + IEEE technical report** in [`documents/thesis/`](documents/thesis/). Legacy paper: [F1_Strategy_Manager_AI.pdf](documents/docs_legacy_strat_manager/F1_Strategy_Manager_AI.pdf).
+> For full documentation see the [README](README.md) and the [DeepWiki](https://deepwiki.com/VforVitorio/F1-StratLab). For the deep reference (methodology, metrics, design rationale): the **TFG thesis + IEEE technical report** in [`documents/thesis/`](documents/thesis/). Legacy paper: [F1_Strategy_Manager_AI.pdf](documents/docs_legacy_strat_manager/F1_Strategy_Manager_AI.pdf).
 
 Notebooks are the primary development artefact. `src/` modules are extracted from notebooks only when they need to be imported by other notebooks or the telemetry app.
 
@@ -89,6 +89,7 @@ Notebooks are the primary development artefact. `src/` modules are extracted fro
 | [N22_ner_models.ipynb](notebooks/nlp/N22_ner_models.ipynb)                   | F1-domain NER on short radio transcriptions; BERT-large CoNLL-03 BIO token classifier (F1 = 0.42); documents GLiNER zero-shot and fine-tuning failures |
 | [N23_rcm_parser.ipynb](notebooks/nlp/N23_rcm_parser.ipynb)                   | Rule-based structured event extractor for FastF1 `race_control_messages`; deterministic, no ML required                                                |
 | [N24_nlp_pipeline.ipynb](notebooks/nlp/N24_nlp_pipeline.ipynb)               | Unified inference pipeline merging N20-N23: sentiment + intent + NER + RCM parsing; GPU P95 latency 59.4 ms; exports `pipeline_config_v1.json`         |
+| [N33_radio_dataset_builder.ipynb](notebooks/nlp/N33_radio_dataset_builder.ipynb) | Builds the static per-GP OpenF1 radio corpus (parquets + MP3s) consumed at replay time by `src/nlp/radio_runner.py`; the CLI's `ensure_radio_corpus()` downloads this corpus lazily per GP |
 
 ### Agents (`notebooks/agents/`)
 
@@ -98,7 +99,7 @@ Notebooks are the primary development artefact. `src/` modules are extracted fro
 | [N30_rag_agent.ipynb](notebooks/agents/N30_rag_agent.ipynb)   | RAG Agent — retrieval-augmented generation over FIA Sporting and Technical Regulations (2023-2025) via local Qdrant; returns structured `RegulationContext` objects with article references |
 | [N34_radio_runner_smoke.ipynb](notebooks/agents/N34_radio_runner_smoke.ipynb) | Radio runner smoke test — end-to-end validation of `src/nlp/radio_runner.py`: cache hit/miss, per-lap radio distribution, transcript sanity, and N29 round-trip via `run_radio_agent_from_state` on Bahrain 2025 (28 radios + 76 RCMs, lap 4 emits a PROBLEM alert) |
 
-> The full multi-agent system (N25–N31) is **complete**. The importable agent + orchestrator modules live in [`src/agents/`](src/agents/) (each exposes `run_*_agent_from_state`). Notebooks N26–N29, N31, plus N33 (decision thresholds + calibration benchmarks) and N34 (radio runner smoke) are under `notebooks/agents/`.
+> The full multi-agent system (N25–N31) is **complete**. The importable agent + orchestrator modules live in [`src/agents/`](src/agents/) (each exposes `run_*_agent_from_state`). Notebooks N26–N29, N30B (RAG benchmark), two N31 notebooks (`N31_strategy_orchestrator.ipynb` + `N31_mc_visualization.ipynb`), N32 (smoke test), N33 (decision thresholds + calibration benchmarks), and N34 (radio runner smoke) are under `notebooks/agents/`. A different, unrelated `N33_radio_dataset_builder.ipynb` lives under `notebooks/nlp/` (see the NLP table below) — the two share a number by coincidence, not by pipeline order.
 
 ---
 
@@ -142,24 +143,35 @@ The two files below are the **legacy** `experta` rule engine, kept for reference
 
 ### `src/strategy/`
 
+`inference/engine.py` is **production**: it is the single shared implementation
+of the per-lap N31 pipeline, and the CLI, Arcade, and FastAPI backend all route
+through it instead of maintaining hand-mirrored copies (a real drift bug once
+caused every `--no-llm` lap to crash, since a signature change was mirrored
+into two of the three copies but not the third). `eval/` backs the `f1-eval`
+console script. The jupytext-exported `models/` files and `training/` (empty)
+are reference/historical only — see [`src/strategy/README.md`](src/strategy/README.md).
+
 | File                                                                                           | Description                                          |
 | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| [src/strategy/models/lap_time_model.py](src/strategy/models/lap_time_model.py)                 | Jupytext-exported lap time model module              |
-| [src/strategy/models/tire_degradation_model.py](src/strategy/models/tire_degradation_model.py) | Jupytext-exported tire degradation model module      |
-| [src/strategy/inference/tire_predictor.py](src/strategy/inference/tire_predictor.py)           | Jupytext-exported tire degradation inference wrapper |
+| [src/strategy/inference/engine.py](src/strategy/inference/engine.py)                           | `run_lap()` — the shared strategy inference engine consumed by the CLI, Arcade, and backend; dispatches on `profile` (`"rich"` re-drives the full N31 orchestrator sequence, `"no-llm"` is the deterministic zero-LLM-client path) |
+| [src/strategy/inference/no_llm.py](src/strategy/inference/no_llm.py)                           | The deterministic `--no-llm` code path consumed by `run_lap` |
+| [src/strategy/eval/](src/strategy/eval/)                                                       | `f1-eval` CLI backend — regenerates the model evaluation reports (metrics registry, calibration, threshold hygiene, NLP per-stage eval, headline-number reproduction, LLM-judged alert precision) under `documents/eval_reports/` |
+| [src/strategy/inference/tire_predictor.py](src/strategy/inference/tire_predictor.py)           | Jupytext-exported tire degradation inference wrapper (N09 era; reference only) |
+| [src/strategy/models/lap_time_model.py](src/strategy/models/lap_time_model.py)                 | Jupytext-exported lap time model module (reference only) |
+| [src/strategy/models/tire_degradation_model.py](src/strategy/models/tire_degradation_model.py) | Jupytext-exported tire degradation model module (reference only) |
 
 ### `src/telemetry/`
 
 A separate full-stack web application for live telemetry visualisation, independent of the agent notebooks.
 
-| Component                                                                | Description                                                                                                             |
-| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| [src/telemetry/backend/main.py](src/telemetry/backend/main.py)           | FastAPI application entry point; mounts endpoints for telemetry, circuit domination, driver comparison, chat, and voice |
-| `src/telemetry/backend/api/`                                             | Versioned API route handlers (`telemetry`, `comparison`, `chatbot`, `voice`)                                            |
-| `src/telemetry/backend/services/`                                        | Business logic:`telemetry_service.py`, `comparison_service.py`, and sub-services for telemetry and voice                |
-| [src/telemetry/frontend/app/main.py](src/telemetry/frontend/app/main.py) | Streamlit multi-page app entry point (dashboard, comparison, chat pages)                                                |
-| `src/telemetry/frontend/app/pages/`                                      | Individual Streamlit pages                                                                                              |
-| `src/telemetry/frontend/app/components/`                                 | Reusable UI components (auth, layout, navbar)                                                                           |
+| Component                                                                | Description                                                                                                                                |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| [src/telemetry/backend/main.py](src/telemetry/backend/main.py)           | FastAPI application entry point; mounts endpoints for telemetry, circuit domination, driver comparison, chat, voice, and strategy             |
+| `src/telemetry/backend/api/`                                             | Versioned API route handlers (`telemetry`, `circuit_domination`, `comparison`, `chat`, `voice`, `strategy` — the last exposes all N25-N31 agents + orchestrator over REST) |
+| `src/telemetry/backend/services/`                                        | Business logic: `telemetry/` (FastF1 client + session cache), `chatbot/` (chat engine, LLM service, MCP bridge), `simulation/` (SSE strategy-replay generator), `voice/` (STT/TTS/audio), plus `comparison_service.py` |
+| [src/telemetry/frontend/app/main.py](src/telemetry/frontend/app/main.py) | Streamlit multi-page app entry point (dashboard, comparison, chat pages)                                                                    |
+| `src/telemetry/frontend/app/pages/`                                      | Individual Streamlit pages                                                                                                                  |
+| `src/telemetry/frontend/app/components/`                                 | Reusable UI components (auth, layout, navbar)                                                                                               |
 
 ### `src/data_extraction/`
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,12 +7,15 @@ prerequisites are on the machine.
 
 ## Prerequisites
 
-- Python **3.10 or 3.11** (the project pins `>=3.10,<3.13` in
-  `pyproject.toml`).
+- Python **3.10, 3.11, or 3.12** (the project pins `>=3.10,<3.13` in
+  `pyproject.toml`; CI runs on 3.12).
 - `OPENAI_API_KEY` in a `.env` at the repo root (or exported in the
-  shell). The Arcade and CLI paths use OpenAI `gpt-4.1-mini` by default;
-  set `F1_LLM_PROVIDER=lmstudio` to route to a local LM Studio server on
-  `http://localhost:1234` instead.
+  shell) for OpenAI `gpt-4.1-mini`, the default model on every provider
+  path. Arcade and Streamlit read `F1_LLM_PROVIDER` from `.env`
+  (`.env.example` ships `openai`). **The CLI is the exception:** `f1-sim`'s
+  `--provider` flag overrides `.env` and defaults to `lmstudio` (a local
+  LM Studio server on `http://localhost:1234`) — pass `--provider openai`
+  to use OpenAI instead, or `--no-llm` to skip the LLM step entirely.
 - For Streamlit Docker flow: **Docker Desktop** (Windows/Mac) or
   `docker + compose` plugin (Linux).
 - For Arcade: a working OpenGL graphics stack (any modern laptop
@@ -32,7 +35,7 @@ prerequisites are on the machine.
 ## CLI — headless strategy replay with Rich live panels
 
 ```bash
-uv tool install "git+https://github.com/VforVitorio/F1_Strat_Manager.git"
+uv tool install "git+https://github.com/VforVitorio/F1-StratLab.git"
 f1-strat
 ```
 
@@ -60,7 +63,7 @@ Already installed from a source checkout? `uv sync && uv run f1-strat`
 ## Arcade — 3-window race replay + live dashboard + telemetry
 
 ```bash
-uv tool install "git+https://github.com/VforVitorio/F1_Strat_Manager.git"
+uv tool install "git+https://github.com/VforVitorio/F1-StratLab.git"
 f1-arcade --viewer --year 2025 --round 3 --driver VER --team "Red Bull Racing" --driver2 LEC --strategy
 ```
 
@@ -83,8 +86,8 @@ controls legend, troubleshooting and window tour.
 ## Streamlit — post-race analysis UI (backend + frontend)
 
 ```bash
-git clone --recurse-submodules https://github.com/VforVitorio/F1_Strat_Manager.git
-cd F1_Strat_Manager
+git clone --recurse-submodules https://github.com/VforVitorio/F1-StratLab.git
+cd F1-StratLab
 cp .env.example .env          # add OPENAI_API_KEY, or set F1_LLM_PROVIDER=lmstudio
 docker compose up
 ```
@@ -128,10 +131,10 @@ All three surfaces read from `data/`:
   and compound allocation
 
 The CLI and Arcade call `ensure_radio_corpus()` and FastF1's cache on
-first run; a warm cache is zero-cost. For a production deploy without a
-repo clone the data tree would be downloaded from the TFG's Hugging Face
-mirror on first run (tracked under `project_cli_distribution_plan.md`,
-deferred past the first release).
+first run; a warm cache is zero-cost. The Docker Streamlit stack does not
+yet have an equivalent auto-download step for a production deploy without
+a host-side repo clone — that gap is a known, deferred follow-up; seed
+`data/` on the host as described below in the meantime.
 
 For the **Docker Streamlit stack**, `./data` is mounted read-only, so the
 container cannot populate it — seed it on the host before `docker compose up`,

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cp .env.example .env          # add OPENAI_API_KEY, or set F1_LLM_PROVIDER=lmstu
 docker compose up
 ```
 
-Requires Python 3.10 / 3.11 and an `OPENAI_API_KEY` (or `F1_LLM_PROVIDER=lmstudio`). Full options (pip fallback, local Streamlit, data bootstrap) in [`INSTALL.md`](INSTALL.md).
+Requires Python 3.10-3.12 and an `OPENAI_API_KEY` (or `F1_LLM_PROVIDER=lmstudio`). Full options (pip fallback, local Streamlit, data bootstrap) in [`INSTALL.md`](INSTALL.md).
 
 ## Project layout
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,8 +20,8 @@ Development follows an incremental approach. v0.1–v0.5 covered project setup a
 
 **Three-release distribution model (v0.12+):** The project ships as three independent artifacts because each has different distribution mechanics:
 - **R1: CLI wheel** (`f1-strat`, `f1-sim`): pip-installable wheel on GitHub Releases, lazy HF data download
-- **R2: Arcade**: container deploy for interactive race replay visualization
-- **R3: Streamlit + Backend**: Docker Compose (FastAPI + Streamlit + Qdrant + LM Studio) or Streamlit Cloud
+- **R2: Arcade**: `uv tool install` console script (`f1-arcade`) for interactive race replay visualization — container deploy was evaluated and descoped (pyglet + Qt need a host OpenGL context and native display; see `INSTALL.md`)
+- **R3: Streamlit + Backend**: Docker Compose (FastAPI + Streamlit; Qdrant runs on-disk in-process, no separate container) or Streamlit Cloud
 
 ---
 
@@ -322,7 +322,7 @@ Extracted N25-N31 agent entry points to importable `src/agents/` modules. Built 
 
 - [X] `pyproject.toml` with `[project.scripts]` entry points (`f1-strat`, `f1-sim`)
 - [X] Lazy first-run data download from HuggingFace Hub (`ensure_setup()`)
-- [X] Installable via `uv tool install git+https://github.com/VforVitorio/F1_Strat_Manager.git`
+- [X] Installable via `uv tool install git+https://github.com/VforVitorio/F1-StratLab.git`
 
 **Success Metrics:**
 
@@ -510,8 +510,8 @@ At session start, the user selects `TEAM` and `DRIVER` (e.g. McLaren / NOR). Thi
 
 **R3: Streamlit + Backend Release:**
 
-- [ ] Docker Compose: FastAPI backend + Streamlit frontend + Qdrant + Kafka + LM Studio sidecar
-- [ ] Alternative: Streamlit Cloud + hosted FastAPI
+- [X] Docker Compose: FastAPI backend + Streamlit frontend (`docker-compose.yml`, two services). Qdrant runs on-disk in-process (no container); LM Studio/OpenAI is reached from the host via `host.docker.internal`. Kafka sidecar descoped (see note above)
+- [ ] Alternative: Streamlit Cloud + hosted FastAPI (documented as viable, not deployed)
 - [ ] Legacy cleanup: archive `base_agent.py`, `strategy_agent.py`, `rules/`; update `src/nlp/pipeline.py` to match N24
 
 **Success Metrics:**
@@ -531,7 +531,7 @@ At session start, the user selects `TEAM` and `DRIVER` (e.g. McLaren / NOR). Thi
 **Test scope actually executed (absorbed into v1.0.0):**
 
 - [X] End-to-end CLI simulation with no-LLM and LLM modes on representative 2025 races
-- [X] Smoke tests for agent imports and Arcade dashboard subprocess (`tests/test_agents.py`, `tests/arcade/*`)
+- [X] Smoke tests for agent imports and Arcade dashboard subprocess (`tests/test_agents.py`, `tests/test_arcade_dashboard_imports.py`)
 - [X] FastAPI + FastMCP integration path validated via `TestClient` and manual chat interactions
 - [X] Historical replay of the Bahrain 2025 GP used as the primary qualitative demo
 

--- a/docs/pages/agents-api.md
+++ b/docs/pages/agents-api.md
@@ -47,7 +47,7 @@ Each agent also exposes a `get_*_react_agent()` factory that returns a compiled 
 | `laps_to_cliff_p10` | float | 10th percentile laps until cliff |
 | `laps_to_cliff_p50` | float | 50th percentile laps until cliff |
 | `laps_to_cliff_p90` | float | 90th percentile laps until cliff |
-| `warning_level` | str | OK, MONITOR, PIT_SOON, or CRITICAL |
+| `warning_level` | str | OK, MONITOR, or PIT_SOON (derived from `laps_to_cliff_p10` against circuit-cluster-aware thresholds; there is no CRITICAL value) |
 | `reasoning` | str | LLM-generated reasoning text |
 
 ### RaceSituationOutput (N27)
@@ -56,8 +56,9 @@ Each agent also exposes a `get_*_react_agent()` factory that returns a compiled 
 |---|---|---|
 | `overtake_prob` | float | Probability of being overtaken (0–1) |
 | `sc_prob_3lap` | float | Safety car probability within 3 laps (0–1) |
-| `sc_currently_active` | bool | A safety car is deployed **right now**. Not a prediction: it is read from the lap's RCM events, because N14 was trained to forecast a future SC and cannot recognise one already out. When true it forces the regulatory facts (`sc_prob_3lap = 1.0`, `overtake_prob = 0` per Art. 55.8, `drs_window = 0` per Art. 22.1(c)) and activates N28. It does **not** force the action: whether to pit under an SC is race state, not a rule. See [Multi-agent system](#/multi-agent). |
-| `threat_level` | str | LOW, MEDIUM, HIGH, CRITICAL |
+| `sc_currently_active` | bool | Any neutralisation (full Safety Car **or** Virtual Safety Car) is deployed **right now**. Not a prediction: it is read from the lap's RCM events, because N14 was trained to forecast a future SC and cannot recognise one already out. When true it forces the regulatory facts (`sc_prob_3lap = 1.0`, `overtake_prob = 0` per Art. 55.8/56.6, `drs_window = 0` per Art. 22.1(c)) and activates N28. It does **not** force the action: whether to pit under a neutralisation is race state, not a rule. See [Multi-agent system](#/multi-agent). |
+| `vsc_active` | bool | The active neutralisation is specifically a **Virtual** Safety Car (Art. 56), only meaningful when `sc_currently_active` is true. Split out (#471) because a VSC and a full SC differ in pit-time saving, and the Monte Carlo / N28 prompt need to tell them apart — the single `sc_currently_active` flag could not. `sc_active` (a derived property, not a stored field) is true only under a full SC: `sc_currently_active and not vsc_active`. |
+| `threat_level` | str | LOW, MEDIUM, HIGH |
 | `gap_ahead_s` | float | Gap to car ahead in seconds |
 | `pace_delta_s` | float | Pace difference vs car ahead |
 | `reasoning` | str | LLM-generated reasoning text |
@@ -66,7 +67,7 @@ Each agent also exposes a `get_*_react_agent()` factory that returns a compiled 
 
 | Field | Type | Description |
 |---|---|---|
-| `action` | str | STAY_OUT, PIT_NOW, UNDERCUT, OVERCUT |
+| `action` | str | STAY_OUT, PIT_NOW, UNDERCUT, OVERCUT, or REACTIVE_SC (box for an elevated-but-not-yet-confirmed SC probability; when an SC is already confirmed deployed, N28 prefers PIT_NOW directly) |
 | `recommended_lap` | int or None | Suggested pit lap |
 | `compound_recommendation` | str | Suggested next compound |
 | `stop_duration_p05` | float | 5th percentile stop duration (s) |
@@ -98,16 +99,24 @@ Each agent also exposes a `get_*_react_agent()` factory that returns a compiled 
 
 ### StrategyRecommendation (N31)
 
+The v2 schema (frozen at 14 fields) surrounds the primary `action` with execution detail, driver-side instructions and a contingency list — see [Multi-agent system](#/multi-agent) for the full rationale.
+
 | Field | Type | Description |
 |---|---|---|
-| `action` | str | STAY_OUT, PIT_NOW, UNDERCUT, OVERCUT, ALERT |
-| `pace_mode` | str | PUSH, NEUTRAL, MANAGE, LIFT_AND_COAST |
-| `risk_posture` | str | AGGRESSIVE, BALANCED, DEFENSIVE |
-| `reasoning` | str | Multi-sentence LLM synthesis |
-| `confidence` | float | 0–1 confidence score |
-| `scenario_scores` | dict | MC scores per strategy candidate |
-| `contingencies` | list[Contingency] | Conditional plan branches |
-| `regulation_context` | str | RAG answer if N30 was activated |
+| `action` | str | STAY_OUT, PIT_NOW, UNDERCUT, OVERCUT, ALERT — the primary decision |
+| `reasoning` | str | Multi-sentence LLM synthesis of all sub-agent inputs, MC scores and regulation constraints |
+| `confidence` | float | 0–1 LLM self-assessed certainty; treat as qualitative, not calibrated |
+| `pit_lap_target` | int or None | Absolute lap of the planned stop. Populated for PIT_NOW/UNDERCUT/OVERCUT, optionally for a forward-looking STAY_OUT plan |
+| `compound_next` | str or None | Compound (SOFT/MEDIUM/HARD) chosen for the next stint; None for STAY_OUT |
+| `undercut_target` | str or None | Rival code targeted by an UNDERCUT/OVERCUT (e.g. "SAI") |
+| `pace_mode` | str | PUSH, NEUTRAL, MANAGE, LIFT_AND_COAST — driving instruction for the next laps (default NEUTRAL) |
+| `target_lap_time_s` | float or None | Target lap time, grounded in N25's CI bounds so the LLM cannot invent a value far outside the model's prediction. Forced to `None` under an active SC/VSC (Art. 55.7 — see [Multi-agent system](#/multi-agent)) |
+| `risk_posture` | str | AGGRESSIVE, BALANCED, DEFENSIVE — the championship stance the LLM reasons under (default BALANCED) |
+| `contingencies` | list[Contingency] | Conditional branches for upcoming laps, capped at four. Each has `trigger` (plain-language event), `switch_to` (replacement action), `priority` (HIGH/MEDIUM/LOW), `rationale` (short justification) |
+| `key_risks` | list[str] | Up to five short bullets flagging risks the LLM wants to surface outside the narrative |
+| `expected_stint_end` | int or None | Lap the current stint is planned to end. Clamped against a physical anchor — `pit_lap_target` plus the shorter of the N26 cliff P50 and the next compound's Pirelli stint capacity, bounded by total race laps — accepting the LLM's value only within ±3 laps of that anchor (#433); falls through unclamped when no anchor (missing `pit_lap_target`/`compound_next`/cliff) is available |
+| `scenario_scores` | dict | Full MC output per candidate — `{"STAY_OUT": {"E", "P10", "P90", "score"}, ...}`. Attached in code after the LLM call, not filled by the LLM |
+| `regulation_context` | str | N30 RAG answer when activated, empty string otherwise. Attached in code after the LLM call |
 
 ## `RaceState` input (N31)
 
@@ -142,6 +151,23 @@ class RaceState(BaseModel):
 | N28 | `data/models/pit_prediction/` | HistGBT P05/P50/P95 + undercut LightGBM |
 | N29 | `data/models/nlp/` | pipeline_config_v1.json + .pt state dicts |
 | N30 | `data/rag/` | Qdrant index (built by `scripts/build_rag_index.py`) |
+
+## LLM tool-level input validation
+
+Every LangChain tool the LLM can call takes free-text arguments (`driver`, `lap_number`, `gp_name`, `year`, ...) with no server-side roster or range check other than what the tool itself enforces. A hardening pass (#476) closed the gap where a hallucinated or long-retired driver code, or a lap outside the loaded session, produced a confident but meaningless prediction instead of a visible failure:
+
+| Agent | Tools guarded | Refuses when |
+|---|---|---|
+| N25 Pace | `predict_pace_tool` | `driver_number`/`gp_name`/`year` do not resolve to a driver on track for that GP/year, or `lap_number` is outside `[1, total_laps]` |
+| N26 Tire | `predict_tire_deg_tool`, `estimate_laps_to_cliff_tool` | `driver` is not on track at the currently loaded lap, or the loaded `current_lap` is outside `[1, total_laps]` |
+| N27 Situation | `predict_overtake_tool`, `predict_sc_tool` | `lap_number` is out of range, or (for `predict_overtake_tool`) either driver is unknown for that lap |
+| N28 Pit | `predict_pit_duration_tool`, `score_undercut_tool` | the named driver (`driver`/`driver_y`) is not present in the live roster for the current lap |
+
+The refusal is a plain string return (e.g. `"error: 'HAM' is not on track at lap 12; valid: [...]"` or `"... REFUSED — {driver} is not on track ..."`), not an exception — the LLM sees a normal-looking tool result it can react to, rather than a traceback. `predict_pit_duration_tool` additionally cross-checks the LLM-supplied `under_sc` flag against the RCM-confirmed `sc_currently_active` ground truth when a real orchestrator run has set it, and trusts the confirmed value over the guess (logging a warning) rather than the other way round.
+
+"On track" is a **presence** check (the driver has a row in the live roster for this lap), the same convention `RaceStateManager` uses for `rivals` — see [Race replay engine → who counts as a rival](#/simulation). An age/lap-count cutoff cannot substitute for it: a finisher can go 20 laps without a row, and a retirement can surface as few as 9 laps in, so the ranges overlap.
+
+The MCP-facing tools one layer up (`src/telemetry/backend/mcp_tools.py`, consumed by chat) apply an equivalent guard on `gp`/`driver`/`lap`/`year` before they even reach these agent-level tools — see [Backend API reference → Tool risk tiers and the chat allowlist](#/backend-api).
 
 ## Testing examples
 

--- a/docs/pages/arcade-quick-start.md
+++ b/docs/pages/arcade-quick-start.md
@@ -14,7 +14,7 @@ One command launches everything: the arcade replay window (pyglet), the strategy
 
 - **Python**: 3.10 or newer. The project pins dependencies with `uv`.
 - **Dependencies**: run `uv sync` from the repo root. The lockfile pulls `arcade`, `PySide6`, `pyqtgraph`, `fastf1`, `langchain-openai`, the model stack (`xgboost`, `lightgbm`, `torch`), and the NLP stack (`transformers`, `sentence-transformers`, `setfit`). No manual install steps required beyond `uv sync`.
-- **LLM credentials**: either set `OPENAI_API_KEY` in a repo-root `.env` (the canonical TFG setup) or run LM Studio locally on `http://localhost:1234/v1` and export `F1_LLM_PROVIDER=lmstudio`. Only the wording of the orchestrator's reasoning changes.
+- **LLM credentials**: either set `OPENAI_API_KEY` in a repo-root `.env` (the canonical TFG setup) or run LM Studio locally on `http://localhost:1234/v1` and pass `--provider lmstudio` on the command line (the arcade's own flag; its default is `openai`, independent of the `F1_LLM_PROVIDER` env var the backend and CLI read). Only the wording of the orchestrator's reasoning changes.
 - **Race data cache**: the replay reads `data/raw/{year}/{Location}/laps.parquet` and optionally `weather.parquet`. The parquet files are produced by FastF1 on first run. Expect a 20–40 second delay on the first launch of a round.
 - **Vector store (optional)**: the N30 RAG agent reads a local Qdrant index under `data/rag/`. If missing, the orchestrator degrades gracefully — regulation lookups return an empty context. Run `python scripts/build_rag_index.py` once to build it.
 

--- a/docs/pages/architecture.md
+++ b/docs/pages/architecture.md
@@ -25,7 +25,7 @@ sequenceDiagram
     MC-->>Orch: scored outcomes
     Orch->>LLM: synthesise recommendation
     LLM-->>Orch: Decision (ACTION · PACE · RISK · Plan)
-    Orch-->>UI: StrategyState payload
+    Orch-->>UI: StrategyRecommendation payload
 ```
 
 The same loop runs in three places: the CLI consumes it in batch, the Arcade renders it in a PySide6 dashboard, and the Streamlit app surfaces it inside a chat tab.
@@ -53,11 +53,11 @@ The atomic payload the simulation engine emits per driver per lap. It carries th
 
 ### `RaceState`
 
-The cumulative session view assembled by `RaceStateManager` from successive `lap_state` ticks. It holds the entire field's stint history, the pit-stop log, the safety-car timeline, and the per-driver tire compound roster. The orchestrator snapshots `RaceState` before each decision so every sub-agent sees the same frozen world, regardless of how fast they each respond.
+A thin, per-lap Pydantic model (`src/agents/strategy_orchestrator.py`) that carries the single-driver context N31 needs for one decision: driver code, lap, total laps, position, compound, tyre age, gap/pace deltas versus the car ahead, weather, radio/RCM windows, and the risk-tolerance dial. It is **not** a cumulative session object — there is exactly one `RaceState` class in the codebase, and it holds no stint history, pit log, or field-wide tire roster. The field-wide picture (every driver's stints, pit stops, and current tyre) lives in the `laps_df` DataFrame the orchestrator and agents load once per session, plus the `rivals` list inside each `lap_state` tick — see [Race replay engine](#/simulation) for that schema. The orchestrator builds a fresh `RaceState` per lap so every sub-agent decision is grounded in the same snapshot, regardless of how fast each agent responds.
 
-### `StrategyState`
+### `StrategyRecommendation`
 
-The structured output the orchestrator emits per decision tick. Fourteen fields are frozen by schema (action, target lap, target compound, expected delta, pace mode, risk level, plan summary, rationale, confidence, sub-agent attributions, scenario scores, and metadata flags); the narrative richness lives inside the LLM-synthesised `Plan` and `Rationale` blocks. `StrategyState` is what the CLI prints, the Arcade renders and the Streamlit chat surfaces.
+The structured output the orchestrator emits per decision tick (called `StrategyState` on the wire protocol some surfaces consume, but the Pydantic type is `StrategyRecommendation`). Fourteen fields are frozen by schema: the primary `action` plus pit-execution detail (`pit_lap_target`, `compound_next`, `undercut_target`), driver-side instructions (`pace_mode`, `target_lap_time_s`, `risk_posture`), multi-lap planning (`contingencies`, `key_risks`, `expected_stint_end`), and post-hoc grounding attached in code (`scenario_scores`, `regulation_context`) around the LLM's own `reasoning` and `confidence`. See [Agents API reference](#/agents-api) for the full field-by-field table. `StrategyRecommendation` is what the CLI prints, the Arcade renders and the Streamlit chat surfaces.
 
 ## How the pieces ship
 

--- a/docs/pages/backend-api.md
+++ b/docs/pages/backend-api.md
@@ -8,15 +8,45 @@ Entry point: `backend/main.py` — creates the FastAPI app and registers all rou
 
 ## Router map
 
+There is no `auth` router. Authentication is a single ASGI middleware wrapping every router (see below), not a mounted endpoint set.
+
 | Router | Prefix | Tags | Source |
 |---|---|---|---|
-| auth | `/api/v1` | auth | `endpoints/auth.py` |
-| telemetry | `/api/v1/telemetry` | telemetry | `endpoints/telemetry.py` |
-| circuit_domination | `/api/v1` | circuit_domination | `endpoints/circuit_domination.py` |
-| comparison | `/api/v1/comparison` | comparison | `endpoints/comparison.py` |
-| chat | `/api/v1/chat` | chat | `endpoints/chat.py` |
-| voice | `/api/v1/voice` | voice | `endpoints/voice.py` |
-| strategy | `/api/v1/strategy` | strategy | `endpoints/strategy.py` |
+| telemetry | `/api/v1/telemetry` | telemetry | `api/v1/endpoints/telemetry.py` |
+| circuit_domination | `/api/v1` | circuit_domination | `api/v1/endpoints/circuit_domination.py` |
+| comparison | `/api/v1/comparison` | comparison | `api/v1/endpoints/comparison.py` |
+| chat | `/api/v1/chat` | chat | `api/v1/endpoints/chat.py` |
+| voice | `/api/v1/voice` | voice | `api/v1/endpoints/voice.py` |
+| strategy | `/api/v1/strategy` | strategy | `api/v1/endpoints/strategy.py` |
+
+Two more mount points sit outside the router list:
+
+- **`GET /`** and **`GET /health`** — unauthenticated liveness endpoints, registered directly on the `FastAPI` app in `main.py`.
+- **`/mcp`** — the FastMCP Streamable-HTTP server, mounted only when `F1_MCP_ENABLED=true` (off by default). The chat pipeline reaches the same tools in-process regardless of this flag, so leaving it unmounted removes an open network surface, not a feature. See "Authentication" and "MCP-Driven Tool Routing" below.
+
+## Authentication
+
+Every router (and the `/mcp` mount, when enabled) sits behind a single shared-secret ASGI middleware, `ApiKeyMiddleware` (`backend/core/auth.py`, Security A1 / issue #224). It is intentionally pure ASGI rather than `BaseHTTPMiddleware`, because the latter buffers the whole response body and would break the SSE streams (`/chat/tool-message-stream`, `/simulate`).
+
+- **Header**: `X-API-Key`, compared against the `F1_API_KEY` env var with `hmac.compare_digest`.
+- **Open paths**: `/` and `/health` always pass unauthenticated (uptime probes). `OPTIONS` (CORS preflight) always passes.
+- **Safe-by-default when unset**: if `F1_API_KEY` is not set, every other request also passes — this is the local-dev default. The dangerous combination is a non-loopback bind (`F1_HOST` other than `127.0.0.1`/`localhost`/`::1`) with no key set: `enforce_startup_security()` refuses to boot in that case rather than come up open on the network.
+- **WebSocket**: gated the same way; an unauthorized WS handshake gets a policy-violation close (code 1008) instead of a 401 body.
+
+This means `F1_API_KEY` and `F1_HOST` (see [Setup and deployment](#/setup)) are the two env vars that decide whether the backend is safe to expose beyond localhost.
+
+## Rate limiting
+
+Every prediction and strategy endpoint (and `/simulate`) sits behind an in-process token-bucket limiter (`backend/core/rate_limit.py`, Security C2 / S-7) keyed on client IP. No external dependency — a stdlib bucket is enough for a single-process local backend. Buckets are per-route, so hammering `/pace` does not exhaust the `/recommend` bucket.
+
+| Route | Burst capacity | Refill rate |
+|---|---|---|
+| `/pace`, `/tire`, `/situation`, `/pit`, `/radio` | 20 | 60/min |
+| `/pace-range`, `/tire-range`, `/rag` | 5 | 10/min |
+| `/recommend` | 5 | 10/min |
+| `/simulate` | 3 | 3/min |
+
+An exhausted bucket returns `429` with a `Retry-After` hint. Set `F1_RATE_LIMIT_OFF=1` to disable limiting entirely (load tests, benchmarking). A token is consumed only at request admission, so a long-lived SSE stream (`/simulate`, `/chat/tool-message-stream`) is metered once and then runs unmetered.
 
 ## Telemetry endpoints
 
@@ -77,6 +107,12 @@ Each tool is mapped to a `DisplayType` hint via `TOOL_DISPLAY_MAP` (`models/tool
 
 `chat_engine._trim_for_llm` caps long arrays before they are sent back to the LLM for summarisation; the unmodified payload still reaches the frontend on `tool_result.data` so charts retain the full series. The four telemetry tools are wired to `CHART` so the frontend renders them as inline Plotly figures (see [Streamlit frontend → chat tool-result rendering](#/streamlit)).
 
+### Tool risk tiers and the chat allowlist (Security A2, #224)
+
+`models/tool_schemas.py` classifies every dispatchable MCP tool into a `ToolRisk` tier — `READ_SAFE` (cheap, e.g. `predict_pace`), `READ_EXPENSIVE` (heavy but still read-only, e.g. `recommend_strategy`'s 500-sample Monte Carlo, or `query_regulations`'s RAG lookup), or `MUTATING` (writes/exports; none exist today). `CHAT_ALLOWED_TOOLS` is the default-deny set built from the first two tiers: a tool absent from `TOOL_RISK_MAP` — hallucinated by the LLM, or a newly added tool nobody classified yet — is refused by both `mcp_bridge` (before it reaches the LLM's tool list) and `chat_engine`'s dispatch guard (before it runs), and a `MUTATING` tool can never join the allowlist. The hard rule: no write/export tool may be added to the MCP server until it has a `TOOL_RISK_MAP` entry.
+
+Every Phase 1 tool (`predict_pace`/`predict_tire`/`predict_situation`/`predict_pit`/`analyze_radio`/`recommend_strategy`) also normalises its `gp`/`driver`/`lap`/`year` arguments in `mcp_tools.py` before building the `lap_state` (`_normalize_gp_name`, `_normalize_driver_code`, `_normalize_lap`, `_normalize_year`). An unparseable lap number used to silently become lap 1 (#442); it now raises `ToolInputError`, which the `_catch_tool_input_error` decorator turns into a plain "X is invalid, here are the valid options" string for the LLM instead of a traceback — the same REFUSED shape the agent-level tool guards described in [Agents API reference](#/agents-api) already use.
+
 ### Smart-spinner stage tracker
 
 The frontend mints a UUID, sends it on every chat request via the `X-Request-Id` header, and polls `/api/v1/chat/status?request_id=...` every second. The backend writes the current stage (`preparing_tools`, `model_choosing_tool`, `calling_<tool>`, `summarizing_with_llm`, ...) into a process-global tracker (`services/chatbot/stage_tracker.py`) at every checkpoint, cleared in a `try/finally` so the dict never leaks. The Streamlit chat page maps these stages to humanised labels so the spinner narrates the slow phases (model loading, tool execution).
@@ -107,6 +143,26 @@ All strategy endpoints live under `/api/v1/strategy/`. They accept JSON bodies a
 
 The `/api/v1/strategy/simulate` SSE endpoint is consumed by the Streamlit app and by `curl` / `TestClient` smoke tests. The arcade replay no longer calls this endpoint — as of Phase 3.5 Proceso B (April 2026), the arcade owns its own strategy pipeline via [`src/arcade/strategy_pipeline.py`](#/arcade-strategy-pipeline).
 
+### `POST /api/v1/strategy/simulate`
+
+Streams per-lap strategy decisions as Server-Sent Events, rate-limited to 3 requests/minute per client (see "Rate limiting" above).
+
+```python
+class SimulateRequest(BaseModel):
+    year: int = 2025            # 2023-2025
+    gp: str
+    driver: str
+    team: str
+    driver2: Optional[str] = None
+    lap_range: Optional[tuple[int, int]] = None
+    risk_tolerance: float = 0.5  # 0-1
+    no_llm: bool = False
+    provider: str = "lmstudio"   # "lmstudio" | "openai"
+    interval_s: float = 0.0      # 0-10, artificial delay between laps
+```
+
+Event stream: one `start` event, then one `lap` (or `error`) event per processed lap, closed with a `summary` event. A blank SSE comment (`:\n\n`) is sent every 15 `lap` events as a heartbeat so long runs survive proxy idle timeouts.
+
 ### Metadata (GET)
 
 | Path | Description |
@@ -115,19 +171,27 @@ The `/api/v1/strategy/simulate` SSE endpoint is consumed by the Streamlit app an
 | `/api/v1/strategy/available-drivers` | Driver codes for a GP |
 | `/api/v1/strategy/lap-range` | Min/max lap for a driver at a GP |
 | `/api/v1/strategy/lap-state` | Build canonical lap_state dict from parquet |
+| `/api/v1/strategy/radio-available-gps` | GPs with a recorded radio/RCM corpus |
+| `/api/v1/strategy/radio-laps` | Laps with radio messages for a GP (optionally filtered by driver) |
+| `/api/v1/strategy/radio-transcript` | Cached Whisper transcript for one driver/lap |
 
 ### Agent endpoints (POST)
 
 | Path | Request Body | Agent | Description |
 |---|---|---|---|
 | `/api/v1/strategy/pace` | `PaceRequest` | N25 | Lap time prediction + CI |
-| `/api/v1/strategy/pace-range` | `PaceRangeRequest` | N25 | Batch predictions over lap range |
+| `/api/v1/strategy/pace-range` | `PaceRangeRequest` | N25 | Batch predictions over a lap range (Model Lab chart) |
 | `/api/v1/strategy/tire` | `TireRequest` | N26 | Tire cliff estimation |
+| `/api/v1/strategy/tire-range` | `PaceRangeRequest` | N26 | Batch degradation over a lap range (actual vs predicted) |
 | `/api/v1/strategy/situation` | `SituationRequest` | N27 | Overtake + SC probability |
 | `/api/v1/strategy/pit` | `PitRequest` | N28 | Pit duration + undercut analysis |
 | `/api/v1/strategy/radio` | `RadioRequest` | N29 | NLP radio pipeline |
 | `/api/v1/strategy/rag` | `RagRequest` | N30 | Regulation retrieval |
 | `/api/v1/strategy/recommend` | `RecommendRequest` | N31 | Full orchestrator pipeline |
+
+`/tire-range` reuses `PaceRangeRequest` — same `{year, gp, driver, lap_start, lap_end}` shape as `/pace-range`, just routed to the TCN instead of the XGBoost model.
+
+Every POST endpoint above (plus `/pace-range` and `/tire-range`) sits behind its own rate-limit bucket — see "Rate limiting" above.
 
 ### Request schemas
 
@@ -149,6 +213,14 @@ class RadioRequest(BaseModel):
     radio_msgs: List[Dict[str, Any]] = []
     rcm_events: List[Dict[str, Any]] = []
 
+class PaceRangeRequest(BaseModel):
+    """Shared by /pace-range and /tire-range."""
+    year: int = 2025
+    gp: str
+    driver: str
+    lap_start: int
+    lap_end: int
+
 class RagRequest(BaseModel):
     question: str
 
@@ -161,21 +233,25 @@ class RecommendRequest(BaseModel):
     risk_tolerance: float = 0.5
     radio_msgs: Optional[List[Dict[str, Any]]] = None
     rcm_events: Optional[List[Dict[str, Any]]] = None
+    # Three-letter code of the rival selected in the Strategy tab. When set,
+    # gap_ahead_s / pace_delta_s are measured against this car instead of the
+    # positional car ahead (#431). None keeps the old positional behaviour.
+    rival: Optional[str] = None
 ```
 
 ### Response schemas
 
-All agent endpoints return `StrategyResponse`:
+All agent endpoints return the generic `StrategyResponse` envelope. Swagger also exposes a typed result model per agent (`PaceResult`, `TireResult`, `SituationResult`, `PitResult`, `RadioResult`, `RagResult` — mirroring the dataclass fields in [Agents API reference](#/agents-api)) for self-documentation, but the actual response body is the untyped envelope below:
 
 ```python
 class StrategyResponse(BaseModel):
-    agent: str       # e.g. "pace", "tire", "orchestrator"
+    agent: str       # e.g. "pace", "tire", "radio", "orchestrator"
     result: Dict[str, Any]
 ```
 
 ### Error handling
 
-Strategy endpoints return structured errors:
+Strategy endpoints catch `(KeyError, TypeError, ValueError)` from the underlying agent and return **422** (a bad/incomplete input); any other exception returns **500**. Both cases share the same structured `StrategyError` body:
 
 ```json
 {
@@ -185,9 +261,11 @@ Strategy endpoints return structured errors:
 }
 ```
 
+`/pace-range` and `/tire-range` also return `503` when the requested year's featured parquet is not cached, and `404` when the GP or driver is not found in it.
+
 ## CORS
 
-The backend allows requests from the frontend URL (default `http://localhost:8501`) via `CORSMiddleware`.
+`CORSMiddleware` allows a single origin — `FRONTEND_URL` (default `http://localhost:8501`) — not a wildcard. Credentials are dropped (`allow_credentials=False`, the Streamlit frontend calls the backend server-side, never from the browser), and both the method and header allowlists are enumerated rather than `"*"`: `GET`/`POST`/`OPTIONS` and `Content-Type`/`Accept`/`X-Request-Id`. The `ApiKeyMiddleware` described under "Authentication" wraps CORS from the outside (registered after it in `main.py`), so an unauthenticated request is rejected before any CORS or routing logic runs; `OPTIONS` preflight is exempted so it still completes.
 
 ## Swagger / OpenAPI
 

--- a/docs/pages/changelog.md
+++ b/docs/pages/changelog.md
@@ -19,6 +19,502 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 
 <!-- next-version-placeholder -->
 
+## [1.10.5](https://github.com/VforVitorio/F1-StratLab/compare/v1.10.4...v1.10.5) (2026-07-16)
+
+
+### Bug Fixes
+
+* **agents:** compute FuelEffect from the stint baseline, not a hardcoded fuel_load factor ([7ac17e5](https://github.com/VforVitorio/F1-StratLab/commit/7ac17e59495c4d8a3a8cc735c442cc8efe99139e)), closes [#446](https://github.com/VforVitorio/F1-StratLab/issues/446)
+* **agents:** encode N15's compound_id as the ordinal rank it was trained on ([6bb025f](https://github.com/VforVitorio/F1-StratLab/commit/6bb025f2ce62557b154ebf2e952a5210a467d64a)), closes [#445](https://github.com/VforVitorio/F1-StratLab/issues/445)
+* **agents:** honour the Safety-Car guard-rail on the final answer, and stop simulating free pit stops ([b423acd](https://github.com/VforVitorio/F1-StratLab/commit/b423acd3d62be44974ea7336ee6c0087604214f6)), closes [#436](https://github.com/VforVitorio/F1-StratLab/issues/436)
+* **agents:** let the overtake model see the elapsed-time gap it was trained on ([46c320f](https://github.com/VforVitorio/F1-StratLab/commit/46c320f8a47b23d41a9974a2e98aa3dfc4daab93))
+* **agents:** re-key the circuit lookup tables to the slug keyspace the agents query with ([02e7a79](https://github.com/VforVitorio/F1-StratLab/commit/02e7a79d5e76e8b9e7fa54e863409bfc69c25b32)), closes [#448](https://github.com/VforVitorio/F1-StratLab/issues/448)
+* **agents:** un-invert the undercut model's top feature and stop feeding it the race lap ([ec0f444](https://github.com/VforVitorio/F1-StratLab/commit/ec0f4448d2737b21146c2abf6349139adb9e52db)), closes [#444](https://github.com/VforVitorio/F1-StratLab/issues/444)
+* **engine:** scope the laps frame to the analysed Grand Prix in run_lap ([454db40](https://github.com/VforVitorio/F1-StratLab/commit/454db40bd213a29b4fffd1b4d10c9086093cf364)), closes [#429](https://github.com/VforVitorio/F1-StratLab/issues/429)
+* **simulation:** guard the stint-baseline precompute against frames without Stint ([4262859](https://github.com/VforVitorio/F1-StratLab/commit/4262859d8b85f62064dc2a4c34a6dc9824abaf73)), closes [#446](https://github.com/VforVitorio/F1-StratLab/issues/446)
+
+
+### Documentation
+
+* **agents:** fix the entry-point table and make the examples actually run ([59b02e0](https://github.com/VforVitorio/F1-StratLab/commit/59b02e071b296802f12489f2ebe187e1394d008e)), closes [#438](https://github.com/VforVitorio/F1-StratLab/issues/438)
+* **strategy:** correct the pages the engine fixes made wrong ([62fa3c5](https://github.com/VforVitorio/F1-StratLab/commit/62fa3c55c3f03cb65cff280b2bdfbaac35c4f6a1)), closes [#438](https://github.com/VforVitorio/F1-StratLab/issues/438)
+
+## [1.10.4](https://github.com/VforVitorio/F1-StratLab/compare/v1.10.3...v1.10.4) (2026-07-15)
+
+
+### Bug Fixes
+
+* **deps:** bump click/kafka-python/transformers past CVEs; waive blocked pillow and setuptools ([97d273d](https://github.com/VforVitorio/F1-StratLab/commit/97d273d3bce732b6f772e56c53d41e045427f113))
+* **deps:** resolve OSV Python CVE backlog (bump click/kafka-python/transformers; waive blocked pillow and setuptools) ([fbd6df2](https://github.com/VforVitorio/F1-StratLab/commit/fbd6df27ba0f826f33859ae9971b7675a7d78a4a))
+
+## [1.10.3](https://github.com/VforVitorio/F1-StratLab/compare/v1.10.2...v1.10.3) (2026-07-12)
+
+
+### Bug Fixes
+
+* **nlp:** DOUBLE YELLOW severity + time-penalty routing ([#398](https://github.com/VforVitorio/F1-StratLab/issues/398) follow-up) ([7f3f7a7](https://github.com/VforVitorio/F1-StratLab/commit/7f3f7a79d9ef96eb92538e702ca4d579332101e1))
+* **nlp:** RCM parser superset + penalty/red-flag routing + arcade SC persistence ([#398](https://github.com/VforVitorio/F1-StratLab/issues/398)) ([47cf9a7](https://github.com/VforVitorio/F1-StratLab/commit/47cf9a74ce2fc92095725dbe97bbe1b3e55c9216))
+* **nlp:** render DOUBLE YELLOW at yellow severity + route time penalties to N30 ([#398](https://github.com/VforVitorio/F1-StratLab/issues/398) follow-up) ([b45d7f1](https://github.com/VforVitorio/F1-StratLab/commit/b45d7f158c6b524da4f0a2c5ca66fe778c1c19ef))
+* **nlp:** widen the RCM parser + route penalty/red-flag alerts + persist SC in arcade ([#398](https://github.com/VforVitorio/F1-StratLab/issues/398)) ([6a223e1](https://github.com/VforVitorio/F1-StratLab/commit/6a223e1ac5809e43c2287959353a6ace860a06ec))
+
+
+### Performance
+
+* **cli:** skip double model load in --no-llm prewarm ([#389](https://github.com/VforVitorio/F1-StratLab/issues/389)) ([56c24f7](https://github.com/VforVitorio/F1-StratLab/commit/56c24f7aa37695f2e2a0026f9abcbf84dd686048))
+* **cli:** skip the tire/situation/pit singleton prewarm in --no-llm mode ([#389](https://github.com/VforVitorio/F1-StratLab/issues/389)) ([f0ba4b4](https://github.com/VforVitorio/F1-StratLab/commit/f0ba4b4b96ecca4146f353252eeb92302bacf626))
+
+## [1.10.2](https://github.com/VforVitorio/F1-StratLab/compare/v1.10.1...v1.10.2) (2026-07-12)
+
+
+### Bug Fixes
+
+* **data:** resolve every GP's radio + compound labels via a canonical name (F-01) ([2ab70d1](https://github.com/VforVitorio/F1-StratLab/commit/2ab70d12fb9d127c7ec95efdfcc647f2dbd70f06))
+* **data:** resolve every GP's radio + compound labels via a canonical name (F-01) ([29d1cac](https://github.com/VforVitorio/F1-StratLab/commit/29d1cac6dc76c228d7f080cebbe5b72d2f103667)), closes [#243](https://github.com/VforVitorio/F1-StratLab/issues/243)
+* **data:** validate the parquet read boundary + surface FastF1 quality flags (F-02) ([80b12b6](https://github.com/VforVitorio/F1-StratLab/commit/80b12b6459cdd7358c4896f80114fbd46488a544))
+* **data:** validate the parquet read boundary and surface FastF1 quality flags (F-02) ([dd44451](https://github.com/VforVitorio/F1-StratLab/commit/dd4445150b13d3984bccae8ddf907618bea0e808)), closes [#244](https://github.com/VforVitorio/F1-StratLab/issues/244)
+* **deps:** drop fitz dummy, declare pypdf, override frozendict (DX-05) ([3a7612c](https://github.com/VforVitorio/F1-StratLab/commit/3a7612ce7d83a8334bb304ee210d3447ddf8cfa7))
+* **deps:** drop the unused fitz dummy, declare pypdf, override frozendict (DX-05) ([794a39b](https://github.com/VforVitorio/F1-StratLab/commit/794a39bd72fc8969cf09e79d5b3469a4c4d20f25)), closes [#253](https://github.com/VforVitorio/F1-StratLab/issues/253)
+* **devex:** unbreak the Docker/Streamlit quickstart + redirected-output crash ([#388](https://github.com/VforVitorio/F1-StratLab/issues/388)) ([75d1b3e](https://github.com/VforVitorio/F1-StratLab/commit/75d1b3ec0d681abe7b6b78afe6e7061cab22e02e))
+* **devex:** unbreak the Docker/Streamlit quickstart and the redirected-output crash ([f7f988a](https://github.com/VforVitorio/F1-StratLab/commit/f7f988a619224bd3adea5cda20cb7b117f689cfa)), closes [#252](https://github.com/VforVitorio/F1-StratLab/issues/252) [#388](https://github.com/VforVitorio/F1-StratLab/issues/388)
+* **nlp:** persist Safety-Car state across laps so the override survives the stint (NR-02) ([c713705](https://github.com/VforVitorio/F1-StratLab/commit/c713705d364271c55bbee42085d1e7c6e5742ac1))
+* **nlp:** persist Safety-Car state across laps so the override survives the stint (NR-02) ([215007b](https://github.com/VforVitorio/F1-StratLab/commit/215007be7d6198d6fd36386d0f3603a018200fdd)), closes [#305](https://github.com/VforVitorio/F1-StratLab/issues/305)
+* **packaging:** bundle the telemetry submodule in the release wheel (PK-01) ([a047b48](https://github.com/VforVitorio/F1-StratLab/commit/a047b485957c3f6fe65bad4b503459a234805d74))
+* **packaging:** bundle the telemetry submodule in the release wheel (PK-01) ([40ae581](https://github.com/VforVitorio/F1-StratLab/commit/40ae581df29022476c7def8f795a1db885b5b293)), closes [#289](https://github.com/VforVitorio/F1-StratLab/issues/289)
+
+
+### Documentation
+
+* **security:** add the Phase A security-boundary design for review ([#224](https://github.com/VforVitorio/F1-StratLab/issues/224)) ([c71eac9](https://github.com/VforVitorio/F1-StratLab/commit/c71eac9e6fb26da59ca3572f7817ff8de3c46a28))
+* **security:** Phase A security-boundary design for review ([#224](https://github.com/VforVitorio/F1-StratLab/issues/224)) ([ed4e829](https://github.com/VforVitorio/F1-StratLab/commit/ed4e8295b200cab373769378f9095335c090d113))
+
+## [1.10.1](https://github.com/VforVitorio/F1-StratLab/compare/v1.10.0...v1.10.1) (2026-07-12)
+
+
+### Bug Fixes
+
+* **cli:** wire the simulation CLI to the shared inference engine ([#236](https://github.com/VforVitorio/F1-StratLab/issues/236)) ([32dcc4b](https://github.com/VforVitorio/F1-StratLab/commit/32dcc4b38a71afd31debf7bccb4359b76a911c2f))
+* **cli:** wire the simulation CLI to the shared inference engine ([#236](https://github.com/VforVitorio/F1-StratLab/issues/236)) ([0694299](https://github.com/VforVitorio/F1-StratLab/commit/06942991dfbd31521ff087841fb2e95754132bf0))
+
+## [1.10.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.9.0...v1.10.0) (2026-07-11)
+
+
+### Features
+
+* **agents:** give every sub-agent ChatOpenAI a finite provider timeout (L-1) ([3eb0eb8](https://github.com/VforVitorio/F1-StratLab/commit/3eb0eb8b48ac88b49e3119d99946017447c34fec))
+* **agents:** give every sub-agent ChatOpenAI a finite provider timeout (L-1) ([401765f](https://github.com/VforVitorio/F1-StratLab/commit/401765fffa132b81d02f862c4c12362ef9d4567d)), closes [#263](https://github.com/VforVitorio/F1-StratLab/issues/263)
+
+
+### Bug Fixes
+
+* **ci:** skip the tiktoken vocab roundtrip on an upstream network outage ([6c26ec2](https://github.com/VforVitorio/F1-StratLab/commit/6c26ec23134029213c365cde787afebfc0069f56))
+* **ci:** skip the tiktoken vocab roundtrip on an upstream network outage ([cdd9f4a](https://github.com/VforVitorio/F1-StratLab/commit/cdd9f4ac895f7a26f21bfd306069d64423b57398))
+
+## [1.9.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.8.0...v1.9.0) (2026-07-11)
+
+
+### Features
+
+* **eval:** reproduce the pace MAE 0.4104 from the featured-laps holdout ([2a2c982](https://github.com/VforVitorio/F1-StratLab/commit/2a2c9827e46e093d35ba426b1e839de395116f0f))
+* **eval:** reproduce the pace MAE 0.4104 from the featured-laps holdout ([998a800](https://github.com/VforVitorio/F1-StratLab/commit/998a800afb838208be17a7469763c614a5513561))
+* **eval:** reproduce the tire MAE 0.7078 and validate the MC-Dropout sigma ([8ce8653](https://github.com/VforVitorio/F1-StratLab/commit/8ce8653dfb4f8cc6e80fc2be00c45443ac030976))
+* **eval:** reproduce the tire MAE 0.7078 and validate the MC-Dropout sigma ([762b030](https://github.com/VforVitorio/F1-StratLab/commit/762b03068d4b709d00447b81621bbc966c2cd720))
+
+
+### Bug Fixes
+
+* **eval:** correct the circuit_cluster hygiene verdict to a real coarse leak ([4328f95](https://github.com/VforVitorio/F1-StratLab/commit/4328f9550be402a68f7383c1aa9ea8d52abf4335))
+* **eval:** correct the circuit_cluster hygiene verdict to a real coarse leak ([679208e](https://github.com/VforVitorio/F1-StratLab/commit/679208e70952540f2238e491235d0e7412571e32))
+
+
+### Documentation
+
+* **eval:** resolve the circuit_cluster hygiene item as an accepted non-target limitation ([33ff301](https://github.com/VforVitorio/F1-StratLab/commit/33ff301fdf756c6870bee2a7e8eaf4c854afdf3e))
+* **eval:** resolve the circuit_cluster hygiene item as an accepted non-target limitation ([c72c9fe](https://github.com/VforVitorio/F1-StratLab/commit/c72c9fe35e4155f21459bceac7f6f39a8e5e46a2))
+
+## [1.8.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.7.0...v1.8.0) (2026-07-11)
+
+
+### Features
+
+* **eval:** add LLM-judge alert-precision module over unlabeled radios ([b727baa](https://github.com/VforVitorio/F1-StratLab/commit/b727baabba5304fa55eac99df2b03e0a8de06812))
+* **eval:** add metrics-registry + calibration harness (f1-eval) ([c08780d](https://github.com/VforVitorio/F1-StratLab/commit/c08780d1373fe265496a86e6d38a997ac7c3e8e7)), closes [#206](https://github.com/VforVitorio/F1-StratLab/issues/206)
+* **eval:** add NLP per-stage eval harness (f1-eval nlp) ([dbf76b1](https://github.com/VforVitorio/F1-StratLab/commit/dbf76b18bf303989a5e3fe3da52c7b323b3ae56a)), closes [#304](https://github.com/VforVitorio/F1-StratLab/issues/304)
+* **eval:** add threshold-provenance + leakage hygiene report (f1-eval hygiene) ([3788167](https://github.com/VforVitorio/F1-StratLab/commit/37881672650ba14404faf7d56a45ec83e62d224f)), closes [#207](https://github.com/VforVitorio/F1-StratLab/issues/207)
+* **eval:** compute radio alert precision from gold intent labels ([16bd305](https://github.com/VforVitorio/F1-StratLab/commit/16bd305ed7bc2ea0d35277dd2bafd10e4ed67cc1)), closes [#304](https://github.com/VforVitorio/F1-StratLab/issues/304)
+* **eval:** LLM-judge alert precision over unlabeled radios ([#304](https://github.com/VforVitorio/F1-StratLab/issues/304) follow-up) ([1651c3b](https://github.com/VforVitorio/F1-StratLab/commit/1651c3bbb51406c66206896eae7623e8f3ab6671))
+* **eval:** ML metrics-registry + calibration harness (f1-eval, [#206](https://github.com/VforVitorio/F1-StratLab/issues/206)) ([380f1d7](https://github.com/VforVitorio/F1-StratLab/commit/380f1d766e4e99f08af9cf2eb176665ce714f9c7))
+* **eval:** NLP per-stage eval harness (f1-eval nlp, [#304](https://github.com/VforVitorio/F1-StratLab/issues/304)) ([1c8ff7c](https://github.com/VforVitorio/F1-StratLab/commit/1c8ff7c850c54c613b54b72e7f0bd55b6b2dfbaa))
+* **eval:** radio alert precision from gold labels (closes [#304](https://github.com/VforVitorio/F1-StratLab/issues/304)) ([da1db0c](https://github.com/VforVitorio/F1-StratLab/commit/da1db0c6f51d8419734756f9ddd828c979c71546))
+* **eval:** recompute SC + undercut calibration + AUC-PR (part of [#364](https://github.com/VforVitorio/F1-StratLab/issues/364)) ([5c97461](https://github.com/VforVitorio/F1-StratLab/commit/5c974617f201bfb215d6525866fb494ecbb0428a))
+* **eval:** recompute SC + undercut calibration and AUC-PR from in-memory holdouts ([7365b50](https://github.com/VforVitorio/F1-StratLab/commit/7365b5074a544f7deb02a2d0f0592b078aa660b9)), closes [#364](https://github.com/VforVitorio/F1-StratLab/issues/364)
+* **eval:** regenerate pit holdout from raw laps (closes [#364](https://github.com/VforVitorio/F1-StratLab/issues/364)) ([d66ddae](https://github.com/VforVitorio/F1-StratLab/commit/d66ddae72a9cfd873348bc6c8541ca5b82ced2b8))
+* **eval:** regenerate pit holdout from raw laps + recompute coverage and MAE ([ccc213d](https://github.com/VforVitorio/F1-StratLab/commit/ccc213d069e8d1f47056d8207652f211b0fe29fb)), closes [#364](https://github.com/VforVitorio/F1-StratLab/issues/364)
+* **eval:** reproduce intent setfit-free + [#303](https://github.com/VforVitorio/F1-StratLab/issues/303) NLP hygiene verdicts ([6bc5413](https://github.com/VforVitorio/F1-StratLab/commit/6bc54135a8c9d08ebaa5f048013e1b8e3a916c60))
+* **eval:** reproduce intent setfit-free and record [#303](https://github.com/VforVitorio/F1-StratLab/issues/303) NLP hygiene verdicts ([275c487](https://github.com/VforVitorio/F1-StratLab/commit/275c487a456c45c61b1371504f668df8f5dd0d35))
+* **eval:** reproduce NER entity-F1 + RCM coverage ([#304](https://github.com/VforVitorio/F1-StratLab/issues/304)) ([bc0350d](https://github.com/VforVitorio/F1-StratLab/commit/bc0350d62d13d0f4b7673a389af949e07dfca58b))
+* **eval:** reproduce NER entity-F1 and RCM coverage in the NLP harness ([1efb133](https://github.com/VforVitorio/F1-StratLab/commit/1efb1331d8ddef3efef70dcdd23631a3ef71268d)), closes [#304](https://github.com/VforVitorio/F1-StratLab/issues/304)
+* **eval:** threshold-provenance + leakage hygiene report ([#207](https://github.com/VforVitorio/F1-StratLab/issues/207)) ([5f1f29d](https://github.com/VforVitorio/F1-StratLab/commit/5f1f29d8ab7bdd6499f098c8e1fcef3d675838fd))
+* **eval:** wire f1-eval alert-llm + report the unlabeled-corpus finding ([1e9fed1](https://github.com/VforVitorio/F1-StratLab/commit/1e9fed178ba2e25582f673a1083d1aebd65e978f)), closes [#304](https://github.com/VforVitorio/F1-StratLab/issues/304)
+
+
+### Bug Fixes
+
+* **eval:** align undercut provenance wording with in-train relabeling (Fable re-verify) ([54e5d42](https://github.com/VforVitorio/F1-StratLab/commit/54e5d42ff757467a4e478f29e9b97b70dcf722ca))
+* **eval:** correct SC operating threshold + window on honest splits ([#363](https://github.com/VforVitorio/F1-StratLab/issues/363)) ([1275101](https://github.com/VforVitorio/F1-StratLab/commit/12751013815c02b4242a50e6465321c77c6d7d37))
+* **eval:** correct SC threshold + window on honest splits (closes [#363](https://github.com/VforVitorio/F1-StratLab/issues/363)) ([e1ee603](https://github.com/VforVitorio/F1-StratLab/commit/e1ee60386b5b91feddde03cc35ea280f20fc6803))
+* **eval:** relabel SC/overtake threshold corrections as in-train (Fable gate) ([c38c94e](https://github.com/VforVitorio/F1-StratLab/commit/c38c94e9fe9641711d99ecb31211f91e33379e9c))
+
+
+### Documentation
+
+* **eval:** regenerate hygiene report with in-train relabeling + correct provenance stamp ([c1af9c1](https://github.com/VforVitorio/F1-StratLab/commit/c1af9c1f84576137cef35a08d7be5dede9f465f6))
+* **roadmap:** reconcile published metrics to thesis/IEEE finals ([2758ec5](https://github.com/VforVitorio/F1-StratLab/commit/2758ec524c37cc79bf3f7a9bc315d5cf058a8bca))
+* **roadmap:** reconcile published metrics to thesis/IEEE finals ([#213](https://github.com/VforVitorio/F1-StratLab/issues/213)) ([50b7ecf](https://github.com/VforVitorio/F1-StratLab/commit/50b7ecfc01681dec372b1bcdeb20f8d0c90bd30d))
+
+## [1.7.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.8...v1.7.0) (2026-07-11)
+
+
+### Features
+
+* **strategy:** add no-llm engine profile (fixes the --no-llm crash) ([f32e38b](https://github.com/VforVitorio/F1-StratLab/commit/f32e38b32acbca0a21defcc569a9aba32433d083))
+* **strategy:** add shared inference engine (rich profile) + arcade delegate ([43c2717](https://github.com/VforVitorio/F1-StratLab/commit/43c271741cf400496280a84cbec1efce6685b401))
+* **strategy:** no-llm engine profile (fixes the --no-llm crash, [#166](https://github.com/VforVitorio/F1-StratLab/issues/166)) ([91b98d3](https://github.com/VforVitorio/F1-StratLab/commit/91b98d3274c0027d3c846ebffcac79a09923f1a7))
+* **strategy:** shared inference engine (rich profile) + arcade delegate ([0e1b793](https://github.com/VforVitorio/F1-StratLab/commit/0e1b793e1a60a637870aa972bad446937a2c7a03))
+
+## [1.6.8](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.7...v1.6.8) (2026-07-09)
+
+
+### Documentation
+
+* **audits:** add program completeness review + reconcile roadmap and Rival design ([d4bdb4e](https://github.com/VforVitorio/F1-StratLab/commit/d4bdb4e29c8c636b82ace36615a4220a79348dec))
+* **audits:** add RAG layer audit plan ([b747de6](https://github.com/VforVitorio/F1-StratLab/commit/b747de6f8a89be0a9e382b9f47e7c59d517485ea))
+* **audits:** add RAG layer audit plan ([3603e73](https://github.com/VforVitorio/F1-StratLab/commit/3603e73f4391937fa7b0b59e55f193e0ed360def))
+* **audits:** add voice stack audit plan ([e6594af](https://github.com/VforVitorio/F1-StratLab/commit/e6594aff61e1bc79f85637ba9f75cf3e9f364d8b))
+* **audits:** add voice stack audit plan ([e61356e](https://github.com/VforVitorio/F1-StratLab/commit/e61356e927f0b41f50a2ad7f41c67d54a09827a6))
+* **audits:** program completeness review + roadmap/Rival reconciliation ([d41e957](https://github.com/VforVitorio/F1-StratLab/commit/d41e957bb083d8800f212c12bd7f38bdeb7f72a1))
+* **audits:** promote program completeness review + reconciliation to main ([c7409c1](https://github.com/VforVitorio/F1-StratLab/commit/c7409c1a4d3daaa6cfcd84045eb22c65caea682b))
+* **audits:** promote RAG layer audit to main ([1366f8c](https://github.com/VforVitorio/F1-StratLab/commit/1366f8c43ee4064390d0c3e2563dccedd247b92b))
+* **audits:** promote voice stack audit to main ([51527f3](https://github.com/VforVitorio/F1-StratLab/commit/51527f37bb296bf058714e2f27e64ae8dc7f5021))
+* fix broken copy-paste commands (promote to main) ([2b07e22](https://github.com/VforVitorio/F1-StratLab/commit/2b07e229d9b7cb4f2cd6ed567949d3b0e966a932))
+* fix broken copy-paste commands in README/INSTALL/CONTRIBUTING ([5a7783b](https://github.com/VforVitorio/F1-StratLab/commit/5a7783be3e5072e013cc3ad65ccb82b66f88d4ac))
+* fix broken copy-paste commands in README/INSTALL/CONTRIBUTING ([be4f058](https://github.com/VforVitorio/F1-StratLab/commit/be4f05847ff0af136cc9cd291e03bb87e1e12c16)), closes [#212](https://github.com/VforVitorio/F1-StratLab/issues/212)
+* **research:** add agent-orchestration-flow design ([e18c4d6](https://github.com/VforVitorio/F1-StratLab/commit/e18c4d60b0814391c00b5f9098dfdcac2d8141bb))
+* **research:** add agent-orchestration-flow design ([2a9d691](https://github.com/VforVitorio/F1-StratLab/commit/2a9d691c491319e65d1a617ff222935b26c37c07))
+* **research:** add ecosystem data-contracts spec ([4bc37ba](https://github.com/VforVitorio/F1-StratLab/commit/4bc37ba50e0d01eb7c817fed61b4755db9c7233d))
+* **research:** add ecosystem data-contracts spec ([7b2c38e](https://github.com/VforVitorio/F1-StratLab/commit/7b2c38e0b8236741cdaf611ab7b2d030328896aa))
+* **research:** promote agent-orchestration-flow design to main ([f5b61f4](https://github.com/VforVitorio/F1-StratLab/commit/f5b61f420224da15a752e56acdabad423f8da7eb))
+* **research:** promote ecosystem data-contracts spec to main ([f8e7303](https://github.com/VforVitorio/F1-StratLab/commit/f8e7303082dcceed77c169a324dad4a01d308805))
+
+## [1.6.7](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.6...v1.6.7) (2026-07-07)
+
+
+### Documentation
+
+* **audits:** add cross-audit implementation roadmap ([3e42914](https://github.com/VforVitorio/F1-StratLab/commit/3e42914a3b5687a16a52b8c31cbaa3aa892eafb8))
+* **audits:** add cross-audit implementation roadmap ([2852af5](https://github.com/VforVitorio/F1-StratLab/commit/2852af5d4728259137722c2f283fb35cd1b71a79))
+* **audits:** promote cross-audit implementation roadmap to main ([cec6297](https://github.com/VforVitorio/F1-StratLab/commit/cec6297e03323e32bb73989cab2ddea6585d9040))
+* **research:** add box-bot multi-platform design ([7739201](https://github.com/VforVitorio/F1-StratLab/commit/77392014faa16c155f00f4cdc03a54c45287e1d2))
+* **research:** add box-bot multi-platform design ([6677167](https://github.com/VforVitorio/F1-StratLab/commit/6677167c3bd3ce8630e0f5b731e0df661ec0743e))
+* **research:** promote box-bot design to main ([793afd7](https://github.com/VforVitorio/F1-StratLab/commit/793afd75eab7c691d672571e02521e018d598258))
+
+## [1.6.6](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.5...v1.6.6) (2026-07-07)
+
+
+### Documentation
+
+* **audits:** add DevEx contributor-setup audit plan ([3c5c0b3](https://github.com/VforVitorio/F1-StratLab/commit/3c5c0b3994406bdd6ee13421b7d1b40faca53d99))
+* **audits:** add DevEx contributor-setup audit plan ([b832509](https://github.com/VforVitorio/F1-StratLab/commit/b832509dbeaced3dae1c06f13396e3773f7bfbaf))
+* **audits:** add LLM cost & latency audit plan ([7417c75](https://github.com/VforVitorio/F1-StratLab/commit/7417c757b3764011b7e04793faae09375e44a5d4))
+* **audits:** add LLM cost & latency audit plan ([2266a41](https://github.com/VforVitorio/F1-StratLab/commit/2266a414b007a0c55a42aebce48c97cfb14a7449))
+* **audits:** add NLP / team-radio pipeline audit plan ([2990a50](https://github.com/VforVitorio/F1-StratLab/commit/2990a501f88f919b0fcfcecf0a4ded7dc2889d45))
+* **audits:** add NLP / team-radio pipeline audit plan ([f26661d](https://github.com/VforVitorio/F1-StratLab/commit/f26661da6ba605db8d94ce0f3d71bed2e61c654b))
+* **audits:** add packaging, release & CI/CD audit plan ([a04f65e](https://github.com/VforVitorio/F1-StratLab/commit/a04f65ee2c74daef6db039bef9f1c1c492f97292))
+* **audits:** add packaging, release & CI/CD audit plan ([59d9e0b](https://github.com/VforVitorio/F1-StratLab/commit/59d9e0bf90a01bdbe61fc51e257588f0090967e5))
+* **audits:** promote DevEx audit plan to main ([e85f4db](https://github.com/VforVitorio/F1-StratLab/commit/e85f4db3020dee12dd447767a7243609c38fc262))
+* **audits:** promote LLM cost & latency audit plan to main ([7bc8481](https://github.com/VforVitorio/F1-StratLab/commit/7bc8481df48c199717e5dc78a49c2d59d5cabc10))
+* **audits:** promote NLP / team-radio pipeline audit to main ([7e256fe](https://github.com/VforVitorio/F1-StratLab/commit/7e256feec7d3d2de08c09506fa70c1f5443bee2a))
+* **audits:** promote packaging & CI/CD audit plan to main ([a6ff04f](https://github.com/VforVitorio/F1-StratLab/commit/a6ff04f721c5dafc269857ff5c739daa85c2319c))
+* **research:** add ecosystem repo-integration architecture note ([d40b6ea](https://github.com/VforVitorio/F1-StratLab/commit/d40b6eae1bafe9168eb6994ddcc3f918af9c1ad3))
+* **research:** add ecosystem repo-integration architecture note ([b51bf97](https://github.com/VforVitorio/F1-StratLab/commit/b51bf971d74d1f836f07eaac32c0d1ddd36780e5))
+* **research:** add gridmind LoRA design ([7c2cb54](https://github.com/VforVitorio/F1-StratLab/commit/7c2cb5438606d863215a887b211e12ff9f344864))
+* **research:** add gridmind LoRA design ([5068343](https://github.com/VforVitorio/F1-StratLab/commit/50683433dfdb6935ef508a1a01c918bf80e5a043))
+* **research:** add pit-wall realism + telemetry-surface design ([db7fb44](https://github.com/VforVitorio/F1-StratLab/commit/db7fb44cb25d51b6dcdc2d9abba4e3947ac57452))
+* **research:** add pit-wall realism + telemetry-surface design ([ad8dfc2](https://github.com/VforVitorio/F1-StratLab/commit/ad8dfc2337d2755a3874e26b1145a4744fae0cd8))
+* **research:** add pitlab Studio design ([3302648](https://github.com/VforVitorio/F1-StratLab/commit/33026484ac8fbe53cc9dc073129e3158bb8399bd))
+* **research:** add pitlab Studio design ([2ae226b](https://github.com/VforVitorio/F1-StratLab/commit/2ae226b6be7eff29cf3fe314c3e48c8abdd2c75d))
+* **research:** add radiogate deception + auto-labeling design ([6a53ffe](https://github.com/VforVitorio/F1-StratLab/commit/6a53ffed92e81e9d1640a4d1fa6f08b0309fe373))
+* **research:** add radiogate deception + auto-labeling design ([1e11430](https://github.com/VforVitorio/F1-StratLab/commit/1e11430f2421bc9ca3aca9c1b761d5ac679948f5))
+* **research:** add real-time OpenF1 consumer design ([5b659ff](https://github.com/VforVitorio/F1-StratLab/commit/5b659ff8a83ab8e582cb5782497d1efa50d85daa))
+* **research:** add real-time OpenF1 consumer design ([faf2937](https://github.com/VforVitorio/F1-StratLab/commit/faf2937dfc562c0687538faab2894cddeaa872dd))
+* **research:** add Rival Agent TFM design ([b458d08](https://github.com/VforVitorio/F1-StratLab/commit/b458d0890f5561b66c9f4bce86144cf6a0a26780))
+* **research:** add Rival Agent TFM design ([4bcd4ea](https://github.com/VforVitorio/F1-StratLab/commit/4bcd4ea32ef0f2ab1f61581fa96b76d93f65bf27))
+* **research:** promote ecosystem repo-integration note to main ([3af311b](https://github.com/VforVitorio/F1-StratLab/commit/3af311b997289378167cc41d27a9f2f28d5bd2be))
+* **research:** promote gridmind LoRA design to main ([373fab9](https://github.com/VforVitorio/F1-StratLab/commit/373fab9fe5faf29af68efca94602eaba9411dcd9))
+* **research:** promote pit-wall realism + telemetry-surface design to main ([8e12e15](https://github.com/VforVitorio/F1-StratLab/commit/8e12e15dd81518d9f0085ed362a002d6c7b43c38))
+* **research:** promote pitlab Studio design to main ([72b3e5e](https://github.com/VforVitorio/F1-StratLab/commit/72b3e5eb8767cff826fa98b4fc64bf8de7c5ed3b))
+* **research:** promote radiogate design to main ([4113ff0](https://github.com/VforVitorio/F1-StratLab/commit/4113ff0d381fe29a3ebf42faaa0da0233032eb1b))
+* **research:** promote real-time OpenF1 consumer design to main ([b220ed1](https://github.com/VforVitorio/F1-StratLab/commit/b220ed1eeb0692bb854fcc73d0bb996f4876f8ae))
+* **research:** promote Rival Agent TFM design to main ([7a314f5](https://github.com/VforVitorio/F1-StratLab/commit/7a314f5e13789b64c738b70117b2f611b8e0cf8a))
+
+## [1.6.5](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.4...v1.6.5) (2026-07-05)
+
+
+### Documentation
+
+* **audits:** add P4 CLI surface audit plan ([fef83ab](https://github.com/VforVitorio/F1-StratLab/commit/fef83abb1762a2a48edf0767bc440d19431976e0))
+* **audits:** add P4 CLI surface audit plan ([7a4da77](https://github.com/VforVitorio/F1-StratLab/commit/7a4da7735f6be4f5f2b38a3434fa7d7223175e73))
+* **audits:** add P5 data-engineering audit plan ([5679490](https://github.com/VforVitorio/F1-StratLab/commit/5679490e6332d036cda3555766b3980c4c3816b4))
+* **audits:** add P5 data-engineering audit plan ([dcda30c](https://github.com/VforVitorio/F1-StratLab/commit/dcda30cc6384b408716e0ca949a7ac0bac96aebd))
+* **audits:** add security & prompt-injection audit plan ([0be2ce9](https://github.com/VforVitorio/F1-StratLab/commit/0be2ce9cfb86bb994882caa34a11b7ad31cabd31))
+* **audits:** add security & prompt-injection audit plan ([4fe8094](https://github.com/VforVitorio/F1-StratLab/commit/4fe8094e8b33e234bbfc7310d1f4597a66b0ff39))
+* **audits:** promote P4 CLI audit plan to main ([9882b45](https://github.com/VforVitorio/F1-StratLab/commit/9882b45be37cb800f0639e82780312e3126a13e2))
+* **audits:** promote P5 data-engineering audit plan to main ([b774014](https://github.com/VforVitorio/F1-StratLab/commit/b774014ac04d8111ecb8c4fd33f8850e0dce79f2))
+* **audits:** promote security audit plan to main ([af3b2ef](https://github.com/VforVitorio/F1-StratLab/commit/af3b2eff1adf2db5fb0881fdc48862b5a77bdde0))
+* **readme:** lead with product value and fix agent count ([05212ef](https://github.com/VforVitorio/F1-StratLab/commit/05212ef533176b8c860ac7222ceb9bf87a269cd7))
+
+## [1.6.4](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.3...v1.6.4) (2026-07-05)
+
+
+### Documentation
+
+* **audits:** add arcade, ML-eval and docs-accuracy audit plans ([dd390bd](https://github.com/VforVitorio/F1-StratLab/commit/dd390bd67d9ec68abd1d1e6540e146614a6b2a73))
+* **audits:** add arcade, ML-eval and docs-accuracy audit plans ([caf4347](https://github.com/VforVitorio/F1-StratLab/commit/caf4347365528f1d879e00d4be4eea77e2f95f2e))
+* **audits:** promote arcade, ML-eval and docs-accuracy audit plans ([574acca](https://github.com/VforVitorio/F1-StratLab/commit/574accaf25fc48c2032ca56a5ea2517d08f888f0))
+
+## [1.6.3](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.2...v1.6.3) (2026-07-05)
+
+
+### Documentation
+
+* add 2026-regulation concept-drift readiness audit ([36148d6](https://github.com/VforVitorio/F1-StratLab/commit/36148d645504a9a492e54c8b23c731b72d3d302a))
+* add 2026-regulation concept-drift readiness audit ([c708b8e](https://github.com/VforVitorio/F1-StratLab/commit/c708b8ec58e270c35c35fbb2d36ab751ca77be71))
+
+## [1.6.2](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.1...v1.6.2) (2026-07-04)
+
+
+### Documentation
+
+* **audits:** add backend, loading and core-compute audit plans ([0b628f2](https://github.com/VforVitorio/F1-StratLab/commit/0b628f2904de4aa69fc010f3bcbfd44e2a140be0))
+* **audits:** add testing and QA strategy audit plan ([ff4d30e](https://github.com/VforVitorio/F1-StratLab/commit/ff4d30ebea85bf7bb05862a291f0c11cf2cce91d))
+* **audits:** P1, P2 and P2b audit plans ([dc90de9](https://github.com/VforVitorio/F1-StratLab/commit/dc90de966b9b3f88142dd30818671f54b63a8f8f))
+* **audits:** testing and QA strategy audit + tests/fixtures carve-out ([bfb9d0f](https://github.com/VforVitorio/F1-StratLab/commit/bfb9d0fb42bbb10a8c9a74071ccc44f0eca89a9e))
+
+## [1.6.1](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.0...v1.6.1) (2026-06-29)
+
+
+### Bug Fixes
+
+* **docs:** accessibility (WCAG AA) pass on the docs site ([1577d9a](https://github.com/VforVitorio/F1-StratLab/commit/1577d9a3f9ea6b6320a760e738a0626dc72e83cd))
+* **docs:** correct the docs-maintenance framework label ([3645987](https://github.com/VforVitorio/F1-StratLab/commit/36459876c26013d30be1e530f0b17855cbd3a2cf))
+* **docs:** hide prerendered placeholder until React mounts ([9dec895](https://github.com/VforVitorio/F1-StratLab/commit/9dec8956580b8b5b19cabff401575617e2829fb3))
+* **docs:** hide prerendered placeholder until React mounts (no FOUC) ([cda4da0](https://github.com/VforVitorio/F1-StratLab/commit/cda4da0e5df055a800f829068516a6ebd313a622))
+* **docs:** Sprint 2 - accessibility (WCAG AA) ([b5c53da](https://github.com/VforVitorio/F1-StratLab/commit/b5c53da795d796e4aff3ba55b74ad397bf18aaa1))
+* **docs:** Sprint 3 - correct docs-maintenance framework label ([15c55ff](https://github.com/VforVitorio/F1-StratLab/commit/15c55ffb255b9f94b8e193a08150601bcbacc5e3))
+
+
+### Performance
+
+* **docs:** drop @babel/standalone, load app as plain scripts ([75b4a10](https://github.com/VforVitorio/F1-StratLab/commit/75b4a108cf64b56a21ec7067cb818b15ada917b5))
+* **docs:** drop @babel/standalone, load app as plain scripts ([e448bae](https://github.com/VforVitorio/F1-StratLab/commit/e448bae8be0f6ada4ffce8c774f892eae86239c8)), closes [#136](https://github.com/VforVitorio/F1-StratLab/issues/136)
+* **docs:** optimize demo media and page load ([6590db2](https://github.com/VforVitorio/F1-StratLab/commit/6590db246559c52678db44dc495eb724fca7e528))
+* **docs:** Sprint 1 - performance & load ([5687206](https://github.com/VforVitorio/F1-StratLab/commit/568720685552b17470161a4bb55b6a4f15ff06fd))
+
+
+### Documentation
+
+* describe the real React stack, drop MkDocs references ([c944640](https://github.com/VforVitorio/F1-StratLab/commit/c944640d56204b993a238d8db9abfdba4397ab80))
+* describe the real React stack, drop MkDocs references ([9b781d4](https://github.com/VforVitorio/F1-StratLab/commit/9b781d48b64c5e5bbbf0a6e752ce85016180407a)), closes [#156](https://github.com/VforVitorio/F1-StratLab/issues/156)
+
+## [1.6.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.5.5...v1.6.0) (2026-06-28)
+
+
+### Features
+
+* **docs:** add GEO quick wins (llms.txt, JSON-LD, AI robots, prod React) ([133c66f](https://github.com/VforVitorio/F1-StratLab/commit/133c66fb51d9989a82a6a602f5b11ff1b46ecc48)), closes [#117](https://github.com/VforVitorio/F1-StratLab/issues/117)
+* **docs:** GEO quick wins — llms.txt, JSON-LD, AI robots, prod React ([ae5a9fd](https://github.com/VforVitorio/F1-StratLab/commit/ae5a9fd7e5ff36132bd223ac9ec0637b20c6d8d6))
+* **docs:** prerender pages to crawlable HTML + real-URL sitemap ([e6d2bfc](https://github.com/VforVitorio/F1-StratLab/commit/e6d2bfcc6293b89fe5740d87e876cb58ea8218bf))
+* **docs:** prerender pages to crawlable HTML with real URLs ([b06ea02](https://github.com/VforVitorio/F1-StratLab/commit/b06ea02ecd6cca8484caa4bd36a3378e75a49cd7)), closes [#118](https://github.com/VforVitorio/F1-StratLab/issues/118)
+
+
+### Bug Fixes
+
+* **ci:** use GITHUB_TOKEN for release-please instead of expired PAT ([e6e6cea](https://github.com/VforVitorio/F1-StratLab/commit/e6e6cea7b42c489c7ef4ab6ba5a10298e77faa92))
+* **ci:** use GITHUB_TOKEN for release-please instead of expired PAT ([605eb97](https://github.com/VforVitorio/F1-StratLab/commit/605eb9716d4c30dfca7b6cbdd555a33a99f20984))
+
+
+### Documentation
+
+* add arcade demo, TFG distinction note, and next-core-releases roadmap ([78e8386](https://github.com/VforVitorio/F1-StratLab/commit/78e8386b53a7be8ed9c30a59487b210734370e8d))
+* add full project timeline roadmap page ([cc39dd3](https://github.com/VforVitorio/F1-StratLab/commit/cc39dd3e1b5a01198b632f9cd1a31a1b1979d671))
+* **content:** add definitional leads, FAQ and routing-rule prose for AI citability ([d01b7c9](https://github.com/VforVitorio/F1-StratLab/commit/d01b7c96ef46f18a3895948d033c4ab6a072803f)), closes [#120](https://github.com/VforVitorio/F1-StratLab/issues/120)
+* **content:** definitional leads + FAQ + routing-rule prose (citability) ([cf92cd7](https://github.com/VforVitorio/F1-StratLab/commit/cf92cd7d06c9fb68af1d5c4465357fc37109934e))
+* embed CLI, Arcade and Streamlit demo gifs and add the demo videos to docs/assets/demo ([7678b57](https://github.com/VforVitorio/F1-StratLab/commit/7678b577220d1e451c8fdd48abf4cf101383d1e8))
+* link the landing demo carousel from the README hero ([f2d14a9](https://github.com/VforVitorio/F1-StratLab/commit/f2d14a934190ebbd23a852f362a9e2c0044178fe))
+* remove em-dashes from README and ROADMAP prose ([5086e58](https://github.com/VforVitorio/F1-StratLab/commit/5086e58d19ba8f1ab8afcc891b3e4d959723083e))
+* update README, CONTRIBUTING, INDEX and ROADMAP; add TFG thesis and IEEE report PDFs ([5a9371c](https://github.com/VforVitorio/F1-StratLab/commit/5a9371cc27f2c766a2f6c54ba6b013bd5e17abce))
+
+## [1.5.5](https://github.com/VforVitorio/F1-StratLab/compare/v1.5.4...v1.5.5) (2026-05-23)
+
+
+### Documentation
+
+* **telemetry:** bump submodule to refreshed README (601fd23) ([195d4aa](https://github.com/VforVitorio/F1-StratLab/commit/195d4aa541de8317bdb98c2a13dbab3b16ae6096))
+
+## [1.5.4](https://github.com/VforVitorio/F1-StratLab/compare/v1.5.3...v1.5.4) (2026-05-22)
+
+
+### Documentation
+
+* añade memoria del TFG y paper bajo documents/thesis/ ([16497cc](https://github.com/VforVitorio/F1-StratLab/commit/16497cc1c4d6379eeb755be28fd4389f10454412))
+
+## [1.5.3](https://github.com/VforVitorio/F1-StratLab/compare/v1.5.2...v1.5.3) (2026-05-21)
+
+
+### Bug Fixes
+
+* **ci:** replace autoupdate action with direct gh api call ([810b9b0](https://github.com/VforVitorio/F1-StratLab/commit/810b9b0f250daab415b9f75d22f35cd1f73d74f3))
+* **ci:** replace autoupdate action with direct gh api call ([5a89b6e](https://github.com/VforVitorio/F1-StratLab/commit/5a89b6efc2d5fd09a210e7a098a6960f887524c5))
+* **ci:** replace autoupdate action with direct gh api call ([a175266](https://github.com/VforVitorio/F1-StratLab/commit/a1752661d82730f7e3befea8097a81ac68205b47))
+
+## [1.5.2](https://github.com/VforVitorio/F1-StratLab/compare/v1.5.1...v1.5.2) (2026-05-20)
+
+
+### Bug Fixes
+
+* **tests:** suppress catboost_info dir creation ([5a5b87d](https://github.com/VforVitorio/F1-StratLab/commit/5a5b87db1392df8e329ea2f37097d334f56ce095))
+* **tests:** suppress catboost_info dir creation on dep-imports test ([d49fa94](https://github.com/VforVitorio/F1-StratLab/commit/d49fa9446940fb3f988b2cc019371011b4ac5679))
+
+## [1.5.1](https://github.com/VforVitorio/F1-StratLab/compare/v1.5.0...v1.5.1) (2026-05-17)
+
+
+### Bug Fixes
+
+* **ci:** key uv cache off pyproject.toml since uv.lock is gitignored ([7fafc9b](https://github.com/VforVitorio/F1-StratLab/commit/7fafc9b04345cb43df062195a9ac12358cb22153))
+* **ci:** set cache-dependency-glob on lint job too ([df90899](https://github.com/VforVitorio/F1-StratLab/commit/df908992d9ec2c515016a00fef73b6fd8daf4594))
+
+## [1.5.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.4.3...v1.5.0) (2026-05-15)
+
+
+### Features
+
+* **agents:** N27 detects deployed Safety Car via RCM events and forces sc_prob=1.0 ([ea8ac95](https://github.com/VforVitorio/F1-StratLab/commit/ea8ac95f59d4ef6eb13f6800033c0ebe281a1e4e))
+* **agents:** N28 honors active Safety Car (banner prompt + STAY_OUT-&gt;PIT_NOW guard-rail) ([c19d887](https://github.com/VforVitorio/F1-StratLab/commit/c19d887d8485a092b39b0dab2ae5942815f68ecc))
+* **agents:** orchestrator threads RCM events to N27 and forces N28+N30 routing under SC ([497afb2](https://github.com/VforVitorio/F1-StratLab/commit/497afb2536ecfd5546ff3715f46c515c06c5eb99))
+* **arcade:** add RaceEventsPanel HUD card (Yellow/SC/VSC/Red flag pill with fade) ([e18c6af](https://github.com/VforVitorio/F1-StratLab/commit/e18c6af6374aeef3b4bb76ee899184e65e48b99c))
+* **arcade:** cache per-lap FastF1 TrackStatus on SessionData (cache v6) ([6f86554](https://github.com/VforVitorio/F1-StratLab/commit/6f8655416dfe35805af9ac41ef388ace6d8f7759))
+* **arcade:** pass sc_currently_active through MoE routing for parity with main orchestrator ([be5b127](https://github.com/VforVitorio/F1-StratLab/commit/be5b127c2302eb2a462447863122505e6c46e89d))
+* **arcade:** wire RaceEventsPanel into F1ArcadeView (anchored under leaderboard) ([cd1b6b5](https://github.com/VforVitorio/F1-StratLab/commit/cd1b6b5bb4e1da13aaee8e26a59de69850ca365c))
+
+
+### Bug Fixes
+
+* **arcade:** SimConnector waits for arcade playback before processing each lap ([e30778e](https://github.com/VforVitorio/F1-StratLab/commit/e30778ee05fc8442a415e3541244bfd4beacee94))
+* **arcade:** skip stale laps when arcade seeks ahead of the strategy loop ([0e5ec0e](https://github.com/VforVitorio/F1-StratLab/commit/0e5ec0e70985c59c79728ee7363b41a3ae3cd218))
+* **arcade:** wire arcade lap provider into SimConnector so pause stops the agent flow ([bb6ef56](https://github.com/VforVitorio/F1-StratLab/commit/bb6ef564000821eb15608a04f8e2e9b40ef76900))
+
+
+### Documentation
+
+* **multi-agent:** document RCM Safety Car override (N27 + N28 + routing) ([9a740dd](https://github.com/VforVitorio/F1-StratLab/commit/9a740ddd44e2cee934099a30bd6906ef09fa22bd))
+
+## [1.4.3](https://github.com/VforVitorio/F1-StratLab/compare/v1.4.2...v1.4.3) (2026-05-14)
+
+
+### Bug Fixes
+
+* **chat:** wire Download Report button to live /tool-message endpoint (submodule a921032) ([1dd018d](https://github.com/VforVitorio/F1-StratLab/commit/1dd018d29a874b5622650794c0cd72102392c889))
+
+## [1.4.2](https://github.com/VforVitorio/F1-StratLab/compare/v1.4.1...v1.4.2) (2026-05-13)
+
+
+### Documentation
+
+* **dev:** update chat smoke commands to /tool-message + MCP examples ([b7526d0](https://github.com/VforVitorio/F1-StratLab/commit/b7526d05cc2cde1e08e56545e0730df7298074d5))
+
+## [1.4.1](https://github.com/VforVitorio/F1-StratLab/compare/v1.4.0...v1.4.1) (2026-05-13)
+
+
+### Documentation
+
+* **api:** document MCP-driven chat endpoints and module layout ([30a5120](https://github.com/VforVitorio/F1-StratLab/commit/30a51208d7e5666d7ffc872629d053620ad8edc5))
+* **diagrams:** rename lmstudio_service.py to llm_service.py in chat MCP flow ([68efe8f](https://github.com/VforVitorio/F1-StratLab/commit/68efe8ff469c9cf5f68c2aadb5572a0013390484))
+* **frontend:** point chat tool-result renderer at /chat/tool-message-stream ([fdaeb6e](https://github.com/VforVitorio/F1-StratLab/commit/fdaeb6ec3356df8eb39dd37da9301779be3e3b01))
+
+## [1.4.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.3.1...v1.4.0) (2026-05-12)
+
+
+### Features
+
+* **docs:** add agents API reference with entry points and schemas ([5ec358a](https://github.com/VforVitorio/F1-StratLab/commit/5ec358aea2f0bd7faca5843857347f36f45003ae))
+* **docs:** add app entry with hash router and global click delegate ([359a831](https://github.com/VforVitorio/F1-StratLab/commit/359a83116fb748d8e1ce813fb51342610e067c6f))
+* **docs:** add apple-touch-icon for iOS home-screen install ([293957f](https://github.com/VforVitorio/F1-StratLab/commit/293957f8be0ac24693bbdec06e32bfae82ed6728))
+* **docs:** add arcade dashboard architecture page ([2959832](https://github.com/VforVitorio/F1-StratLab/commit/29598326746dc1ff811eeedb9361ae3b997b70c1))
+* **docs:** add arcade quick start page with three-window boot ([6f34e66](https://github.com/VforVitorio/F1-StratLab/commit/6f34e6683f38c34a63bbf7a2eb3273304c9f14a0))
+* **docs:** add arcade strategy pipeline page on local N31 duplicate ([84facc6](https://github.com/VforVitorio/F1-StratLab/commit/84facc65a146e22be57a705473ded2247dc49865))
+* **docs:** add architecture page with end-to-end layer tour ([f98e1f6](https://github.com/VforVitorio/F1-StratLab/commit/f98e1f698b53dd3d9f9139b83185406696b7a7e2))
+* **docs:** add brand design tokens mirroring f1stratlab.com palette ([2aeccad](https://github.com/VforVitorio/F1-StratLab/commit/2aeccad7da2b951e84dd08ac4c964371b58b0c9f))
+* **docs:** add changelog mirror page sourced from repo root CHANGELOG ([2d9c6df](https://github.com/VforVitorio/F1-StratLab/commit/2d9c6df7ffd9c295029147e15f29003a698e79ea))
+* **docs:** add CI/CD pipeline page covering release-please and deploy ([caef8e2](https://github.com/VforVitorio/F1-StratLab/commit/caef8e2c3d333a9eb1259f8c22e9fd50b70ac18c))
+* **docs:** add custom home page with hero agent grid stats and graph teaser ([2081e25](https://github.com/VforVitorio/F1-StratLab/commit/2081e25db096ada8e35ef88787cdb4f7330524e7))
+* **docs:** add design upload pasted-1778611374655 to uploads ([e077698](https://github.com/VforVitorio/F1-StratLab/commit/e0776988f9f393c100b0cab743f5f7482e98b813))
+* **docs:** add design upload pasted-1778611401163 to uploads ([3e37fef](https://github.com/VforVitorio/F1-StratLab/commit/3e37fefe57530b102a9f9135661040f2da5edc77))
+* **docs:** add design upload pasted-1778611468905 to uploads ([b307929](https://github.com/VforVitorio/F1-StratLab/commit/b3079290adfdafa227bbd706e0eea441e118a9ab))
+* **docs:** add design upload pasted-1778612008927 to uploads ([2bada27](https://github.com/VforVitorio/F1-StratLab/commit/2bada276922afbd4b130a4ee2de635fe5403a3fd))
+* **docs:** add design upload pasted-1778612233726 to uploads ([76e2ccb](https://github.com/VforVitorio/F1-StratLab/commit/76e2ccbf4d9edc4b37fb03080c85c44413cf813c))
+* **docs:** add design upload pasted-1778612297400 to uploads ([661263f](https://github.com/VforVitorio/F1-StratLab/commit/661263f0e0e35e6e12d6dd0a96d20cd900c3e5ac))
+* **docs:** add development hub page with contributor map ([b2e835d](https://github.com/VforVitorio/F1-StratLab/commit/b2e835d17a56517cccac7ce5eb8c52bdde290c3b))
+* **docs:** add docs maintenance page covering build and theming ([81c943a](https://github.com/VforVitorio/F1-StratLab/commit/81c943a6e82b0d8c12273aebb9772b379f7c813f))
+* **docs:** add docs.css with three-pane layout and component styles ([575f70b](https://github.com/VforVitorio/F1-StratLab/commit/575f70b60c34eb45cb90393c27ff4e0ee6fd1230))
+* **docs:** add driver colors page describing year-aware palette ([48d6937](https://github.com/VforVitorio/F1-StratLab/commit/48d69379212cb7d0933a9dd59a4eca2613110511))
+* **docs:** add FastAPI backend page with router map and SSE flow ([4c98f84](https://github.com/VforVitorio/F1-StratLab/commit/4c98f84f079bd3a70c78109a154230ca4b8e05cc))
+* **docs:** add favicon copied from f1stratlab-web landing assets ([bab2720](https://github.com/VforVitorio/F1-StratLab/commit/bab2720015daf52acd4e8fc6f960796f4dda5d31))
+* **docs:** add force-directed Obsidian-style knowledge graph with tags ([d042c9d](https://github.com/VforVitorio/F1-StratLab/commit/d042c9d4edadc891e9502c3c93b4c7502b07d4f9))
+* **docs:** add getting started page with dynamic wheel URL placeholder ([47c8964](https://github.com/VforVitorio/F1-StratLab/commit/47c8964227b3123ae62ff3bb37d2f4c717fd85bc))
+* **docs:** add home page content with current release row ([932eac5](https://github.com/VforVitorio/F1-StratLab/commit/932eac5c508b351273b0b08c68c303db5db590d1))
+* **docs:** add markdown renderer with mermaid and prism highlighting ([b1d2fdd](https://github.com/VforVitorio/F1-StratLab/commit/b1d2fddf0059d7d395463d8ad7976d226488964b))
+* **docs:** add meet the author page with bio and contact links ([a33053d](https://github.com/VforVitorio/F1-StratLab/commit/a33053d11ac085ddcffc9b917de1af53f2c7b224))
+* **docs:** add Meet the author visual section to home with avatar and link cards ([628c774](https://github.com/VforVitorio/F1-StratLab/commit/628c77458d4a03523a596cdee74115026fee4f19))
+* **docs:** add multi-agent page covering N25 through N31 ([4a28b91](https://github.com/VforVitorio/F1-StratLab/commit/4a28b91af7936213dec2305acfe8ba4055f61b3c))
+* **docs:** add nav.js with PAGES config and meet-the-author entry ([ff69cf4](https://github.com/VforVitorio/F1-StratLab/commit/ff69cf456096371a19db237278739da08b5dbec9))
+* **docs:** add Open Graph card image from landing banner ([d4035ba](https://github.com/VforVitorio/F1-StratLab/commit/d4035bade0058c052d7d717dcf48380af54552e5))
+* **docs:** add race replay engine page with lap_state schema ([79acd96](https://github.com/VforVitorio/F1-StratLab/commit/79acd9607aa950af5e46f507b1de34dd2c5ed03d))
+* **docs:** add React docs entry HTML with CDN imports and favicon ([6c4011d](https://github.com/VforVitorio/F1-StratLab/commit/6c4011d8e4c51f9a08a6cdb5da5e4fa5f4da6ef5))
+* **docs:** add responsive overrides for 1280 1024 768 and 480 breakpoints ([c768e6a](https://github.com/VforVitorio/F1-StratLab/commit/c768e6a1bd8e3d84bc3b2be50dcbf95897927a96))
+* **docs:** add robots.txt allowing all and disallowing uploads ([6a25602](https://github.com/VforVitorio/F1-StratLab/commit/6a25602c5593b4cb98941db43a4ea639e4e62647))
+* **docs:** add setup and deployment page with platform matrix ([58ff652](https://github.com/VforVitorio/F1-StratLab/commit/58ff65295f0248ce412b965583ea53d4149ec093))
+* **docs:** add sidebar backdrop body scroll lock and Escape to close ([8150e2c](https://github.com/VforVitorio/F1-StratLab/commit/8150e2c913deb9b50fd16e24da97b786fea58021))
+* **docs:** add sitemap.xml listing all 18 docs site pages ([d8e4f64](https://github.com/VforVitorio/F1-StratLab/commit/d8e4f649e3fc07183a667b3ad4f644597f6287c1))
+* **docs:** add Streamlit frontend page with tab tour ([11feebd](https://github.com/VforVitorio/F1-StratLab/commit/11feebdee3f6b4fd9b0a02e40d3f7d8378d6ede2))
+* **docs:** add tags index page grouped by Concepts Surfaces Operations Data ([de7d876](https://github.com/VforVitorio/F1-StratLab/commit/de7d876d9c9315129d676b2d3a08308a12050493))
+* **docs:** add thesis results page with verified benchmark metrics ([3a0da70](https://github.com/VforVitorio/F1-StratLab/commit/3a0da70f50667644e63a951967388b29ecae22d7))
+* **docs:** add top nav sidebar TOC search footer with version placeholder ([281016e](https://github.com/VforVitorio/F1-StratLab/commit/281016e75a44f8d5c23f4c9b32c13c5d311f57f5))
+* **docs:** brand favicon meet-the-author SEO analytics tags changelog and mobile graph ([58ba7b9](https://github.com/VforVitorio/F1-StratLab/commit/58ba7b9ab6a082b96c0763c2035f29988401848a))
+* **docs:** bump components cache buster to v7 for responsive sidebar ([debc2c7](https://github.com/VforVitorio/F1-StratLab/commit/debc2c792bcc1f594f983eaea92b80128660e0f2))
+* **docs:** full responsive overhaul for mobile tablet and print ([7a6fc7f](https://github.com/VforVitorio/F1-StratLab/commit/7a6fc7ff75e9673e3a1e91a28ba60457d549ed85))
+* **docs:** register tags index and changelog mirror pages in nav ([b6328f1](https://github.com/VforVitorio/F1-StratLab/commit/b6328f169ab587900b4ec8a7d34966c139fb1de9))
+* **docs:** replace cube brand-mark with favicon image and add author card styles ([eb14471](https://github.com/VforVitorio/F1-StratLab/commit/eb14471d953d493ce01281682100aad93c98e55e))
+* **docs:** replace mkdocs with React docs site and dynamic version ([8eebbd6](https://github.com/VforVitorio/F1-StratLab/commit/8eebbd6fe777373f48640ae04e8bbe6c066990e2))
+* **docs:** tighter graph physics on mobile so full layout fits viewport ([3934c0c](https://github.com/VforVitorio/F1-StratLab/commit/3934c0c9a0dfa3bab5c20c75fe9748f77cc18ab7))
+* **docs:** wire favicon OG meta Twitter card analytics and cache busters ([a4207f8](https://github.com/VforVitorio/F1-StratLab/commit/a4207f80656809a04baf84c73a35597d01c33d1b))
+
+
+### Documentation
+
+* **components:** point Connect column at HF dataset URL not profile ([7f937b9](https://github.com/VforVitorio/F1-StratLab/commit/7f937b9aae481e981cff3fe6c4aef10216d12ab2))
+* **diagrams:** rescue arcade three-window architecture drawio source ([5626a1c](https://github.com/VforVitorio/F1-StratLab/commit/5626a1cc58bc8e4b828d199eba20d0f90205ff0c))
+* **diagrams:** rescue backend API drawio source ([9abf8ce](https://github.com/VforVitorio/F1-StratLab/commit/9abf8cee511da5dac0e64f524d6191969887e518))
+* **diagrams:** rescue chat MCP flow drawio source ([06fa01d](https://github.com/VforVitorio/F1-StratLab/commit/06fa01d45172ddc708b13c92c1e03d0eb795f06e))
+* **diagrams:** rescue data pipeline drawio source ([7e95139](https://github.com/VforVitorio/F1-StratLab/commit/7e95139abf44c5feb66f3b49b82769bb0dad0ba5))
+* **diagrams:** rescue docker deployment drawio source ([cfc842e](https://github.com/VforVitorio/F1-StratLab/commit/cfc842edd3416a860e1aee64521b0eedc9d52c64))
+* **diagrams:** rescue frontend pages drawio source ([ae27a63](https://github.com/VforVitorio/F1-StratLab/commit/ae27a638657abccd47f6a5f22f49f21d1a17ea71))
+* **diagrams:** rescue multi-agent flow drawio source ([6ab6de4](https://github.com/VforVitorio/F1-StratLab/commit/6ab6de46c2fe5991e37b3c2c6f2683eacbda4f1b))
+* **diagrams:** rescue strategy pipeline flow drawio source ([33b368c](https://github.com/VforVitorio/F1-StratLab/commit/33b368cd34a0e960af39fa89c83695fca5ba2706))
+* **diagrams:** rescue subprocess launch sequence drawio source ([0a44781](https://github.com/VforVitorio/F1-StratLab/commit/0a44781a2f5825ceae06c7a9e969d7d3573f0d0d))
+* **diagrams:** rescue system architecture drawio source ([c3779cb](https://github.com/VforVitorio/F1-StratLab/commit/c3779cbb6b5a5a15f94409d3a6857868166189bc))
+* **diagrams:** rescue TCP broadcast dataflow drawio source ([f6ac9e5](https://github.com/VforVitorio/F1-StratLab/commit/f6ac9e5027a60facfa50f89f98f8084d1800689c))
+* **pages:** point meet-the-author HF link at dataset URL ([5f56064](https://github.com/VforVitorio/F1-StratLab/commit/5f560640ab435b563999d49808b63a2bfc3775bb))
+* **readme:** add status badges and link to docs.f1stratlab.com ([922f462](https://github.com/VforVitorio/F1-StratLab/commit/922f4626a9d1f42b8698b03f335fb3f907729a47))
+
 ## [1.3.1](https://github.com/VforVitorio/F1-StratLab/compare/v1.3.0...v1.3.1) (2026-05-12)
 
 
@@ -290,3 +786,4 @@ First CLI release (R1 milestone). Distributed as the
 [0.7.0]: https://github.com/VforVitorio/F1-StratLab/releases/tag/v0.7.0
 [0.6.0]: https://github.com/VforVitorio/F1-StratLab/releases/tag/v0.6
 [0.1.1]: https://github.com/VforVitorio/F1-StratLab/releases/tag/v0.1.1
+</content>

--- a/docs/pages/ci-cd.md
+++ b/docs/pages/ci-cd.md
@@ -6,12 +6,11 @@ The pipeline is split across three GitHub Actions workflows, a release-please bo
 
 ## Branching strategy
 
-The repository uses a layered branching model. Feature work lands on `test` first, gets promoted to `dev` once it stabilises, and only reaches `main` when it is release-ready.
+Three long-lived branches, in increasing order of stability. Every change branches off (`feat/…`, `fix/…`, `docs/…`) and opens a **pull request directly against `dev`** — `test` is a personal, day-to-day branch that is not part of the enforced PR chain (no PRs are opened against it in practice; `git log` shows feature branches merging straight into `dev`). `dev` is periodically promoted to `main` via its own PR, and `main` is release-only.
 
 ```mermaid
 graph TD
-    A[feature work] --> T[test]
-    T -->|PR| D[dev]
+    A[feature branch: feat/ fix/ docs/] -->|PR| D[dev]
     D -->|PR| M[main]
     H[chore/* or fix/* hotfix] -->|PR| M
     M -->|push trigger| RP[release-please branch]
@@ -21,14 +20,14 @@ graph TD
 
 | Branch | Purpose | Who pushes |
 |---|---|---|
-| `main` | Production / release branch | Merge commits from PRs only |
-| `dev` | Integration branch | Merge commits from PRs originating on `test` |
-| `test` | Active development branch | Developers, frequently |
+| `main` | Production / release branch | Merge commits from PRs only (from `dev`, or a hotfix branch) |
+| `dev` | Integration branch | Merge commits from `feat/`/`fix/`/`docs/` PRs |
+| `test` | Personal day-to-day branch | Direct commits; not part of the automated PR promotion chain |
 | `legacy_version` | Historical snapshot | Nobody. Frozen |
 | `gh-pages` | Published output of the `docs.yml` React SPA deploy | The `docs.yml` workflow |
 | `release-please--...` | Auto-managed by the release-please bot | The release-please GitHub Action |
 
-The default flow is `feature → test → dev → main`. Hotfixes go via a `chore/...` or `fix/...` branch straight to `main`.
+The default flow is `feature branch → dev → main`. Hotfixes go via a `chore/...` or `fix/...` branch straight to `main`. See [CONTRIBUTING.md](https://github.com/VforVitorio/F1-StratLab/blob/main/CONTRIBUTING.md) for the canonical statement of this rule.
 
 ## CI workflows
 
@@ -36,20 +35,22 @@ Three workflows live under `.github/workflows/`. They run independently, on diff
 
 ### `.github/workflows/ci.yml`
 
-Triggered on push to `main`, `dev`, `feat/**`, `fix/**`, and on pull request targeting `main` or `dev`. Three jobs run in parallel on `ubuntu-latest` with Python 3.12:
+Triggered on push to `main`, `dev`, `test`, `feat/**`, `fix/**`, `docs/**`, and on pull request targeting `main` or `dev`. Four jobs run in parallel on `ubuntu-latest`:
 
-- `test` — `uv sync --all-extras` followed by `uv run pytest -v`.
-- `lint` — `uv run ruff check .` and `uv run ruff format --check .`.
-- `typecheck` — `uv run mypy src/rag/`. Narrow scope: only production-ready typed modules are checked.
+- `test` — path-filter gated on `src/**`, `tests/**`, `pyproject.toml`, `uv.lock` (via `dorny/paths-filter@v3`; skips entirely on a docs-only or unrelated diff). When triggered: `uv sync --all-extras --frozen` (Python 3.12), a "collected-count floor" check (`pytest --co -q` must collect at least 40 nodes, guarding against a refactor silently gutting the suite), then `uv run pytest -v --cov=src --cov-report=term-missing`.
+- `lint` — always runs, no `uv sync` needed. `uvx ruff check .` and `uvx ruff format --check .` as ephemeral tools, so it skips installing the whole ML/torch stack just to lint style.
+- `typecheck` — same path-filter gate as `test`. `uv sync --extra dev --frozen` then `uv run mypy src/rag/`. Narrow scope: only production-ready typed modules are checked. Caches `.mypy_cache/` keyed on `pyproject.toml` + `src/rag/**`.
+- `pip-audit` — always runs, no path filter. Exports the locked dependency set (`uv export --frozen --all-extras`) and runs `pip-audit` against it for same-day CVE alerts, independent of whether the diff touches `uv.lock`. Advisory (`continue-on-error: true`) while baselining.
 
-The jobs are deliberately decoupled. A red `lint` does not stop `test` from running.
+The jobs are deliberately decoupled. A red `lint` does not stop `test` from running. `test` and `typecheck` both checkout with `fetch-depth: 0` **before** the paths-filter step, because the filter falls back to `git diff` on `push` events and needs full history.
 
 ### `.github/workflows/release-please.yml`
 
-Triggered on push to `main`. Two jobs:
+Triggered on push to `main`. Three jobs:
 
-1. **release-please** — runs `googleapis/release-please-action@v4`. Reads commits since the last tag and, if any commit uses a bumpable prefix (`feat:`, `fix:`, `feat!:`), opens or updates a `chore(main): release X.Y.Z` PR on the bot branch. When that PR is merged, the same job creates the tag and the GitHub Release.
-2. **publish-wheel** — gated by `if: needs.release-please.outputs.release_created == 'true'`. Runs `uv build` to produce a wheel and an sdist, then `gh release upload` to attach both artefacts.
+1. **release-please** — runs `googleapis/release-please-action@v5` with the built-in `GITHUB_TOKEN` (not a PAT — `main` carries no required status checks on the release PR, so a PAT buys nothing here). Reads commits since the last tag and, if any commit uses a bumpable prefix (`feat:`, `fix:`, `feat!:`), opens or updates a `chore(main): release X.Y.Z` PR on the bot branch. When that PR is merged, the same job creates the tag and the GitHub Release.
+2. **publish-wheel** — gated by `if: needs.release-please.outputs.release_created == 'true'`. Checks out with `submodules: recursive` (so `src/telemetry`, the Streamlit surface, is baked into the wheel — a prior release shipped without it, PK-01), runs `uv build` to produce a wheel and an sdist, then **smoke-tests the wheel** before uploading: installs it with `--no-deps` into a scratch venv and asserts all five console scripts (`f1-strat`, `f1-sim`, `f1-arcade`, `f1-streamlit`, `f1-eval`) resolve, plus the bundled Streamlit app and the compiled audio-viz component assets are present. Only then does `gh release upload` attach the wheel and sdist.
+3. **sync-uv-lock** — gated by `if: needs.release-please.outputs.prs_created == 'true'`, so it runs every time release-please opens or updates the release PR (not only on merge). release-please bumps `pyproject.toml`'s version but never `uv.lock`'s own root `version` field (PK-02), which would otherwise leave the next `uv sync --frozen` CI run red on the mismatch. This job checks out the release PR's branch, runs `uv lock`, and commits the re-locked `uv.lock` back onto that branch if it changed.
 
 ```yaml
 jobs:
@@ -57,9 +58,14 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      prs_created: ${{ steps.release.outputs.prs_created }}
+      pr: ${{ steps.release.outputs.pr }}
   publish-wheel:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
+  sync-uv-lock:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.prs_created == 'true' }}
 ```
 
 ### `.github/workflows/docs.yml`
@@ -74,7 +80,7 @@ See [docs maintenance](#/docs-maintenance) for the site-specific details.
 
 ## The release-please pipeline
 
-A release goes through nine steps from the first commit to the published wheel.
+A release goes through ten steps from the first commit to the published wheel.
 
 ```mermaid
 sequenceDiagram
@@ -87,11 +93,12 @@ sequenceDiagram
     Dev->>Repo: push commits (feat / fix)
     Repo->>Bot: push trigger on main
     Bot->>Bot: read commits since last tag
-    Bot->>Repo: open chore(main): release X.Y.Z PR
+    Bot->>Repo: open/update chore(main): release X.Y.Z PR
+    Bot->>Repo: sync-uv-lock: re-lock uv.lock, push to the release PR branch
     Dev->>Repo: review and merge release PR
     Repo->>Bot: push trigger on main (again)
     Bot->>Rel: create tag vX.Y.Z + GitHub Release
-    Art->>Art: uv build -> dist/*.whl + dist/*.tar.gz
+    Art->>Art: uv build -> dist/*.whl + dist/*.tar.gz, then smoke-test the wheel
     Art->>Rel: gh release upload vX.Y.Z dist/*
     Rel-->>Dev: release page with artefacts attached
 ```
@@ -109,13 +116,14 @@ Release cadence is event-driven, not calendar-driven. Releases happen whenever a
 
 | Ecosystem | Cadence | Open PR cap | Ignored |
 |---|---|---|---|
-| `pip` | weekly, Monday 08:00 Europe/Madrid | 5 | `torch`, `torchvision`, `transformers` (major bumps) |
+| `pip` | weekly, Monday 08:00 Europe/Madrid | 5 | `torch`, `torchvision` (any bump); `transformers`, `numpy`, `pandas`, `scikit-learn`, `lightgbm`, `xgboost` (major bumps only) |
 | `github-actions` | monthly | 3 | none |
 
 The ignore list exists for hard technical reasons:
 
-- `torch` and `torchvision` are routed through CUDA-specific indexes. Any automatic bump would invalidate the `cu128` wheel routing.
-- `transformers` is pinned because the production model artefacts under `data/models/nlp/` are saved with tokeniser and config layouts that are not forward-compatible across major versions.
+- `torch` and `torchvision` are routed through CUDA-specific indexes (`[tool.uv.sources]`). Any automatic bump would invalidate the `cu128` wheel routing on Windows/Linux.
+- `transformers` major bumps are blocked because the production model artefacts under `data/models/nlp/` are saved with tokeniser and config layouts that are not forward-compatible across major versions; bump only alongside re-training the affected notebooks (N17-N24).
+- `numpy`, `pandas`, `scikit-learn`, `lightgbm`, `xgboost` block major bumps only (minor/patch flow through normally): their `2.x`/`3.x` releases have historically removed APIs the project relies on (e.g. `numpy` 2.0 dropped `np.bool_` aliases, `pandas` 3.0 removes several `DataFrame` methods). `tests/test_dep_imports.py` exercises the relied-on surface so silent breakage is caught even on allowed bumps.
 
 ## Documentation deployment
 
@@ -138,24 +146,29 @@ gh api -X PUT repos/VforVitorio/F1-StratLab/pages \
 - **Allow auto-merge on the repository.** Required for `gh pr merge --auto` to be a valid option.
 - **GitHub Pages source = `gh-pages` branch.** Required for the docs site to publish.
 - **Branch protection on `main` and `dev`.** Required to ensure CI checks pass before merge.
-- **`RELEASE_PLEASE_TOKEN` repository secret.** A fine-grained PAT with `contents: write` and `pull-requests: write`.
+
+The release-please job runs on the built-in `GITHUB_TOKEN`, not a repository-secret PAT. An earlier setup used a `RELEASE_PLEASE_TOKEN` fine-grained PAT, but `main` carries no required status checks on the release PR, so the PAT bought nothing and an expired one silently broke the job (a stale-but-truthy secret does not fall back to `GITHUB_TOKEN`). If a future deploy needs the release PR itself to trigger CI checks, reintroducing a PAT is the fix; until then, none is configured.
 
 ## Contributor checklist
 
-Before opening a PR, run the same three commands CI runs:
+Before opening a PR, run the same commands CI runs:
 
 ```bash
 uv run pytest -v
-uv run ruff check . && uv run ruff format --check .
+uvx ruff check . && uvx ruff format --check .
 uv run mypy src/rag/
 ```
 
-Once the PR is open and green, queue it for auto-merge:
+`lint` uses `uvx` (ephemeral tool run, no `uv sync`), not `uv run` — matching the actual CI job saves a needless full-environment sync just to check style.
+
+Once the PR is open and green, target `dev` (see "Branching strategy" above — `main` is release-only) and queue it for auto-merge:
 
 ```bash
 gh pr create --base dev --title "feat(arcade): live telemetry chart" --body "..."
-gh pr merge <num> --auto --squash
+gh pr merge <num> --auto --merge --body ""
 ```
+
+The repo does not squash merges (release-please relies on individual commit messages), so use `--merge`, not `--squash`. Pass `--body ""`: `gh pr merge --merge` otherwise puts the PR title into the merge commit's body, and release-please parses that body too — a Conventional-Commit PR title there duplicates the CHANGELOG entry the branch commit already produced (hit in production on release 1.10.5).
 
 ## Failure modes and recovery
 

--- a/docs/pages/driver-colors.md
+++ b/docs/pages/driver-colors.md
@@ -4,7 +4,7 @@
 
 `src/telemetry/frontend/components/common/driver_colors.py`
 
-Also used by the backend: `src/telemetry/backend/core/driver_colors.py`.
+**This is not shared with the backend.** `src/telemetry/backend/core/driver_colors.py` is a separate, older implementation — a single flat `DRIVER_COLORS` dict labelled "F1 2024 Driver Colors" with its own (different) hex values and no `year` parameter at all: `get_driver_color(driver_code, default='#A259F7')`. It predates the 2025 driver-swap handling described below (it still maps `HAM` to a Mercedes-silver hex and has no entry for `ANT`, `BOR`, `HAD`, or the 2025 `SAI`-to-Williams move). Used only by `backend/api/v1/endpoints/comparison.py` and `backend/services/telemetry_service.py`. Treat the two files as independent palettes to keep in sync by hand, not one shared module — a known piece of tech debt, not a design intent.
 
 ## Purpose
 
@@ -37,7 +37,7 @@ Notable changes across seasons:
 
 `DRIVER_COLORS = DRIVER_COLORS_BY_YEAR[2025]` provides backward compatibility for code that does not pass a year.
 
-## Public API
+## Public API (frontend module)
 
 ### `get_driver_color(driver_code, default='#A259F7', year=None) -> str`
 
@@ -46,6 +46,8 @@ Returns the hex color for a driver in a given season. Falls back to the 2025 fla
 ### `get_driver_colors_for_list(driver_codes, year=None) -> list`
 
 Batch version — returns a list of hex colors matching the input list of driver codes.
+
+The backend's `core/driver_colors.py` exposes the same two function names but without the `year` parameter (`get_driver_color(driver_code, default='#A259F7')`), always reading its own static 2024-era `DRIVER_COLORS` dict.
 
 ## Usage
 
@@ -62,10 +64,19 @@ color = get_driver_color("VER")  # '#3671C6'
 
 ## Where it is used
 
+Frontend (year-aware module, `components/common/driver_colors.py`):
+
 - `pages/race_analysis.py` — tire and gap chart color assignment
+- `pages/strategy.py` — strategy tab driver color assignment
 - `components/race_analysis/tire_charts.py` — per-driver tire degradation plots
 - `components/race_analysis/gap_charts.py` — gap evolution charts
+- `components/chatbot/chart_builders.py` — chat tool-result chart colors
+- `components/common/data_selectors.py` and `components/dashboard/data_selectors.py` — driver selectors
+- `components/dashboard/css_styles.py` — dashboard CSS color injection
 - `utils/race_viz.py` — general race visualization helpers
-- `components/dashboard/data_selectors.py` — dashboard driver selector
-- `backend/core/driver_colors.py` — server-side comparison endpoint color assignment
+- `utils/chat_navigation.py` — chat navigation color tagging
+
+Backend (static module, `backend/core/driver_colors.py`):
+
+- `backend/api/v1/endpoints/comparison.py` — comparison endpoint color assignment
 - `backend/services/telemetry_service.py` — telemetry data color tagging

--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -18,14 +18,17 @@ The quickest path. Installs the latest release into your current environment wit
 uv pip install https://github.com/VforVitorio/F1-StratLab/releases/download/v__DOCS_VERSION__/f1_strat_manager-__DOCS_VERSION__-py3-none-any.whl
 ```
 
-After install you have four console entry points:
+After install you have five console entry points:
 
 ```bash
 f1-strat       # interactive launcher (recommended starting point)
 f1-sim         # headless CLI simulation against a saved race
 f1-arcade      # three-window PySide6 + pyglet experience
 f1-streamlit   # Streamlit dashboards
+f1-eval        # regenerate the evaluation reports (registry, calibration, hygiene, ...)
 ```
+
+`f1-eval` is a developer/thesis tool, not an end-user surface — it writes versioned markdown + JSON reports under `documents/eval_reports/` (`f1-eval registry`, `f1-eval calibration`, `f1-eval all`, ...). The first four are what a new user actually runs.
 
 First boot triggers a one-time download of the cached models and reference data into `~/.f1-strat/`. Subsequent runs are offline.
 

--- a/docs/pages/home.md
+++ b/docs/pages/home.md
@@ -72,4 +72,4 @@ The narratives on this site stop at the contract level. For per-file deep-dives 
 | Release automation (`release-please`) | v1.1.0 | shipped |
 | Current release | v__DOCS_VERSION__ | shipped |
 
-The current focus is documentation polish for the thesis defence; see the [project changelog](https://github.com/VforVitorio/F1-StratLab/blob/main/CHANGELOG.md) for the full history.
+F1 StratLab was defended as a Final Degree Project in June 2026, graded 10/10 with Distinction (Matricula de Honor) and unanimously recommended by the tribunal for publication as a research article. Development continues past the defence: a React front-end migration is underway (Streamlit remains the current production surface in the meantime) alongside ongoing correctness hardening across the multi-agent pipeline. See the [project changelog](https://github.com/VforVitorio/F1-StratLab/blob/main/CHANGELOG.md) for the full history.

--- a/docs/pages/meet-the-author.md
+++ b/docs/pages/meet-the-author.md
@@ -1,13 +1,16 @@
 # Meet the author
 
-Hi — I'm **Victor Vega Sobral** (a.k.a. VforVitorio), a fourth-year
-Intelligent Systems Engineering student at UIE Campus Coruña and
-AI & Data Intern at NTT DATA Spain. F1 StratLab is my Final-Degree
-Project: an open-source multi-agent AI for real-time Formula 1 race
-strategy, built end-to-end from telemetry ingestion and ML modelling
-to a LangGraph orchestrator and four operator surfaces. I built it
-because I wanted to see how far a single thesis could push a digital
-twin of an F1 race — and because nobody else was going to do it for me.
+Hi — I'm **Victor Vega Sobral** (a.k.a. VforVitorio), a graduate in
+Intelligent Systems Engineering from UIE Campus Coruña and AI & Data
+Intern at NTT DATA Spain. F1 StratLab was my Final-Degree Project,
+defended in June 2026 with a 10/10 grade and Distinction (Matricula de
+Honor) and unanimously recommended by the tribunal for publication as
+a research article: an open-source multi-agent AI for real-time
+Formula 1 race strategy, built end-to-end from telemetry ingestion and
+ML modelling to a LangGraph orchestrator and three operator surfaces.
+I built it because I wanted to see how far a single thesis could push
+a digital twin of an F1 race — and because nobody else was going to do
+it for me.
 
 ## Where to find me
 
@@ -24,17 +27,19 @@ F1 StratLab is a multi-agent system that turns a live (or replayed)
 Formula 1 race into actionable strategy. Seven ML models cover the
 quantitative core — lap-time delta, tire degradation with MC Dropout,
 overtake probability, safety-car prior, pit duration and undercut
-success — and feed six LangGraph sub-agents (pace, tire, gap, pit,
-radio, safety) which a single orchestrator (N31) fuses into a
+success — and feed six LangGraph sub-agents (pace, tire, race
+situation, pit strategy, radio, RAG) which a single orchestrator
+(N31) fuses into a
 Pydantic-typed decision per lap: action, pace target, risk level,
 and a plan for the next pit window.
 
-The same engine drives four operator surfaces: a Streamlit dashboard
-for analysts, a CLI for headless replays, a FastAPI/MCP backend for
-programmatic access, and a three-window arcade (race replay,
-strategy dashboard, live telemetry) built in PySide6 + pyglet for the
-demo experience. The whole stack is open under Apache-2.0 and shipped
-as wheels and GitHub releases through release-please automation.
+The same engine drives three operator surfaces: a Streamlit dashboard
+for analysts (backed by a FastAPI/MCP API for programmatic access and
+chat tool-calling), a CLI for headless replays, and a three-window
+arcade (race replay, strategy dashboard, live telemetry) built in
+PySide6 + pyglet for the demo experience. The whole stack is open
+under Apache-2.0 and shipped as wheels and GitHub releases through
+release-please automation.
 
 This documentation site is the engineering companion to the thesis
 memoria — every notebook, model, agent and surface is wired into the

--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -107,18 +107,20 @@ Wraps per-compound TireDegTCN models (N09/N10) with MC Dropout inference. Answer
 
 - **Model**: Causal TCN per compound + Platt calibration
 - **Output**: `TireOutput` (laps_to_cliff_p10/p50/p90, warning_level, deg_rate)
-- **Warning levels**: OK, MONITOR, PIT_SOON, CRITICAL
+- **Warning levels**: OK, MONITOR, PIT_SOON (derived from `laps_to_cliff_p10` against circuit-cluster-aware thresholds; there is no CRITICAL level)
 
 ### N27 — Race Situation Agent (`race_situation_agent.py`)
 
 Combines N12 (overtake probability via LightGBM) and N14 (safety car probability via LightGBM) into a single threat assessment per lap.
 
 - **Models**: LightGBM overtake (AUC-PR 0.5491) + LightGBM SC (AUC-PR 0.0723)
-- **Output**: `RaceSituationOutput` (overtake_prob, sc_prob_3lap, threat_level, **sc_currently_active**)
+- **Output**: `RaceSituationOutput` (overtake_prob, sc_prob_3lap, threat_level, **sc_currently_active**, **vsc_active**)
 
 #### RCM Safety Car override
 
-The N14 LightGBM was trained to predict a *future* SC, not to recognise one already deployed. To close that gap, N27 inspects the lap's `rcm_events` (forwarded by the orchestrator from `RadioPipelineRunner`) and, when any event matches `SAFETY_CAR_DEPLOYED` or `VIRTUAL_SAFETY_CAR_DEPLOYED`, forces `sc_prob_3lap = 1.0`, sets `sc_currently_active = True`, and elevates `threat_level` to `HIGH`. Release events (`SAFETY_CAR_ENDING`, `SAFETY_CAR_IN_PIT_LANE`, `VIRTUAL_SAFETY_CAR_ENDING`) take priority in the same window so the override clears as soon as the SC ends. The override is logged in the `reasoning` field with an `[RCM OVERRIDE: ...]` prefix so the audit trail survives the chat / arcade summary path.
+The N14 LightGBM was trained to predict a *future* SC, not to recognise one already deployed. To close that gap, N27 inspects the lap's `rcm_events` (forwarded by the orchestrator from `RadioPipelineRunner`) and, when any event matches `SAFETY_CAR_DEPLOYED` or `VIRTUAL_SAFETY_CAR_DEPLOYED`, forces `sc_prob_3lap = 1.0`, sets `sc_currently_active = True`, and elevates `threat_level` to `HIGH`. Release events (`SAFETY_CAR_ENDING`, `SAFETY_CAR_IN_PIT_LANE`, `VIRTUAL_SAFETY_CAR_ENDING`) take priority in the same window so the override clears as soon as the neutralisation ends. The override is logged in the `reasoning` field with an `[RCM OVERRIDE: ...]` prefix so the audit trail survives the chat / arcade summary path.
+
+`sc_currently_active` is deliberately a single back-compat flag: true under **either** a full Safety Car (Art. 55) or a Virtual Safety Car (Art. 56). A second field, `vsc_active`, records whether the specific neutralisation is a VSC — a full SC and a VSC differ in the pit-time saving they offer, so the Monte Carlo and the N28 prompt need to tell them apart (#471), which the single flag could not. `sc_active` (a derived property, not stored) is true only for a full SC: `sc_currently_active and not vsc_active`.
 
 ### N28 — Pit Strategy Agent (`pit_strategy_agent.py`)
 

--- a/docs/pages/roadmap.md
+++ b/docs/pages/roadmap.md
@@ -264,7 +264,8 @@
     <p class="rl-title">ML foundation: lap time and tire degradation</p>
     <p class="rl-summary">First two production ML models. XGBoost delta-lap-time predictor (N06) and a Temporal Convolutional Network for tire degradation with MC Dropout uncertainty (N07-N10, per-compound fine-tuning on SOFT / MEDIUM / HARD).</p>
     <div class="rl-metrics">
-      <span class="rl-metric">MAE 0.4104 s</span>
+      <span class="rl-metric">Pace MAE 0.4104 s</span>
+      <span class="rl-metric">Tire MAE 0.708 s</span>
       <span class="rl-metric">MC Dropout N=50</span>
     </div>
   </div>
@@ -334,9 +335,9 @@
       <span class="rl-badge done-badge"><span class="sr-only">Status: </span>Shipped</span>
     </div>
     <p class="rl-title">Multi-agent system: N25 to N31</p>
-    <p class="rl-summary">Seven LangGraph ReAct agents coordinated by a three-layer Strategy Orchestrator: MoE-style dynamic routing, Monte Carlo simulation over 500 samples ranking four strategy candidates by risk-adjusted expected outcome, and LLM synthesis producing a 14-field <code>StrategyRecommendation</code>. Bahrain 2025 end-to-end demo.</p>
+    <p class="rl-summary">Six LangGraph ReAct sub-agents coordinated by the N31 Strategy Orchestrator's three-layer pipeline: MoE-style dynamic routing, Monte Carlo simulation over 500 samples ranking four strategy candidates by risk-adjusted expected outcome, and LLM synthesis producing a 14-field <code>StrategyRecommendation</code>. Bahrain 2025 end-to-end demo.</p>
     <div class="rl-metrics">
-      <span class="rl-metric">7 agents</span>
+      <span class="rl-metric">6 agents + 1 orchestrator</span>
       <span class="rl-metric">MC N=500</span>
       <span class="rl-metric">MoE routing</span>
     </div>
@@ -433,7 +434,7 @@
       <span class="rl-badge done-badge"><span class="sr-only">Status: </span>Shipped</span>
     </div>
     <p class="rl-title">Documentation site launch and custom domain</p>
-    <p class="rl-summary">React + Babel docs site published under <code>docs.f1stratlab.com</code>. Full architecture pages, agent API reference, arcade quick-start, CI/CD narrative, and graph-based page discovery. Five drawio architecture diagrams. Brand theme aligned with the F1 StratLab purple palette.</p>
+    <p class="rl-summary">React docs site (plain <code>React.createElement</code> scripts, no JSX, no Babel, no build step) published under <code>docs.f1stratlab.com</code>. Full architecture pages, agent API reference, arcade quick-start, CI/CD narrative, and graph-based page discovery. Five drawio architecture diagrams. Brand theme aligned with the F1 StratLab purple palette.</p>
   </div>
 </li>
 
@@ -451,7 +452,7 @@
       <span class="rl-badge planned-badge"><span class="sr-only">Status: </span>Planned</span>
     </div>
     <p class="rl-title">Modern frontend</p>
-    <p class="rl-summary">React / Vite UI replaces Streamlit. The FastAPI backend stays unchanged. A presentation-layer swap: menus, flows, and all agent endpoints remain the same; only the client is rewritten for faster load times and a production-grade SPA experience.</p>
+    <p class="rl-summary">React / Vite UI replaces Streamlit. In progress under <code>src/telemetry/webapp/</code>: foundations, dashboard, home, and the strategy tab (Race Trace) are largely shipped on <code>dev</code>; comparison, race, lab, and chat tabs remain. The FastAPI backend stays unchanged, and Streamlit remains the production surface until the migration completes. A presentation-layer swap: menus, flows, and all agent endpoints remain the same; only the client is rewritten for faster load times and a production-grade SPA experience.</p>
   </div>
 </li>
 

--- a/docs/pages/setup.md
+++ b/docs/pages/setup.md
@@ -12,16 +12,13 @@
 ### 1. Clone and install
 
 ```bash
-git clone https://github.com/VforVitorio/F1_Strat_Manager.git
-cd F1_Strat_Manager
-pip install -e .
+git clone https://github.com/VforVitorio/F1-StratLab.git
+cd F1-StratLab
+git submodule update --init --recursive   # src/telemetry/ is a submodule
+uv sync --all-extras
 ```
 
-Or with uv:
-
-```bash
-uv pip install -e .
-```
+`uv` is the project's package manager (the lockfile `uv.lock` is committed and CI runs `uv sync --frozen`); a bare `pip install -e .` will not resolve the pinned, CUDA-routed PyTorch wheel the way `uv sync` does.
 
 ### 2. Data
 
@@ -54,11 +51,18 @@ Create a `.env` file at the repo root:
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `BACKEND_URL` | no | `http://localhost:8000` | Backend URL for frontend |
-| `FRONTEND_URL` | no | `http://localhost:8501` | Frontend URL for CORS |
+| `BACKEND_URL` | no | `http://localhost:8000` | Backend URL, read by the frontend |
+| `FRONTEND_URL` | no | `http://localhost:8501` | Frontend URL, read by the backend for CORS |
 | `F1_LLM_PROVIDER` | no | `lmstudio` | Set to `openai` for OpenAI API |
 | `OPENAI_API_KEY` | if provider=openai | — | OpenAI API key |
 | `F1_STRAT_DATA_ROOT` | no | repo `data/` | Override data directory |
+| `F1_API_KEY` | no | unset | Shared secret for the `X-API-Key` header. Unset = unauthenticated (safe only on a loopback bind, see `F1_HOST` below) |
+| `F1_HOST` | no | `127.0.0.1` | The host uvicorn binds to. A non-loopback bind (e.g. `0.0.0.0`) with `F1_API_KEY` unset refuses to start |
+| `F1_MCP_ENABLED` | no | `false` | Mount the external `/mcp` Streamable-HTTP endpoint. The chat pipeline uses the same tools in-process regardless |
+| `F1_CHAT_MAX_TOKENS` | no | `2048` | Server-side cap on completion tokens per chat turn |
+| `F1_RATE_LIMIT_OFF` | no | unset | Set to `1` to disable the per-route rate limiter (load tests only) |
+
+See [Backend API reference → Authentication](#/backend-api) for how `F1_API_KEY` and `F1_HOST` interact.
 
 ### 4. Run the backend
 
@@ -84,9 +88,9 @@ Start LM Studio with a model loaded, serving on `http://localhost:1234/v1`. The 
 
 ## Docker deployment
 
-### Root `docker-compose.yml`
+Two equivalent compose files exist, one at the repo root and one path-relative copy inside the submodule — both already mount volumes for live code reload and data access, so pick whichever working directory is convenient.
 
-The repo root `docker-compose.yml` provides a simple two-service setup:
+### Root `docker-compose.yml`
 
 ```bash
 docker-compose up --build
@@ -94,25 +98,21 @@ docker-compose up --build
 
 Services:
 
-- **backend**: FastAPI on port 8000
-- **frontend**: Streamlit on port 8501
+- **backend**: FastAPI on port 8000. Volumes: `./src:/app/src:ro` (read-only source — agents import from here), `./data:/app/data:ro` (read-only data), `./data/rag:/app/data/rag:rw` (writable RAG index, N30 may write here).
+- **frontend**: Streamlit on port 8501, depends on `backend`.
+
+The `:ro` mounts mean agents must handle `OSError` / `PermissionError` gracefully when they attempt to create export directories inside the container.
 
 ### Telemetry `docker-compose.yml`
-
-A more detailed compose file at `src/telemetry/docker-compose.yml` mounts volumes for live code reload and data access:
 
 ```bash
 cd src/telemetry
 docker-compose up --build
 ```
 
-Key volume mounts:
+Same two services (paths relative to `src/telemetry/` instead of the repo root) plus a third:
 
-- `../../src:/app/src:ro` — read-only source code (agents import from here)
-- `../../data:/app/data:ro` — read-only data directory
-- `../../data/rag:/app/data/rag:rw` — writable RAG index (N30 may write here)
-
-The `:ro` mount means agents handle `OSError` / `PermissionError` gracefully when they attempt to create export directories inside Docker.
+- **webapp**: the React SPA replacing Streamlit (migration epic #25, a strangler-pattern rollout). Host port `3000` during the migration; takes over `8501` at cutover (#43). Not present in the root compose file.
 
 ### Frontend Dockerfile (multi-stage)
 

--- a/docs/pages/simulation.md
+++ b/docs/pages/simulation.md
@@ -22,9 +22,9 @@ RaceReplayEngine
         └── get_lap_state()     ← merges all into lap_state dict
               ↓
     lap_state dict → all 7 agents → strategy orchestrator
-              ↓
-    to_arcade_frame() → WebSocket /ws/replay → Arcade UI
 ```
+
+`RaceReplayEngine.to_arcade_frame()` still exists in `replay_engine.py`, but nothing calls it and its docstring's `/ws/replay` WebSocket route was never registered on the backend — the arcade's real live path is the direct in-process pipeline broadcasting over a local TCP socket, documented in [Arcade strategy pipeline](#/arcade-strategy-pipeline) and [Multi-agent system → Three-window arcade](#/multi-agent).
 
 ## Data boundary (architectural constraint)
 
@@ -139,6 +139,10 @@ python -m src.simulation Silverstone VER "Red Bull Racing" --data-dir data/raw/2
     "lap_number": int,
     "driver": {
         "lap_time_s": float | None,
+        # This lap's Prev_LapTime feature, never last lap's own lap_time_s
+        # reused as a stand-in — that self-reference used to feed the pace
+        # agent its own most recent prediction back in as "previous" (#435).
+        "prev_lap_time": float | None,
         "sector1_s": float | None,
         "sector2_s": float | None,
         "sector3_s": float | None,
@@ -148,6 +152,9 @@ python -m src.simulation Silverstone VER "Red Bull Racing" --data-dir data/raw/2
         "compound_id": int | None,
         "tyre_life": int | None,
         "stint": int | None,
+        # TyreLife at the first lap of the current stint. N06's FuelEffect is
+        # measured from this baseline, not from lap 1 of the race (#446).
+        "stint_baseline_tyre_life": int | None,
         "fresh_tyre": bool,
         "speed_i1": float | None,
         "speed_i2": float | None,
@@ -184,6 +191,10 @@ python -m src.simulation Silverstone VER "Red Bull Racing" --data-dir data/raw/2
         "track_status": str,
         "air_temp": float | None,
         "track_temp": float | None,
+        # The session's FIRST track temperature, not this lap's — a session
+        # constant carried in the weather dict because that is the channel
+        # its consumer (N14's track_temp_delta feature) reads from (#486).
+        "track_temp_start": float | None,
         "humidity": float | None,
         "wind_speed": float | None,
         "rainfall": bool,

--- a/docs/pages/tags.md
+++ b/docs/pages/tags.md
@@ -46,7 +46,7 @@ Tags that appear on a single page are listed under **Other** at the end.
 | `uv` | [Getting started](#/getting-started), [Setup & deployment](#/setup), [CI/CD pipeline](#/ci-cd) |
 | `dev` | [Development overview](#/development), [Docs maintenance](#/docs-maintenance), [CI/CD pipeline](#/ci-cd) |
 | `git` | [Development overview](#/development), [CI/CD pipeline](#/ci-cd) |
-| `release` | [Development overview](#/development), [CI/CD pipeline](#/ci-cd) |
+| `release` | [Development overview](#/development), [CI/CD pipeline](#/ci-cd), [Roadmap](#/roadmap), [Changelog](#/changelog) |
 | `github-actions` | [Docs maintenance](#/docs-maintenance), [CI/CD pipeline](#/ci-cd) |
 
 ## Data
@@ -61,6 +61,7 @@ Tags that appear on a single page are listed under **Other** at the end.
 
 | Tag | Pages |
 |---|---|
-| `overview` | [Welcome](#/home), [Meet the author](#/meet-the-author), [How it is wired](#/architecture) |
+| `overview` | [Welcome](#/home), [Meet the author](#/meet-the-author), [How it is wired](#/architecture), [Tags index](#/tags), [Roadmap](#/roadmap) |
 | `fastapi` | [Backend API](#/backend-api) |
 | `evaluation` | [Thesis results](#/thesis) |
+| `engine` | [Strategy pipeline](#/arcade-strategy-pipeline) |

--- a/docs/pages/thesis.md
+++ b/docs/pages/thesis.md
@@ -52,3 +52,5 @@ Both notebooks emit CSV and Markdown tables alongside their PNGs:
 | MC Dropout (C2) | calibrated 80 % coverage | **0.840** | `data/eval/mc_dropout_coverage.{csv,md}` |
 
 All numbers reproducible with the commands above.
+
+**Note on the NLP pipeline figure.** The thesis and IEEE report publish **47.8 ms mean / 59.4 ms P95** for `run_pipeline` (the original N24 benchmark run). The **42.1 ms** figure in the table above comes from re-running the same benchmark on the current hardware and environment, as this page's figures are regenerated automatically rather than pinned to the publication. Both numbers are valid measurements of the same pipeline; the difference is measurement lineage (published vs. regenerated), not a correction.


### PR DESCRIPTION
Three parallel reviewers audited the project docs (root) and the docs.f1stratlab.com site (`docs/pages/`), **verifying every claim/command/path/signature/example against the current code** before editing — the repo's standing rule that docs must not 'teach the bugs'. 22 files, +856/-159.

## Highlights
- **Root**: Python 3.10-3.12; correct `F1-StratLab` URLs; CLI defaults to `lmstudio` (not OpenAI); full CI job set + security workflows; `INDEX.md` now documents `engine.py::run_lap` (the shared per-lap pipeline) + the strategy router.
- **backend-api.md**: real auth / rate-limit / `/mcp` layers, actual endpoints + 422-vs-500 split, removed a phantom `auth` router.
- **agents-api.md**: new #476 LLM input-validation section; full 14-field `StrategyRecommendation` table incl the #433 clamp + `vsc_active`; fixed a fabricated tire warning level.
- **architecture.md**: `RaceState` corrected to a per-lap single-driver snapshot.
- **simulation.md**: dropped the dead Kafka / `/ws/replay` path.
- **ci-cd.md**: branching diagram `feature -> dev`, release-please v5, missing jobs.
- **changelog / home / meet-the-author / roadmap**: refreshed to the defended 10/10 project, 6 sub-agents, Babel dropped. Streamlit docs left accurate (v2 migration not done yet).

## Flags for a human check (reviewers could not verify)
- URL conflict: `home.md`/`meet-the-author.md` link `f1stratlab.com` while `README.md` links the GitHub-Pages subdomain.
- Your current NTT DATA internship title (in `meet-the-author.md`).
- Dead `--provider` CLI flag in `src/arcade/main.py` (code, not docs).