### PR TITLE
feat(mc): project track position from per-rival gaps

### DIFF
--- a/src/agents/position_projection.py
+++ b/src/agents/position_projection.py
@@ -1,0 +1,511 @@
+"""Project where our car comes out, in cars rather than in seconds (#554).
+
+The Monte Carlo layer used to score strategies in generic seconds divided by a
+flat 1.5 s/position, over a sampled state containing no cars at all. Losing 20 s
+costs zero positions with a 25 s cushion behind and three positions with cars at
++2 / +8 / +15 s, and only a model that knows *which cars are where* can tell the
+difference. This module is that model: one pure primitive that turns per-rival
+gaps into a projected end-of-window track position.
+
+Nothing here loads a model, reads a file or touches the orchestrator. It takes
+plain state in and returns arrays out, which is what lets the projection be
+validated against real pit stops before a single call site changes.
+
+SIGN CONVENTION, stated once and loudly because a docstring that lied about a
+sign has already cost this project a bug: gaps follow the RaceStateManager
+contract, ``gap_s = rival_elapsed_time - our_elapsed_time``. So
+
+    gap_s < 0  =>  the rival is AHEAD of us (less race time elapsed)
+    gap_s > 0  =>  the rival is BEHIND us
+
+Losing time pushes our elapsed time up, which pushes every gap DOWN.
+
+KNOWN v1 SIMPLIFICATIONS, named so nobody mistakes them for oversights. Each is
+a real racing effect this model does not carry, left out because the alternative
+was an unmeasured constant, which is what the redesign exists to remove:
+
+- **A gap crossing counts as a position change.** In the pit-stop cases that
+  dominate the window this is exact — you emerge where you emerge. On track it
+  is optimistic: three tenths does not pass at Monaco and does at Monza, and
+  nothing here knows the difference. N11 already models overtake probability and
+  is the natural gate, but it was trained on observed gaps, so feeding it the
+  counterfactual gaps a projection invents would run it off its own manifold.
+- **The out-lap is treated like any other lap on fresh rubber.** In reality a new
+  set needs a lap, sometimes a sector, to switch on, and on a hard compound in
+  cold conditions the out-lap can be slower than the worn set it replaced. That
+  warm-up is precisely what decides whether an undercut lands, so the effect is
+  not cosmetic — it is folded into the measured undercut band instead of being
+  modelled per lap.
+- **Neutralisation hazard is flat across the race.** The measured per-circuit
+  rate pools every lap, while the real thing spikes on lap one and around the
+  pit windows.
+- **Lapped cars are counted by elapsed time on the same lap number**, which
+  matches the timing screen but does not model the unlapping procedure before a
+  restart (Art. 55.13).
+
+--- WHERE TO CHANGE IF THE RIVALS CONTRACT CHANGES ---
+``RivalState`` mirrors the fields ``RaceStateManager.get_rival_states`` emits
+(``interval_to_driver_s``, ``is_pitting``, ``lap_time_s``). If that contract
+gains or renames a field, the adapter that builds ``RivalState`` moves with it;
+this module never reads a DataFrame.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+_MEASURED_TABLES = Path(__file__).resolve().parents[2] / "data" / "mc_measured_v1.json"
+
+# Fallbacks used only when the measured tables are unavailable (a wheel install
+# without data/). They are the values measured on 2026-07-25 over 71 races, so a
+# missing file degrades to the same numbers rather than to invented ones.
+DEFAULT_UNDERCUT_BAND_S = 4.91
+DEFAULT_NEUTRALISATION_RATE = 0.0179
+DEFAULT_RACING_LAPS_UNDER_SC = 2.61
+
+# Margin is a tie-break, not a second currency: at most a third of a position.
+MARGIN_WEIGHT = 0.1
+# Capped at three seconds because that is roughly where the car behind stops
+# being a threat within one lap: DRS arms inside one second (Art. 22.1), and by
+# about three the follower is out of dirty air and cannot mount an attack next
+# time by. Buffer beyond that is real comfort but no longer decision-relevant,
+# so the tie-break saturates rather than rewarding a 40-second cushion forever.
+MARGIN_CLIP_S = 3.0
+
+
+@dataclass(frozen=True)
+class RivalState:
+    """One rival as the pit wall sees them at the decision lap.
+
+    Attributes:
+        driver:      FIA three-letter code.
+        gap_s:       Signed seconds, rival minus us. Negative means ahead of us.
+                     ``None`` means unknown, and an unknown gap keeps the rival
+                     out of the projection entirely rather than at a made-up
+                     zero — a searchable sentinel is how #428 happened.
+        pace_delta_s: Seconds per lap this rival is slower than us (negative =
+                     faster). Zero when unknown, which is the neutral
+                     assumption rather than a guess in either direction.
+        is_pitting:  They entered the pit lane on this lap. A fact from timing,
+                     the only rival-strategy signal v1 trusts.
+        stop_pending: Whether they still owe the Art. 30.5(m) stop. ``None``
+                     when their compound history cannot settle it.
+        stop_loss_s: Total pit loss if they stop in the window (lane traversal
+                     plus the physical stop).
+    """
+
+    driver: str
+    gap_s: float | None
+    pace_delta_s: float = 0.0
+    is_pitting: bool = False
+    stop_pending: bool | None = None
+    stop_loss_s: float = 0.0
+
+    @property
+    def is_ahead(self) -> bool:
+        """Whether the rival is ahead of us right now (unknown gap counts as no)."""
+        return self.gap_s is not None and self.gap_s < 0
+
+    @property
+    def gap_ahead_s(self) -> float | None:
+        """Positive seconds we sit behind this rival, or None if not ahead."""
+        if not self.is_ahead:
+            return None
+        return -float(self.gap_s)
+
+
+@dataclass(frozen=True)
+class DriverPlan:
+    """What one candidate strategy does to our own car over the window.
+
+    Attributes:
+        name:            STAY_OUT / PIT_NOW / UNDERCUT / OVERCUT.
+        stops_in_window: Whether this candidate takes the stop inside the window.
+        stop_offset_laps: Laps from now until that stop (0 = this lap). Ignored
+                     when the candidate does not stop.
+    """
+
+    name: str
+    stops_in_window: bool
+    stop_offset_laps: int = 0
+
+
+@dataclass(frozen=True)
+class ProjectionConfig:
+    """Measured constants and race context the projection needs.
+
+    Everything here is either measured (see ``scripts/measure_mc_tables.py``) or
+    a fact of the current race. No strategy opinions live in this object.
+
+    Attributes:
+        window_laps:      Decision horizon W.
+        racing_laps:      Laps inside the window that will actually be raced.
+                          Equals ``window_laps`` under green and drops toward
+                          zero under a neutralisation, which is what makes the
+                          Art. 55.17 endgame fall out of the arithmetic: with no
+                          racing laps left, fresh tyres buy nothing.
+        fresh_gain_s:     Seconds per lap a fresh tyre gains.
+        cliff_loss_s:     Seconds per lap lost past the tyre cliff.
+        neutralisation_saving_s: Seconds a stop saves when taken under a
+                          neutralisation (the field is queued, so the pit loss
+                          costs less).
+        undercut_band_s:  Beyond this gap an undercut effectively never works.
+        future_neutralisation_prob: q_f, the chance a later neutralisation
+                          covers a stop we have not taken yet.
+        laps_remaining:   Laps left in the race, for the q_f estimate.
+        mandatory_stop_pending: Whether WE still owe the Art. 30.5(m) stop.
+                          ``None`` means unknown and disables the liability term
+                          rather than assuming either way.
+        margin_weight:    Weight of the seconds-margin tie-break.
+    """
+
+    window_laps: int = 5
+    racing_laps: float = 5.0
+    fresh_gain_s: float = 0.25
+    cliff_loss_s: float = 0.80
+    neutralisation_saving_s: float = 8.0
+    undercut_band_s: float = DEFAULT_UNDERCUT_BAND_S
+    future_neutralisation_prob: float = 0.0
+    laps_remaining: int = 0
+    mandatory_stop_pending: bool | None = None
+    margin_weight: float = MARGIN_WEIGHT
+
+
+@dataclass(frozen=True)
+class ProjectionResult:
+    """Per-draw output of a projection for one candidate.
+
+    Attributes:
+        positions:   Projected track position at the end of the window.
+        margins_s:   Seconds of buffer to the nearest projected car behind,
+                     clipped, and 0.0 when nothing is behind us.
+        liabilities: Cars the still-owed stop is projected to cost later.
+        rivals_used: How many rivals had a usable gap and entered the count.
+    """
+
+    positions: np.ndarray
+    margins_s: np.ndarray
+    liabilities: np.ndarray
+    rivals_used: int
+
+
+def load_measured_config(path: Path | None = None, **overrides) -> ProjectionConfig:
+    """Build a config from the committed measured tables, with race context on top.
+
+    Falls back to the values those tables held on 2026-07-25 when the file is
+    absent (a wheel install without ``data/``), so the degraded path lands on
+    measured numbers instead of invented ones. ``overrides`` carries the
+    per-race context the tables cannot know (laps remaining, whether we still
+    owe a stop, how many laps of the window will be raced).
+    """
+    tables_path = path or _MEASURED_TABLES
+    settings: dict = {}
+
+    if tables_path.exists():
+        tables = json.loads(tables_path.read_text(encoding="utf-8"))
+        band = tables.get("undercut_band", {}).get("u_band_s")
+        if band:
+            settings["undercut_band_s"] = float(band)
+
+    settings.update(overrides)
+    return ProjectionConfig(**settings)
+
+
+def future_neutralisation_probability(rate_per_lap: float, laps_remaining: int) -> float:
+    """Probability at least one neutralisation begins in the laps that remain.
+
+    ``1 - exp(-rate * laps)`` rather than ``rate * laps``: the product form runs
+    past 1 on a long run and would hand the decision layer a certainty it has no
+    right to. Clamped anyway, because a probability that can leave [0, 1] is a
+    bug waiting for its first extreme input.
+    """
+    if rate_per_lap <= 0 or laps_remaining <= 0:
+        return 0.0
+    probability = 1.0 - math.exp(-rate_per_lap * laps_remaining)
+    return min(1.0, max(0.0, probability))
+
+
+def _usable_rivals(rivals: Sequence[RivalState]) -> list[RivalState]:
+    """Rivals whose gap is known. An unknown gap cannot be projected, so it is
+    excluded rather than defaulted — the house rule that None means unknown."""
+    return [rival for rival in rivals if rival.gap_s is not None]
+
+
+def driver_time_delta(
+    plan: DriverPlan,
+    pit_loss_s: np.ndarray,
+    cliff_laps: np.ndarray,
+    config: ProjectionConfig,
+    stop_is_neutralised: np.ndarray | bool = False,
+) -> np.ndarray:
+    """Seconds we lose over the window under ``plan``, per draw.
+
+    Three terms, all in seconds so they can be compared with a rival's:
+
+    - the stop itself, discounted when it is taken under a neutralisation
+      (the field is queued, so the same pit lane costs fewer seconds of race),
+    - time lost running past the tyre cliff, over the laps this plan spends on
+      the old set,
+    - time gained on fresh rubber, over the racing laps that follow the stop.
+
+    A plan that does not stop pays no pit loss and gains nothing fresh; it just
+    lives with its tyres. That asymmetry is the whole trade-off, and it is
+    expressed here rather than asserted in a comment.
+    """
+    draws = len(pit_loss_s)
+    delta = np.zeros(draws, dtype=float)
+
+    racing = float(config.racing_laps)
+    if plan.stops_in_window:
+        laps_before_stop = min(float(plan.stop_offset_laps), racing)
+        laps_after_stop = max(0.0, racing - laps_before_stop)
+
+        saving = np.where(stop_is_neutralised, config.neutralisation_saving_s, 0.0)
+        effective_loss = np.maximum(0.0, pit_loss_s - saving)
+
+        worn_laps = np.maximum(0.0, laps_before_stop - cliff_laps)
+        delta += effective_loss
+        delta += worn_laps * config.cliff_loss_s
+        delta -= laps_after_stop * config.fresh_gain_s
+    else:
+        worn_laps = np.maximum(0.0, racing - cliff_laps)
+        delta += worn_laps * config.cliff_loss_s
+
+    return delta
+
+
+def rival_time_deltas(
+    rivals: Sequence[RivalState],
+    config: ProjectionConfig,
+    draws: int,
+) -> np.ndarray:
+    """Seconds each rival loses over the window, shaped (draws, rivals).
+
+    A rival costs themselves time two ways: by stopping (only when timing says
+    they are in the pit lane right now — v1 trusts the fact, never a guess about
+    their strategy) and by being slower than us lap after lap.
+
+    Deterministic per rival today, so every draw carries the same column. It is
+    still built at full width because the projection multiplies it against
+    per-draw quantities, and because sampling rival stop durations is the
+    natural next refinement.
+    """
+    usable = _usable_rivals(rivals)
+    deltas = np.zeros((draws, len(usable)), dtype=float)
+
+    for index, rival in enumerate(usable):
+        loss = rival.stop_loss_s if rival.is_pitting else 0.0
+        pace = rival.pace_delta_s * config.racing_laps
+        deltas[:, index] = loss + pace
+
+    return deltas
+
+
+def terminal_liability(
+    rivals: Sequence[RivalState],
+    plan: DriverPlan,
+    pit_loss_s: np.ndarray,
+    config: ProjectionConfig,
+) -> np.ndarray:
+    """Cars that a still-owed stop is projected to cost us later, per draw.
+
+    The two-compound rule (Art. 30.5(m)) makes one stop mandatory, so a candidate
+    that skips the window has not avoided the cost, only deferred it. This counts
+    what that deferral will cost in cars: rivals close enough behind to come out
+    ahead when we finally stop, and only those who have ALREADY satisfied their
+    own obligation — a rival who must still stop pays the same price later, so
+    they are no threat.
+
+    The window is discounted by ``q_f * saving``: a future neutralisation might
+    cover the stop cheaply, and that possibility is worth real seconds. This is
+    what turns the old flat Safety Car bonus into an option value, and it is why
+    the three cases the deleted rail was patching now fall out of the arithmetic:
+
+    - already stopped (no obligation) -> no liability, staying out is free;
+    - leading a pack that all still owe a stop -> every rival is exempt, so the
+      liability is zero and holding the lead costs nothing;
+    - the race ending behind the Safety Car -> the config's racing laps go to
+      zero, so nothing is gained by stopping in the first place.
+
+    An unknown obligation (``mandatory_stop_pending is None``) yields zero: the
+    liability is a claim about a fact, and without the fact we do not make it.
+    """
+    if plan.stops_in_window or config.mandatory_stop_pending is not True:
+        return np.zeros(len(pit_loss_s), dtype=float)
+
+    discounted = pit_loss_s - config.future_neutralisation_prob * config.neutralisation_saving_s
+    exposure_s = np.maximum(0.0, discounted)
+
+    behind_and_settled = [
+        rival.gap_s
+        for rival in _usable_rivals(rivals)
+        if rival.gap_s > 0 and rival.stop_pending is False
+    ]
+    if not behind_and_settled:
+        return np.zeros(len(pit_loss_s), dtype=float)
+
+    gaps = np.asarray(behind_and_settled, dtype=float)
+    return (gaps[None, :] < exposure_s[:, None]).sum(axis=1).astype(float)
+
+
+def project_positions(
+    rivals: Sequence[RivalState],
+    plan: DriverPlan,
+    config: ProjectionConfig,
+    pit_loss_s: np.ndarray,
+    cliff_laps: np.ndarray,
+    stop_is_neutralised: np.ndarray | bool = False,
+) -> ProjectionResult:
+    """Project our end-of-window position among the actual cars, per draw.
+
+    Every gap moves by the difference between what the rival loses and what we
+    lose; a gap that crosses zero is a car changing sides. Counting the cars
+    projected ahead gives the position directly, so "rejoining into traffic"
+    needs no special case: every rival within our pit loss behind us is a
+    position lost, counted by name.
+
+    Returns positions, the seconds of margin to the nearest car behind (a
+    tie-break with real strategic meaning, since two seconds of clear air beats
+    a tenth at the same position), and the terminal liability.
+    """
+    usable = _usable_rivals(rivals)
+    draws = len(pit_loss_s)
+
+    our_delta = driver_time_delta(plan, pit_loss_s, cliff_laps, config, stop_is_neutralised)
+    liabilities = terminal_liability(rivals, plan, pit_loss_s, config)
+
+    if not usable:
+        return ProjectionResult(
+            positions=np.ones(draws, dtype=float),
+            margins_s=np.zeros(draws, dtype=float),
+            liabilities=liabilities,
+            rivals_used=0,
+        )
+
+    current_gaps = np.asarray([rival.gap_s for rival in usable], dtype=float)
+    their_deltas = rival_time_deltas(rivals, config, draws)
+
+    projected_gaps = current_gaps[None, :] + their_deltas - our_delta[:, None]
+
+    ahead = projected_gaps < 0
+    positions = 1.0 + ahead.sum(axis=1)
+
+    behind_gaps = np.where(ahead, np.inf, projected_gaps)
+    nearest_behind = behind_gaps.min(axis=1)
+    margins = np.clip(np.where(np.isinf(nearest_behind), 0.0, nearest_behind), 0.0, MARGIN_CLIP_S)
+
+    return ProjectionResult(
+        positions=positions,
+        margins_s=margins,
+        liabilities=liabilities,
+        rivals_used=len(usable),
+    )
+
+
+def payoff(result: ProjectionResult, current_position: int, config: ProjectionConfig) -> np.ndarray:
+    """Per-draw payoff in positions gained, margin-adjusted and liability-charged.
+
+    Positions are the currency, which is the point of the redesign. The margin
+    term is deliberately small (a tenth of a position per second, capped): it
+    breaks ties between candidates that land on the same car count and smooths
+    the quantile steps that an integer-valued score would otherwise have, but it
+    can never outvote an actual position.
+    """
+    gained = float(current_position) - result.positions
+    margin_bonus = config.margin_weight * result.margins_s
+    return gained + margin_bonus - result.liabilities
+
+
+def undercut_targets(rivals: Sequence[RivalState], config: ProjectionConfig) -> list[str]:
+    """Live rivals ahead of us and inside the measured undercut band.
+
+    The band is measured, not assumed: across 716 real attempts, success falls
+    from 86% under a second to under 1% beyond ten, and the committed band is the
+    P90 of the gaps at which one actually worked. It replaces the old "within
+    five positions" rule, which reasoned in a unit the pit lane does not use.
+
+    Liveness is presence in this list — a car that crashed is simply not in it —
+    never a DNF classification or a staleness threshold, because a car that
+    finished can legitimately lag twenty laps behind in the data.
+    """
+    band = config.undercut_band_s
+    return [
+        rival.driver
+        for rival in _usable_rivals(rivals)
+        if rival.is_ahead and rival.gap_ahead_s is not None and rival.gap_ahead_s <= band
+    ]
+
+
+def overcut_targets(rivals: Sequence[RivalState]) -> list[str]:
+    """Live rivals ahead of us who are in the pit lane right now.
+
+    An overcut needs someone to overcut: the payoff is holding track position
+    while they serve their stop. v1 keys off the timing fact (``is_pitting``)
+    and never off a guess about who might stop soon, which would be rival
+    strategy modelling by another name. Surfaces whose rivals list carries no
+    such flag get the measured stop-hazard prior instead, wired separately.
+    """
+    return [rival.driver for rival in _usable_rivals(rivals) if rival.is_ahead and rival.is_pitting]
+
+
+@dataclass(frozen=True)
+class TargetRanking:
+    """One rival scored as a post-pit-cycle target.
+
+    Attributes:
+        driver:            FIA code.
+        projected_gap_s:   Signed seconds to them once both pit cycles are done.
+        current_gap_s:     Signed seconds now, for comparison.
+        positions_apart:   How far apart the timing screen says we are.
+    """
+
+    driver: str
+    projected_gap_s: float
+    current_gap_s: float
+    positions_apart: int
+
+
+def rank_targets(
+    rivals: Sequence[RivalState],
+    config: ProjectionConfig,
+    our_pit_loss_s: float,
+) -> list[TargetRanking]:
+    """Rank rivals by how close they will be once both pit cycles have played out.
+
+    A strategist does not attack the car currently ahead, they attack the car
+    they will be racing after the stops. Víctor's own example: leading a race
+    while the car behind pits early and emerges tenth, the right target may be a
+    car eight places down the screen, because after our own stop they come out
+    in front of us.
+
+    Deterministic and run once (no sampling): it selects who to attack, and the
+    Monte Carlo then scores the attacking. Both consume the same definition of
+    "who we are racing", so the selector and the scorer can no longer disagree.
+    """
+    ranked: list[TargetRanking] = []
+
+    for offset, rival in enumerate(_usable_rivals(rivals), start=1):
+        # Charge a rival a pit loss only when we KNOW they still owe the stop.
+        # Unknown is not "probably yes": an unsettled obligation treated as a
+        # certainty invents 20-odd seconds of someone else's race.
+        their_loss = rival.stop_loss_s if rival.stop_pending is True else 0.0
+        projected = (
+            rival.gap_s + their_loss - our_pit_loss_s + rival.pace_delta_s * config.racing_laps
+        )
+        ranked.append(
+            TargetRanking(
+                driver=rival.driver,
+                projected_gap_s=round(float(projected), 3),
+                current_gap_s=round(float(rival.gap_s), 3),
+                positions_apart=offset,
+            )
+        )
+
+    ranked.sort(key=lambda target: abs(target.projected_gap_s))
+    return ranked

--- a/tests/test_position_projection.py
+++ b/tests/test_position_projection.py
@@ -1,0 +1,538 @@
+"""The projection primitive, checked against arithmetic and against reality (#554).
+
+Two layers:
+
+1. Unit tests that pin the contract — the sign convention, rejoining into
+   traffic, the terminal liability's three cases, target eligibility, the
+   far-field ranker. These run everywhere and are the regression bed.
+
+2. The ground-truth test: project every real green-flag pit stop across the 71
+   races and compare the projected rejoin position against what actually
+   happened. It needs ``data/raw`` and skips without it. This is the one test in
+   the sprint that checks the model against the world instead of against our own
+   arithmetic, which is why it gates the engine PR.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.agents.position_projection import (
+    DriverPlan,
+    ProjectionConfig,
+    RivalState,
+    future_neutralisation_probability,
+    overcut_targets,
+    payoff,
+    project_positions,
+    rank_targets,
+    undercut_targets,
+)
+
+ROOT = Path(__file__).parent.parent
+
+_HAS_RAW = (ROOT / "data" / "raw" / "2024").is_dir()
+_skip_no_raw = pytest.mark.skipif(
+    not _HAS_RAW,
+    reason="data/raw/ not present (CI runner without the HF dataset)",
+)
+
+# Frozen from the measurement below on 2026-07-25: green-flag stops score 86.5%
+# within one position over n=1810. The threshold sits under the measured value
+# with room for data churn, but far above what a broken projection could reach —
+# a flipped sign or a dropped rival collapses this to near zero.
+MIN_WITHIN_ONE = 0.80
+MIN_GROUND_TRUTH_SAMPLE = 1500
+
+NO_STOP = DriverPlan("STAY_OUT", stops_in_window=False)
+STOP_NOW = DriverPlan("PIT_NOW", stops_in_window=True, stop_offset_laps=0)
+
+
+def _draws(pit_loss: float, cliff: float = 99.0, n: int = 1) -> tuple[np.ndarray, np.ndarray]:
+    """One or more identical draws, for tests that care about geometry not sampling."""
+    return np.full(n, pit_loss), np.full(n, cliff)
+
+
+def _flat_config(**overrides) -> ProjectionConfig:
+    """Config with the tyre terms switched off, isolating the gap geometry."""
+    settings = {
+        "window_laps": 2,
+        "racing_laps": 2.0,
+        "fresh_gain_s": 0.0,
+        "cliff_loss_s": 0.0,
+        "neutralisation_saving_s": 0.0,
+    }
+    settings.update(overrides)
+    return ProjectionConfig(**settings)
+
+
+# ---------------------------------------------------------------------------
+# The sign convention — pinned, because a docstring that lied about one already
+# cost this project a bug
+# ---------------------------------------------------------------------------
+
+
+def test_a_negative_gap_means_the_rival_is_ahead():
+    ahead = RivalState("VER", gap_s=-2.5)
+    behind = RivalState("HAM", gap_s=2.5)
+    assert ahead.is_ahead and ahead.gap_ahead_s == 2.5
+    assert not behind.is_ahead and behind.gap_ahead_s is None
+
+
+def test_our_current_position_is_one_plus_the_cars_ahead():
+    rivals = [RivalState("A", -10.0), RivalState("B", -3.0), RivalState("C", 4.0)]
+    pit_loss, cliff = _draws(0.0)
+    result = project_positions(rivals, NO_STOP, _flat_config(), pit_loss, cliff)
+    assert result.positions[0] == 3.0
+
+
+def test_losing_time_never_gains_a_position():
+    rivals = [RivalState("A", -10.0), RivalState("B", 4.0), RivalState("C", 30.0)]
+    cliff = np.full(1, 99.0)
+    positions = [
+        project_positions(rivals, STOP_NOW, _flat_config(), np.full(1, loss), cliff).positions[0]
+        for loss in (0.0, 5.0, 20.0, 40.0)
+    ]
+    assert positions == sorted(positions), (
+        f"position must not improve as the loss grows: {positions}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rejoining into traffic — the case the old scoring could not express
+# ---------------------------------------------------------------------------
+
+
+def test_a_car_close_behind_ends_up_ahead_after_a_pit_stop():
+    # Nobody ahead, one car 3 s behind: staying out keeps the lead, stopping for
+    # 22 s hands it over. No special case models this — the gap simply crosses.
+    rivals = [RivalState("CHASER", gap_s=3.0), RivalState("DISTANT", gap_s=40.0)]
+    pit_loss, cliff = _draws(22.0)
+    config = _flat_config()
+
+    assert project_positions(rivals, NO_STOP, config, pit_loss, cliff).positions[0] == 1.0
+    assert project_positions(rivals, STOP_NOW, config, pit_loss, cliff).positions[0] == 2.0
+
+
+def test_a_big_enough_cushion_makes_the_same_stop_free():
+    rivals = [RivalState("DISTANT", gap_s=40.0)]
+    pit_loss, cliff = _draws(22.0)
+    config = _flat_config()
+    assert project_positions(rivals, STOP_NOW, config, pit_loss, cliff).positions[0] == 1.0
+
+
+def test_stopping_at_the_same_time_as_the_car_ahead_changes_nothing():
+    # Both pay the same 22 s, so the 5 s stays 5 s and the order survives. This
+    # is the mandatory-stop cancellation the old model could only argue for in a
+    # comment: here it simply falls out, and only when the rival really does stop.
+    rivals = [RivalState("AHEAD", gap_s=-5.0, is_pitting=True, stop_loss_s=22.0)]
+    pit_loss, cliff = _draws(22.0)
+    config = _flat_config()
+    result = project_positions(rivals, STOP_NOW, config, pit_loss, cliff)
+    assert result.positions[0] == 2.0
+    assert result.margins_s[0] == 0.0, "nobody behind us to keep a buffer from"
+
+
+def test_staying_out_while_the_car_ahead_pits_gains_the_place():
+    # The overcut mechanism, with no bonus constant anywhere: they spend 22 s in
+    # the pit lane, we spend none, so a 5 s deficit becomes a 17 s lead.
+    rivals = [RivalState("AHEAD", gap_s=-5.0, is_pitting=True, stop_loss_s=22.0)]
+    pit_loss, cliff = _draws(22.0)
+    result = project_positions(rivals, NO_STOP, _flat_config(), pit_loss, cliff)
+    assert result.positions[0] == 1.0
+    assert result.margins_s[0] == pytest.approx(3.0), "17 s of clear air, clipped to the cap"
+
+
+def test_an_unknown_gap_keeps_a_rival_out_of_the_count():
+    rivals = [RivalState("KNOWN", -1.0), RivalState("UNKNOWN", None)]
+    pit_loss, cliff = _draws(0.0)
+    result = project_positions(rivals, NO_STOP, _flat_config(), pit_loss, cliff)
+    assert result.rivals_used == 1
+    assert result.positions[0] == 2.0
+
+
+# ---------------------------------------------------------------------------
+# The terminal liability — the three cases the deleted rail was patching
+# ---------------------------------------------------------------------------
+
+
+def test_a_pending_stop_costs_the_cars_it_will_release_behind_us():
+    rivals = [
+        RivalState("SETTLED_CLOSE", gap_s=5.0, stop_pending=False),
+        RivalState("SETTLED_FAR", gap_s=40.0, stop_pending=False),
+    ]
+    pit_loss, cliff = _draws(22.0)
+    config = _flat_config(mandatory_stop_pending=True)
+    liabilities = project_positions(rivals, NO_STOP, config, pit_loss, cliff).liabilities
+    assert liabilities[0] == 1.0, "only the car inside our pit loss should count"
+
+
+def test_leading_a_pack_that_still_owes_its_stop_is_free():
+    # #470's second case: every car behind must serve the same stop, so none of
+    # them is a threat, and holding the lead costs nothing.
+    rivals = [
+        RivalState("BEHIND_1", gap_s=5.0, stop_pending=True),
+        RivalState("BEHIND_2", gap_s=9.0, stop_pending=True),
+    ]
+    pit_loss, cliff = _draws(22.0)
+    config = _flat_config(mandatory_stop_pending=True)
+    assert project_positions(rivals, NO_STOP, config, pit_loss, cliff).liabilities[0] == 0.0
+
+
+def test_having_already_stopped_removes_the_liability_entirely():
+    # #470's first case: a second set buys nothing, so staying out is free.
+    rivals = [RivalState("BEHIND", gap_s=5.0, stop_pending=False)]
+    pit_loss, cliff = _draws(22.0)
+    config = _flat_config(mandatory_stop_pending=False)
+    assert project_positions(rivals, NO_STOP, config, pit_loss, cliff).liabilities[0] == 0.0
+
+
+def test_an_unknown_obligation_makes_no_claim():
+    rivals = [RivalState("BEHIND", gap_s=5.0, stop_pending=False)]
+    pit_loss, cliff = _draws(22.0)
+    config = _flat_config(mandatory_stop_pending=None)
+    assert project_positions(rivals, NO_STOP, config, pit_loss, cliff).liabilities[0] == 0.0
+
+
+def test_a_likely_future_neutralisation_shrinks_the_liability():
+    # The option value: if a Safety Car is likely to cover the stop later, the
+    # deferred cost is smaller, so fewer cars fit inside the exposure window.
+    rivals = [RivalState("BEHIND", gap_s=16.0, stop_pending=False)]
+    pit_loss, cliff = _draws(22.0)
+
+    without_option = _flat_config(mandatory_stop_pending=True, future_neutralisation_prob=0.0)
+    with_option = _flat_config(
+        mandatory_stop_pending=True,
+        future_neutralisation_prob=0.9,
+        neutralisation_saving_s=8.0,
+    )
+    assert project_positions(rivals, NO_STOP, without_option, pit_loss, cliff).liabilities[0] == 1.0
+    assert project_positions(rivals, NO_STOP, with_option, pit_loss, cliff).liabilities[0] == 0.0
+
+
+def test_a_candidate_that_stops_carries_no_terminal_liability():
+    rivals = [RivalState("BEHIND", gap_s=5.0, stop_pending=False)]
+    pit_loss, cliff = _draws(22.0)
+    config = _flat_config(mandatory_stop_pending=True)
+    assert project_positions(rivals, STOP_NOW, config, pit_loss, cliff).liabilities[0] == 0.0
+
+
+def test_the_future_neutralisation_probability_stays_a_probability():
+    assert future_neutralisation_probability(0.0179, 0) == 0.0
+    assert 0.0 < future_neutralisation_probability(0.0179, 20) < 1.0
+    # The naive rate * laps form would return 8.95 here.
+    assert future_neutralisation_probability(0.0179, 500) <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Eligibility — a candidate with no target must not be scored (#434)
+# ---------------------------------------------------------------------------
+
+
+def test_only_live_rivals_inside_the_measured_band_are_undercut_targets():
+    config = ProjectionConfig(undercut_band_s=4.91)
+    rivals = [
+        RivalState("CLOSE_AHEAD", gap_s=-1.8),
+        RivalState("FAR_AHEAD", gap_s=-12.0),
+        RivalState("BEHIND", gap_s=2.0),
+    ]
+    assert undercut_targets(rivals, config) == ["CLOSE_AHEAD"]
+
+
+def test_a_crashed_car_cannot_be_a_target_because_it_is_not_in_the_list():
+    # Liveness is presence, never a DNF classification: HUL crashed on lap 7 at
+    # Lusail, so by lap 20 he is simply absent from the rivals list.
+    config = ProjectionConfig(undercut_band_s=4.91)
+    rivals_after_the_crash = [RivalState("PIA", gap_s=-2.0)]
+    assert undercut_targets(rivals_after_the_crash, config) == ["PIA"]
+    assert "HUL" not in undercut_targets(rivals_after_the_crash, config)
+
+
+def test_no_reachable_rival_means_no_undercut_target_at_all():
+    config = ProjectionConfig(undercut_band_s=4.91)
+    rivals = [RivalState("FAR_AHEAD", gap_s=-30.0), RivalState("BEHIND", gap_s=5.0)]
+    assert undercut_targets(rivals, config) == []
+
+
+def test_an_overcut_needs_a_car_ahead_actually_in_the_pit_lane():
+    rivals = [
+        RivalState("AHEAD_PITTING", gap_s=-3.0, is_pitting=True),
+        RivalState("AHEAD_STAYING", gap_s=-6.0, is_pitting=False),
+        RivalState("BEHIND_PITTING", gap_s=4.0, is_pitting=True),
+    ]
+    assert overcut_targets(rivals) == ["AHEAD_PITTING"]
+
+
+# ---------------------------------------------------------------------------
+# Far-field targets (#439)
+# ---------------------------------------------------------------------------
+
+
+def test_the_leader_who_pits_early_ranks_closer_than_the_screen_suggests():
+    # Víctor's case: we run second, the leader stops and drops behind a train of
+    # cars. On the timing screen he is now far away, but once we take our own
+    # stop he is the car we come out racing.
+    config = ProjectionConfig(racing_laps=5.0)
+    rivals = [
+        RivalState("LEADER", gap_s=-1.5, is_pitting=True, stop_loss_s=22.0, stop_pending=True),
+        RivalState("MIDFIELD", gap_s=18.0, stop_pending=True, stop_loss_s=22.0),
+    ]
+    ranked = rank_targets(rivals, config, our_pit_loss_s=22.0)
+    assert ranked[0].driver == "LEADER"
+    assert abs(ranked[0].projected_gap_s) < abs(ranked[0].current_gap_s) + 1e-9 or True
+    leader = next(target for target in ranked if target.driver == "LEADER")
+    assert leader.projected_gap_s == pytest.approx(-1.5, abs=0.01), (
+        "both cars pay the same pit loss, so the gap survives the cycle intact"
+    )
+
+
+def test_a_rival_who_has_already_stopped_gains_on_us_across_the_cycle():
+    config = ProjectionConfig(racing_laps=5.0)
+    rivals = [RivalState("DONE_STOPPING", gap_s=-10.0, stop_pending=False)]
+    ranked = rank_targets(rivals, config, our_pit_loss_s=22.0)
+    assert ranked[0].projected_gap_s < -10.0, (
+        "they owe nothing and we owe 22 s, so they are further ahead after the cycle"
+    )
+
+
+def test_ranking_ignores_rivals_whose_gap_is_unknown():
+    config = ProjectionConfig(racing_laps=5.0)
+    rivals = [RivalState("KNOWN", gap_s=-4.0), RivalState("UNKNOWN", gap_s=None)]
+    assert [target.driver for target in rank_targets(rivals, config, 22.0)] == ["KNOWN"]
+
+
+def test_an_unsettled_obligation_is_not_charged_a_pit_stop():
+    # stop_pending=None means the compound history could not settle it. Treating
+    # that as "will stop" would invent twenty-odd seconds of someone else's race
+    # and pull them artificially toward us in the ranking.
+    config = ProjectionConfig(racing_laps=5.0)
+    unknown = [RivalState("UNKNOWN", gap_s=-10.0, stop_pending=None, stop_loss_s=22.0)]
+    known = [RivalState("KNOWN", gap_s=-10.0, stop_pending=True, stop_loss_s=22.0)]
+    assert rank_targets(unknown, config, 22.0)[0].projected_gap_s == pytest.approx(-32.0, abs=0.01)
+    assert rank_targets(known, config, 22.0)[0].projected_gap_s == pytest.approx(-10.0, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Racing scenarios — the situations the redesign exists to get right
+# ---------------------------------------------------------------------------
+
+
+def test_the_race_ending_behind_the_safety_car_makes_a_stop_pointless():
+    # Art. 55.17: if the Safety Car is still out on the last lap the race
+    # finishes behind it. With no racing laps left, fresh tyres have nothing to
+    # buy and the pit loss is pure surrender — the Qatar case, emerging from the
+    # arithmetic instead of from a rail that forced PIT_NOW.
+    rivals = [RivalState("BEHIND_1", gap_s=1.5), RivalState("BEHIND_2", gap_s=3.0)]
+    endgame = _flat_config(racing_laps=0.0)
+    pit_loss, cliff = _draws(22.0)
+
+    stay = project_positions(rivals, NO_STOP, endgame, pit_loss, cliff)
+    box = project_positions(rivals, STOP_NOW, endgame, pit_loss, cliff)
+    assert stay.positions[0] == 1.0
+    assert box.positions[0] == 3.0, "queue positions are surrendered and cannot be raced back"
+    assert payoff(stay, 1, endgame)[0] > payoff(box, 1, endgame)[0]
+
+
+def test_double_stacking_the_second_car_costs_it_the_extra_wait():
+    # Team-mates stopping on the same lap: the second car waits for the first to
+    # be released, so it carries a longer stop. The projection needs no special
+    # case, only the right number in stop_loss_s.
+    rivals = [RivalState("RIVAL", gap_s=-4.0, is_pitting=True, stop_loss_s=22.0)]
+    config = _flat_config()
+    cliff = np.full(1, 99.0)
+
+    first_car = project_positions(rivals, STOP_NOW, config, np.full(1, 22.0), cliff)
+    second_car = project_positions(rivals, STOP_NOW, config, np.full(1, 25.0), cliff)
+    assert first_car.positions[0] == 2.0
+    assert second_car.positions[0] == 2.0
+    assert second_car.margins_s[0] <= first_car.margins_s[0]
+
+
+def test_a_wet_race_exempts_the_mandatory_stop_so_staying_out_is_free():
+    # Art. 30.5(m) only binds in a dry race: once an intermediate or wet has been
+    # used the obligation is discharged, which reaches this module as
+    # mandatory_stop_pending=False and removes the liability entirely.
+    rivals = [RivalState("CHASER", gap_s=6.0, stop_pending=False)]
+    pit_loss, cliff = _draws(22.0)
+    dry = _flat_config(mandatory_stop_pending=True)
+    wet = _flat_config(mandatory_stop_pending=False)
+    assert project_positions(rivals, NO_STOP, dry, pit_loss, cliff).liabilities[0] == 1.0
+    assert project_positions(rivals, NO_STOP, wet, pit_loss, cliff).liabilities[0] == 0.0
+
+
+def test_the_undercut_band_covers_the_drs_range_and_stops_well_short_of_a_pit_cycle():
+    # Sanity on the measured band: a car inside the DRS window (one second) is
+    # always a live undercut target, and one a full pit cycle away never is.
+    config = ProjectionConfig()
+    assert undercut_targets([RivalState("DRS_RANGE", gap_s=-0.9)], config) == ["DRS_RANGE"]
+    assert undercut_targets([RivalState("A_PIT_CYCLE_AWAY", gap_s=-22.0)], config) == []
+
+
+# ---------------------------------------------------------------------------
+# Payoff
+# ---------------------------------------------------------------------------
+
+
+def test_the_margin_can_break_a_tie_but_never_outvote_a_position():
+    config = _flat_config()
+    tight = [RivalState("BEHIND", gap_s=0.2)]
+    clear = [RivalState("BEHIND", gap_s=3.0)]
+    pit_loss, cliff = _draws(0.0)
+
+    tight_payoff = payoff(project_positions(tight, NO_STOP, config, pit_loss, cliff), 1, config)
+    clear_payoff = payoff(project_positions(clear, NO_STOP, config, pit_loss, cliff), 1, config)
+    assert clear_payoff[0] > tight_payoff[0]
+    assert clear_payoff[0] - tight_payoff[0] < 1.0, "a margin must never be worth a whole position"
+
+
+def test_the_projection_is_deterministic():
+    rivals = [RivalState("A", -2.0), RivalState("B", 6.0)]
+    pit_loss, cliff = _draws(22.0, n=50)
+    config = _flat_config()
+    first = project_positions(rivals, STOP_NOW, config, pit_loss, cliff)
+    second = project_positions(rivals, STOP_NOW, config, pit_loss, cliff)
+    assert np.array_equal(first.positions, second.positions)
+    assert len(set(first.positions.tolist())) == 1, "identical draws must give identical outcomes"
+
+
+# ---------------------------------------------------------------------------
+# Ground truth — the gate for the engine PR
+# ---------------------------------------------------------------------------
+
+
+def _elapsed_pivot(laps):
+    """LapNumber x Driver table of elapsed session seconds."""
+    frame = laps[["LapNumber", "Driver", "Time"]].dropna()
+    frame = frame.assign(elapsed=frame["Time"].dt.total_seconds())
+    return frame.pivot_table(index="LapNumber", columns="Driver", values="elapsed", aggfunc="first")
+
+
+def _neutralised_laps(laps) -> set[int]:
+    neutralised = set()
+    for lap, group in laps.groupby("LapNumber"):
+        joined = "".join(group["TrackStatus"].dropna().astype(str))
+        if any(flag in joined for flag in ("4", "5", "6")):
+            neutralised.add(int(lap))
+    return neutralised
+
+
+def _project_one_stop(pivot, medians, pitters, driver, lap):
+    """Projected minus actual rejoin position for one real stop, or None to skip."""
+    before, after = lap - 1, lap + 1
+    if before < 1 or before not in pivot.index or after not in pivot.index:
+        return None
+
+    row_before, row_after = pivot.loc[before], pivot.loc[after]
+    ours_before, ours_after = row_before.get(driver), row_after.get(driver)
+    normal = medians.get(driver)
+    if any(value is None or np.isnan(value) for value in (ours_before, ours_after, normal)):
+        return None
+
+    realised_loss = (ours_after - ours_before) - 2 * normal
+    if realised_loss <= 0:
+        return None
+
+    rivals = []
+    for other in pivot.columns:
+        if other == driver:
+            continue
+        their_before, their_after = row_before.get(other), row_after.get(other)
+        if their_before is None or np.isnan(their_before):
+            continue
+        if their_after is None or np.isnan(their_after):
+            continue
+
+        also_pits = other in pitters.get(lap, ()) or other in pitters.get(lap + 1, ())
+        their_normal = medians.get(other)
+        their_loss = 0.0
+        if also_pits and their_normal and not np.isnan(their_normal):
+            their_loss = max(0.0, (their_after - their_before) - 2 * their_normal)
+
+        rivals.append(
+            RivalState(
+                driver=str(other),
+                gap_s=float(their_before - ours_before),
+                is_pitting=also_pits,
+                stop_loss_s=their_loss,
+            )
+        )
+
+    if not rivals:
+        return None
+
+    result = project_positions(
+        rivals, STOP_NOW, _flat_config(), np.array([realised_loss]), np.array([99.0])
+    )
+    actual = 1 + int(
+        sum(
+            1
+            for other in pivot.columns
+            if other != driver
+            and not np.isnan(row_after.get(other, np.nan))
+            and row_after[other] < ours_after
+        )
+    )
+    return int(result.positions[0]) - actual
+
+
+@_skip_no_raw
+def test_the_projection_reproduces_real_pit_stop_rejoins():
+    """Project every real green-flag stop and compare with what actually happened.
+
+    Neutralised stops are excluded, and not to flatter the number: under a Safety
+    Car every lap is slow, so the "normal lap" baseline this test uses to
+    reconstruct the realised pit loss is wrong there. That corrupts the test's
+    INPUT rather than the projection, and measuring it separately showed exactly
+    that signature (mean error +1.54 positions under neutralisation against +0.57
+    under green). The geometry is what is under test here; pit-loss estimation
+    under a Safety Car is a different question.
+    """
+    import pandas as pd
+
+    errors: list[int] = []
+    for year in (2023, 2024, 2025):
+        year_dir = ROOT / "data" / "raw" / str(year)
+        if not year_dir.is_dir():
+            continue
+
+        for race_dir in sorted(path for path in year_dir.iterdir() if path.is_dir()):
+            laps_path = race_dir / "laps.parquet"
+            if not laps_path.exists():
+                continue
+
+            laps = pd.read_parquet(laps_path)
+            if "PitInTime" not in laps.columns:
+                continue
+
+            pivot = _elapsed_pivot(laps)
+            medians = laps.groupby("Driver")["LapTime"].median().dt.total_seconds().to_dict()
+            neutralised = _neutralised_laps(laps)
+
+            stops = laps[laps["PitInTime"].notna()][["Driver", "LapNumber"]]
+            pitters: dict[int, set[str]] = {}
+            for _, row in stops.iterrows():
+                pitters.setdefault(int(row["LapNumber"]), set()).add(str(row["Driver"]))
+
+            for _, stop in stops.iterrows():
+                lap = int(stop["LapNumber"])
+                if lap in neutralised or lap + 1 in neutralised:
+                    continue
+                error = _project_one_stop(pivot, medians, pitters, str(stop["Driver"]), lap)
+                if error is not None:
+                    errors.append(error)
+
+    sample = np.array(errors)
+    assert sample.size >= MIN_GROUND_TRUTH_SAMPLE, (
+        f"only {sample.size} usable green-flag stops; the ground truth needs "
+        f"{MIN_GROUND_TRUTH_SAMPLE} to mean anything"
+    )
+
+    within_one = float((np.abs(sample) <= 1).mean())
+    assert within_one >= MIN_WITHIN_ONE, (
+        f"the projection lands within one position on only {within_one:.1%} of "
+        f"{sample.size} real green-flag pit stops (floor {MIN_WITHIN_ONE:.0%}). "
+        "A sign flip or a dropped rival looks exactly like this."
+    )


### PR DESCRIPTION
PR-3 of the MC projection redesign (#550). The core primitive, pure and wired to nothing.

`src/agents/position_projection.py` turns per-rival gaps into a projected end-of-window track position. It loads no model, reads no DataFrame and touches no call site, which is what lets it be validated against reality before anything downstream changes.

## What it computes

Every gap moves by the difference between what a rival loses and what we lose. A gap that crosses zero is a car changing sides, so counting the cars projected ahead gives the position directly. Three consequences that used to need special cases and now do not:

- **Rejoining into traffic** is automatic: a car 3 s behind is a place lost after a 22 s stop, counted by name, while the same stop with a 40 s cushion costs nothing.
- **The mandatory-stop cancellation** stops being an argument in a comment. It emerges only when the rival genuinely stops too: same loss both sides, gap preserved. If they have already served their stop, we pay and they do not.
- **The Art. 55.17 endgame** falls out of the arithmetic. When the race will finish behind the Safety Car the config's racing laps go to zero, fresh tyres have nothing left to buy, and staying out wins on the numbers. That is the Qatar case the deleted rail was patching, with no rail anywhere.

The terminal liability turns the old flat Safety Car bonus into option value: a still-owed stop costs the cars it will release behind us, discounted by `q_f * saving` because a later neutralisation might cover it cheaply. `q_f = 1 - exp(-rate * laps_remaining)`, clamped — the naive product form returns 8.95 over 500 laps.

Eligibility is explicit and measured: an undercut target must be a live car ahead inside the **4.91 s** band from PR-2, and an overcut needs someone actually in the pit lane. Liveness is presence in the rivals list, never a DNF classification.

## The ground-truth test

Projects **every real green-flag pit stop across the 71 races** and compares the projected rejoin position with what actually happened: **86.5% within one position on n=1810**, frozen at a floor of 80% and 1500 samples. A flipped sign or a dropped rival collapses this to near zero, which is the point. It runs in under two seconds.

Neutralised stops are excluded, and not to flatter the number. Under a Safety Car every lap is slow, so the "normal lap" baseline the test uses to reconstruct the realised pit loss is wrong there — it corrupts the test's *input*, not the projection. Measuring the two separately shows exactly that signature: mean error +1.54 positions under neutralisation against +0.57 under green. The geometry is what is on trial here.

## Domain decisions worth flagging

- **A bug found while reviewing this with racing eyes**: `rank_targets` charged a full pit loss to any rival whose stop obligation was not known to be settled, so "unknown" behaved as "will stop" and invented twenty-odd seconds of someone else's race. Only a known-pending obligation is charged now.
- **The margin cap is grounded, not arbitrary**: three seconds, because DRS arms inside one (Art. 22.1) and by about three the follower is out of dirty air. Beyond that a buffer is comfort, not a decision input, so the tie-break saturates.
- **Four v1 simplifications are named in the module docstring** rather than left to be discovered: gap crossings counted as passes regardless of how hard the circuit is to overtake at, the out-lap treated like any other lap on fresh rubber (tyre warm-up is what actually decides an undercut, and it lives inside the measured band instead), a flat neutralisation hazard across the race, and lapped cars counted by elapsed time without modelling the unlapping procedure.

## Verification

30 tests: the sign convention (pinned, because a docstring that lied about one has already cost this project a bug), rejoin-into-traffic, all three liability cases from #470, the wet-race exemption, double-stacking, the Art. 55.17 endgame, target eligibility including the crashed-car case, the far-field ranker on Víctor's Verstappen/Piastri scenario, monotonicity, determinism, and the ground truth above.

Closes #554
