### PR TITLE
docs: diagram the three things the docs site had no picture of

### DIFF
--- a/docs/pages/arcade-strategy-pipeline.md
+++ b/docs/pages/arcade-strategy-pipeline.md
@@ -4,6 +4,34 @@
 
 ## One engine, three surfaces
 
+```mermaid
+graph LR
+    subgraph cli["CLI"]
+        C1[f1-strat<br/>interactive menu] -->|subprocess| C2[f1-sim<br/>run_simulation_cli.py]
+    end
+    subgraph arc["Arcade"]
+        A1[SimConnector thread] --> A2[strategy_pipeline.py]
+    end
+    subgraph web["Web app"]
+        W1[React SPA] -->|HTTP| W2["/api/v1/strategy/recommend"]
+        W1 -->|SSE| W3["/api/v1/strategy/simulate"]
+    end
+
+    C2 --> ENG
+    A2 --> ENG
+    W2 --> ENG
+    W3 --> ENG
+
+    ENG["run_lap<br/>src/strategy/inference/engine.py"]
+    ENG --> P1["profile=rich<br/>LLM synthesis, full per-stage payloads"]
+    ENG --> P2["profile=no-llm<br/>MC argmax plus the regulatory guard-rails,<br/>no provider call"]
+    P1 --> SUBS[six sub-agents through their<br/>public *_from_state entry points]
+    P2 --> SUBS
+    SUBS --> OUT[StrategyRecommendation<br/>plus agent_outputs and stage timings]
+```
+
+The arrow that matters is the one that is missing: no surface has its own copy. **A strategy call in the web app is the same call the CLI would print for that lap.** If they ever disagree, that is a bug, not a difference of surface.
+
 Every surface needs the same six sub-agents, the same MoE routing, the same Monte Carlo pass and the same synthesis. They differ only in what they render. So the pipeline lives in one place and the surfaces choose how much of its output to consume:
 
 ```

--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -191,6 +191,63 @@ Three-layer pipeline:
 
 ## What the Monte Carlo actually scores
 
+```mermaid
+graph TD
+    LS[lap_state] --> CTX[race_context_from_lap_state<br/>gp_name, traversal_s, mandatory_stop_pending,<br/>rival_stop_pending per driver]
+    LS --> RIV[rivals list]
+    RIV --> GATE{any usable gap?}
+    GATE -->|no| LEG[legacy path<br/>seconds / 1.5, unchanged<br/>pinned by the strategy goldens]
+    GATE -->|yes| STATES[RivalState per car<br/>gap_s, is_pitting, stop_pending]
+
+    subgraph draws["Per-draw samples, n=500, seed 42"]
+        D1[cliff_s from N26]
+        D2[sc_s from N27]
+        D3[pit_s from N28 / N15]
+        D4[ucut_s from N28 / N16]
+    end
+
+    subgraph tables["data/mc_measured_v1.json"]
+        T1[undercut_band 4.91 s]
+        T2[neutralisation_rate per circuit<br/>floored: an observed zero means<br/>never seen, not impossible]
+        T3[clean_air per circuit]
+        T4[racing laps under SC 2.61]
+    end
+
+    STATES --> ELIG{eligibility}
+    T1 --> ELIG
+    ELIG -->|"ahead and inside the band<br/>and not already in the pit lane"| UC[UNDERCUT]
+    ELIG -->|"ahead and in the pit lane now"| OC[OVERCUT]
+    ELIG -->|"no target"| NULL["eligible: false, score: null<br/>never a numeric sentinel"]
+
+    CTX --> CFG[two ProjectionConfigs]
+    T2 --> CFG
+    T3 --> CFG
+    T4 --> CFG
+    CFG --> GC[racing config<br/>clean air and SC option value live here]
+    CFG --> NC[neutralised config<br/>both terms zero: the field runs to a delta]
+
+    D1 --> PROJ
+    D3 --> PROJ
+    STATES --> PROJ[project_positions per candidate<br/>gap_r + delta_r - delta_us,<br/>a crossing is a place]
+    GC --> PROJ
+    NC --> PROJ
+
+    D2 -->|selects which config each draw uses| PROJ
+    PROJ --> PAY[payoff<br/>positions plus a clipped margin tie-break]
+    PAY --> LIAB[terminal_liability<br/>only for candidates that do NOT stop:<br/>the deferred mandatory stop, discounted by q_f]
+    D4 -->|"only on racing draws, Art. 55.8"| PAY
+
+    LIAB --> SCORE["score = alpha·E + 1-alpha·P10"]
+    UC --> SCORE
+    OC --> SCORE
+    SCORE --> ARG[best_mc_candidate<br/>argmax over scoreable candidates only]
+    NULL --> ARG
+    LEG --> ARG
+    ARG --> OUT[scenario_scores into the LLM prompt]
+```
+
+Four things in that graph are the whole redesign. Eligibility can return **no number at all** rather than a sentinel. The measured tables enter as *configuration*, not as constants in the code. Each draw picks a racing or a neutralised config, which is what makes the Art. 55.17 endgame arithmetic rather than a rule. And the terminal liability applies only to the candidates that do not stop, because a deferred obligation is a cost only while it is still owed.
+
 The layer used to score in generic seconds divided by a flat 1.5 s/position, over a sampled state that contained **no cars at all**. That constant cannot be right in both regimes: measured across 71 races, the median gap between consecutive cars is **2.23 s while racing and 1.48 s under a Safety Car**, so a single figure was a bunched-field number applied to green-flag racing. And losing 20 s costs zero positions with a 25 s cushion behind but three positions with cars at +2 / +8 / +15 s — a difference only a model that knows *which cars are where* can see.
 
 Scoring now runs on a per-rival gap projection (`src/agents/position_projection.py`). Each candidate moves every gap by the difference between what a rival loses and what we lose; a gap crossing zero is a car changing sides, so counting the cars projected ahead gives the position directly. Three behaviours that used to need special cases now fall out of that arithmetic:

--- a/docs/pages/setup.md
+++ b/docs/pages/setup.md
@@ -89,6 +89,30 @@ Start LM Studio with a model loaded, serving on `http://localhost:1234/v1`. The 
 
 ## Docker deployment
 
