### PR TITLE
feat(mc): name the target we will actually be racing

### DIFF
--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -838,6 +838,17 @@ def _finite_or_none(value) -> float | None:
     return None if math.isnan(number) or math.isinf(number) else number
 
 
+def _ordered_by(choices: list[str], preference: list[str]) -> list[str]:
+    """``choices`` sorted to follow ``preference``, keeping anything it omits.
+
+    Used to put the nearest post-pit-cycle rival at the head of an eligibility
+    list, so ``target`` names the car we will actually be racing rather than
+    whichever one the rivals list happened to mention first.
+    """
+    rank = {driver: index for index, driver in enumerate(preference)}
+    return sorted(choices, key=lambda driver: rank.get(driver, len(rank)))
+
+
 def _bounded_by_race_end(racing_laps: float, laps_remaining: int) -> float:
     """Racing laps the window can actually contain, given the race ends.
 
@@ -958,6 +969,7 @@ def _run_projection_mc(
         overcut_targets,
         payoff,
         project_positions,
+        rank_targets,
         undercut_targets,
     )
 
@@ -1034,8 +1046,16 @@ def _run_projection_mc(
     green_config = _config(racing_when_racing)
     neutralised_config = _config(racing_when_neutralised)
 
-    undercut_choices = undercut_targets(rival_states, green_config)
-    overcut_choices = overcut_targets(rival_states)
+    # Eligible targets, ordered by where they will be once BOTH pit cycles have
+    # played out rather than by where they sit on the timing screen now. That
+    # ordering is the whole point of the far-field ranker (#439): the car we end
+    # up racing is not always the car currently in front, and picking the first
+    # entry of an unordered list made "target" a coincidence of iteration order.
+    ranking = rank_targets(rival_states, green_config, our_pit_loss_s=float(pit_loss_s.mean()))
+    by_post_cycle_proximity = [target.driver for target in ranking]
+
+    undercut_choices = _ordered_by(undercut_targets(rival_states, green_config), by_post_cycle_proximity)
+    overcut_choices = _ordered_by(overcut_targets(rival_states), by_post_cycle_proximity)
 
     plans = {
         "STAY_OUT": DriverPlan("STAY_OUT", stops_in_window=False),

--- a/tests/test_mc_is_a_real_decision.py
+++ b/tests/test_mc_is_a_real_decision.py
@@ -390,3 +390,42 @@ def test_the_racing_lap_clamp_only_fires_near_the_flag():
     assert _bounded_by_race_end(5.0, 3) == 3.0
     assert _bounded_by_race_end(2.61, 1) == 1.0
     assert _bounded_by_race_end(2.61, 0) == 2.61
+
+
+def test_the_named_target_is_the_car_we_will_be_racing_not_the_first_in_the_list():
+    """#439 delivered: eligibility is ordered by post-pit-cycle proximity.
+
+    Two cars are inside the undercut band. The one further away on the timing
+    screen is the one still owing a stop, so once both cycles play out it is the
+    one we come out racing. Picking the first entry of an unordered list made
+    `target` a coincidence of iteration order.
+    """
+    from src.agents.strategy_orchestrator import _run_projection_mc
+
+    rivals = [
+        # Listed first, but it has already stopped, so it keeps gaining on us.
+        {"driver": "GONE", "interval_to_driver_s": -1.0, "is_pitting": False},
+        # Listed second and further away, but it still owes the stop we are
+        # about to take, so after both cycles it is right next to us.
+        {"driver": "RACING_US", "interval_to_driver_s": -3.5, "is_pitting": False},
+    ]
+    scores = _run_projection_mc(
+        rivals=rivals,
+        position=3,
+        laps_remaining=25,
+        pit_context={
+            "traversal_s": 21.0,
+            "mandatory_stop_pending": True,
+            "neutralisation_rate": 0.0179,
+            "rival_stop_pending": {"GONE": False, "RACING_US": True},
+            "rival_pit_loss_s": 23.8,
+        },
+        cliff_s=np.full(_DRAWS, 8.0),
+        sc_s=np.zeros(_DRAWS, dtype=bool),
+        pit_s=np.full(_DRAWS, 2.8),
+        ucut_s=np.zeros(_DRAWS, dtype=bool),
+        alpha=0.5,
+        neutralisation_saving_s=8.0,
+    )
+    assert scores["UNDERCUT"]["eligible"]
+    assert scores["UNDERCUT"]["target"] == "RACING_US"


### PR DESCRIPTION
Two findings from the final audit that resolve together.

`rank_targets` shipped in #562 as the deliverable for **#439** and then had **zero production callers** — while PR #565 carried `Closes #439`. Separately, the engine picked `target` as `choices[0]`: whichever car the rivals list happened to mention first.

Eligible targets are now ordered by **where they will be once both pit cycles have played out**, which is precisely the question the ranker was built to answer.

## The case it fixes

Two cars inside the undercut band. One is a second ahead but has **already stopped**, so it keeps gaining on us. The other is 3.5 s ahead and **still owes the stop we are about to take**, so once both cycles finish it is the car we are actually racing. The old code named the first; the new code names the second.

This is Víctor's original scenario from #439 in miniature: the car worth attacking is not always the car currently in front.

Refs #550
Closes #439
