### PR TITLE
docs(site): mark the v2 migration shipped + refresh author bio and getting-started hero

### DIFF
--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -5,9 +5,9 @@
 Three ways to get F1 StratLab running on your machine, from fastest to deepest.
 
 <p align="center">
-  <video src="/assets/demo/cli-demo.mp4" poster="/assets/demo/cli-demo-poster.jpg" width="760" autoplay loop muted playsinline preload="metadata" aria-label="F1 StratLab CLI wizard in action"></video>
+  <video src="/assets/demo/arcade-demo.mp4" poster="/assets/demo/arcade-demo-poster.jpg" width="760" autoplay loop muted playsinline preload="metadata" aria-label="F1 StratLab Arcade replay in action"></video>
   <br/>
-  <sub>The <code>f1-strat</code> interactive wizard: pick the GP, drivers and provider, then watch the live inference panel.</sub>
+  <sub>The <code>f1-arcade</code> replay: a 2D race with the strategy dashboard and live telemetry, all from one command.</sub>
 </p>
 
 ## 1. Install the latest wheel
@@ -54,7 +54,7 @@ Drop `--no-llm` once you have an LLM provider configured (LM Studio at `http://l
 
 ## 3. Docker
 
-For a reproducible all-in-one setup, see [Setup and deployment](#/setup) for the Docker compose recipe that boots the FastAPI backend, the Streamlit frontend and the Qdrant store in one command.
+For a reproducible all-in-one setup, see [Setup and deployment](#/setup) for the Docker compose recipe that boots the FastAPI backend, the React web app and the Qdrant store in one command.
 
 ## Where to next
 

--- a/docs/pages/home.md
+++ b/docs/pages/home.md
@@ -43,7 +43,7 @@ graph TD
     subgraph Surfaces["Operator surfaces"]
         CLI[Headless CLI]
         ARC[Arcade dashboard]
-        STR[Streamlit web app]
+        STR[React web app]
     end
 
     Sources --> RRE
@@ -72,4 +72,4 @@ The narratives on this site stop at the contract level. For per-file deep-dives 
 | Release automation (`release-please`) | v1.1.0 | shipped |
 | Current release | v__DOCS_VERSION__ | shipped |
 
-F1 StratLab was defended as a Final Degree Project in June 2026, graded 10/10 with Distinction (Matricula de Honor) and unanimously recommended by the tribunal for publication as a research article. Development continues past the defence: a React front-end migration is underway (Streamlit remains the current production surface in the meantime) alongside ongoing correctness hardening across the multi-agent pipeline. See the [project changelog](https://github.com/VforVitorio/F1-StratLab/blob/main/CHANGELOG.md) for the full history.
+F1 StratLab was defended as a Final Degree Project in June 2026, graded 10/10 with Distinction (Matricula de Honor) and unanimously recommended by the tribunal for publication as a research article. Development continues past the defence: the React front-end migration is complete (v2.0.0, the React web app replaced Streamlit as the post-race UI) alongside ongoing correctness hardening across the multi-agent pipeline. See the [project changelog](https://github.com/VforVitorio/F1-StratLab/blob/main/CHANGELOG.md) for the full history.

--- a/docs/pages/meet-the-author.md
+++ b/docs/pages/meet-the-author.md
@@ -1,16 +1,19 @@
 # Meet the author
 
-Hi — I'm **Victor Vega Sobral** (a.k.a. VforVitorio), a graduate in
-Intelligent Systems Engineering from UIE Campus Coruña and AI & Data
-Intern at NTT DATA Spain. F1 StratLab was my Final-Degree Project,
-defended in June 2026 with a 10/10 grade and Distinction (Matricula de
-Honor) and unanimously recommended by the tribunal for publication as
-a research article: an open-source multi-agent AI for real-time
-Formula 1 race strategy, built end-to-end from telemetry ingestion and
-ML modelling to a LangGraph orchestrator and three operator surfaces.
-I built it because I wanted to see how far a single thesis could push
-a digital twin of an F1 race — and because nobody else was going to do
-it for me.
+Hi, I'm **Victor Vega Sobral** (a.k.a. VforVitorio). I graduated in
+Intelligent Systems Engineering from UIE Campus Coruña (9.0/10 average,
+four Distinctions / Matricula de Honor) and I'm now a **Junior AI
+Engineer at NTT DATA Spain**, working across computer vision, LLM
+behavior, agentic AI, and tooling such as Model Context Protocol (MCP)
+servers. Alongside the role I'm pursuing a Master's in Artificial
+Intelligence Research (AEPIA / UIMP). F1 StratLab was my Final-Degree
+Project, defended in June 2026 with a 10/10 grade and Distinction
+(Matricula de Honor) and unanimously recommended by the tribunal for
+publication as a research article: an open-source multi-agent AI for
+real-time Formula 1 race strategy, built end-to-end from telemetry
+ingestion and ML modelling to a LangGraph orchestrator and three
+operator surfaces. I built it to see how far a single thesis could push
+a digital twin of an F1 race.
 
 ## Where to find me
 
@@ -33,7 +36,7 @@ situation, pit strategy, radio, RAG) which a single orchestrator
 Pydantic-typed decision per lap: action, pace target, risk level,
 and a plan for the next pit window.
 
-The same engine drives three operator surfaces: a Streamlit dashboard
+The same engine drives three operator surfaces: a React web app
 for analysts (backed by a FastAPI/MCP API for programmatic access and
 chat tool-calling), a CLI for headless replays, and a three-window
 arcade (race replay, strategy dashboard, live telemetry) built in
@@ -53,8 +56,8 @@ graph view so you can navigate by topic, by tag, or by cross-reference.
   [OpenF1](https://openf1.org) provide the telemetry, lap and timing
   data this entire project depends on.
 - **Open-source libraries** — LangGraph, LightGBM, XGBoost, PyTorch,
-  Pydantic, FastAPI, Streamlit, PySide6, pyglet, Qdrant, and the
-  Hugging Face ecosystem.
+  Pydantic, FastAPI, React, Vite, ECharts, PySide6, pyglet, Qdrant, and
+  the Hugging Face ecosystem.
 - **Reference work** — TUMFTM race-simulation for the pit-delta
   framing, plus the wider F1 analytics community whose public
   notebooks shaped the early modelling decisions.

--- a/docs/pages/roadmap.md
+++ b/docs/pages/roadmap.md
@@ -438,6 +438,19 @@
   </div>
 </li>
 
+<li class="rl-item">
+  <div class="rl-dot done"></div>
+  <div class="rl-card">
+    <div class="rl-header">
+      <span class="rl-version"><span class="sr-only">Version: </span>v2.0.0</span>
+      <span class="rl-date"><span class="sr-only">Date: </span>2026-07-21</span>
+      <span class="rl-badge done-badge"><span class="sr-only">Status: </span>Shipped</span>
+    </div>
+    <p class="rl-title">Modern frontend: the post-race UI moves to a React web app</p>
+    <p class="rl-summary">The Streamlit post-race interface is fully replaced by a React web app (React 19, Vite, TypeScript, Tailwind, ECharts, TanStack Router/Query, Zustand) across six surfaces: dashboard, comparison (60fps replay), model lab, strategy, race analysis, and a streaming chat that renders each tool result inline. The FastAPI backend, the six agents, the orchestrator and the models are unchanged: a presentation-layer swap, not a rebuild.</p>
+  </div>
+</li>
+
 </ul>
 
 <p class="rl-section-label">Planned milestones</p>
@@ -448,19 +461,7 @@
   <div class="rl-dot planned"></div>
   <div class="rl-card planned">
     <div class="rl-header">
-      <span class="rl-version"><span class="sr-only">Version: </span>v1.6.0</span>
-      <span class="rl-badge planned-badge"><span class="sr-only">Status: </span>Planned</span>
-    </div>
-    <p class="rl-title">Modern frontend</p>
-    <p class="rl-summary">React / Vite UI replaces Streamlit. In progress under <code>src/telemetry/webapp/</code>: foundations, dashboard, home, and the strategy tab (Race Trace) are largely shipped on <code>dev</code>; comparison, race, lab, and chat tabs remain. The FastAPI backend stays unchanged, and Streamlit remains the production surface until the migration completes. A presentation-layer swap: menus, flows, and all agent endpoints remain the same; only the client is rewritten for faster load times and a production-grade SPA experience.</p>
-  </div>
-</li>
-
-<li class="rl-item">
-  <div class="rl-dot planned"></div>
-  <div class="rl-card planned">
-    <div class="rl-header">
-      <span class="rl-version"><span class="sr-only">Version: </span>v1.7.0</span>
+      <span class="rl-version"><span class="sr-only">Version: </span>v2.1.0</span>
       <span class="rl-badge planned-badge"><span class="sr-only">Status: </span>Planned</span>
     </div>
     <p class="rl-title">Rival Agent: anticipate each rival's next move</p>
@@ -472,7 +473,7 @@
   <div class="rl-dot planned"></div>
   <div class="rl-card planned">
     <div class="rl-header">
-      <span class="rl-version"><span class="sr-only">Version: </span>v1.8.0</span>
+      <span class="rl-version"><span class="sr-only">Version: </span>v2.2.0</span>
       <span class="rl-badge planned-badge"><span class="sr-only">Status: </span>Planned</span>
     </div>
     <p class="rl-title">Live race inference and 2026 regulation adaptation</p>


### PR DESCRIPTION
Docs-site content updates for the v2 release (deploys to docs.f1stratlab.com on merge).

- **Roadmap**: Modern frontend moves from Planned to **Shipped (v2.0.0, 2026-07-21)**; the next milestones shift to v2.1.0 (Rival Agent) and v2.2.0 (Live race inference).
- **Home**: the migration is now described as complete (the React web app replaced Streamlit); the operator-surfaces diagram node is updated.
- **Meet the author**: **Junior AI Engineer at NTT DATA Spain** (was AI & Data Intern), graduation details and the Master's (AEPIA / UIMP), and the surfaces line names the React web app instead of Streamlit.
- **Getting started**: the hero video is the **Arcade** replay (more eye-catching than the CLI terminal); the docker recipe boots the React web app.

The displayed site version (`__DOCS_VERSION__`) is a build-time placeholder, so it picks up v2.0.0 on the next deploy automatically.