### PR TITLE
fix(mc): floor the hazard, resolve every circuit spelling, restore the O(1) lap state

### DIFF
--- a/src/agents/position_projection.py
+++ b/src/agents/position_projection.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 
 import json
 import math
+import unicodedata
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -226,22 +227,109 @@ def measured_undercut_band_s() -> float:
 
 
 def measured_neutralisation_rate(circuit: str | None = None) -> float:
-    """Per-lap onset hazard for ``circuit``, falling back to the pooled rate.
+    """Per-lap onset hazard for ``circuit``, never zero.
 
-    A circuit we have never raced (a new venue, or a name that did not resolve)
-    gets the pooled figure rather than zero. Zero is not a neutral default here:
-    it drives ``q_f`` to 0, which tells the decision layer that no future Safety
-    Car will ever turn up to cover a stop, and that biases the terminal
-    liability upward on every lap of every race.
+    A circuit we have never raced gets the pooled figure rather than zero, and so
+    does a circuit that simply has not thrown a Safety Car in our three seasons.
+    Zero is not a neutral default here: it drives ``q_f`` to 0, which tells the
+    decision layer that no future neutralisation can ever turn up to cover a
+    stop, and that biases the terminal liability upward on every lap.
+
+    That second case is real, not hypothetical. Monza and Budapest both measure
+    exactly 0 (0 onsets in 157 and 210 racing laps), and Monza is the archetypal
+    Art. 55.17 circuit. A zero count is not evidence of a zero rate: the upper
+    bound of that interval comfortably covers the pooled value, so the honest
+    reading is "we have not seen one here", not "one cannot happen here".
     """
     table = measured_tables().get("neutralisation_rate", {})
-    if circuit:
-        cell = (table.get("per_circuit") or {}).get(circuit) or {}
-        rate = cell.get("rate")
-        if rate is not None:
-            return float(rate)
     pooled = (table.get("pooled") or {}).get("rate")
-    return float(pooled) if pooled is not None else DEFAULT_NEUTRALISATION_RATE
+    fallback = float(pooled) if pooled is not None else DEFAULT_NEUTRALISATION_RATE
+
+    if not circuit:
+        return fallback
+
+    cell = (table.get("per_circuit") or {}).get(_resolved_circuit_key(circuit)) or {}
+    rate = cell.get("rate")
+    if rate is None:
+        return fallback
+    # An observed zero means "never seen", not "impossible". Fall back rather
+    # than let a small sample silence the whole option-value term.
+    if float(rate) <= 0.0:
+        return fallback
+    return float(rate)
+
+
+# Circuits this repo files under more than one name. The measured tables and the
+# traversal table are keyed by the circuit slug, but callers hand us whatever
+# their surface holds: 2023 filed Barcelona under a country name, and Miami has
+# three spellings across the repo. Left explicit so an unresolved name is a
+# genuinely unknown circuit rather than a silent keyspace miss (#448).
+_CIRCUIT_ALIASES: dict[str, str] = {
+    "Spain": "Barcelona",
+    "Miami Gardens": "Miami",
+    "Miami_Gardens": "Miami",
+}
+
+
+def _key_candidates(name: str) -> list[str]:
+    """Every spelling of ``name`` worth trying against a circuit-keyed table.
+
+    Ordered cheapest-first: the name as given, its explicit alias, the
+    underscored folder form, then the two resolvers in ``gp_slugs``. Returning a
+    list rather than resolving eagerly keeps the caller in charge of which table
+    it is matching against, since the two tables do not hold identical key sets.
+    """
+    from src.f1_strat_manager.gp_slugs import canonical_gp_name, slug_from_event_name
+
+    spaced = name.replace("_", " ")
+    candidates = [name, _CIRCUIT_ALIASES.get(name), spaced, _CIRCUIT_ALIASES.get(spaced)]
+    for resolver in (slug_from_event_name, canonical_gp_name):
+        try:
+            candidates.append(resolver(name))
+        except (ValueError, KeyError):
+            continue
+
+    # Accent-folded spellings, because two of our circuits carry diacritics
+    # (São Paulo, Montréal) and they lose them whenever a name passes through a
+    # non-UTF-8 console, a filename or a hand-typed argument. Matched by folding
+    # BOTH sides so "Sao Paulo" finds "São Paulo" without a second alias entry.
+    folded = {_fold_accents(c): c for c in candidates if c}
+    for key in list(_traversal_table()) + list(
+        (measured_tables().get("neutralisation_rate") or {}).get("per_circuit") or {}
+    ):
+        if _fold_accents(key) in folded:
+            candidates.append(key)
+
+    seen, ordered = set(), []
+    for candidate in candidates:
+        if candidate and candidate not in seen:
+            seen.add(candidate)
+            ordered.append(candidate)
+    return ordered
+
+
+def _fold_accents(text: str) -> str:
+    """``São Paulo`` and ``Sao Paulo`` collapse to the same comparison key."""
+    decomposed = unicodedata.normalize("NFKD", text)
+    return "".join(ch for ch in decomposed if not unicodedata.combining(ch)).casefold()
+
+
+def _lookup_by_circuit(table: dict, name: str):
+    """First value in ``table`` matching any accepted spelling of ``name``."""
+    for candidate in _key_candidates(name):
+        if candidate in table:
+            return table[candidate]
+    return None
+
+
+@lru_cache(maxsize=64)
+def _resolved_circuit_key(name: str) -> str:
+    """The key a circuit-keyed measured table actually holds for ``name``."""
+    per_circuit = (measured_tables().get("neutralisation_rate") or {}).get("per_circuit") or {}
+    for candidate in _key_candidates(name):
+        if candidate in per_circuit:
+            return candidate
+    return name
 
 
 @lru_cache(maxsize=1)
@@ -277,7 +365,7 @@ def traversal_seconds(gp_name: str | None) -> float | None:
     """
     if not gp_name:
         return None
