### PR TITLE
refactor(errors): narrow 19 exception clauses and document the 36 left broad

### DIFF
--- a/scripts/bench_subagent_latency.py
+++ b/scripts/bench_subagent_latency.py
@@ -46,7 +46,7 @@ try:
     if _env.exists():
         load_dotenv(_env)
 except ImportError:
-    pass
+    pass  # python-dotenv not installed - rely on env vars being set manually
 
 # Library log noise: silence aggressive INFO from transformers / setfit
 warnings.filterwarnings("ignore", category=FutureWarning)

--- a/scripts/cli/pickers.py
+++ b/scripts/cli/pickers.py
@@ -43,6 +43,11 @@ if _IS_WIN:
         # ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING
         _k32.SetConsoleMode(_k32.GetStdHandle(-11), 7)
     except Exception:
+        # Best-effort cosmetic setup only: on failure the console just falls
+        # back to plain (non-ANSI) output, which is harmless. The failure
+        # surface here is ctypes/OS-level (unsupported console host, sandboxed
+        # environment) rather than a specific Python exception type worth
+        # enumerating.
         pass
 
 
@@ -213,13 +218,30 @@ def discover_races(repo_root: Path, year: int = 2025) -> list[str]:
 _DRIVER_TEAM_CACHE: dict[str, str] | None = None
 
 
+def _resolve_laps_parquet_path(repo_root: Path) -> Path:
+    """Resolve the featured-laps parquet path, preferring ``get_data_root``.
+
+    Routes through ``get_data_root`` when the f1_strat_manager package is
+    importable so ``uv tool install`` cached layouts work; otherwise falls
+    back to the repo-relative path for bare dev checkouts (e.g. running
+    ``scripts/f1_cli.py`` before ``uv sync``).
+    """
+    try:
+        from src.f1_strat_manager.data_cache import get_data_root
+
+        return get_data_root() / "processed" / "laps_featured_2025.parquet"
+    except ImportError:
+        return repo_root / "data" / "processed" / "laps_featured_2025.parquet"
+
+
 def _load_driver_team_map(repo_root: Path) -> dict[str, str]:
     """Return {driver_code: team} built from laps_featured_2025.parquet (cached).
 
-    Resolves the parquet path through ``get_data_root`` when the
-    f1_strat_manager package is importable so that ``uv tool install``
-    cached layouts work; otherwise falls back to the repo-relative path
-    for bare dev checkouts.
+    Best-effort only: any failure to read or parse the parquet (file
+    missing, corrupt parquet, unexpected schema) degrades to an empty map
+    rather than raising. ``pick_driver``/``pick_rival_code`` already fall
+    back to asking the user to type the team manually whenever the code is
+    not found in this map, so a read failure here is never fatal to the CLI.
     """
     global _DRIVER_TEAM_CACHE
     if _DRIVER_TEAM_CACHE is not None:
@@ -227,12 +249,7 @@ def _load_driver_team_map(repo_root: Path) -> dict[str, str]:
     try:
         import pandas as pd
 
