### PR TITLE
fix(data): share one FastF1 cache and stop download_data pulling the whole hub

### DIFF
--- a/scripts/build_rag_index.py
+++ b/scripts/build_rag_index.py
@@ -562,15 +562,19 @@ def build_index(
         log.error("No valid PDFs loaded — check naming convention")
         sys.exit(1)
 
+    # Counted in the same pass that collects them. The skipped total used to come
+    # from a second `iter_chunks` over every document, which re-ran the sliding
+    # window, the article regexes and a SHA-256 over the whole corpus purely to
+    # produce one number for the log line below.
     all_chunks: list[TextChunk] = []
+    skipped = 0
     for doc in documents:
         for chunk in iter_chunks(doc):
-            if chunk.chunk_hash not in existing_hashes:
+            if chunk.chunk_hash in existing_hashes:
+                skipped += 1
+            else:
                 all_chunks.append(chunk)
 
-    skipped = sum(
-        1 for doc in documents for chunk in iter_chunks(doc) if chunk.chunk_hash in existing_hashes
-    )
     log.info("New chunks to index: %d  |  skipped (already indexed): %d", len(all_chunks), skipped)
 
     if not all_chunks:

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -1,27 +1,49 @@
-"""
-Download F1 strategy dataset from Hugging Face Hub.
+"""Download the F1 StratLab dataset and model weights from Hugging Face Hub.
 
 Dataset: https://huggingface.co/datasets/VforVitorio/f1-strategy-dataset
-Contains:
-  - data/raw/      : Raw FastF1 parquets (2023, 2024, 2025 seasons)
-  - data/processed/: Feature-engineered parquets (N04 output)
 
-Usage:
     python scripts/download_data.py
+
+A thin front-end to :func:`src.f1_strat_manager.data_cache.ensure_setup`, which
+is the same routine the CLI runs on first launch. This script used to call
+``snapshot_download`` directly with no ``allow_patterns``, pulling the full
+~31.7 GB repository rather than the curated ~7-8 GB a working install needs,
+and with no error handling, so a dropped connection surfaced as a raw
+``huggingface_hub`` traceback with nothing actionable in it.
+
+Keeping one implementation matters more than the twenty lines it saves: the
+pattern list, the offline escape hatch and the failure message all live in
+``data_cache`` and would otherwise have had to be kept in step by hand.
+
+--- WHERE TO CHANGE IF THE DATASET LAYOUT CHANGES ---
+Nothing here. The pattern list is ``data_cache._build_allow_patterns`` and the
+repo id is ``data_cache.HF_DATASET_REPO_ID``.
 """
 
+from __future__ import annotations
+
+import sys
 from pathlib import Path
 
-from huggingface_hub import snapshot_download
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-REPO_ID = "VforVitorio/f1-strategy-dataset"
-LOCAL_DIR = Path(__file__).parent.parent / "data"
+from src.f1_strat_manager.data_cache import ensure_setup, get_data_root  # noqa: E402
+
+
+def main() -> int:
+    """Fetch the curated dataset, reporting failure the way the CLI does."""
+    try:
+        # skip_if_offline=False: someone running this script explicitly asked
+        # for a download, so quietly doing nothing under $F1_STRAT_OFFLINE
+        # would look like success.
+        ensure_setup(skip_if_offline=False)
+    except RuntimeError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    print(f"Done. Data cached under {get_data_root()}")
+    return 0
+
 
 if __name__ == "__main__":
-    print(f"Downloading dataset from {REPO_ID} ...")
-    snapshot_download(
-        repo_id=REPO_ID,
-        repo_type="dataset",
-        local_dir=str(LOCAL_DIR),
-    )
-    print(f"Done. Data saved to {LOCAL_DIR}")
+    sys.exit(main())

--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -14,6 +14,8 @@ import os
 from pathlib import Path
 from typing import Final
 
+from src.f1_strat_manager.data_cache import get_data_root
+
 logger = logging.getLogger(__name__)
 
 # --- Playback & timing ----------------------------------------------------
@@ -147,9 +149,15 @@ FLAG_COLORS: Final[dict[str, tuple[int, int, int]]] = {
 }
 
 # --- Paths ----------------------------------------------------------------
+# Resolved through data_cache rather than from __file__, so the arcade lands in
+# the same directory as every other surface and honours $F1_STRAT_DATA_ROOT
+# (docker-compose sets it to /app/data). The FastF1 cache in particular was
+# fragmented: this surface wrote 3.8 GB under data/cache/fastf1 while the
+# backend kept its own 274 MB copy of the same sessions, so whichever one
+# touched a race first paid the full parse cost and the other paid it again.
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
-FASTF1_CACHE_DIR: Final[Path] = REPO_ROOT / "data" / "cache" / "fastf1"
-ARCADE_CACHE_DIR: Final[Path] = REPO_ROOT / "data" / "cache" / "arcade"
+FASTF1_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "fastf1"
+ARCADE_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "arcade"
 CACHE_VERSION: Final[str] = "v6"  # adds track_status_by_lap for the race-events HUD card
 
 # --- Multiprocessing pool -------------------------------------------------


### PR DESCRIPTION
Data-engineering audit fixes. **Held on `dev` deliberately** — these wait for the pipeline walkthrough before promotion.

## The FastF1 disk cache was two caches

The arcade resolved it from `__file__` to `data/cache/fastf1` (**3.8 GB** on this machine); the backend resolved its own to `src/telemetry/cache` (**274 MB**). Both live, both written, same 2023-25 sessions. Whichever surface opened a race first paid the full FastF1 parse and the other paid it again from scratch.

Both now resolve through `get_data_root()`, which also means the arcade finally honours `$F1_STRAT_DATA_ROOT` like the rest of the project.

## `download_data.py` pulled the whole repository, with nothing to say when it failed

No `allow_patterns` (the full **~31.7 GB** rather than the curated ~7-8 GB a working install needs) and no error handling, so a dropped connection surfaced as a raw `huggingface_hub` traceback.

It is now a thin front-end to `ensure_setup` — the same routine the CLI runs on first launch, which already carries the pattern list, the offline escape hatch and an actionable failure message. Keeping one implementation matters more than the twenty lines it saves: the alternative was two copies of the pattern list to hold in step by hand. As a side effect `scripts/README.md`'s "~7 GB" claim becomes true.

## Also

`build_rag_index` counted its skipped chunks with a **second full pass** over every document, re-running the sliding window, the article regexes and a SHA-256 over the whole corpus to produce one number for a log line.

## Submodule

Carries F1_Telemetry_Manager#194: `/telemetry/race-data` returned **null gaps for every driver-filtered request** (their #193), plus caches for the two radio endpoints. Numbers in that PR.

## Not touched, needs your call

`src/agents/strategy_agent.py` and the four `src/agents/rules/*.py` are a dead island — nothing imports them, and they hardcode `../../f1-strategy/f1_cache`, a path from before the repo was renamed. They are the experta rule-engine prototype from the thesis. Delete, or move under `legacy/`? I did not want to decide that one.