### PR TITLE
docs(src): fix contradicting docstrings, thin prose, and LLM-sounding wording

### DIFF
--- a/scripts/bench/__init__.py
+++ b/scripts/bench/__init__.py
@@ -1,1 +1,1 @@
-"""Benchmark scripts package — shared helpers under :mod:`scripts.bench._common`."""
+"""Benchmark scripts package: shared helpers under :mod:`scripts.bench._common`."""

--- a/scripts/bench_nlp_pipeline_cpu.py
+++ b/scripts/bench_nlp_pipeline_cpu.py
@@ -1,4 +1,4 @@
-"""NLP pipeline CPU latency benchmark — replicates N24 inline.
+"""NLP pipeline CPU latency benchmark, replicates N24 inline.
 
 Loads the three N24 NLP models (sentiment, intent, NER) using the
 exact same loaders the notebook uses, then times two entry points
@@ -31,7 +31,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 # ---------------------------------------------------------------------------
-# Repo-root path injection — must happen before any src.* import
+# Repo-root path injection: must happen before any src.* import
 # ---------------------------------------------------------------------------
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _REPO_ROOT = next(
@@ -47,7 +47,7 @@ for noisy in ("transformers", "setfit", "sentence_transformers", "torch"):
     logging.getLogger(noisy).setLevel(logging.ERROR)
 import transformers.training_args as _tra  # noqa: E402
 
-# SetFit compatibility shim — same one N24 applies at the top of the notebook.
+# SetFit compatibility shim: same one N24 applies at the top of the notebook.
 if not hasattr(_tra, "default_logdir"):
     _tra.default_logdir = lambda: "runs"
 
@@ -86,7 +86,7 @@ _BENCHMARK_MESSAGES: tuple[str, ...] = (
     "Safety car deployed, pit this lap.",
 )
 
-# RCM rows mirror those used in N24's RCM demo — kept identical so the
+# RCM rows mirror those used in N24's RCM demo, kept identical so the
 # rule-based parser sees the same input shape it does in the notebook.
 _RCM_ROWS: tuple[dict[str, Any], ...] = (
     {
@@ -322,7 +322,7 @@ def _predict_entities(text: str, models: _NlpModels) -> list[dict[str, str]]:
     ``is_split_into_words=True``, mapping the first sub-token of each
     word to its predicted tag, and stitching contiguous ``B-/I-``
     runs into spans is what the agent's :mod:`src.agents.radio_agent`
-    does at simulation time — the benchmark must match that surface
+    does at simulation time; the benchmark must match that surface
     so the latency is comparable.
     """
     words = text.split()
@@ -385,7 +385,7 @@ def _run_pipeline(text: str, models: _NlpModels) -> dict[str, Any]:
     """Run sentiment + intent + NER on a single team-radio string.
 
     Mirrors N24's ``run_pipeline``. The caller is responsible for
-    deciding whether the result is forwarded to the orchestrator —
+    deciding whether the result is forwarded to the orchestrator;
     this function only synthesises the structured analysis dict that
     the radio agent expects.
     """
@@ -407,7 +407,7 @@ def _run_pipeline(text: str, models: _NlpModels) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# RCM rule-based parser (no ML — direct transcription of N24)
+# RCM rule-based parser (no ML, direct transcription of N24)
 # ---------------------------------------------------------------------------
 
 
@@ -572,7 +572,7 @@ class NlpPipelineRunner:
         """Return one row per entry point on ``device``."""
         models = _build_models(device)
 
-        # ── run_pipeline — sentiment + intent + NER on every BENCHMARK message ──
+        # ── run_pipeline: sentiment + intent + NER on every BENCHMARK message ──
         msg_idx_pipe = {"i": 0}
 
         def _call_pipeline() -> None:
@@ -587,7 +587,7 @@ class NlpPipelineRunner:
             n_runs=n_total_pipeline,
         )
 
-        # ── run_rcm_pipeline — rule-based, iterate the RCM rows ──
+        # ── run_rcm_pipeline: rule-based, iterate the RCM rows ──
         msg_idx_rcm = {"i": 0}
 
         def _call_rcm() -> None:
@@ -667,8 +667,9 @@ def _resolve_devices(device_arg: str) -> list[str]:
     """Translate the CLI ``--device`` argument into a concrete device list.
 
     ``both`` expands to ``[cpu, cuda]`` only when CUDA is available;
-    otherwise it silently downgrades to CPU and prints a warning so
-    the operator notices the GPU row is missing.
+    otherwise it downgrades to CPU and prints a warning so the operator
+    notices the GPU row is missing rather than assuming it was skipped
+    on purpose.
     """
     if device_arg == "cpu":
         return ["cpu"]

--- a/scripts/bench_pace_baselines.py
+++ b/scripts/bench_pace_baselines.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Optional
 
 # ---------------------------------------------------------------------------
-# Repo-root path injection — must happen before any src.* import
+# Repo-root path injection: must happen before any src.* import
 # ---------------------------------------------------------------------------
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _REPO_ROOT = next(

--- a/scripts/bench_subagent_latency.py
+++ b/scripts/bench_subagent_latency.py
@@ -1,9 +1,9 @@
-"""Sub-agent isolated latency benchmark — six agents, one fixed lap_state.
+"""Sub-agent isolated latency benchmark: six agents, one fixed lap_state.
 
 Builds a single ``lap_state`` from Suzuka 2025 NOR lap 21 (or the
 documented Bahrain fallback) and times every ``run_*_from_state``
 entry point in isolation. The orchestrator (N31) is intentionally
-excluded — the goal is to characterise each sub-agent's per-call cost
+excluded: the goal is to characterise each sub-agent's per-call cost
 rather than the end-to-end pipeline.
 
 Some agents make external calls at runtime: ``RadioAgent`` and
@@ -48,7 +48,7 @@ try:
 except ImportError:
     pass
 
-# Library log noise — silence aggressive INFO from transformers / setfit
+# Library log noise: silence aggressive INFO from transformers / setfit
 warnings.filterwarnings("ignore", category=FutureWarning)
 for noisy in ("transformers", "setfit", "sentence_transformers", "torch", "src"):
     logging.getLogger(noisy).setLevel(logging.ERROR)
@@ -133,7 +133,7 @@ class SubAgentLatencyRunner:
         self.lap_state["lap"] = fixture["lap_number"]
         self.lap_state["question"] = "What is the minimum pit stop duration under Safety Car?"
 
-        # Featured 2025 laps — required by Tire / RaceSituation / Pit / Radio
+        # Featured 2025 laps: required by Tire / RaceSituation / Pit / Radio
         # agents because they pull historical context out of the laps frame. Route through
         # the shared augmenter so Time_s is present; a raw read collapses the overtake gap
         # to a lap-time delta (#486), which would skew the very latencies this bench reports.
@@ -165,7 +165,7 @@ class SubAgentLatencyRunner:
         """Return ``(agent_name, call_closure, notes)`` for each measured row.
 
         Imports happen here so a missing optional dependency only
-        breaks the affected row — every other agent still gets timed.
+        breaks the affected row; every other agent still gets timed.
         Each closure captures ``self.lap_state`` and any per-agent
         DataFrame so the timed call surface is exactly the public
         ``run_*_from_state`` entry point.
@@ -213,7 +213,7 @@ class SubAgentLatencyRunner:
 
         Runs the agent sequence in declaration order. A failure inside
         any single agent is captured into the artefact with a NaN
-        latency and the exception message in ``notes`` — this is rare
+        latency and the exception message in ``notes``. This is rare
         in practice but lets the bench surface a partial failure
         without aborting the whole run.
         """
@@ -234,7 +234,7 @@ class SubAgentLatencyRunner:
                         },
                     )
                 )
-            except Exception as exc:  # noqa: BLE001 — log + continue
+            except Exception as exc:  # noqa: BLE001 - log + continue
                 rows.append(
                     BenchResult(
                         name=agent_name,

--- a/scripts/bench_whisper.py
+++ b/scripts/bench_whisper.py
@@ -1,4 +1,4 @@
-"""Whisper transcription latency benchmark — overall bucket only.
+"""Whisper transcription latency benchmark: overall bucket only.
 
 Loads the production :class:`WhisperTranscriber` (model ``turbo``) the
 same way :mod:`src.nlp.radio_runner` does at simulation time, samples
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Optional
 
 # ---------------------------------------------------------------------------
-# Repo-root path injection — must happen before any src.* import
+# Repo-root path injection: must happen before any src.* import
 # ---------------------------------------------------------------------------
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _REPO_ROOT = next(
@@ -113,7 +113,7 @@ class WhisperLatencyRunner:
         """Return up to ``sample_size`` distinct mp3 paths drawn with a fixed seed.
 
         The seed is hard-coded so the benchmark is reproducible across
-        runs — a different seed would change which clips contribute to
+        runs: a different seed would change which clips contribute to
         the latency distribution and therefore the final P95. When
         fewer than ``sample_size`` files exist on disk every available
         file is returned and the script proceeds with a smaller

--- a/scripts/build_radio_dataset.py
+++ b/scripts/build_radio_dataset.py
@@ -11,7 +11,7 @@ The output is the offline corpus the N29 Radio Agent will consume during
 race replay. Two parquets are produced per GP: one for team radios (driver,
 lap, recording_url, audio_path) and one for race control messages (driver?,
 lap, flag, category, message). Both are filtered with the same structural
-rule — formation lap, race-start lap and chequered-flag lap dropped — so
+rule: formation lap, race-start lap and chequered-flag lap dropped, so
 every row left in either parquet belongs to a normal race lap and could
 plausibly inform a strategy decision.
 
@@ -21,7 +21,7 @@ per year, GP slug, and driver number. The radio parquet's ``audio_path``
 column carries the path **relative to** the audio root so the on-disk
 corpus stays portable across machines. The actual transcription
 (Whisper / Nemotron) and NLP (sentiment / intent / NER) stays out of this
-script — those steps happen on demand at simulation runtime in the
+script: those steps happen on demand at simulation runtime in the
 ``RadioPipelineRunner`` consumed by the future N29 Radio Agent.
 
 Usage:
@@ -36,7 +36,7 @@ Usage:
 
 Rate limiting:
     Every HTTP call inherits a retry-with-exponential-backoff policy from a
-    shared ``requests.Session`` mounted in ``build_retry_session`` — 429 and
+    shared ``requests.Session`` mounted in ``build_retry_session``: 429 and
     5xx responses retry up to five times (1s, 2s, 4s, 8s, 16s). On top of
     that, the build loop sleeps ``--gp-delay`` seconds between consecutive
     GPs (default 1.0s) so the steady-state request rate stays below OpenF1's
@@ -214,8 +214,8 @@ class RaceMeta:
         circuit_short_name: OpenF1 circuit short name (e.g. ``"Imola"`` /
                             ``"Monza"`` / ``"Miami"`` / ``"COTA"``). Required
                             to disambiguate countries that host more than one
-                            GP per season — Italy (Imola + Monza) and the
-                            United States (Miami + Austin + Las Vegas) — so
+                            GP per season: Italy (Imola + Monza) and the
+                            United States (Miami + Austin + Las Vegas), so
                             the builder writes them to distinct ``italy_imola`` /
                             ``italy_monza`` / ``united_states_*`` slugs instead
                             of overwriting each other under a shared
@@ -241,7 +241,7 @@ class BuildResult:
     of raised exceptions because the CLI loop wants to keep going past
     individual GP errors and only report at the end.
 
-    Each successful build produces two parquets per GP — radios and RCMs —
+    Each successful build produces two parquets per GP, radios and RCMs,
     plus (when audio is enabled) one MP3 per radio row, so this result
     tracks all three numbers separately. The summary aggregates them into
     a single ``"(N radios, M RCMs, K audio)"`` line per GP and into
@@ -426,7 +426,7 @@ class RadioDatasetCLI:
         (Italy → Imola/Monza, United States → Miami/Austin/Las Vegas)
         because the country alone would rebuild every sibling race for
         that country. With circuit-name matching the operator can target a
-        single race precisely — ``--gps Imola`` only rebuilds Imola, while
+        single race precisely: ``--gps Imola`` only rebuilds Imola, while
         ``--gps Italy`` rebuilds both Imola and Monza in one go.
 
         Logs a warning for any GP name that did not match anything so a typo
@@ -499,8 +499,8 @@ class RadioDatasetCLI:
         because an earlier build ran before the RCM extension landed), the
         GP is rebuilt in full so the on-disk corpus stays internally
         consistent. Re-building a GP that already has both parquets is
-        idempotent — it simply overwrites the existing files with fresh
-        data — so the worst case of skipping incorrectly is a wasted
+        idempotent: it simply overwrites the existing files with fresh
+        data, so the worst case of skipping incorrectly is a wasted
         round trip, never data corruption.
         """
         results: list[BuildResult] = []
@@ -629,7 +629,7 @@ class RadioDatasetCLI:
     def _rcm_target_path(self, race: RaceMeta) -> Path:
         """Compute the RCM parquet path the builder will write for a race.
 
-        The RCM analogue of :meth:`_radio_target_path` — same per-GP
+        The RCM analogue of :meth:`_radio_target_path`, same per-GP
         directory, but the ``rcm.parquet`` filename
         :meth:`RadioDatasetBuilder.write_rcm_parquet` writes to. Both
         targets are checked together by the skip-existing logic so a GP

--- a/scripts/build_rag_index.py
+++ b/scripts/build_rag_index.py
@@ -2,7 +2,7 @@
 One-shot ingestion script: PDF → chunks → embeddings → Qdrant.
 
 Run this script once to build (or incrementally update) the local Qdrant index
-from FIA regulation PDFs. Subsequent runs are idempotent — each chunk is hashed
+from FIA regulation PDFs. Subsequent runs are idempotent: each chunk is hashed
 and skipped if it already exists in the collection, so adding a new PDF only
 indexes the new content without rebuilding from scratch.
 
@@ -50,11 +50,11 @@ class IndexConfig:
 
     Attributes:
         collection_name:  Name of the Qdrant collection to populate. Must match
-                          ``RagConfig.collection_name`` in ``retriever.py`` —
+                          ``RagConfig.collection_name`` in ``retriever.py``:
                           a mismatch means the retriever queries an empty collection.
         embedding_model:  Sentence-transformers model used to encode chunks. Must
-                          be the same model used at query time in ``retriever.py``
-                          — incompatible models produce meaningless similarity scores.
+                          be the same model used at query time in ``retriever.py``,
+                          since incompatible models produce meaningless similarity scores.
         embedding_dim:    Output vector size of the embedding model. BGE-M3 produces
                           1024-dim vectors; changing the model requires updating this
                           value or Qdrant will reject the upsert silently.
@@ -115,7 +115,7 @@ class PDFDocument:
     Attributes:
         path:     Absolute path to the source PDF, kept for error messages and
                   logging so failures can be traced back to a specific file.
-        doc_type: Regulatory domain of the document — either ``"sporting_regs"``
+        doc_type: Regulatory domain of the document: either ``"sporting_regs"``
                   or ``"technical_regs"``. Derived from the filename prefix and
                   stored on every chunk so downstream agents can filter by domain.
         year:     Season the document applies to (2023–2025). F1 regulations
@@ -145,12 +145,12 @@ class TextChunk:
     Attributes:
         text:          The regulation passage itself, trimmed and normalised.
                        This is the string that gets embedded and stored as the
-                       Qdrant payload — what the RAG agent returns to the LLM.
+                       Qdrant payload: what the RAG agent returns to the LLM.
         doc_type:      Inherited from the parent ``PDFDocument``. Lets callers
                        filter retrieval results by regulatory domain without
                        parsing the text.
         year:          Inherited from the parent ``PDFDocument``. Determines
-                       which season's rules apply — critical when regulations
+                       which season's rules apply, critical when regulations
                        changed between years (e.g. cost-cap rules 2023 vs 2025).
         article:       Article or section reference extracted by regex from the
                        chunk text (e.g. ``"Article 48.3"``). Empty string when
@@ -160,7 +160,7 @@ class TextChunk:
                        document, when available. Provides coarse context about
                        which part of the regulations the chunk belongs to.
         chunk_hash:    SHA-256 of the normalised text, used for idempotent
-                       upserts — chunks already present in Qdrant are skipped
+                       upserts: chunks already present in Qdrant are skipped
                        so re-running the script only indexes new content.
     """
 
@@ -183,7 +183,7 @@ def parse_pdf_filename(path: Path) -> tuple[str, int] | None:
     """Extract doc_type and year from a PDF filename following the naming convention.
 
     Returns ``None`` for files that do not match the expected pattern so the
-    caller can skip them with a warning rather than raising an exception — this
+    caller can skip them with a warning rather than raising an exception: this
     lets the script process a directory that may contain unrelated files without
     aborting the whole run.
 
@@ -198,7 +198,7 @@ def parse_pdf_filename(path: Path) -> tuple[str, int] | None:
 
 
 def extract_text_from_pdf(path: Path) -> str:
-    """Extract all plain text from a PDF file using PyMuPDF.
+    """Extract all plain text from a PDF file using pypdf.
 
     Concatenates text from every page separated by a newline so that page
     boundaries do not create artificial word splits during chunking. pypdf
@@ -207,7 +207,7 @@ def extract_text_from_pdf(path: Path) -> str:
 
     Args:
         path: Path to the PDF file to read. Raises ``FileNotFoundError`` if
-              the file does not exist — callers should validate the path first.
+              the file does not exist: callers should validate the path first.
     """
     reader = pypdf.PdfReader(str(path))
     pages = [page.extract_text() or "" for page in reader.pages]
@@ -293,7 +293,7 @@ def extract_section_title(text: str) -> str:
     Matches lines that look like numbered section headings in FIA documents:
     a number followed by all-caps words, e.g. ``"48 SAFETY CAR PROCEDURE"``.
     Returns the first match found, or an empty string when none is present.
-    This is a best-effort heuristic — not every chunk will have a heading.
+    This is a best-effort heuristic: not every chunk will have a heading.
 
     Args:
         text: The regulation chunk to search.
@@ -374,16 +374,17 @@ def ensure_collection(client: QdrantClient, name: str, dim: int) -> None:
     """Create the Qdrant collection if it does not already exist.
 
     Uses cosine distance to match the L2-normalised embeddings produced by
-    ``all-MiniLM-L6-v2``. Does nothing if the collection already exists, making
-    this function safe to call on every script run without risk of wiping the
-    existing index.
+    ``CFG.embedding_model`` (BGE-M3 by default; see :func:`embed_chunks`'s
+    ``normalize_embeddings=True`` call). Does nothing if the collection
+    already exists, making this function safe to call on every script run
+    without risk of wiping the existing index.
 
     Args:
         client: An initialised ``QdrantClient`` pointing to the local storage.
-        name:   Name of the collection to create. Must match ``COLLECTION_NAME``
+        name:   Name of the collection to create. Must match ``RagConfig.collection_name``
                 used in ``retriever.py`` or queries will hit the wrong collection.
         dim:    Embedding dimension. Must match the output size of the model
-                used during indexing — mismatches cause silent wrong results.
+                used during indexing: mismatches cause silent wrong results.
     """
     existing = {c.name for c in client.get_collections().collections}
     if name not in existing:
@@ -399,7 +400,7 @@ def ensure_collection(client: QdrantClient, name: str, dim: int) -> None:
 def get_existing_hashes(client: QdrantClient, name: str) -> set[str]:
     """Retrieve all chunk hashes currently stored in a Qdrant collection.
 
-    Used to determine which chunks are new before embedding — skipping already-
+    Used to determine which chunks are new before embedding: skipping already-
     indexed chunks avoids redundant embedding calls and prevents duplicates.
     Scrolls through the full collection in pages of 1000 to handle large indexes
     without loading everything into memory at once.
@@ -442,9 +443,10 @@ def embed_chunks(
 ) -> np.ndarray:
     """Embed a list of chunks in batches and return the embedding matrix.
 
-    Processes chunks in batches of ``EMBED_BATCH_SIZE`` to keep GPU/CPU memory
-    usage bounded. Normalisation is applied so cosine similarity equals dot
-    product, consistent with how the retriever queries the collection.
+    Processes chunks in batches of ``CFG.embed_batch_size`` to keep GPU/CPU
+    memory usage bounded. Normalisation is applied so cosine similarity
+    equals dot product, consistent with how the retriever queries the
+    collection.
 
     Args:
         chunks:  The chunks to embed. Their ``text`` field is used as input;

--- a/scripts/cli/pickers.py
+++ b/scripts/cli/pickers.py
@@ -200,7 +200,7 @@ def discover_races(repo_root: Path, year: int = 2025) -> list[str]:
 
     if not raw_dir.exists():
         return []
-    # Only return folders that actually contain race files — empty
+    # Only return folders that actually contain race files: empty
     # placeholders from a partial download would otherwise crash the
     # downstream RaceReplayEngine.
     return sorted(d.name for d in raw_dir.iterdir() if d.is_dir() and any(d.iterdir()))

--- a/scripts/cli/theme.py
+++ b/scripts/cli/theme.py
@@ -3,8 +3,8 @@
 F1 brand colors, shared Rich Console singleton, and the ASCII banner.
 
 Exported symbols used by the rest of the cli package:
-  console   — single Rich Console for the whole session
-  F1_*      — color constants (#rrggbb)
+  console   : single Rich Console for the whole session
+  F1_*      : color constants (#rrggbb)
   make_banner() → Panel
 """
 
@@ -32,7 +32,7 @@ F1_GREEN = "#10b981"  # success / green flag
 F1_AMBER = "#f59e0b"  # warning / yellow flag / driver 2 accent
 
 # ─────────────────────────────────────────────────────────────────────────────
-# ASCII art — "F1" + "STRAT" in Unicode block chars
+# ASCII art: "F1" + "STRAT" in Unicode block chars
 #
 # F1 part (red) + STRAT part (white), 6 rows, ~57 visual columns total.
 # Renders cleanly in any 80-column terminal with UTF-8 support.

--- a/scripts/debug_agent.py
+++ b/scripts/debug_agent.py
@@ -1,5 +1,5 @@
 """
-Single-agent debug harness — run and inspect any agent in isolation.
+Single-agent debug harness: run and inspect any agent in isolation.
 
 Builds a minimal lap_state from CLI arguments (no replay engine, no
 full pipeline), loads the featured parquet once, and calls the selected
@@ -11,13 +11,13 @@ Usage
 
 Agents
 ------
-    pace        N25 — lap time prediction + CI
-    tire        N26 — tire degradation + laps to cliff
-    situation   N27 — overtake probability + SC risk
-    pit         N28 — pit duration, undercut score, compound recommendation
-    radio       N29 — sentiment, intent, NER, RCM parsing
-    rag         N30 — regulation context retrieval
-    orchestrator N31 — full multi-agent synthesis (calls all sub-agents)
+    pace        N25: lap time prediction + CI
+    tire        N26: tire degradation + laps to cliff
+    situation   N27: overtake probability + SC risk
+    pit         N28: pit duration, undercut score, compound recommendation
+    radio       N29: sentiment, intent, NER, RCM parsing
+    rag         N30: regulation context retrieval
+    orchestrator N31: full multi-agent synthesis (calls all sub-agents)
 
 Examples
 --------
@@ -67,7 +67,7 @@ try:
     if _env_path:
         load_dotenv(_env_path)
 except ImportError:
-    pass  # python-dotenv not installed — rely on env vars being set manually
+    pass  # python-dotenv not installed - rely on env vars being set manually
 
 # ---------------------------------------------------------------------------
 # Repo-root sys.path injection

--- a/scripts/download_fia_pdfs.py
+++ b/scripts/download_fia_pdfs.py
@@ -9,7 +9,7 @@ Tries two strategies in order:
 Downloaded files are renamed to the project naming convention:
   <doc_type>_<year>.pdf   e.g. sporting_regs_2025.pdf
 
-Only the most recent issue of each (doc_type, year) pair is kept — if the FIA
+Only the most recent issue of each (doc_type, year) pair is kept: if the FIA
 publishes a corrected version, re-running this script replaces the old file.
 
 Usage:
@@ -51,7 +51,7 @@ class DownloadConfig:
     Attributes:
         supported_years:  List of regulation years to consider when scraping
                           and downloading. Passed as-is to the scraper and used
-                          to filter links — add a new year here when the FIA
+                          to filter links: add a new year here when the FIA
                           publishes a new season's regulations.
         request_timeout:  Maximum seconds to wait for a single HTTP response.
                           Set conservatively because FIA PDFs can be large and
@@ -89,7 +89,7 @@ class DownloadConfig:
 CFG = DownloadConfig()
 
 # FIA regulation category pages for Formula 1.
-# Only Sporting Regulations are indexed — they cover the rules relevant to
+# Only Sporting Regulations are indexed: they cover the rules relevant to
 # race strategy: safety car procedures, pit lane, tyre allocations, penalties,
 # blue flags, DRS, and race director directives. Technical Regulations (car
 # construction) are not needed by the strategy agents.
@@ -127,7 +127,7 @@ class RegulationLink:
 
     Attributes:
         url:      Full URL of the PDF file to download. May be relative on the
-                  FIA website — resolved to absolute before storage.
+                  FIA website, resolved to absolute before storage.
         doc_type: Regulatory domain inferred from the page title or link text
                   (``"sporting_regs"`` or ``"technical_regs"``).
         year:     Regulation year parsed from the document title or URL. Used
@@ -177,7 +177,7 @@ def _make_session() -> requests.Session:
     """Create a requests session with browser-like headers.
 
     The FIA website returns 403 for requests without a User-Agent, so we
-    mimic a standard browser request. No authentication is needed — all
+    mimic a standard browser request. No authentication is needed: all
     regulation PDFs are publicly accessible.
     """
     session = requests.Session()
@@ -319,7 +319,7 @@ def save_known_urls_template() -> None:
 
     Creates the file with one commented example entry so the operator knows
     exactly what format to use when adding URLs manually. The file is only
-    written on first run — subsequent runs never overwrite it so manually
+    written on first run: subsequent runs never overwrite it so manually
     added entries are preserved.
     """
     if CFG.known_urls_file.exists():
@@ -348,7 +348,7 @@ def save_known_urls_template() -> None:
 
 
 def deduplicate_links(links: list[RegulationLink]) -> list[RegulationLink]:
-    """Keep only one link per (doc_type, year) pair — the first one seen.
+    """Keep only one link per (doc_type, year) pair: the first one seen.
 
     The FIA category pages list issues from newest to oldest, so the first
     link encountered for a given (doc_type, year) is the most recent issue.
@@ -389,8 +389,9 @@ def download_link(
     """Download a single regulation PDF and save it to ``CFG.docs_dir``.
 
     Skips the download if a file with the same name already exists, assuming
-    it is the correct version. Re-running the script after a FIA erratum
-    requires manually deleting the old file first, or using ``--force``.
+    it is the correct version. There is no force-overwrite flag: re-running
+    the script after a FIA erratum requires manually deleting the old file
+    first.
 
     Args:
         link:    The ``RegulationLink`` describing what to download and where.
@@ -454,7 +455,7 @@ def download_all(
     Args:
         years:   List of years to download (e.g. ``[2024, 2025]``). When
                  ``None``, downloads all ``CFG.supported_years``.
-        dry_run: Pass through to ``download_link`` — logs actions without
+        dry_run: Pass through to ``download_link``, logs actions without
                  writing files.
     """
     target_years = set(years) if years else set(CFG.supported_years)

--- a/scripts/f1_cli.py
+++ b/scripts/f1_cli.py
@@ -1,5 +1,5 @@
 """
-F1 StratLab — Interactive CLI Launcher
+F1 StratLab: Interactive CLI Launcher
 
 Usage
 -----
@@ -7,14 +7,14 @@ Usage
 
 Menu
 ----
-    1  Single Driver   — lap-by-lap strategy for one driver
-    2  Head-to-Head    — two drivers, same race, shown back-to-back
+    1  Single Driver   : lap-by-lap strategy for one driver
+    2  Head-to-Head    : two drivers, same race, shown back-to-back
     3  Quit
 
 All UI logic lives in scripts/cli/:
-    theme.py    — colors, console, ASCII banner
-    pickers.py  — Rich prompts (mode / race / driver / laps / provider)
-    runner.py   — subprocess helpers + mode handlers
+    theme.py    : colors, console, ASCII banner
+    pickers.py  : Rich prompts (mode / race / driver / laps / provider)
+    runner.py   : subprocess helpers + mode handlers
 """
 
 from __future__ import annotations
@@ -95,7 +95,7 @@ def _run_wizard() -> None:
         if is_first_run():
             ensure_setup()
     except ImportError:
-        # Package not installed (extremely rare — only if the user copied
+        # Package not installed (extremely rare: only if the user copied
         # scripts/ in isolation). Fall through and let discover_races error.
         pass
 

--- a/scripts/measure_mc_tables.py
+++ b/scripts/measure_mc_tables.py
@@ -12,7 +12,7 @@ Six tables, each value carrying its sample size and a 95% interval:
 - ``neutralisation_rate``  per-circuit onset hazard, the input to
                       ``q_f = 1 - exp(-rate * laps_remaining)`` (clamped to [0, 1]).
 - ``gap_density``     measured seconds between consecutive cars while racing and
-                      under neutralisation — the empirical answer to the
+                      under neutralisation, the empirical answer to the
                       ``POS_GAP_S = 1.5`` constant the redesign retires.
 - ``undercut_band``   undercut success by gap-to-target in SECONDS, so target
                       eligibility stops being the ad-hoc "within 5 positions".
@@ -20,7 +20,7 @@ Six tables, each value carrying its sample size and a 95% interval:
                       neutralisation), for the surfaces whose rivals list carries
                       no ``is_pitting`` flag.
 - ``clean_air``       per-circuit seconds a follower gains once the car DIRECTLY
-                      ahead pits — the term that decides whether an overcut has
+                      ahead pits, the term that decides whether an overcut has
                       anything to win, and the one v1 of the projection lacks.
 
 Why RAW and never the featured parquet: N04's ``IsAccurate`` gate drops laps run
@@ -31,7 +31,7 @@ source of truth for track status.
 
 RACING, not "green": a lap counts as racing when it is not neutralised, which
 includes laps run under a local yellow (4.1% of all laps). A yellow flag covers
-one marshalling sector — cars lift there and race the rest of the lap — so for
+one marshalling sector, cars lift there and race the rest of the lap, so for
 "how much of this window is still worth racing" it belongs with the clear laps,
 and for "is this lap at risk of a Safety Car" it belongs there even more firmly,
 being the usual precursor. The distinction is kept in the status mix rather than
@@ -153,7 +153,7 @@ CLEAN_AIR_LAPS = 3
 
 
 # ---------------------------------------------------------------------------
-# Statistics helpers — every measured value ships with n and an interval
+# Statistics helpers, every measured value ships with n and an interval
 # ---------------------------------------------------------------------------
 
 
@@ -274,7 +274,7 @@ class RaceLaps:
         return self.status_by_lap.get(lap, CLEAR) in NEUTRALISED_STATUSES
 
     def is_racing(self, lap: int) -> bool:
-        """Whether ``lap`` was raced — clear or under a local yellow."""
+        """Whether ``lap`` was raced, clear or under a local yellow."""
         return not self.is_neutralised(lap)
 
 
@@ -287,8 +287,8 @@ def _status_by_lap(laps: pd.DataFrame) -> dict[int, str]:
     a lap that saw an SC deployed and withdrawn is an SC lap for the decision
     layer, since no racing happened on it.
 
-    That precedence is also why the usual incident sequence — yellow first, then
-    the Safety Car — mostly does not show up as a yellow lap followed by an SC
+    That precedence is also why the usual incident sequence (yellow first, then
+    the Safety Car) mostly does not show up as a yellow lap followed by an SC
     lap: at ~90 s per lap, race control escalates inside the same lap, and this
     function labels it by the stronger flag. Only 27% of onsets are preceded by a
     lap that was yellow and nothing else.
@@ -372,7 +372,7 @@ def load_races(years: tuple[int, ...] = YEARS) -> list[RaceLaps]:
 
 
 # ---------------------------------------------------------------------------
-# Table 1 — the neutralisation window (racing laps left, and spell length)
+# Table 1, the neutralisation window (racing laps left, and spell length)
 # ---------------------------------------------------------------------------
 
 
@@ -458,7 +458,7 @@ def measure_sc_window(races: list[RaceLaps], window: int = WINDOW_LAPS) -> dict[
 
 
 # ---------------------------------------------------------------------------
-# Table 2 — neutralisation onset hazard (the q_f input)
+# Table 2, neutralisation onset hazard (the q_f input)
 # ---------------------------------------------------------------------------
 
 
@@ -467,7 +467,7 @@ def measure_neutralisation_rate(races: list[RaceLaps]) -> dict[str, Any]:
 
     Feeds the option-value term: ``q_f = 1 - exp(-rate * laps_remaining)`` is the
     probability that a future neutralisation turns up to cover a stop we have not
-    taken yet. The exponential form is what keeps q_f a probability — the naive
+    taken yet. The exponential form is what keeps q_f a probability: the naive
     ``rate * laps_remaining`` exceeds 1 on a long racing run and would hand the MC
     a nonsense certainty.
 
@@ -511,7 +511,7 @@ def measure_neutralisation_rate(races: list[RaceLaps]) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# Table 3 — how many seconds a position is actually worth
+# Table 3, how many seconds a position is actually worth
 # ---------------------------------------------------------------------------
 
 
@@ -531,7 +531,7 @@ def measure_gap_density(races: list[RaceLaps]) -> dict[str, Any]:
     time loss into positions. This measures what that constant approximates, and
     separates the two regimes: under a Safety Car the field closes up, so the
     same 20-second pit loss costs a very different number of cars. The projection
-    needs no such constant — it counts the actual cars — but publishing the
+    needs no such constant: it counts the actual cars. But publishing the
     measurement is what retires the constant honestly instead of by assertion.
     """
     intervals: dict[str, list[float]] = {RACING: [], SAFETY_CAR: []}
@@ -561,7 +561,7 @@ def measure_gap_density(races: list[RaceLaps]) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# Table 4 — the undercut band, in seconds
+# Table 4, the undercut band, in seconds
 # ---------------------------------------------------------------------------
 
 
@@ -600,7 +600,7 @@ def measure_undercut_band(races: list[RaceLaps]) -> dict[str, Any]:
     Reuses N16's own labelled attempts (``undercut_clean.parquet``) rather than
     re-deriving what counts as an undercut: a second definition would drift from
     the model the MC already samples from. What this adds is the gap in SECONDS,
-    which the labels do not carry — they encode the gap in positions, and the
+    which the labels do not carry: they encode the gap in positions, and the
     projection reasons in time.
 
     The keyspace trap: those labels are keyed by FastF1 event name while the raw
@@ -672,7 +672,7 @@ def measure_undercut_band(races: list[RaceLaps]) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# Table 5 — will that rival stop soon?
+# Table 5, will that rival stop soon?
 # ---------------------------------------------------------------------------
 
 
@@ -695,8 +695,8 @@ def measure_stop_hazard(races: list[RaceLaps], window: int = WINDOW_LAPS) -> dic
 
     It is deliberately a prior and not a prediction: it answers "how often does a
     car on this compound at this tyre age stop within five laps", never "will this
-    car stop", which would need the rival's strategy — the full-race modelling the
-    redesign rules out.
+    car stop", which would need the rival's strategy (the full-race modelling the
+    redesign rules out).
     """
     cells: dict[tuple[str, str, str], list[bool]] = defaultdict(list)
 
@@ -740,7 +740,7 @@ def measure_stop_hazard(races: list[RaceLaps], window: int = WINDOW_LAPS) -> dic
 
 
 # ---------------------------------------------------------------------------
-# Table 6 — what clean air is worth, per circuit
+# Table 6, what clean air is worth, per circuit
 # ---------------------------------------------------------------------------
 
 

--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -1207,9 +1207,11 @@ def _make_inference_panel(
         None; each row helper no-ops when its input is missing, so a failed
         sub-agent does not crash the panel.
     active_agents:
-        Set of conditional agent keys ({'N28', 'N30'}) returned by the MoE
-        routing layer. When None the routing row is omitted (LLM mode does
-        not expose the routing set through the orchestrator output).
+        Accepted for backward compatibility with older call sites but not
+        read by this function anymore: the routing row it used to drive was
+        removed (see the ``_AGENT_DISPLAY`` comment above), and every
+        sub-agent row now renders unconditionally via its own ``_add_*_row``
+        helper, idle or not. Safe to pass ``None`` or omit.
     rival_data:
         Dict in the RaceStateManager rival format when a rival is tracked,
         otherwise None.

--- a/scripts/upload_radio_corpus.py
+++ b/scripts/upload_radio_corpus.py
@@ -3,12 +3,12 @@
 The corpus is built locally by ``scripts/build_radio_dataset.py`` and lives in
 two parallel trees on disk:
 
-* ``data/processed/race_radios/{year}/{slug}/{radios.parquet, rcm.parquet}``
-  — small metadata parquets (~22 KB per GP, ~536 KB total) that the runner
+* ``data/processed/race_radios/{year}/{slug}/{radios.parquet, rcm.parquet}``:
+  small metadata parquets (~22 KB per GP, ~536 KB total) that the runner
   reads to enumerate the team-radio rows and the FIA race-control messages
   for a given lap.
 
-* ``data/raw/radio_audio/{year}/{slug}/*.mp3`` — the original OpenF1 MP3
+* ``data/raw/radio_audio/{year}/{slug}/*.mp3``: the original OpenF1 MP3
   files that Whisper transcribes on the consumer side. ~3 MB per GP,
   ~82 MB total for the full 2025 calendar.
 
@@ -37,7 +37,7 @@ Usage
         export HF_TOKEN=hf_xxx
         python scripts/upload_radio_corpus.py
 
-    # Dry run — list what would be uploaded without touching the Hub::
+    # Dry run: list what would be uploaded without touching the Hub::
 
         python scripts/upload_radio_corpus.py --dry-run
 
@@ -63,7 +63,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-# Repo root walker — same pattern used everywhere else in the codebase so the
+# Repo root walker: same pattern used everywhere else in the codebase so the
 # script keeps running when invoked from any sub-directory.
 _HERE = Path(__file__).resolve()
 _REPO_ROOT = next(
@@ -138,7 +138,7 @@ def _upload_tree(
     """Upload one local folder to the dataset preserving the relative layout.
 
     Wraps ``HfApi.upload_folder`` so the two trees (parquets + audio) can be
-    pushed by a single call site. The function is intentionally chatty —
+    pushed by a single call site. The function is intentionally chatty:
     this is a one-shot operation, not a hot path, so the user benefits from
     knowing exactly which folder is in flight and where it lands on the Hub.
     """
@@ -205,7 +205,7 @@ def _parse_args() -> argparse.Namespace:
 def run(args: argparse.Namespace) -> None:
     """Resolve folders, validate auth, and upload the requested trees in order.
 
-    Parquets go first because they are tiny — if the auth handshake or the
+    Parquets go first because they are tiny: if the auth handshake or the
     network is broken the user finds out in seconds instead of waiting for
     the 80 MB MP3 transfer to fail. The audio tree only kicks off after the
     parquet upload succeeds.
@@ -313,7 +313,7 @@ def run(args: argparse.Namespace) -> None:
 
 
 def main() -> None:
-    """Console entry point — parses argv and dispatches to :func:`run`."""
+    """Console entry point: parses argv and dispatches to :func:`run`."""
     run(_parse_args())
 
 

--- a/scripts/verify_drs_zones.py
+++ b/scripts/verify_drs_zones.py
@@ -1,4 +1,4 @@
-"""Audit DRS zones per GP — sanity check against the FIA 2025 circuit docs.
+"""Audit DRS zones per GP: sanity check against the FIA 2025 circuit docs.
 
 Uses the same ``_extract_reference_lap`` pattern the arcade's
 ``SessionLoader`` relies on: fastest qualifying lap telemetry, ``DRS``
@@ -15,7 +15,7 @@ For each DRS activation zone the script reports:
 
 The FIA publishes a per-GP PDF with zones as "detection at X m before
 Turn Y, activation from Z m after Turn W". Cross-reference the corner
-tags and the metre offsets below with that PDF — they should match
+tags and the metre offsets below with that PDF: they should match
 within ~30 m (sampling resolution of FastF1 telemetry).
 
 Anomalies to expect:
@@ -56,7 +56,7 @@ def extract_zones(tel, corners_df=None, min_length_m: float = 80.0) -> list[dict
 
     FastF1 publishes ``DRS`` as a status byte; values ``>= 10`` mean the
     flap is open. A "zone" is any maximal run of open samples. Zones
-    shorter than ``min_length_m`` are dropped as telemetry blips — real
+    shorter than ``min_length_m`` are dropped as telemetry blips: real
     F1 DRS activation zones are always several hundred metres long.
 
     When ``corners_df`` is provided (from ``session.get_circuit_info()``)
@@ -122,7 +122,7 @@ def _nearest_corner(x: float, y: float, corners_df) -> str:
 
 
 def audit_one(year: int, round_: int, min_length_m: float) -> dict:
-    """Load quali, fastest lap, telemetry + add_distance — then
+    """Load quali, fastest lap, telemetry + add_distance, then
     extract zones with corner tags. Exceptions become error dicts so a
     single bad session does not halt the batch."""
     try:
@@ -144,7 +144,7 @@ def audit_one(year: int, round_: int, min_length_m: float) -> dict:
             corners_df = ci.corners
         except Exception:
             # Circuit info is only available on recent FastF1 versions /
-            # for circuits FastF1 has the corner database for — graceful
+            # for circuits FastF1 has the corner database for: graceful
             # degrade, the zone tags will read "—".
             pass
         zones = extract_zones(tel, corners_df=corners_df, min_length_m=min_length_m)

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -272,6 +272,11 @@ class PaceAgent:
             total_laps: Total scheduled race laps.
             prev_speed_st: Speed trap reading in km/h from the previous lap.
             mean_sector_speed: Average sector speed; None → use prev_speed_st.
+            stint_baseline_tyre_life: TyreLife recorded at the start of the
+                current stint. None means the caller has not been updated to
+                supply it, in which case FuelEffect is forced to NaN instead
+                of falling back to the old (wrong) formula — see the comment
+                in the body for why NaN is the safe default here (#446).
 
         Returns:
             Dict with keys FreshTyre, FuelEffect, laps_remaining,
@@ -581,6 +586,9 @@ class PaceAgent:
             prev_deg_rate: Degradation rate from the previous lap (s/lap).
             prev_cum_deg: Cumulative degradation at the previous lap.
             prev_deg_accel: Second derivative of degradation (s/lap²).
+            stint_baseline_tyre_life: TyreLife at the start of the current
+                stint. None forces FuelEffect to NaN rather than a fabricated
+                estimate — see _compute_derived.
 
         Returns:
             PaceOutput with all fields populated and a reasoning string.

--- a/src/agents/radio_agent.py
+++ b/src/agents/radio_agent.py
@@ -14,7 +14,7 @@ The LLM cannot miss or hallucinate alerts.
 Entry points
 ------------
 run_radio_agent(lap_state)
-    Requires LAPS/SESSION_META globals populated first via setup_session().
+    Self-contained — everything it needs comes from lap_state itself.
     lap_state keys: lap (int), radio_msgs (list[RadioMessage]),
     rcm_events (list[RCMEvent]).
 
@@ -80,7 +80,12 @@ try:
 except Exception:
     _DATA_ROOT = _REPO_ROOT / "data"
 
-# ── Module-level globals (populated by entry points) ──────────────────────────
+# ── Module-level globals ───────────────────────────────────────────────────────
+# Left over from the notebook's global-state design. Only run_radio_agent_from_state
+# writes LAPS/SESSION_META (for total_laps/year bookkeeping — see its docstring:
+# "not queried during inference"), and nothing in this module ever reads them back.
+# run_radio_agent itself is self-contained through lap_state and never touches
+# these. RCM_DF is declared here but not written or read anywhere.
 LAPS:         pd.DataFrame = pd.DataFrame()
 RCM_DF:       pd.DataFrame = pd.DataFrame()
 SESSION_META: dict         = {}

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -16,9 +16,9 @@ Entry points
 ------------
 run_strategy_orchestrator(race_state, lap_state)
     Primary entry point. Accepts a RaceState Pydantic model and a lap_state dict
-    (compatible with the FastF1 entry points of the sub-agents). The sub-agents
-    are called with their standard entry points — requires populated FastF1 session
-    globals inside each sub-agent module.
+    (compatible with the FastF1 entry points of the sub-agents). Every sub-agent
+    is self-contained through the arguments passed to it here — nothing needs to
+    be set up on any sub-agent module beforehand.
 
 run_strategy_orchestrator_from_state(race_state, laps_df)
     RSM adapter. Calls the *_from_state entry points of each sub-agent so no
@@ -2010,9 +2010,11 @@ def run_strategy_orchestrator(
 ) -> "StrategyRecommendation":
     """Run the Strategy Orchestrator for one lap and return a StrategyRecommendation.
 
-    Primary entry point. Uses the FastF1-dependent entry points of each sub-agent,
-    which require the sub-agent LAPS/SESSION_META globals to be populated in advance
-    (i.e. each sub-agent's setup_session or equivalent must have been called).
+    Primary entry point. Uses the FastF1-dependent entry points of each sub-agent
+    (run_pace_agent, run_tire_agent, run_race_situation_agent, run_radio_agent,
+    run_pit_strategy_agent). Each one is self-contained through the lap_state
+    dict it receives here — no pre-populated globals or setup call is needed on
+    any sub-agent module.
 
     race_state:
         Validated Pydantic RaceState for this lap. Contains driver, position,
@@ -2128,7 +2130,9 @@ def run_strategy_orchestrator_from_state(
         Validated Pydantic RaceState for this lap.
     laps_df:
         Full lap DataFrame from RaceStateManager. Forwarded to each sub-agent's
-        RSM adapter to populate LAPS / SESSION_META globals.
+        RSM adapter (run_pace_agent_from_state, run_tire_agent_from_state, etc.),
+        each of which derives its own laps_df / session_meta state from the call
+        arguments — no shared globals involved.
     lap_state:
         Optional supplementary scalar dict. When None, a minimal lap_state is
         derived automatically from race_state and laps_df. Provide it when

--- a/src/arcade/__init__.py
+++ b/src/arcade/__init__.py
@@ -1,4 +1,4 @@
-"""F1 StratLab — Arcade race replay UI.
+"""F1 StratLab: Arcade race replay UI.
 
 This package exposes a Python Arcade window that consumes the backend
 SSE simulation stream (/api/v1/strategy/simulate) and renders the race

--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -100,7 +100,7 @@ class F1ArcadeView(arcade.View):
     """Renders the race replay and owns the playback state machine.
 
     Lives inside a `arcade.Window` provided by `main.py`. The window is
-    passed in so self.window is populated immediately — every arcade.Text
+    passed in so self.window is populated immediately: every arcade.Text
     created in this __init__ or its child panels sees the active GL context
     right away. Call via `window.show_view(F1ArcadeView(window, ...))`."""
 
@@ -269,7 +269,7 @@ class F1ArcadeView(arcade.View):
         """Start the local strategy driver, the TCP broadcast server and
         the PySide6 dashboard subprocess.
 
-        The strategy UI lives entirely in the dashboard subprocess — the
+        The strategy UI lives entirely in the dashboard subprocess: the
         arcade replay keeps the track, leaderboard and car animations
         (the replay-first concerns) and broadcasts merged
         arcade+strategy state over TCP so the dashboard can render the
@@ -661,7 +661,7 @@ class F1ArcadeView(arcade.View):
 
         Skips the main and rival codes (they draw later with the full
         radius + label + outline, so they always sit on top of the
-        field). Small cars are unlabeled — 20 labels at once would turn
+        field). Small cars are unlabeled: 20 labels at once would turn
         the track into a tag cloud. Alpha is applied so the featured
         dots still dominate visually."""
         featured = {self._driver_main}

--- a/src/arcade/dashboard/__main__.py
+++ b/src/arcade/dashboard/__main__.py
@@ -1,6 +1,6 @@
 """Dashboard entry point: ``python -m src.arcade.dashboard``.
 
-One Qt subprocess, two QMainWindows — ``MainWindow`` for the strategy
+One Qt subprocess, two QMainWindows: ``MainWindow`` for the strategy
 surface (orchestrator / agents / reasoning / charts) and
 ``TelemetryWindow`` for the live speed/throttle/brake/DRS view. Both
 subscribe to the same arcade TCP stream independently, so the user can

--- a/src/arcade/dashboard/agent_card.py
+++ b/src/arcade/dashboard/agent_card.py
@@ -3,7 +3,7 @@
 One instance per N25/N26/N27/N28/N29/N30 card in the dashboard's right
 grid. Formatter functions in ``agent_formatters`` produce the data
 tuple the card renders; the card itself is a dumb view that does not
-know which agent it represents — caller sets the title + icon at
+know which agent it represents: caller sets the title + icon at
 construction time.
 
 Visual sections:
@@ -160,7 +160,7 @@ class AgentCard(QFrame):
     def attach_chart(self, widget: QWidget) -> None:
         """Drop a pyqtgraph ``PlotWidget`` (or similar) inside the body.
 
-        Bumps the card height caps so the chart + body text both fit —
+        Bumps the card height caps so the chart + body text both fit:
         the tighter max set in ``__init__`` is for text-only cards
         (Situation, Radio, RAG) where charts would dominate."""
         while self._chart_layout.count():

--- a/src/arcade/dashboard/agent_formatters.py
+++ b/src/arcade/dashboard/agent_formatters.py
@@ -12,7 +12,7 @@ where ``body_lines`` is ``list[tuple[str, color]]`` (one line per
 pair) and ``status`` is ``"OK" | "WATCH" | "ALERT" | "IDLE"``. The card
 widget maps ``status`` to the glyph + colour.
 
-No agent package imports — formatters accept plain dicts already
+No agent package imports: formatters accept plain dicts already
 serialised by ``src/arcade/strategy.py::_dump_dataclass``.
 """
 
@@ -74,7 +74,7 @@ def _truncate(text: str | None, limit: int = 70) -> str:
 
 
 def format_pace(p: dict[str, Any] | None) -> Formatted:
-    """CLI §1.1 — pace delta to next predicted lap, with absolute predicted lap time.
+    """CLI §1.1: pace delta to next predicted lap, with absolute predicted lap time.
 
     The headline pairs the signed delta vs the previous lap with the
     absolute predicted lap time in parentheses. The delta is the actionable
@@ -121,7 +121,7 @@ _TIRE_CLIFF_MAX_SANE: float = 100.0  # laps — anything above this is early-sti
 
 
 def format_tire(t: dict[str, Any] | None) -> Formatted:
-    """CLI §1.2 — cliff p50, range p10-p90, deg rate, warning_level, and stint length.
+    """CLI §1.2: cliff p50, range p10-p90, deg rate, warning_level, and stint length.
 
     The headline pairs the cliff projection (median laps remaining before
     the compound falls off) with the laps already run on the current set,
@@ -184,7 +184,7 @@ def format_tire(t: dict[str, Any] | None) -> Formatted:
 
 
 def format_situation(s: dict[str, Any] | None) -> Formatted:
-    """CLI §1.3 — threat level headline, with overtake / SC probabilities and gap-plus-pace context.
+    """CLI §1.3: threat level headline, with overtake / SC probabilities and gap-plus-pace context.
 
     The headline carries the categorical threat level and is colour-coded
     by the same status mapping used for the other agent cards. Body rows
@@ -266,7 +266,7 @@ def radio_tooltip_html(r: dict[str, Any] | None) -> str:
     """Build the Qt rich-text tooltip listing every radio and RCM in the lap.
 
     The tooltip exists because the body ticker only shows the most recent
-    radio and the most recent RCM — the strategist sometimes needs the
+    radio and the most recent RCM, and the strategist sometimes needs the
     full transcript of the lap (e.g. several PROBLEM radios in a row, or
     a chain of yellow flags clearing) and the body labels do not have the
     vertical budget for that. Returning the empty string is the documented
@@ -310,7 +310,7 @@ def radio_tooltip_html(r: dict[str, Any] | None) -> str:
 
 
 def format_radio(r: dict[str, Any] | None) -> Formatted:
-    """CLI §1.4 — alert intents headline, plus a per-lap transcript ticker.
+    """CLI §1.4: alert intents headline, plus a per-lap transcript ticker.
 
     The headline branches the same way as the CLI: chip row when the
     deterministic alert filter fires (PROBLEM / WARNING radios or
@@ -390,7 +390,7 @@ def format_radio(r: dict[str, Any] | None) -> Formatted:
 
 
 def format_pit(p: dict[str, Any] | None, active: bool) -> Formatted:
-    """CLI §1.5 — active shows pit p50 → compound; idle shows trigger hint.
+    """CLI §1.5: active shows pit p50 → compound; idle shows trigger hint.
 
     When the upstream ``PitDecision`` flags ``sc_reactive=True`` the
     headline is suffixed with ``" · SC"`` to disclose to the engineer
@@ -400,7 +400,7 @@ def format_pit(p: dict[str, Any] | None, active: bool) -> Formatted:
     reactive SC-window opportunism, which carry different risk profiles
     (an SC stop saves around ten seconds but only pays off if the SC
     actually deploys within the window). The headline colour stays
-    ``WARNING`` in both active sub-cases — the suffix alone communicates
+    ``WARNING`` in both active sub-cases: the suffix alone communicates
     SC reactivity, preserving non-SC active rendering exactly as before.
     """
     if not active or not p:
@@ -443,7 +443,7 @@ def _format_article_refs(articles: list[Any] | None) -> str:
     available in the tooltip.
 
     Returns the empty string when no usable identifier survives the
-    filtering — callers then skip the body line and ``AgentCard`` hides
+    filtering; callers then skip the body line and ``AgentCard`` hides
     it automatically.
     """
     if not articles:
@@ -521,7 +521,7 @@ def rag_tooltip_html(r: dict[str, Any] | None) -> str:
 
 
 def format_rag(rag: dict[str, Any] | str | None, active: bool) -> Formatted:
-    """CLI §1.6 — answer snippet plus article references for the active branch.
+    """CLI §1.6: answer snippet plus article references for the active branch.
 
     The active branch surfaces a 70-character snippet of the LLM answer
     on body line 1 and the first three deduplicated article references

--- a/src/arcade/dashboard/orchestrator_card.py
+++ b/src/arcade/dashboard/orchestrator_card.py
@@ -1,13 +1,13 @@
-"""N31 orchestrator card — the top-left decision panel.
+"""N31 orchestrator card: the top-left decision panel.
 
 Reads one ``latest`` LapDecision dict per update and renders:
 
 - Action badge (big, coloured by ``classify_action``).
 - Confidence bar (red → amber → green based on value).
-- Plan strip — pace_mode · risk_posture chips + pit target + undercut
+- Plan strip: pace_mode · risk_posture chips + pit target + undercut
   target, matching the CLI's execution-plan table (``06_cli_inference_panel.md``
   §3) so the dashboard reads as a visual extension of the CLI view.
-- Guardrail line — DANGER-coloured when ``guardrail_reason`` is set so
+- Guardrail line: DANGER-coloured when ``guardrail_reason`` is set so
   the user sees *why* the orchestrator overrode the MC winner.
 
 Idle state (``latest is None``) keeps the layout intact with ``"--"``

--- a/src/arcade/dashboard/pace_chart.py
+++ b/src/arcade/dashboard/pace_chart.py
@@ -1,4 +1,4 @@
-"""Pace chart — predicted lap time vs actual, with P10/P90 CI band.
+"""Pace chart: predicted lap time vs actual, with P10/P90 CI band.
 
 Embedded inside the Pace N25 AgentCard (the chart slot reserved in C5).
 pyqtgraph is used instead of matplotlib because PlotDataItem/FillBetweenItem
@@ -14,7 +14,7 @@ Data model (fed by ``MainWindow._pace_history``):
     }}
 
 ``update`` rebuilds the three plot items each lap (window size ≤30, so
-the cost is negligible). Missing values are simply skipped — laps before
+the cost is negligible). Missing values are simply skipped: laps before
 the dashboard connected will only have ``actual`` and the predicted line
 / CI band start from the first lap we saw the per-agent payload for.
 """
@@ -83,7 +83,7 @@ class PaceChart(pg.PlotWidget):
         Lap times outside the plausible F1 range (30-200 s) are dropped
         so an occasional stub value cannot blow the Y-axis autoscale and
         flatten the real series to a hairline. The whole 30-lap window
-        is rebuilt per update — cheap at these sizes (<1 ms)."""
+        is rebuilt per update, cheap at these sizes (<1 ms)."""
         if not history:
             self._clear()
             return

--- a/src/arcade/dashboard/reasoning_tabs.py
+++ b/src/arcade/dashboard/reasoning_tabs.py
@@ -10,8 +10,8 @@ string at the top (the LLM-authored explanation the CLI shows), then
 an auto-formatted block of the agent's key metrics below it, so even
 when the agent did not emit a reasoning (stub path, conditional agent
 not fired, older checkpoint) the tab still surfaces the raw numbers.
-The RAG agent has no LLM reasoning — its retrieved text lives in the
-RAG card already — so it is not tabbed here.
+The RAG agent has no LLM reasoning; its retrieved text lives in the
+RAG card already, so it is not tabbed here.
 """
 
 from __future__ import annotations

--- a/src/arcade/dashboard/scenario_bars.py
+++ b/src/arcade/dashboard/scenario_bars.py
@@ -97,12 +97,13 @@ class ScenarioBars(QFrame):
     def update_from(self, scores: dict[str, Any] | None) -> None:
         """Paint the four bars from a ``scenario_scores`` dict.
 
-        MC scores are computed as ``mean - α·std`` and can go negative.
-        We shift the four values so the worst one lands at 0 then scale
-        by the (positive) range — so the winner always reaches full
-        width and the loser draws an empty bar, regardless of whether
-        all four are negative. The raw score is printed with two
-        decimals on the right so the sign and magnitude stay readable.
+        MC scores are computed as ``alpha * E[S] + (1 - alpha) * P10[S]``
+        (``src/agents/strategy_orchestrator.py::_run_mc_simulation``) and can
+        go negative. We shift the four values so the worst one lands at 0
+        then scale by the (positive) range, so the winner always reaches
+        full width and the loser draws an empty bar, regardless of whether
+        all four are negative. The raw score is printed with two decimals
+        on the right so the sign and magnitude stay readable.
         """
         raw: dict[str, float] = {}
         if scores:

--- a/src/arcade/dashboard/stream_client.py
+++ b/src/arcade/dashboard/stream_client.py
@@ -4,7 +4,7 @@ Mirrors ``TelemetryStreamServer`` in ``src/arcade/stream.py``: the arcade
 process (pyglet + arcade) broadcasts newline-delimited JSON to all
 connected clients; this QThread reads the socket, splits on ``\\n`` and
 emits one ``dict`` per message via ``data_received``. The dashboard
-never talks to the arcade in the other direction — it is a pure
+never talks to the arcade in the other direction: it is a pure
 subscriber.
 
 Port of the ``TelemetryStreamClient`` class from
@@ -30,10 +30,10 @@ class TelemetryStreamClient(QThread):
     """Subscriber thread for the arcade telemetry stream.
 
     Signals:
-        ``data_received(dict)`` — one payload per decoded JSON line.
-        ``connection_status(str)`` — ``"Connecting..."``, ``"Connected"``
+        ``data_received(dict)``: one payload per decoded JSON line.
+        ``connection_status(str)``: ``"Connecting..."``, ``"Connected"``
         or ``"Disconnected"``; suitable for a status chip.
-        ``error_occurred(str)`` — human-readable error, routed to the
+        ``error_occurred(str)``: human-readable error, routed to the
         status bar.
 
     Lifecycle:

--- a/src/arcade/dashboard/telemetry_panel.py
+++ b/src/arcade/dashboard/telemetry_panel.py
@@ -1,4 +1,4 @@
-"""Live telemetry panel — 2×2 grid of pyqtgraph charts with fixed axes.
+"""Live telemetry panel: 2×2 grid of pyqtgraph charts with fixed axes.
 
 Layout mirrors the Streamlit circuit-comparison page:
 
@@ -10,15 +10,15 @@ Layout mirrors the Streamlit circuit-comparison page:
     │ (main + rival)     │ (main + rival)     │
     └────────────────────┴────────────────────┘
 
-Axes are locked so only the lines move between updates — a moving
+Axes are locked so only the lines move between updates: a moving
 viewport on every broadcast is visually noisy and masks where on the
 lap the car actually is. X is fixed to ``[0, circuit_length]`` and Y
 is per-metric:
 
-- Speed: 0-340 km/h (modern F1 top speeds cluster below 340).
+- Speed: 0-360 km/h (Monza's straight tops out around 357).
 - Brake / Throttle: -5 to 105 % with tiny padding so traces at 0 and
   100 do not kiss the frame.
-- Delta: ±3 s — generous for one lap, clipped when the series wanders.
+- Delta: ±3 s, generous for one lap, clipped when the series wanders.
 
 Each chart carries a title label above the plot and a mini colour
 legend (``MAIN · VER`` · ``RIVAL · LEC``) so the user never has to

--- a/src/arcade/dashboard/telemetry_window.py
+++ b/src/arcade/dashboard/telemetry_window.py
@@ -1,4 +1,4 @@
-"""Live telemetry window — independent QMainWindow subscribing to the
+"""Live telemetry window: independent QMainWindow subscribing to the
 same TCP stream the strategy dashboard uses.
 
 Two subscribers (strategy + telemetry) share a broadcast so the user
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 class TelemetryWindow(QMainWindow):
     """Standalone window showing the ``TelemetryPanel`` over the TCP stream.
 
-    Owns its own ``TelemetryStreamClient`` — the arcade's
+    Owns its own ``TelemetryStreamClient``: the arcade's
     ``TelemetryStreamServer`` supports N clients, so the telemetry
     window and the strategy dashboard connect independently. Both can
     survive a restart of the other."""

--- a/src/arcade/dashboard/theme.py
+++ b/src/arcade/dashboard/theme.py
@@ -1,10 +1,10 @@
-"""Dashboard theme — palette, compound colours, action classification.
+"""Dashboard theme: palette, compound colours, action classification.
 
 Constants are duplicated from ``src/arcade/config.py`` on purpose: the
 dashboard runs in its own process and importing the arcade config would
 pull pyglet / arcade / fastf1 into the Qt process (cold start ~2 s and
 no way to ever call the API without paying the price). Keep both files
-in sync when the palette changes upstream — they are the two sources
+in sync when the palette changes upstream: they are the two sources
 of truth for the TFG's visual identity.
 
 Values here mirror ``src/telemetry/frontend/app/styles.py`` (the
@@ -209,7 +209,7 @@ def flag_chip_html(intent: str | None) -> str:
 def apply_dark_palette(app) -> None:
     """Apply the dashboard dark palette to ``QApplication`` and install a
     global stylesheet that widgets inherit without having to set colours
-    one by one. Keep the widget tree declarative — child widgets only
+    one by one. Keep the widget tree declarative: child widgets only
     override specific roles (action badges, cliff lines, etc.).
     """
     palette = QPalette()

--- a/src/arcade/dashboard/tire_chart.py
+++ b/src/arcade/dashboard/tire_chart.py
@@ -1,4 +1,4 @@
-"""Tire chart — lap time over laps with per-stint colour and cliff projection.
+"""Tire chart: lap time over laps with per-stint colour and cliff projection.
 
 Embedded inside the Tire N26 ``AgentCard`` (chart slot reserved in C5).
 The previous version plotted ``tyre_life`` (laps on the current set) on
@@ -8,7 +8,7 @@ the user reads degradation the same way an engineer does on a pit-wall:
 
 - **X axis** is the lap number, identical to ``PaceChart`` so the two
   cards line up vertically and the eye does not have to recalibrate.
-- **Y axis** is the lap time in seconds — every climb on the curve is
+- **Y axis** is the lap time in seconds: every climb on the curve is
   literal degradation, every drop is a fresh tyre.
 - **One ``PlotDataItem`` per stint**, coloured with the Pirelli palette
   for that compound (red / yellow / white / green / blue). pyqtgraph
@@ -30,7 +30,7 @@ Data model (fed by ``MainWindow._tire_history``):
     [{lap: int, lap_time_s: float | None,
       tyre_life: float | None, compound: str | None}, ...]
 
-The widget keeps no domain state of its own — the per-stint segment list
+The widget keeps no domain state of its own: the per-stint segment list
 is rebuilt on every ``update_from`` call. At the dashboard's 30-lap
 window the cost is well under a millisecond.
 """
@@ -74,7 +74,7 @@ class TireChart(pg.PlotWidget):
     """PlotWidget that pairs per-stint lap-time segments with a cliff band.
 
     The widget is intentionally a thin renderer over ``MainWindow``'s
-    ``_tire_history`` dict — every render rebuilds segments and the
+    ``_tire_history`` dict: every render rebuilds segments and the
     cliff annotations from scratch so a stale stint cannot survive a
     pit stop or a mid-stream reconnect. Pre-allocated items (the cliff
     band edges, the median marker, the dashed smoothing overlay) keep
@@ -360,7 +360,7 @@ def _sane_cliff(value: Any, ceiling: float) -> float | None:
 def _rolling_mean(ys: list[float], window: int = 3) -> list[float]:
     """3-point centred rolling mean over a list of lap times.
 
-    The window is small on purpose — heavier smoothing (5 or more)
+    The window is small on purpose: heavier smoothing (5 or more)
     visibly lags the underlying trend in the 25-30-lap windows the
     dashboard renders, defeating the point of the overlay. ``min_periods=1``
     semantics: edges are averaged over whatever points exist so the line

--- a/src/arcade/dashboard/window.py
+++ b/src/arcade/dashboard/window.py
@@ -3,17 +3,19 @@
 Subscribes to the arcade telemetry stream and routes updates to three
 areas:
 
-- Header bar (top, 40 px) — session label, driver, connection chip,
+- Header bar (top, 44 px): session label, driver, connection chip,
   playback chip, lap counter. Populated from ``arcade`` + ``strategy.start``
   + ``playback`` keys of each broadcast.
-- Central ``QSplitter(Qt.Horizontal)`` — two content panels that future
-  commits fill with the orchestrator card, the six sub-agent cards,
-  charts, alerts feed and reasoning view.
-- Status bar (bottom) — last error from the stream, last payload size.
+- Central ``QSplitter(Qt.Horizontal)``: left panel holds the
+  orchestrator card, the scenario-score bars and the six-tab reasoning
+  view; right panel holds the 3x2 grid of sub-agent cards (Pace and
+  Tire carry an embedded pyqtgraph chart).
+- Status bar (bottom): last pipeline error, or the current lap while
+  streaming normally.
 
-The scaffold deliberately leaves the content panels empty so later
-commits can add widgets one at a time without touching the window
-class.
+``_on_data`` is the single router: one incoming broadcast dict fans out
+to every widget below, plus the two rolling history dicts
+(``_pace_history`` / ``_tire_history``) the charts read from.
 """
 
 from __future__ import annotations
@@ -126,12 +128,14 @@ class HeaderBar(QWidget):
 
 
 class MainWindow(QMainWindow):
-    """Dashboard shell with header + QSplitter + status bar.
+    """Dashboard shell: header + QSplitter (left panel / right panel) + status bar.
 
-    Placeholder widgets in the left / right panels expose a stable public
-    API (``set_left_content`` / ``set_right_content``) that later commits
-    use to inject the orchestrator card, agent grid and charts without
-    having to touch this class.
+    Owns the ``TelemetryStreamClient`` connection and every widget the
+    left and right panels hold. ``_on_data`` is the sole entry point for
+    a new broadcast; it updates the header, the left-panel widgets, the
+    right-panel agent cards, and the two chart history dicts in that
+    order, then sets the status-bar message last so it reflects whatever
+    the pipeline reported for this tick.
     """
 
     def __init__(self) -> None:
@@ -209,7 +213,7 @@ class MainWindow(QMainWindow):
         self._client.start()
 
     def _on_data(self, data: dict[str, Any]) -> None:
-        """Router for incoming broadcasts — fans out to widgets."""
+        """Router for incoming broadcasts: fans out to widgets."""
         self._header.update_from(data)
         strategy = data.get("strategy") or {}
         latest = strategy.get("latest") or {}
@@ -236,7 +240,7 @@ class MainWindow(QMainWindow):
         """Backfill chart dicts with lap_time_s / tyre_life actuals from the
         broadcast history_tail. ``per_agent`` is stripped there (wire-size
         trade-off) so predicted / CI values stay empty for past laps until
-        we observe them via ``latest`` — that's an accepted limitation of
+        we observe them via ``latest``, an accepted limitation of
         the mid-stream reconnect path."""
         for row in tail:
             lap = row.get("lap_number")

--- a/src/arcade/data.py
+++ b/src/arcade/data.py
@@ -9,7 +9,7 @@ stops DNF'd drivers from sitting as ghosts at their crash position.
 Output is a `SessionData` dataclass holding per-driver lists of `FrameData`
 plus the geometry of a single reference lap that `track.py` consumes for the
 circuit outline. All telemetry is kept in raw FastF1 units (1/10 mm for X/Y,
-km/h for speed, seconds for time) — conversion happens at render boundaries.
+km/h for speed, seconds for time); conversion happens at render boundaries.
 """
 
 from __future__ import annotations
@@ -79,7 +79,7 @@ class SessionData:
     `ref_lap_xy` is the raw (non-rotated) fastest-lap polyline used by
     `track.py` for circuit geometry; rotation is applied at render time via
     `circuit_rotation_deg`. `timeline` is the common 25 Hz grid shared by
-    every driver — its length is the total frame count of the replay."""
+    every driver; its length is the total frame count of the replay."""
 
     version: str = CACHE_VERSION
     gp_name: str = ""
@@ -114,7 +114,7 @@ class SessionData:
 
 
 def _enable_fastf1_cache() -> None:
-    """Point FastF1 at our repo-local cache. Idempotent — safe across spawn."""
+    """Point FastF1 at our repo-local cache. Idempotent, safe across spawn."""
     FASTF1_CACHE_DIR.mkdir(parents=True, exist_ok=True)
     fastf1.Cache.enable_cache(str(FASTF1_CACHE_DIR))
 
@@ -425,7 +425,7 @@ class SessionLoader:
         Rationale (cf. f1_replay/main.py:43-68): in qualifying, drivers open
         their DRS wing in every activation zone because they are on a push
         lap, so a single quali telemetry has the full DRS picture. A race
-        fastest lap only has DRS open where the driver had a car to catch —
+        fastest lap only has DRS open where the driver had a car to catch,
         producing the fragmented zones we saw earlier. Falls back to race
         fastest if qualifying data cannot be loaded."""
         quali_result = self._try_quali_reference(year, round_)
@@ -501,7 +501,7 @@ class SessionLoader:
         """Pick the most trustworthy circuit length we can derive.
 
         Preferred path: the fastest lap's FastF1 ``add_distance()``
-        telemetry — that column is cumulative metres within the lap, so
+        telemetry: that column is cumulative metres within the lap, so
         its last value IS the track length (Suzuka ≈ 5807 m, Monaco ≈
         3337 m, Las Vegas ≈ 6201 m). Falls back to the reference-lap
         polyline estimator when the fastest-lap query fails (qualifying

--- a/src/arcade/overlays.py
+++ b/src/arcade/overlays.py
@@ -5,7 +5,7 @@ leaderboard, driver info, progress bar, controls legend. Every `arcade.Text`
 is pre-allocated in each panel's `__init__` (which runs after the Window's
 GL context is active); `draw()` only mutates `.text / .x / .y / .color`.
 Creating `Text` inside `draw()` would leak glyph textures at 60 FPS × 20
-rows — a bug that bit both the reference and our earlier attempts.
+rows, a bug that bit both the reference and our earlier attempts.
 """
 
 from __future__ import annotations
@@ -74,7 +74,7 @@ class WeatherPanel:
 
     Visual identity: translucent CONTENT_BG card with a 1 px BORDER outline and
     a 3 px ACCENT top-strip. Readings are Inter body text, label in TERTIARY
-    and value in PRIMARY — same convention the Streamlit sidebar uses."""
+    and value in PRIMARY, the same convention the Streamlit sidebar uses."""
 
     PANEL_PADDING: int = 12
     STRIP_H: int = 3
@@ -340,7 +340,7 @@ class DriverInfoPanel:
 class LeaderboardPanel:
     """Right-edge list of all drivers ranked by race-cumulative progress.
 
-    Visual identity: same card language as Weather/DriverInfo — translucent
+    Visual identity: same card language as Weather/DriverInfo, translucent
     CONTENT_BG, 1 px BORDER outline, 3 px ACCENT top-strip, rank numbers in
     TERTIARY, codes in team colour, compound letter in compound colour on the
     right edge. Selected row is filled with SECONDARY_BG instead of a bare
@@ -518,7 +518,7 @@ class RaceEventsPanel:
     on ``SessionData.track_status_by_lap`` by ``SessionLoader``) and renders
     a Safety Car / VSC / Yellow / Red flag banner the same way a TV broadcast
     would.  The card is hidden when the status is clear (``"1"`` or empty)
-    and fades in / out over ~0.4 s on transitions so consecutive laps with
+    and fades in / out over ~0.35 s on transitions so consecutive laps with
     the same status do not flicker.
 
     Multi-digit codes are parsed with priority ``red > SC > VSC > yellow``,

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -5,7 +5,7 @@ same ``RaceReplayEngine`` + featured-laps parquet the backend SSE endpoint
 uses, and mutates a shared ``StrategyState`` so ``F1ArcadeView.on_draw``
 and the dashboard subprocess can pick up the latest ``LapDecision`` plus
 every raw sub-agent output without blocking. The arcade no longer depends
-on the FastAPI backend at runtime — it owns its own simulation loop, which
+on the FastAPI backend at runtime: it owns its own simulation loop, which
 keeps the TFG's CLI/Streamlit path isolated from any arcade change.
 
 Lap loop order matches ``backend/services/simulation/simulator.py::simulate_race``
@@ -82,7 +82,7 @@ class PerAgentOutputsDTO:
     """Raw per-agent outputs for one lap, ready to be rendered by the
     dashboard. Each field is the dict form of the corresponding agent
     dataclass (``PaceOutput``, ``TireOutput``, ``RaceSituationOutput``,
-    ``RadioOutput``, ``PitStrategyOutput``) — obtained via
+    ``RadioOutput``, ``PitStrategyOutput``), obtained via
     ``dataclasses.asdict`` so the DTO stays pure-Python and
     JSON-serialisable without pulling ``src/agents/`` types into the
     dashboard process.
@@ -161,7 +161,7 @@ class StrategyState:
         cliff percentiles, overtake/SC probabilities, etc. ``history_tail``
         strips ``per_agent`` from each past decision to keep the wire
         payload small (charts accumulate their own per-agent history from
-        successive ``latest`` updates — the backend does not need to
+        successive ``latest`` updates; the backend does not need to
         replay 30 copies of the dataclass on every broadcast).
         """
         with self._lock:
@@ -187,13 +187,13 @@ class SimConnector(threading.Thread):
     the backend uses, builds a ``RaceState`` per lap, invokes
     ``run_strategy_pipeline`` (verbose wrapper that returns both the
     synthesised ``StrategyRecommendation`` and every raw sub-agent
-    output), and pushes the merged decision into ``StrategyState`` — so
+    output), and pushes the merged decision into ``StrategyState`` so
     the arcade replay panel and the dashboard subprocess both get the
     full model telemetry without the arcade depending on the FastAPI
     backend at runtime.
 
     Class name kept for backwards-compatibility with ``F1ArcadeView``'s
-    wiring (``self._strategy_connector = SimConnector(...)``) — that call
+    wiring (``self._strategy_connector = SimConnector(...)``); that call
     site does not need to know the driver is now local.
     """
 
@@ -240,7 +240,7 @@ class SimConnector(threading.Thread):
 
         Returns ``True`` when the wait succeeded (arcade caught up or no
         provider was wired) and ``False`` when ``stop()`` was called while
-        we were waiting — the caller propagates that as a clean exit.
+        we were waiting; the caller propagates that as a clean exit.
         Polls instead of using a condition variable because the arcade
         view's frame index is read from a different thread without a lock
         and we only need lap-level granularity, not frame-level.
@@ -262,7 +262,7 @@ class SimConnector(threading.Thread):
     def _should_skip_stale(self, lap_num: int) -> bool:
         """True when arcade has seeked far enough ahead to drop this lap.
 
-        Always ``False`` when no playback provider is wired — CLI / smoke
+        Always ``False`` when no playback provider is wired: CLI / smoke
         tests must keep processing every lap end-to-end.
         """
         if self._current_lap_provider is None:
@@ -571,7 +571,7 @@ class SimConnector(threading.Thread):
         return candidate  # report the primary miss so error messaging stays clean
 
     def _build_race_state(self, lap_state: dict[str, Any], prev_lap_time: float):
-        """Duplicate of ``_local_build_race_state`` from simulator.py — small
+        """Duplicate of ``_local_build_race_state`` from simulator.py, small
         enough to inline so the arcade stays independent of
         ``backend.utils.race_state_builder`` (which requires a sys.path
         shim that only the FastAPI startup provides). Populates
@@ -721,7 +721,7 @@ def _dump_dataclass(obj: Any) -> dict[str, Any] | None:
     """Convert an agent-output dataclass to a plain dict, tolerating ``None``.
 
     ``dataclasses.asdict`` recurses into nested dataclasses, which is what
-    we want for the per-agent serialisation — ``PaceOutput``, ``TireOutput``,
+    we want for the per-agent serialisation: ``PaceOutput``, ``TireOutput``,
     etc. turn into JSON-ready dicts without hand-written field mappings."""
     if obj is None:
         return None

--- a/src/arcade/strategy_pipeline.py
+++ b/src/arcade/strategy_pipeline.py
@@ -1,4 +1,4 @@
-"""Arcade-local strategy pipeline — thin delegate over the shared engine.
+"""Arcade-local strategy pipeline: thin delegate over the shared engine.
 
 The arcade process runs the full N31 multi-agent pipeline in-process (no backend
 SSE hop) so its dashboard subprocess can subscribe to the arcade TCP stream and
@@ -7,7 +7,7 @@ outputs on the same wire.
 
 This module used to be a body-copy of
 ``src.agents.strategy_orchestrator.run_strategy_orchestrator_from_state`` with a
-"mirror the change here" warning — the exact drift the audit (AUDIT_P2B_CORE_COMPUTE
+"mirror the change here" warning: the exact drift the audit (AUDIT_P2B_CORE_COMPUTE
 F10) flagged and the #166 crash proved real. It now delegates to the single shared
 engine ``src.strategy.inference.engine.run_lap`` (``rich`` profile), which reproduces
 the orchestrator byte-for-byte AND returns the agent outputs. One code path, three

--- a/src/arcade/stream.py
+++ b/src/arcade/stream.py
@@ -2,15 +2,15 @@
 
 The race replay hosts this server (when strategy mode is on) and publishes
 a merged arcade+strategy state as newline-delimited JSON on each arcade
-frame. A separate PySide6 dashboard process (to be added in a later
-session) subscribes via a `TelemetryStreamClient` and reacts to updates on
-its Qt event loop.
+frame. The PySide6 dashboard subprocess subscribes via
+`src.arcade.dashboard.stream_client.TelemetryStreamClient` and reacts to
+updates on its Qt event loop.
 
 Pattern ported from Tom Shaw's `f1_replay/f1-race-replay/src/services/stream.py`
 and trimmed to stdlib-only: the arcade process must not import PySide6 so
 we can launch the dashboard as a subprocess without pulling Qt into the
-replay window. The client class lives in the dashboard package (Qt-aware)
-and is added when that package lands.
+replay window. The client class lives in the dashboard package (Qt-aware),
+kept separate so this module never needs to import PySide6.
 """
 
 from __future__ import annotations
@@ -29,7 +29,7 @@ class TelemetryStreamServer:
 
     Runs in a daemon thread, accepts up to many simultaneous connections,
     writes `json.dumps(data).encode() + b"\\n"` to every live socket on
-    `broadcast()`. Dead sockets are pruned on the next broadcast — no
+    `broadcast()`. Dead sockets are pruned on the next broadcast; no
     heartbeat needed because the replay pushes at ≥5 Hz. Designed to be
     started inside `F1ArcadeView._init_strategy_layer` and torn down in
     `on_hide_view`."""

--- a/src/arcade/track.py
+++ b/src/arcade/track.py
@@ -1,9 +1,9 @@
 """Circuit geometry + rendering for the Arcade race replay.
 
 Ported from Tom Shaw's f1-race-replay reference (see
-`c:/tmp/arcade_analysis/01_track_rendering.md`). The heavy lifting —
-reference-lap interpolation, shoelace-corrected normals, DRS zone index
-remap, world-to-screen with rotation about the bbox centre — mirrors that
+`c:/tmp/arcade_analysis/01_track_rendering.md`). The heavy lifting
+(reference-lap interpolation, shoelace-corrected normals, DRS zone index
+remap, world-to-screen with rotation about the bbox centre) mirrors that
 source but expects raw (non-rotated) telemetry from `SessionLoader`. We
 rotate ONCE inside this class: the previous round's bug was rotating both
 here and in the loader, which collapsed the outline into a pseudo-circle.

--- a/src/arcade/views.py
+++ b/src/arcade/views.py
@@ -1,6 +1,6 @@
 """Pre-replay menu view: keyboard-navigable form for session selection.
 
-No `arcade.gui` dependency — each field is a pre-allocated `arcade.Text`
+No `arcade.gui` dependency: each field is a pre-allocated `arcade.Text`
 object that reads its current value from a `LaunchConfig` dataclass. UP/DOWN
 move focus between fields, LEFT/RIGHT mutate discrete fields (year, round,
 mode, strategy toggle), typing appends to driver/team strings, ENTER

--- a/src/f1_strat_manager/__init__.py
+++ b/src/f1_strat_manager/__init__.py
@@ -1,7 +1,7 @@
 """Cross-cutting infrastructure package for the F1 StratLab CLI.
 
 Hosts modules that do not fit any single domain sub-package under ``src/``
-(`agents`, `nlp`, `rag`, `simulation`, …) — currently just the first-run
+(`agents`, `nlp`, `rag`, `simulation`, …): currently just the first-run
 data cache resolver and HuggingFace Hub downloader used by ``f1-strat``
 and ``f1-sim`` to bootstrap the ~15 GB of models and race data when the
 user installs the CLI via ``uv tool install`` without cloning the repo.

--- a/src/f1_strat_manager/data_cache.py
+++ b/src/f1_strat_manager/data_cache.py
@@ -3,7 +3,7 @@
 The CLI ships as two console scripts (``f1-strat``, ``f1-sim``) that can be
 installed globally via ``uv tool install git+https://…`` without cloning
 the repository. In that install mode the code arrives on disk but the
-~15 GB of trained models and FastF1 race dumps do not — they live on the
+~15 GB of trained models and FastF1 race dumps do not: they live on the
 HuggingFace Dataset ``VforVitorio/f1-strategy-dataset``. This module is
 the bridge: it resolves which on-disk directory should hold those assets
 (preferring an editable-dev checkout when one is present) and downloads
@@ -13,12 +13,12 @@ All resolution goes through :func:`get_data_root` so that sub-agents,
 scripts, and the CLI land on the same directory regardless of how the
 user installed the project. The order of precedence is:
 
-    1. ``$F1_STRAT_DATA_ROOT`` — explicit override for power users who
+    1. ``$F1_STRAT_DATA_ROOT``: explicit override for power users who
        want the cache on a different volume.
-    2. ``<repo>/data/`` — when the running module sits inside a git
+    2. ``<repo>/data/``: when the running module sits inside a git
        checkout, the walker finds the repo root and prefers the existing
        ``data/`` tree so editable-dev workflows never trigger downloads.
-    3. ``~/.f1-strat/data/`` — user cache directory for the global
+    3. ``~/.f1-strat/data/``: user cache directory for the global
        ``uv tool install`` scenario where there is no repo to live next to.
 
 Environment variables respected
@@ -68,8 +68,8 @@ DEFAULT_SENTINEL_RACE: tuple[int, str] = (2025, "Melbourne")
 
 # ── Critical files used to detect whether a setup has already happened ────────
 # If any of these are missing we consider the install "fresh" and trigger the
-# download flow. Kept deliberately small — only the load-bearing artefacts
-# that every sub-agent touches — so that a partially-populated cache still
+# download flow. Kept deliberately small: only the load-bearing artefacts
+# that every sub-agent touches, so that a partially-populated cache still
 # boots as long as it has the essentials.
 _CRITICAL_MODEL_FILES: tuple[str, ...] = (
     "tire_degradation/tiredeg_modelA_v4.pt",
@@ -105,20 +105,20 @@ _DEFAULT_MODEL_PATTERNS: tuple[str, ...] = (
     "data/models/xgb_laptime_final_feature_names.json",
     "data/models/xgb_laptime_global_v1.json",
     "data/models/model_registry.json",
-    # Featured parquet + supporting configs — the CLI loads these directly
+    # Featured parquet + supporting configs: the CLI loads these directly
     "data/processed/laps_featured_2025.parquet",
     "data/processed/feature_manifest_laptime.json",
     "data/processed/tiredeg_feature_manifest.json",
     "data/processed/tiredeg_sequence_config.json",
     "data/processed/circuit_clustering/**",
-    # Radio corpus metadata — small parquets (~430 KB total for the full
+    # Radio corpus metadata: small parquets (~430 KB total for the full
     # 2025 calendar) that the runner reads to enumerate per-lap team-radio
     # rows and FIA race-control messages. The matching MP3 audio tree under
     # data/raw/radio_audio/** is intentionally NOT pulled by default
-    # (~80 MB) — :func:`ensure_radio_corpus` downloads it lazily per GP
+    # (~80 MB); :func:`ensure_radio_corpus` downloads it lazily per GP
     # only when the simulation actually targets that race.
     "data/processed/race_radios/**",
-    # RAG index — optional, the Hub may not have it yet. snapshot_download
+    # RAG index: optional, the Hub may not have it yet. snapshot_download
     # ignores missing patterns silently.
     "data/rag/**",
 )
@@ -174,12 +174,12 @@ def get_data_root() -> Path:
 def get_models_root() -> Path:
     """Resolve the models directory using the same precedence as data root.
 
-    Returns ``<data_root>/../models`` when running from a repo checkout
-    (because the repo keeps models under ``data/models/``… actually the
-    on-disk layout is ``data/models/<family>/``) and mirrors that structure
-    under the user cache. In all cases the resolved path sits beneath
-    ``get_data_root()`` so a single HF ``snapshot_download`` call populates
-    both trees in one pass.
+    Returns ``<data_root>/models``: the same directory whether running from
+    a repo checkout (``<repo>/data/models``) or the user cache
+    (``~/.f1-strat/data/models``), since :func:`get_data_root` has already
+    resolved which one applies. Models sit inside the data root rather than
+    beside it, so a single HF ``snapshot_download`` call populates both
+    trees in one pass.
     """
     # Both editable-dev and user-cache layouts keep models under data/models/
     root = get_data_root() / "models"
@@ -195,7 +195,7 @@ def get_models_root() -> Path:
 def is_first_run() -> bool:
     """Return True when the essential data and models are not on disk yet.
 
-    The check is intentionally permissive — we only look for one race
+    The check is intentionally permissive: it only looks for one race
     folder under ``data/raw/<year>/`` and the handful of model files listed
     in ``_CRITICAL_MODEL_FILES``. Partial installs where only some of the
     extras are missing (e.g. the RAG Qdrant index) do NOT trigger the
@@ -277,7 +277,7 @@ def _snapshot_download(
         ) from exc
 
     data_root = get_data_root()
-    # snapshot_download writes into local_dir/ preserving the repo layout —
+    # snapshot_download writes into local_dir/ preserving the repo layout,
     # which already matches ``data/…`` + ``models/…`` on the remote, so we
     # point local_dir at the data_root parent (so ``models/`` lands next to
     # ``data/`` on disk) when running in user-cache mode, or at the repo
@@ -291,7 +291,7 @@ def _snapshot_download(
 
     local_dir.mkdir(parents=True, exist_ok=True)
 
-    # tqdm on/off — ``snapshot_download`` does not accept a progress arg
+    # tqdm on/off: ``snapshot_download`` does not accept a progress arg
     # directly but respects the HF_HUB_DISABLE_PROGRESS_BARS env var.
     if not show_progress:
         os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
@@ -418,7 +418,7 @@ def ensure_race(year: int, gp_name: str, show_progress: bool = True) -> Path:
     ``scripts/cli/pickers.py``) that already know which GP they need but
     want to be robust to a partially-populated cache. Skips the download
     entirely when the folder already exists or when
-    ``F1_STRAT_OFFLINE=1`` — in the offline case the caller receives the
+    ``F1_STRAT_OFFLINE=1``: in the offline case the caller receives the
     (possibly empty) path and can decide whether to raise.
     """
     data_root = get_data_root()
@@ -461,14 +461,14 @@ def ensure_radio_corpus(
     importing huggingface_hub, so the hot path of an already-warm install
     pays no startup cost beyond the slug lookup itself.
     """
-    # Lightweight import — gp_slugs has zero heavy deps so this stays cheap
+    # Lightweight import: gp_slugs has zero heavy deps so this stays cheap
     # even when the rest of src.agents has not been touched yet.
     from src.f1_strat_manager.gp_slugs import resolve_gp_slug
 
     try:
         slug = resolve_gp_slug(gp_name)
     except ValueError:
-        # Unknown name even after canonical normalisation — a genuine typo or an
+        # Unknown name even after canonical normalisation: a genuine typo or an
         # as-yet-unmapped GP. We do NOT raise here (the runner may accept the raw
         # gp_name path and gives a clearer error), but warn so the miss is not
         # fully silent: a zero-radio simulation used to look identical to a

--- a/src/f1_strat_manager/gp_slugs.py
+++ b/src/f1_strat_manager/gp_slugs.py
@@ -15,7 +15,7 @@ do not necessarily match the country (``Sakhir``, ``Imola``, ``Marina Bay``,
 those friendly names to the on-disk slugs, so the runner, the FastAPI
 endpoints, and the lazy first-run downloader (``data_cache``) all stay in
 sync. Both ``src/nlp/radio_runner.py`` and
-``src/f1_strat_manager/data_cache.py`` import the resolver from here —
+``src/f1_strat_manager/data_cache.py`` import the resolver from here,
 keeping it in this module (not under ``src/agents/`` or ``src/nlp/``)
 avoids dragging the radio-NLP package init (Whisper, librosa, the
 sentiment / intent / NER classifiers) into the lightweight data-bootstrap
@@ -35,9 +35,9 @@ logger = logging.getLogger(__name__)
 # two double-header countries (Italy = Imola + Monza, United States = Miami
 # + Austin + Las Vegas). Adding another double-header country in a future
 # season is a one-line change here followed by a Phase 0 rebuild of the
-# affected GPs — no agent code needs to know.
+# affected GPs, no agent code needs to know.
 COUNTRY_SLUG_BY_GP: dict[str, str] = {
-    # Single-race countries — slug is just the lowercased country name
+    # Single-race countries, slug is just the lowercased country name
     "Sakhir": "bahrain",
     "Jeddah": "saudi_arabia",
     "Melbourne": "australia",
@@ -59,7 +59,7 @@ COUNTRY_SLUG_BY_GP: dict[str, str] = {
     "Sao Paulo": "brazil",  # ASCII fallback for CLI input
     "Lusail": "qatar",
     "Yas Island": "united_arab_emirates",
-    # Multi-race countries — slug carries the circuit suffix from Phase 0
+    # Multi-race countries, slug carries the circuit suffix from Phase 0
     "Imola": "italy_imola",
     "Monza": "italy_monza",
     "Miami": "united_states_miami",
@@ -69,7 +69,7 @@ COUNTRY_SLUG_BY_GP: dict[str, str] = {
 
 
 # On-disk raw folder names that differ from the friendly key by more than the
-# underscore substitution — a mid-season circuit rename. Keyed by the folder
+# underscore substitution, a mid-season circuit rename. Keyed by the folder
 # name under ``data/raw/{year}/``, value is the canonical friendly name used by
 # both :data:`COUNTRY_SLUG_BY_GP` and ``data/tire_compounds_by_race.json``. The
 # space-vs-underscore forms (``Las_Vegas`` → ``Las Vegas``) are handled generically
@@ -110,15 +110,15 @@ def canonical_gp_name(name: str) -> str:
 # ── Featured-parquet slug ⇄ FastF1 event name ────────────────────────────────
 # A THIRD GP keyspace, distinct from the radio-corpus slugs above. The featured
 # laps parquet (and therefore RaceStateManager's session_meta.gp_name, and every
-# agent lookup key) uses circuit slugs — 'Budapest', 'Lusail'. But the circuit
-# lookup TABLES the agents index into use FastF1 full event names —
+# agent lookup key) uses circuit slugs, 'Budapest', 'Lusail'. But the circuit
+# lookup TABLES the agents index into use FastF1 full event names:
 # 'Hungarian Grand Prix', 'Qatar Grand Prix': circuit_traversal_lookup in N15's
 # model_config.json, undercut_clean.parquet's GP_Name (which feeds
 # circuit_undercut_rate), and the SC-labelled frame.
 #
 # The overlap between the two keyspaces is EXACTLY ZERO, so every circuit lookup
 # missed and silently took its default: pit-lane traversal was permanently 20.0 s,
-# circuit_undercut_rate 0.38, circuit_sc_rate 0.10 — Monaco and Monza given
+# circuit_undercut_rate 0.38, circuit_sc_rate 0.10, Monaco and Monza given
 # identical pit-lane physics, three trained per-circuit features frozen (#448).
 #
 # No mechanical derivation works: the full names are adjectival ('Hungarian', not
@@ -165,7 +165,7 @@ def slug_from_event_name(event_name: str) -> Optional[str]:
     once at the boundary beats translating at each call site: there is one place
     to keep correct, and the tables then speak the agents' native keyspace.
 
-    Returns ``None`` for an unknown name — callers should log it rather than drop
+    Returns ``None`` for an unknown name, callers should log it rather than drop
     the row silently, since a miss means the keyspaces have drifted again (#448).
     Already-slugged input passes through, keeping the call reentrant.
     """
@@ -177,7 +177,7 @@ def slug_from_event_name(event_name: str) -> Optional[str]:
 def rekey_by_slug(table: dict, table_name: str) -> dict:
     """Re-key a circuit lookup table from FastF1 event names to parquet slugs.
 
-    The agents query these tables with ``session_meta.gp_name`` — a circuit slug —
+    The agents query these tables with ``session_meta.gp_name``, a circuit slug,
     but the tables ship keyed by full event names, and the two keyspaces do not
     overlap at all, so every lookup missed and quietly returned its default (#448).
     Normalising once at load is why the call sites need almost no change: the tables
@@ -221,7 +221,7 @@ def resolve_gp_slug(gp_name: str) -> str:
     builder for the corpus directories under
     ``data/processed/race_radios/{year}/`` and
     ``data/raw/radio_audio/{year}/``. Falls through silently when the
-    input is *already* a slug, which keeps callers reentrant — passing
+    input is *already* a slug, which keeps callers reentrant, passing
     the canonical form a second time is a no-op instead of an error,
     which matters for ``ensure_radio_corpus`` retrying after a partial
     download.

--- a/src/nlp/radio_runner.py
+++ b/src/nlp/radio_runner.py
@@ -8,7 +8,7 @@ under ``data/processed/race_radios/{year}/{slug}/`` (``radios.parquet`` +
 multi-agent system needs at simulation time, but it cannot be plugged into
 ``RaceState.radio_msgs`` / ``RaceState.rcm_events`` directly:
 
-* the radio rows reference an MP3 on disk, not a transcript — Whisper has
+* the radio rows reference an MP3 on disk, not a transcript, so Whisper has
   to run on every audio clip and turn it into text before N29 can do any
   NLP on it
 * the parquet uses ``driver_number`` (int), but ``RadioMessage.driver``
@@ -28,7 +28,7 @@ nothing in N29 itself needs to change.
 
 The module lives under ``src/nlp/`` rather than next to ``radio_agent.py``
 because its main job is **transcription** (Whisper) plus a thin
-parquet → dict adapter — no inference, no LangGraph, no LLM. Sitting next
+parquet -> dict adapter, no inference, no LangGraph, no LLM. Sitting next
 to ``src/nlp/pipeline.py`` and the sentiment / intent / NER classifiers
 keeps all the radio-NLP plumbing in one place and means the lazy
 first-run downloader (``src/f1_strat_manager/data_cache.py``) can call
@@ -82,15 +82,15 @@ class WhisperTranscriber:
     re-loading it on every :class:`RadioPipelineRunner` constructor would
     dominate the simulation startup cost. Wrapping the load behind
     :meth:`ensure_loaded` and stashing the result on the instance lets two
-    runners in the same process — e.g. the smoke notebook constructing one
-    runner per GP — share the weights once they have been paid for. The
+    runners in the same process (e.g. the smoke notebook constructing one
+    runner per GP) share the weights once they have been paid for. The
     module-level :func:`_get_whisper` factory takes care of returning the
     same instance for callers that ask for the same model name; passing a
     different ``model_name`` rebuilds the singleton because Whisper has no
     runtime way to swap weights in place.
 
     The class deliberately keeps no audio cache or transcript cache of its
-    own — those concerns belong to :class:`RadioPipelineRunner`, which knows
+    own: those concerns belong to :class:`RadioPipelineRunner`, which knows
     what to key the cache by (the relative ``audio_path`` from the parquet)
     and where to persist it (``data/processed/radio_nlp/...``). Keeping the
     transcriber stateless w.r.t. content makes it trivially reusable across
@@ -116,7 +116,7 @@ class WhisperTranscriber:
         Subsequent calls are no-ops, so the runner can put this at the
         top of every transcribe loop without worrying about repeated
         loads. The import is local to avoid pulling Whisper into module
-        import time — the radio_runner module is also imported by
+        import time: the radio_runner module is also imported by
         ``data_cache.ensure_radio_corpus`` (for ``resolve_gp_slug``) and
         we do not want bare-metal first-run downloads to cost a Whisper
         load that the user may never need.
@@ -134,7 +134,7 @@ class WhisperTranscriber:
         to Whisper's native 16 kHz mono via ``librosa.resample``. We
         avoid ``librosa.load`` because on Windows it can fall back to
         the ``audioread`` backend which spawns ``ffmpeg`` with a piped
-        stderr that emits cp1252 bytes — Python's subprocess reader
+        stderr that emits cp1252 bytes, and Python's subprocess reader
         thread then crashes trying to decode that as UTF-8. Going
         through ``soundfile`` directly skips that codepath entirely and
         is also faster on the OpenF1 MP3 corpus. ``fp16`` is only
@@ -220,7 +220,7 @@ class RadioPipelineRunner:
 
     1. resolves the GP name to its corpus slug via :func:`resolve_gp_slug`
     2. loads ``radios.parquet`` and ``rcm.parquet`` if they exist (empty
-       DataFrame + warning if either is missing — the simulation should
+       DataFrame + warning if either is missing, since the simulation should
        degrade gracefully, not crash)
     3. builds the per-GP ``driver_number → 3-letter code`` map from the
        featured laps DataFrame, falling back to ``D{n}`` for any number
@@ -231,7 +231,7 @@ class RadioPipelineRunner:
        re-transcribes the corpus that ``turbo`` left behind)
     5. eagerly transcribes every uncached radio when ``eager_transcribe``
        is True, lazily loading Whisper only if at least one row is
-       actually missing — a fully-warm cache pays zero Whisper cost
+       actually missing: a fully-warm cache pays zero Whisper cost
 
     The public API is :meth:`radios_for_lap`, which returns
     ``(radio_dicts, rcm_dicts)`` for the requested lap shaped exactly the
@@ -323,8 +323,8 @@ class RadioPipelineRunner:
         to the dict shape that
         ``strategy_orchestrator._to_radio_message`` and
         ``strategy_orchestrator._to_rcm_event`` accept. Radios always
-        carry a transcript field — empty string when the MP3 was
-        missing or transcription failed — so N29 sees a row even when
+        carry a transcript field (empty string when the MP3 was
+        missing or transcription failed), so N29 sees a row even when
         the corresponding audio is unavailable; this matches the
         contract the legacy mock generator has been honouring and lets
         the radio agent emit a ``no usable text`` warning instead of
@@ -355,7 +355,7 @@ class RadioPipelineRunner:
 
         A missing parquet is logged as a warning but never raises
         because the simulation should still be runnable when the
-        corpus is partial — e.g. the user is replaying a 2024 GP that
+        corpus is partial, e.g. the user is replaying a 2024 GP that
         we have not yet built radios for. The same logic applies to
         the RCM loader; both halves degrade independently.
         """
@@ -429,7 +429,7 @@ class RadioPipelineRunner:
         """Load the JSON cache from disk, dropping malformed or stale entries.
 
         The on-disk schema is a flat dict keyed by the **normalized**
-        relative ``audio_path`` (forward slashes — see the path-norm
+        relative ``audio_path`` (forward slashes, see the path-norm
         helper below) with values shaped as
         ``{text, duration_s, model}``. Entries are silently dropped
         when:
@@ -438,7 +438,7 @@ class RadioPipelineRunner:
         * the JSON parses but the top-level value is not a dict
         * an individual entry is missing the ``text`` field
         * the entry's ``model`` does not match
-          :attr:`whisper_model_name` — switching from ``turbo`` to
+          :attr:`whisper_model_name`: switching from ``turbo`` to
           ``base`` rebuilds the cache cleanly without any extra flag
 
         Always returns a dict so the rest of the runner can use it
@@ -499,7 +499,7 @@ class RadioPipelineRunner:
         (backslashes on the Windows build host, forward slashes
         elsewhere). Normalizing both on the read side and on the write
         side of the cache key keeps the JSON cache portable across
-        OSes — the file built on Windows still hits in the cache when
+        OSes: the file built on Windows still hits in the cache when
         the same parquet is loaded on macOS or Linux.
         """
         return rel.replace("\\", "/")
@@ -566,7 +566,7 @@ class RadioPipelineRunner:
         failed) and on any other Whisper exception, an empty-text
         entry is written to the cache so the runner does not retry
         the same broken file on every subsequent run. The radio row
-        is still emitted downstream — N29 sees a row with ``text=""``
+        is still emitted downstream: N29 sees a row with ``text=""``
         and treats it as "no usable transcript", which is the same
         behaviour as a clip Whisper genuinely could not understand.
         """
@@ -587,7 +587,7 @@ class RadioPipelineRunner:
         """Return the cached transcript text for one radio row.
 
         Returns the empty string when the row has no ``audio_path`` or
-        the cache key is missing — both cases mean N29 should see a
+        the cache key is missing: both cases mean N29 should see a
         row but treat it as having no usable text. Centralised here
         so the row-to-dict converter does not have to repeat the
         normalization + null handling.

--- a/src/nlp/rcm_state.py
+++ b/src/nlp/rcm_state.py
@@ -1,11 +1,11 @@
-"""Stateful Race Control tracker — fixes the Safety-Car override drop (NR-02, #305).
+"""Stateful Race Control tracker: fixes the Safety-Car override drop (NR-02, #305).
 
 ``sc_currently_active`` was derived per lap from ONLY that lap's Race Control
 Messages. A real "SAFETY CAR DEPLOYED" message is a one-shot FIA announcement (a
 single row at the deploy lap); it is never repeated on laps 8, 9, 10 of the same
 neutralisation, while the per-lap simulation loop rebuilds ``RaceState`` from
 scratch each lap with ``rcm_events=[]``. So a stateless classifier saw an empty
-window after the deploy lap and reported the Safety Car GONE mid-stint — exactly
+window after the deploy lap and reported the Safety Car GONE mid-stint, exactly
 when the STAY_OUT-under-SC pit override matters most.
 
 :class:`RaceControlStateTracker` persists the SC/VSC state across laps: it goes
@@ -42,7 +42,7 @@ def _event_types(rcm_events: list | None) -> list[str]:
     Mirrors ``race_situation_agent._sc_active_from_rcm``'s dispatch:
     pre-classified dicts (already carrying ``event_type``) pass through;
     ``RCMEvent`` instances and raw FastF1-shaped dicts are classified via
-    ``radio_agent`` — imported lazily to avoid the agents import loop.
+    ``radio_agent``, imported lazily to avoid the agents import loop.
     """
     if not rcm_events:
         return []

--- a/src/rag/__init__.py
+++ b/src/rag/__init__.py
@@ -1,8 +1,8 @@
 """
-src/rag — Retrieval-Augmented Generation module for FIA regulation lookup.
+src/rag: Retrieval-Augmented Generation module for FIA regulation lookup.
 
 Public interface:
-    RagRetriever   — initialise once; call .query() at inference time
-    RegulationChunk — dataclass returned by every query
-    query_rag_tool  — LangChain @tool wrapper around RagRetriever singleton
+    RagRetriever    - initialise once; call .query() at inference time
+    RegulationChunk - dataclass returned by every query
+    query_rag_tool  - LangChain @tool wrapper around RagRetriever singleton
 """

--- a/src/rag/retriever.py
+++ b/src/rag/retriever.py
@@ -37,10 +37,10 @@ class RagConfig:
     Attributes:
         collection_name: Name of the Qdrant collection that holds the FIA
                          regulation vectors. Must match the name used in
-                         ``build_rag_index.py`` — a mismatch means queries
+                         ``build_rag_index.py``: a mismatch means queries
                          silently hit an empty or wrong collection.
         embedding_model: Sentence-transformers model identifier. Must be the
-                         same model used at index build time — mixing models
+                         same model used at index build time. Mixing models
                          produces meaningless similarity scores because the
                          vector spaces are incompatible.
         top_k:           Default number of chunks returned per query. Five is
@@ -97,13 +97,13 @@ class RegulationChunk:
     by regulatory domain without having to re-parse the text themselves.
 
     Attributes:
-        text:          The regulation passage itself — the verbatim paragraph
+        text:          The regulation passage itself, the verbatim paragraph
                        extracted from the FIA document after chunking.
         article:       The article or section identifier found inside the chunk
                        (e.g. ``"Article 48.3"``). Used by the LLM to cite the
                        source precisely and by callers to filter by article range.
                        Empty string when no reference could be extracted.
-        doc_type:      Which FIA document the chunk comes from — distinguishes
+        doc_type:      Which FIA document the chunk comes from: distinguishes
                        sporting rules (race procedures, penalties) from technical
                        rules (equipment, pit stop mechanics). Callers can restrict
                        queries to a specific document type when the context is clear.
@@ -148,8 +148,8 @@ class RagRetriever:
     Both the Qdrant client and the embedding model are loaded eagerly on
     construction so that the first call to ``query()`` has no cold-start
     penalty. Instantiate once at module level (or via ``get_retriever()``)
-    and reuse across all agent calls — re-creating the encoder on every query
-    would add ~2–3 s of overhead per call.
+    and reuse across all agent calls: re-creating the encoder on every query
+    would add ~2-3 s of overhead per call.
     """
 
     def __init__(
@@ -170,7 +170,7 @@ class RagRetriever:
                              ``RuntimeError`` with an actionable message rather than
                              a cryptic Qdrant error.
             embedding_model: Sentence-transformers model identifier used to encode
-                             queries. Must be the same model used during indexing —
+                             queries. Must be the same model used during indexing:
                              mixing models produces meaningless similarity scores.
             top_k:           Default number of chunks to return per query. Can be
                              overridden per call in ``query()`` when a broader or
@@ -197,7 +197,7 @@ class RagRetriever:
         Normalisation (L2) is applied so that dot product and cosine similarity
         are equivalent in Qdrant, which is the convention used during indexing.
         Returns a plain Python list because that is what ``QdrantClient.search``
-        expects — passing a numpy array causes a silent type error in some versions.
+        expects. Passing a numpy array causes a silent type error in some versions.
 
         Args:
             text: The string to embed. Typically a user query, but can also be
@@ -221,7 +221,7 @@ class RagRetriever:
         Args:
             question: The natural-language query to answer. Can be a full sentence
                       ("What are the pit lane speed limits?") or a short phrase
-                      ("safety car restart procedure") — the embedding handles both
+                      ("safety car restart procedure"): the embedding handles both
                       equally well.
             top_k:    Number of chunks to return. When ``None``, falls back to the
                       instance default set at construction time. Pass a larger value
@@ -258,7 +258,7 @@ class RagRetriever:
         """Return a summary of the collection's current state for diagnostics.
 
         Useful at notebook startup to confirm the index was built correctly before
-        running agent demos — reports the number of indexed vectors, the embedding
+        running agent demos. Reports the number of indexed vectors, the embedding
         model in use, and the Qdrant storage path so misconfigurations are caught
         early rather than at query time.
 
@@ -293,8 +293,8 @@ def get_retriever(
     Wrapped in ``functools.lru_cache`` so the embedded Qdrant client is
     instantiated exactly once per process. A second ``QdrantClient(path=...)``
     on the same storage directory raises ``AlreadyLocked`` (local mode holds a
-    file lock), which would break any caller — N31 orchestrator, the chat tool
-    ``query_rag_tool`` — that reaches into the retriever more than once.
+    file lock), which would break any caller (N31 orchestrator, the chat tool
+    ``query_rag_tool``) that reaches into the retriever more than once.
 
     Args:
         qdrant_path:     Path to the on-disk Qdrant storage. Defaults to
@@ -320,7 +320,7 @@ def query_rag_tool(question: str) -> str:
 
     This is the LangGraph-compatible wrapper around ``RagRetriever.query()``.
     The output is a plain string rather than a list of ``RegulationChunk`` objects
-    because the LLM receives tool results as text — structured formatting here
+    because the LLM receives tool results as text: structured formatting here
     (article reference on its own line, score in brackets) makes it easy for the
     model to cite specific articles in its final answer.
 

--- a/src/shared/data_extraction/data_augmentation.py
+++ b/src/shared/data_extraction/data_augmentation.py
@@ -1,7 +1,16 @@
-"""
+"""Albumentations pipeline that balances the YOLO team-logo training set by class.
 
-Data augmentation file for the train training set of the image dataset.
+Archived (see ``src/shared/README.md``): an early iteration of the extraction
+layer, superseded by ``src/data_extraction/legacy/image_augmentation.py``.
+Kept here only because a notebook under ``src/vision/`` still imports it by
+name; not part of any active pipeline.
 
+For every team under ``TARGET_PER_CLASS`` training images, repeatedly picks a
+random existing image for that team and writes a transformed copy (flip,
+brightness/contrast, shift-scale-rotate, Gaussian blur) until the target is
+reached, so no team's detector is starved of examples relative to the others.
+``BASE_DIR`` is a machine-local path from an earlier university term and will
+not resolve elsewhere.
 """
 
 
@@ -19,7 +28,7 @@ CLASS_NAMES = [
 TARGET_PER_CLASS = 250
 BASE_DIR = r"C:\Users\victo\Desktop\Documents\Tercer año\Segundo Cuatrimestre\Finales\f1-strategy\f1-dataset"
 
-# Transformaciones con Albumentations
+# Albumentations transform pipeline
 transform = A.Compose(
     [
         A.HorizontalFlip(p=0.5),
@@ -40,7 +49,12 @@ transform = A.Compose(
 
 
 def get_dominant_class_id(label_path):
-    """Obtiene la clase dominante de las etiquetas YOLO"""
+    """Return the most frequent class id in a YOLO label file, or None if absent/empty.
+
+    Majority vote rather than the first line: a frame can carry boxes for more
+    than one team (overlapping cars), and the image is filed under whichever
+    team dominates it for the per-class counting in ``main``.
+    """
     if not os.path.exists(label_path):
         return None
 
@@ -60,7 +74,11 @@ def get_dominant_class_id(label_path):
 
 
 def read_yolo_labels(label_path):
-    """Lee archivos de etiquetas YOLO"""
+    """Read a YOLO label file into a list of normalized ``[x, y, w, h]`` boxes.
+
+    Returns an empty list when the file is missing rather than raising, so
+    ``augment_image`` can still transform an image with no labelled boxes.
+    """
     bboxes = []
     if os.path.exists(label_path):
         with open(label_path, 'r') as f:
@@ -72,36 +90,46 @@ def read_yolo_labels(label_path):
 
 
 def write_yolo_labels(label_path, bboxes, class_id):
-    """Escribe etiquetas en formato YOLO"""
+    """Write ``bboxes`` to a YOLO-format label file, one line per box, all tagged with ``class_id``.
+
+    Opens in write mode, so any prior contents at ``label_path`` are discarded.
+    """
     with open(label_path, 'w') as f:
         for bbox in bboxes:
             f.write(f"{class_id} {' '.join(map(str, bbox))}\n")
 
 
 def augment_image(img_path, label_path, output_img_path, output_label_path, class_id):
-    """Realiza el aumento de datos usando Pillow"""
+    """Apply the Albumentations transform to one image and its boxes, write the result.
+
+    When the transform drops every box (``ShiftScaleRotate`` can push a box
+    fully out of frame), an empty label file is written anyway rather than
+    skipping the pair, so a YOLO training run never hits an image with no
+    matching label file. Any failure is caught and logged per image so one
+    corrupt source file does not abort the whole class's augmentation pass.
+    """
     try:
-        # Cargar imagen con Pillow
+        # Load the image with Pillow
         with Image.open(img_path) as img:
             image_np = np.array(img.convert('RGB'))
             height, width = image_np.shape[:2]
 
-            # Leer bounding boxes
+            # Read the bounding boxes
             bboxes = read_yolo_labels(label_path)
             class_labels = [class_id] * len(bboxes)
 
-            # Aplicar transformaciones
+            # Apply the transform
             transformed = transform(
                 image=image_np,
                 bboxes=bboxes,
                 class_labels=class_labels
             )
 
-            # Guardar imagen aumentada
+            # Save the augmented image
             aug_img = Image.fromarray(transformed['image'])
             aug_img.save(output_img_path, quality=95)
 
-            # Guardar etiquetas
+            # Save the labels
             if transformed['bboxes']:
                 write_yolo_labels(output_label_path,
                                   transformed['bboxes'], class_id)
@@ -113,10 +141,17 @@ def augment_image(img_path, label_path, output_img_path, output_label_path, clas
 
 
 def main():    # Configure directories
+    """Top up every team's training images to ``TARGET_PER_CLASS``.
+
+    Groups the existing images by dominant class, then for each team short of
+    the target, repeatedly augments a random source image from that team
+    until it is reached. Teams already at or above target are left alone; no
+    image is ever deleted.
+    """
     train_images_dir = os.path.join(BASE_DIR, "train", "images")
     train_labels_dir = os.path.join(BASE_DIR, "train", "labels")
 
-    # Verify directories
+    # Verify the directories exist
     if not os.path.exists(train_images_dir):
         raise FileNotFoundError(
             f"Directory not found: {train_images_dir}")
@@ -142,7 +177,7 @@ def main():    # Configure directories
         if class_id is not None and class_id in class_files:
             class_files[class_id].append((img_path, label_path))
 
-    # Balancear clases
+    # Balance the classes
     for class_id, files in class_files.items():
         class_name = CLASS_NAMES[class_id]
         current_count = len(files)

--- a/src/shared/data_extraction/fastf1_extractor.py
+++ b/src/shared/data_extraction/fastf1_extractor.py
@@ -1,5 +1,10 @@
-"""
-Archive for extracting data from Spanish Grand Prix 2023
+"""First-iteration FastF1 wrapper, archived (see ``src/shared/README.md``).
+
+Superseded by ``src/data_extraction/fastf1/session_extractor.py`` and
+``scripts/download_data.py``. ``extract_f1_data`` takes any year/GP/session,
+but the ``__main__`` block below only ever ran it against the 2023 Spanish
+GP, the first race this project pulled data for. Kept because
+``notebooks/data_engineering/N01_data_download.ipynb`` still imports it.
 """
 
 import fastf1 as ff1
@@ -8,7 +13,14 @@ from pathlib import Path
 
 
 def extract_f1_data(year: int, gp: str, session_type: str = 'R'):
-    """Extrae datos de FastF1 y los guarda en Parquet."""
+    """Load one FastF1 session and write its laps, pit stops, and weather to Parquet.
+
+    Pit stops are derived from ``laps`` by filtering on a non-null
+    ``PitInTime``, not fetched separately, so they are always a strict subset
+    of the laps file. Any failure (bad GP name, missing session, network
+    error) is caught and printed rather than raised, so a batch of calls over
+    several GPs does not stop at the first one that fails to load.
+    """
     Path("f1_cache").mkdir(parents=True, exist_ok=True)
     ff1.Cache.enable_cache("f1_cache")
 

--- a/src/shared/data_extraction/video_processor.py
+++ b/src/shared/data_extraction/video_processor.py
@@ -1,9 +1,25 @@
+"""YouTube downloader for the archived YOLO car-livery vision experiments.
+
+Archived (see ``src/shared/README.md``); superseded by
+``src/data_extraction/legacy/video_downloader.py``. Downloads full race
+videos, it does not extract frames, that step happened separately once a
+video had landed on disk.
+"""
+
 import subprocess
 from pathlib import Path
 
 
 def download_f1_video(url: str, filename: str):
-    """Download YouTube F1 Highlight videos (Creative Commons) using yt-dlp"""
+    """Download a Creative-Commons-licensed F1 highlight video via yt-dlp.
+
+    Writes to ``../f1-strategy/data/videos``, a path relative to wherever the
+    process is launched from and left over from an earlier repo layout; it
+    will not resolve unless run from that specific working directory. Any
+    failure (missing yt-dlp binary, network error, invalid URL) is caught
+    and printed rather than raised, so a batch of calls in ``__main__`` does
+    not stop at the first video that fails to download.
+    """
     try:
         output_path = Path("../f1-strategy/data/videos")
         output_path.mkdir(parents=True, exist_ok=True)

--- a/src/simulation/race_state_manager.py
+++ b/src/simulation/race_state_manager.py
@@ -366,9 +366,12 @@ class RaceStateManager:
 
         ``TrackStatus`` is always present (sourced from laps). Optional
         ``weather_df`` (from weather.parquet) adds temperature, humidity,
-        wind, and rainfall when available. The row is selected by linear
-        interpolation of the lap fraction — weather changes slowly enough
-        that a simple fractional index is sufficient for a replay demo.
+        wind, and rainfall when available. The row is picked by mapping the
+        lap fraction onto ``weather_df``'s row index (``int(lap_frac *
+        (len(weather_df) - 1))``): a proportional lookup, not an
+        interpolation between two samples. Weather changes slowly enough
+        over a race that a single nearest row is close enough for a replay
+        demo.
 
         Args:
             lap_number:  1-indexed lap number.

--- a/src/strategy/eval/__init__.py
+++ b/src/strategy/eval/__init__.py
@@ -11,6 +11,8 @@ Public API:
 - ``build_registry`` / ``load_registry`` - the consolidated metrics table.
 - ``build_calibration_report`` - reliability/Brier/ECE + quantile coverage.
 - ``build_reproduction_report`` - headline numbers re-derived vs the configs.
+- ``build_hygiene_report`` - data-leakage / train-serve-skew checks.
+- ``build_nlp_report`` - sentiment/intent/NER holdout metrics for the radio pipeline.
 """
 
 from src.strategy.eval.calibration import build_calibration_report

--- a/src/strategy/inference/tire_predictor.py
+++ b/src/strategy/inference/tire_predictor.py
@@ -1050,7 +1050,7 @@ if __name__ == "main":
     predictions_history = simulate_real_time_predictions(
         csv_path='../../outputs/week3/lap_prediction_data.csv',
         models_path='../../outputs/week5/models/',
-        interval=0.1,  # 5 seconds between updates
+        interval=0.1,  # seconds between updates
         compound_start_laps=compound_start_laps,
         max_rows=200,  # Optional: limit number of rows for testing
         prediction_horizon=3  # Show predictions for next 3 laps


### PR DESCRIPTION
Closes #621. Point 2 of the queue. Three parallel workers over disjoint scopes, **prose only, no code changed** (verified by diffing for non-comment lines).

Priority order was deliberate: **a docstring that contradicts its code is the only one of the three defects that can create a bug**, because it is how someone later "fixes" a correct sign into a broken one. That is not hypothetical here: `get_rival_states` once documented "positive = ahead" while returning the opposite.

Workers could only correct a contradiction where the code reads unambiguously. Where either side could be the wrong one, they reported and left it alone.

## 14 contradictions found, 11 fixed, 3 left alone

Roughly **90 % of what was read was left untouched** because it was already good. That was the instruction: volume of edits is not the goal, and much of this prose carries history that rewriting would destroy.

| where | claimed | actually |
|---|---|---|
| `radio_agent.py` + `strategy_orchestrator.py` | sub-agents need `LAPS`/`SESSION_META` globals via `setup_session()` | **that function exists nowhere in the repo**, and no sub-agent reads any such global |
| `scripts/build_rag_index.py` | embeddings from `all-MiniLM-L6-v2` | **BGE-M3**, 1024-dim |
| `scenario_bars.py` | MC score is `mean - alpha*std` | `alpha*E[S] + (1-alpha)*P10[S]` |
| `stream.py` + `window.py` | PySide6 dashboard not yet built, `set_left_content` API | fully implemented; those methods exist nowhere |
| `_make_inference_panel` (CLI) | routing-row behaviour for `active_agents` | **AST-verified as the only unused parameter**: both call sites pass it, the body never reads it |
| `RaceEventsPanel` | fade of ~0.4 s | 0.35 |
| `telemetry_panel.py` | speed range 0-340 km/h | 360, which its own comment ties to Monza's 357 peak |

The `build_rag_index` one has teeth beyond prose: anyone rebuilding the index off that docstring would expect the wrong vector dimension.

## Filed rather than fixed

The sweep was prose-only, so the code findings became issues: **#619** (a `NameError` on the fallback that exists to survive missing data) and **#620** (a duplicated severity dict that drifted and reproduces #398, so a double yellow renders grey in the dashboard).

## Verification

Ruff check and format clean repo-wide. Every touched file compiles. A scan of the diff for non-comment, non-docstring lines returns only em-dash replacements inside comments.