-        try:
-            from src.f1_strat_manager.data_cache import get_data_root
-
-            parquet = get_data_root() / "processed" / "laps_featured_2025.parquet"
-        except ImportError:
-            parquet = repo_root / "data" / "processed" / "laps_featured_2025.parquet"
+        parquet = _resolve_laps_parquet_path(repo_root)
         if parquet.exists():
             df = pd.read_parquet(parquet, columns=["Driver", "Team"])
             _DRIVER_TEAM_CACHE = (
@@ -244,6 +261,10 @@ def _load_driver_team_map(repo_root: Path) -> dict[str, str]:
         else:
             _DRIVER_TEAM_CACHE = {}
     except Exception:
+        # pandas/pyarrow raise a wide, version-dependent set of types for a
+        # malformed or unreadable parquet (OSError variants, pyarrow's own
+        # ArrowInvalid/ArrowIOError, KeyError on an unexpected schema) - not
+        # worth enumerating for a best-effort convenience lookup.
         _DRIVER_TEAM_CACHE = {}
     return _DRIVER_TEAM_CACHE
 

--- a/scripts/f1_cli.py
+++ b/scripts/f1_cli.py
@@ -24,7 +24,12 @@ import sys
 import warnings
 from pathlib import Path
 
-# Ensure UTF-8 on Windows terminals
+# Ensure UTF-8 on Windows terminals. Some hosts (IDE consoles, pytest's
+# capture, certain CI runners) replace sys.stdout/stderr with objects that
+# support reconfigure() but raise ValueError/OSError for an unsupported
+# combination of args on that particular stream - not worth enumerating for
+# a best-effort cosmetic setting; on failure the stream just keeps its
+# original encoding.
 if hasattr(sys.stdout, "reconfigure"):
     try:
         sys.stdout.reconfigure(encoding="utf-8", errors="replace")
@@ -67,7 +72,7 @@ try:
     if _env.exists():
         load_dotenv(_env)
 except ImportError:
-    pass
+    pass  # python-dotenv not installed - rely on env vars being set manually
 
 # ── CLI package imports ────────────────────────────────────────────────────────
 from cli.pickers import ask_again, discover_races, pick_mode  # noqa: E402

--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -51,12 +51,17 @@ if hasattr(sys.stdout, "reconfigure"):
     try:
         sys.stdout.reconfigure(encoding="utf-8", errors="replace")
     except Exception:
+        # Some hosts (IDE consoles, pytest capture, certain CI runners) replace
+        # sys.stdout with an object that supports reconfigure() but raises for
+        # this particular stream/arg combination (ValueError, OSError). Not
+        # worth enumerating for this best-effort setting; on failure the
+        # stream just keeps its original encoding.
         pass
 if hasattr(sys.stderr, "reconfigure"):
     try:
         sys.stderr.reconfigure(encoding="utf-8", errors="replace")
     except Exception:
-        pass
+        pass  # same rationale as sys.stdout above
 
 # Suppress stray SWIG DeprecationWarnings from C-extension imports.
 warnings.filterwarnings("ignore", message=".*builtin type.*__module__.*")
@@ -124,7 +129,7 @@ try:
     if _env.exists():
         load_dotenv(_env)
 except ImportError:
-    pass
+    pass  # python-dotenv not installed - rely on env vars being set manually
 
 # ---------------------------------------------------------------------------
 # Imports — NLP models load eagerly when strategy_orchestrator imports radio_agent
@@ -1338,6 +1343,9 @@ def run(args: argparse.Namespace) -> None:
             if is_first_run():
                 ensure_setup()
         except ImportError:
+            # Package not installed (extremely rare: only if the user copied
+            # scripts/ in isolation). Fall through and let the race-dir/
+            # featured-parquet existence checks below error with a clear message.
             pass
 
     raw_dir = Path(args.raw_dir)

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -43,7 +43,15 @@ while not (_REPO_ROOT / '.git').exists():
 try:
     from src.f1_strat_manager.data_cache import get_data_root as _get_data_root
     _DATA_ROOT = _get_data_root()
-except Exception:
+except (ImportError, OSError, RuntimeError):
+    # Every way get_data_root() can fail, enumerated against its body in
+    # src/f1_strat_manager/data_cache.py: ImportError from the import itself on a
+    # bare dev checkout; OSError from the three mkdir() calls (read-only mount,
+    # permissions); RuntimeError from Path.home() and Path.expanduser(), which
+    # raise when no home directory resolves. That last one is not hypothetical:
+    # the Path.home() branch IS the `uv tool install` path this block exists to
+    # serve, and a container with no HOME would take it. Falling back to the
+    # repo-relative data/ is right for all three.
     _DATA_ROOT = _REPO_ROOT / 'data'
 
 _MODELS_DIR = _DATA_ROOT / 'models' / 'lap_time'

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -37,7 +37,15 @@ while not (_REPO_ROOT / '.git').exists():
 try:
     from src.f1_strat_manager.data_cache import get_data_root as _get_data_root
     _DATA_ROOT = _get_data_root()
-except Exception:
+except (ImportError, OSError, RuntimeError):
+    # Every way get_data_root() can fail, enumerated against its body in
+    # src/f1_strat_manager/data_cache.py: ImportError from the import itself on a
+    # bare dev checkout; OSError from the three mkdir() calls (read-only mount,
+    # permissions); RuntimeError from Path.home() and Path.expanduser(), which
+    # raise when no home directory resolves. That last one is not hypothetical:
+    # the Path.home() branch IS the `uv tool install` path this block exists to
+    # serve, and a container with no HOME would take it. Falling back to the
+    # repo-relative data/ is right for all three.
     _DATA_ROOT = _REPO_ROOT / 'data'
 
 from src.f1_strat_manager.gp_slugs import (  # noqa: E402

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -42,7 +42,15 @@ while not (_REPO_ROOT / '.git').exists():
 try:
     from src.f1_strat_manager.data_cache import get_data_root as _get_data_root
     _DATA_ROOT = _get_data_root()
-except Exception:
+except (ImportError, OSError, RuntimeError):
+    # Every way get_data_root() can fail, enumerated against its body in
+    # src/f1_strat_manager/data_cache.py: ImportError from the import itself on a
+    # bare dev checkout; OSError from the three mkdir() calls (read-only mount,
+    # permissions); RuntimeError from Path.home() and Path.expanduser(), which
+    # raise when no home directory resolves. That last one is not hypothetical:
+    # the Path.home() branch IS the `uv tool install` path this block exists to
+    # serve, and a container with no HOME would take it. Falling back to the
+    # repo-relative data/ is right for all three.
     _DATA_ROOT = _REPO_ROOT / 'data'
 
 from src.f1_strat_manager.gp_slugs import rekey_by_slug, slug_from_event_name  # noqa: E402

--- a/src/agents/radio_agent.py
+++ b/src/agents/radio_agent.py
@@ -77,7 +77,15 @@ if str(_REPO_ROOT) not in sys.path:
 try:
     from src.f1_strat_manager.data_cache import get_data_root as _get_data_root
     _DATA_ROOT = _get_data_root()
-except Exception:
+except (ImportError, OSError, RuntimeError):
+    # Every way get_data_root() can fail, enumerated against its body in
+    # src/f1_strat_manager/data_cache.py: ImportError from the import itself on a
+    # bare dev checkout; OSError from the three mkdir() calls (read-only mount,
+    # permissions); RuntimeError from Path.home() and Path.expanduser(), which
+    # raise when no home directory resolves. That last one is not hypothetical:
+    # the Path.home() branch IS the `uv tool install` path this block exists to
+    # serve, and a container with no HOME would take it. Falling back to the
+    # repo-relative data/ is right for all three.
     _DATA_ROOT = _REPO_ROOT / "data"
 
 # ── Module-level globals ───────────────────────────────────────────────────────

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -48,7 +48,15 @@ while not (_REPO_ROOT / '.git').exists():
 try:
     from src.f1_strat_manager.data_cache import get_data_root as _get_data_root
     _DATA_ROOT = _get_data_root()
-except Exception:
+except (ImportError, OSError, RuntimeError):
+    # Every way get_data_root() can fail, enumerated against its body in
+    # src/f1_strat_manager/data_cache.py: ImportError from the import itself on a
+    # bare dev checkout; OSError from the three mkdir() calls (read-only mount,
+    # permissions); RuntimeError from Path.home() and Path.expanduser(), which
+    # raise when no home directory resolves. That last one is not hypothetical:
+    # the Path.home() branch IS the `uv tool install` path this block exists to
+    # serve, and a container with no HOME would take it. Falling back to the
+    # repo-relative data/ is right for all three.
     _DATA_ROOT = _REPO_ROOT / 'data'
 
 logger = logging.getLogger(__name__)

--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -333,7 +333,10 @@ class F1ArcadeView(arcade.View):
                 creationflags=creationflags,
             )
             logger.info("Dashboard subprocess spawned (pid=%s)", self._dashboard_proc.pid)
-        except Exception as exc:
+        except (OSError, ValueError) as exc:
+            # subprocess.Popen documents OSError (e.g. the interpreter path
+            # cannot be executed) and ValueError (bad argument combination)
+            # as its failure modes; nothing else escapes a plain Popen() call.
             logger.warning(
                 "Dashboard spawn failed (%s) — arcade continues without it",
                 exc,
@@ -369,7 +372,10 @@ class F1ArcadeView(arcade.View):
             except subprocess.TimeoutExpired:
                 logger.warning("Dashboard did not exit in 3s — killing")
                 self._dashboard_proc.kill()
-            except Exception as exc:
+            except OSError as exc:
+                # terminate()/wait() on an already-dead or inaccessible
+                # process raise OSError subclasses (e.g. ProcessLookupError);
+                # nothing else is documented for these two calls.
                 logger.warning("Dashboard teardown error: %s", exc)
             self._dashboard_proc = None
 

--- a/src/arcade/dashboard/stream_client.py
+++ b/src/arcade/dashboard/stream_client.py
@@ -132,5 +132,6 @@ class TelemetryStreamClient(QThread):
             try:
                 self._socket.close()
             except OSError:
+                # Socket may already be broken/closed on the far end — nothing to undo.
                 pass
             self._socket = None

--- a/src/arcade/data.py
+++ b/src/arcade/data.py
@@ -273,7 +273,12 @@ class SessionLoader:
         # round number.
         try:
             location = str(session.event.get("Location", "") or "")
-        except Exception:
+        except (AttributeError, KeyError):
+            # session.event is a pandas Series (fastf1.events.Event); its
+            # .get() already returns the default instead of raising for a
+            # missing key. The only realistic failure is session.event
+            # itself not being Series-like (AttributeError on .get) or a
+            # custom __getitem__ override raising KeyError internally.
             location = ""
 
         driver_nums = list(session.drivers)
@@ -440,7 +445,11 @@ class SessionLoader:
             y = tel["Y"].to_numpy().astype(float)
             drs = tel["DRS"].to_numpy().astype(float) if "DRS" in tel.columns else np.zeros(len(x))
             return x, y, drs
-        except Exception as exc:
+        except (KeyError, ValueError, AttributeError) as exc:
+            # Same enumeration as _process_driver_data's get_telemetry() catch
+            # above: pick_fastest() returning None -> AttributeError,
+            # get_car_data/get_pos_data doing DriverNumber/column lookups ->
+            # KeyError, numeric casts on malformed telemetry -> ValueError.
             logger.warning("Reference lap extraction failed (%s) - using empty geometry", exc)
             return np.zeros(0), np.zeros(0), np.zeros(0)
 
@@ -485,7 +494,12 @@ class SessionLoader:
                 return {}
             grouped = subset.groupby("LapNumber")["TrackStatus"].first()
             return {int(lap): str(code) for lap, code in grouped.items()}
-        except Exception:
+        except (KeyError, ValueError, TypeError) as exc:
+            # KeyError: "LapNumber" missing despite the "TrackStatus" presence
+            # check above. ValueError/TypeError: a lap value int() cannot
+            # convert. Pure pandas indexing beyond this is not expected to
+            # raise anything else.
+            logger.debug("Track-status-by-lap extraction failed (%s) - panel stays hidden", exc)
             return {}
 
     def _safe_rotation(self, session: Any) -> float:
@@ -494,7 +508,13 @@ class SessionLoader:
             if info is None or not hasattr(info, "rotation"):
                 return 0.0
             return float(info.rotation)
-        except Exception:
+        except Exception as exc:
+            # session.get_circuit_info() fetches from the MultiViewer API
+            # (fastf1.mvapi.get_circuit_info) — genuine network I/O with an
+            # undocumented exception surface (HTTP/connection/JSON errors),
+            # so this stays broad. Logged so a real regression still leaves
+            # a trace instead of silently flattening every rotation to 0.
+            logger.debug("Circuit rotation lookup failed (%s) - defaulting to 0.0", exc)
             return 0.0
 
     def _session_circuit_length(self, session, ref_x: np.ndarray, ref_y: np.ndarray) -> float:
@@ -514,8 +534,12 @@ class SessionLoader:
             length = float(tel["Distance"].iloc[-1])
             if 1500.0 < length < 12000.0:
                 return length
-        except Exception:
-            pass
+        except (KeyError, ValueError, IndexError, AttributeError) as exc:
+            # pick_fastest() may return None (AttributeError on
+            # .get_car_data()); get_car_data/add_distance do DriverNumber
+            # and channel lookups (KeyError), numeric casts (ValueError),
+            # and .iloc[-1] on a possibly-empty Distance column (IndexError).
+            logger.debug("Fastest-lap circuit length failed (%s) - using polyline estimate", exc)
         return self._estimate_circuit_length(ref_x, ref_y)
 
     def _estimate_circuit_length(self, ref_x: np.ndarray, ref_y: np.ndarray) -> float:

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -609,7 +609,11 @@ class SimConnector(threading.Thread):
         if self._radio_runner is not None:
             try:
                 radio_msgs, rcm_events = self._radio_runner.radios_for_lap(lap_num)
-            except Exception as exc:
+            except (KeyError, ValueError, TypeError) as exc:
+                # radios_for_lap does plain pandas row indexing + int/str
+                # casts (see RadioPipelineRunner._radio_row_to_dict /
+                # _rcm_row_to_dict) — a malformed lap_number or a missing
+                # column are the only realistic failure modes here.
                 logger.debug("radios_for_lap(%d) failed: %s", lap_num, exc)
 
         # Re-assert an active Safety Car on the laps whose RCM window carries no

--- a/src/arcade/stream.py
+++ b/src/arcade/stream.py
@@ -64,6 +64,7 @@ class TelemetryStreamServer:
             try:
                 self._server_socket.close()
             except OSError:
+                # Already closed/broken (e.g. peer reset first) — nothing to undo.
                 pass
             self._server_socket = None
         with self._clients_lock:
@@ -71,6 +72,7 @@ class TelemetryStreamServer:
                 try:
                     client.close()
                 except OSError:
+                    # Same idempotent-close rationale as the server socket above.
                     pass
             self._clients.clear()
         logger.info("TelemetryStreamServer stopped")
@@ -139,6 +141,7 @@ class TelemetryStreamServer:
             try:
                 client_socket.close()
             except OSError:
+                # Remote end may have already dropped the connection.
                 pass
             self._prune_clients([client_socket])
 
@@ -148,4 +151,5 @@ class TelemetryStreamServer:
                 try:
                     self._clients.remove(client)
                 except ValueError:
+                    # Another thread already pruned this socket first — fine.
                     pass

--- a/src/f1_strat_manager/laps_augment.py
+++ b/src/f1_strat_manager/laps_augment.py
@@ -53,7 +53,18 @@ try:
     from src.f1_strat_manager.gp_slugs import FOLDER_ALIASES as _FOLDER_ALIASES
 
     _FRIENDLY_TO_FOLDER: Dict[str, str] = {v: k for k, v in _FOLDER_ALIASES.items()}
-except Exception:  # pragma: no cover
+except ImportError as exc:  # pragma: no cover
+    # gp_slugs failed to import, or FOLDER_ALIASES was renamed/removed there
+    # (a `from X import NAME` raises ImportError for both). FOLDER_ALIASES is
+    # a plain dict literal in gp_slugs.py, so the dict-comprehension line
+    # below cannot itself raise anything else. This falls back to a single
+    # stale entry, so it is worth a warning rather than a fully silent degrade.
+    logger.warning(
+        "Could not load FOLDER_ALIASES from gp_slugs (%s); falling back to a "
+        "single hardcoded Miami mapping. _raw_race_dir may misresolve other "
+        "renamed circuits.",
+        exc,
+    )
     _FRIENDLY_TO_FOLDER = {"Miami": "Miami_Gardens"}
 
 

--- a/src/rag/retriever.py
+++ b/src/rag/retriever.py
@@ -71,7 +71,12 @@ class RagConfig:
             from src.f1_strat_manager.data_cache import get_data_root
 
             return get_data_root() / "rag"
-        except Exception:
+        except (ImportError, OSError):
+            # ImportError: helper not on sys.path (uv tool install layout).
+            # OSError: get_data_root()/_find_repo_root() only ever touch the
+            # local filesystem (env var, path resolve, mkdir) — read in full,
+            # neither does network I/O, so OSError is the only realistic
+            # runtime failure besides the import itself.
             return self._repo_root / "data" / "rag"
 
     @property

--- a/src/shared/data_extraction/openf1_extractor.py
+++ b/src/shared/data_extraction/openf1_extractor.py
@@ -193,8 +193,10 @@ def extract_openf1_intervals(year, gp_name, max_interval=None):
                 try:
                     # Try to convert to numeric
                     intervals_df[col] = pd.to_numeric(intervals_df[col])
-                except:
-                    # If it fails, ensure it's string
+                except (ValueError, TypeError):
+                    # pd.to_numeric raises ValueError for unparseable strings
+                    # and TypeError for incompatible element types. Either way,
+                    # ensure it's string.
                     intervals_df[col] = intervals_df[col].astype(str)
 
         # Save data in Parquet format


### PR DESCRIPTION
Closes #626. Point 3 of the queue.

`src/` held **211 `except` clauses. 107 were `except Exception` or a bare `except:`** More than half did not say what they caught.

## The rule, and why it was strict

**Narrow only if you can enumerate what the `try` block actually raises, by reading the code it calls.** If you cannot enumerate it, leave it and log why.

Both mistakes are real here and both are expensive:

- **Too broad** is how a bare `except` once hid a `ValueError` on **every routed lap** while the system kept paying for LLM calls it discarded.
- **Too narrow** turns a graceful degradation into a production crash, and **no test here would catch it**, because these blocks guard the paths that only fire when a parquet is missing, FastF1 fails, or a weight file is absent.

**19 narrowed or fixed. 36 deliberately left broad, each with its reason logged.** The left-alone list is the more useful half: it tells the next reader what has already been considered. Where a comment already explained a broad catch, that was treated as evidence it was deliberate. `src/nlp/` needed nothing.

## The one that had to be corrected on review

A worker narrowed the data-root resolution in **all five sub-agents** to `except (ImportError, OSError)`, reporting that it had enumerated `get_data_root()` and found only the import and `Path.mkdir`.

**It missed two.** `Path.home()` and `Path.expanduser()` raise **`RuntimeError`**, not `OSError`:

```
Path.home() -> RuntimeError: Could not determine home directory.
```

And the `Path.home()` branch is not obscure: it **is** the `uv tool install` path that the comment directly above the try block says the fallback exists to serve. A container with no `HOME` takes it. The narrowing would have turned a working fallback into an **import-time crash in all five agents**, in precisely the scenario the block was written for.

Corrected to `(ImportError, OSError, RuntimeError)` with each source named against `get_data_root`'s body.

The lesson is worth stating: **requiring enumeration was necessary but not sufficient.** A worker can believe it enumerated and be wrong, so the enumeration itself needs verifying. That check is the only reason this PR is not shipping a regression.

## Also

Three swallows in `arcade/data.py` (`_safe_rotation`, `_session_circuit_length`, `_extract_track_status_by_lap`) caught `Exception` with **zero logging**. A future regression in circuit geometry or the safety-car panel would have vanished without trace. They keep the broad catch, which is right for their network and library boundaries, and now leave a `logger.debug`.

## Verification

Ruff check and format clean repo-wide, every touched module imports, and a real `f1-sim --no-llm` run on Lusail completes.