### PR TITLE
Promote dev to main: the stint-end guard fix and the projection results report

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Five entry points after install (`pyproject.toml::[project.scripts]`):
 | `f1-sim` | Headless CLI strategy simulation with Rich live panel (the scripted form) |
 | `f1-arcade --strategy` | 2D replay + PySide6 dashboard + telemetry |
 | `f1-webapp` | Post-race web app (wraps `docker compose up`: FastAPI backend + React SPA) |
-| `f1-eval` | Regenerates the model evaluation reports (`registry`, `calibration`, `hygiene`, `nlp`, `models`, `alert-llm` subcommands) under `documents/eval_reports/` |
+| `f1-eval` | Regenerates the model evaluation reports (`registry`, `calibration`, `hygiene`, `nlp`, `models`, `projection`, `alert-llm` subcommands) under `documents/eval_reports/` |
 
 ## Code style
 

--- a/INDEX.md
+++ b/INDEX.md
@@ -162,7 +162,7 @@ are reference/historical only, see [`src/strategy/README.md`](src/strategy/READM
 | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | [src/strategy/inference/engine.py](src/strategy/inference/engine.py)                           | `run_lap()`, the shared strategy inference engine consumed by the CLI, Arcade, and backend; dispatches on `profile` (`"rich"` re-drives the full N31 orchestrator sequence, `"no-llm"` is the deterministic zero-LLM-client path) |
 | [src/strategy/inference/no_llm.py](src/strategy/inference/no_llm.py)                           | The deterministic `--no-llm` code path consumed by `run_lap` |
-| [src/strategy/eval/](src/strategy/eval/)                                                       | `f1-eval` CLI backend, regenerates the model evaluation reports (metrics registry, calibration, threshold hygiene, NLP per-stage eval, headline-number reproduction, LLM-judged alert precision) under `documents/eval_reports/` |
+| [src/strategy/eval/](src/strategy/eval/)                                                       | `f1-eval` CLI backend, regenerates the model evaluation reports (metrics registry, calibration, threshold hygiene, NLP per-stage eval, headline-number reproduction, Monte Carlo projection accuracy, LLM-judged alert precision) under `documents/eval_reports/` |
 | [src/strategy/inference/tire_predictor.py](src/strategy/inference/tire_predictor.py)           | Jupytext-exported tire degradation inference wrapper (N09 era; reference only) |
 
 ### `src/telemetry/`

--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -25,7 +25,7 @@ f1-strat       # interactive launcher (recommended starting point)
 f1-sim         # headless CLI simulation against a saved race
 f1-arcade      # three-window PySide6 + pyglet experience
 f1-webapp      # post-race web app (wraps `docker compose up`)
-f1-eval        # regenerate the evaluation reports (registry, calibration, hygiene, ...)
+f1-eval        # regenerate the evaluation reports (registry, calibration, hygiene, projection, ...)
 ```
 
 `f1-eval` is a developer/thesis tool, not an end-user surface, it writes versioned markdown + JSON reports under `documents/eval_reports/` (`f1-eval registry`, `f1-eval calibration`, `f1-eval all`, ...). The first four are what a new user actually runs.

--- a/docs/pages/thesis.md
+++ b/docs/pages/thesis.md
@@ -24,9 +24,39 @@ The TCN tire-degradation model (N09 global + N10 per-compound fine-tunes) uses 5
 
 Raw coverage stays around **0.20** across all compounds, active dropout only captures the model-weight uncertainty, not the lap-to-lap aleatoric noise. The calibrated coverage matches the **0.80** nominal target by construction.
 
+## Monte Carlo projection accuracy
+
+The strategy layer scores its four candidates in **projected track position**, not in seconds. That claim is directly checkable, because every real pit stop in the dataset is already a labelled example of it: project the stop from the lap before, then compare against where the car actually came out on the lap after. No hand-labelling is involved, which is what makes this a measured result rather than a plausibility argument.
+
+Over **1810 green-flag stops across 71 races** (2023 to 2025), the projection lands **within one position 86.5 %** of the time and is **exactly right 59.1 %** of the time, with a mean signed error of **+0.57 positions**. The bias is positive, so the projection is mildly pessimistic about the rejoin, which is the safer direction for a strategy call.
+
+Neutralised stops are excluded, and not to flatter the number. Under a Safety Car every lap is slow, so the "two normal laps" baseline used to reconstruct the realised pit loss is wrong there: that corrupts the measurement's **input** rather than the projection itself. Measured separately, those stops show a mean error of +1.54 positions against +0.57 under green, which is the signature of exactly that problem.
+
+### The tables the scorer reads
+
+Seven tables are counted off the same 71 races of raw laps rather than assumed, and the scorer reads them at runtime from `data/mc_measured_v1.json`.
+
+| Table | What it answers |
+|---|---|
+| `clean_air` | seconds a lap a follower gains once the car directly ahead pits, per circuit |
+| `gap_density` | seconds between consecutive cars, so a projected gap maps to a place |
+| `neutralisation_rate` | chance a Safety Car arrives while a stop is being deferred |
+| `sc_window` | green laps left inside the 5-lap decision window once neutralised |
+| `status_mix` | share of laps that are actually racing, the denominator for the rest |
+| `stop_hazard` | chance a rival stops in the window, by tyre life |
+| `undercut_band` | undercut success against the gap to the target |
+
+The source is the **raw** parquet and never the featured one, which drops the neutralised and pit laps these tables are precisely about.
+
 ## How to regenerate
 
 ```bash
+# Monte Carlo projection accuracy + the measured-table inventory (~1 min)
+uv run f1-eval projection
+
+# The measured tables themselves, from 71 races of raw laps (~10 min)
+uv run python scripts/measure_mc_tables.py
+
 # Threshold sweeps + MC Dropout figures (one notebook, ~5 min on GPU)
 uv run jupyter nbconvert --execute --inplace notebooks/agents/N33_thresholds_and_calibration.ipynb
 
@@ -39,6 +69,8 @@ Both notebooks emit CSV and Markdown tables alongside their PNGs:
 - Sweeps: `data/eval/threshold_sweep_{overtake,sc,undercut}.{csv,md}`
 - MC Dropout: `data/eval/mc_dropout_coverage.{csv,md}`
 - RAG benchmark: `data/rag_eval/results_v1.md`
+- Projection accuracy: `documents/eval_reports/projection.{md,json}`
+- Measured MC tables: `data/mc_measured_v1.json`, with thesis-facing extracts at `data/eval/mc_{clean_air,gap_density,sc_window,undercut_band}.{csv,md}`
 
 ## Numeric headline metrics
 
@@ -50,6 +82,7 @@ Both notebooks emit CSV and Markdown tables alongside their PNGs:
 | Sub-agent latency | min / max mean | **487 ms** (pace) / **4.4 s** (rag w/ LLM) | `data/eval/subagent_latency.{csv,md}` |
 | RAG agent | Content P@5 | **0.80** | `data/rag_eval/results_v1.md` |
 | MC Dropout (C2) | calibrated 80 % coverage | **0.840** | `data/eval/mc_dropout_coverage.{csv,md}` |
+| Position projection | within one place, 1810 real stops | **86.5 %** | `documents/eval_reports/projection.{md,json}` |
 
 All numbers reproducible with the commands above.
 

--- a/documents/eval_reports/projection.json
+++ b/documents/eval_reports/projection.json
@@ -1,0 +1,65 @@
+{
+  "header": {
+    "harness_sha": "0c95c1b",
+    "dataset": "data/raw laps 2023-2025 (RAW, not featured)",
+    "seed_policy": "deterministic",
+    "era_tag": "2022-2025",
+    "llm": "none",
+    "schema_version": "1",
+    "generated_at": "2026-07-26T11:39:52+00:00",
+    "artifacts": {}
+  },
+  "ground_truth": {
+    "sample_size": 1810,
+    "races": 71,
+    "within_one": 0.8646408839779005,
+    "exact": 0.5911602209944752,
+    "mean_signed_error": 0.5718232044198895,
+    "mean_absolute_error": 0.6591160220994475
+  },
+  "tables": [
+    {
+      "table": "clean_air",
+      "answers": "seconds a lap a follower gains once the car directly ahead pits, per circuit",
+      "cells": "34",
+      "present": true
+    },
+    {
+      "table": "gap_density",
+      "answers": "seconds between consecutive cars, so a projected gap maps to a place",
+      "cells": "12",
+      "present": true
+    },
+    {
+      "table": "neutralisation_rate",
+      "answers": "chance a Safety Car arrives while a stop is being deferred",
+      "cells": "29",
+      "present": true
+    },
+    {
+      "table": "sc_window",
+      "answers": "green laps left inside the 5-lap decision window once neutralised",
+      "cells": "2",
+      "present": true
+    },
+    {
+      "table": "status_mix",
+      "answers": "share of laps that are actually racing, the denominator for the rest",
+      "cells": "5",
+      "present": true
+    },
+    {
+      "table": "stop_hazard",
+      "answers": "chance a rival stops in the window, by tyre life",
+      "cells": "36",
+      "present": true
+    },
+    {
+      "table": "undercut_band",
+      "answers": "undercut success against the gap to the target",
+      "cells": "15",
+      "present": true
+    }
+  ],
+  "measured_tables_path": "data/mc_measured_v1.json"
+}

--- a/documents/eval_reports/projection.md
+++ b/documents/eval_reports/projection.md
@@ -1,0 +1,38 @@
+# projection
+
+- harness `0c95c1b` · schema v1 · generated 2026-07-26T11:39:52+00:00
+- era 2022-2025 · dataset data/raw laps 2023-2025 (RAW, not featured) · seed deterministic · llm none
+- artifacts: —
+
+## Position projection against real pit stops
+
+| quantity | value |
+|---|---|
+| green-flag stops projected | 1810 |
+| races covered | 71 |
+| within one position | 86.5% |
+| exactly right | 59.1% |
+| mean signed error (positions) | +0.572 |
+| mean absolute error (positions) | 0.659 |
+
+Every real stop is a labelled example of the claim the projection makes, so
+this is measured accuracy and not a proxy. Neutralised stops are excluded
+because the pit-loss reconstruction, not the projection, is wrong under a
+Safety Car.
+
+## Measured tables the scorer reads
+
+| table | answers | cells |
+|---|---|---|
+| clean_air | seconds a lap a follower gains once the car directly ahead pits, per circuit | 34 |
+| gap_density | seconds between consecutive cars, so a projected gap maps to a place | 12 |
+| neutralisation_rate | chance a Safety Car arrives while a stop is being deferred | 29 |
+| sc_window | green laps left inside the 5-lap decision window once neutralised | 2 |
+| status_mix | share of laps that are actually racing, the denominator for the rest | 5 |
+| stop_hazard | chance a rival stops in the window, by tyre life | 36 |
+| undercut_band | undercut success against the gap to the target | 15 |
+
+Counted off 71 races (2023, 2024, 2025) of raw laps. The raw parquet is the source
+and not the featured one, which drops the neutralised and pit laps these tables
+are about.
+

--- a/src/strategy/eval/cli.py
+++ b/src/strategy/eval/cli.py
@@ -9,6 +9,7 @@ one-line summary of where it landed and what it flagged.
     f1-eval models         # reproduce headline numbers vs the model_configs
     f1-eval hygiene        # E-02 threshold provenance + leakage verdicts (#207)
     f1-eval nlp            # NLP per-stage eval: sentiment + gated stages (#304)
+    f1-eval projection     # MC projection accuracy vs real stops + the measured tables
     f1-eval alert-llm      # PROXY alert precision via an LLM judge (#304; spends API calls)
     f1-eval all            # every report EXCEPT alert-llm (opt-in: it spends API calls)
 """
@@ -22,6 +23,7 @@ from src.strategy.eval.alert_llm import build_alert_llm_report
 from src.strategy.eval.calibration import build_calibration_report
 from src.strategy.eval.hygiene import build_hygiene_report
 from src.strategy.eval.nlp import build_nlp_report
+from src.strategy.eval.projection import build_projection_report
 from src.strategy.eval.registry import build_registry
 from src.strategy.eval.reproduce import build_reproduction_report
 
@@ -64,6 +66,17 @@ def _run_nlp() -> None:
     print("nlp " + _summarise(payload, "results", ("flagged", "delta", "blocked", "pending")))
 
 
+def _run_projection() -> None:
+    payload = build_projection_report()
+    truth = payload["ground_truth"]
+    accuracy = (
+        "not measured (no data/raw)"
+        if truth is None
+        else f"{truth.within_one:.1%} within one position over {truth.sample_size} real stops"
+    )
+    print(f"projection -> {payload['md_path']} ({accuracy}; {len(payload['tables'])} tables)")
+
+
 def _run_alert_llm() -> None:
     payload = build_alert_llm_report()
     result = payload["result"]
@@ -80,6 +93,7 @@ _COMMANDS: dict[str, Callable[[], None]] = {
     "models": _run_models,
     "hygiene": _run_hygiene,
     "nlp": _run_nlp,
+    "projection": _run_projection,
 }
 
 

--- a/src/strategy/eval/projection.py
+++ b/src/strategy/eval/projection.py
@@ -1,0 +1,391 @@
+"""Eval report for the Monte Carlo projection layer: its tables and its accuracy.
+
+Two things live here, and they answer two different questions.
+
+**Is the layer measured?** ``data/mc_measured_v1.json`` carries six tables the
+Monte Carlo scorer reads at runtime, each one counted off real laps rather than
+assumed. This report lists them with their sample sizes, so "measured" is a
+number a reader can check and not a word in a commit message.
+
+**Is the layer right?** The projection claims that a stop lands a car in a given
+place. Every real pit stop in the dataset is a labelled example of exactly that
+claim, which makes the accuracy checkable without anyone hand-labelling
+anything: project the stop from the lap before, compare with where the car
+actually came out.
+
+The measurement itself is here rather than in the test that gates it. Reversing
+that would mean the harness reimplements the test, and this repo has already
+paid for one parallel implementation drifting away from the reference it copied.
+The test imports ``measure_projection_ground_truth`` and asserts a floor on it.
+
+WHERE TO CHANGE IF THE PROJECTION CHANGES:
+- ``src/agents/position_projection.py`` holds the geometry under test. A change
+  there moves the number here, and ``MIN_WITHIN_ONE`` in
+  ``tests/mc/test_position_projection.py`` is the floor that notices.
+- ``scripts/measure_mc_tables.py`` regenerates ``data/mc_measured_v1.json``;
+  this report reads that file and never recomputes the tables.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from src.agents.position_projection import (
+    DriverPlan,
+    ProjectionConfig,
+    RivalState,
+    project_positions,
+)
+from src.f1_strat_manager.data_cache import _find_repo_root
+from src.strategy.eval.report import build_header, write_report
+
+MEASURED_TABLES_PATH = "data/mc_measured_v1.json"
+
+# A stop is a stop whether or not the tyre falls off a cliff two laps later, so
+# the ground truth uses a flat degradation profile and a cliff far outside the
+# window. What is under test is the geometry of the rejoin, not the tyre model.
+_GROUND_TRUTH_CLIFF_LAPS = 99.0
+
+# The horizon has to be the one the comparison uses. Each stop is projected from
+# the lap before and checked against the lap after, which is two laps, so the
+# config projects two laps. Leaving the runtime default of five measures a
+# five-lap outcome against a two-lap observation and scores several points too
+# high for the wrong reason: the extra laps let rivals separate, and a projection
+# graded on a horizon it was not asked about is not validated at all. The tyre
+# terms are off for the same reason the cliff is far away.
+_GROUND_TRUTH_CONFIG = ProjectionConfig(
+    window_laps=2,
+    racing_laps=2.0,
+    fresh_gain_s=0.0,
+    cliff_loss_s=0.0,
+    neutralisation_saving_s=0.0,
+)
+
+_STOP_NOW = DriverPlan("PIT_NOW", stops_in_window=True, stop_offset_laps=0)
+
+# What each measured table exists to answer, in one line. Kept beside the report
+# rather than in the JSON because it is editorial, and the JSON is machine-read.
+_TABLE_PURPOSE: dict[str, str] = {
+    "clean_air": "seconds a lap a follower gains once the car directly ahead pits, per circuit",
+    "gap_density": "seconds between consecutive cars, so a projected gap maps to a place",
+    "neutralisation_rate": "chance a Safety Car arrives while a stop is being deferred",
+    "sc_window": "green laps left inside the 5-lap decision window once neutralised",
+    "status_mix": "share of laps that are actually racing, the denominator for the rest",
+    "stop_hazard": "chance a rival stops in the window, by tyre life",
+    "undercut_band": "undercut success against the gap to the target",
+}
+
+
+@dataclass(frozen=True)
+class GroundTruth:
+    """Accuracy of the position projection against real pit stops.
+
+    ``errors`` is signed (projected minus actual) so a systematic bias is
+    visible rather than absorbed into a magnitude. ``within_one`` is the headline
+    because a strategy call that lands one place either side of the projection is
+    still the same call; being three places out is a different race.
+    """
+
+    errors: np.ndarray
+    races: int
+
+    @property
+    def sample_size(self) -> int:
+        return int(self.errors.size)
+
+    @property
+    def within_one(self) -> float:
+        return float((np.abs(self.errors) <= 1).mean())
+
+    @property
+    def exact(self) -> float:
+        return float((self.errors == 0).mean())
+
+    @property
+    def mean_signed_error(self) -> float:
+        return float(self.errors.mean())
+
+    @property
+    def mean_absolute_error(self) -> float:
+        return float(np.abs(self.errors).mean())
+
+
+def _raw_data_root() -> Path | None:
+    """``data/raw/`` if this is a checkout with the dataset pulled, else None."""
+    repo = _find_repo_root()
+    if repo is None:
+        return None
+    raw = repo / "data" / "raw"
+    return raw if raw.is_dir() else None
+
+
+def _elapsed_pivot(laps):
+    """LapNumber x Driver table of elapsed session seconds."""
+    frame = laps[["LapNumber", "Driver", "Time"]].dropna()
+    frame = frame.assign(elapsed=frame["Time"].dt.total_seconds())
+    return frame.pivot_table(index="LapNumber", columns="Driver", values="elapsed", aggfunc="first")
+
+
+def _neutralised_laps(laps) -> set[int]:
+    """Lap numbers showing a Safety Car, VSC or red flag on any car's status."""
+    neutralised = set()
+    for lap, group in laps.groupby("LapNumber"):
+        joined = "".join(group["TrackStatus"].dropna().astype(str))
+        if any(flag in joined for flag in ("4", "5", "6")):
+            neutralised.add(int(lap))
+    return neutralised
+
+
+def _rivals_around(pivot, medians, pitters, driver, lap, row_before, row_after, ours_before):
+    """Every car with a lap either side of the stop, with its own stop loss if it pitted."""
+    rivals: list[RivalState] = []
+    for other in pivot.columns:
+        if other == driver:
+            continue
+        their_before, their_after = row_before.get(other), row_after.get(other)
+        if their_before is None or np.isnan(their_before):
+            continue
+        if their_after is None or np.isnan(their_after):
+            continue
+
+        also_pits = other in pitters.get(lap, ()) or other in pitters.get(lap + 1, ())
+        their_normal = medians.get(other)
+        their_loss = 0.0
+        if also_pits and their_normal and not np.isnan(their_normal):
+            their_loss = max(0.0, (their_after - their_before) - 2 * their_normal)
+
+        rivals.append(
+            RivalState(
+                driver=str(other),
+                gap_s=float(their_before - ours_before),
+                is_pitting=also_pits,
+                stop_loss_s=their_loss,
+            )
+        )
+    return rivals
+
+
+def _actual_position(pivot, row_after, driver, ours_after) -> int:
+    """Where the car actually came out: one plus the cars ahead of it on the lap after."""
+    ahead = sum(
+        1
+        for other in pivot.columns
+        if other != driver
+        and not np.isnan(row_after.get(other, np.nan))
+        and row_after[other] < ours_after
+    )
+    return 1 + int(ahead)
+
+
+def project_one_stop(pivot, medians, pitters, driver, lap) -> int | None:
+    """Projected minus actual rejoin position for one real stop, or None to skip.
+
+    Returns None rather than a sentinel when the stop cannot be reconstructed:
+    a missing lap either side, or a realised pit loss that comes out negative,
+    which means the "two normal laps" baseline does not describe what happened.
+    Feeding those through would measure the reconstruction, not the projection.
+    """
+    before, after = lap - 1, lap + 1
+    if before < 1 or before not in pivot.index or after not in pivot.index:
+        return None
+
+    row_before, row_after = pivot.loc[before], pivot.loc[after]
+    ours_before, ours_after = row_before.get(driver), row_after.get(driver)
+    normal = medians.get(driver)
+    if any(value is None or np.isnan(value) for value in (ours_before, ours_after, normal)):
+        return None
+
+    realised_loss = (ours_after - ours_before) - 2 * normal
+    if realised_loss <= 0:
+        return None
+
+    rivals = _rivals_around(
+        pivot, medians, pitters, driver, lap, row_before, row_after, ours_before
+    )
+    if not rivals:
+        return None
+
+    result = project_positions(
+        rivals,
+        _STOP_NOW,
+        _GROUND_TRUTH_CONFIG,
+        np.array([realised_loss]),
+        np.array([_GROUND_TRUTH_CLIFF_LAPS]),
+    )
+    return int(result.positions[0]) - _actual_position(pivot, row_after, driver, ours_after)
+
+
+def measure_projection_ground_truth(years: tuple[int, ...] = (2023, 2024, 2025)) -> GroundTruth:
+    """Project every real green-flag pit stop and compare with what actually happened.
+
+    Neutralised stops are excluded, and not to flatter the number. Under a Safety
+    Car every lap is slow, so the "two normal laps" baseline used to reconstruct
+    the realised pit loss is wrong there: that corrupts the INPUT rather than the
+    projection. Measuring the two separately showed exactly that signature, a
+    mean error of +1.54 positions under neutralisation against +0.57 under green.
+
+    Raises FileNotFoundError when ``data/raw/`` is absent, since a silently empty
+    sample would report perfect accuracy over zero stops.
+    """
+    import pandas as pd
+
+    raw = _raw_data_root()
+    if raw is None:
+        raise FileNotFoundError(
+            "data/raw/ is not present; the ground truth needs the raw laps from the "
+            "Hugging Face dataset (the featured parquet drops the pit and neutralised laps)"
+        )
+
+    errors: list[int] = []
+    races = 0
+    for year in years:
+        year_dir = raw / str(year)
+        if not year_dir.is_dir():
+            continue
+
+        for race_dir in sorted(path for path in year_dir.iterdir() if path.is_dir()):
+            laps_path = race_dir / "laps.parquet"
+            if not laps_path.exists():
+                continue
+
+            laps = pd.read_parquet(laps_path)
+            if "PitInTime" not in laps.columns:
+                continue
+
+            races += 1
+            pivot = _elapsed_pivot(laps)
+            medians = laps.groupby("Driver")["LapTime"].median().dt.total_seconds().to_dict()
+            neutralised = _neutralised_laps(laps)
+
+            stops = laps[laps["PitInTime"].notna()][["Driver", "LapNumber"]]
+            pitters: dict[int, set[str]] = {}
+            for _, row in stops.iterrows():
+                pitters.setdefault(int(row["LapNumber"]), set()).add(str(row["Driver"]))
+
+            for _, stop in stops.iterrows():
+                lap = int(stop["LapNumber"])
+                if lap in neutralised or lap + 1 in neutralised:
+                    continue
+                error = project_one_stop(pivot, medians, pitters, str(stop["Driver"]), lap)
+                if error is not None:
+                    errors.append(error)
+
+    return GroundTruth(errors=np.array(errors, dtype=int), races=races)
+
+
+def _measured_tables() -> dict[str, Any]:
+    """The six runtime tables, or an empty dict when the file has not been generated."""
+    repo = _find_repo_root()
+    path = (repo / MEASURED_TABLES_PATH) if repo else Path(MEASURED_TABLES_PATH)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _table_rows(tables: dict[str, Any]) -> list[dict[str, Any]]:
+    """One row per measured table: what it answers and how many cells back it."""
+    rows = []
+    for name, purpose in sorted(_TABLE_PURPOSE.items()):
+        body = tables.get(name)
+        cells = "-"
+        if isinstance(body, dict):
+            keyed = {k: v for k, v in body.items() if isinstance(v, dict)}
+            if keyed:
+                cells = str(sum(len(v) for v in keyed.values()))
+        rows.append(
+            {
+                "table": name,
+                "answers": purpose,
+                "cells": cells,
+                "present": body is not None,
+            }
+        )
+    return rows
+
+
+def _render_table(rows: list[dict[str, Any]], truth: GroundTruth | None, tables: dict) -> str:
+    """Two sections: the accuracy headline, then the tables that feed the scorer."""
+    lines = ["## Position projection against real pit stops", ""]
+    if truth is None:
+        lines += ["Not measured: `data/raw/` is absent from this checkout.", ""]
+    else:
+        lines += [
+            "| quantity | value |",
+            "|---|---|",
+            f"| green-flag stops projected | {truth.sample_size} |",
+            f"| races covered | {truth.races} |",
+            f"| within one position | {truth.within_one:.1%} |",
+            f"| exactly right | {truth.exact:.1%} |",
+            f"| mean signed error (positions) | {truth.mean_signed_error:+.3f} |",
+            f"| mean absolute error (positions) | {truth.mean_absolute_error:.3f} |",
+            "",
+            "Every real stop is a labelled example of the claim the projection makes, so",
+            "this is measured accuracy and not a proxy. Neutralised stops are excluded",
+            "because the pit-loss reconstruction, not the projection, is wrong under a",
+            "Safety Car.",
+            "",
+        ]
+
+    lines += ["## Measured tables the scorer reads", ""]
+    if not tables:
+        lines += [f"`{MEASURED_TABLES_PATH}` not present; run `scripts/measure_mc_tables.py`.", ""]
+        return "\n".join(lines)
+
+    lines += ["| table | answers | cells |", "|---|---|---|"]
+    for row in rows:
+        cells = row["cells"] if row["present"] else "MISSING"
+        lines.append(f"| {row['table']} | {row['answers']} | {cells} |")
+
+    races = tables.get("races_measured", "-")
+    years = ", ".join(str(y) for y in tables.get("years", []))
+    lines += [
+        "",
+        f"Counted off {races} races ({years}) of raw laps. The raw parquet is the source",
+        "and not the featured one, which drops the neutralised and pit laps these tables",
+        "are about.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def build_projection_report() -> dict[str, Any]:
+    """Write ``documents/eval_reports/projection.{md,json}`` and return the payload."""
+    tables = _measured_tables()
+    rows = _table_rows(tables)
+
+    try:
+        truth: GroundTruth | None = measure_projection_ground_truth()
+    except FileNotFoundError:
+        truth = None
+
+    header = build_header(dataset="data/raw laps 2023-2025 (RAW, not featured)")
+    md_path, json_path = write_report(
+        "projection",
+        header,
+        _render_table(rows, truth, tables),
+        {
+            "ground_truth": None
+            if truth is None
+            else {
+                "sample_size": truth.sample_size,
+                "races": truth.races,
+                "within_one": truth.within_one,
+                "exact": truth.exact,
+                "mean_signed_error": truth.mean_signed_error,
+                "mean_absolute_error": truth.mean_absolute_error,
+            },
+            "tables": rows,
+            "measured_tables_path": MEASURED_TABLES_PATH,
+        },
+    )
+    return {
+        "md_path": str(md_path),
+        "json_path": str(json_path),
+        "ground_truth": truth,
+        "tables": rows,
+    }

--- a/src/strategy/inference/engine.py
+++ b/src/strategy/inference/engine.py
@@ -289,6 +289,15 @@ def _run_rich(
             # /simulate, the arcade and the CLI. That is the whole class this engine
             # exists to prevent: one call sequence, or every caller drifts.
             live_drivers=_live_drivers_from(lap_state),
+            # Same class, same profile, two arguments further along. Without
+            # these `_clamp_expected_stint_end` has no physical anchor and
+            # returns the LLM's `expected_stint_end` unclamped, so #433's guard
+            # was dead everywhere the default profile runs. The fix for
+            # `live_drivers` above landed and these two were missed, which is
+            # the argument for the threading test rather than for reading the
+            # call twice.
+            cliff_p50=tire_out.laps_to_cliff_p50,
+            total_laps=race_state.total_laps,
         )
 
     timings["total"] = sum(timings.values())

--- a/tests/mc/test_position_projection.py
+++ b/tests/mc/test_position_projection.py
@@ -32,6 +32,7 @@ from src.agents.position_projection import (
     rank_targets,
     undercut_targets,
 )
+from src.strategy.eval.projection import measure_projection_ground_truth
 
 ROOT = Path(__file__).parent.parent.parent
 
@@ -420,137 +421,24 @@ def test_the_projection_is_deterministic():
 # ---------------------------------------------------------------------------
 
 
-def _elapsed_pivot(laps):
-    """LapNumber x Driver table of elapsed session seconds."""
-    frame = laps[["LapNumber", "Driver", "Time"]].dropna()
-    frame = frame.assign(elapsed=frame["Time"].dt.total_seconds())
-    return frame.pivot_table(index="LapNumber", columns="Driver", values="elapsed", aggfunc="first")
-
-
-def _neutralised_laps(laps) -> set[int]:
-    neutralised = set()
-    for lap, group in laps.groupby("LapNumber"):
-        joined = "".join(group["TrackStatus"].dropna().astype(str))
-        if any(flag in joined for flag in ("4", "5", "6")):
-            neutralised.add(int(lap))
-    return neutralised
-
-
-def _project_one_stop(pivot, medians, pitters, driver, lap):
-    """Projected minus actual rejoin position for one real stop, or None to skip."""
-    before, after = lap - 1, lap + 1
-    if before < 1 or before not in pivot.index or after not in pivot.index:
-        return None
-
-    row_before, row_after = pivot.loc[before], pivot.loc[after]
-    ours_before, ours_after = row_before.get(driver), row_after.get(driver)
-    normal = medians.get(driver)
-    if any(value is None or np.isnan(value) for value in (ours_before, ours_after, normal)):
-        return None
-
-    realised_loss = (ours_after - ours_before) - 2 * normal
-    if realised_loss <= 0:
-        return None
-
-    rivals = []
-    for other in pivot.columns:
-        if other == driver:
-            continue
-        their_before, their_after = row_before.get(other), row_after.get(other)
-        if their_before is None or np.isnan(their_before):
-            continue
-        if their_after is None or np.isnan(their_after):
-            continue
-
-        also_pits = other in pitters.get(lap, ()) or other in pitters.get(lap + 1, ())
-        their_normal = medians.get(other)
-        their_loss = 0.0
-        if also_pits and their_normal and not np.isnan(their_normal):
-            their_loss = max(0.0, (their_after - their_before) - 2 * their_normal)
-
-        rivals.append(
-            RivalState(
-                driver=str(other),
-                gap_s=float(their_before - ours_before),
-                is_pitting=also_pits,
-                stop_loss_s=their_loss,
-            )
-        )
-
-    if not rivals:
-        return None
-
-    result = project_positions(
-        rivals, STOP_NOW, _flat_config(), np.array([realised_loss]), np.array([99.0])
-    )
-    actual = 1 + int(
-        sum(
-            1
-            for other in pivot.columns
-            if other != driver
-            and not np.isnan(row_after.get(other, np.nan))
-            and row_after[other] < ours_after
-        )
-    )
-    return int(result.positions[0]) - actual
-
-
 @_skip_no_raw
 def test_the_projection_reproduces_real_pit_stop_rejoins():
     """Project every real green-flag stop and compare with what actually happened.
 
-    Neutralised stops are excluded, and not to flatter the number: under a Safety
-    Car every lap is slow, so the "normal lap" baseline this test uses to
-    reconstruct the realised pit loss is wrong there. That corrupts the test's
-    INPUT rather than the projection, and measuring it separately showed exactly
-    that signature (mean error +1.54 positions under neutralisation against +0.57
-    under green). The geometry is what is under test here; pit-loss estimation
-    under a Safety Car is a different question.
+    The measurement lives in ``src/strategy/eval/projection.py`` and is imported
+    rather than repeated here, so the number this test gates is the same number
+    ``f1-eval projection`` publishes. A second copy would drift, and a floor
+    asserted against a drifted copy gates nothing.
     """
-    import pandas as pd
+    truth = measure_projection_ground_truth()
 
-    errors: list[int] = []
-    for year in (2023, 2024, 2025):
-        year_dir = ROOT / "data" / "raw" / str(year)
-        if not year_dir.is_dir():
-            continue
-
-        for race_dir in sorted(path for path in year_dir.iterdir() if path.is_dir()):
-            laps_path = race_dir / "laps.parquet"
-            if not laps_path.exists():
-                continue
-
-            laps = pd.read_parquet(laps_path)
-            if "PitInTime" not in laps.columns:
-                continue
-
-            pivot = _elapsed_pivot(laps)
-            medians = laps.groupby("Driver")["LapTime"].median().dt.total_seconds().to_dict()
-            neutralised = _neutralised_laps(laps)
-
-            stops = laps[laps["PitInTime"].notna()][["Driver", "LapNumber"]]
-            pitters: dict[int, set[str]] = {}
-            for _, row in stops.iterrows():
-                pitters.setdefault(int(row["LapNumber"]), set()).add(str(row["Driver"]))
-
-            for _, stop in stops.iterrows():
-                lap = int(stop["LapNumber"])
-                if lap in neutralised or lap + 1 in neutralised:
-                    continue
-                error = _project_one_stop(pivot, medians, pitters, str(stop["Driver"]), lap)
-                if error is not None:
-                    errors.append(error)
-
-    sample = np.array(errors)
-    assert sample.size >= MIN_GROUND_TRUTH_SAMPLE, (
-        f"only {sample.size} usable green-flag stops; the ground truth needs "
+    assert truth.sample_size >= MIN_GROUND_TRUTH_SAMPLE, (
+        f"only {truth.sample_size} usable green-flag stops; the ground truth needs "
         f"{MIN_GROUND_TRUTH_SAMPLE} to mean anything"
     )
-
-    within_one = float((np.abs(sample) <= 1).mean())
-    assert within_one >= MIN_WITHIN_ONE, (
-        f"the projection lands within one position on only {within_one:.1%} of "
-        f"{sample.size} real green-flag pit stops (floor {MIN_WITHIN_ONE:.0%}). "
+    assert truth.within_one >= MIN_WITHIN_ONE, (
+        f"the projection lands within one position on only {truth.within_one:.1%} of "
+        f"{truth.sample_size} real green-flag pit stops (floor {MIN_WITHIN_ONE:.0%}). "
         "A sign flip or a dropped rival looks exactly like this."
     )
 


### PR DESCRIPTION
Two changes on top of the post-v2.1.0 cleanup sprint already on `main`.

## fix(engine): thread `cliff_p50` and `total_laps` (#566)

`_clamp_expected_stint_end` grounds the LLM's free-text `expected_stint_end` against a physical anchor. Without `cliff_p50` it has no anchor and returns the LLM value **unclamped**, by design.

The engine never passed it, nor `total_laps`, so that guard was dead on the `rich` profile, **which is the default** for `/simulate`, the Arcade and the CLI.

Same class as the `live_drivers` gap, and the comment directly above the call site already says it: *one call sequence, or every caller drifts.* That fix landed; these two arguments in the same call were missed.

## feat(eval): publish the projection accuracy and the measured tables (#609)

The Monte Carlo redesign produced two measured outputs and neither was recorded where a reader looks for results. Adds `f1-eval projection` as a seventh report in the existing harness.

| quantity | value |
|---|---|
| green-flag stops projected | 1810 |
| races covered | 71 |
| within one position | **86.5 %** |
| exactly right | 59.1 % |
| mean signed error | +0.57 positions |

The measurement moved out of the test and into the harness; the test now imports it, so the gate and the published number cannot diverge.

**An error that move surfaced.** The first version ran the ground truth on the default runtime config, which projects five laps, while the comparison observes two. It scored 89.3 % instead of 86.5 %: several points too high for the wrong reason, since the extra laps let rivals separate. Stated plainly because the wrong number looked better, which is the direction that does not get questioned.

## Verification

`dev` is green on CI, CodeQL, gitleaks and auto-update-prs at `863c6f1`. Locally: `tests/mc/` 112 passed, ruff check and format clean repo-wide, and a real `f1-sim --no-llm` run on Lusail completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `f1-eval projection` command to generate Monte Carlo position-projection evaluation reports.
  * Added projection accuracy reports with ground-truth metrics and measured-table summaries.
  * Added projection accuracy to the documented headline metrics, including an 86.5% within-one-position result.

* **Documentation**
  * Updated setup instructions and evaluation command descriptions.
  * Expanded thesis documentation with validation methodology, data coverage, and report outputs.

* **Bug Fixes**
  * Improved rich-profile recommendations by incorporating tire-cliff and race-length context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->