### PR TITLE
feat(mc): wire the projection into every surface

### DIFF
--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -334,20 +334,36 @@ def _generate_rcm_event(lap_num: int) -> dict | None:
     return evt
 
 
-def _score_float(v: Any) -> float:
+def _score_float(v: Any) -> float | None:
     """Extract a scalar score from an MC simulation result entry.
 
     _run_mc_simulation returns {scenario: {"E": float, "P10": float, "P90": float,
     "score": float}}. When scenario_scores holds these inner dicts (full LLM path),
     we extract the "score" key. When it holds plain floats (no-llm path), we cast
     directly.
+
+    Returns None for a candidate the projection layer declined to score — an
+    undercut with no reachable target, an overcut with nobody in the pit lane.
+    That used to read as 0.0, which is a real-looking score for a strategy that
+    was never on the table; callers must skip a None instead of ranking it.
     """
     if isinstance(v, dict):
-        return float(v.get("score", 0.0))
+        score = v.get("score")
+        return float(score) if score is not None else None
     try:
         return float(v)
     except (TypeError, ValueError):
-        return 0.0
+        return None
+
+
+def _fmt_score(score: float | None) -> str:
+    """Render one Monte Carlo score, or a dash for a candidate never offered.
+
+    A dash rather than 0.000: the panel is read at a glance during a race, and a
+    zero in a score column looks like a strategy that was considered and found
+    unattractive, not one that had no target to aim at.
+    """
+    return "--" if score is None else f"{score:.3f}"
 
 
 def _load_tire_alloc(repo_root: Path) -> None:
@@ -1720,7 +1736,7 @@ def run(args: argparse.Namespace) -> None:
                     ucut = _score_float(scores.get("UNDERCUT", 0.0))
                     ocut = _score_float(scores.get("OVERCUT", 0.0))
                 else:
-                    stay = pit = ucut = ocut = 0.0
+                    stay = pit = ucut = ocut = None
 
                 # Extract v2 tactical fields for Decision + Plan columns. Both
                 # modes now return a StrategyRecommendation (#236), so read them
@@ -1783,10 +1799,10 @@ def run(args: argparse.Namespace) -> None:
                         decision_text,
                         plan_text,
                         f"{confidence:.2f}",
-                        f"{stay:.3f}",
-                        f"{pit:.3f}",
-                        f"{ucut:.3f}",
-                        f"{ocut:.3f}",
+                        _fmt_score(stay),
+                        _fmt_score(pit),
+                        _fmt_score(ucut),
+                        _fmt_score(ocut),
                         _style_reasoning(reasoning[:200]),
                     ]
                 )

--- a/src/agents/position_projection.py
+++ b/src/agents/position_projection.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 import json
 import math
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import Sequence
 
@@ -195,26 +196,91 @@ class ProjectionResult:
     rivals_used: int
 
 
-def load_measured_config(path: Path | None = None, **overrides) -> ProjectionConfig:
-    """Build a config from the committed measured tables, with race context on top.
+@lru_cache(maxsize=1)
+def measured_tables(path: str | None = None) -> dict:
+    """The committed measurements, read once and cached.
 
