### PR TITLE
Promote dev to main: the exception sweep, the eval team alias, and six behaviour fixes past an adversarial gate

### DIFF
--- a/scripts/bench_nlp_pipeline_cpu.py
+++ b/scripts/bench_nlp_pipeline_cpu.py
@@ -456,7 +456,15 @@ def _classify_rcm_event(row: dict[str, Any]) -> str:
         if flag in ("YELLOW", "DOUBLE YELLOW"):
             scope = str(row.get("Scope", "")).strip()
             sector = row.get("Sector")
-            if scope == "Sector" or (pd.notna(sector) if not isinstance(sector, str) else sector):
+            # "Is a sector present?" means two different things by type, and packing
+            # both into one guard hid which: an empty string counts as absent, a NaN
+            # counts as absent, anything else counts as present.
+            if isinstance(sector, str):
+                has_sector = bool(sector)
+            else:
+                has_sector = bool(pd.notna(sector))
+
+            if scope == "Sector" or has_sector:
                 return "YELLOW_FLAG_SECTOR"
             return "YELLOW_FLAG"
         return "OTHER"

--- a/scripts/bench_subagent_latency.py
+++ b/scripts/bench_subagent_latency.py
@@ -46,7 +46,7 @@ try:
     if _env.exists():
         load_dotenv(_env)
 except ImportError:
-    pass
+    pass  # python-dotenv not installed - rely on env vars being set manually
 
 # Library log noise: silence aggressive INFO from transformers / setfit
 warnings.filterwarnings("ignore", category=FutureWarning)

--- a/scripts/cli/pickers.py
+++ b/scripts/cli/pickers.py
@@ -43,6 +43,11 @@ if _IS_WIN:
         # ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING
         _k32.SetConsoleMode(_k32.GetStdHandle(-11), 7)
     except Exception:
+        # Best-effort cosmetic setup only: on failure the console just falls
+        # back to plain (non-ANSI) output, which is harmless. The failure
+        # surface here is ctypes/OS-level (unsupported console host, sandboxed
+        # environment) rather than a specific Python exception type worth
+        # enumerating.
         pass
 
 
@@ -213,13 +218,30 @@ def discover_races(repo_root: Path, year: int = 2025) -> list[str]:
 _DRIVER_TEAM_CACHE: dict[str, str] | None = None
 
 
+def _resolve_laps_parquet_path(repo_root: Path) -> Path:
+    """Resolve the featured-laps parquet path, preferring ``get_data_root``.
+
+    Routes through ``get_data_root`` when the f1_strat_manager package is
+    importable so ``uv tool install`` cached layouts work; otherwise falls
+    back to the repo-relative path for bare dev checkouts (e.g. running
+    ``scripts/f1_cli.py`` before ``uv sync``).
+    """
+    try:
+        from src.f1_strat_manager.data_cache import get_data_root
+
+        return get_data_root() / "processed" / "laps_featured_2025.parquet"
+    except ImportError:
+        return repo_root / "data" / "processed" / "laps_featured_2025.parquet"
+
+
 def _load_driver_team_map(repo_root: Path) -> dict[str, str]:
     """Return {driver_code: team} built from laps_featured_2025.parquet (cached).
 
-    Resolves the parquet path through ``get_data_root`` when the
-    f1_strat_manager package is importable so that ``uv tool install``
-    cached layouts work; otherwise falls back to the repo-relative path
-    for bare dev checkouts.
+    Best-effort only: any failure to read or parse the parquet (file
+    missing, corrupt parquet, unexpected schema) degrades to an empty map
+    rather than raising. ``pick_driver``/``pick_rival_code`` already fall
+    back to asking the user to type the team manually whenever the code is
+    not found in this map, so a read failure here is never fatal to the CLI.
     """
     global _DRIVER_TEAM_CACHE
     if _DRIVER_TEAM_CACHE is not None:
@@ -227,12 +249,7 @@ def _load_driver_team_map(repo_root: Path) -> dict[str, str]:
     try:
         import pandas as pd
 
