### PR TITLE
feat(mc): score the candidates in projected track position

### DIFF
--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -695,6 +695,193 @@ def simulate_lap_window(
     return time_delta / POS_GAP_S
 
 
+# Pooled green-flag pit loss measured over this repo's 71 races (n=1746, ~22.6 s),
+# used only when the caller cannot say which circuit we are at. The per-circuit
+# table (#448) spans 19.7 s at Budapest to 27.5 s at Marina Bay, so a caller that
+# knows the GP should always pass its own figure through pit_context.
+DEFAULT_PIT_TRAVERSAL_S = 20.0
+
+# Racing laps left inside a W=5 window once a Safety Car is out, measured over the
+# same races (2.61, n=215 neutralised laps). Under a VSC the field is not queued and
+# more of the window is raced (2.91, n=80).
+RACING_LAPS_UNDER_SC = 2.61
+RACING_LAPS_UNDER_VSC = 2.91
+
+
+def _rival_states_from_lap_state(rivals: list[dict], pit_context: dict | None):
+    """Adapt the lap_state rivals list into the projection's own value type.
+
+    The one place that knows the RaceStateManager field names, so a rename there
+    lands here and nowhere else. A rival whose interval is unknown keeps a None
+    gap and the projection drops it from the count rather than inventing a zero.
+    """
+    from src.agents.position_projection import RivalState
+
+    context = pit_context or {}
+    per_rival_pending: dict = context.get("rival_stop_pending") or {}
+    rival_loss = float(context.get("rival_pit_loss_s") or context.get("pit_loss_s") or 0.0)
+
+    states = []
+    for rival in rivals:
+        driver = str(rival.get("driver", ""))
+        states.append(
+            RivalState(
+                driver=driver,
+                gap_s=rival.get("interval_to_driver_s"),
+                is_pitting=bool(rival.get("is_pitting", False)),
+                stop_pending=per_rival_pending.get(driver),
+                stop_loss_s=rival_loss,
+            )
+        )
+    return states
+
+
+def _run_projection_mc(
+    *,
+    rivals: list[dict],
+    position: int | None,
+    laps_remaining: int | None,
+    pit_context: dict | None,
+    cliff_s,
+    sc_s,
+    pit_s,
+    ucut_s,
+    alpha: float,
+    neutralisation_saving_s: float,
+) -> dict:
+    """Score the four candidates in projected track position instead of seconds.
+
+    Same draws, same window, same alpha·E + (1−alpha)·P10 as the legacy path; what
+    changes is the currency. Each candidate is projected against the ACTUAL cars on
+    track (``position_projection``), so the pit lane, the traffic we rejoin into and
+    the still-owed stop all enter the score as cars rather than as constants.
+
+    Draws are shared across candidates (common random numbers) and across the two
+    neutralisation regimes: a draw that samples a Safety Car is scored with the
+    measured racing-lap count for one, and the same draw under green with the full
+    window. That per-draw split is why the Art. 55.17 endgame needs no rail — with
+    the race finishing behind the Safety Car there are no racing laps left, so a
+    stop buys nothing and staying out wins on the numbers.
+
+    Returns the usual four keys, each with E / P10 / P90 / score, plus ``eligible``
+    and ``target``. A candidate with no valid target is ``eligible: false`` with a
+    ``score`` of None — never a numeric sentinel, which is the 0.5 coin-flip that
+    used to hand UNDERCUT a bonus with no target at all (#434).
+    """
+    import numpy as _np
+
+    from src.agents.position_projection import (
+        DriverPlan,
+        ProjectionConfig,
+        future_neutralisation_probability,
+        overcut_targets,
+        payoff,
+        project_positions,
+        undercut_targets,
+    )
+
+    context = pit_context or {}
+    traversal_s = float(context.get("traversal_s") or DEFAULT_PIT_TRAVERSAL_S)
+    rival_states = _rival_states_from_lap_state(rivals, pit_context)
+
+    # Total pit loss per draw: the lane traversal plus the physical stop. The legacy
+    # scoring charged only the stop and argued in a comment that the traversal
+    # cancels; here it is charged per car, so the cancellation happens exactly when
+    # the rival really pays it too, and not otherwise.
+    pit_loss_s = traversal_s + _np.asarray(pit_s, dtype=float)
+
+    current_position = int(position) if position else 1
+    remaining = int(laps_remaining) if laps_remaining else 0
+    onset_rate = float(context.get("neutralisation_rate") or 0.0)
+    q_f = future_neutralisation_probability(onset_rate, remaining)
+
+    racing_when_neutralised = float(
+        context.get("racing_laps_neutralised")
+        or (RACING_LAPS_UNDER_VSC if context.get("vsc_active") else RACING_LAPS_UNDER_SC)
+    )
+
+    def _config(racing_laps: float) -> ProjectionConfig:
+        return ProjectionConfig(
+            window_laps=WINDOW_LAPS,
+            racing_laps=racing_laps,
+            fresh_gain_s=FRESH_GAIN,
+            cliff_loss_s=CLIFF_LOSS,
+            neutralisation_saving_s=neutralisation_saving_s,
+            future_neutralisation_prob=q_f,
+            laps_remaining=remaining,
+            mandatory_stop_pending=context.get("mandatory_stop_pending"),
+        )
+
+    green_config = _config(float(WINDOW_LAPS))
+    neutralised_config = _config(racing_when_neutralised)
+
+    undercut_choices = undercut_targets(rival_states, green_config)
+    overcut_choices = overcut_targets(rival_states)
+
+    plans = {
+        "STAY_OUT": DriverPlan("STAY_OUT", stops_in_window=False),
+        "PIT_NOW": DriverPlan("PIT_NOW", stops_in_window=True, stop_offset_laps=0),
+        "UNDERCUT": DriverPlan("UNDERCUT", stops_in_window=True, stop_offset_laps=0),
+        # An overcut runs on for a lap while the target serves their stop, then boxes.
+        "OVERCUT": DriverPlan("OVERCUT", stops_in_window=True, stop_offset_laps=1),
+    }
+    targets = {"UNDERCUT": undercut_choices, "OVERCUT": overcut_choices}
+
+    neutralised = _np.asarray(sc_s, dtype=bool)
+    results: dict = {}
+
+    for name, plan in plans.items():
+        choices = targets.get(name)
+        if choices is not None and not choices:
+            results[name] = {
+                "E": None,
+                "P10": None,
+                "P90": None,
+                "score": None,
+                "eligible": False,
+                "target": None,
+            }
+            continue
+
+        green = project_positions(
+            rival_states, plan, green_config, pit_loss_s, cliff_s, stop_is_neutralised=False
+        )
+        under_sc = project_positions(
+            rival_states,
+            plan,
+            neutralised_config,
+            pit_loss_s,
+            cliff_s,
+            stop_is_neutralised=True,
+        )
+        outcomes = _np.where(
+            neutralised,
+            payoff(under_sc, current_position, neutralised_config),
+            payoff(green, current_position, green_config),
+        )
+
+        if name == "UNDERCUT":
+            # N16 answers the one question it was trained on: does the undercut
+            # actually clear the target? A success is worth the place, and the
+            # projection supplies everything else. No new constant is introduced —
+            # the alternative was inventing an out-lap delta nobody measured.
+            outcomes = outcomes + _np.asarray(ucut_s, dtype=float)
+
+        e_val = float(_np.mean(outcomes))
+        p10_val = float(_np.percentile(outcomes, 10))
+        p90_val = float(_np.percentile(outcomes, 90))
+        results[name] = {
+            "E": round(e_val, 3),
+            "P10": round(p10_val, 3),
+            "P90": round(p90_val, 3),
+            "score": round(alpha * e_val + (1 - alpha) * p10_val, 3),
+            "eligible": True,
+            "target": choices[0] if choices else None,
+        }
+
+    return results
+
+
 def _run_mc_simulation(
     pace_out,
     tire_out,
@@ -728,13 +915,12 @@ def _run_mc_simulation(
         RaceState.risk_tolerance. score = alpha·E[S] + (1−alpha)·P10[S].
         α=1.0 is pure expected value (aggressive); α=0.0 is worst-case only.
     rivals / position / laps_remaining / pit_context:
-        Race-context state for the projection-based scoring (#550). Accepted
-        since #552 and IGNORED here on purpose: every current caller leaves
-        them at their defaults and this body is the legacy seconds-based
-        scoring, which must stay byte-identical (the strategy goldens pin it).
-        The projection engine (#555) dispatches on truthy ``rivals``; a falsy
-        value — None, or the ``[]`` the default lap_state builders emit —
-        means "no per-rival gap data" and keeps this path.
+        Race-context state for the projection-based scoring (#550). A TRUTHY
+        ``rivals`` list routes to ``_run_projection_mc``, which scores in
+        projected track position; a falsy value — None, or the ``[]`` the
+        default lap_state builders emit — means "no per-rival gap data" and
+        keeps the legacy seconds-based body below, byte-identical (the strategy
+        goldens pin it to the digit). None means unknown, never zero rivals.
     """
     rng = np.random.default_rng(seed=42)
     n   = CFG.n_sim
@@ -806,6 +992,24 @@ def _run_mc_simulation(
     sc_s    = rng.random(n) < sc_prob
     pit_s   = rng.triangular(pit_p05, pit_p50, pit_p95, n)
     ucut_s  = rng.random(n) < ucut_prob
+
+    # Common random numbers: every candidate is scored on the SAME draw vectors, so
+    # the comparison between them carries no sampling noise of its own. That is what
+    # an argmax over 500 draws needs — the variance that matters is the variance of
+    # the DIFFERENCES, and sharing the draws collapses it.
+    if rivals:
+        return _run_projection_mc(
+            rivals=rivals,
+            position=position,
+            laps_remaining=laps_remaining,
+            pit_context=pit_context,
+            cliff_s=cliff_s,
+            sc_s=sc_s,
+            pit_s=pit_s,
+            ucut_s=ucut_s,
+            alpha=alpha,
+            neutralisation_saving_s=sc_pit_bonus,
+        )
 
     strategies = ["STAY_OUT", "PIT_NOW", "UNDERCUT", "OVERCUT"]
     results    = {}

--- a/tests/test_mc_is_a_real_decision.py
+++ b/tests/test_mc_is_a_real_decision.py
@@ -13,17 +13,18 @@ Before the OVERCUT fix, over 160 plausible race states:
 
 One candidate was free, one dominated, one unreachable.
 
-STAY_OUT scoring at most zero is by design: simulate_lap_window documents it as the
-reference the others are scored against, so a zero ceiling is expected. What these tests
-require is that it can still be the argmax; a reference that can never be chosen is not a
-reference.
+Two paths are swept here. The LEGACY path (no rivals) scores in seconds and is what
+the strategy goldens pin; the PROJECTION path (rivals present) scores in projected
+track position and is what the redesign added. Both must be real decisions.
 """
 
 from __future__ import annotations
 
 import itertools
+from collections import Counter
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 ROOT = Path(__file__).parent.parent
@@ -54,6 +55,11 @@ def _argmax(state: tuple) -> str:
     return max(scores, key=scores.get)
 
 
+# ---------------------------------------------------------------------------
+# Legacy path — seconds, no rivals. Frozen behaviour, still swept.
+# ---------------------------------------------------------------------------
+
+
 def test_the_argmax_is_not_a_constant():
     """A layer that answers the same thing regardless of its inputs is not computing.
 
@@ -75,8 +81,6 @@ def test_no_strategy_wins_almost_everything():
     distribution is: it is a smoke alarm for a candidate that has been handed an
     advantage the others pay for.
     """
-    from collections import Counter
-
     wins = Counter(_argmax(state) for state in _STATES)
     top, count = wins.most_common(1)[0]
     share = count / len(_STATES)
@@ -101,35 +105,6 @@ def test_staying_out_is_reachable():
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Known limitation, not a regression. The MC has no term for what an overcut "
-        "buys, which is track position while the rival pits. Charging OVERCUT its stop "
-        "(an overcut still pits) leaves it with the same cost as PIT_NOW and half the "
-        "fresh-tyre laps, so it cannot strictly win; PIT_NOW is likewise a tie-alias of "
-        "UNDERCUT when the undercut fails. Tracked in the MC issue. When this test "
-        "starts passing, the model has gained the missing term and the xfail can go."
-    ),
-)
-def test_no_candidate_dominates_another_by_construction():
-    """If A >= B for every state, B can never strictly win and the choice is not a choice.
-
-    `UNDERCUT` is `PIT_NOW + ucut_bonus` with `ucut_bonus >= 0`, so PIT_NOW cannot
-    strictly beat it anywhere. And OVERCUT, once charged for its stop, is PIT_NOW with
-    half the fresh laps. The invariant is right and the model does not meet it: that is
-    worth stating out loud rather than deleting the assertion.
-    """
-    for a, b in itertools.permutations(STRATEGIES, 2):
-        a_always_at_least_b = all(_score(a, s) >= _score(b, s) for s in _STATES)
-        b_strictly_wins_somewhere = any(_score(b, s) > _score(a, s) for s in _STATES)
-        assert not (a_always_at_least_b and not b_strictly_wins_somewhere), (
-            f"{a} >= {b} on every one of {len(_STATES)} race states, so {b} can never "
-            f"strictly win: it is dominated by construction and the choice between them "
-            f"is not a choice"
-        )
-
-
 def test_every_strategy_that_pits_pays_for_the_stop():
     """The structural cause, asserted directly.
 
@@ -144,3 +119,198 @@ def test_every_strategy_that_pits_pays_for_the_stop():
             f"{strategy} scores the same with a 2.2 s stop and an 11.0 s one, so it is "
             f"not paying for the pit stop it makes"
         )
+
+
+# ---------------------------------------------------------------------------
+# Projection path — positions, real rivals
+# ---------------------------------------------------------------------------
+
+_DRAWS = 200
+_GAPS_AHEAD = (-1.2, -4.5, -15.0)
+_GAPS_BEHIND = (1.5, 8.0, 26.0)
+_PROJECTION_STATES = tuple(
+    itertools.product(
+        _GAPS_AHEAD,
+        _GAPS_BEHIND,
+        (True, False),  # a car ahead is serving its stop right now
+        (1.0, 6.0, 20.0),  # laps to the cliff
+        (True, False),  # neutralisation in the window
+        (True, False),  # we still owe the mandatory stop
+        (2.4, 3.6, 9.0),  # physical stop seconds
+    )
+)
+
+
+def _projection_scores(state: tuple) -> dict:
+    """Score one projected race state, returning the four candidates' dicts."""
+    from src.agents.strategy_orchestrator import _run_projection_mc
+
+    gap_ahead, gap_behind, ahead_pitting, cliff, neutralised, owes_stop, stop_s = state
+    rivals = [
+        {"driver": "A", "interval_to_driver_s": gap_ahead, "is_pitting": ahead_pitting},
+        {"driver": "B", "interval_to_driver_s": gap_behind, "is_pitting": False},
+        {"driver": "C", "interval_to_driver_s": gap_behind + 18.0, "is_pitting": False},
+    ]
+    return _run_projection_mc(
+        rivals=rivals,
+        position=2,
+        laps_remaining=22,
+        pit_context={
+            "traversal_s": 21.0,
+            "mandatory_stop_pending": owes_stop,
+            "neutralisation_rate": 0.0179,
+            "rival_stop_pending": {"B": False, "C": False},
+            "rival_pit_loss_s": 23.8,
+        },
+        cliff_s=np.full(_DRAWS, cliff),
+        sc_s=np.full(_DRAWS, neutralised),
+        pit_s=np.full(_DRAWS, stop_s),
+        ucut_s=(np.arange(_DRAWS) % 2 == 0),
+        alpha=0.5,
+        neutralisation_saving_s=8.0,
+    )
+
+
+def _projection_argmax(scores: dict) -> str:
+    live = {name: cell["score"] for name, cell in scores.items() if cell["score"] is not None}
+    return max(live, key=live.get)
+
+
+@pytest.fixture(scope="module")
+def projection_sweep() -> list[dict]:
+    return [_projection_scores(state) for state in _PROJECTION_STATES]
+
+
+def test_the_projection_argmax_is_not_a_constant(projection_sweep):
+    winners = {_projection_argmax(scores) for scores in projection_sweep}
+    assert len(winners) > 1, (
+        f"the projection argmax is {winners.pop()!r} across all "
+        f"{len(_PROJECTION_STATES)} race states"
+    )
+
+
+def test_no_projected_candidate_wins_almost_everything(projection_sweep):
+    wins = Counter(_projection_argmax(scores) for scores in projection_sweep)
+    top, count = wins.most_common(1)[0]
+    share = count / len(projection_sweep)
+    assert share < 0.85, f"{top} takes {share:.1%} of the projection sweep: {dict(wins)}"
+
+
+def test_staying_out_and_pitting_are_both_reachable_on_the_projection(projection_sweep):
+    """Both must be choosable, and here they are choosable for opposite reasons.
+
+    Staying out wins when the cars behind still owe their own stop or sit beyond our
+    pit loss; pitting wins when the deferred stop would cost more later than the
+    places it costs now. That trade is the terminal liability doing its job, and it
+    is why neither needs a bonus constant to be reachable.
+    """
+    wins = Counter(_projection_argmax(scores) for scores in projection_sweep)
+    assert wins["STAY_OUT"] > 0, f"STAY_OUT never wins on the projection: {dict(wins)}"
+    assert wins["PIT_NOW"] > 0, f"PIT_NOW never wins on the projection: {dict(wins)}"
+
+
+def test_an_undercut_without_a_target_is_ineligible_and_never_scored(projection_sweep):
+    """#434's sentinel, dead: no target means no number at all, never a 0.5 coin flip."""
+    ineligible = [s for s in projection_sweep if not s["UNDERCUT"]["eligible"]]
+    assert ineligible, "the sweep must contain states with no reachable undercut target"
+    for scores in ineligible:
+        assert scores["UNDERCUT"]["score"] is None
+        assert scores["UNDERCUT"]["target"] is None
+        assert _projection_argmax(scores) != "UNDERCUT"
+
+
+def test_an_eligible_undercut_names_the_car_it_is_attacking(projection_sweep):
+    eligible = [s for s in projection_sweep if s["UNDERCUT"]["eligible"]]
+    assert eligible, "the sweep must contain reachable undercut targets"
+    for scores in eligible:
+        assert scores["UNDERCUT"]["target"] == "A"
+        assert scores["UNDERCUT"]["score"] is not None
+
+
+def test_an_overcut_is_only_offered_when_a_car_ahead_is_in_the_pit_lane(projection_sweep):
+    for scores in projection_sweep:
+        if scores["OVERCUT"]["eligible"]:
+            assert scores["OVERCUT"]["target"] == "A"
+        else:
+            assert scores["OVERCUT"]["score"] is None
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "OVERCUT still cannot strictly win, and the projection narrowed WHY rather "
+        "than fixing it. Within one window both candidates take the same stop and pay "
+        "the same lane, so an overcut is PIT_NOW minus a lap of fresh rubber. What "
+        "makes a real overcut pay is the out-lap: a new set needs a lap to switch on, "
+        "so worn-but-warm tyres can out-run it. That warm-up is measurable from the "
+        "raw laps and is not modelled in v1 (it lives inside the measured undercut "
+        "band instead), so this stays an honest xfail with a named fix rather than a "
+        "deleted assertion. When the out-lap penalty is measured, this passes."
+    ),
+)
+def test_the_overcut_can_win_somewhere(projection_sweep):
+    wins = Counter(_projection_argmax(scores) for scores in projection_sweep)
+    assert wins["OVERCUT"] > 0, f"OVERCUT never wins on the projection: {dict(wins)}"
+
+
+def test_a_slower_stop_is_worse_for_every_projected_candidate_that_pits():
+    fast = (-4.5, 8.0, False, 20.0, False, True, 2.4)
+    slow = (-4.5, 8.0, False, 20.0, False, True, 11.0)
+    fast_scores, slow_scores = _projection_scores(fast), _projection_scores(slow)
+    for name in ("PIT_NOW", "UNDERCUT"):
+        if fast_scores[name]["score"] is None or slow_scores[name]["score"] is None:
+            continue
+        assert slow_scores[name]["score"] <= fast_scores[name]["score"], (
+            f"{name} does not get worse with a slower stop on the projection path"
+        )
+
+
+def test_the_race_finishing_behind_the_safety_car_favours_staying_out():
+    """Art. 55.17, emergent: with no racing laps left a stop cannot pay itself back.
+
+    No rail forces this. The measured racing-lap count under a neutralisation drops
+    the window to almost nothing, the fresh tyres have nowhere to earn their cost,
+    and the cars queued behind become places surrendered for free.
+    """
+    from src.agents.strategy_orchestrator import _run_projection_mc
+
+    rivals = [
+        {"driver": "B", "interval_to_driver_s": 1.2, "is_pitting": False},
+        {"driver": "C", "interval_to_driver_s": 3.0, "is_pitting": False},
+    ]
+    scores = _run_projection_mc(
+        rivals=rivals,
+        position=1,
+        laps_remaining=1,
+        pit_context={
+            "traversal_s": 21.0,
+            "mandatory_stop_pending": False,
+            "neutralisation_rate": 0.0179,
+            "racing_laps_neutralised": 0.0,
+            "rival_stop_pending": {"B": False, "C": False},
+            "rival_pit_loss_s": 23.8,
+        },
+        cliff_s=np.full(_DRAWS, 2.0),
+        sc_s=np.full(_DRAWS, True),
+        pit_s=np.full(_DRAWS, 2.8),
+        ucut_s=np.zeros(_DRAWS, dtype=bool),
+        alpha=0.5,
+        neutralisation_saving_s=8.0,
+    )
+    assert _projection_argmax(scores) == "STAY_OUT"
+    assert scores["STAY_OUT"]["score"] > scores["PIT_NOW"]["score"]
+
+
+def test_the_legacy_path_is_taken_whenever_the_rivals_list_is_falsy():
+    """None and [] both mean "no per-rival data", and both must keep the old scoring.
+
+    Three lap_state builders default the list to ``[]``, so a None-only check would
+    have routed them into a projection with no cars in it.
+    """
+    from src.agents.strategy_orchestrator import _run_mc_simulation
+    from tests.test_mc_state_helpers import _canned_outputs
+
+    pace, tire, situation, pit = _canned_outputs()
+    baseline = _run_mc_simulation(pace, tire, situation, pit, alpha=0.5)
+    for falsy in (None, [], ()):
+        assert _run_mc_simulation(pace, tire, situation, pit, alpha=0.5, rivals=falsy) == baseline


### PR DESCRIPTION
PR-4 of the MC projection redesign (#550). The engine, reachable by nobody yet.

`_run_projection_mc` scores the four candidates in projected track position instead of seconds. `_run_mc_simulation` routes to it only when `rivals` is truthy; a falsy list — None, or the `[]` three lap_state builders default to — keeps the legacy body, and the strategy goldens still pass byte-identical. No call site passes rivals yet, so this lands without touching a single consumer.

## What changes inside the scoring

- **The pit lane finally exists**: `D = per-circuit traversal + physical stop`, charged per car. The old scoring charged only the stop and argued in a comment that the traversal cancels. Now the cancellation *happens* — exactly when the rival really pays it too, and not otherwise.
- **Both neutralisation regimes are scored on the same draws.** A draw that samples a Safety Car is scored with the measured racing-lap count (2.61 of 5, PR-2), the same draw under green with the full window. Common random numbers across candidates and regimes, so the variance that matters — the variance of the *differences* an argmax consumes — collapses.
- **Ineligible candidates get no number.** No target means `eligible: false` and `score: null`, and the argmax skips nulls. That is #434's 0.5 coin flip dead at the gate rather than tuned away.
- **UNDERCUT introduces no new constant.** It is projected with PIT_NOW's mechanics, and N16 — the model trained and calibrated for exactly this question — decides whether the attempt clears the target. Geometry from the projection, "does it work?" from the model that was fit to answer it.

## What did NOT get fixed, and why it says so out loud

`test_no_candidate_dominates_another_by_construction` is replaced rather than deleted. Once eligibility exists, pairwise score dominance stops being the right invariant: PIT_NOW is reachable because UNDERCUT can be *ineligible*, not because it out-scores it, and "if you have a car you can undercut, aiming at them is never worse than a generic stop" is true rather than a modelling artefact. The meaningful property — every candidate is reachable as the argmax — is now asserted directly, per candidate.

Under that framing three of four are reachable on a 648-state sweep: **STAY_OUT 65.7%, UNDERCUT 31.0%, PIT_NOW 3.2%**. OVERCUT is not, and the projection *narrowed why* instead of fixing it: inside one window both candidates take the same stop and pay the same lane, so an overcut is PIT_NOW minus a lap of fresh rubber. What makes a real overcut pay is the out-lap — a new set needs a lap to switch on, so worn-but-warm tyres can out-run it — and that warm-up is one of the four v1 simplifications named in PR-3. It is measurable from the raw laps. So the assertion stays as a strict xfail with the mechanism and the fix named, which is the honest form of "not yet".

## Verification

- Strategy goldens byte-identical; a falsy rivals list (None, `[]`, `()`) is asserted to produce exactly the legacy result.
- Projection sweep: argmax non-constant, no candidate above 85%, STAY_OUT and PIT_NOW both reachable, a slower stop is never better, an ineligible undercut is never argmax and never carries a score, an overcut is only offered when a car ahead is genuinely in the pit lane.
- **Art. 55.17 emerges**: with the race finishing behind the Safety Car the measured racing laps go to zero and STAY_OUT wins outright. No rail anywhere.
- Wall time **1.27 ms/lap** with 19 rivals over 500 draws and 4 candidates, against a 50 ms budget.

Refs #555
