### PR TITLE
feat(mc): thread race context to the MC boundary

### DIFF
--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -701,6 +701,11 @@ def _run_mc_simulation(
     situation_out,
     pit_out=None,
     alpha: float = 0.5,
+    *,
+    rivals: list[dict] | None = None,
+    position: int | None = None,
+    laps_remaining: int | None = None,
+    pit_context: dict | None = None,
 ) -> dict:
     """Layer 2 Monte Carlo simulation over strategy candidates.
 
@@ -722,6 +727,14 @@ def _run_mc_simulation(
     alpha:
         RaceState.risk_tolerance. score = alpha·E[S] + (1−alpha)·P10[S].
         α=1.0 is pure expected value (aggressive); α=0.0 is worst-case only.
+    rivals / position / laps_remaining / pit_context:
+        Race-context state for the projection-based scoring (#550). Accepted
+        since #552 and IGNORED here on purpose: every current caller leaves
+        them at their defaults and this body is the legacy seconds-based
+        scoring, which must stay byte-identical (the strategy goldens pin it).
+        The projection engine (#555) dispatches on truthy ``rivals``; a falsy
+        value — None, or the ``[]`` the default lap_state builders emit —
+        means "no per-rival gap data" and keeps this path.
     """
     rng = np.random.default_rng(seed=42)
     n   = CFG.n_sim

--- a/src/simulation/race_state_manager.py
+++ b/src/simulation/race_state_manager.py
@@ -25,6 +25,7 @@ from typing import Any
 import pandas as pd
 
 from src.simulation.data_validation import validate_laps_df
+from src.simulation.stint_history import stint_history_flags
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -418,6 +419,25 @@ class RaceStateManager:
             "team": self.team,
             "total_laps": self.total_laps,
         }
