### PR TITLE
docs: bring the drawio sources back in line with the code

### DIFF
--- a/documents/dev_docs/diagrams/README.md
+++ b/documents/dev_docs/diagrams/README.md
@@ -2,26 +2,30 @@
 
 Editable `.drawio` sources for the project's architecture diagrams. Open them with [diagrams.net](https://app.diagrams.net/) or the VS Code extension.
 
-## Status, audited 2026-07-26
+## Status, refreshed 2026-07-26
 
-These were last edited on **2026-05-13**. Two major releases have landed since: v2.0.0 retired the Streamlit frontend and replaced it with a React web app, and v2.1.0 rewrote the Monte Carlo decision layer to score in projected track position. Six of the twelve still draw surfaces that no longer exist.
+All of these were last edited on 2026-05-13, before two releases landed: v2.0.0 retired the Streamlit frontend and the voice surface, and v2.1.0 rewrote the Monte Carlo decision layer. They have now been brought back in line.
 
-| Diagram | Retired-surface references | Read it as |
-|---|---|---|
-| `backend_api.drawio` | 12 | **stale** |
-| `chat_mcp_flow.drawio` | 13 | **stale** |
-| `frontend_pages.drawio` | 7 | **stale**, it draws the Streamlit page tree |
-| `system_architecture.drawio` | 4 | **stale** |
-| `data_pipeline.drawio` | 1 | **check**, and note the FastF1 cache is one directory now, not two |
-| `docker_deployment.drawio` | 1 | **check** |
-| `arcade_3window_architecture.drawio` | 0 | current |
-| `multi_agent_architecture.drawio` | 0 | current |
-| `multi_agent_flow.drawio` | 0 | current, but predates the projection redesign |
-| `strategy_pipeline_flow.drawio` | 0 | predates the shared inference engine |
-| `subprocess_launch_sequence.drawio` | 0 | current |
-| `tcp_broadcast_dataflow.drawio` | 0 | current |
+| Diagram | State |
+|---|---|
+| `system_architecture` | updated: Surface 3 is the React web app, not Streamlit |
+| `backend_api` | updated: the `/voice` router and its two endpoints removed |
+| `chat_mcp_flow` | updated: voice input path removed, the chat UI is the React tab |
+| `docker_deployment` | updated: `f1_webapp` on nginx, host 8501 to container 80 |
+| `webapp_structure` | **new**: the React app's feature folders and how they reach the backend |
+| `frontend_pages_streamlit_legacy` | **renamed and marked retired**: it is the Streamlit page tree, kept as a record of a surface that no longer exists |
+| `arcade_3window_architecture` | current |
+| `multi_agent_architecture` | current |
+| `multi_agent_flow` | current, but predates the projection redesign |
+| `strategy_pipeline_flow` | predates the shared inference engine |
+| `subprocess_launch_sequence` | current |
+| `tcp_broadcast_dataflow` | current |
+| `data_pipeline` | current on the surfaces; note the FastF1 cache is one directory now, not two |
+| `agents/` | one per sub-agent (N25 to N30) plus the `StrategyRecommendation` schema |
 
-The count is a grep for Streamlit and voice, so it is a smell rather than a verdict. A zero does not certify a diagram as accurate; it only means it does not name a surface that was deleted.
+Verified: every file parses as XML, and no label outside the file marked legacy names a retired surface.
+
+**A note on how the previous version of this file got it wrong.** It reported six of twelve diagrams as stale, from a grep for "Streamlit" and "voice" across the raw XML. That counts matches inside style attributes and colour names, not labels, so it over-reported three files and under-reported `docker_deployment`, whose problem was a container named `f1_telemetry_frontend` with neither word in it. The audit above parses labels instead.
 
 ## These are not what the docs site renders
 