-    Falls back to the values those tables held on 2026-07-25 when the file is
-    absent (a wheel install without ``data/``), so the degraded path lands on
-    measured numbers instead of invented ones. ``overrides`` carries the
-    per-race context the tables cannot know (laps remaining, whether we still
-    owe a stop, how many laps of the window will be raced).
+    Returns an empty dict when the file is absent (a wheel install without
+    ``data/``), which leaves every caller on the module's DEFAULT_* constants.
+    Those are not invented numbers: they are the values this same file held on
+    2026-07-25, so a missing table degrades to the last measured state rather
+    than to a guess. Regenerate with ``scripts/measure_mc_tables.py``.
     """
-    tables_path = path or _MEASURED_TABLES
-    settings: dict = {}
+    tables_path = Path(path) if path else _MEASURED_TABLES
+    if not tables_path.exists():
+        return {}
+    return json.loads(tables_path.read_text(encoding="utf-8"))
 
-    if tables_path.exists():
-        tables = json.loads(tables_path.read_text(encoding="utf-8"))
-        band = tables.get("undercut_band", {}).get("u_band_s")
-        if band:
-            settings["undercut_band_s"] = float(band)
 
-    settings.update(overrides)
-    return ProjectionConfig(**settings)
+def measured_undercut_band_s() -> float:
+    """The measured undercut band, or the last measured value if the file is gone."""
+    band = measured_tables().get("undercut_band", {}).get("u_band_s")
+    return float(band) if band else DEFAULT_UNDERCUT_BAND_S
+
+
+def measured_neutralisation_rate(circuit: str | None = None) -> float:
+    """Per-lap onset hazard for ``circuit``, falling back to the pooled rate.
+
+    A circuit we have never raced (a new venue, or a name that did not resolve)
+    gets the pooled figure rather than zero. Zero is not a neutral default here:
+    it drives ``q_f`` to 0, which tells the decision layer that no future Safety
+    Car will ever turn up to cover a stop, and that biases the terminal
+    liability upward on every lap of every race.
+    """
+    table = measured_tables().get("neutralisation_rate", {})
+    if circuit:
+        cell = (table.get("per_circuit") or {}).get(circuit) or {}
+        rate = cell.get("rate")
+        if rate is not None:
+            return float(rate)
+    pooled = (table.get("pooled") or {}).get("rate")
+    return float(pooled) if pooled is not None else DEFAULT_NEUTRALISATION_RATE
+
+
+@lru_cache(maxsize=1)
+def _traversal_table() -> dict:
+    """Per-circuit pit-lane traversal seconds, keyed by the slug agents query with.
+
+    Read straight from N15's committed model config rather than through the pit
+    agent, because the decision layer needs this number on the no-LLM path too and
+    constructing N28 there would load a stack of models to answer one lookup.
+
+    Re-keyed through ``rekey_by_slug``: the table ships keyed by FastF1 event names
+    whose overlap with the slug keyspace is exactly zero, which is how every
+    circuit lookup silently missed and froze traversal at a single constant (#448).
+    """
+    config_path = Path(__file__).resolve().parents[2] / "data" / "models" / "pit_prediction"
+    config_file = config_path / "model_config.json"
+    if not config_file.exists():
+        return {}
+
+    from src.f1_strat_manager.gp_slugs import rekey_by_slug
+
+    payload = json.loads(config_file.read_text(encoding="utf-8"))
+    return rekey_by_slug(payload.get("circuit_traversal_lookup", {}), "circuit_traversal_lookup")
+
+
+def traversal_seconds(gp_name: str | None) -> float | None:
+    """Pit-lane traversal for ``gp_name``, or None when the circuit is unknown.
+
+    None rather than a pooled average on purpose: the caller decides whether to
+    fall back, and a silent average would hide a keyspace drift exactly the way
+    #448 did. The real spread is 19.7 s at Budapest to 27.5 s at Marina Bay, which
+    is the difference between a stop that costs a place and one that does not.
+    """
+    if not gp_name:
+        return None
+    value = _traversal_table().get(gp_name)
+    return float(value) if value is not None else None
+
+
+def measured_racing_laps(neutralisation: str = "sc") -> float:
+    """Measured racing laps left inside the window under ``sc`` or ``vsc``."""
+    kinds = measured_tables().get("sc_window", {}).get("by_kind", {})
+    mean = (kinds.get(neutralisation) or {}).get("racing_laps_in_window", {}).get("mean")
+    if mean is not None:
+        return float(mean)
+    return DEFAULT_RACING_LAPS_UNDER_VSC if neutralisation == "vsc" else DEFAULT_RACING_LAPS_UNDER_SC
 
 
 def future_neutralisation_probability(rate_per_lap: float, laps_remaining: int) -> float:
@@ -433,12 +499,20 @@ def undercut_targets(rivals: Sequence[RivalState], config: ProjectionConfig) -> 
     Liveness is presence in this list — a car that crashed is simply not in it —
     never a DNF classification or a staleness threshold, because a car that
     finished can legitimately lag twenty laps behind in the data.
+
+    A car already in the pit lane is NOT a target. You cannot undercut someone
+    who is serving their stop as you decide: the whole move is to reach the pit
+    lane before they do. Offering them as a target credited the undercut with a
+    place it had no way to take.
     """
     band = config.undercut_band_s
     return [
         rival.driver
         for rival in _usable_rivals(rivals)
-        if rival.is_ahead and rival.gap_ahead_s is not None and rival.gap_ahead_s <= band
+        if rival.is_ahead
+        and not rival.is_pitting
+        and rival.gap_ahead_s is not None
+        and rival.gap_ahead_s <= band
     ]
 
 

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -695,31 +695,40 @@ def simulate_lap_window(
     return time_delta / POS_GAP_S
 
 
-# Pooled green-flag pit loss measured over this repo's 71 races (n=1746, ~22.6 s),
-# used only when the caller cannot say which circuit we are at. The per-circuit
-# table (#448) spans 19.7 s at Budapest to 27.5 s at Marina Bay, so a caller that
-# knows the GP should always pass its own figure through pit_context.
+# PIT-LANE TRAVERSAL, NOT TOTAL PIT LOSS. This is the time spent transiting the
+# lane, to which the sampled physical stop is added: D = traversal + stop. The
+# per-circuit table (#448) spans 19.7 s at Budapest to 27.5 s at Marina Bay and a
+# caller that knows the GP must pass its own figure through pit_context, because
+# a 7.9 s spread is the difference between a stop that costs a place and one that
+# does not. The 20.0 fallback is a traversal, so adding a ~2.6 s stop lands near
+# the 22.6 s pooled green pit loss measured over this repo's 71 races (n=1746) —
+# do NOT pass that 22.6 s figure in as traversal or the stop is counted twice.
 DEFAULT_PIT_TRAVERSAL_S = 20.0
 
-# Racing laps left inside a W=5 window once a Safety Car is out, measured over the
-# same races (2.61, n=215 neutralised laps). Under a VSC the field is not queued and
-# more of the window is raced (2.91, n=80).
-RACING_LAPS_UNDER_SC = 2.61
-RACING_LAPS_UNDER_VSC = 2.91
+# Physical-stop prior used for a RIVAL when the caller cannot supply one: the mode
+# of N15's conservative Triangular(2.2, 2.8, 3.8). A rival who is in the pit lane
+# has to lose the same kind of time we would, and defaulting that to zero made
+# their stop free — a car ahead could serve a stop and stay ahead, which is a
+# sentinel wearing a plausible number (the #428 lesson in a new place).
+RIVAL_STOP_PRIOR_S = 2.8
 
 
-def _rival_states_from_lap_state(rivals: list[dict], pit_context: dict | None):
+def _rival_states_from_lap_state(rivals: list[dict], pit_context: dict | None, traversal_s: float):
     """Adapt the lap_state rivals list into the projection's own value type.
 
     The one place that knows the RaceStateManager field names, so a rename there
     lands here and nowhere else. A rival whose interval is unknown keeps a None
     gap and the projection drops it from the count rather than inventing a zero.
+
+    ``traversal_s`` is threaded in so a pitting rival is charged the same kind of
+    pit loss we charge ourselves. Callers can override per rival through
+    ``pit_context['rival_pit_loss_s']`` once that figure is available per car.
     """
     from src.agents.position_projection import RivalState
 
     context = pit_context or {}
     per_rival_pending: dict = context.get("rival_stop_pending") or {}
-    rival_loss = float(context.get("rival_pit_loss_s") or context.get("pit_loss_s") or 0.0)
+    rival_loss = float(context.get("rival_pit_loss_s") or (traversal_s + RIVAL_STOP_PRIOR_S))
 
     states = []
     for rival in rivals:
@@ -734,6 +743,104 @@ def _rival_states_from_lap_state(rivals: list[dict], pit_context: dict | None):
             )
         )
     return states
