### PR TITLE
chore(tests): group the Monte Carlo suites under tests/mc

### DIFF
--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -157,7 +157,7 @@ It also silenced the computation built to weigh it: with an SC deployed `sc_prob
 
 Staying out under an SC is right whenever you have already stopped, you lead a pack that must stop anyway, you would rejoin into traffic, or the race is ending. Boxing is right when you must stop anyway, the tyres are near the cliff, or the two-compound rule is unsatisfied and time is short. Not one of those is a rule. All of them are race state the model is given, and a rail sees none of it.
 
-See `tests/test_sc_regulatory_rails.py`.
+See `tests/mc/test_sc_regulatory_rails.py`.
 
 ### N29 — Radio Agent (`radio_agent.py`)
 

--- a/scripts/measure_mc_tables.py
+++ b/scripts/measure_mc_tables.py
@@ -44,7 +44,7 @@ Regenerate with::
     uv run python scripts/measure_mc_tables.py
 
 The output is deterministic: same parquets in, byte-identical JSON out. A test
-(``tests/test_mc_measured_tables.py``) asserts the committed file matches a fresh
+(``tests/mc/test_mc_measured_tables.py``) asserts the committed file matches a fresh
 run, so a silent data change cannot drift the tables the engine reads.
 
 --- WHERE TO CHANGE IF THE RACE DATA LAYOUT CHANGES ---

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -1524,7 +1524,7 @@ class PitStrategyAgent:
         # is right whenever you have already stopped, you lead a pack that must stop
         # anyway, or the race is ending (Art. 55.17 finishes it behind the SC, making
         # the surrendered position unrecoverable). The regulatory facts an SC does
-        # force live in N27; see tests/test_sc_regulatory_rails.py.
+        # force live in N27; see tests/mc/test_sc_regulatory_rails.py.
         sc_reactive = sc_currently_active or (action == 'REACTIVE_SC') or (
             sc_prob >= 0.30 and action in ('PIT_NOW', 'UNDERCUT')
         )

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -691,7 +691,7 @@ def simulate_lap_window(
         # two-compound rule, so pit-now and pit-later both pay it and it cancels in a
         # comparison scored relative to STAY_OUT; charging one side only puts PIT_NOW near
         # -14 positions against a worst-case STAY_OUT of about -2.7 and suppresses pitting.
-        # See tests/test_mc_is_a_real_decision.py.
+        # See tests/mc/test_mc_is_a_real_decision.py.
         if sc_i:
             time_delta = -pit_i + sc_pit_bonus + FRESH_GAIN * window
         else:
@@ -1898,7 +1898,7 @@ def _assemble_recommendation(
     Art. 22.1(c)). Only `target_lap_time_s` is forced here, because this is the layer
     that emits it — see the note at its assignment below. Add a new fact only if the
     regulation removes the field's SOURCE; if it merely makes a choice usually smart,
-    it belongs in the prompt or the MC. See tests/test_sc_regulatory_rails.py.
+    it belongs in the prompt or the MC. See tests/mc/test_sc_regulatory_rails.py.
 
     Defaults to False so a caller that does not thread N27's output keeps the previous
     behaviour rather than silently changing it.
@@ -1971,7 +1971,7 @@ def _assemble_recommendation(
     # valid value. None is forced by ABSENCE OF A SOURCE, not by a strategy view, and
     # the schema already documents None as "the LLM prefers not to commit".
     # Inventing a delta would only launder the breach into looking authoritative.
-    # See tests/test_sc_regulatory_rails.py.
+    # See tests/mc/test_sc_regulatory_rails.py.
     action    = synth.action
     reasoning = synth.reasoning
 

--- a/tests/audit/test_race_situation_hardening.py
+++ b/tests/audit/test_race_situation_hardening.py
@@ -89,7 +89,7 @@ def test_thresholds_loaded_from_model_config_not_hardcoded():
 def agent_at_lap_50():
     """RaceSituationAgent wired exactly as run_from_state wires it, Lusail lap 50.
 
-    Reuses the same real-bug scenario as tests/test_undercut_targets_are_on_track.py:
+    Reuses the same real-bug scenario as tests/mc/test_undercut_targets_are_on_track.py:
     HUL crashed on lap 7, so he is absent from the RaceStateManager ``rivals`` this
     replay actually produces at lap 50 — a real retired-driver case, not a made-up one.
     """

--- a/tests/mc/test_mc_is_a_real_decision.py
+++ b/tests/mc/test_mc_is_a_real_decision.py
@@ -27,7 +27,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-ROOT = Path(__file__).parent.parent
+ROOT = Path(__file__).parent.parent.parent
 _HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
 pytestmark = pytest.mark.skipif(
     not _HAS_MODELS,
@@ -411,7 +411,7 @@ def test_the_legacy_path_is_taken_whenever_the_rivals_list_is_falsy():
     have routed them into a projection with no cars in it.
     """
     from src.agents.strategy_orchestrator import _run_mc_simulation
-    from tests.test_mc_state_helpers import _canned_outputs
+    from tests.mc.test_mc_state_helpers import _canned_outputs
 
     pace, tire, situation, pit = _canned_outputs()
     baseline = _run_mc_simulation(pace, tire, situation, pit, alpha=0.5)

--- a/tests/mc/test_mc_measured_tables.py
+++ b/tests/mc/test_mc_measured_tables.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).parent.parent
+ROOT = Path(__file__).parent.parent.parent
 TABLES_PATH = ROOT / "data" / "mc_measured_v1.json"
 
 _HAS_RAW = (ROOT / "data" / "raw" / "2024").is_dir()

--- a/tests/mc/test_mc_state_helpers.py
+++ b/tests/mc/test_mc_state_helpers.py
@@ -22,7 +22,7 @@ import pytest
 
 from src.simulation.stint_history import stint_history_flags
 
-ROOT = Path(__file__).parent.parent
+ROOT = Path(__file__).parent.parent.parent
 
 _HAS_DATA = (ROOT / "data" / "processed" / "laps_featured_2024.parquet").exists()
 _skip_no_data = pytest.mark.skipif(
@@ -202,7 +202,7 @@ def test_rsm_get_stint_flags_matches_the_pure_helper(raw_lusail_2024):
 
 
 def _canned_outputs():
-    """Same canned near-cliff fixture as tests/test_strategy_goldens.py."""
+    """Same canned near-cliff fixture as tests/mc/test_strategy_goldens.py."""
     from src.agents.pace_agent import PaceOutput
     from src.agents.pit_strategy_agent import PitStrategyOutput
     from src.agents.race_situation_agent import RaceSituationOutput

--- a/tests/mc/test_position_projection.py
+++ b/tests/mc/test_position_projection.py
@@ -33,7 +33,7 @@ from src.agents.position_projection import (
     undercut_targets,
 )
 
-ROOT = Path(__file__).parent.parent
+ROOT = Path(__file__).parent.parent.parent
 
 _HAS_RAW = (ROOT / "data" / "raw" / "2024").is_dir()
 _skip_no_raw = pytest.mark.skipif(

--- a/tests/mc/test_sc_regulatory_rails.py
+++ b/tests/mc/test_sc_regulatory_rails.py
@@ -21,7 +21,7 @@ import pytest
 
 # Importing the orchestrator pulls the sub-agent modules, which read model configs at
 # import time, so this carries the same guard as the other agent-touching tests.
-ROOT = Path(__file__).parent.parent
+ROOT = Path(__file__).parent.parent.parent
 _HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
 pytestmark = pytest.mark.skipif(
     not _HAS_MODELS,

--- a/tests/mc/test_strategy_goldens.py
+++ b/tests/mc/test_strategy_goldens.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).parent.parent
+ROOT = Path(__file__).parent.parent.parent
 _HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
 _skip_no_models = pytest.mark.skipif(
     not _HAS_MODELS,

--- a/tests/mc/test_undercut_targets_are_on_track.py
+++ b/tests/mc/test_undercut_targets_are_on_track.py
@@ -30,7 +30,7 @@ import pandas as pd
 import pytest
 
 RACE_DIR = Path("data/raw/2025/Lusail")
-ROOT = Path(__file__).parent.parent
+ROOT = Path(__file__).parent.parent.parent
 _HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
 
 # Importing N28 reads model configs at import time, and the fixture needs the raw


### PR DESCRIPTION
`tests/` had `audit/`, `eval/` and `fixtures/` as folders and then **twenty loose files** on top, which made the decision-layer suites impossible to find as a set.

The seven that cover the Monte Carlo now live together under `tests/mc/`:

| file | what it holds |
|---|---|
| `test_mc_is_a_real_decision.py` | the argmax invariants, both paths |
| `test_position_projection.py` | the pure primitive |
| `test_mc_measured_tables.py` | the committed measurements match a fresh run |
| `test_mc_state_helpers.py` | lap_state to MC plumbing |
| `test_undercut_targets_are_on_track.py` | target eligibility |
| `test_sc_regulatory_rails.py` | what the rulebook makes certain |
| `test_strategy_goldens.py` | freezes the legacy seconds path |

A pure move plus the three things a move breaks: the repo-root walk gains a level, the one cross-test import is repointed, and the prose references in the engine, the docs page and the measurement script follow the files.

The audit reports under `documents/` keep the old paths — they describe where the tests were when those audits ran.

Thirteen loose files remain (engine, CLI, smoke, deps). Those still read fine as a flat list; if a second obvious group appears it gets its own change.