### PR TITLE
docs: stop describing Streamlit as a live surface, and document the one that replaced it

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,7 +24,7 @@ All three consume the same core:
 - `data/processed/laps_featured_<year>.parquet` + `data/raw/<year>/<Location>/` +
   `data/tire_compounds_by_race.json`.
 
-The Streamlit path also runs a FastAPI backend (`src/telemetry/backend/`).
+The web app path also runs a FastAPI backend (`src/telemetry/backend/`).
 The Arcade path calls `run_lap` in-process without going through the
 backend (see [`docs/pages/arcade-strategy-pipeline.md`](docs/pages/arcade-strategy-pipeline.md)).
 
@@ -67,6 +67,7 @@ See [`docs/pages/simulation.md`](docs/pages/simulation.md) for the wire-level vi
 - **Roadmap:** [`ROADMAP.md`](ROADMAP.md).
 - **Agents reference:** [`docs/pages/agents-api.md`](docs/pages/agents-api.md).
 - **Backend API:** [`docs/pages/backend-api.md`](docs/pages/backend-api.md).
-- **Streamlit frontend:** [`docs/pages/streamlit.md`](docs/pages/streamlit.md).
+- **Web app:** [`docs/pages/webapp.md`](docs/pages/webapp.md). The Streamlit surface it
+  replaced is recorded at [`docs/pages/streamlit.md`](docs/pages/streamlit.md).
 - **Simulation engine:** [`docs/pages/simulation.md`](docs/pages/simulation.md).
 - **All draw.io diagrams:** [`docs/diagrams/`](docs/diagrams/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,8 +72,8 @@ Some code carries hard rules set by the TFG author:
 
 - **`scripts/run_simulation_cli.py`** — the TFG's PMV (first working
   CLI). Duplicate before modifying; do not refactor in-place.