+```mermaid
+graph TD
+    U[browser] -->|":8501"| NG
+    subgraph net["f1_network"]
+        subgraph wsvc["webapp service"]
+            NG[nginx<br/>serves the built SPA<br/>and reverse-proxies /api]
+        end
+        subgraph bsvc["backend service"]
+            API["uvicorn backend.main:app<br/>:8000, --reload"]
+        end
+        NG -->|"/api -> backend:8000"| API
+    end
+    API -->|F1_LLM_PROVIDER| LLM[["OpenAI, or LM Studio<br/>on the host"]]
+
+    V1["./src:/app/src :ro"] --> API
+    V2["./data:/app/data :ro"] --> API
+    V3["./data/rag :rw<br/>Qdrant writes its on-disk index here"] --> API
+    V4["backend_cache:/root/.cache<br/>named volume, survives a rebuild"] --> API
+```
+
+Two things are worth reading off that. **Qdrant is not a service:** it runs on-disk inside the backend process, which is why `data/rag` is the one mount that is read-write. And the browser only ever talks to `:8501`; `/api` is reverse-proxied, so there is no second origin and no CORS to configure.
+
+`f1-webapp` wraps `docker compose up` on this file. `F1_STRAT_DATA_ROOT=/app/data` is what makes the container agree with a local checkout about where data lives.
+
 Two equivalent compose files exist, one at the repo root and one path-relative copy inside the submodule — both already mount volumes for live code reload and data access, so pick whichever working directory is convenient.
 
 ### Root `docker-compose.yml`

