### PR TITLE
docs: send contributors at dev, and repair six links that resolve nowhere

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -69,4 +69,4 @@ See [`docs/pages/simulation.md`](docs/pages/simulation.md) for the wire-level vi
 - **Backend API:** [`docs/pages/backend-api.md`](docs/pages/backend-api.md).
 - **Streamlit frontend:** [`docs/pages/streamlit.md`](docs/pages/streamlit.md).
 - **Simulation engine:** [`docs/pages/simulation.md`](docs/pages/simulation.md).
-- **All draw.io diagrams:** [`docs/diagrams/`](docs/diagrams/).
+- **All draw.io diagrams:** [`documents/dev_docs/diagrams/`](documents/dev_docs/diagrams/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ these safeguards trigger there. They are no-ops on POSIX.
 - [ ] One logical change per commit; imperative subject line; **no
       `Co-Authored-By` or AI-attribution trailers, ever.**
 - [ ] If you added a new sub-agent output, update
-      `docs/agents-api-reference.md`.
+      `docs/pages/agents-api.md`.
 
 ## CI pipeline
 

--- a/INDEX.md
+++ b/INDEX.md
@@ -24,7 +24,7 @@ Notebooks are the primary development artefact. `src/` modules are extracted fro
 | NLP pipeline for radio       | N17-N24                                                                                                                                                             |
 | Multi-agent system           | N25 (Pace) → N30 (RAG) → N26-N29 → N31 (Orchestrator)                                                                                                               |
 | Query RAG at runtime         | [`src/rag/retriever.py`](src/rag/retriever.py) — `RagRetriever` + `query_rag_tool`                                                                                  |
-| Telemetry web app            | [`src/telemetry/backend/main.py`](src/telemetry/backend/main.py) (FastAPI) + [`src/telemetry/frontend/app/main.py`](src/telemetry/frontend/app/main.py) (Streamlit) |
+| Telemetry web app            | [`src/telemetry/backend/main.py`](src/telemetry/backend/main.py) (FastAPI) + [`src/telemetry/webapp/`](src/telemetry/webapp/) (React), launched together with `f1-webapp`                              |
 
 ---
 
@@ -164,8 +164,6 @@ are reference/historical only — see [`src/strategy/README.md`](src/strategy/RE
 | [src/strategy/inference/no_llm.py](src/strategy/inference/no_llm.py)                           | The deterministic `--no-llm` code path consumed by `run_lap` |
 | [src/strategy/eval/](src/strategy/eval/)                                                       | `f1-eval` CLI backend — regenerates the model evaluation reports (metrics registry, calibration, threshold hygiene, NLP per-stage eval, headline-number reproduction, LLM-judged alert precision) under `documents/eval_reports/` |
 | [src/strategy/inference/tire_predictor.py](src/strategy/inference/tire_predictor.py)           | Jupytext-exported tire degradation inference wrapper (N09 era; reference only) |
-| [src/strategy/models/lap_time_model.py](src/strategy/models/lap_time_model.py)                 | Jupytext-exported lap time model module (reference only) |
-| [src/strategy/models/tire_degradation_model.py](src/strategy/models/tire_degradation_model.py) | Jupytext-exported tire degradation model module (reference only) |
 
 ### `src/telemetry/`
 
@@ -174,11 +172,9 @@ A separate full-stack web application for live telemetry visualisation, independ
 | Component                                                                | Description                                                                                                                                |
 | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | [src/telemetry/backend/main.py](src/telemetry/backend/main.py)           | FastAPI application entry point; mounts endpoints for telemetry, circuit domination, driver comparison, chat, voice, and strategy             |
-| `src/telemetry/backend/api/`                                             | Versioned API route handlers (`telemetry`, `circuit_domination`, `comparison`, `chat`, `voice`, `strategy` — the last exposes all N25-N31 agents + orchestrator over REST) |
-| `src/telemetry/backend/services/`                                        | Business logic: `telemetry/` (FastF1 client + session cache), `chatbot/` (chat engine, LLM service, MCP bridge), `simulation/` (SSE strategy-replay generator), `voice/` (STT/TTS/audio), plus `comparison_service.py` |
-| [src/telemetry/frontend/app/main.py](src/telemetry/frontend/app/main.py) | Streamlit multi-page app entry point (dashboard, comparison, chat pages)                                                                    |
-| `src/telemetry/frontend/app/pages/`                                      | Individual Streamlit pages                                                                                                                  |
-| `src/telemetry/frontend/app/components/`                                 | Reusable UI components (auth, layout, navbar)                                                                                               |
+| `src/telemetry/backend/api/`                                             | Versioned API route handlers (`telemetry`, `circuit_domination`, `comparison`, `chat`, `strategy` — the last exposes all N25-N31 agents + orchestrator over REST) |
+| `src/telemetry/backend/services/`                                        | Business logic: `telemetry/` (FastF1 client + session cache), `chatbot/` (chat engine, LLM service, MCP bridge), `simulation/` (SSE strategy-replay generator), plus `comparison_service.py` |
+| `src/telemetry/webapp/src/`                                              | React + TypeScript single-page app that replaced the Streamlit frontend in v2.0.0; served by nginx behind `/api` in the compose stack        |
 
 ### `src/data_extraction/`
 
@@ -204,7 +200,6 @@ historical reference scripts.
 | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | [src/data_extraction/legacy/image_augmentation.py](src/data_extraction/legacy/image_augmentation.py) | Albumentations augmentation pipeline for the YOLO car-team image dataset (early vision experiments)  |
 | [src/data_extraction/legacy/video_downloader.py](src/data_extraction/legacy/video_downloader.py)     | yt-dlp wrapper for downloading Creative Commons F1 highlight videos                                  |
-| [src/data_extraction/legacy/extract_radios.ipynb](src/data_extraction/legacy/extract_radios.ipynb)   | Original notebook radio dump (pre-N33), kept as a baseline reference for the OpenF1 pipeline         |
 
 ---
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -78,7 +78,7 @@ context and a native display. Cross-platform X forwarding from a
 container is fragile on Windows / Mac and has no benefit over a local
 install. Use `uv tool install` and run on the host.
 
-See [`docs/arcade-quick-start.md`](docs/arcade-quick-start.md) for the
+See [`docs/pages/arcade-quick-start.md`](docs/pages/arcade-quick-start.md) for the
 controls legend, troubleshooting and window tour.
 
 ---

--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ Requires Python 3.10-3.12 and an `OPENAI_API_KEY` (or `F1_LLM_PROVIDER=lmstudio`
 - [`src/rag/`](src/rag/): Qdrant retriever over FIA sporting regulations
 - [`src/f1_strat_manager/`](src/f1_strat_manager/): CLI infrastructure (data bootstrap, GP slug resolver)
 - [`scripts/`](scripts/): CLI entry points and maintenance tools
-- [`docs/`](docs/): architecture, API reference, arcade guides, draw.io diagrams
+- [`docs/`](docs/): architecture, API reference, arcade guides (the docs site source)
+- [`documents/dev_docs/diagrams/`](documents/dev_docs/diagrams/): draw.io diagram sources
 
 ## Contributing
 

--- a/docs/pages/development.md
+++ b/docs/pages/development.md
@@ -45,9 +45,12 @@ Match the prefix you would use in the commit:
 
 - `feat/<short-slug>` — feature work
 - `fix/<short-slug>` — bug fixes
-- `chore/<short-slug>` — maintenance, including docs revamps and tooling
+- `docs/<short-slug>` — documentation
+- `chore/<short-slug>` — maintenance and tooling
 - `release-please--branches--main--components--f1-strat-manager` — managed by the bot
 
-Pull requests target `main`; required checks must pass (lint, build, docs build) before a maintainer merges.
+**Pull requests target `dev`, not `main`.** `main` is release-only: it is protected, and `release-please` tags from it. Work flows `feature branch -> dev -> main`, and only a promotion PR opens against `main`.
+
+The required checks are `test`, `lint` and `typecheck`. All three must pass before a merge.
 
 > **Two more references worth bookmarking.** The repo root carries [CONTRIBUTING.md](https://github.com/VforVitorio/F1-StratLab/blob/main/CONTRIBUTING.md) with the canonical contribution flow. For a code-level map of every module, open the [F1 StratLab DeepWiki](https://deepwiki.com/VforVitorio/F1-StratLab). It auto-regenerates on every push.


### PR DESCRIPTION
Closes #586. Part of #584.

## The branch model was documented backwards

`docs/pages/development.md` told contributors that pull requests target `main`. **They target `dev`.** `main` is protected and release-only, and `release-please` tags from it, so a contributor following that page opens a PR against a release branch. The page also named checks that do not exist (the real ones are `test`, `lint`, `typecheck`) and omitted the `docs/` branch prefix.

## Dead links, each checked against the filesystem

| where | pointed at | reality |
|---|---|---|
| `ARCHITECTURE.md`, `README.md` | `docs/diagrams/` | **the promise was true, the path was wrong** |
| `INSTALL.md` | `docs/arcade-quick-start.md` | it is under `docs/pages/` |
| `CONTRIBUTING.md` | `docs/agents-api-reference.md` | the page is `docs/pages/agents-api.md` |
| `INDEX.md` x3 | `src/telemetry/frontend/` | deleted in v2.0.0 |
| `INDEX.md` x2 | `src/strategy/models/` | has never existed |
| `INDEX.md` | `extract_radios.ipynb` | does not exist |

**The draw.io one is worth calling out.** The documentation audit concluded no `.drawio` files exist anywhere and recommended deleting the claim. That is wrong: there are **eleven**, tracked, at `documents/dev_docs/diagrams/`, plus seven per-agent ones. Repointed rather than deleted. (They are also 2.5 months stale, which is #592.)

`INDEX.md` also still listed the `voice` router and service, retired in v2.0.1, and the three Streamlit frontend rows are replaced by the React webapp that took their place.

The submodule half of this is VforVitorio/F1_Telemetry_Manager#196.