-- **`src/agents/` internals** — stable contract for the CLI + Streamlit
-  + Arcade paths. Additive entry points are welcome (see
+- **`src/agents/` internals** — stable contract for the CLI, the Arcade
+  and the web app backend. Additive entry points are welcome (see
   `src/strategy/inference/engine.py::run_lap`, the shared per-lap pipeline
   call all three surfaces route through), but do not refactor existing
   agent modules in place.

--- a/docs/app/nav.js
+++ b/docs/app/nav.js
@@ -83,6 +83,15 @@ window.PAGES = [
     tags: ["api", "fastapi", "telemetry", "chat", "voice", "mcp", "rag", "pydantic"],
   },
   {
+    slug: "webapp",
+    title: "Web app",
+    section: "Surfaces",
+    file: "pages/webapp.md",
+    description: "React SPA over the FastAPI backend, launched with f1-webapp.",
+    eyebrow: "React",
+    tags: ["frontend", "ui", "telemetry", "chat", "mcp"],
+  },
+  {
     slug: "streamlit",
     title: "Streamlit frontend (legacy)",
     section: "Surfaces",

--- a/docs/pages/arcade-strategy-pipeline.md
+++ b/docs/pages/arcade-strategy-pipeline.md
@@ -13,7 +13,7 @@ src/strategy/inference/engine.py
         -> tuple[StrategyRecommendation, dict | None, dict[str, float]]
 ```
 
-- **`StrategyRecommendation`** — the synthesised decision (14 fields). What the CLI and Streamlit consume.
+- **`StrategyRecommendation`** — the synthesised decision (14 fields). What the CLI and the web app consume.
 - **`agent_outputs`** — the raw per-sub-agent dataclasses, keyed `pace_out`, `tire_out`, `situation_out`, `radio_out`, `pit_out`, `regulation_context`, `rag`, `active`, `guardrail_reason`. What the arcade dashboard renders its cards and charts from.
 - **stage timings** — per-stage seconds, for the surfaces that show them.
 

--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -257,7 +257,7 @@ data/raw/2025/<GP>/laps.parquet
        |
   StrategyRecommendation --> FastAPI /api/v1/strategy/recommend
        |
-  JSON response --> Streamlit Strategy Page
+  JSON response --> web app Strategy tab
 ```
 
 ## References

--- a/docs/pages/tags.md
+++ b/docs/pages/tags.md
@@ -28,13 +28,13 @@ Tags that appear on a single page are listed under **Other** at the end.
 |---|---|
 | `arcade` | [Arcade quick start](#/arcade-quick-start), [Dashboard architecture](#/arcade-dashboard), [Strategy pipeline](#/arcade-strategy-pipeline) |
 | `pyside6` | [Arcade quick start](#/arcade-quick-start), [Dashboard architecture](#/arcade-dashboard) |
-| `frontend` | [Streamlit frontend](#/streamlit), [Driver colors](#/driver-colors) |
-| `ui` | [Streamlit frontend](#/streamlit), [Dashboard architecture](#/arcade-dashboard) |
+| `frontend` | [Web app](#/webapp), [Driver colors](#/driver-colors), [Streamlit frontend](#/streamlit) (legacy) |
+| `ui` | [Web app](#/webapp), [Dashboard architecture](#/arcade-dashboard), [Streamlit frontend](#/streamlit) (legacy) |
 | `api` | [Agents API reference](#/agents-api), [Backend API](#/backend-api) |
-| `telemetry` | [Race replay engine](#/simulation), [Backend API](#/backend-api), [Streamlit frontend](#/streamlit), [Dashboard architecture](#/arcade-dashboard) |
-| `chat` | [Backend API](#/backend-api), [Streamlit frontend](#/streamlit) |
+| `telemetry` | [Race replay engine](#/simulation), [Backend API](#/backend-api), [Web app](#/webapp), [Dashboard architecture](#/arcade-dashboard) |
+| `chat` | [Backend API](#/backend-api), [Web app](#/webapp) |
 | `voice` | [Streamlit frontend](#/streamlit) (legacy — the voice surface was retired in v2) |
-| `mcp` | [Backend API](#/backend-api), [Streamlit frontend](#/streamlit) |
+| `mcp` | [Backend API](#/backend-api), [Web app](#/webapp) |
 
 ## Operations
 

--- a/docs/pages/webapp.md
+++ b/docs/pages/webapp.md
@@ -1,0 +1,43 @@
+# Web app
+
+**The web app is the post-race surface: a React single-page app over the FastAPI backend, launched with `f1-webapp`.** It replaced the Streamlit frontend in v2.0.0, and it is where you go after a race rather than during one. The Arcade is the live surface; this one is for looking back at what happened and asking why.
+
+## Launching it
+
+```bash
+f1-webapp
+```
+
+That wraps `docker compose up` and brings two services online: the FastAPI backend on `:8000` and the SPA served by nginx on `:8501`, with `/api` reverse-proxied to the backend so the browser only ever talks to one origin.
+
+`f1-webapp --help` works without Docker installed, so you can read the options before committing to a pull.
+
+You need a `.env` with `OPENAI_API_KEY`, or `F1_LLM_PROVIDER=lmstudio` if you are running a local model. The chat tab is the only part that needs it; everything else works without an LLM.
+
+## What is in it
+
+| Tab | What it answers |
+|---|---|
+| Telemetry | What the car did, lap by lap: speed traces, sector times, tyre life |
+| Comparison | Two drivers at 60 fps over the same lap, synchronised |
+| Lab | The ML models themselves, with their calibration and thresholds |
+| Race | The multi-agent pit-wall call for any lap, with each agent's reasoning |
+| Chat | Natural language over the finished race, streaming, rendering tool results inline |
+
+The Chat tab is an MCP client: it reaches the same fourteen tools the agents expose, so an answer about lap 32 runs the same code path the Race tab does rather than a parallel implementation.
+
+## How it relates to the other surfaces
+
+All three surfaces call one shared inference engine, `src/strategy/inference/engine.py::run_lap`. The web app reaches it over HTTP through the backend, the Arcade calls it in-process, and the CLI calls it directly. That is deliberate: an earlier arrangement had the Arcade carrying its own copy of the orchestrator, it drifted, and it shipped wrong results.
+
+So a strategy call you see in the web app is the same call the CLI would print for that lap. If they ever disagree, that is a bug rather than a difference of surface.
+
+## Where the code lives
+
+The SPA is a git submodule at `src/telemetry/`, under `webapp/`: React 19, Vite, TypeScript, Tailwind and ECharts. The backend it talks to is `src/telemetry/backend/`, documented in [Backend API](#/backend-api).
+
+Its build artefact is not committed. CI builds it, and the compose file builds it for a local run.
+
+## The surface it replaced
+
+Streamlit served this role until v2.0.0. That page is kept as a historical record at [Streamlit frontend (legacy)](#/streamlit); the paths it describes no longer exist on `main`.


### PR DESCRIPTION
Closes #587. Part of #584.

## The tense

Streamlit was retired in v2.0.0. Five surfaces still described it as current:

- `ARCHITECTURE.md:27` — "The Streamlit path also runs a FastAPI backend"
- `CONTRIBUTING.md:75` — the untouchable-files list named it as a live consumer
- `docs/pages/multi-agent.md:260` — the data-flow block ended `JSON response --> Streamlit Strategy Page`
- `docs/pages/arcade-strategy-pipeline.md:16` — "What the CLI and Streamlit consume"
- `docs/pages/tags.md` — five tag rows routed `frontend`, `ui`, `telemetry`, `chat` and `mcp` readers at a retired page

## The gap underneath was bigger than the tense

**The retirement was documented. The replacement never was.** The React web app is one of the project's three delivery surfaces and had **no docs page at all**.

It has one now: how to launch it, what each of the five tabs answers, and the architectural point worth knowing, which is that all three surfaces call the same `run_lap`. A strategy call in the web app is the same call the CLI would print for that lap. They disagreed once, the Arcade carried its own drifting copy, and that is why the shared engine exists.

Registered in `docs/app/nav.js` under Surfaces. Verified all 22 registered pages resolve to a file on disk.

The legacy Streamlit page already declared itself retired in its own first paragraph, so it stays as the historical record it says it is, and the tag index now points at both with the legacy one marked.