### PR TITLE
docs(site): expand the roadmap (v2.5 modern arcade, v2.8 rival, v3.0 live)

### DIFF
--- a/docs/pages/roadmap.md
+++ b/docs/pages/roadmap.md
@@ -461,7 +461,19 @@
   <div class="rl-dot planned"></div>
   <div class="rl-card planned">
     <div class="rl-header">
-      <span class="rl-version"><span class="sr-only">Version: </span>v2.1.0</span>
+      <span class="rl-version"><span class="sr-only">Version: </span>v2.5.0</span>
+      <span class="rl-badge planned-badge"><span class="sr-only">Status: </span>Planned</span>
+    </div>
+    <p class="rl-title">Arcade, modernized: a web-native trackside frontend</p>
+    <p class="rl-summary">Bring the web app's modern frontend to part of the live Arcade experience, running alongside the PySide6 / pyglet 2D replay rather than replacing it. The strategy and telemetry surfaces move to a web-native view; the <code>lap_state</code> contract and the agents stay unchanged.</p>
+  </div>
+</li>
+
+<li class="rl-item">
+  <div class="rl-dot planned"></div>
+  <div class="rl-card planned">
+    <div class="rl-header">
+      <span class="rl-version"><span class="sr-only">Version: </span>v2.8.0</span>
       <span class="rl-badge planned-badge"><span class="sr-only">Status: </span>Planned</span>
     </div>
     <p class="rl-title">Rival Agent: anticipate each rival's next move</p>
@@ -473,7 +485,7 @@
   <div class="rl-dot planned"></div>
   <div class="rl-card planned">
     <div class="rl-header">
-      <span class="rl-version"><span class="sr-only">Version: </span>v2.2.0</span>
+      <span class="rl-version"><span class="sr-only">Version: </span>v3.0.0</span>
       <span class="rl-badge planned-badge"><span class="sr-only">Status: </span>Planned</span>
     </div>
     <p class="rl-title">Live race inference and 2026 regulation adaptation</p>


### PR DESCRIPTION
Adds a v2.5.0 milestone (a web-native frontend for part of the live Arcade experience, running alongside the 2D replay) and renumbers the next milestones to v2.8.0 (Rival Agent) and v3.0.0 (Live race inference), matching the landing roadmap. Deploys to docs.f1stratlab.com on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap with a planned v2.5.0 milestone for a modernized web-native trackside experience.
  * Revised planned release versions for the rival strategy and live race inference milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->