-        try:
-            from src.f1_strat_manager.data_cache import get_data_root
-
-            parquet = get_data_root() / "processed" / "laps_featured_2025.parquet"
-        except ImportError:
-            parquet = repo_root / "data" / "processed" / "laps_featured_2025.parquet"
+        parquet = _resolve_laps_parquet_path(repo_root)
         if parquet.exists():
             df = pd.read_parquet(parquet, columns=["Driver", "Team"])
             _DRIVER_TEAM_CACHE = (
@@ -244,6 +261,10 @@ def _load_driver_team_map(repo_root: Path) -> dict[str, str]:
         else:
             _DRIVER_TEAM_CACHE = {}
     except Exception:
+        # pandas/pyarrow raise a wide, version-dependent set of types for a
+        # malformed or unreadable parquet (OSError variants, pyarrow's own
+        # ArrowInvalid/ArrowIOError, KeyError on an unexpected schema) - not
+        # worth enumerating for a best-effort convenience lookup.
         _DRIVER_TEAM_CACHE = {}
     return _DRIVER_TEAM_CACHE
 

--- a/scripts/f1_cli.py
+++ b/scripts/f1_cli.py
@@ -24,7 +24,12 @@ import sys
 import warnings
 from pathlib import Path
 
-# Ensure UTF-8 on Windows terminals
+# Ensure UTF-8 on Windows terminals. Some hosts (IDE consoles, pytest's
+# capture, certain CI runners) replace sys.stdout/stderr with objects that
+# support reconfigure() but raise ValueError/OSError for an unsupported
+# combination of args on that particular stream - not worth enumerating for
+# a best-effort cosmetic setting; on failure the stream just keeps its
+# original encoding.
 if hasattr(sys.stdout, "reconfigure"):
     try:
         sys.stdout.reconfigure(encoding="utf-8", errors="replace")
@@ -67,7 +72,7 @@ try:
     if _env.exists():
         load_dotenv(_env)
 except ImportError:
-    pass
+    pass  # python-dotenv not installed - rely on env vars being set manually
 
 # ── CLI package imports ────────────────────────────────────────────────────────
 from cli.pickers import ask_again, discover_races, pick_mode  # noqa: E402

--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -1287,6 +1287,13 @@ def _make_inference_panel(
 # RaceState builder
 # ---------------------------------------------------------------------------
 
+# Imported, not redeclared: this number had grown a copy in the CLI, the arcade and
+# the telemetry backend, and three copies of one convention is how the next drift
+# starts. Its rationale and its honest limitation live with it (#628).
+from src.agents.position_projection import (  # noqa: E402
+    GAP_UNKNOWN_FALLBACK_S as _GAP_UNKNOWN_FALLBACK_S,
+)
+
 
 def _build_race_state(
     lap_state: dict[str, Any],
@@ -1298,9 +1305,29 @@ def _build_race_state(
     rivals = lap_state.get("rivals", [])
     weather = lap_state.get("weather", {})
 
-    our_pos = driver_st.get("position", 99)
+    our_pos = driver_st.get("position")
+    # The incomplete-lap guard in run()'s main loop (`_pos_raw is None or ...`)
+    # already skips any lap where the driver's position is unknown before
+    # _build_race_state is ever called. Reaching here with a None position
+    # means that invariant broke. Fail loudly instead of defaulting to a
+    # searchable P99: a fabricated position is exactly the value the
+    # `our_pos - 1` lookup below searches by, so an unknown position and a
+    # genuinely-last car would silently resolve to the same rival — the #428
+    # bug shape. Mirrors src/arcade/strategy.py's _build_race_state (fixed for
+    # the identical shape under #465); the caller's per-lap try/except (in
+    # run()) turns this into an [ERROR] row for the lap, not a crashed run.
+    if our_pos is None:
+        raise ValueError(
+            "_build_race_state: driver position is None; the incomplete-lap "
+            "guard should have skipped this lap before it reached "
+            "_build_race_state (#628)"
+        )
     car_ahead = next((r for r in rivals if r.get("position") == our_pos - 1), None)
-    gap_ahead_s = abs(car_ahead.get("interval_to_driver_s") or 0.0) if car_ahead else 0.0
+    if car_ahead is not None:
+        _interval = car_ahead.get("interval_to_driver_s")
+        gap_ahead_s = abs(_interval) if _interval is not None else _GAP_UNKNOWN_FALLBACK_S
+    else:
+        gap_ahead_s = 0.0
 
     cur_lap_time = driver_st.get("lap_time_s") or 0.0
     pace_delta_s = cur_lap_time - prev_lap_time if prev_lap_time else 0.0

--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -51,12 +51,17 @@ if hasattr(sys.stdout, "reconfigure"):
     try:
         sys.stdout.reconfigure(encoding="utf-8", errors="replace")
     except Exception:
+        # Some hosts (IDE consoles, pytest capture, certain CI runners) replace
+        # sys.stdout with an object that supports reconfigure() but raises for
+        # this particular stream/arg combination (ValueError, OSError). Not
+        # worth enumerating for this best-effort setting; on failure the
+        # stream just keeps its original encoding.
         pass
 if hasattr(sys.stderr, "reconfigure"):
     try:
         sys.stderr.reconfigure(encoding="utf-8", errors="replace")
     except Exception:
-        pass
+        pass  # same rationale as sys.stdout above
 
 # Suppress stray SWIG DeprecationWarnings from C-extension imports.
 warnings.filterwarnings("ignore", message=".*builtin type.*__module__.*")
@@ -124,7 +129,7 @@ try:
     if _env.exists():
         load_dotenv(_env)
 except ImportError:
-    pass
+    pass  # python-dotenv not installed - rely on env vars being set manually
 
 # ---------------------------------------------------------------------------
 # Imports — NLP models load eagerly when strategy_orchestrator imports radio_agent
@@ -1338,6 +1343,9 @@ def run(args: argparse.Namespace) -> None:
             if is_first_run():
                 ensure_setup()
         except ImportError:
+            # Package not installed (extremely rare: only if the user copied
+            # scripts/ in isolation). Fall through and let the race-dir/
+            # featured-parquet existence checks below error with a clear message.
             pass
 
     raw_dir = Path(args.raw_dir)

--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -1287,9 +1287,15 @@ def _make_inference_panel(
 # RaceState builder
 # ---------------------------------------------------------------------------
 
-# Imported, not redeclared: this number had grown a copy in the CLI, the arcade and
-# the telemetry backend, and three copies of one convention is how the next drift
-# starts. Its rationale and its honest limitation live with it (#628).
+# Imported, not redeclared. Its rationale and its honest limitation live with it.
+#
+# Be precise about how far this got, because a comment claiming a closed drift is
+# worse than no comment: the CLI and the arcade now share one constant, and the
+# telemetry BACKEND does not. It is a git submodule and cannot be changed from this
+# commit, and an adversarial gate counted SIX surviving copies of this convention
+# there and here, including one in `strategy.py` that defaults the same concept to
+# 2.0 on one request model and 0.0 on its sibling in the same file. Tracked, not
+# closed (#628).
 from src.agents.position_projection import (  # noqa: E402
     GAP_UNKNOWN_FALLBACK_S as _GAP_UNKNOWN_FALLBACK_S,
 )
@@ -1648,10 +1654,15 @@ def run(args: argparse.Namespace) -> None:
             # Gap to car directly ahead (from rivals list)
             rivals = lap_state.get("rivals", [])
             car_ahead = next((r for r in rivals if r.get("position") == position - 1), None)
+            # Display path, deliberately NOT using GAP_UNKNOWN_FALLBACK_S. Here a
+            # missing interval should read as missing, and the em-dash below does
+            # that: the fallback exists to stop the DECISION layer seeing a
+            # fabricated zero, and a table cell has no such problem. Keeping the
+            # two apart on purpose, rather than by oversight, which is what an
+            # adversarial gate flagged this line as.
             try:
-                gap_ahead = (
-                    abs(float(car_ahead.get("interval_to_driver_s") or 0.0)) if car_ahead else 0.0
-                )
+                measured = car_ahead.get("interval_to_driver_s") if car_ahead else None
+                gap_ahead = abs(float(measured)) if measured is not None else 0.0
             except (TypeError, ValueError):
                 gap_ahead = 0.0
             gap_str = f"{gap_ahead:.2f}" if gap_ahead > 0 else "—"

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -326,7 +326,7 @@ class PaceAgent:
         stint: int,
         tyre_life: int,
         compound: str,
-        position: int,
+        position: Optional[int],
         team: str,
         laps_since_pit: int,
         fuel_load: float,
@@ -544,7 +544,7 @@ class PaceAgent:
         stint: int,
         tyre_life: int,
         compound: str,
-        position: int,
+        position: Optional[int],
         team: str,
         laps_since_pit: int,
         fuel_load: float,
@@ -576,7 +576,12 @@ class PaceAgent:
             stint: Stint number (1-indexed), forwarded as a raw feature.
             tyre_life: Laps on current tyre set; drives FreshTyre flag.
             compound: Pirelli compound name.
-            position: Current race position (1-based).
+            position: Current race position (1-based). None when the source
+                telemetry has no reading for this lap; propagates as a missing
+                'Position' feature (NaN after _build_feature_row's numeric
+                coercion) rather than a fabricated grid slot, since XGBoost
+                splits natively on missing values (see the belt-and-braces
+                comment in _build_feature_row).
             team: Team name matching self.team_id encoding map.
             laps_since_pit: Laps since most recent pit stop.
             fuel_load: Estimated fuel fraction in [0, 1].
@@ -686,7 +691,17 @@ class PaceAgent:
             stint          = d.get('stint') or 1,
             tyre_life      = d.get('tyre_life') or 1,
             compound       = d.get('compound') or 'MEDIUM',
-            position       = d.get('position') or 1,
+            # Plain .get, no `or` fallback: `d.get('position') or 1` collapsed a
+            # missing telemetry reading AND the #428 sentinel (a stored `0`)
+            # into P1, the race leader, straight into the live N06 XGBoost
+            # feature (#628). Unlike race_situation_agent/pit_strategy_agent,
+            # this value is never used in a `position - 1` rival lookup here,
+            # so there is no lookup to fool — the honest fix is simply to let
+            # an unknown position propagate as None. _build_feature_row's
+            # existing pd.to_numeric(errors='coerce') turns that into NaN, and
+            # XGBoost handles a missing 'Position' natively via its
+            # default-left split direction, so no fabricated value is needed.
+            position       = d.get('position'),
             team           = meta.get('team') or 'Unknown',
             laps_since_pit = d.get('tyre_life') or 1,
             fuel_load      = laps_remaining / max(total_laps, 1),

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -43,7 +43,15 @@ while not (_REPO_ROOT / '.git').exists():
 try:
     from src.f1_strat_manager.data_cache import get_data_root as _get_data_root
     _DATA_ROOT = _get_data_root()
-except Exception:
+except (ImportError, OSError, RuntimeError):
+    # Every way get_data_root() can fail, enumerated against its body in
+    # src/f1_strat_manager/data_cache.py: ImportError from the import itself on a
+    # bare dev checkout; OSError from the three mkdir() calls (read-only mount,
+    # permissions); RuntimeError from Path.home() and Path.expanduser(), which
+    # raise when no home directory resolves. That last one is not hypothetical:
+    # the Path.home() branch IS the `uv tool install` path this block exists to
+    # serve, and a container with no HOME would take it. Falling back to the
+    # repo-relative data/ is right for all three.
     _DATA_ROOT = _REPO_ROOT / 'data'
 
 _MODELS_DIR = _DATA_ROOT / 'models' / 'lap_time'

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -68,8 +68,11 @@ TIRE_COMPOUNDS: dict = (
 )
 
 # ── Module-level constants ─────────────────────────────────────────────────────
-# FastF1 team name variants → N15 training names
-_TEAM_ALIASES: dict[str, str] = {'Racing Bulls': 'RB'}
+# FastF1 team name variants -> N15 training names. Imported rather than declared:
+# this map used to live here alone, and the eval harness that reproduces N15's
+# published MAE never got it, so 20 of 252 rows in the 2025 pit holdout were scored
+# as a different team (#629). One map, two consumers, no drift.
+from src.f1_strat_manager.team_aliases import TEAM_ALIASES as _TEAM_ALIASES  # noqa: E402
 
 # Fallback color→compound_id when TIRE_COMPOUNDS has no entry for the circuit/year
 _COMPOUND_FALLBACK: dict[str, int] = {'HARD': 1, 'MEDIUM': 3, 'SOFT': 5}

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -37,7 +37,15 @@ while not (_REPO_ROOT / '.git').exists():
 try:
     from src.f1_strat_manager.data_cache import get_data_root as _get_data_root
     _DATA_ROOT = _get_data_root()
-except Exception:
+except (ImportError, OSError, RuntimeError):
+    # Every way get_data_root() can fail, enumerated against its body in
+    # src/f1_strat_manager/data_cache.py: ImportError from the import itself on a
+    # bare dev checkout; OSError from the three mkdir() calls (read-only mount,
+    # permissions); RuntimeError from Path.home() and Path.expanduser(), which
+    # raise when no home directory resolves. That last one is not hypothetical:
+    # the Path.home() branch IS the `uv tool install` path this block exists to
+    # serve, and a container with no HOME would take it. Falling back to the
+    # repo-relative data/ is right for all three.
     _DATA_ROOT = _REPO_ROOT / 'data'
 
 from src.f1_strat_manager.gp_slugs import (  # noqa: E402

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -611,7 +611,10 @@ PIT WINDOW — end of race:
   NEVER recommend PIT_NOW, UNDERCUT, or OVERCUT when remaining laps <= 3.
   Exception: tyre failure is imminent (laps_to_cliff P10 < 2) or Safety Car deployed.
   Rationale: a pit stop costs ~22-25s; with ≤3 laps, fresh tyres recover at most ~1.5s
-  total. Net loss ≈ 20s = ~13 positions.
+  total. Net loss ≈ 20s. Under green-flag racing, where consecutive cars sit a
+  measured median 2.226s apart, that is worth ~9 positions, not 13: 13 positions
+  is the Safety Car bunched-field figure (median gap 1.4795s), and that case is
+  the exception handled above, not this rule.
 
 MINIMUM STINT LENGTH before a pit makes sense:
   SOFT: current tyre_life must be >= 8 laps before recommending a stop.
@@ -1181,7 +1184,14 @@ class PitStrategyAgent:
             Priority 1 — laps_to_cliff from N26 TireOutput: drives compound choice
             directly when available. Priority 2 — Pirelli average stint capacities
             (SOFT ~18 laps, MEDIUM ~30 laps, HARD ~38 laps) as fallback.
-            FIA mandatory two-compound rule is always applied.
+            Compound choice only excludes the compound currently fitted, it never
+            refits what you are on. That is not the FIA two-compound rule, Art.
+            30.5(m) for 2024-2025 (30.5(n) in 2023): this tool has no compound
+            history, so it cannot tell whether the obligation is already met, and
+            it forbids the legal, sometimes optimal same-compound refit, measured
+            in 629 of 2274 dry stints (27.7%) across data/raw/ 2023-2025. The real
+            obligation is `mandatory_stop_pending` in
+            src/agents/position_projection.py; this tool does not consult it.
 
             Args:
                 driver: FastF1 driver abbreviation.

--- a/src/agents/position_projection.py
+++ b/src/agents/position_projection.py
@@ -81,6 +81,20 @@ DEFAULT_RACING_LAPS_UNDER_SC = 2.61
 # missing data/ raised NameError on exactly the VSC branch it was there to serve.
 DEFAULT_RACING_LAPS_UNDER_VSC = 2.90
 
+# What a gap becomes when a car ahead exists but its interval was never measured.
+# NOT zero: 0.0 reads as side by side, and both the clean-air band above and N27's
+# sub-1.0s DRS window act on that, so a missing measurement would look like the most
+# aggressive possible situation. Three places needed this number (the CLI, the arcade
+# and the telemetry backend) and each had grown its own, which is how they drift.
+#
+# It is still a FABRICATED number and a real 2.0s gap is common, so it does not meet
+# the rule that a default must never be a value the code can also legitimately find.
+# It is less harmful than 0.0, not correct. The correct fix is RaceState.gap_ahead_s
+# becoming `float | None` the way RivalState.gap_ahead_s already is here, where every
+# consumer guards with `is not None`. That is a Pydantic contract change, so it is
+# tracked rather than smuggled in.
+GAP_UNKNOWN_FALLBACK_S = 2.0
+
 # How close we must be for the car ahead to be costing us downforce. This is not
 # a tuning knob: it is the proximity the clean-air table was measured at, so
 # crediting the gain to a car eight seconds back would apply a number outside

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -42,7 +42,15 @@ while not (_REPO_ROOT / '.git').exists():
 try:
     from src.f1_strat_manager.data_cache import get_data_root as _get_data_root
     _DATA_ROOT = _get_data_root()
-except Exception:
+except (ImportError, OSError, RuntimeError):
+    # Every way get_data_root() can fail, enumerated against its body in
+    # src/f1_strat_manager/data_cache.py: ImportError from the import itself on a
+    # bare dev checkout; OSError from the three mkdir() calls (read-only mount,
+    # permissions); RuntimeError from Path.home() and Path.expanduser(), which
+    # raise when no home directory resolves. That last one is not hypothetical:
+    # the Path.home() branch IS the `uv tool install` path this block exists to
+    # serve, and a container with no HOME would take it. Falling back to the
+    # repo-relative data/ is right for all three.
     _DATA_ROOT = _REPO_ROOT / 'data'
 
 from src.f1_strat_manager.gp_slugs import rekey_by_slug, slug_from_event_name  # noqa: E402

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -686,13 +686,19 @@ def _ensure_timedelta_laps(laps_df: pd.DataFrame) -> pd.DataFrame:
 
     # Normalise TrackStatus: featured parquet has track_status_clean (int 0/1/2),
     # but feature builders call _dominant_status() which accesses TrackStatus (string).
+    #
+    # track_status_clean is documented as a 3-class signal (0=green, 1=yellow/VSC,
+    # 2=SC/red), but it is measured uniformly 0 across all 204366 rows of every
+    # published featured parquet (#615). The cause is structural, not a data bug:
+    # N04's IsAccurate gate drops neutralised and pit laps before a lap reaches the
+    # featured frame, so any lap that survives into it genuinely is green. A lap
+    # carrying this column cannot hold a 1 or a 2, not merely happens not to. A
+    # reverse map keyed on those two values would therefore never fire, and keeping
+    # it would advertise a 3-class reconstruction this frame cannot deliver. If a
+    # lap's real track status is needed (yellow/VSC/SC), it has to come from
+    # data/raw/, where the neutralised laps are still present.
     if 'TrackStatus' not in df.columns:
-        if 'track_status_clean' in df.columns:
-            # Reverse map: 0=green→'1', 1=yellow/VSC→'6', 2=SC/red→'4'
-            ts_reverse = {0: '1', 1: '6', 2: '4'}
-            df['TrackStatus'] = df['track_status_clean'].map(ts_reverse).fillna('1')
-        else:
-            df['TrackStatus'] = '1'
+        df['TrackStatus'] = '1'
 
     return df
 

--- a/src/agents/radio_agent.py
+++ b/src/agents/radio_agent.py
@@ -77,7 +77,15 @@ if str(_REPO_ROOT) not in sys.path:
 try:
     from src.f1_strat_manager.data_cache import get_data_root as _get_data_root
     _DATA_ROOT = _get_data_root()
-except Exception:
+except (ImportError, OSError, RuntimeError):
+    # Every way get_data_root() can fail, enumerated against its body in
+    # src/f1_strat_manager/data_cache.py: ImportError from the import itself on a
+    # bare dev checkout; OSError from the three mkdir() calls (read-only mount,
+    # permissions); RuntimeError from Path.home() and Path.expanduser(), which
+    # raise when no home directory resolves. That last one is not hypothetical:
+    # the Path.home() branch IS the `uv tool install` path this block exists to
+    # serve, and a container with no HOME would take it. Falling back to the
+    # repo-relative data/ is right for all three.
     _DATA_ROOT = _REPO_ROOT / "data"
 
 # ── Module-level globals ───────────────────────────────────────────────────────

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -2149,11 +2149,16 @@ def run_strategy_orchestrator_from_state(
         # first row of the whole-season frame): the latter blends one race's GP with
         # another race's stint/team — the #465 wrong-GP bug engine._build_default_lap_state
         # also has to avoid. Fall back to iloc[0] only when the row is absent.
-        gp_name     = (
-            str(lap_row["GP_Name"].iloc[0])
-            if not lap_row.empty and "GP_Name" in lap_row
-            else (str(laps_df["GP_Name"].iloc[0]) if "GP_Name" in laps_df.columns else "")
-        )
+        # Flattened from a nested ternary. The middle branch reads as redundant and
+        # is not: lap_row can be non-empty and still lack GP_Name, which happens only
+        # when laps_df lacks it too, since lap_row is a slice of it. Written as three
+        # branches the reader sees that without having to re-derive it.
+        if not lap_row.empty and "GP_Name" in lap_row:
+            gp_name = str(lap_row["GP_Name"].iloc[0])
+        elif "GP_Name" in laps_df.columns:
+            gp_name = str(laps_df["GP_Name"].iloc[0])
+        else:
+            gp_name = ""
         stint = int(lap_row["Stint"].iloc[0]) if not lap_row.empty else 1
         team  = (
             str(lap_row["Team"].iloc[0]) if not lap_row.empty and "Team" in lap_row else "Unknown"

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -48,7 +48,15 @@ while not (_REPO_ROOT / '.git').exists():
 try:
     from src.f1_strat_manager.data_cache import get_data_root as _get_data_root
     _DATA_ROOT = _get_data_root()
-except Exception:
+except (ImportError, OSError, RuntimeError):
+    # Every way get_data_root() can fail, enumerated against its body in
+    # src/f1_strat_manager/data_cache.py: ImportError from the import itself on a
+    # bare dev checkout; OSError from the three mkdir() calls (read-only mount,
+    # permissions); RuntimeError from Path.home() and Path.expanduser(), which
+    # raise when no home directory resolves. That last one is not hypothetical:
+    # the Path.home() branch IS the `uv tool install` path this block exists to
+    # serve, and a container with no HOME would take it. Falling back to the
+    # repo-relative data/ is right for all three.
     _DATA_ROOT = _REPO_ROOT / 'data'
 
 logger = logging.getLogger(__name__)

--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -648,18 +648,18 @@ class F1ArcadeView(arcade.View):
             if code == self._driver_main:
                 main_frame = f
 
+        lap = main_frame.lap if main_frame else 1
         return {
-            "lap": main_frame.lap if main_frame else 1,
+            "lap": lap,
             "t": main_frame.t if main_frame else 0.0,
             "drivers": drivers_dict,
-            "weather": {
-                "track_temp": 45.0,
-                "air_temp": 18.0,
-                "humidity": 55.0,
-                "wind_speed": 12.0,
-                "wind_direction": 180.0,
-                "rain_state": "DRY",
-            },
+            # Real per-lap FastF1 weather (#616), built once at session load
+            # by SessionLoader._extract_weather_by_lap and cached on
+            # SessionData.weather_by_lap. An older cache or a session with no
+            # weather data resolves to {}; WeatherPanel.draw already falls
+            # back to its own constants per missing key, so this degrades to
+            # exactly the old hardcoded display instead of raising.
+            "weather": self._session.weather_by_lap.get(lap, {}),
         }
 
     def _draw_background_cars(self, frame_idx: int) -> None:

--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -333,7 +333,10 @@ class F1ArcadeView(arcade.View):
                 creationflags=creationflags,
             )
             logger.info("Dashboard subprocess spawned (pid=%s)", self._dashboard_proc.pid)
-        except Exception as exc:
+        except (OSError, ValueError) as exc:
+            # subprocess.Popen documents OSError (e.g. the interpreter path
+            # cannot be executed) and ValueError (bad argument combination)
+            # as its failure modes; nothing else escapes a plain Popen() call.
             logger.warning(
                 "Dashboard spawn failed (%s) — arcade continues without it",
                 exc,
@@ -369,7 +372,10 @@ class F1ArcadeView(arcade.View):
             except subprocess.TimeoutExpired:
                 logger.warning("Dashboard did not exit in 3s — killing")
                 self._dashboard_proc.kill()
-            except Exception as exc:
+            except OSError as exc:
+                # terminate()/wait() on an already-dead or inaccessible
+                # process raise OSError subclasses (e.g. ProcessLookupError);
+                # nothing else is documented for these two calls.
                 logger.warning("Dashboard teardown error: %s", exc)
             self._dashboard_proc = None
 

--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -158,7 +158,7 @@ FLAG_COLORS: Final[dict[str, tuple[int, int, int]]] = {
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
 FASTF1_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "fastf1"
 ARCADE_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "arcade"
-CACHE_VERSION: Final[str] = "v6"  # adds track_status_by_lap for the race-events HUD card
+CACHE_VERSION: Final[str] = "v7"  # adds weather_by_lap, real FastF1 weather for the weather panel
 
 # --- Multiprocessing pool -------------------------------------------------
 # Serial by default — Windows spawn + pickling a loaded session across 8

--- a/src/arcade/dashboard/stream_client.py
+++ b/src/arcade/dashboard/stream_client.py
@@ -132,5 +132,6 @@ class TelemetryStreamClient(QThread):
             try:
                 self._socket.close()
             except OSError:
+                # Socket may already be broken/closed on the far end — nothing to undo.
                 pass
             self._socket = None

--- a/src/arcade/dashboard/theme.py
+++ b/src/arcade/dashboard/theme.py
@@ -19,6 +19,8 @@ from typing import Final
 
 from PySide6.QtGui import QColor, QPalette
 
+from src.arcade.strategy import _ALERT_SEVERITY
+
 # --- Palette (RGB tuples) ------------------------------------------------
 BG_COLOR: Final[tuple[int, int, int]] = (18, 17, 39)  # #121127 PRIMARY_BG
 CONTENT_BG: Final[tuple[int, int, int]] = (24, 22, 51)  # #181633 panel bg
@@ -65,16 +67,16 @@ _ACTION_STYLE: Final[dict[str, tuple[tuple[int, int, int], str]]] = {
     "ERROR": (DANGER, "ERROR"),
 }
 
-# --- Severity (mirrors src/arcade/strategy.py::_ALERT_SEVERITY) ---------
-_ALERT_SEVERITY: Final[dict[str, int]] = {
-    "SAFETY_CAR": 3,
-    "RED_FLAG": 3,
-    "VIRTUAL_SAFETY_CAR": 2,
-    "VSC": 2,
-    "YELLOW_FLAG": 2,
-    "PROBLEM": 1,
-    "WARNING": 1,
-}
+# --- Severity --------------------------------------------------------------
+# Imported from src.arcade.strategy (not duplicated): a hand-copied version of
+# this dict lived here until #620, and it drifted the moment #398 added the
+# "YELLOW_FLAG_SECTOR" key to the original without anyone updating the copy.
+# A double yellow rendered neutral grey in this dashboard while the arcade
+# banner showed it correctly, because a "mirrors X" comment told readers the
+# two dicts were already checked. Importing the single dict removes that
+# drift risk. The extra pandas import this pulls in from strategy.py is a
+# small addition next to the PySide6 + pyqtgraph cost this process already
+# pays on cold start.
 
 
 def classify_action(action: str) -> tuple[tuple[int, int, int], str]:

--- a/src/arcade/data.py
+++ b/src/arcade/data.py
@@ -273,7 +273,12 @@ class SessionLoader:
         # round number.
         try:
             location = str(session.event.get("Location", "") or "")
-        except Exception:
+        except (AttributeError, KeyError):
+            # session.event is a pandas Series (fastf1.events.Event); its
+            # .get() already returns the default instead of raising for a
+            # missing key. The only realistic failure is session.event
+            # itself not being Series-like (AttributeError on .get) or a
+            # custom __getitem__ override raising KeyError internally.
             location = ""
 
         driver_nums = list(session.drivers)
@@ -440,7 +445,11 @@ class SessionLoader:
             y = tel["Y"].to_numpy().astype(float)
             drs = tel["DRS"].to_numpy().astype(float) if "DRS" in tel.columns else np.zeros(len(x))
             return x, y, drs
-        except Exception as exc:
+        except (KeyError, ValueError, AttributeError) as exc:
+            # Same enumeration as _process_driver_data's get_telemetry() catch
+            # above: pick_fastest() returning None -> AttributeError,
+            # get_car_data/get_pos_data doing DriverNumber/column lookups ->
+            # KeyError, numeric casts on malformed telemetry -> ValueError.
             logger.warning("Reference lap extraction failed (%s) - using empty geometry", exc)
             return np.zeros(0), np.zeros(0), np.zeros(0)
 
@@ -485,7 +494,12 @@ class SessionLoader:
                 return {}
             grouped = subset.groupby("LapNumber")["TrackStatus"].first()
             return {int(lap): str(code) for lap, code in grouped.items()}
-        except Exception:
+        except (KeyError, ValueError, TypeError) as exc:
+            # KeyError: "LapNumber" missing despite the "TrackStatus" presence
+            # check above. ValueError/TypeError: a lap value int() cannot
+            # convert. Pure pandas indexing beyond this is not expected to
+            # raise anything else.
+            logger.debug("Track-status-by-lap extraction failed (%s) - panel stays hidden", exc)
             return {}
 
     def _safe_rotation(self, session: Any) -> float:
@@ -494,7 +508,13 @@ class SessionLoader:
             if info is None or not hasattr(info, "rotation"):
                 return 0.0
             return float(info.rotation)
-        except Exception:
+        except Exception as exc:
+            # session.get_circuit_info() fetches from the MultiViewer API
+            # (fastf1.mvapi.get_circuit_info) — genuine network I/O with an
+            # undocumented exception surface (HTTP/connection/JSON errors),
+            # so this stays broad. Logged so a real regression still leaves
+            # a trace instead of silently flattening every rotation to 0.
+            logger.debug("Circuit rotation lookup failed (%s) - defaulting to 0.0", exc)
             return 0.0
 
     def _session_circuit_length(self, session, ref_x: np.ndarray, ref_y: np.ndarray) -> float:
@@ -514,8 +534,12 @@ class SessionLoader:
             length = float(tel["Distance"].iloc[-1])
             if 1500.0 < length < 12000.0:
                 return length
-        except Exception:
-            pass
+        except (KeyError, ValueError, IndexError, AttributeError) as exc:
+            # pick_fastest() may return None (AttributeError on
+            # .get_car_data()); get_car_data/add_distance do DriverNumber
+            # and channel lookups (KeyError), numeric casts (ValueError),
+            # and .iloc[-1] on a possibly-empty Distance column (IndexError).
+            logger.debug("Fastest-lap circuit length failed (%s) - using polyline estimate", exc)
         return self._estimate_circuit_length(ref_x, ref_y)
 
     def _estimate_circuit_length(self, ref_x: np.ndarray, ref_y: np.ndarray) -> float:

--- a/src/arcade/data.py
+++ b/src/arcade/data.py
@@ -565,11 +565,24 @@ class SessionLoader:
             for _, row in merged.iterrows():
                 out[int(row["LapNumber"])] = self._weather_row_to_dict(row)
             return out
-        except (KeyError, ValueError, TypeError) as exc:
-            # KeyError: an expected weather/laps column absent. ValueError/
+        except Exception as exc:  # noqa: BLE001 - see the enumeration below
+            # KeyError: an expected weather/laps column absent. ValueError and
             # TypeError: int()/float() casts on a malformed row, or a dtype
-            # mismatch merge_asof rejects. Pure pandas indexing beyond this
-            # is not expected to raise anything else.
+            # mismatch merge_asof rejects.
+            #
+            # And the one that made this catch broad on purpose: reading
+            # `session.weather_data` raises fastf1's DataNotLoadedError when the
+            # weather channel is unavailable, and that subclasses Exception
+            # DIRECTLY, not any of the three above. An adversarial gate caught it
+            # by executing it: session.load() returns normally and the property
+            # raises afterwards, so a narrow tuple let it escape and killed the
+            # entire arcade load, after the full cold path, for a session that
+            # used to degrade quietly to the panel's own constants.
+            #
+            # The docstring above promises exactly that degradation. Catching
+            # narrowly here would have made the docstring a lie and turned a
+            # missing optional channel into a crash, which is the failure this
+            # repo has a written lesson about.
             logger.debug("Weather-by-lap extraction failed (%s) - panel keeps defaults", exc)
             return {}
 

--- a/src/arcade/data.py
+++ b/src/arcade/data.py
@@ -111,6 +111,17 @@ class SessionData:
     # Empty dict means the loader did not populate it (e.g. older cache);
     # the panel treats unknown laps as clear and stays hidden.
     track_status_by_lap: dict[int, str] = field(default_factory=dict)
+    # Per-lap weather reading built from FastF1's ``session.weather_data``
+    # (see #616): ``{lap_number: {"air_temp", "track_temp", "humidity",
+    # "wind_speed", "wind_direction", "rain_state"}}``. Before this field
+    # existed the weather was already fetched (``session.load(weather=True)``)
+    # and then thrown away; the arcade UI showed a hardcoded 45 C / 18 C / DRY
+    # constant on every lap of every race while the strategy pipeline used the
+    # real values from a different path. Empty dict means the loader could not
+    # extract weather (older cache, or the session genuinely has none); the
+    # panel's own ``.get(key, default)`` calls keep the old constants as the
+    # last-resort display instead of raising.
+    weather_by_lap: dict[int, dict[str, Any]] = field(default_factory=dict)
 
 
 def _enable_fastf1_cache() -> None:
@@ -298,6 +309,7 @@ class SessionLoader:
         rotation_deg = self._safe_rotation(session)
         circuit_length = self._session_circuit_length(session, ref_x, ref_y)
         track_status_by_lap = self._extract_track_status_by_lap(session)
+        weather_by_lap = self._extract_weather_by_lap(session)
 
         sd = SessionData(
             version=CACHE_VERSION,
@@ -316,6 +328,7 @@ class SessionLoader:
             ref_lap_drs=ref_drs,
             events=[],
             track_status_by_lap=track_status_by_lap,
+            weather_by_lap=weather_by_lap,
         )
 
         with cache_path.open("wb") as f:
@@ -501,6 +514,82 @@ class SessionLoader:
             # raise anything else.
             logger.debug("Track-status-by-lap extraction failed (%s) - panel stays hidden", exc)
             return {}
+
+    def _extract_weather_by_lap(self, session: Any) -> dict[int, dict[str, Any]]:
+        """Build ``{lap_number: {air_temp, track_temp, humidity, wind_speed,
+        wind_direction, rain_state}}`` from FastF1's ``session.weather_data``.
+
+        ``session.load(weather=True)`` already pulls this DataFrame (one row
+        roughly every 60 s, columns ``Time``, ``AirTemp``, ``TrackTemp``,
+        ``Humidity``, ``WindSpeed``, ``WindDirection``, ``Rainfall``); before
+        #616 the arcade UI paid that cost and then discarded the result,
+        showing a fixed 45 C / 18 C / DRY on every lap instead. ``Time`` in
+        both ``weather_data`` and ``session.laps`` is the same session-elapsed
+        timedelta, so each lap's completion time can be matched against the
+        closest weather sample with ``pd.merge_asof(..., direction="nearest")``:
+        weather changes slowly enough over a race that the nearest reading
+        (rather than an interpolation between two samples) is close enough for
+        a replay. Missing/malformed data returns an empty dict so the panel
+        falls back to its own built-in constants instead of raising at load
+        time, exactly as it did before this field existed.
+        """
+        try:
+            weather = session.weather_data
+            laps = session.laps
+            if weather is None or weather.empty or laps is None or laps.empty:
+                return {}
+            if "Time" not in weather.columns or "Time" not in laps.columns:
+                return {}
+            lap_times = laps[["LapNumber", "Time"]].dropna()
+            if lap_times.empty:
+                return {}
+            # One row per lap number: the last driver to cross the line that
+            # lap, close enough to "lap N is done" for a slowly-changing
+            # weather reading. Sorted ascending because merge_asof requires
+            # the "on" column to be sorted on both sides.
+            per_lap = lap_times.groupby("LapNumber")["Time"].max().reset_index()
+            per_lap = per_lap.sort_values("Time")
+            wx_columns = [
+                "Time",
+                "AirTemp",
+                "TrackTemp",
+                "Humidity",
+                "WindSpeed",
+                "WindDirection",
+                "Rainfall",
+            ]
+            wx = weather[wx_columns].sort_values("Time")
+            merged = pd.merge_asof(per_lap, wx, on="Time", direction="nearest")
+
+            out: dict[int, dict[str, Any]] = {}
+            for _, row in merged.iterrows():
+                out[int(row["LapNumber"])] = self._weather_row_to_dict(row)
+            return out
+        except (KeyError, ValueError, TypeError) as exc:
+            # KeyError: an expected weather/laps column absent. ValueError/
+            # TypeError: int()/float() casts on a malformed row, or a dtype
+            # mismatch merge_asof rejects. Pure pandas indexing beyond this
+            # is not expected to raise anything else.
+            logger.debug("Weather-by-lap extraction failed (%s) - panel keeps defaults", exc)
+            return {}
+
+    def _weather_row_to_dict(self, row: "pd.Series") -> dict[str, Any]:
+        """Map one merged weather+lap row to the ``WeatherPanel``-facing shape.
+
+        Key names match ``WeatherPanel.draw``'s ``weather.get(key, default)``
+        calls exactly, so a row missing a single reading (rare, but possible
+        on an incomplete weather sample) only loses that one field to the
+        panel's own default instead of dropping the whole lap."""
+        return {
+            "air_temp": float(row["AirTemp"]) if pd.notna(row.get("AirTemp")) else None,
+            "track_temp": float(row["TrackTemp"]) if pd.notna(row.get("TrackTemp")) else None,
+            "humidity": float(row["Humidity"]) if pd.notna(row.get("Humidity")) else None,
+            "wind_speed": float(row["WindSpeed"]) if pd.notna(row.get("WindSpeed")) else None,
+            "wind_direction": (
+                float(row["WindDirection"]) if pd.notna(row.get("WindDirection")) else None
+            ),
+            "rain_state": "WET" if bool(row.get("Rainfall")) else "DRY",
+        }
 
     def _safe_rotation(self, session: Any) -> float:
         try:

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -578,6 +578,7 @@ class SimConnector(threading.Thread):
         ``radio_msgs`` / ``rcm_events`` from the ``RadioPipelineRunner``
         corpus so the Radio agent sees the real OpenF1 team messages
         (same as the CLI); empty lists when the corpus could not load."""
+        from src.agents.position_projection import GAP_UNKNOWN_FALLBACK_S
         from src.agents.strategy_orchestrator import RaceState
 
         driver_st = lap_state.get("driver", {})
@@ -601,7 +602,26 @@ class SimConnector(threading.Thread):
                 "should have skipped this lap before calling _build_race_state (#465)"
             )
         car_ahead = next((r for r in rivals if r.get("position") == our_pos - 1), None)
-        gap_ahead_s = abs(car_ahead.get("interval_to_driver_s") or 0.0) if car_ahead else 0.0
+        # Two different zeros used to hide under one expression. No car ahead means we
+        # lead, and 0.0 is honest there. A car ahead whose interval was never measured
+        # is NOT a zero gap: 0.0 reads as side by side, which the orchestrator's
+        # clean-air band and N27's sub-1.0s DRS window both act on. It degrades to
+        # GAP_UNKNOWN_FALLBACK_S instead, matching the CLI and the telemetry backend.
+        #
+        # Be honest about what that fallback still is: 2.0 is fabricated, and a real
+        # 2.0s gap is common, so it does not satisfy the rule that a default must never
+        # be a value the code can also legitimately find. It is less harmful than 0.0,
+        # not correct. The real fix is RaceState.gap_ahead_s becoming `float | None`,
+        # which RivalState in position_projection.py already is and whose consumers
+        # already guard with `is not None`. That is a Pydantic contract change.
+        if car_ahead is None:
+            gap_ahead_s = 0.0
+        else:
+            measured_interval = car_ahead.get("interval_to_driver_s")
+            if measured_interval is None:
+                gap_ahead_s = GAP_UNKNOWN_FALLBACK_S
+            else:
+                gap_ahead_s = abs(measured_interval)
 
         lap_num = int(lap_state.get("lap_number", 1) or 1)
         radio_msgs: list[dict] = []

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -606,7 +606,9 @@ class SimConnector(threading.Thread):
         # lead, and 0.0 is honest there. A car ahead whose interval was never measured
         # is NOT a zero gap: 0.0 reads as side by side, which the orchestrator's
         # clean-air band and N27's sub-1.0s DRS window both act on. It degrades to
-        # GAP_UNKNOWN_FALLBACK_S instead, matching the CLI and the telemetry backend.
+        # GAP_UNKNOWN_FALLBACK_S instead, which the CLI now shares. The telemetry
+        # backend still has its own copies and is a submodule, so this is a two-way
+        # unification, not the three-way one an earlier draft of this comment claimed.
         #
         # Be honest about what that fallback still is: 2.0 is fabricated, and a real
         # 2.0s gap is common, so it does not satisfy the rule that a default must never

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -609,7 +609,11 @@ class SimConnector(threading.Thread):
         if self._radio_runner is not None:
             try:
                 radio_msgs, rcm_events = self._radio_runner.radios_for_lap(lap_num)
-            except Exception as exc:
+            except (KeyError, ValueError, TypeError) as exc:
+                # radios_for_lap does plain pandas row indexing + int/str
+                # casts (see RadioPipelineRunner._radio_row_to_dict /
+                # _rcm_row_to_dict) — a malformed lap_number or a missing
+                # column are the only realistic failure modes here.
                 logger.debug("radios_for_lap(%d) failed: %s", lap_num, exc)
 
         # Re-assert an active Safety Car on the laps whose RCM window carries no

--- a/src/arcade/stream.py
+++ b/src/arcade/stream.py
@@ -64,6 +64,7 @@ class TelemetryStreamServer:
             try:
                 self._server_socket.close()
             except OSError:
+                # Already closed/broken (e.g. peer reset first) — nothing to undo.
                 pass
             self._server_socket = None
         with self._clients_lock:
@@ -71,6 +72,7 @@ class TelemetryStreamServer:
                 try:
                     client.close()
                 except OSError:
+                    # Same idempotent-close rationale as the server socket above.
                     pass
             self._clients.clear()
         logger.info("TelemetryStreamServer stopped")
@@ -139,6 +141,7 @@ class TelemetryStreamServer:
             try:
                 client_socket.close()
             except OSError:
+                # Remote end may have already dropped the connection.
                 pass
             self._prune_clients([client_socket])
 
@@ -148,4 +151,5 @@ class TelemetryStreamServer:
                 try:
                     self._clients.remove(client)
                 except ValueError:
+                    # Another thread already pruned this socket first — fine.
                     pass

--- a/src/f1_strat_manager/laps_augment.py
+++ b/src/f1_strat_manager/laps_augment.py
@@ -53,7 +53,18 @@ try:
     from src.f1_strat_manager.gp_slugs import FOLDER_ALIASES as _FOLDER_ALIASES
 
     _FRIENDLY_TO_FOLDER: Dict[str, str] = {v: k for k, v in _FOLDER_ALIASES.items()}
-except Exception:  # pragma: no cover
+except ImportError as exc:  # pragma: no cover
+    # gp_slugs failed to import, or FOLDER_ALIASES was renamed/removed there
+    # (a `from X import NAME` raises ImportError for both). FOLDER_ALIASES is
+    # a plain dict literal in gp_slugs.py, so the dict-comprehension line
+    # below cannot itself raise anything else. This falls back to a single
+    # stale entry, so it is worth a warning rather than a fully silent degrade.
+    logger.warning(
+        "Could not load FOLDER_ALIASES from gp_slugs (%s); falling back to a "
+        "single hardcoded Miami mapping. _raw_race_dir may misresolve other "
+        "renamed circuits.",
+        exc,
+    )
     _FRIENDLY_TO_FOLDER = {"Miami": "Miami_Gardens"}
 
 

--- a/src/f1_strat_manager/team_aliases.py
+++ b/src/f1_strat_manager/team_aliases.py
@@ -1,0 +1,37 @@
+"""Canonical team names, so a mid-window rebrand does not silently become another team.
+
+F1 teams change name inside the 2023-2025 window this project trains and tests on.
+FastF1 reports whatever the season used, but every frozen model artefact carries the
+label-encoder classes from ITS training years, so a 2025 name can be absent from a
+2024-fitted encoder. Resolving that mismatch is a one-line lookup, and it lived in one
+line inside ``pit_strategy_agent`` while the eval harness never got it: 20 of 252 rows
+in the 2025 pit holdout were being encoded as ``Alfa Romeo``, a different team (#629).
+
+This module exists so there is one lookup rather than two that drift. It holds no
+logic beyond the mapping and the resolver, and nothing here imports an agent, so the
+eval layer can use it without pulling the agent stack in behind it.
+
+--- WHERE TO CHANGE IF A TEAM RENAMES AGAIN ---
+Add the new FastF1 name here mapping to whatever the trained encoders already know.
+If instead you RETRAIN, the encoder learns the new name and the alias becomes
+redundant, but leaving it costs nothing and keeps older artefacts loadable.
+"""
+
+from __future__ import annotations
+
+# FastF1's current name -> the name the frozen encoders were fitted on.
+# `Racing Bulls` is the 2025 entrant; the 2024 encoders know it as `RB`, and the 2023
+# ones as `AlphaTauri`. Only the 2025 case is mapped because that is the one the
+# holdout hits; a 2023-fitted artefact loaded against 2025 data would need the other.
+TEAM_ALIASES: dict[str, str] = {"Racing Bulls": "RB"}
+
+
+def canonical_team(name: str) -> str:
+    """The name a frozen encoder is likely to know, or the input unchanged.
+
+    Deliberately total rather than raising on an unknown name: the caller decides
+    what an unrecognised team means, because that answer differs between an agent
+    (degrade and carry on) and an eval harness (say so loudly, the metric is at
+    stake). Returning the input unchanged keeps that decision at the call site.
+    """
+    return TEAM_ALIASES.get(name, name)

--- a/src/rag/retriever.py
+++ b/src/rag/retriever.py
@@ -71,7 +71,12 @@ class RagConfig:
             from src.f1_strat_manager.data_cache import get_data_root
 
             return get_data_root() / "rag"
-        except Exception:
+        except (ImportError, OSError):
+            # ImportError: helper not on sys.path (uv tool install layout).
+            # OSError: get_data_root()/_find_repo_root() only ever touch the
+            # local filesystem (env var, path resolve, mkdir) — read in full,
+            # neither does network I/O, so OSError is the only realistic
+            # runtime failure besides the import itself.
             return self._repo_root / "data" / "rag"
 
     @property

--- a/src/shared/data_extraction/openf1_extractor.py
+++ b/src/shared/data_extraction/openf1_extractor.py
@@ -193,8 +193,10 @@ def extract_openf1_intervals(year, gp_name, max_interval=None):
                 try:
                     # Try to convert to numeric
                     intervals_df[col] = pd.to_numeric(intervals_df[col])
-                except:
-                    # If it fails, ensure it's string
+                except (ValueError, TypeError):
+                    # pd.to_numeric raises ValueError for unparseable strings
+                    # and TypeError for incompatible element types. Either way,
+                    # ensure it's string.
                     intervals_df[col] = intervals_df[col].astype(str)
 
         # Save data in Parquet format

--- a/src/strategy/eval/pit_holdout.py
+++ b/src/strategy/eval/pit_holdout.py
@@ -20,10 +20,13 @@ published 0.487 (delta 0.0023, within tolerance).
 
 from __future__ import annotations
 
+import logging
+
 import json
 from typing import Any
 
 from src.f1_strat_manager.data_cache import get_data_root, get_models_root
+from src.f1_strat_manager.team_aliases import canonical_team
 
 _PIT_DIR = "pit_prediction"
 _COMPOUND_ORDER = {"SOFT": 0, "MEDIUM": 1, "HARD": 2, "INTERMEDIATE": 3, "WET": 4}
@@ -124,6 +127,35 @@ def _add_team_year_median(train: Any, target_slice: Any) -> Any:
     return target_slice
 
 
+
+logger = logging.getLogger(__name__)
+
+
+def _team_class_index(raw_team: str, team_classes: list[str]) -> int:
+    """Encoder index for a team name, resolving a rebrand first and warning if it fails.
+
+    The fallback is index 0, and index 0 is NOT "unknown": it is a real class the
+    frozen model trained on, so an unrecognised name is silently scored as another
+    team. That is what happened to the 2025 holdout, where FastF1 says `Racing Bulls`
+    and the 2024-fitted encoder knows `RB`: 20 of 252 rows were evaluated as
+    `Alfa Romeo` (#629). Measured impact on the published P50 MAE was -0.0045 s, so
+    the number stands, but a reproduction harness that quietly reinterprets its own
+    input is not reproducing anything, which is why the fallback now shouts.
+    """
+    resolved = canonical_team(raw_team)
+    if resolved in team_classes:
+        return team_classes.index(resolved)
+
+    logger.warning(
+        "Team %r is not in this artefact's label-encoder classes (%s) and has no alias; "
+        "scoring it as %r, which is a DIFFERENT team. Add it to TEAM_ALIASES in "
+        "src/f1_strat_manager/team_aliases.py or the metric is measuring the wrong car.",
+        raw_team,
+        ", ".join(team_classes),
+        team_classes[0],
+    )
+    return 0
+
 def load_pit_holdout(year: int = 2025) -> tuple[Any, dict[str, Any], list[str]] | None:
     """Rebuild the pit holdout and return ``(test_slice, quantile_models, features)``.
 
@@ -162,7 +194,7 @@ def load_pit_holdout(year: int = 2025) -> tuple[Any, dict[str, Any], list[str]] 
     features = cfg["features"]
     team_classes = list(cfg["label_encoder_classes"]["team"])
     target_slice["team"] = target_slice["team"].map(
-        lambda x: team_classes.index(x) if x in team_classes else 0
+        lambda raw: _team_class_index(raw, team_classes)
     )
 
     models = {}


### PR DESCRIPTION
Everything from the autonomous run, promoted together. Three landed pieces plus the corrections an adversarial gate forced on them.

## What landed

**#627, the exception sweep.** `src/` held 211 `except` clauses and 107 were `except Exception` or bare. **19 narrowed, 36 deliberately left broad with the reason logged.** One narrowing had to be corrected on review: a worker reported enumerating `get_data_root()` and missed that `Path.home()` raises `RuntimeError`, not `OSError`, which would have crashed all five agents at import time in exactly the `uv tool install` scenario the fallback exists for.

**#630, the eval team alias.** `pit_holdout` scored 20 of 252 rows as `Alfa Romeo` because FastF1 says `Racing Bulls` and the encoder knows `RB`. **Measured before fixing: P50 MAE 0.4893 as shipped, 0.4848 corrected, delta -0.0045 s.** The published 0.487 s stands. The alias now lives in one module both the agent and the harness import.

**#631, six behaviour fixes.** #613 (green stop priced at 9 positions, not the Safety Car field's 13), #614 (docstring stops claiming Art. 30.5(m)), #615 (a reverse map that could only ever return one of its three classes), #616 (real per-lap weather, `CACHE_VERSION` v6 to v7), #620 (the drifted severity dict), #628 (a defaulted position is a searchable value).

## What the adversarial gate caught, in this batch's own work

**A regression the batch introduced.** `_extract_weather_by_lap` caught `(KeyError, ValueError, TypeError)`, and `session.weather_data` raises fastf1's `DataNotLoadedError`, which subclasses `Exception` **directly**. A session with no weather channel killed the whole arcade load, after the full cold path, where before it degraded to the panel's own constants exactly as the docstring above the catch promises. Reproduced live, then fixed with every reachable exception enumerated in place.

That is the precise failure the exception sweep in this same promotion was warned about. A catch too narrow turns graceful degradation into a crash, and nothing tests it because the path only fires when data is absent.

**An overclaim in the batch's comments.** They said the CLI, the arcade **and the telemetry backend** now share one gap constant. Two of three moved; the backend is a submodule. Six copies survive there, including one file defaulting the same concept to 2.0 on one request model and 0.0 on its sibling. Comments corrected, because a comment asserting a closed drift is worse than no comment: that is how #620 stayed broken behind its own "mirrors X" note.

## Filed, not fixed here

- **#632** — the published RCM coverage measures a **copy** of the parser, not the one that ships. They disagree on **427 of 1515** real messages (28.2 %), the shipped one is the correct side on `SAFETY CAR IN THIS LAP`, and the report over-states it by 2.24 points on a row marked `reproduced`.
- **#633** — the six surviving gap copies in the submodule.
- **#634** — a calibration golden stale on `dev`, which CI is structurally blind to because `tests/eval/` needs the dataset the runners lack.

## Verification

`dev` green. Locally: 118 tests across `tests/mc/` and the engine suites, plus a full-suite run of **340 passed, 4 skipped** with the one pre-existing golden deselected (proved pre-existing by running it on `dev`). Ruff check and format clean repo-wide. Real `f1-sim --no-llm` runs on Lusail throughout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-lap weather data to arcade session playback and weather displays.
  * Improved handling of team-name aliases for more reliable strategy evaluation.
* **Bug Fixes**
  * Corrected sector-specific yellow-flag classification.
  * Improved race-state and gap handling when telemetry is incomplete.
  * Prevented missing position data from being silently misidentified.
* **Improvements**
  * CLI tools now continue using existing environment variables when optional environment loading is unavailable.
  * Improved Windows terminal compatibility and graceful handling of closed or unavailable connections.
  * Refined fallback behavior for missing race data and track-status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->