+
+    def get_stint_flags(
+        self,
+        lap_number: int,
+        driver_code: str | None = None,
+    ) -> dict[str, Any]:
+        """Art. 30.5(m) facts for one driver up to ``lap_number``.
+
+        Defaults to our driver; pass a rival's code for their view. Exposing
+        this for rivals does not break the single-driver boundary: stint counts
+        and compound history are timing-screen knowledge on any real pit wall.
+
+        Added for the MC projection redesign (#552). Nothing in
+        ``get_lap_state`` consumes it yet, so every emitted payload is
+        unchanged; the projection engine picks it up when the MC learns to
+        read race context (#555, #556).
+        """
+        code = driver_code or self.driver_code
+        return stint_history_flags(self._all, code, lap_number)
 
     def get_lap_state(
         self,

--- a/src/simulation/stint_history.py
+++ b/src/simulation/stint_history.py
@@ -1,0 +1,111 @@
+"""Art. 30.5(m) stint-history facts for the strategy decision layer.
+
+Pure, frame-agnostic helpers that read a GP-scoped laps frame and answer three
+questions about one driver at one lap: how many stops they have made, which
+compounds they have used, and whether the mandatory two-dry-compound obligation
+(F1 Sporting Regulations Art. 30.5(m), 2024/25 numbering; 30.5(n) in 2023) is
+still pending. Using intermediate or wet tyres at any point exempts the driver.
+
+Invariant these helpers protect: the featured parquet drops laps (SC / pit /
+out-laps fail N04's ``IsAccurate`` gate) and can therefore hide WHOLE stints
+(e.g. Lusail 2024 VER shows stints 1 and 4 only). So the helpers distinguish
+"seen" from "certain": ``stops_made`` comes from the highest stint NUMBER (a
+sequential FastF1 index), never from the count of visible stints, and when an
+invisible stint could hide the second compound, ``mandatory_stop_pending`` is
+``None`` (unknown) rather than a guess. None means unknown, never a default.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+DRY_COMPOUNDS = frozenset({"SOFT", "MEDIUM", "HARD"})
+WET_COMPOUNDS = frozenset({"INTERMEDIATE", "WET"})
+
+_REQUIRED_COLUMNS = frozenset({"Driver", "LapNumber", "Compound"})
+
+
+def _unknown_flags() -> dict[str, Any]:
+    """The honest empty answer: nothing observed, nothing asserted."""
+    return {"stops_made": None, "compounds_used": [], "mandatory_stop_pending": None}
+
+
+def _visible_compounds(rows: pd.DataFrame) -> list[str]:
+    """Ordered unique compound names seen in ``rows``, unknown strings dropped.
+
+    First-seen order is preserved so the list reads as the driver's compound
+    history. Strings outside the five FIA compound names (empty cells, test
+    placeholders) are excluded: they are neither dry nor wet evidence.
+    """
+    seen = rows["Compound"].dropna().astype(str).str.upper()
+    known = seen[seen.isin(DRY_COMPOUNDS | WET_COMPOUNDS)]
+    ordered_unique = list(dict.fromkeys(known))
+    return ordered_unique
+
+
+def _visible_stint_numbers(rows: pd.DataFrame) -> list[int]:
+    """Sorted distinct stint numbers present in ``rows`` (empty if no column)."""
+    if "Stint" not in rows.columns:
+        return []
+    numbers = sorted({int(s) for s in rows["Stint"].dropna()})
+    return numbers
+
+
+def stint_history_flags(
+    gp_laps: pd.DataFrame | None,
+    driver: str,
+    lap_number: int,
+) -> dict[str, Any]:
+    """Stops made, compounds used and the Art. 30.5(m) flag up to ``lap_number``.
+
+    Args:
+        gp_laps:    GP-scoped laps frame (scoping is the caller's duty, #429
+                    lesson: an unscoped season frame would blend races). Needs
+                    Driver / LapNumber / Compound; Stint is optional.
+        driver:     FIA three-letter code.
+        lap_number: Inclusive upper bound — only laps at or before it count.
+
+    Returns:
+        ``stops_made``: highest visible stint number minus one (FastF1 numbers
+        stints sequentially from 1, so this counts stops even when the featured
+        frame hides intermediate stints), or None without Stint data.
+        ``compounds_used``: first-seen-ordered unique compounds observed.
+        ``mandatory_stop_pending``: False on positive evidence (a wet-weather
+        compound used, or two different dry compounds seen); True only when
+        EVERY stint so far is visible and still shows a single dry compound;
+        None when the history is empty or an invisible stint could hide the
+        second compound.
+    """
+    if gp_laps is None or gp_laps.empty or not _REQUIRED_COLUMNS <= set(gp_laps.columns):
+        return _unknown_flags()
+
+    in_window = (gp_laps["Driver"] == driver) & (gp_laps["LapNumber"] <= lap_number)
+    rows = gp_laps[in_window]
+    if rows.empty:
+        return _unknown_flags()
+
+    stints = _visible_stint_numbers(rows)
+    stops_made = stints[-1] - 1 if stints else None
+
+    compounds = _visible_compounds(rows)
+    used_wet = any(c in WET_COMPOUNDS for c in compounds)
+    dry_seen = {c for c in compounds if c in DRY_COMPOUNDS}
+    all_stints_visible = bool(stints) and set(range(1, stints[-1] + 1)) <= set(stints)
+
+    if not compounds:
+        pending: bool | None = None
+    elif used_wet or len(dry_seen) >= 2:
+        pending = False
+    elif all_stints_visible:
+        pending = True
+    else:
+        pending = None
+
+    flags = {
+        "stops_made": stops_made,
+        "compounds_used": compounds,
+        "mandatory_stop_pending": pending,
+    }
+    return flags

--- a/tests/test_mc_state_helpers.py
+++ b/tests/test_mc_state_helpers.py
@@ -1,0 +1,256 @@
+"""PR-1 of the MC projection redesign (#552): stint-history facts + MC kwargs.
+
+Two guarantees:
+
+1. ``stint_history_flags`` answers Art. 30.5(m) questions honestly — positive
+   evidence flips the flag to False, full visibility is required for True, and
+   anything an invisible stint could hide comes back None (never a guess).
+   Synthetic frames cover the logic everywhere; the real featured parquet
+   (skipped on data-less CI runners) pins three hand-checked histories.
+
+2. ``_run_mc_simulation`` accepts the new race-context kwargs and IGNORES
+   them: passing them must be byte-identical to not passing them, because the
+   legacy scoring path is golden-pinned and no caller threads context yet.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.simulation.stint_history import stint_history_flags
+
+ROOT = Path(__file__).parent.parent
+
+_HAS_DATA = (ROOT / "data" / "processed" / "laps_featured_2024.parquet").exists()
+_skip_no_data = pytest.mark.skipif(
+    not _HAS_DATA,
+    reason="data/processed/ not present (CI runner without the HF dataset)",
+)
+
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+_skip_no_models = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="data/models/ not present (CI runner without model weights)",
+)
+
+
+def _frame(rows: list[tuple]) -> pd.DataFrame:
+    """Build a minimal laps frame from (driver, lap, stint, compound) tuples."""
+    frame = pd.DataFrame(rows, columns=["Driver", "LapNumber", "Stint", "Compound"])
+    return frame
+
+
+# ---------------------------------------------------------------------------
+# Synthetic frames — the logic, exhaustively
+# ---------------------------------------------------------------------------
+
+
+def test_two_stints_same_dry_compound_keeps_the_obligation_pending():
+    laps = _frame([("VER", 1, 1, "MEDIUM"), ("VER", 10, 1, "MEDIUM"), ("VER", 20, 2, "MEDIUM")])
+    flags = stint_history_flags(laps, "VER", 25)
+    assert flags["stops_made"] == 1
+    assert flags["compounds_used"] == ["MEDIUM"]
+    assert flags["mandatory_stop_pending"] is True
+
+
+def test_two_different_dry_compounds_satisfy_the_obligation():
+    laps = _frame([("VER", 1, 1, "MEDIUM"), ("VER", 20, 2, "HARD")])
+    flags = stint_history_flags(laps, "VER", 57)
+    assert flags["mandatory_stop_pending"] is False
+
+
+def test_wet_weather_compound_exempts_even_with_one_dry_compound():
+    laps = _frame([("VER", 1, 1, "INTERMEDIATE"), ("VER", 20, 2, "SOFT")])
+    flags = stint_history_flags(laps, "VER", 30)
+    assert flags["mandatory_stop_pending"] is False
+
+
+def test_lap_bound_excludes_later_compounds():
+    laps = _frame([("VER", 1, 1, "MEDIUM"), ("VER", 30, 2, "HARD")])
+    flags = stint_history_flags(laps, "VER", 10)
+    assert flags["compounds_used"] == ["MEDIUM"]
+    assert flags["stops_made"] == 0
+    assert flags["mandatory_stop_pending"] is True
+
+
+def test_invisible_stint_downgrades_pending_true_to_unknown():
+    # Stint 2 never appears in the frame (its laps all failed the quality
+    # gate), so the second compound may be hiding there: the honest answer
+    # is None, while stops_made still counts from the stint NUMBER.
+    laps = _frame([("VER", 1, 1, "MEDIUM"), ("VER", 30, 3, "MEDIUM")])
+    flags = stint_history_flags(laps, "VER", 40)
+    assert flags["stops_made"] == 2
+    assert flags["mandatory_stop_pending"] is None
+
+
+def test_invisible_stint_cannot_hide_positive_evidence():
+    laps = _frame([("VER", 1, 1, "MEDIUM"), ("VER", 30, 4, "HARD")])
+    flags = stint_history_flags(laps, "VER", 40)
+    assert flags["stops_made"] == 3
+    assert flags["mandatory_stop_pending"] is False
+
+
+def test_empty_history_is_unknown_not_false():
+    laps = _frame([("VER", 1, 1, "MEDIUM")])
+    flags = stint_history_flags(laps, "HAM", 10)
+    assert flags == {"stops_made": None, "compounds_used": [], "mandatory_stop_pending": None}
+
+
+def test_missing_stint_column_still_reads_compounds():
+    laps = pd.DataFrame(
+        [("VER", 1, "MEDIUM"), ("VER", 20, "HARD")],
+        columns=["Driver", "LapNumber", "Compound"],
+    )
+    flags = stint_history_flags(laps, "VER", 30)
+    assert flags["stops_made"] is None
+    assert flags["compounds_used"] == ["MEDIUM", "HARD"]
+    assert flags["mandatory_stop_pending"] is False
+
+
+def test_unknown_compound_strings_are_neither_evidence_nor_crash():
+    laps = _frame([("VER", 1, 1, ""), ("VER", 2, 1, "TEST_UNKNOWN")])
+    flags = stint_history_flags(laps, "VER", 5)
+    assert flags["compounds_used"] == []
+    assert flags["mandatory_stop_pending"] is None
+
+
+def test_none_frame_is_unknown():
+    assert stint_history_flags(None, "VER", 10)["mandatory_stop_pending"] is None
+
+
+# ---------------------------------------------------------------------------
+# Real featured parquet — three hand-checked histories (probed 2026-07-23)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def laps_2024() -> pd.DataFrame:
+    # Direct featured read is fine HERE only: these tests consume nothing but
+    # Driver/LapNumber/Stint/Compound. The augment_featured_laps rule exists
+    # for Time_s/TrackStatus consumers; stint history needs neither.
+    frame = pd.read_parquet(ROOT / "data" / "processed" / "laps_featured_2024.parquet")
+    return frame
+
+
+_HAS_RAW = (ROOT / "data" / "raw" / "2024" / "Lusail" / "laps.parquet").exists()
+_skip_no_raw = pytest.mark.skipif(
+    not _HAS_RAW,
+    reason="data/raw/ not present (CI runner without the HF dataset)",
+)
+
+
+@pytest.fixture(scope="module")
+def raw_lusail_2024() -> pd.DataFrame:
+    frame = pd.read_parquet(ROOT / "data" / "raw" / "2024" / "Lusail" / "laps.parquet")
+    return frame
+
+
+@_skip_no_data
+def test_sao_paulo_2024_ver_wet_race_is_exempt(laps_2024):
+    gp = laps_2024[laps_2024["GP_Name"] == "São Paulo"]
+    flags = stint_history_flags(gp, "VER", 69)
+    assert flags["compounds_used"] == ["INTERMEDIATE"]
+    assert flags["stops_made"] == 1
+    assert flags["mandatory_stop_pending"] is False
+
+
+@_skip_no_data
+def test_lusail_2024_ver_single_compound_early_race_is_pending(laps_2024):
+    gp = laps_2024[laps_2024["GP_Name"] == "Lusail"]
+    flags = stint_history_flags(gp, "VER", 10)
+    assert flags["compounds_used"] == ["MEDIUM"]
+    assert flags["stops_made"] == 0
+    assert flags["mandatory_stop_pending"] is True
+
+
+@_skip_no_data
+def test_lusail_2024_ver_counts_stops_through_invisible_stints(laps_2024):
+    # The featured frame shows VER's stints 1 and 4 only (2 and 3 dropped by
+    # the quality gate). Stint NUMBERS still say three stops happened, and
+    # MEDIUM + HARD is positive evidence the obligation is satisfied.
+    gp = laps_2024[laps_2024["GP_Name"] == "Lusail"]
+    flags = stint_history_flags(gp, "VER", 57)
+    assert flags["stops_made"] == 3
+    assert flags["compounds_used"] == ["MEDIUM", "HARD"]
+    assert flags["mandatory_stop_pending"] is False
+
+
+@_skip_no_raw
+def test_rsm_get_stint_flags_matches_the_pure_helper(raw_lusail_2024):
+    # The RSM consumes the RAW per-race laps parquet (all laps, full stint
+    # visibility: VER shows stints 1-4 here where the featured frame keeps
+    # only 1 and 4), so on this path the invisible-stint None rarely fires.
+    from src.simulation.race_state_manager import RaceStateManager
+
+    rsm = RaceStateManager(
+        raw_lusail_2024, driver_code="VER", team="Red Bull Racing", gp_name="Lusail", year=2024
+    )
+    flags = rsm.get_stint_flags(10)
+    assert flags == stint_history_flags(raw_lusail_2024, "VER", 10)
+    assert flags["compounds_used"] == ["MEDIUM"]
+    assert flags["mandatory_stop_pending"] is True
+    rival_flags = rsm.get_stint_flags(10, driver_code="HAM")
+    assert rival_flags == stint_history_flags(raw_lusail_2024, "HAM", 10)
+
+
+# ---------------------------------------------------------------------------
+# MC kwargs — accepted and ignored, byte-identical output
+# ---------------------------------------------------------------------------
+
+
+def _canned_outputs():
+    """Same canned near-cliff fixture as tests/test_strategy_goldens.py."""
+    from src.agents.pace_agent import PaceOutput
+    from src.agents.pit_strategy_agent import PitStrategyOutput
+    from src.agents.race_situation_agent import RaceSituationOutput
+    from src.agents.tire_agent import TireOutput
+
+    pace = PaceOutput(
+        lap_time_pred=91.0, delta_vs_prev=-0.2, delta_vs_median=0.3, ci_p10=90.5, ci_p90=91.8
+    )
+    tire = TireOutput(
+        compound="MEDIUM",
+        current_tyre_life=18,
+        deg_rate=0.05,
+        laps_to_cliff_p10=3.0,
+        laps_to_cliff_p50=5.0,
+        laps_to_cliff_p90=8.0,
+        gp_name="",
+    )
+    situation = RaceSituationOutput(overtake_prob=0.2, sc_prob_3lap=0.10)
+    pit = PitStrategyOutput(
+        action="PIT_NOW",
+        recommended_lap=20,
+        compound_recommendation="HARD",
+        stop_duration_p05=2.2,
+        stop_duration_p50=2.8,
+        stop_duration_p95=3.6,
+        undercut_prob=0.55,
+        undercut_target="VER",
+        sc_reactive=False,
+        reasoning="",
+    )
+    return pace, tire, situation, pit
+
+
+@_skip_no_models
+def test_mc_race_context_kwargs_are_accepted_and_ignored():
+    from src.agents.strategy_orchestrator import _run_mc_simulation
+
+    pace, tire, situation, pit = _canned_outputs()
+    baseline = _run_mc_simulation(pace, tire, situation, pit, alpha=0.5)
+    with_context = _run_mc_simulation(
+        pace,
+        tire,
+        situation,
+        pit,
+        alpha=0.5,
+        rivals=[{"driver": "HAM", "interval_to_driver_s": -1.8}],
+        position=5,
+        laps_remaining=20,
+        pit_context={"mandatory_stop_pending": True},
+    )
+    assert with_context == baseline


### PR DESCRIPTION
## What

PR-1 of the MC projection redesign (#550): pure state, zero behaviour change.

- New `src/simulation/stint_history.py`: frame-agnostic Art. 30.5(m) facts per driver per lap. `stops_made` derives from stint NUMBERS (FastF1's sequential index), so stops still count when the featured frame hides whole stints; the wet-weather exemption applies at driver level; and when an invisible stint could hide the second compound the flag is `None` — unknown, never a guess.
- `RaceStateManager.get_stint_flags(lap, driver_code=None)`: additive, works for our driver or any rival (stint counts and compound history are timing-screen knowledge, so the single-driver boundary holds). Nothing in `get_lap_state` consumes it yet — every emitted payload is unchanged.
- `_run_mc_simulation` accepts keyword-only `rivals` / `position` / `laps_remaining` / `pit_context`, documented as accepted-and-ignored. The projection engine (#555) will dispatch on truthy `rivals`.

## Verification

- 10 synthetic-frame tests covering the logic matrix (same-compound stints stay pending, wet exemption, lap bound, invisible-stint downgrade to None, missing columns, unknown strings).
- 4 real-data tests (skip on data-less runners), hand-checked before freezing: São Paulo 2024 VER (2 stints, both INTERMEDIATE: exempt), Lusail 2024 VER at lap 10 (pending) and lap 57 (stints 1+4 visible only, `stops_made == 3` through the hidden stints), plus RSM-vs-helper parity on the RAW Lusail frame.
- Kwargs identity test: calling the MC with the new context args is byte-identical to calling without.
- `tests/test_strategy_goldens.py` untouched and green — the legacy MC output is pinned to the digit.

Refs #552
