### PR TITLE
fix(agents): define DEFAULT_RACING_LAPS_UNDER_VSC and turn on the check that would have caught it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,23 +196,44 @@ target-version = ['py310', 'py311']
 
 [tool.ruff]
 line-length = 100
+# These packages predate the style rules and carry notebook-extracted code, so they
+# are not style-policed. They are NOT skipped outright: see per-file-ignores below,
+# which keeps undefined-name checking on. An undefined name is not a style opinion,
+# it is code that raises, and one had been sitting in src/agents/ unnoticed (#619).
 exclude = [
     "legacy/",
     ".nb_py/",
     "notebooks/",
-    "src/agents/",
-    "src/nlp/",
     "src/data_extraction/",
-    "src/strategy/",
     "src/telemetry/",
     "src/vision/",
-    "src/shared/",
     ".venv/",
 ]
+
+# The formatter does NOT read lint.per-file-ignores, so dropping these paths from the
+# global exclude above would have pulled them into `ruff format` as well: 15 files, a
+# reformat diff nobody asked for, on packages whose layout is deliberate. Keep the
+# formatter off them and let only the linter in.
+[tool.ruff.format]
+exclude = ["src/agents/**", "src/nlp/**", "src/strategy/**", "src/shared/**"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]
 ignore = ["E501"]
+
+# The formerly-excluded packages, now checked for ONE thing: F821, undefined name.
+# Everything else these files would trip is silenced, because enabling the full rule
+# set here means 40 style findings (27 unused imports, 7 import-position, 3 ambiguous
+# names) against the single real bug, and drowning a gate is how a gate gets ignored.
+#
+# Measured 2026-07-26: with only F821 live, these paths report exactly one finding,
+# which is #619 and is fixed in the same commit as this config. So this costs nothing
+# today and catches the next one on the first CI run.
+[tool.ruff.lint.per-file-ignores]
+"src/agents/**" = ["E", "I", "W", "F401", "F811", "F541", "F841", "F601", "F632"]
+"src/nlp/**" = ["E", "I", "W", "F401", "F811", "F541", "F841", "F601", "F632"]
+"src/strategy/**" = ["E", "I", "W", "F401", "F811", "F541", "F841", "F601", "F632"]
+"src/shared/**" = ["E", "I", "W", "F401", "F811", "F541", "F841", "F601", "F632"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/src/agents/position_projection.py
+++ b/src/agents/position_projection.py
@@ -75,6 +75,11 @@ _MEASURED_TABLES = Path(__file__).resolve().parents[2] / "data" / "mc_measured_v
 DEFAULT_UNDERCUT_BAND_S = 4.91
 DEFAULT_NEUTRALISATION_RATE = 0.0179
 DEFAULT_RACING_LAPS_UNDER_SC = 2.61
+# Measured separately from the SC figure because a VSC leaves more of the window
+# raceable (2.90 laps against 2.61). This constant was REFERENCED at the bottom of
+# measured_racing_laps and never defined, so the fallback that exists to survive a
+# missing data/ raised NameError on exactly the VSC branch it was there to serve.
+DEFAULT_RACING_LAPS_UNDER_VSC = 2.90
 
 # How close we must be for the car ahead to be costing us downforce. This is not
 # a tuning knob: it is the proximity the clean-air table was measured at, so

--- a/src/strategy/inference/tire_predictor.py
+++ b/src/strategy/inference/tire_predictor.py
@@ -1021,37 +1021,3 @@ def simulate_real_time_predictions(csv_path, models_path, interval=5, compound_s
     print(f"Total predictions generated: {len(all_predictions)}")
 
     return all_predictions
-
-
-if __name__ == "main":
-    # Define path to the CSV file
-    csv_path = '../../outputs/week3/lap_prediction_data.csv'
-
-    # Define path to models
-    models_path = '../../outputs/week5/models/'
-
-    # Define monitoring thresholds by compound
-    compound_start_laps = {
-        1: 6,   # Soft tires: monitor from lap 6 onwards
-        2: 12,  # Medium tires: monitor from lap 12 onwards
-        3: 25   # Hard tires: monitor from lap 25 onwards
-    }
-
-    # Call the prediction function
-    predictions = predict_tire_degradation(
-        csv_path,
-        models_path,
-        compound_start_laps=compound_start_laps
-    )
-    # Display the predictions
-    predictions.head()
-
-    # Run simulation
-    predictions_history = simulate_real_time_predictions(
-        csv_path='../../outputs/week3/lap_prediction_data.csv',
-        models_path='../../outputs/week5/models/',
-        interval=0.1,  # 5 seconds between updates
-        compound_start_laps=compound_start_laps,
-        max_rows=200,  # Optional: limit number of rows for testing
-        prediction_horizon=3  # Show predictions for next 3 laps
-    )


### PR DESCRIPTION
Closes #619.

`measured_racing_laps` referenced `DEFAULT_RACING_LAPS_UNDER_VSC`. **Nothing defined it.** Only the SC constant existed.

## Why nobody hit it

The line is a fallback, reached only when the measured tables are absent. On a normal checkout the function returns from the table first:

```
sc  -> 2.6093     vsc -> 2.9012      (from the table)
```

Force the tables away and the asymmetry appears:

```
sc  -> 2.61
vsc -> NameError: name 'DEFAULT_RACING_LAPS_UNDER_VSC' is not defined
```

That fallback exists **precisely so the projection survives a missing `data/mc_measured_v1.json`**, which is the state of every fresh clone before the Hugging Face download runs. It degraded gracefully on one branch and crashed on the other. A defence that only works when it is not needed is not a defence.

Defined at its measured value, **2.90** racing laps in a 5-lap window. A VSC leaves more of the window raceable than a Safety Car does, which is why it is a separate number rather than a reuse of 2.61.

## The check that would have caught it

`src/agents/` and `src/strategy/` were excluded from ruff **outright**, so the two most load-bearing packages in the repo got no undefined-name checking at all.

Dropping the exclusion is the wrong fix: it surfaces **40 style findings** (27 unused imports, 7 import-position, 3 ambiguous names) against this **one** real bug, and drowning a gate is how a gate gets ignored. So the packages are now linted for **F821 alone**, via `per-file-ignores`.

Measured: exactly one finding, this one. **Reverting the fix makes `ruff check` fail**, so the gate is demonstrably live rather than decorative.

### A second-order effect worth naming

The **formatter does not read `lint.per-file-ignores`**. Removing these paths from the global `exclude` also pulled them into `ruff format`, which wanted to reformat **15 files** on packages whose layout is deliberate. `[tool.ruff.format]` now excludes them explicitly, and `format --check` reports the same 95 files as before the change.

## Also: a dead block, where fixing the typo is the wrong move

`tire_predictor.py` ended with `if __name__ == "main":` instead of `"__main__"`, so 32 lines never ran.

The obvious fix is the typo. It would be wrong: the block points at `../../outputs/week3/lap_prediction_data.csv` and `../../outputs/week5/models/`, paths from the notebook era that **do not exist in this repo**. Correcting the guard would activate code that fails on its first line. Removed instead.

## Verification

48 tests in `tests/mc/` (projection + strategy goldens), ruff check and format clean repo-wide, and a real `f1-sim --no-llm` run on Lusail completes.