### PR TITLE
fix(ci): pin ruff so a linter release cannot turn every branch red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Pinned so a linter release cannot turn every branch red on its own. See the
+  # note above the lint steps before bumping — the bump and the reformatting it
+  # implies belong in one deliberate PR.
+  RUFF_VERSION: "0.15.22"
+
 # Notes on dependency strategy across the three jobs:
 #   - All three jobs enable uv's built-in cache (`enable-cache: true`) and
 #     key it off `uv.lock`. uv.lock is now committed so the cache only
@@ -105,11 +111,18 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
+      # Ruff is PINNED. `uvx ruff` resolves the latest release at run time, so a
+      # ruff release could turn every branch red without a single line of our code
+      # changing — and worse, inconsistently: 0.16.0 shipped on 2026-07-23 and
+      # started formatting Python code blocks inside Markdown, yet runs kept
+      # passing while the tool cache still held 0.15.x, so the same commit passed
+      # one run and failed the next. Bump this deliberately, with the reformat it
+      # implies in the same PR (the webapp CI pins prettier for this same reason).
       - name: Ruff check
-        run: uvx ruff check .
+        run: uvx ruff@${{ env.RUFF_VERSION }} check .
 
       - name: Ruff format check
-        run: uvx ruff format --check .
+        run: uvx ruff@${{ env.RUFF_VERSION }} format --check .
 
   typecheck:
     name: typecheck


### PR DESCRIPTION
## What

Pins ruff in the `lint` job to `0.15.22` via a workflow-level `RUFF_VERSION`, instead of letting `uvx ruff` resolve whatever is newest at run time.

## Why — CI is red on `dev` right now, and no code caused it

`ruff 0.16.0` shipped on 2026-07-23 and started formatting Python code blocks **inside Markdown files**. That immediately puts 8 files out of format (`docs/pages/{agents-api,backend-api,driver-colors,multi-agent,simulation,streamlit}.md`, `src/simulation/README.md`, `.github/ISSUE_TEMPLATE/data_issue.md`) and fails `Ruff format check` on every branch.

The worse half is the nondeterminism: PR #559 passed all 16 checks earlier today with the same repo contents, because the runner's tool cache still held a 0.15.x ruff. A cache miss on the next run pulled 0.16.0 and the identical tree went red. **An unpinned linter means the same commit can pass one run and fail the next**, which is exactly the failure the webapp CI already pins prettier (3.9.5) to avoid.

## Why pin rather than accept the new formatting

The affected files are documentation. Ruff 0.16 strips the deliberate comment alignment in their snippets, e.g. in `docs/pages/agents-api.md`:

```
driver: str           # Three-letter driver code
lap: int              # Current lap number
```

becomes single-spaced, which reads worse on the published docs site. Adopting 0.16.0 is a fine future call, but it is a docs-formatting decision that deserves its own PR with the diff visible — not a side effect of an upstream release landing mid-sprint.

## Verification

With the pin, locally: `uvx ruff@0.15.22 check .` and `uvx ruff@0.15.22 format --check .` both clean over 93 files. No source file changes in this PR.

## Follow-up

Bumping to 0.16.x later is a deliberate PR: change `RUFF_VERSION`, run `ruff format .`, review what it does to the docs snippets, land both together.
