### PR TITLE
fix(deps): drop python-jose, which nothing imported

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -136,14 +136,13 @@ reason = "Pillow: fix in 12.3.0 blocked by arcade==3.3.3 (<11.4 pin); no untrust
 id = "GHSA-rrmf-rvhw-rf47"
 reason = "torch: no upstream fix; CUDA-pinned; requires attacker-controlled in-process model input, outside the single-user local threat model."
 
-# --- ecdsa (no upstream fix, transitive, not on a hot path) -------------------
-# PYSEC-2026-1325 (Minerva-class timing side-channel on P-256) has no upstream
-# fix. ecdsa is transitive via python-jose[cryptography] and is not exercised:
-# the backend auth uses a static API key, not ECDSA/JWT. A timing side-channel
-# needs local co-resident measurement, outside the single-user localhost model.
-[[IgnoredVulns]]
-id = "GHSA-wj6h-64fc-37mp"
-reason = "ecdsa: no upstream fix; transitive via python-jose and not on any hot path (auth is a static API key, not ECDSA); timing attack needs local co-residence."
+# --- ecdsa: waiver removed, the dependency is gone ----------------------------
+# GHSA-wj6h-64fc-37mp was waived here on the grounds that ecdsa arrived
+# transitively through python-jose and was never exercised, since the backend
+# authenticates with a static API key rather than JWT. That reasoning was the
+# argument for deleting the dependency, not for tolerating it: nothing in the
+# codebase imported python-jose at all. Dropping it took ecdsa, rsa and pyasn1
+# out of the lock with it, so there is no longer a vulnerability to ignore.
 
 # --- setuptools (fix blocked by torch's setuptools<82 pin) --------------------
 # The fix is setuptools 83.0.0, but torch 2.11/2.12 (the CUDA-pinned wheel this

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ dependencies = [
     "websockets>=11.0.0",
     "kafka-python>=2.0.2",
     "python-multipart>=0.0.31",
-    "python-jose[cryptography]>=3.3.0",
     "passlib[bcrypt]>=1.7.4",
     "httpx>=0.25.0",
     "aiofiles>=23.0.0",

--- a/tests/test_dep_imports.py
+++ b/tests/test_dep_imports.py
@@ -325,7 +325,6 @@ _TIER2_IMPORTS = [
     "websockets",
     "aiofiles",
     "multipart",  # python-multipart imports as ``multipart``
-    "jose",  # python-jose
     "passlib",
     "kafka",  # kafka-python
     # Database

--- a/uv.lock
+++ b/uv.lock
@@ -1062,18 +1062,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ecdsa"
-version = "0.19.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
-]
-
-[[package]]
 name = "evaluate"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1168,7 +1156,6 @@ dependencies = [
     { name = "pyqtgraph" },
     { name = "pyside6" },
     { name = "python-dotenv" },
-    { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
     { name = "pytorch-lightning" },
     { name = "pyyaml" },
@@ -1259,7 +1246,6 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
-    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "python-multipart", specifier = ">=0.0.31" },
     { name = "pytorch-lightning", specifier = ">=2.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
@@ -3856,15 +3842,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyasn1"
-version = "0.6.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4184,25 +4161,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
-]
-
-[[package]]
-name = "python-jose"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ecdsa" },
-    { name = "pyasn1" },
-    { name = "rsa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
-]
-
-[package.optional-dependencies]
-cryptography = [
-    { name = "cryptography" },
 ]
 
 [[package]]
@@ -4694,18 +4652,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
     { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## The waiver was the clue

`osv-scanner.toml` waived `GHSA-wj6h-64fc-37mp` (ecdsa, Minerva-class timing side-channel) on these grounds:

> ecdsa is transitive via python-jose and not on any hot path (auth is a static API key, not ECDSA)

**That is the argument for deleting the dependency, not for tolerating it.**

## Nothing imports it

Checked `src/`, the backend submodule, `scripts/` and `tests/`: zero `from jose` / `import jose` / `jwt` matches outside `.venv`. The only reference in the entire repo was `tests/test_dep_imports.py` asserting the package is importable, which is a test pinning a dependency the project does not use.

## What it removes

```
Removed ecdsa v0.19.2
Removed pyasn1 v0.6.4
Removed python-jose v3.5.0
Removed rsa v4.9.1
```

The advisory is **gone rather than ignored**, so the waiver goes with it.

## Verification

`uv lock` removes exactly those four. `uv sync --all-extras --frozen` succeeds. `tests/test_dep_imports.py` and `tests/test_smoke.py`: 64 passed, 5 skipped (the skips are pre-existing optional extras).

## The rest of the alert list, checked rather than assumed

| package | status |
|---|---|
| **pillow** | genuinely blocked. `arcade==3.3.3` is the **latest release on PyPI** and pins `pillow~=11.3.0`, so 12.x is unreachable while arcade is a dependency. |
| **setuptools** | genuinely blocked. `torch` requires `setuptools<82`, verified by introspection; the fix is 83.0.0. |
| **torch** | no upstream fix. |

Those three waivers stay, and stay honest.