+
+
+def race_context_from_lap_state(lap_state: dict | None, race_state=None) -> dict:
+    """Assemble the projection's race context from a lap_state, or an empty dict.
+
+    Built here rather than at each surface so the CLI, the arcade and the backend
+    cannot drift on what "race context" means — three hand-mirrored copies of a
+    payload is how this codebase acquired most of its cross-surface bugs.
+
+    Everything is optional and everything degrades honestly: no rivals means the
+    caller stays on the legacy scoring, an unknown circuit means the traversal
+    falls back with a warning rather than to a silent average, and an unsettled
+    stop obligation stays None so the terminal liability makes no claim.
+    """
+    if not lap_state:
+        return {}
+
+    from src.agents.position_projection import traversal_seconds
+
+    driver = lap_state.get("driver") or {}
+    meta = lap_state.get("session_meta") or {}
+    gp_name = meta.get("gp_name")
+
+    total_laps = meta.get("total_laps") or (getattr(race_state, "total_laps", 0) or 0)
+    current_lap = lap_state.get("lap_number") or getattr(race_state, "lap", 0) or 0
+    traversal = traversal_seconds(gp_name)
+    if traversal is None and gp_name:
+        logger.warning(
+            "no pit-lane traversal for GP %r — the projection falls back to %.1f s, "
+            "which is right to within a few seconds but wrong per circuit (#448)",
+            gp_name,
+            DEFAULT_PIT_TRAVERSAL_S,
+        )
+
+    context = {
+        "gp_name": gp_name,
+        "laps_remaining": max(0, int(total_laps) - int(current_lap)),
+        "position": driver.get("position"),
+        "pit_context": {
+            "gp_name": gp_name,
+            "traversal_s": traversal,
+            "mandatory_stop_pending": (lap_state.get("stint_flags") or {}).get(
+                "mandatory_stop_pending"
+            ),
+            "rival_stop_pending": lap_state.get("rival_stop_pending") or {},
+        },
+    }
+    return context
+
+
+def _has_usable_gaps(rivals: list[dict] | None) -> bool:
+    """Whether any rival carries a gap the projection can actually use.
+
+    A list of cars whose intervals are all unknown is truthy but carries no
+    geometry: projecting from it counted zero rivals and reported P1 with no
+    uncertainty, which is a confident "you will finish first" assembled from no
+    information at all. Unknown is not zero, and a list of unknowns is not a
+    race state — those runs belong on the legacy path.
+    """
+    return any(rival.get("interval_to_driver_s") is not None for rival in rivals or ())
+
+
+def best_mc_candidate(mc_results: dict) -> str:
+    """The argmax over scored candidates, skipping the ones never offered.
+
+    Four call sites used to do ``max(results, key=lambda s: results[s]["score"])``
+    directly, which raises the moment a score is None — and None is exactly what
+    the projection engine emits for a candidate with no valid target. Sharing one
+    helper is also what stops the four from drifting apart, which is how this
+    codebase acquired most of its duplicate-logic bugs.
+
+    Falls back to the first key when nothing is scoreable at all (no rivals, every
+    candidate ineligible): callers need a string, and an arbitrary-but-stable pick
+    beats raising inside a race.
+    """
+    scored = {name: cell for name, cell in mc_results.items() if cell.get("score") is not None}
+    if not scored:
+        return next(iter(mc_results), "STAY_OUT")
+    return max(scored, key=lambda name: scored[name]["score"])
+
+
+def _format_mc_row(name: str, cell: dict) -> str:
+    """One line of the Monte Carlo table for the LLM prompt.
+
+    An ineligible candidate is stated as such rather than formatted: ``%+.3f``
+    raises on None, and a candidate with no target is information the model
+    should have — "there is nobody to undercut" is a reason, not a gap.
+    """
+    if cell.get("score") is None:
+        reason = "no valid target" if cell.get("eligible") is False else "not scored"
+        return f"  {name}: not offered ({reason})"
+
+    target = cell.get("target")
+    suffix = f"  target={target}" if target else ""
+    return (
+        f"  {name}: E={cell['E']:+.3f}  P10={cell['P10']:+.3f}  "
+        f"P90={cell['P90']:+.3f}  score={cell['score']:+.3f}{suffix}"
+    )
 
 
 def _run_projection_mc(
@@ -774,6 +881,9 @@ def _run_projection_mc(
         DriverPlan,
         ProjectionConfig,
         future_neutralisation_probability,
+        measured_neutralisation_rate,
+        measured_racing_laps,
+        measured_undercut_band_s,
         overcut_targets,
         payoff,
         project_positions,
@@ -782,7 +892,7 @@ def _run_projection_mc(
 
     context = pit_context or {}
     traversal_s = float(context.get("traversal_s") or DEFAULT_PIT_TRAVERSAL_S)
-    rival_states = _rival_states_from_lap_state(rivals, pit_context)
+    rival_states = _rival_states_from_lap_state(rivals, pit_context, traversal_s)
 
     # Total pit loss per draw: the lane traversal plus the physical stop. The legacy
     # scoring charged only the stop and argued in a comment that the traversal
@@ -790,14 +900,37 @@ def _run_projection_mc(
     # the rival really pays it too, and not otherwise.
     pit_loss_s = traversal_s + _np.asarray(pit_s, dtype=float)
 
-    current_position = int(position) if position else 1
-    remaining = int(laps_remaining) if laps_remaining else 0
-    onset_rate = float(context.get("neutralisation_rate") or 0.0)
-    q_f = future_neutralisation_probability(onset_rate, remaining)
+    # Our position, preferably as reported, otherwise counted from the same gaps
+    # the projection is about to use. It has to be derived rather than defaulted:
+    # the featured parquet drops laps run under a Safety Car, so on exactly the
+    # laps this layer matters most the driver row is missing and the position
+    # arrives as None. Defaulting that to 1 claimed we were leading the race.
+    # Counting rivals ahead is not a guess — it is the same arithmetic that
+    # produces the projected position, so both sides of the delta agree.
+    rivals_ahead = sum(1 for state in rival_states if state.is_ahead)
+    current_position = int(position) if position else 1 + rivals_ahead
 
+    remaining = int(laps_remaining) if laps_remaining else 0
+
+    # Every constant below comes from the committed measurements
+    # (data/mc_measured_v1.json, regenerated by scripts/measure_mc_tables.py). A
+    # caller may override any of them through pit_context; what it may not do is
+    # leave the onset rate at zero, which would tell the layer that no future
+    # Safety Car can ever cover a stop and bias the terminal liability upward on
+    # every lap of every race.
+    onset_rate = context.get("neutralisation_rate")
+    if onset_rate is None:
+        onset_rate = measured_neutralisation_rate(context.get("gp_name"))
+    q_f = future_neutralisation_probability(float(onset_rate), remaining)
+
+    # ONE source for which neutralisation we are in: the saving passed by the
+    # caller already encodes it (VSC_PIT_BONUS vs SC_PIT_BONUS), so reading a
+    # separate `vsc_active` here as well let the two disagree — a VSC saving
+    # scored against a full-SC racing window.
+    is_vsc = neutralisation_saving_s <= VSC_PIT_BONUS
     racing_when_neutralised = float(
         context.get("racing_laps_neutralised")
-        or (RACING_LAPS_UNDER_VSC if context.get("vsc_active") else RACING_LAPS_UNDER_SC)
+        or measured_racing_laps("vsc" if is_vsc else "sc")
     )
 
     def _config(racing_laps: float) -> ProjectionConfig:
@@ -807,6 +940,7 @@ def _run_projection_mc(
             fresh_gain_s=FRESH_GAIN,
             cliff_loss_s=CLIFF_LOSS,
             neutralisation_saving_s=neutralisation_saving_s,
+            undercut_band_s=measured_undercut_band_s(),
             future_neutralisation_prob=q_f,
             laps_remaining=remaining,
             mandatory_stop_pending=context.get("mandatory_stop_pending"),
@@ -997,7 +1131,7 @@ def _run_mc_simulation(
     # the comparison between them carries no sampling noise of its own. That is what
     # an argmax over 500 draws needs — the variance that matters is the variance of
     # the DIFFERENCES, and sharing the draws collapses it.
-    if rivals:
+    if _has_usable_gaps(rivals):
         return _run_projection_mc(
             rivals=rivals,
             position=position,
@@ -1090,10 +1224,7 @@ def _build_orchestrator_prompt(
     regulation context, radio alerts, or a planned contingency justify a
     different action.
     """
-    mc_table = "\n".join(
-        f"  {s}: E={v['E']:+.3f}  P10={v['P10']:+.3f}  P90={v['P90']:+.3f}  score={v['score']:+.3f}"
-        for s, v in mc_results.items()
-    )
+    mc_table = "\n".join(_format_mc_row(name, cell) for name, cell in mc_results.items())
 
     reg_block = (
         f"REGULATION CONSTRAINT (hard — exclude non-compliant actions):\n"

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -702,11 +702,18 @@ def _normalize_scores(raw: Any) -> dict[str, float]:
     for k, v in raw.items():
         key = str(k).upper()
         if isinstance(v, dict):
-            v = v.get("score", 0.0)
+            v = v.get("score")
+        # A candidate the projection engine declined to score arrives as None.
+        # It used to become 0.0 here, which painted a full-height bar at the
+        # zero line for a strategy that was never on the table — a numeric
+        # sentinel by accident. Dropping the key instead leaves the dashboard
+        # with three bars, and an absent bar cannot be misread as a score.
+        if v is None:
+            continue
         try:
             out[key] = float(v)
         except (TypeError, ValueError):
-            out[key] = 0.0
+            continue
     return out
 
 

--- a/src/simulation/race_state_manager.py
+++ b/src/simulation/race_state_manager.py
@@ -469,10 +469,25 @@ class RaceStateManager:
                     "session_meta": dict,   # see get_session_meta
                 }
         """
+        rivals = self.get_rival_states(lap_number)
         return {
             "lap_number": lap_number,
             "driver": self.get_driver_state(lap_number),
-            "rivals": self.get_rival_states(lap_number),
+            "rivals": rivals,
             "weather": self.get_weather_state(lap_number, weather_df),
             "session_meta": self.get_session_meta(),
+            # Art. 30.5(m) state for us and for every rival on track. The decision
+            # layer needs both sides: our own pending stop is what makes staying
+            # out a deferral rather than a saving, and a rival who still owes a
+            # stop is no threat to us, because they will pay the same price later.
+            # Emitted here rather than fetched separately so the four surfaces
+            # cannot drift on how they ask for it.
+            "stint_flags": self.get_stint_flags(lap_number),
+            "rival_stop_pending": {
+                rival["driver"]: self.get_stint_flags(lap_number, rival["driver"])[
+                    "mandatory_stop_pending"
+                ]
+                for rival in rivals
+                if rival.get("driver")
+            },
         }

--- a/src/strategy/inference/engine.py
+++ b/src/strategy/inference/engine.py
@@ -59,6 +59,8 @@ from src.agents.strategy_orchestrator import (
     _run_always_on_agents_from_state,
     _run_conditional_agents,
     _run_mc_simulation,
+    best_mc_candidate,
+    race_context_from_lap_state,
 )
 
 # The profiles #169 delivers. ``fast`` (direct-mode sub-agents + event-triggered
@@ -247,14 +249,19 @@ def _run_rich(
         regulation_context = regulation_context or ""
 
     with _StageTimer(timings, "mc"):
+        _ctx = race_context_from_lap_state(lap_state, race_state)
         mc_results = _run_mc_simulation(
             pace_out=pace_out,
             tire_out=tire_out,
             situation_out=situation_out,
             pit_out=pit_out,
             alpha=race_state.risk_tolerance,
+            rivals=(lap_state or {}).get("rivals"),
+            position=_ctx.get("position"),
+            laps_remaining=_ctx.get("laps_remaining"),
+            pit_context=_ctx.get("pit_context"),
         )
-        best_mc = max(mc_results, key=lambda s: mc_results[s]["score"])
+        best_mc = best_mc_candidate(mc_results)
 
     with _StageTimer(timings, "synthesis"):
         prompt = _build_orchestrator_prompt(

--- a/src/strategy/inference/no_llm.py
+++ b/src/strategy/inference/no_llm.py
@@ -40,6 +40,8 @@ from src.agents.strategy_orchestrator import (
     _decide_agents_to_call,
     _LLMSynthesis,
     _run_mc_simulation,
+    best_mc_candidate,
+    race_context_from_lap_state,
     _to_radio_message,
     _to_rcm_event,
 )
@@ -304,14 +306,19 @@ def run_no_llm_lap(
         pit_out, regulation_context, rag_dict = None, "", None
 
     with _StageTimer(timings, "mc"):
+        _ctx = race_context_from_lap_state(lap_state, race_state)
         mc_results = _run_mc_simulation(
             pace_out=pace_out,
             tire_out=tire_out,
             situation_out=situation_out,
             pit_out=pit_out,  # None -> conservative prior (Triangular 2.2/2.8/3.8, ucut 0.5)
             alpha=race_state.risk_tolerance,
+            rivals=(lap_state or {}).get("rivals"),
+            position=_ctx.get("position"),
+            laps_remaining=_ctx.get("laps_remaining"),
+            pit_context=_ctx.get("pit_context"),
         )
-        best_mc = max(mc_results, key=lambda s: mc_results[s]["score"])
+        best_mc = best_mc_candidate(mc_results)
 
     with _StageTimer(timings, "synthesis"):
         action, guardrail_reason = apply_guard_rails(

--- a/tests/test_engine_no_llm.py
+++ b/tests/test_engine_no_llm.py
@@ -101,7 +101,16 @@ def test_no_llm_sweep_produces_a_decision_every_lap_with_zero_clients(no_llm_cli
         assert rec.reasoning.startswith("[no-llm"), f"lap {lap}: {rec.reasoning[:40]}"
         assert set(rec.scenario_scores) == {"STAY_OUT", "PIT_NOW", "UNDERCUT", "OVERCUT"}
         for scores in rec.scenario_scores.values():
-            assert set(scores) == {"E", "P10", "P90", "score"}
+            # The projection path adds `eligible` and `target`; the legacy path
+            # emits the four numbers alone. Both are valid, so assert the numeric
+            # core is always present rather than pinning an exact key set — the
+            # exact-set form failed the moment the engine started threading
+            # rivals, which is a schema change the surfaces tolerate by design.
+            assert {"E", "P10", "P90", "score"} <= set(scores)
+            if scores.get("eligible") is False:
+                assert scores["score"] is None, "an unoffered candidate must carry no score"
+            else:
+                assert scores["score"] is not None
         assert outs["pit_out"] is None  # N28 is LLM-backed, never run in no-llm
         assert "total" in timings
 

--- a/tests/test_mc_state_helpers.py
+++ b/tests/test_mc_state_helpers.py
@@ -237,7 +237,19 @@ def _canned_outputs():
 
 
 @_skip_no_models
-def test_mc_race_context_kwargs_are_accepted_and_ignored():
+def test_race_context_without_rivals_still_takes_the_legacy_path():
+    """The kwargs alone change nothing — only a usable rivals list switches paths.
+
+    This test pinned a contract that has since moved. When PR-1 added the kwargs
+    they were accepted and ignored, so passing a rivals list had to be a no-op;
+    PR-4 gave that list meaning and made it the dispatch key. The assertion now
+    covers what is still true: race context with no rivals is legacy scoring.
+
+    Worth remembering how it surfaced. It failed only on a machine holding the
+    dataset, because ``_skip_no_models`` hides it on CI — the same shape as the
+    voice-retirement test that pinned a retired contract and only broke on the
+    promotion. A test that guards a contract must fail where the contract lives.
+    """
     from src.agents.strategy_orchestrator import _run_mc_simulation
 
     pace, tire, situation, pit = _canned_outputs()
@@ -248,9 +260,38 @@ def test_mc_race_context_kwargs_are_accepted_and_ignored():
         situation,
         pit,
         alpha=0.5,
-        rivals=[{"driver": "HAM", "interval_to_driver_s": -1.8}],
         position=5,
         laps_remaining=20,
         pit_context={"mandatory_stop_pending": True},
     )
     assert with_context == baseline
+
+
+@_skip_no_models
+def test_rivals_with_no_usable_gap_cannot_conjure_a_projection():
+    """A list of cars whose intervals are all unknown is not race context.
+
+    It is truthy, so it used to route into the projection, which then counted
+    zero rivals and reported P1 with no uncertainty — "you will finish first",
+    fabricated from nothing. Unknown gaps mean the projection has no geometry to
+    work with, and the honest fallback is the legacy scoring it would have used
+    had the list been empty.
+    """
+    from src.agents.strategy_orchestrator import _run_mc_simulation
+
+    pace, tire, situation, pit = _canned_outputs()
+    baseline = _run_mc_simulation(pace, tire, situation, pit, alpha=0.5)
+    blind = _run_mc_simulation(
+        pace,
+        tire,
+        situation,
+        pit,
+        alpha=0.5,
+        rivals=[
+            {"driver": "HAM", "interval_to_driver_s": None},
+            {"driver": "VER", "interval_to_driver_s": None},
+        ],
+        position=5,
+        laps_remaining=20,
+    )
+    assert blind == baseline

--- a/tests/test_position_projection.py
+++ b/tests/test_position_projection.py
@@ -257,6 +257,22 @@ def test_no_reachable_rival_means_no_undercut_target_at_all():
     assert undercut_targets(rivals, config) == []
 
 
+def test_a_car_already_in_the_pit_lane_cannot_be_undercut():
+    """You cannot beat someone to the pit lane once they are in it.
+
+    The whole move is arriving first. Offering a stopping car as an undercut
+    target credited the candidate with a place it had no mechanism to take, and
+    the projection agreed with itself: both cars pay the same loss, so the order
+    survives, yet the candidate still collected the success bonus.
+    """
+    config = ProjectionConfig(undercut_band_s=4.91)
+    rivals = [
+        RivalState("SERVING_A_STOP", gap_s=-2.0, is_pitting=True),
+        RivalState("RACING", gap_s=-3.0, is_pitting=False),
+    ]
+    assert undercut_targets(rivals, config) == ["RACING"]
+
+
 def test_an_overcut_needs_a_car_ahead_actually_in_the_pit_lane():
     rivals = [
         RivalState("AHEAD_PITTING", gap_s=-3.0, is_pitting=True),


### PR DESCRIPTION
PR-5b of the MC projection redesign (#550). Makes the projection **reachable**: until now no call site passed `rivals`, so the engine was dead code.

## Wiring

- `race_context_from_lap_state` assembles the payload once, so the CLI, arcade and backend cannot drift on what race context means.
- `RaceStateManager.get_lap_state` now emits `stint_flags` + `rival_stop_pending`.
- `best_mc_candidate` replaces four raw argmax sites that raise on a null score. The prompt states an unoffered candidate instead of formatting None; the arcade drops it instead of coercing to 0.0; the CLI prints a dash.
- Submodule bumped to the nullable-schema commit (F1_Telemetry_Manager#191).

## Defects found and fixed

**By the Fable correctness gate:**
- A rivals list whose gaps are **all unknown** entered the projection, counted zero rivals and returned P1 with no uncertainty — a confident "you will finish first" assembled from no information.
- A rival **already in the pit lane** was offered as an undercut target. You cannot beat someone to the pit lane once they are in it, and the success bonus was phantom there.
- **The measured tables never reached the engine.** `load_measured_config` had no caller; the neutralisation rate fell back to `0.0`, which told the layer no future Safety Car would ever cover a stop and biased the terminal liability upward on every lap.
- A pitting rival's loss defaulted to **0.0 — a free stop**, so a car ahead could serve a stop and stay ahead.
- A test still pinned the PR-1 "kwargs are ignored" contract that PR-4 replaced; it failed only where the dataset exists, the same shape as the voice-retirement test that only broke on promotion.

**By actually running it on Lusail 2025:**
- `mandatory_stop_pending` was always None, because `get_stint_flags` existed but nothing put it in the lap_state. **The terminal liability never fired in production** — the option-value mechanism was dead on arrival.
- On Safety Car laps the featured parquet has no driver row, so position arrived as None and **defaulted to 1**. It is now counted from the rival gaps, the same arithmetic the projection uses for the projected side.

## Verification

78 tests pass on the touched files; lint and format clean on the pinned ruff. Real-lap probe on Lusail 2025 (NOR): the liability now varies with the stop obligation (True through lap 40, False by lap 50) and STAY_OUT/PIT_NOW separate by 1.4 to 17 positions depending on traffic, where before every liability was zero.

Two failures on this branch are **pre-existing on clean dev** (verified by stashing): `test_cli_no_llm_smoke` (subprocess capture returns None) and `test_engine_threads_every_argument` (the rich profile does not thread `cliff_p50`/`total_laps` into `_assemble_recommendation` — a live dead-guard bug worth its own issue).

Closes #556