### PR TITLE
Promote dev to main: web-app compose cutover

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -100,22 +100,24 @@ data from a **read-only** `./data` mount, so seed `data/` on the host first (see
 
 Opens:
 
-- Frontend at `http://localhost:8501`
+- React web app at `http://localhost:8501`
 - FastAPI backend at `http://localhost:8000`
 
-Both containers mount `./src/telemetry` so edits reload without a
-rebuild. `.env` at repo root is picked up by the backend image.
+The backend container mounts `./src/telemetry` so its edits reload without a
+rebuild; the web app ships as a built nginx image (rebuild to pick up frontend
+changes, or use the dev server below). `.env` at repo root is picked up by the
+backend image.
 
-If you prefer a local (non-Docker) Streamlit run:
+For frontend development without Docker:
 
 ```bash
-uv sync
-uv run f1-streamlit
+cd src/telemetry/webapp
+npm install && npm run dev   # Vite dev server, proxies /api to :8000
 ```
 
-`f1-streamlit` is a wrapper around `python -m streamlit run
-src/telemetry/frontend/app/main.py` that forwards any extra flag
-(`--server.port`, `--server.headless`, etc.).
+The legacy Streamlit app no longer ships in compose, but stays on disk and
+still runs locally via `uv run f1-streamlit` (a wrapper around
+`python -m streamlit run src/telemetry/frontend/app/main.py`).
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,21 +24,17 @@ services:
       - f1_network
     restart: unless-stopped
 
-  # Streamlit Frontend
-  frontend:
+  # React web app (v2). nginx serves the built SPA and reverse-proxies /api to
+  # the backend service, so the browser stays same-origin. The legacy Streamlit
+  # app no longer ships in compose (cutover #43); it stays on disk under
+  # src/telemetry/frontend/ and runs locally via f1-streamlit.
+  webapp:
     build:
-      context: ./src/telemetry
-      dockerfile: frontend/Dockerfile
-    container_name: f1_telemetry_frontend
+      context: ./src/telemetry/webapp
+      dockerfile: Dockerfile
+    container_name: f1_webapp
     ports:
-      - "8501:8501"
-    environment:
-      - PYTHONUNBUFFERED=1
-      - BACKEND_URL=http://backend:8000
-    volumes:
-      - ./src/telemetry/frontend:/app/frontend
-      - frontend_cache:/root/.cache
-    command: streamlit run frontend/app/main.py --server.port 8501 --server.address 0.0.0.0
+      - "8501:80"
     depends_on:
       - backend
     networks:
@@ -51,4 +47,3 @@ networks:
 
 volumes:
   backend_cache:
-  frontend_cache:


### PR DESCRIPTION
Brings the #43 cutover to main: docker compose now serves the React web app on :8501 (Streamlit service removed from compose; legacy stays behind f1-streamlit) + INSTALL.md refresh + submodule bump. Merge with --body "".