### PR TITLE
fix(mc): bound the window by the race end and gate the undercut by regime

### DIFF
--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -838,6 +838,18 @@ def _finite_or_none(value) -> float | None:
     return None if math.isnan(number) or math.isinf(number) else number
 
 
+def _bounded_by_race_end(racing_laps: float, laps_remaining: int) -> float:
+    """Racing laps the window can actually contain, given the race ends.
+
+    ``laps_remaining`` of 0 means unknown here, not "the race is over": several
+    callers cannot supply it, and clamping an unknown to zero would silence the
+    whole window. Only a positive, smaller count clamps.
+    """
+    if laps_remaining <= 0:
+        return racing_laps
+    return min(racing_laps, float(laps_remaining))
+
+
 def _position_or(reported, counted: int) -> int:
     """The reported classification position, or the one counted from the gaps.
 
@@ -992,11 +1004,19 @@ def _run_projection_mc(
     # measured average, so the case could not be expressed at all and a test that
     # passed 0.0 silently received 2.61 and went green for the wrong reason.
     override_racing_laps = _finite_or_none(context.get("racing_laps_neutralised"))
-    racing_when_neutralised = (
-        float(override_racing_laps)
-        if override_racing_laps is not None
-        else measured_racing_laps("vsc" if is_vsc else "sc")
-    )
+    if override_racing_laps is not None:
+        racing_when_neutralised = float(override_racing_laps)
+    else:
+        racing_when_neutralised = measured_racing_laps("vsc" if is_vsc else "sc")
+
+    # The window cannot outlast the race. A decision three laps from the flag
+    # cannot bank five laps of racing, and under a neutralisation that runs to
+    # the end it banks none at all — which is the Art. 55.17 endgame the docs
+    # describe, and until this clamp existed the code could not express it: the
+    # racing-lap count was always the measured average, so a stop always looked
+    # as though it had laps left to pay itself back over.
+    racing_when_racing = _bounded_by_race_end(float(WINDOW_LAPS), remaining)
+    racing_when_neutralised = _bounded_by_race_end(racing_when_neutralised, remaining)
 
     def _config(racing_laps: float) -> ProjectionConfig:
         return ProjectionConfig(
@@ -1011,7 +1031,7 @@ def _run_projection_mc(
             mandatory_stop_pending=context.get("mandatory_stop_pending"),
         )
 
-    green_config = _config(float(WINDOW_LAPS))
+    green_config = _config(racing_when_racing)
     neutralised_config = _config(racing_when_neutralised)
 
     undercut_choices = undercut_targets(rival_states, green_config)
@@ -1064,7 +1084,15 @@ def _run_projection_mc(
             # actually clear the target? A success is worth the place, and the
             # projection supplies everything else. No new constant is introduced —
             # the alternative was inventing an out-lap delta nobody measured.
-            outcomes = outcomes + _np.asarray(ucut_s, dtype=float)
+            #
+            # Only on RACING draws. Under a neutralisation the move does not
+            # exist: overtaking is prohibited (Art. 55.8), the field is queued
+            # and everyone reaches the pit lane on the same delta, so there is no
+            # advantage to arriving first. Granting it there was worth about half
+            # a position on a fully neutralised state — a place awarded for a
+            # manoeuvre the regulations forbid.
+            landed = _np.asarray(ucut_s, dtype=float) * (~neutralised).astype(float)
+            outcomes = outcomes + landed
 
         e_val = float(_np.mean(outcomes))
         p10_val = float(_np.percentile(outcomes, 10))

--- a/tests/test_mc_is_a_real_decision.py
+++ b/tests/test_mc_is_a_real_decision.py
@@ -314,3 +314,79 @@ def test_the_legacy_path_is_taken_whenever_the_rivals_list_is_falsy():
     baseline = _run_mc_simulation(pace, tire, situation, pit, alpha=0.5)
     for falsy in (None, [], ()):
         assert _run_mc_simulation(pace, tire, situation, pit, alpha=0.5, rivals=falsy) == baseline
+
+
+def test_an_undercut_earns_nothing_under_a_neutralisation():
+    """Art. 55.8 forbids overtaking under a Safety Car, so the move does not exist.
+
+    The field is queued and everyone reaches the pit lane on the same delta, so
+    arriving first buys nothing. The bonus used to be granted regardless of
+    regime, which awarded roughly half a position for a manoeuvre the
+    regulations prohibit.
+    """
+    racing = _projection_scores((-1.2, 8.0, False, 20.0, False, True, 2.4))
+    neutralised = _projection_scores((-1.2, 8.0, False, 20.0, True, True, 2.4))
+
+    assert racing["UNDERCUT"]["score"] > racing["PIT_NOW"]["score"]
+    assert neutralised["UNDERCUT"]["score"] == pytest.approx(
+        neutralised["PIT_NOW"]["score"], abs=1e-9
+    )
+
+
+def test_the_window_cannot_outlast_the_race():
+    """With one lap left behind the Safety Car a stop cannot pay itself back.
+
+    This is the Art. 55.17 endgame, and until the racing-lap count was bounded
+    by the laps that actually remain, the code could not express it: the count
+    was always the measured average, so a stop always appeared to have laps left
+    to earn its cost over. The docs described the mechanism; the code did not
+    have it.
+    """
+    from src.agents.strategy_orchestrator import _run_projection_mc
+
+    rivals = [
+        {"driver": "B", "interval_to_driver_s": 1.2, "is_pitting": False},
+        {"driver": "C", "interval_to_driver_s": 3.0, "is_pitting": False},
+    ]
+
+    def _scores(laps_remaining: int) -> dict:
+        return _run_projection_mc(
+            rivals=rivals,
+            position=1,
+            laps_remaining=laps_remaining,
+            pit_context={
+                "traversal_s": 21.0,
+                "mandatory_stop_pending": False,
+                "neutralisation_rate": 0.0179,
+                "rival_stop_pending": {"B": False, "C": False},
+                "rival_pit_loss_s": 23.8,
+            },
+            cliff_s=np.full(_DRAWS, 2.0),
+            sc_s=np.full(_DRAWS, True),
+            pit_s=np.full(_DRAWS, 2.8),
+            ucut_s=np.zeros(_DRAWS, dtype=bool),
+            alpha=0.5,
+            neutralisation_saving_s=8.0,
+        )
+
+    endgame = _scores(1)
+    assert _projection_argmax(endgame) == "STAY_OUT"
+    assert endgame["STAY_OUT"]["score"] > endgame["PIT_NOW"]["score"]
+
+
+def test_the_racing_lap_clamp_only_fires_near_the_flag():
+    """The bound belongs to the end of the race, not to every lap of it.
+
+    Asserted on the helper rather than through a score, because with one lap
+    left or thirty the stop loses the same two cars — the sub-second difference
+    in fresh-tyre laps does not move a whole position, so the score cannot show
+    the clamp working. Zero means unknown here, not "the race is over": several
+    callers cannot supply a lap count, and clamping an unknown to zero would
+    silence the window entirely.
+    """
+    from src.agents.strategy_orchestrator import _bounded_by_race_end
+
+    assert _bounded_by_race_end(5.0, 30) == 5.0
+    assert _bounded_by_race_end(5.0, 3) == 3.0
+    assert _bounded_by_race_end(2.61, 1) == 1.0
+    assert _bounded_by_race_end(2.61, 0) == 2.61


### PR DESCRIPTION
Two findings from the final adversarial audit. Both are cases of the model **claiming something the code did not do**.

## The Art. 55.17 endgame was documented but not implemented

The docs and the `terminal_liability` docstring describe the mechanism as *racing laps dropping to zero*. The code could not express it: the racing-lap count was always the measured average (2.61 under a Safety Car), so a stop **always looked as though it had laps left to pay itself back over**, even on the last lap of the race.

The window is now bounded by the laps that actually remain. Verified on a real state: one lap left behind the Safety Car gives **STAY_OUT the win outright**. A `laps_remaining` of 0 means unknown rather than race-over, so it does not clamp — several callers cannot supply it.

## The undercut was paid under a Safety Car

The N16 success bonus was granted on every draw regardless of regime. Under a neutralisation the move **does not exist**: overtaking is prohibited (Art. 55.8), the field is queued, and everyone reaches the pit lane on the same delta, so arriving first buys nothing. It was worth about half a position on a fully neutralised state — a place awarded for a manoeuvre the regulations forbid.

Measured after the fix: **1.000 of advantage under green, exactly 0.000 under a Safety Car.**

## Verification

83 tests pass; goldens byte-identical; lint and format clean. Three new tests: the regime gate, the endgame behaviour, and the clamp itself (asserted on the helper, because with one lap left or thirty the stop loses the same two cars — the sub-second difference in fresh-tyre laps cannot move a whole position, so a score-level assertion could not see it).

Refs #550