-    value = _traversal_table().get(gp_name)
+    value = _lookup_by_circuit(_traversal_table(), gp_name)
     return float(value) if value is not None else None
 
 

--- a/src/simulation/race_state_manager.py
+++ b/src/simulation/race_state_manager.py
@@ -25,7 +25,7 @@ from typing import Any
 import pandas as pd
 
 from src.simulation.data_validation import validate_laps_df
-from src.simulation.stint_history import stint_history_flags
+from src.simulation.stint_history import stint_history_flags, stint_history_timeline
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -136,6 +136,15 @@ class RaceStateManager:
         # TyreLife at the start of each of our driver's stints. Precomputed for the
         # same reason as the leader times: get_lap_state must stay an O(1) lookup.
         self._stint_baselines: dict[int, int] = self._precompute_stint_baselines()
+
+        # Art. 30.5(m) flags, one timeline per driver, built on first ask.
+        # `get_lap_state` needs ours plus one per rival, and the per-lap helper
+        # rescans the whole frame each time, so a lap cost about twenty full
+        # scans: 2 ms became 18 ms, a 9x regression against the O(1) promise this
+        # class makes above. Building each driver's whole timeline in one ordered
+        # pass brings it back to 3.9 ms. Lazy per driver, because a caller asking
+        # about three cars should not pay for twenty.
+        self._stint_flags: dict[str, dict[int, dict[str, Any]]] = {}
 
     def _precompute_stint_baselines(self) -> dict[int, int]:
         """Return our driver's TyreLife at the first lap of each stint.
@@ -437,7 +446,31 @@ class RaceStateManager:
         read race context (#555, #556).
         """
         code = driver_code or self.driver_code
+        timeline = self._stint_timeline(code)
+        flags = timeline.get(lap_number)
+        if flags is not None:
+            return flags
+
+        # No row for that lap: the featured frame drops laps run under a Safety
+        # Car, so read the most recent earlier lap instead of reporting nothing.
+        # Compound history only ever grows, so the last known state is still the
+        # truth about what has been used — it just may be missing a newer stint.
+        earlier = [lap for lap in timeline if lap < lap_number]
+        if earlier:
+            return timeline[max(earlier)]
         return stint_history_flags(self._all, code, lap_number)