--- a/documents/dev_docs/diagrams/README.md
+++ b/documents/dev_docs/diagrams/README.md
@@ -1,0 +1,38 @@
+# draw.io diagram sources
+
+Editable `.drawio` sources for the project's architecture diagrams. Open them with [diagrams.net](https://app.diagrams.net/) or the VS Code extension.
+
+## Status, audited 2026-07-26
+
+These were last edited on **2026-05-13**. Two major releases have landed since: v2.0.0 retired the Streamlit frontend and replaced it with a React web app, and v2.1.0 rewrote the Monte Carlo decision layer to score in projected track position. Six of the twelve still draw surfaces that no longer exist.
+
+| Diagram | Retired-surface references | Read it as |
+|---|---|---|
+| `backend_api.drawio` | 12 | **stale** |
+| `chat_mcp_flow.drawio` | 13 | **stale** |
+| `frontend_pages.drawio` | 7 | **stale**, it draws the Streamlit page tree |
+| `system_architecture.drawio` | 4 | **stale** |
+| `data_pipeline.drawio` | 1 | **check**, and note the FastF1 cache is one directory now, not two |
+| `docker_deployment.drawio` | 1 | **check** |
+| `arcade_3window_architecture.drawio` | 0 | current |
+| `multi_agent_architecture.drawio` | 0 | current |
+| `multi_agent_flow.drawio` | 0 | current, but predates the projection redesign |
+| `strategy_pipeline_flow.drawio` | 0 | predates the shared inference engine |
+| `subprocess_launch_sequence.drawio` | 0 | current |
+| `tcp_broadcast_dataflow.drawio` | 0 | current |
+
+The count is a grep for Streamlit and voice, so it is a smell rather than a verdict. A zero does not certify a diagram as accurate; it only means it does not name a surface that was deleted.
+
+## These are not what the docs site renders
+
+The site at docs.f1stratlab.com renders **Mermaid**, written directly into `docs/pages/*.md` as fenced code blocks. It has no draw.io renderer, so a diagram here reaches a reader only if someone exports it to SVG and embeds the image.
+
+That split is deliberate. Mermaid is text: it diffs in review, it cannot drift out of sync with the page it sits in, and it renders live. draw.io is where a diagram goes when it needs a layout Mermaid cannot express, or when it is meant to be edited visually.
+
+**If you fix one of the stale files above, consider whether the diagram belongs in `docs/pages/` as Mermaid instead.** Several of them describe things the docs site currently has no diagram for at all.
+
+## Also here
+
+`agents/` holds one diagram per sub-agent (N25 to N30) plus the `StrategyRecommendation` schema.
+
+`site/diagrams/` at the repo root holds byte-identical copies of these files. It is **not tracked by git**, being the build output of an older docs site. Do not edit it and do not treat it as a second source.


### PR DESCRIPTION
Refs #592. Part of #584.

## Format: Mermaid here, draw.io in the repo

The docs site **renders Mermaid natively** (`docs/app/markdown.js:139-158`, mermaid 10.9.1) and has no draw.io renderer. Mermaid is text: it diffs in review, it cannot drift out of sync with the page around it, and it renders live. The `.drawio` sources stay where they are, as the editable originals.

## Three diagrams that carry information no page had

**The Monte Carlo decision layer.** Existing pages stopped at "500 draws over 4 candidates". Nothing showed which measured tables are live, which candidates can return **no number at all**, or why the Art. 55.17 endgame needs no special case. Four things in the graph are the whole redesign: eligibility returning `null` rather than a sentinel, measured tables entering as *configuration*, each draw selecting a racing or neutralised config, and the terminal liability applying only to candidates that do **not** stop.

**The shared inference engine.** It lived only in prose across two pages. The diagram makes the *missing* arrow visible: no surface carries its own copy, so a strategy call in the web app is the same call the CLI would print.

**The Docker topology.** Nothing covered it. Two things now read straight off it: **Qdrant is not a service** (it runs on-disk inside the backend, which is why `data/rag` is the one read-write mount), and the browser only ever talks to `:8501` because `/api` is reverse-proxied, so there is no second origin and no CORS to configure.

## The draw.io sources are stale, and now say so

Last edited **2026-05-13**, before v2.0.0 retired Streamlit and before v2.1.0 rewrote the decision layer. **Six of twelve still draw retired surfaces**, `frontend_pages.drawio` most bluntly: it is the Streamlit page tree.

A `README.md` in that folder now states which are stale and why, rather than leaving twelve diagrams to be trusted equally. Redrawing them deserves its own pass; #592 stays open for it.

All five Mermaid blocks validated for balanced `subgraph`/`end` and quoting.