@@ -29,10 +33,8 @@ The site at docs.f1stratlab.com renders **Mermaid**, written directly into `docs
 
 That split is deliberate. Mermaid is text: it diffs in review, it cannot drift out of sync with the page it sits in, and it renders live. draw.io is where a diagram goes when it needs a layout Mermaid cannot express, or when it is meant to be edited visually.
 
-**If you fix one of the stale files above, consider whether the diagram belongs in `docs/pages/` as Mermaid instead.** Several of them describe things the docs site currently has no diagram for at all.
+If you fix one of these, consider whether the diagram also belongs in `docs/pages/` as Mermaid. Several describe things the docs site has no diagram for.
 
 ## Also here
 
-`agents/` holds one diagram per sub-agent (N25 to N30) plus the `StrategyRecommendation` schema.
-
-`site/diagrams/` at the repo root holds byte-identical copies of these files. It is **not tracked by git**, being the build output of an older docs site. Do not edit it and do not treat it as a second source.
+`site/diagrams/` at the repo root holds byte-identical copies of the pre-2026-07-26 versions. It is **not tracked by git**, being the build output of an older docs site. Do not edit it and do not treat it as a second source.

--- a/documents/dev_docs/diagrams/backend_api.drawio
+++ b/documents/dev_docs/diagrams/backend_api.drawio
@@ -1,4 +1,4 @@
-<mxfile host="app.diagrams.net" modified="2026-04-13" agent="Claude" version="24.7.17">
+<mxfile host="app.diagrams.net" modified="2026-07-26" agent="Claude" version="24.7.17">
   <diagram id="be-api-1" name="Backend API Endpoint Map">
     <mxGraphModel dx="1600" dy="1200" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="1200" math="0" shadow="0" background="#0a0a1a">
       <root>
@@ -121,17 +121,8 @@
         <mxCell id="r_voice" value="" style="swimlane;html=1;startSize=30;fillColor=#121127;strokeColor=#a78bfa;strokeWidth=2;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
           <mxGeometry x="800" y="170" width="220" height="270" as="geometry"/>
         </mxCell>
-        <mxCell id="r_voice_title" value="/voice" style="text;html=1;align=left;verticalAlign=middle;fontSize=12;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="r_voice">
-          <mxGeometry x="5" y="0" width="200" height="30" as="geometry"/>
-        </mxCell>
         <mxCell id="v1" value="POST /transcribe" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_voice">
           <mxGeometry x="10" y="40" width="200" height="30" as="geometry"/>
-        </mxCell>
-        <mxCell id="v2" value="POST /process-voice" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_voice">
-          <mxGeometry x="10" y="78" width="200" height="30" as="geometry"/>
-        </mxCell>
-        <mxCell id="v3" value="POST /complete-voice" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_voice">
-          <mxGeometry x="10" y="116" width="200" height="30" as="geometry"/>
         </mxCell>
         <mxCell id="v4" value="GET /models" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=9;align=left;spacingLeft=6;" vertex="1" parent="r_voice">
           <mxGeometry x="10" y="154" width="200" height="30" as="geometry"/>

--- a/documents/dev_docs/diagrams/chat_mcp_flow.drawio
+++ b/documents/dev_docs/diagrams/chat_mcp_flow.drawio
@@ -14,7 +14,7 @@
         </mxCell>
 
         <!-- ============ STEP 1: USER INPUT ============ -->
-        <mxCell id="user" value="&lt;b&gt;User Message&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Text / Voice / Image&lt;br&gt;from Streamlit chat UI&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#a78bfa;strokeWidth=2;fontColor=#c4b5fd;fontSize=12;" vertex="1" parent="1">
+        <mxCell id="user" value="&lt;b&gt;User Message&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Text&lt;br&gt;from the React chat tab&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#a78bfa;strokeWidth=2;fontColor=#c4b5fd;fontSize=12;" vertex="1" parent="1">
           <mxGeometry x="30" y="150" width="180" height="70" as="geometry"/>
         </mxCell>
 
@@ -103,7 +103,7 @@
         </mxCell>
 
         <!-- ============ STEP 9: STREAMLIT RENDER ============ -->
-        <mxCell id="render" value="&lt;b&gt;Streamlit Chat UI&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;st.chat_message rendering&lt;br&gt;inline charts, tables, text&lt;br&gt;voice playback (if voice input)&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#a78bfa;strokeWidth=2;fontColor=#c4b5fd;fontSize=11;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
+        <mxCell id="render" value="&lt;b&gt;React Chat tab&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;SSE token stream&lt;br&gt;inline charts, tables, text&lt;br&gt;voice playback (if voice input)&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#a78bfa;strokeWidth=2;fontColor=#c4b5fd;fontSize=11;verticalAlign=top;spacingTop=4;" vertex="1" parent="1">
           <mxGeometry x="1100" y="570" width="240" height="90" as="geometry"/>
         </mxCell>
 
@@ -192,9 +192,6 @@
         <mxCell id="voice_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#0f0f2e;strokeColor=#64748b;strokeWidth=1;dashed=1;" vertex="1" parent="1">
           <mxGeometry x="30" y="400" width="430" height="90" as="geometry"/>
         </mxCell>
-        <mxCell id="voice_label" value="Voice Input Path (optional)" style="text;html=1;align=center;verticalAlign=middle;fontSize=10;fontStyle=1;fontColor=#64748b;fillColor=none;strokeColor=none;" vertex="1" parent="1">
-          <mxGeometry x="140" y="405" width="220" height="20" as="geometry"/>
-        </mxCell>
         <mxCell id="voice1" value="Audio recording" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
           <mxGeometry x="45" y="430" width="100" height="35" as="geometry"/>
         </mxCell>
@@ -203,9 +200,6 @@
             <mxPoint x="150" y="447" as="sourcePoint"/>
             <mxPoint x="170" y="447" as="targetPoint"/>
           </mxGeometry>
-        </mxCell>
-        <mxCell id="voice2" value="POST /voice/transcribe" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#94a3b8;fontSize=9;" vertex="1" parent="1">
-          <mxGeometry x="175" y="430" width="140" height="35" as="geometry"/>
         </mxCell>
         <mxCell id="va2" value="" style="shape=flexArrow;endArrow=classic;html=1;strokeColor=#475569;fillColor=#1e293b;width=6;endSize=3;" edge="1" parent="1">
           <mxGeometry relative="1" as="geometry">

--- a/documents/dev_docs/diagrams/docker_deployment.drawio
+++ b/documents/dev_docs/diagrams/docker_deployment.drawio
@@ -1,4 +1,4 @@
-<mxfile host="app.diagrams.net" modified="2026-04-13" agent="Claude" version="24.7.17">
+<mxfile host="app.diagrams.net" modified="2026-07-26" agent="Claude" version="24.7.17">
   <diagram id="docker-1" name="Docker Deployment">
     <mxGraphModel dx="1200" dy="800" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1200" pageHeight="800" math="0" shadow="0" background="#0a0a1a">
       <root>
@@ -30,15 +30,15 @@
         <mxCell id="fe_container" value="" style="swimlane;html=1;startSize=35;fillColor=#1e1b4b;strokeColor=#7c3aed;strokeWidth=2;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
           <mxGeometry x="100" y="150" width="440" height="350" as="geometry"/>
         </mxCell>
-        <mxCell id="fe_label" value="f1_telemetry_frontend" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="fe_container">
+        <mxCell id="fe_label" value="f1_webapp" style="text;html=1;align=left;verticalAlign=middle;fontSize=14;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="fe_container">
           <mxGeometry x="10" y="0" width="250" height="35" as="geometry"/>
         </mxCell>
 
-        <mxCell id="fe_img" value="&lt;b&gt;Image&lt;/b&gt;: python:3.11-slim&lt;br&gt;&lt;b&gt;Dockerfile&lt;/b&gt;: frontend/Dockerfile&lt;br&gt;&lt;b&gt;Context&lt;/b&gt;: ./src/telemetry" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#312e81;strokeColor=#6366f1;fontColor=#a5b4fc;fontSize=10;align=left;spacingLeft=8;verticalAlign=top;spacingTop=4;" vertex="1" parent="fe_container">
+        <mxCell id="fe_img" value="&lt;b&gt;Image&lt;/b&gt;: nginx (multi-stage node build)&lt;br&gt;&lt;b&gt;Dockerfile&lt;/b&gt;: webapp/Dockerfile&lt;br&gt;&lt;b&gt;Context&lt;/b&gt;: ./src/telemetry/webapp" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#312e81;strokeColor=#6366f1;fontColor=#a5b4fc;fontSize=10;align=left;spacingLeft=8;verticalAlign=top;spacingTop=4;" vertex="1" parent="fe_container">
           <mxGeometry x="20" y="45" width="400" height="60" as="geometry"/>
         </mxCell>
 
-        <mxCell id="fe_port" value="&lt;font style=&quot;font-size:16px&quot;&gt;:8501&lt;/font&gt;&lt;br&gt;Streamlit" style="ellipse;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#a855f7;fontColor=#e9d5ff;fontSize=11;fontStyle=1;" vertex="1" parent="fe_container">
+        <mxCell id="fe_port" value="&lt;font style=&quot;font-size:16px&quot;&gt;:8501&lt;/font&gt;&lt;br&gt;React SPA via nginx" style="ellipse;whiteSpace=wrap;html=1;fillColor=#3b0764;strokeColor=#a855f7;fontColor=#e9d5ff;fontSize=11;fontStyle=1;" vertex="1" parent="fe_container">
           <mxGeometry x="20" y="120" width="100" height="60" as="geometry"/>
         </mxCell>
 
@@ -113,7 +113,7 @@
         </mxCell>
 
         <!-- Port mapping annotations -->
-        <mxCell id="port_note_fe" value="&lt;font style=&quot;font-size:9px&quot;&gt;host 8501 &amp;rarr; container 8501&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;fontColor=#818cf8;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+        <mxCell id="port_note_fe" value="&lt;font style=&quot;font-size:9px&quot;&gt;host 8501 &amp;rarr; container 80&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;fontColor=#818cf8;fillColor=none;strokeColor=none;" vertex="1" parent="1">
           <mxGeometry x="100" y="530" width="180" height="18" as="geometry"/>
         </mxCell>
         <mxCell id="port_note_be" value="&lt;font style=&quot;font-size:9px&quot;&gt;host 8000 &amp;rarr; container 8000&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;fontColor=#5eead4;fillColor=none;strokeColor=none;" vertex="1" parent="1">

--- a/documents/dev_docs/diagrams/frontend_pages_streamlit_legacy.drawio
+++ b/documents/dev_docs/diagrams/frontend_pages_streamlit_legacy.drawio
@@ -1,12 +1,12 @@
 <mxfile host="app.diagrams.net" modified="2026-04-13" agent="Claude" version="24.7.17">
-  <diagram id="fe-pages-1" name="Frontend Page Hierarchy">
+  <diagram id="fe-pages-1" name="Streamlit Frontend (retired v2.0.0)">
     <mxGraphModel dx="1400" dy="1000" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1400" pageHeight="1000" math="0" shadow="0" background="#0a0a1a">
       <root>
         <mxCell id="0"/>
         <mxCell id="1" parent="0"/>
 
         <!-- TITLE -->
-        <mxCell id="title" value="Streamlit Frontend — Page Hierarchy &amp; Components" style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+        <mxCell id="title" value="RETIRED &#8212; Streamlit Frontend, replaced by the React web app in v2.0.0. Kept as a record of what the surface was." style="text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="1">
           <mxGeometry x="250" y="10" width="900" height="40" as="geometry"/>
         </mxCell>
 

--- a/documents/dev_docs/diagrams/system_architecture.drawio
+++ b/documents/dev_docs/diagrams/system_architecture.drawio
@@ -56,16 +56,16 @@
         </mxCell>
 
         <!-- Surface 3: Streamlit -->
-        <mxCell id="st-box" value="Surface 3 &#8212; Streamlit + FastAPI&#10;src/telemetry/frontend/ &#183; src/telemetry/api/" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1A2138;strokeColor=#EC4899;fontColor=#E6E8EF;fontStyle=1;fontSize=13;verticalAlign=top;spacingTop=10;strokeWidth=2;" vertex="1" parent="1">
+        <mxCell id="st-box" value="Surface 3 &#8212; Web app + FastAPI&#10;src/telemetry/webapp/ &#183; src/telemetry/backend/" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1A2138;strokeColor=#EC4899;fontColor=#E6E8EF;fontStyle=1;fontSize=13;verticalAlign=top;spacingTop=10;strokeWidth=2;" vertex="1" parent="1">
           <mxGeometry x="1320" y="230" width="520" height="280" as="geometry"/>
         </mxCell>
-        <mxCell id="st-desc" value="post-race analysis &#183; chat &#183; voice&#10;FastMCP tools on top of FastAPI" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3F1D2D;strokeColor=#EC4899;fontColor=#E6E8EF;fontSize=11;" vertex="1" parent="1">
+        <mxCell id="st-desc" value="post-race analysis &#183; chat&#10;FastMCP tools on top of FastAPI" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#3F1D2D;strokeColor=#EC4899;fontColor=#E6E8EF;fontSize=11;" vertex="1" parent="1">
           <mxGeometry x="1350" y="280" width="460" height="60" as="geometry"/>
         </mxCell>
         <mxCell id="st-api" value="FastAPI /api/v1/strategy/simulate (SSE)&#10;GET yields per-lap events from simulate_race()" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#243049;strokeColor=#EC4899;fontColor=#F2B7D4;fontSize=10;" vertex="1" parent="1">
           <mxGeometry x="1350" y="350" width="460" height="60" as="geometry"/>
         </mxCell>
-        <mxCell id="st-ui" value="pages/strategy.py &#183; race_analysis.py (5 tabs)&#10;chat charts inline &#183; voice: Whisper + Edge-TTS" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#243049;strokeColor=#EC4899;fontColor=#F2B7D4;fontSize=10;" vertex="1" parent="1">
+        <mxCell id="st-ui" value="React SPA, 5 tabs &#183; served by nginx&#10;chat renders tool results inline over SSE" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#243049;strokeColor=#EC4899;fontColor=#F2B7D4;fontSize=10;" vertex="1" parent="1">
           <mxGeometry x="1350" y="420" width="460" height="60" as="geometry"/>
         </mxCell>
 

--- a/documents/dev_docs/diagrams/webapp_structure.drawio
+++ b/documents/dev_docs/diagrams/webapp_structure.drawio
@@ -1,0 +1,79 @@
+<mxfile host="app.diagrams.net" modified="2026-07-26" agent="Claude" version="24.7.17">
+  <diagram id="webapp-structure-1" name="Web App Structure">
+    <mxGraphModel dx="1400" dy="1000" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1400" pageHeight="1000" math="0" shadow="0" background="#0a0a1a">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+
+        <mxCell id="title" value="React Web App &#8212; src/telemetry/webapp/src/" style="text;html=1;align=center;verticalAlign=middle;fontSize=20;fontStyle=1;fontColor=#a78bfa;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="360" y="20" width="680" height="40" as="geometry"/>
+        </mxCell>
+        <mxCell id="subtitle" value="Replaced the Streamlit frontend in v2.0.0. Vite + TypeScript + Tailwind + ECharts, served by nginx behind /api." style="text;html=1;align=center;verticalAlign=middle;fontSize=11;fontColor=#94a3b8;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="360" y="56" width="680" height="24" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="feat_box" value="features/ &#8212; one folder per tab" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=13;fontStyle=1;verticalAlign=top;spacingTop=8;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="80" y="120" width="620" height="260" as="geometry"/>
+        </mxCell>
+        <mxCell id="f_home" value="home&#10;session launcher, recent sessions" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="100" y="160" width="180" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="f_dash" value="dashboard&#10;telemetry over a race" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="300" y="160" width="180" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="f_comp" value="comparison&#10;two drivers, 60 fps, synced" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="500" y="160" width="180" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="f_lab" value="lab&#10;the ML models and their calibration" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="100" y="230" width="180" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="f_race" value="race&#10;the pit-wall call, per lap" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="300" y="230" width="180" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="f_strat" value="strategy&#10;agent outputs and MC scores" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="500" y="230" width="180" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="f_chat" value="chat&#10;MCP client, SSE, tool results inline" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#a78bfa;fontColor=#ddd6fe;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="100" y="300" width="280" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="f_dev" value="dev&#10;internal tooling, not shipped to users" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#111827;strokeColor=#475569;fontColor=#94a3b8;fontSize=10;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="400" y="300" width="280" height="50" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="shared_box" value="shared" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#475569;fontColor=#94a3b8;fontSize=13;fontStyle=1;verticalAlign=top;spacingTop=8;dashed=1;" vertex="1" parent="1">
+          <mxGeometry x="740" y="120" width="300" height="260" as="geometry"/>
+        </mxCell>
+        <mxCell id="s_charts" value="charts/&#10;ECharts wrappers, one per chart kind" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#cbd5e1;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="760" y="160" width="260" height="44" as="geometry"/>
+        </mxCell>
+        <mxCell id="s_comp" value="components/&#10;design-system primitives" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#cbd5e1;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="760" y="214" width="260" height="44" as="geometry"/>
+        </mxCell>
+        <mxCell id="s_stores" value="stores/&#10;zustand, incl. persisted recent sessions" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#cbd5e1;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="760" y="268" width="260" height="44" as="geometry"/>
+        </mxCell>
+        <mxCell id="s_lib" value="lib/&#10;api client, queryKeys, driver colours" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e293b;strokeColor=#475569;fontColor=#cbd5e1;fontSize=10;" vertex="1" parent="1">
+          <mxGeometry x="760" y="322" width="260" height="44" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="nginx" value="nginx&#10;serves the built SPA, reverse-proxies /api" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1e1b4b;strokeColor=#a78bfa;fontColor=#ddd6fe;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="380" y="440" width="300" height="50" as="geometry"/>
+        </mxCell>
+        <mxCell id="backend" value="FastAPI backend :8000&#10;src/telemetry/backend/" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#14532d;strokeColor=#22c55e;fontColor=#bbf7d0;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="380" y="530" width="300" height="50" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="e_lib_nginx" value="fetch /api/v1/&#8230;" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#7c3aed;fontColor=#c4b5fd;fontSize=9;" edge="1" parent="1" source="s_lib" target="nginx">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="e_nginx_backend" value="proxy_pass, same origin, no CORS" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#22c55e;fontColor=#bbf7d0;fontSize=9;" edge="1" parent="1" source="nginx" target="backend">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="note" value="Every feature folder reaches the backend through lib/api only. There is no second HTTP client and no direct fetch inside a component, which is what keeps the query keys and the caching in one place." style="text;html=1;align=left;verticalAlign=top;fontSize=10;fontColor=#94a3b8;fillColor=none;strokeColor=none;" vertex="1" parent="1">
+          <mxGeometry x="80" y="620" width="960" height="40" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>


### PR DESCRIPTION
Refs #592. The redraw that #602 deliberately deferred.

All of these predated **two releases** and had not moved since 2026-05-13.

| diagram | what was wrong |
|---|---|
| `system_architecture` | Surface 3 was "Streamlit + FastAPI", pointing at `src/telemetry/frontend/`, a directory that no longer exists |
| `backend_api` | still drew a `/voice` router with `POST /process-voice` and `POST /complete-voice` |
| `chat_mcp_flow` | a voice input path, and a Streamlit chat UI rendering `st.chat_message` |
| `docker_deployment` | container `f1_telemetry_frontend` on `python:3.11-slim`; it is `f1_webapp` on nginx, and the port maps **8501 to 80**, not 8501 to 8501 |

## One was not stale in parts, it was stale entirely

`frontend_pages` **is** the Streamlit page tree: its services are `telemetry_service`, `chat_service`, `strategy_service`, `voice_api`. Renamed to `frontend_pages_streamlit_legacy` and marked retired rather than corrected, because it is an accurate picture of something that really existed and is part of the thesis record.

**New `webapp_structure.drawio`** takes its place, drawn from the actual feature folders (`home`, `dashboard`, `comparison`, `lab`, `race`, `strategy`, `chat`, `dev`) and the shared `charts/`, `components/`, `stores/`, `lib/`, with the point that matters: every feature reaches the backend through `lib/api` only, which is what keeps query keys and caching in one place.

## I got the previous audit wrong, and the README now says so

The README I wrote in #602 reported **six of twelve** stale, from a grep for "Streamlit" and "voice" across the raw XML. That counts matches inside **style attributes and colour names**, not labels. It over-reported three files that were fine, and **missed `docker_deployment`**, whose problem was a container named `f1_telemetry_frontend` containing neither word.

The audit is now done by parsing labels, and the correction is written into the README so the next reader can check the method rather than trust the number.

## Verification

All **20** files parse as XML. **Zero** labels outside the file marked legacy name a retired surface.