### PR TITLE
fix(engine): thread cliff_p50 and total_laps so the stint-end guard is not dead

### DIFF
--- a/src/strategy/inference/engine.py
+++ b/src/strategy/inference/engine.py
@@ -289,6 +289,15 @@ def _run_rich(
             # /simulate, the arcade and the CLI. That is the whole class this engine
             # exists to prevent: one call sequence, or every caller drifts.
             live_drivers=_live_drivers_from(lap_state),
+            # Same class, same profile, two arguments further along. Without
+            # these `_clamp_expected_stint_end` has no physical anchor and
+            # returns the LLM's `expected_stint_end` unclamped, so #433's guard
+            # was dead everywhere the default profile runs. The fix for
+            # `live_drivers` above landed and these two were missed, which is
+            # the argument for the threading test rather than for reading the
+            # call twice.
+            cliff_p50=tire_out.laps_to_cliff_p50,
+            total_laps=race_state.total_laps,
         )
 
     timings["total"] = sum(timings.values())


### PR DESCRIPTION
Closes #566.

`_clamp_expected_stint_end` grounds the LLM's free-text `expected_stint_end` against a physical anchor: the pit lap plus the shorter of the N26 cliff P50 and the Pirelli capacity for the next compound, bounded by the race length. **Without `cliff_p50` it has no anchor and returns the LLM value unclamped**, by design.

The engine never passed it, nor `total_laps`. So that guard was dead on the `rich` profile, **which is the default** for `/simulate`, the Arcade and the CLI. Nothing in the schema stops the LLM naming a lap the stint cannot physically reach, and on every default-profile surface nothing did.

## The part worth noticing

This is the **same class** as the `live_drivers` gap, and the comment directly above the call site already describes it:

> The orchestrator threads it; this path did not, so #462's guard was dead on the `rich` profile. **That is the whole class this engine exists to prevent: one call sequence, or every caller drifts.**

That fix landed. These two arguments, in the same call, were missed. Which is the argument for keeping `test_engine_threads_every_argument` rather than trusting a second read of the call site.

## Verification

The threading test passes, the no-LLM engine suite passes (6 total), ruff is clean repo-wide, and a real `f1-sim` run on Lusail completes.