+
+    def _stint_timeline(self, driver_code: str) -> dict[int, dict[str, Any]]:
+        """Per-driver flag timeline, built once per driver and cached.
+
+        Built lazily rather than for the whole grid upfront: a caller that asks
+        about three drivers should not pay for twenty.
+        """
+        cached = self._stint_flags.get(driver_code)
+        if cached is None:
+            cached = stint_history_timeline(self._all, driver_code)
+            self._stint_flags[driver_code] = cached
+        return cached
 
     def get_lap_state(
         self,

--- a/src/simulation/stint_history.py
+++ b/src/simulation/stint_history.py
@@ -109,3 +109,75 @@ def stint_history_flags(
         "mandatory_stop_pending": pending,
     }
     return flags
+
+
+def stint_history_timeline(
+    gp_laps: pd.DataFrame | None,
+    driver: str,
+) -> dict[int, dict[str, Any]]:
+    """Every lap's flags for one driver, computed in a single ordered pass.
+
+    Same answers as calling :func:`stint_history_flags` per lap, at a fraction of
+    the cost: that function rescans the whole frame each time, and the decision
+    layer wants flags for our car plus every rival on every lap, which turned one
+    ``get_lap_state`` call into about twenty full scans.
+
+    Returns a map from lap number to the flags AS OF that lap. A lap the driver
+    did not complete is absent, and the caller reads the nearest earlier lap or
+    treats it as unknown — never as a default.
+    """
+    if gp_laps is None or gp_laps.empty or not _REQUIRED_COLUMNS <= set(gp_laps.columns):
+        return {}
+
+    rows = gp_laps[gp_laps["Driver"] == driver]
+    if rows.empty:
+        return {}
+
+    has_stint = "Stint" in rows.columns
+    ordered = rows.sort_values("LapNumber")
+
+    timeline: dict[int, dict[str, Any]] = {}
+    compounds: list[str] = []
+    stints: set[int] = set()
+
+    for _, row in ordered.iterrows():
+        compound = str(row.get("Compound") or "").upper()
+        if compound in (DRY_COMPOUNDS | WET_COMPOUNDS) and compound not in compounds:
+            compounds.append(compound)
+
+        if has_stint and pd.notna(row.get("Stint")):
+            stints.add(int(row["Stint"]))
+
+        timeline[int(row["LapNumber"])] = _flags_from_history(compounds, stints)
+
+    return timeline
+
+
+def _flags_from_history(compounds: list[str], stints: set[int]) -> dict[str, Any]:
+    """Turn an accumulated compound list and stint set into the three flags.
+
+    Shared by the per-lap and whole-timeline entry points so the two can never
+    disagree about what the same history means — a duplicated rule here would be
+    the kind of drift that costs a race.
+    """
+    highest_stint = max(stints) if stints else None
+    stops_made = highest_stint - 1 if highest_stint is not None else None
+
+    used_wet = any(c in WET_COMPOUNDS for c in compounds)
+    dry_seen = {c for c in compounds if c in DRY_COMPOUNDS}
+    all_stints_visible = bool(stints) and set(range(1, highest_stint + 1)) <= stints
+
+    if not compounds:
+        pending: bool | None = None
+    elif used_wet or len(dry_seen) >= 2:
+        pending = False
+    elif all_stints_visible:
+        pending = True
+    else:
+        pending = None
+
+    return {
+        "stops_made": stops_made,
+        "compounds_used": list(compounds),
+        "mandatory_stop_pending": pending,
+    }

--- a/tests/test_mc_state_helpers.py
+++ b/tests/test_mc_state_helpers.py
@@ -302,30 +302,48 @@ def test_rivals_with_no_usable_gap_cannot_conjure_a_projection():
 # ---------------------------------------------------------------------------
 
 
-def test_every_spelling_of_a_circuit_finds_the_same_measured_values():
-    """Three keyspaces meet in this repo and a miss used to be silent.
+# Circuits this repo spells more than one way: underscored folder forms, the
+# country name 2023 filed Barcelona under, Miami's three variants, and the two
+# that carry diacritics and lose them through a non-UTF-8 console.
+_CIRCUIT_SPELLINGS = (
+    ("Barcelona", "Spain"),
+    ("Miami", "Miami Gardens", "Miami_Gardens"),
+    ("Lusail", "Qatar Grand Prix"),
+    ("Yas Island", "Yas_Island"),
+    ("São Paulo", "Sao Paulo", "Sao_Paulo"),
+    ("Montréal", "Montreal"),
+)
 
-    Folder names underscore multi-word slugs, 2023 filed Barcelona under a
-    country name, Miami has three spellings, and two circuits carry diacritics
-    that vanish through a non-UTF-8 console. A traversal lookup that missed fell
-    back to a flat 20.0 with a warning; a hazard lookup that missed fell back to
-    the pooled rate in silence, which is the #448 failure exactly.
+
+def test_every_spelling_of_a_circuit_finds_the_same_hazard():
+    """Three keyspaces meet in this repo, and a hazard miss used to be silent.
+
+    Unlike the traversal lookup, which at least warns when it falls back, a
+    hazard miss quietly returned the pooled rate — a table that looks populated
+    while every lookup misses is the #448 failure exactly. Reads the committed
+    measured tables, so it runs everywhere.
     """
-    from src.agents.position_projection import measured_neutralisation_rate, traversal_seconds
+    from src.agents.position_projection import measured_neutralisation_rate
 
-    for spellings in (
-        ("Barcelona", "Spain"),
-        ("Miami", "Miami Gardens", "Miami_Gardens"),
-        ("Lusail", "Qatar Grand Prix"),
-        ("Yas Island", "Yas_Island"),
-        ("São Paulo", "Sao Paulo", "Sao_Paulo"),
-        ("Montréal", "Montreal"),
-    ):
-        traversals = {traversal_seconds(name) for name in spellings}
+    for spellings in _CIRCUIT_SPELLINGS:
         hazards = {round(measured_neutralisation_rate(name), 6) for name in spellings}
+        assert len(hazards) == 1, f"{spellings} disagree on hazard: {hazards}"
+
+
+@_skip_no_models
+def test_every_spelling_of_a_circuit_finds_the_same_traversal():
+    """Same keyspace check for the per-circuit pit-lane traversal.
+
+    Separate from the hazard test because this table lives in ``data/models/``,
+    which is distributed through the Hugging Face Hub rather than git — so a CI
+    runner without the weights has no table to look anything up in.
+    """
+    from src.agents.position_projection import traversal_seconds
+
+    for spellings in _CIRCUIT_SPELLINGS:
+        traversals = {traversal_seconds(name) for name in spellings}
         assert len(traversals) == 1, f"{spellings} disagree on traversal: {traversals}"
         assert None not in traversals, f"{spellings} has no traversal at all"
-        assert len(hazards) == 1, f"{spellings} disagree on hazard: {hazards}"
 
 
 def test_a_circuit_that_has_never_thrown_a_safety_car_is_not_given_a_zero_rate():

--- a/tests/test_mc_state_helpers.py
+++ b/tests/test_mc_state_helpers.py
@@ -295,3 +295,53 @@ def test_rivals_with_no_usable_gap_cannot_conjure_a_projection():
         laps_remaining=20,
     )
     assert blind == baseline
+
+
+# ---------------------------------------------------------------------------
+# Keyspace and hazard floor (final-audit F3-6, F3-7)
+# ---------------------------------------------------------------------------
+
+
+def test_every_spelling_of_a_circuit_finds_the_same_measured_values():
+    """Three keyspaces meet in this repo and a miss used to be silent.
+
+    Folder names underscore multi-word slugs, 2023 filed Barcelona under a
+    country name, Miami has three spellings, and two circuits carry diacritics
+    that vanish through a non-UTF-8 console. A traversal lookup that missed fell
+    back to a flat 20.0 with a warning; a hazard lookup that missed fell back to
+    the pooled rate in silence, which is the #448 failure exactly.
+    """
+    from src.agents.position_projection import measured_neutralisation_rate, traversal_seconds
+
+    for spellings in (
+        ("Barcelona", "Spain"),
+        ("Miami", "Miami Gardens", "Miami_Gardens"),
+        ("Lusail", "Qatar Grand Prix"),
+        ("Yas Island", "Yas_Island"),
+        ("São Paulo", "Sao Paulo", "Sao_Paulo"),
+        ("Montréal", "Montreal"),
+    ):
+        traversals = {traversal_seconds(name) for name in spellings}
+        hazards = {round(measured_neutralisation_rate(name), 6) for name in spellings}
+        assert len(traversals) == 1, f"{spellings} disagree on traversal: {traversals}"
+        assert None not in traversals, f"{spellings} has no traversal at all"
+        assert len(hazards) == 1, f"{spellings} disagree on hazard: {hazards}"
+
+
+def test_a_circuit_that_has_never_thrown_a_safety_car_is_not_given_a_zero_rate():
+    """Monza and Budapest measure exactly zero onsets, and zero is not a rate.
+
+    A zero drives q_f to 0, which tells the decision layer that no future
+    neutralisation can ever cover a stop and biases the terminal liability
+    upward on every lap. Monza is also the archetypal Art. 55.17 circuit, so
+    that is the worst possible place to lose the term. A zero count means "not
+    seen here", not "cannot happen here".
+    """
+    from src.agents.position_projection import measured_neutralisation_rate
+
+    pooled = measured_neutralisation_rate(None)
+    for quiet_circuit in ("Monza", "Budapest"):
+        assert measured_neutralisation_rate(quiet_circuit) == pooled
+
+    # A circuit that HAS thrown them keeps its own measured, higher rate.
+    assert measured_neutralisation_rate("Melbourne") > pooled


### PR DESCRIPTION
Three more findings from the final adversarial audit.

## A measured zero is not a rate (MEDIUM)

Monza and Budapest measure **exactly 0 onsets** (0 in 157 and 210 racing laps). That drove `q_f` to 0, which tells the decision layer that no future neutralisation can ever turn up to cover a stop — and biases the terminal liability upward on every lap. Monza is also the archetypal Art. 55.17 circuit, so it is the worst possible place to lose the term.

A zero count means *not seen here*, not *cannot happen here*: the upper bound of that interval comfortably covers the pooled rate. Both now fall back to pooled, while Melbourne keeps its measured 0.0746.

## Three keyspaces, and two circuits fell through both tables (MEDIUM)

A sweep of the 71 races found **Spain 2023 and Miami Gardens 2025 missing from BOTH** the traversal and hazard tables — traversal fell back to a flat 20.0 with a warning, the hazard fell back to pooled in silence, which is the #448 failure exactly.

Fixed with explicit aliases for the country-named and multi-word folder forms, plus **accent folding**, so a name that lost its diacritics through a non-UTF-8 console still finds São Paulo and Montréal. A new test asserts every spelling of six circuits agrees on both tables.

## The lap state is O(1) again (MEDIUM)

Emitting stint flags for our car plus every rival called a helper that rescans the whole frame — about **twenty full scans per lap**, taking `get_lap_state` from 2.0 to **18.0 ms/lap**, against the O(1) promise the class docstring makes.

Each driver's whole timeline is now built in one ordered pass and cached lazily: **3.9 ms/lap**. A lap with no row (the featured frame drops Safety Car laps) reads the most recent earlier lap rather than reporting nothing — compound history only grows, so the last known state is still true. Verified against the per-lap function: **0 mismatches over 3 drivers x 57 laps**.

Refs #550