### PR TITLE
docs: make the first example runnable, and stop describing fields that do not exist

### DIFF
--- a/docs/pages/agents-api.md
+++ b/docs/pages/agents-api.md
@@ -22,7 +22,7 @@ Every agent has two entry points:
 `lap_state`, which is why the stint fuel baseline is carried there rather than derived from a
 frame. The adapters are not uniform, so check the signature before assuming.
 
-Each agent also exposes a `get_*_react_agent()` factory that returns a compiled LangGraph `CompiledGraph` for direct LangGraph usage.
+Every agent except N29 also exposes a `get_*_react_agent()` factory returning a compiled LangGraph `CompiledGraph`, for callers that want to drive the graph directly. The radio agent has none: its pipeline is a fixed sequence of model calls rather than a ReAct loop, so there is no graph to compile.
 
 ## Output dataclasses
 
@@ -182,8 +182,10 @@ result = process_radio_tool.invoke({
 
 **Agent-level (no LLM needed):**
 
-The `*_from_state` entry points take **only** a `lap_state`, and it must be the real
-nested dict (`driver` / `rivals` / `weather` / `session_meta`), not a flat one. Build it
+Whatever else a `*_from_state` entry point takes, its `lap_state` must be the real
+nested dict (`driver` / `rivals` / `weather` / `session_meta`), not a flat one. Most of
+them take a `laps_df` alongside it; the table above has the exact shapes, and they are
+not uniform. Build it
 with `RaceStateManager` rather than by hand: it is the component that owns the contract,
 and hand-rolling one is how the second, buggy implementation of this got written.
 

--- a/docs/pages/arcade-strategy-pipeline.md
+++ b/docs/pages/arcade-strategy-pipeline.md
@@ -41,7 +41,7 @@ The arcade needs the raw outputs and the CLI does not, but that is a difference 
 
 ## Why this replaced a duplicate
 
-This module used to be a body-copy of the orchestrator, and this page used to document a "how to stay in sync" ritual: open both files side by side and transcribe every edit by hand. That ritual was the bug. A copy kept in sync by discipline drifts the first time someone edits one file and not the other, and it did: the audit flagged it (`AUDIT_P2B_CORE_COMPUTE` F10) and the #166 crash proved it.
+This module used to be a body-copy of the orchestrator, and this page used to document a "how to stay in sync" ritual: open both files side by side and transcribe every edit by hand. That ritual was the bug. A copy kept in sync by discipline drifts the first time someone edits one file and not the other, and it did: an audit flagged it and the #166 crash proved it.
 
 The lesson generalises beyond the arcade, and the strategy engine relearned it the hard way. `src/simulation/race_state_manager.py` had already solved a pile of race-data problems correctly (NaN never becomes a searchable number, gaps come from the elapsed-time column, retired cars fall out on their own). A second implementation was later written alongside it for the API path, and it reproduced every one of those bugs from scratch, silently, for months. Two implementations of the same idea do not stay equal because someone intends them to.
 
@@ -52,7 +52,7 @@ So: **before writing a second path that shapes race data, check whether a clean 
 The arcade strategy driver is `src/arcade/strategy.py::SimConnector`. It is a plain Python class, not a Qt object, spawned as a `threading.Thread` from `F1ArcadeView._init_strategy_layer`.
 
 - Owns a `StrategyState` dataclass caching the latest `LapDecision`, the per-agent outputs and playback metadata, behind a `threading.Lock`.
-- Owns the background thread that iterates `RaceReplayEngine.replay()` and calls `run_strategy_pipeline(race_state, laps_df)` per lap.
+- Owns the background thread that iterates `RaceReplayEngine.replay()` and calls `run_strategy_pipeline(race_state, laps_df, lap_state=None)` per lap.
 - Emits `StartEventDTO` once on the first frame, then `LapDecisionDTO` per lap.
 
 ## Why not SSE from the backend

--- a/docs/pages/architecture.md
+++ b/docs/pages/architecture.md
@@ -49,7 +49,7 @@ Three structures cross every boundary in the system. If you remember nothing els
 
 ### `lap_state`
 
-The atomic payload the simulation engine emits per driver per lap. It carries the bare-minimum slice of telemetry the agents need: current lap number, compound and tire age, current and previous lap times, gap to leader and rivals, sector deltas, pit-window flag, each driver's Art. 30.5(m) stint history (stops made, compounds used, whether the mandatory two-compound stop is still pending), and the active race-control state. Every downstream agent treats `lap_state` as immutable; mutations happen in the orchestrator's state machine, not inside the agents.
+The atomic payload the simulation engine emits per driver per lap. It carries the bare-minimum slice of telemetry the agents need: current lap number, compound and tire age, current and previous lap times, absolute sector times, gap to leader and per-rival intervals, in-lap and out-lap flags, the Art. 30.5(m) stint history for our driver and every rival (stops made, compounds used, whether the mandatory two-compound stop is still pending), and the active race-control state. Every downstream agent treats `lap_state` as immutable; mutations happen in the orchestrator's state machine, not inside the agents.
 
 ### `RaceState`
 

--- a/docs/pages/backend-api.md
+++ b/docs/pages/backend-api.md
@@ -57,7 +57,7 @@ An exhausted bucket returns `429` with a `Retry-After` hint. Set `F1_RATE_LIMIT_
 | GET | `/api/v1/telemetry/drivers` | List drivers for a session |
 | GET | `/api/v1/telemetry/race-data` | Full-field featured-parquet frame for a GP (positions, lap times, inter-driver gaps), optionally filtered to driver codes |
 
-**Query parameters**: `year` (int), `gp` (str), `session` (str), `drivers` (comma-separated).
+**Query parameters** vary by endpoint. `year` (int) and `gp` (str) are common to all of them; `session` (str) applies to the lap-time and telemetry endpoints; `drivers` (comma-separated) to the comparison ones. `/race-data` takes `driver`, **singular**, and treats it as an optional filter over the full-field frame.
 
 `/race-data` computes the inter-driver gap columns (`GapToCarAhead`, `GapToCarBehind`) over the whole field first, then applies the optional `driver` filter afterwards: a single-car frame has no second car to measure a gap against, so filtering before computing the gaps used to return `null` on every lap whenever a `driver` was supplied. The gap-annotated frame is cached per `(year, gp)`, since it is a pure function of the static featured parquet.
 

--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -47,14 +47,14 @@ uv sync --all-extras
 Run the simulation against a saved race:
 
 ```bash
-uv run scripts/run_simulation_cli.py Bahrain NOR McLaren --no-llm
+uv run scripts/run_simulation_cli.py Sakhir NOR McLaren --no-llm
 ```
 
 Drop `--no-llm` once you have an LLM provider configured (LM Studio at `http://localhost:1234/v1` or `OPENAI_API_KEY` in `.env`).
 
 ## 3. Docker
 
-For a reproducible all-in-one setup, see [Setup and deployment](#/setup) for the Docker compose recipe that boots the FastAPI backend, the React web app and the Qdrant store in one command.
+For a reproducible all-in-one setup, see [Setup and deployment](#/setup) for the Docker compose recipe that boots the FastAPI backend and the React web app in one command. Qdrant runs on-disk inside the backend process rather than as its own container, so there is nothing extra to start.
 
 ## Where to next
 

--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -186,6 +186,8 @@ Three-layer pipeline:
 
 - **Output**: `StrategyRecommendation` (action, reasoning, confidence, scenario_scores, contingencies)
 - **Action values**: STAY_OUT, PIT_NOW, UNDERCUT, OVERCUT, ALERT
+- **Pace modes**: PUSH, NEUTRAL, MANAGE, LIFT_AND_COAST
+- **Risk levels**: AGGRESSIVE, BALANCED, DEFENSIVE
 
 ## What the Monte Carlo actually scores
 
@@ -203,7 +205,7 @@ Candidates carry **explicit eligibility**. An undercut with no live rival inside
 
 **Where the overcut works, and why.** Inside one window an overcut takes the same stop and pays the same pit lane as PIT_NOW, so it forfeits exactly one lap of fresh rubber. What it buys instead is a lap of **clean air**, and whether that is a good trade is a property of the circuit rather than of the strategy.
 
-Both sides are measured. A fresh set is worth 0.25 s/lap; clean air is measured per circuit over 479 cases where a car sat within two seconds of, and directly behind, a driver who then pitted — **+0.77 s/lap at Suzuka, +0.65 at Monaco, +0.63 at Silverstone**, down to **−0.02 at Monza and −0.29 at Spielberg**, where losing the car ahead costs a slipstream worth more than the clear track. The ordering is high-downforce circuits first and slipstream circuits last, and nothing in the measurement knows what downforce is.
+Both sides are measured. A fresh set is worth 0.25 s/lap; clean air is measured per circuit over 479 cases where a car sat within two seconds of, and directly behind, a driver who then pitted — **+0.77 s/lap at Suzuka, +0.65 at Monaco, +0.63 at Silverstone**, down to **−0.015 at Monza and −0.285 at Spielberg**, where losing the car ahead costs a slipstream worth more than the clear track. The ordering is high-downforce circuits first and slipstream circuits last, and nothing in the measurement knows what downforce is.
 
 Clean air is one of two reasons to hold a car out. The other is **option value**: one more lap before the stop is one more lap of exposure to a neutralisation that would make that stop cheap, worth the circuit's measured onset hazard times what a neutralised stop saves. **Melbourne** separates the two cleanly — its clean-air gain is +0.008 s, effectively nothing, but Albert Park throws more neutralisations per lap than any circuit in the sample, so an overcut pays there on Safety Car odds alone.
 
@@ -220,8 +222,6 @@ Together the two terms decide it against the 0.25 s/lap the delay costs:
 The invariant tests assert both directions, comparing the overcut against the same stop taken now: it must out-score a plain stop at Suzuka and at Melbourne, and must lose to one at Monza.
 
 Dirty air is priced at the moment the car ahead boxes and not continuously, so running a whole window stuck in traffic is still under-penalised. That one is named in the module docstring rather than hidden here.
-- **Pace modes**: PUSH, NEUTRAL, MANAGE, LIFT_AND_COAST
-- **Risk levels**: AGGRESSIVE, BALANCED, DEFENSIVE
 
 ## RSM adapter pattern
 

--- a/docs/pages/simulation.md
+++ b/docs/pages/simulation.md
@@ -138,6 +138,11 @@ python -m src.simulation Silverstone VER "Red Bull Racing" --data-dir data/raw/2
 {
     "lap_number": int,
     "driver": {
+        # Identity, repeated inside the sub-dict so a consumer that has been
+        # handed only this slice still knows whose lap it is holding.
+        "driver": str,
+        "team": str,
+        "lap_number": int,
         "lap_time_s": float | None,
         # This lap's Prev_LapTime feature, never last lap's own lap_time_s
         # reused as a stand-in — that self-reference used to feed the pace
@@ -168,7 +173,7 @@ python -m src.simulation Silverstone VER "Red Bull Racing" --data-dir data/raw/2
     # Only cars classified on this lap. A car that has retired, crashed or has
     # not yet completed the lap has no row for it, so it is simply ABSENT from
     # `rivals` — never present with a filled-in default. See "Who counts as a
-    # rival" below.
+    # rival" above.
     "rivals": [
         {
             "driver": str,

--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -17,7 +17,7 @@ Examples
     python scripts/run_simulation_cli.py Melbourne NOR McLaren --no-llm
 
     # Laps 15-25 with LLM synthesis (LM Studio must be running)
-    python scripts/run_simulation_cli.py Bahrain NOR McLaren --laps 15-25
+    python scripts/run_simulation_cli.py Sakhir NOR McLaren --laps 15-25
 
     # Custom data paths
     python scripts/run_simulation_cli.py Monaco LEC Ferrari \\
@@ -2045,7 +2045,7 @@ def _parse_args() -> argparse.Namespace:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )
-    p.add_argument("gp_name", help="Grand Prix folder name (e.g. Melbourne, Bahrain)")
+    p.add_argument("gp_name", help="Grand Prix folder name (e.g. Melbourne, Sakhir)")
     p.add_argument("driver", help="FIA three-letter driver code (e.g. NOR, HAM)")
     p.add_argument("team", help="Team name as stored in laps parquet (e.g. McLaren)")
     p.add_argument(

--- a/tests/test_cli_no_llm.py
+++ b/tests/test_cli_no_llm.py
@@ -43,12 +43,22 @@ def test_cli_no_llm_smoke():
         capture_output=True,
         text=True,
         timeout=600,
-        # Force UTF-8 stdout: capture_output pipes stdout, so on Windows the
-        # Rich header's non-ASCII glyphs would hit the cp1252 codec and crash
-        # for reasons unrelated to #166 (redirect-encoding is DevEx #252, not
-        # this test's subject).
+        # Both halves of this are needed, and only one of them was here.
+        #
+        # PYTHONUTF8 tells the CHILD to emit UTF-8: capture_output pipes stdout,
+        # so on Windows the Rich header's non-ASCII glyphs would otherwise hit
+        # the cp1252 codec and crash for reasons unrelated to this test.
+        #
+        # encoding tells the PARENT how to read it back. Without it, text=True
+        # decodes using the parent's locale, which on Windows is cp1252, and the
+        # decode raises inside subprocess. The visible symptom is not an error:
+        # returncode comes back 0 and proc.stdout comes back None, so the test
+        # died on `None + str` while the run underneath had actually succeeded.
+        encoding="utf-8",
+        errors="replace",
         env={**os.environ, "PYTHONUTF8": "1"},
     )
+    assert proc.stdout is not None, "the CLI produced no capturable stdout"
     combined = proc.stdout + proc.stderr
     assert proc.returncode == 0, f"exit {proc.returncode}\n{combined[-2000:]}"
     assert "[ERROR]" not in combined, "no-LLM run logged [ERROR]"


### PR DESCRIPTION
Closes #588 and #567. Part of #584.

## The first command a new user copies does not work

`getting-started.md` names `Bahrain` as the Grand Prix. **There is no `Bahrain` race folder** and it is not in the slug keyspace: it is `Sakhir`. The same wrong name sat in the CLI's own `--help`. Both corrected, and the CLI was run on `Sakhir` to confirm it completes.

The same page pitched a Qdrant container the compose file does not define. Qdrant runs **on-disk inside the backend process**, so there is nothing extra to start, which is a better story than the one being told.

## Descriptions that had drifted from their contracts

- `architecture.md` listed a **pit-window flag** `lap_state` does not carry, and called the sector values *deltas* when they are absolute times.
- `simulation.md`'s `driver` schema omitted `driver`, `team` and `lap_number`, verified against a live `get_lap_state` call.
- `arcade-strategy-pipeline.md` documented `run_strategy_pipeline` without its third argument, and carried `AUDIT_P2B_CORE_COMPUTE F10` in public prose.

## Pages that contradicted themselves

`agents-api.md` claimed every agent exposes a `get_*_react_agent()` factory. **N29 has none** (checked by `dir()` over all six): its pipeline is a fixed sequence of model calls, not a ReAct loop. The same page said `*_from_state` take *only* a `lap_state` while its own table showed five of seven also taking `laps_df`.

`backend-api.md` gave one blanket query-parameter list; `/race-data` takes `driver`, singular.

## And a test that was lying about why it failed

`test_cli_no_llm_smoke` crashed on `None + str`. **The cause was not a missing guard.** The test forced UTF-8 in the *child* via `PYTHONUTF8` but let the *parent* decode with the Windows locale, so the decode raised inside `subprocess` and left `stdout` as `None` with `returncode` **0**. The run underneath had succeeded the whole time. Fixed with `encoding="utf-8"` on the parent side rather than by tolerating the `None`.