### PR TITLE
fix(docs): correct two published diagram errors

### DIFF
--- a/docs/pages/home.md
+++ b/docs/pages/home.md
@@ -26,7 +26,7 @@ graph TD
         M4[Safety-car LightGBM · N14]
         M5[Pit duration HistGBT · N15]
         M6[Undercut LightGBM · N16]
-        M7[Circuit clusters · N30]
+        M7[Circuit clusters · N03]
     end
 
     subgraph Agents["LangGraph sub-agents · 6"]

--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -33,6 +33,8 @@ graph TD
     N29 -->|PROBLEM or WARNING alert| N28
     N27 -->|sc_prob > 0.30| N30
     N28 -->|always when N28 active| N30
+    N27 -->|sc_currently_active, overrides every threshold| N28
+    N27 -->|sc_currently_active, overrides every threshold| N30
 
     subgraph "Layer 2 — Monte Carlo Simulation"
         MC[500 draws x 4 candidates<br/>STAY_OUT / PIT_NOW / UNDERCUT / OVERCUT<br/>score = alpha * E + 1-alpha * P10]


### PR DESCRIPTION
Both found while inventorying the codebase for new diagrams. Both are live on the docs site.

## `home.md`: circuit clustering attributed to N30

`docs/pages/home.md:29` labelled it `Circuit clusters · N30`. **N30 is the RAG agent.** The clustering is N03 (`notebooks/data_engineering/N03_circuit_clustering.ipynb`, confirmed present).

## `multi-agent.md`: the routing diagram was missing an edge its own prose describes

A Safety Car confirmed by race control (`sc_currently_active`) forces **both** N28 and N30, bypassing every probability threshold the diagram draws (`strategy_orchestrator.py:563-565`).

The text underneath already said so. The picture did not, so a reader working from the diagram would conclude the pit agent stays idle under a Safety Car whenever the tyre warning has not fired. Diagram and prose now agree.