### PR TITLE
fix(eval): measure the RCM parser that ships, not a private copy of it

### DIFF
--- a/documents/eval_reports/nlp.json
+++ b/documents/eval_reports/nlp.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "bc0350d",
+    "harness_sha": "81656b0",
     "dataset": "radio + intent labeled CSVs, entity annotations, 2025 RCM corpus",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-11T16:38:31+00:00",
+    "generated_at": "2026-07-26T18:47:28+00:00",
     "artifacts": {
       "roberta_sentiment": "d7d0ada739c6",
       "intent_head": "7c995ba21bc0",
@@ -81,10 +81,10 @@
     {
       "stage": "rcm",
       "metric": "coverage",
-      "value": 0.9868,
+      "value": 0.9644,
       "reference": null,
       "status": "reproduced",
-      "detail": "n=1515 across 24 2025 races; per-category [Drs 1.000, Flag 1.000, Other 0.971, SafetyCar 1.000]; vs config Flag 1.0/Other 0.928/Drs 1.0/SafetyCar 1.0 (N23 sample differs)"
+      "detail": "n=1515 across 24 2025 races; per-category [Drs 1.000, Flag 0.997, Other 0.924, SafetyCar 1.000]; vs config Flag 1.0/Other 0.928/Drs 1.0/SafetyCar 1.0 (N23 sample differs)"
     },
     {
       "stage": "ner",

--- a/documents/eval_reports/nlp.md
+++ b/documents/eval_reports/nlp.md
@@ -1,6 +1,6 @@
 # nlp
 
-- harness `bc0350d` · schema v1 · generated 2026-07-11T16:38:31+00:00
+- harness `81656b0` · schema v1 · generated 2026-07-26T18:47:28+00:00
 - era 2022-2025 · dataset radio + intent labeled CSVs, entity annotations, 2025 RCM corpus · seed deterministic · llm none
 - artifacts: roberta_sentiment=`d7d0ada739c6`, intent_head=`7c995ba21bc0`, ner_bert_bio=`9e60de9bf538`
 
@@ -15,4 +15,4 @@
 | alert_precision | precision | 0.9185 | - | reproduced | n=529 (145 gold alerts); radio PROBLEM/WARNING channel from hand-labeled gold intent; R 0.855/F1 0.886; full-set optimistic |
 | intent | predict_proba_order | 1.0000 | 1 | reproduced | head.classes_=[0, 1, 2, 3, 4] map to intent_names via intent_mapping; 5/5 columns aligned (no swap) |
 | ner | entity_f1 | 0.4248 | 0.4151 | reproduced | n=529; micro entity-F1 (P 0.304/R 0.704); full-set optimistic; 4 dead classes flagged separately |
-| rcm | coverage | 0.9868 | - | reproduced | n=1515 across 24 2025 races; per-category [Drs 1.000, Flag 1.000, Other 0.971, SafetyCar 1.000]; vs config Flag 1.0/Other 0.928/Drs 1.0/SafetyCar 1.0 (N23 sample differs) |
+| rcm | coverage | 0.9644 | - | reproduced | n=1515 across 24 2025 races; per-category [Drs 1.000, Flag 0.997, Other 0.924, SafetyCar 1.000]; vs config Flag 1.0/Other 0.928/Drs 1.0/SafetyCar 1.0 (N23 sample differs) |

--- a/src/agents/radio_agent.py
+++ b/src/agents/radio_agent.py
@@ -118,36 +118,22 @@ _SAFETY_FLAGS = {
     "TIME_PENALTY",
 }
 
-_FLAG_MAP = {
-    "RED":       "RED_FLAG",
-    "GREEN":     "GREEN_FLAG",
-    "CLEAR":     "CLEAR_FLAG",
-    "BLUE":      "BLUE_FLAG",
-    "CHEQUERED": "CHEQUERED_FLAG",
-}
 
-# NR-03 (#398) — flag values that resolve through the same scope-aware branch as
-# a plain YELLOW. DOUBLE YELLOW is the highest-danger *local* flag (an incident
-# sits directly on the racing line; cars must slow far more than for a single
-# yellow) and is a frequent precursor to a full Safety Car. Before this fix it
-# matched neither `_FLAG_MAP` nor the old exact `flag == "YELLOW"` check, so it
-# fell all the way through to OTHER — invisible to `_SAFETY_FLAGS` and to N31.
-# Folding it into the YELLOW branch below means it inherits YELLOW_FLAG /
-# YELLOW_FLAG_SECTOR's existing alert status for free, with no edit needed to
-# `_SAFETY_FLAGS` itself and no change to how a plain YELLOW is handled.
-_YELLOW_FLAG_VALUES = {"YELLOW", "DOUBLE YELLOW"}
-
-# NR-03 (#398) — message-keyword families that fell through to OTHER. Verified
-# against the real 2025 rcm.parquet corpus (data/processed/race_radios/2025/**)
-# except _SESSION_* (see _classify_rcm_event docstring for the caveat: no race
-# in that corpus contains a red-flag suspension, so this family is unverified).
-_TRACK_LIMITS_KEYWORDS      = ("TRACK LIMITS", "TIME DELETED", "LAP DELETED", "DELETED")
-_INVESTIGATION_KEYWORDS     = ("UNDER INVESTIGATION", "NOTED")
-_SESSION_SUSPENDED_KEYWORDS = ("SESSION SUSPENDED", "RACE SUSPENDED")
-_SESSION_RESUMED_KEYWORDS   = (
-    "SESSION RESUMED", "RACE RESUMED", "RACE WILL RESUME", "SESSION WILL RESUME",
+# -- RCM classification: imported, never redeclared ---------------------------
+# RCMEvent, the flag maps and the classifier used to live here, and the eval
+# harness kept its own port because importing this module loads every NLP model.
+# That port drifted: over the real 1515-row 2025 corpus the two disagreed on 427
+# messages (28.2%), this side being the correct one on "SAFETY CAR IN THIS LAP"
+# because #305's fix never crossed. So the published RCM coverage measured the copy
+# rather than what ships. The logic is pure string rules with no model behind it, so
+# it now lives where the harness can import it without the model stack (#632).
+from src.f1_strat_manager.rcm_events import (  # noqa: E402
+    RCMEvent,
+    classify_rcm_event as _classify_rcm_event,
 )
-_SESSION_STARTED_KEYWORDS   = ("SESSION WILL START", "RACE WILL START")
+
+
+
 
 
 # ==============================================================================
@@ -178,32 +164,6 @@ class RadioMessage:
     timestamp: Optional[str] = None
 
 
-@dataclass
-class RCMEvent:
-    """A single Race Control Message row prepared for the RCM parser.
-
-    message:
-        Raw message string from FastF1 session.race_control_messages.
-    flag:
-        Flag type string (e.g. 'YELLOW', 'GREEN', 'SAFETY CAR'). Empty
-        string when the RCM is informational and carries no flag.
-    category:
-        RCM category from FastF1 (e.g. 'SafetyCar', 'Flag', 'Other').
-    lap:
-        Race lap number at which the RCM was issued.
-    racing_number:
-        Car number referenced by the message, if any. None when no specific
-        car is referenced (e.g. track-wide SC deployment).
-    scope:
-        Spatial scope of the message ('Track', 'Sector', 'Driver').
-    """
-
-    message:       str
-    flag:          str
-    category:      str
-    lap:           int
-    racing_number: Optional[str] = None
-    scope:         str           = ""
 
 
 @dataclass
@@ -603,99 +563,6 @@ def run_pipeline(text: str, rcm_result: Optional[dict] = None) -> dict:
 # RCM parser (inlined from N23/N24)
 # ==============================================================================
 
-def _classify_rcm_event(event: "RCMEvent") -> str:
-    """Map a raw RCMEvent to a canonical event type string.
-
-    Priority: SafetyCar category -> flag keyword -> incident keyword ->
-    NR-03 (#398) coverage additions -> OTHER. Mirrors the N23 rule-based
-    classifier used in N24's run_rcm_pipeline.
-
-    NR-03 (#398) note on placement: every new branch below sits AFTER the
-    pre-existing DRS/collision/retired/penalty checks so no message that
-    already resolves to a specific event type changes classification — the
-    additions only catch what used to fall through to OTHER. One consequence,
-    verified against the real 2025 rcm.parquet corpus: nearly every real
-    "UNDER INVESTIGATION" / "NOTED" message also contains the word "INCIDENT"
-    (e.g. "TURN 1 INCIDENT INVOLVING CAR 7 (DOO) NOTED - MOVING UNDER
-    BRAKING"), so it is already caught by the COLLISION/CONTACT/INCIDENT
-    branch above and never reaches the new INVESTIGATION branch. That overlap
-    is pre-existing behaviour (unrelated to this fix, and out of scope to
-    narrow here since doing so would reclassify messages that already resolve
-    today) — the INVESTIGATION branch is genuine coverage only for messages
-    that use "NOTED"/"UNDER INVESTIGATION" wording without those keywords.
-    """
-    cat   = event.category.strip()
-    flag  = event.flag.strip().upper()
-    msg   = event.message.upper()
-    # NR-03 (#398): scope casing is not guaranteed by the data source (FastF1
-    # vs OpenF1-sourced corpora disagree on "Sector" vs "SECTOR"), so normalise
-    # before comparing rather than relying on the exact-case match used before.
-    scope = event.scope.strip().upper()
-
-    if cat == "SafetyCar":
-        # "SAFETY CAR IN THIS LAP" is the FIA end-of-neutralisation message (the
-        # car comes into the pit lane this lap). It carries none of the other
-        # keywords, so it used to fall through to SAFETY_CAR_DEPLOYED — which
-        # kept the stateful tracker pinned ON for the rest of the race. Treat it
-        # as ending. (NR-02 / NR-03, #305)
-        ending = "ENDING" in msg or "IN THIS LAP" in msg
-        if "VIRTUAL" in msg:
-            return "VIRTUAL_SAFETY_CAR_ENDING" if ending else "VIRTUAL_SAFETY_CAR_DEPLOYED"
-        if "IN THE PIT LANE" in msg:
-            return "SAFETY_CAR_IN_PIT_LANE"
-        if ending:
-            return "SAFETY_CAR_ENDING"
-        return "SAFETY_CAR_DEPLOYED"
-
-    if flag in _FLAG_MAP:
-        return _FLAG_MAP[flag]
-    if flag in _YELLOW_FLAG_VALUES:
-        return "YELLOW_FLAG_SECTOR" if scope == "SECTOR" else "YELLOW_FLAG"
-
-    if "DRS ENABLED"  in msg:
-        return "DRS_ENABLED"
-    if "DRS DISABLED" in msg:
-        return "DRS_DISABLED"
-    if any(k in msg for k in ("COLLISION", "CONTACT", "INCIDENT")):
-        return "CAR_COLLISION"
-    if "RETIRED" in msg:
-        return "CAR_RETIRED"
-    if "PENALTY" in msg:
-        return "TIME_PENALTY"
-
-    # ── NR-03 (#398) additive coverage ──────────────────────────────────────
-    # Track-limit / lap-time deletions ("CAR 1 (VER) LAP DELETED - TRACK
-    # LIMITS AT TURN 14 ..."): a penalty-risk signal for us or a rival that
-    # was previously indistinguishable from any other unclassified message.
-    if any(k in msg for k in _TRACK_LIMITS_KEYWORDS):
-        return "LAP_DELETED"
-    # Stewards reviewing an incident ("... UNDER INVESTIGATION" / "... NOTED"):
-    # penalty anticipation, worth surfacing even though (see docstring) the
-    # broader COLLISION/CONTACT/INCIDENT check above already intercepts the
-    # large majority of real-world instances of this phrasing.
-    if any(k in msg for k in _INVESTIGATION_KEYWORDS):
-        return "INVESTIGATION"
-    # Pit lane entry/exit status ("PIT LANE ENTRY CLOSED" / "... OPEN"): a hard
-    # veto or permission on PIT_NOW, so CLOSED and OPEN are kept as distinct
-    # event types rather than a single generic "pit lane event" bucket.
-    if "PIT" in msg and "CLOSED" in msg:
-        return "PIT_LANE_CLOSED"
-    if "PIT" in msg and "OPEN" in msg:
-        return "PIT_LANE_OPEN"
-    # Session suspend/resume/start announcements. Unlike the families above,
-    # no race in the local 2025 rcm.parquet corpus contains a red-flag
-    # suspension, so these keyword sets are best-effort FIA phrasing and are
-    # NOT corpus-verified — flagged in the PR/issue for validation against a
-    # real red-flag race before being relied on for the restart-procedure logic
-    # the audit describes (AUDIT_NLP_RADIO_PIPELINE.md section 5.2 item 4).
-    if any(k in msg for k in _SESSION_SUSPENDED_KEYWORDS):
-        return "SESSION_SUSPENDED"
-    if any(k in msg for k in _SESSION_RESUMED_KEYWORDS):
-        return "SESSION_RESUMED"
-    if any(k in msg for k in _SESSION_STARTED_KEYWORDS):
-        return "SESSION_STARTED"
-
-    return "OTHER"
 
 
 def run_rcm_pipeline(event: "RCMEvent") -> dict:

--- a/src/f1_strat_manager/rcm_events.py
+++ b/src/f1_strat_manager/rcm_events.py
@@ -1,0 +1,181 @@
+"""The Race Control Message classifier, in one place so it cannot be measured twice.
+
+Pure rule-based logic over strings: no model, no torch, no pandas. It was inlined in
+``src/agents/radio_agent.py`` and separately PORTED into ``src/strategy/eval/nlp.py``,
+whose docstring asserted the two were identical. They were not. Over the real
+1515-row 2025 RCM corpus they disagreed on **427 messages, 28.2 percent**, and the
+eval copy was the older side: #305's fix for ``SAFETY CAR IN THIS LAP`` never crossed
+into it. The published coverage in ``documents/eval_reports/nlp.md`` therefore
+measured a private copy rather than the parser that ships, over-stating it by 2.24
+points on a row marked ``reproduced`` (#632).
+
+The port existed because importing ``radio_agent`` loads every NLP model, which is a
+real cost the harness was right to avoid. The answer was to move the logic somewhere
+importable without that stack, not to copy it.
+
+--- WHERE TO CHANGE IF THE FIA MESSAGE FORMAT CHANGES ---
+Here, and only here. ``notebooks/nlp/N23_rcm_parser.ipynb`` is the historical origin
+and is read-only; if it and this file disagree, THIS file is what runs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+_FLAG_MAP = {
+    "RED": "RED_FLAG",
+    "GREEN": "GREEN_FLAG",
+    "CLEAR": "CLEAR_FLAG",
+    "BLUE": "BLUE_FLAG",
+    "CHEQUERED": "CHEQUERED_FLAG",
+}
+
+# NR-03 (#398) — flag values that resolve through the same scope-aware branch as
+# a plain YELLOW. DOUBLE YELLOW is the highest-danger *local* flag (an incident
+# sits directly on the racing line; cars must slow far more than for a single
+# yellow) and is a frequent precursor to a full Safety Car. Before this fix it
+# matched neither `_FLAG_MAP` nor the old exact `flag == "YELLOW"` check, so it
+# fell all the way through to OTHER — invisible to `_SAFETY_FLAGS` and to N31.
+# Folding it into the YELLOW branch below means it inherits YELLOW_FLAG /
+# YELLOW_FLAG_SECTOR's existing alert status for free, with no edit needed to
+# `_SAFETY_FLAGS` itself and no change to how a plain YELLOW is handled.
+_YELLOW_FLAG_VALUES = {"YELLOW", "DOUBLE YELLOW"}
+
+# NR-03 (#398) — message-keyword families that fell through to OTHER. Verified
+# against the real 2025 rcm.parquet corpus (data/processed/race_radios/2025/**)
+# except _SESSION_* (see _classify_rcm_event docstring for the caveat: no race
+# in that corpus contains a red-flag suspension, so this family is unverified).
+_TRACK_LIMITS_KEYWORDS = ("TRACK LIMITS", "TIME DELETED", "LAP DELETED", "DELETED")
+_INVESTIGATION_KEYWORDS = ("UNDER INVESTIGATION", "NOTED")
+_SESSION_SUSPENDED_KEYWORDS = ("SESSION SUSPENDED", "RACE SUSPENDED")
+_SESSION_RESUMED_KEYWORDS = (
+    "SESSION RESUMED",
+    "RACE RESUMED",
+    "RACE WILL RESUME",
+    "SESSION WILL RESUME",
+)
+_SESSION_STARTED_KEYWORDS = ("SESSION WILL START", "RACE WILL START")
+
+
+@dataclass
+class RCMEvent:
+    """A single Race Control Message row prepared for the RCM parser.
+
+    message:
+        Raw message string from FastF1 session.race_control_messages.
+    flag:
+        Flag type string (e.g. 'YELLOW', 'GREEN', 'SAFETY CAR'). Empty
+        string when the RCM is informational and carries no flag.
+    category:
+        RCM category from FastF1 (e.g. 'SafetyCar', 'Flag', 'Other').
+    lap:
+        Race lap number at which the RCM was issued.
+    racing_number:
+        Car number referenced by the message, if any. None when no specific
+        car is referenced (e.g. track-wide SC deployment).
+    scope:
+        Spatial scope of the message ('Track', 'Sector', 'Driver').
+    """
+
+    message: str
+    flag: str
+    category: str
+    lap: int
+    racing_number: Optional[str] = None
+    scope: str = ""
+
+
+def classify_rcm_event(event: "RCMEvent") -> str:
+    """Map a raw RCMEvent to a canonical event type string.
+
+    Priority: SafetyCar category -> flag keyword -> incident keyword ->
+    NR-03 (#398) coverage additions -> OTHER. Mirrors the N23 rule-based
+    classifier used in N24's run_rcm_pipeline.
+
+    NR-03 (#398) note on placement: every new branch below sits AFTER the
+    pre-existing DRS/collision/retired/penalty checks so no message that
+    already resolves to a specific event type changes classification — the
+    additions only catch what used to fall through to OTHER. One consequence,
+    verified against the real 2025 rcm.parquet corpus: nearly every real
+    "UNDER INVESTIGATION" / "NOTED" message also contains the word "INCIDENT"
+    (e.g. "TURN 1 INCIDENT INVOLVING CAR 7 (DOO) NOTED - MOVING UNDER
+    BRAKING"), so it is already caught by the COLLISION/CONTACT/INCIDENT
+    branch above and never reaches the new INVESTIGATION branch. That overlap
+    is pre-existing behaviour (unrelated to this fix, and out of scope to
+    narrow here since doing so would reclassify messages that already resolve
+    today) — the INVESTIGATION branch is genuine coverage only for messages
+    that use "NOTED"/"UNDER INVESTIGATION" wording without those keywords.
+    """
+    cat = event.category.strip()
+    flag = event.flag.strip().upper()
+    msg = event.message.upper()
+    # NR-03 (#398): scope casing is not guaranteed by the data source (FastF1
+    # vs OpenF1-sourced corpora disagree on "Sector" vs "SECTOR"), so normalise
+    # before comparing rather than relying on the exact-case match used before.
+    scope = event.scope.strip().upper()
+
+    if cat == "SafetyCar":
+        # "SAFETY CAR IN THIS LAP" is the FIA end-of-neutralisation message (the
+        # car comes into the pit lane this lap). It carries none of the other
+        # keywords, so it used to fall through to SAFETY_CAR_DEPLOYED — which
+        # kept the stateful tracker pinned ON for the rest of the race. Treat it
+        # as ending. (NR-02 / NR-03, #305)
+        ending = "ENDING" in msg or "IN THIS LAP" in msg
+        if "VIRTUAL" in msg:
+            return "VIRTUAL_SAFETY_CAR_ENDING" if ending else "VIRTUAL_SAFETY_CAR_DEPLOYED"
+        if "IN THE PIT LANE" in msg:
+            return "SAFETY_CAR_IN_PIT_LANE"
+        if ending:
+            return "SAFETY_CAR_ENDING"
+        return "SAFETY_CAR_DEPLOYED"
+
+    if flag in _FLAG_MAP:
+        return _FLAG_MAP[flag]
+    if flag in _YELLOW_FLAG_VALUES:
+        return "YELLOW_FLAG_SECTOR" if scope == "SECTOR" else "YELLOW_FLAG"
+
+    if "DRS ENABLED" in msg:
+        return "DRS_ENABLED"
+    if "DRS DISABLED" in msg:
+        return "DRS_DISABLED"
+    if any(k in msg for k in ("COLLISION", "CONTACT", "INCIDENT")):
+        return "CAR_COLLISION"
+    if "RETIRED" in msg:
+        return "CAR_RETIRED"
+    if "PENALTY" in msg:
+        return "TIME_PENALTY"
+
+    # ── NR-03 (#398) additive coverage ──────────────────────────────────────
+    # Track-limit / lap-time deletions ("CAR 1 (VER) LAP DELETED - TRACK
+    # LIMITS AT TURN 14 ..."): a penalty-risk signal for us or a rival that
+    # was previously indistinguishable from any other unclassified message.
+    if any(k in msg for k in _TRACK_LIMITS_KEYWORDS):
+        return "LAP_DELETED"
+    # Stewards reviewing an incident ("... UNDER INVESTIGATION" / "... NOTED"):
+    # penalty anticipation, worth surfacing even though (see docstring) the
+    # broader COLLISION/CONTACT/INCIDENT check above already intercepts the
+    # large majority of real-world instances of this phrasing.
+    if any(k in msg for k in _INVESTIGATION_KEYWORDS):
+        return "INVESTIGATION"
+    # Pit lane entry/exit status ("PIT LANE ENTRY CLOSED" / "... OPEN"): a hard
+    # veto or permission on PIT_NOW, so CLOSED and OPEN are kept as distinct
+    # event types rather than a single generic "pit lane event" bucket.
+    if "PIT" in msg and "CLOSED" in msg:
+        return "PIT_LANE_CLOSED"
+    if "PIT" in msg and "OPEN" in msg:
+        return "PIT_LANE_OPEN"
+    # Session suspend/resume/start announcements. Unlike the families above,
+    # no race in the local 2025 rcm.parquet corpus contains a red-flag
+    # suspension, so these keyword sets are best-effort FIA phrasing and are
+    # NOT corpus-verified — flagged in the PR/issue for validation against a
+    # real red-flag race before being relied on for the restart-procedure logic
+    # the audit describes (AUDIT_NLP_RADIO_PIPELINE.md section 5.2 item 4).
+    if any(k in msg for k in _SESSION_SUSPENDED_KEYWORDS):
+        return "SESSION_SUSPENDED"
+    if any(k in msg for k in _SESSION_RESUMED_KEYWORDS):
+        return "SESSION_RESUMED"
+    if any(k in msg for k in _SESSION_STARTED_KEYWORDS):
+        return "SESSION_STARTED"
+
+    return "OTHER"

--- a/src/strategy/eval/nlp.py
+++ b/src/strategy/eval/nlp.py
@@ -41,6 +41,7 @@ from dataclasses import asdict, dataclass
 from typing import Any
 
 from src.f1_strat_manager.data_cache import get_data_root, get_models_root
+from src.f1_strat_manager.rcm_events import RCMEvent, classify_rcm_event
 from src.strategy.eval.report import build_header, write_report
 
 NLP_NAME = "nlp"
@@ -587,103 +588,34 @@ def reproduce_ner() -> list[StageResult]:
 
 
 def _classify_rcm_event(category: str, flag: Any, scope: Any, sector: Any, message: str) -> str:
-    """Rule-based RCM event classifier ported from N23 (``_classify_event``).
+    """Adapt one persisted RCM row to the SHIPPED classifier and return its verdict.
 
-    Reads the persisted lowercase RCM schema (category/flag/scope/sector/
-    message). The branch logic is identical to the N23 notebook parser and the
-    inlined ``radio_agent`` copy; only the field access is adapted to the
-    on-disk column names. Kept in the harness because importing ``radio_agent``
-    loads every NLP model.
+    This used to be a hand-written PORT of the classifier, and the port drifted.
+    Over this very corpus the two disagreed on 427 of 1515 messages, 28.2 percent,
+    with the port on the wrong side of #305's ``SAFETY CAR IN THIS LAP`` fix. So the
+    coverage this harness published described a copy nobody runs, over-stating the
+    real parser by 2.24 points on a row whose status column read ``reproduced``
+    (#632). A reproduction harness measuring its own private fork is not reproducing
+    anything.
 
-    --- WHERE TO CHANGE IF THE PARSER CHANGES ---
-    ``notebooks/nlp/N23_rcm_parser.ipynb`` (_classify_event) is the source of
-    truth; mirror any edit there into this port and the radio_agent copy.
+    The port existed for a real reason, that importing ``radio_agent`` loads every
+    NLP model. ``src.f1_strat_manager.rcm_events`` now holds the logic with no model
+    behind it, so this is a thin field-name adapter and nothing more.
+
+    ``sector`` is accepted and deliberately UNUSED: the persisted schema carries it,
+    the shipped ``RCMEvent`` has no such field, and the old port branched on it while
+    the shipped parser decides sector-scoping from ``scope`` alone. Reconciling that
+    is a question about which behaviour is right, tracked separately; measuring what
+    ships is this function's only job.
     """
-    import pandas as pd
-
-    cat = str(category).strip()
-    flag_up = str(flag).strip().upper()
-    msg = str(message).upper()
-
-    if cat == "SafetyCar":
-        if "VIRTUAL" in msg:
-            return (
-                "VIRTUAL_SAFETY_CAR_DEPLOYED" if "DEPLOYED" in msg else "VIRTUAL_SAFETY_CAR_ENDING"
-            )
-        if "DEPLOYED" in msg:
-            return "SAFETY_CAR_DEPLOYED"
-        if "PIT LANE" in msg or "IN THIS LAP" in msg:
-            return "SAFETY_CAR_IN_PIT_LANE"
-        if "ENDING" in msg or "WITHDRAWN" in msg:
-            return "SAFETY_CAR_ENDING"
-        return "OTHER"
-
-    if cat == "Flag":
-        if flag_up == "CHEQUERED" or "CHEQUERED" in msg:
-            return "CHEQUERED_FLAG"
-        if flag_up == "BLUE":
-            return "BLUE_FLAG"
-        if flag_up == "BLACK AND WHITE":
-            return "BLACK_AND_WHITE_FLAG"
-        if flag_up in ("VIRTUAL_SAFETY_CAR", "VSC"):
-            return "VIRTUAL_SAFETY_CAR_DEPLOYED"
-        if flag_up == "SAFETY_CAR":
-            return "SAFETY_CAR_DEPLOYED"
-        if flag_up == "RED" or "RED FLAG" in msg:
-            return "RED_FLAG"
-        if flag_up == "GREEN" or "GREEN FLAG" in msg:
-            return "GREEN_FLAG"
-        if flag_up == "CLEAR":
-            return "CLEAR_FLAG"
-        if flag_up in ("YELLOW", "DOUBLE YELLOW"):
-            if str(scope).strip() == "Sector" or pd.notna(sector):
-                return "YELLOW_FLAG_SECTOR"
-            return "YELLOW_FLAG"
-        return "OTHER"
-
-    if cat == "Drs":
-        return "DRS_ENABLED" if "ENABLED" in msg else "DRS_DISABLED"
-
-    if cat == "CarEvent":
-        if "RETIRED" in msg or "ABANDON" in msg:
-            return "CAR_RETIRED"
-        if "COLLISION" in msg or "CONTACT" in msg:
-            return "CAR_COLLISION"
-        if "MECHANICAL" in msg or "ENGINE" in msg or "GEARBOX" in msg:
-            return "CAR_MECHANICAL"
-        return "OTHER"
-
-    if cat == "Other":
-        if "DRS ENABLED" in msg:
-            return "DRS_ENABLED"
-        if "DRS DISABLED" in msg:
-            return "DRS_DISABLED"
-        if (
-            "TRACK LIMITS" in msg
-            or "TIME DELETED" in msg
-            or "LAP DELETED" in msg
-            or "DELETED" in msg
-        ):
-            return "LAP_DELETED"
-        if "UNDER INVESTIGATION" in msg or "FIA STEWARDS" in msg or "NOTED" in msg:
-            return "INVESTIGATION"
-        if "PENALTY" in msg or ("TIME" in msg and "SECOND" in msg):
-            return "TIME_PENALTY"
-        if "PIT EXIT" in msg or "PIT LANE" in msg:
-            return "PIT_EXIT"
-        track_surface = "TRACK" in msg and (
-            "CONDITION" in msg or "SLIPPERY" in msg or "SURFACE" in msg
-        )
-        other_surface = any(k in msg for k in ("DEBRIS", "FLUID", "LOW GRIP", "RAIN", "AWNING"))
-        if track_surface or other_surface:
-            return "TRACK_CONDITION"
-        if "LAPPED" in msg and "OVERTAKE" in msg:
-            return "LAPPED_CARS_OVERTAKE"
-        if "ALL CARS MAY OVERTAKE" in msg:
-            return "SAFETY_CAR_ENDING"
-        return "OTHER"
-
-    return "OTHER"
+    event = RCMEvent(
+        message=str(message or ""),
+        flag=str(flag or ""),
+        category=str(category or ""),
+        lap=0,
+        scope=str(scope or ""),
+    )
+    return classify_rcm_event(event)
 
 
 def reproduce_rcm() -> list[StageResult]:


### PR DESCRIPTION
Closes #632. The worst of the thirteen twin-drift defects found today, because this one **measured different code**.

`_classify_rcm_event` existed twice: inlined in `radio_agent` (**ships**) and ported into `strategy/eval/nlp.py` (**is measured**), with the harness docstring asserting they were identical.

## What the divergence actually was

Over the real 1515-row 2025 RCM corpus:

```
DISAGREE: 427/1515 = 28.2%
```

| message | port said | shipped says |
|---|---|---|
| `SAFETY CAR IN THIS LAP` | `SAFETY_CAR_IN_PIT_LANE` | **`SAFETY_CAR_ENDING`** |
| `INCIDENT INVOLVING CAR 14 (ALO) NOTED` | `INVESTIGATION` | `CAR_COLLISION` |

**The shipped side is the correct one on the first row**: #305 fixed it because `SAFETY CAR IN THIS LAP` is the FIA end-of-neutralisation message, and leaving it as DEPLOYED pinned the stateful tracker ON for the rest of the race. That fix never crossed into the port, so what was being measured was the older, more wrong parser.

There was also a structural divergence: `RCMEvent` has **no `sector` field** while the port branched on one.

## What it did to the published number

| parser | coverage |
|---|---|
| the port, which is what `nlp.md` published | **0.9868** |
| **the parser that ships** | **0.9644** |

Over-stated by **2.24 points**, upward, on a row whose status column read `reproduced`.

## The fix, and why not simply patch the port

The port existed for a real reason the docstring stated: importing `radio_agent` loads every NLP model. But the classifier is **pure string rules with no model behind it**, so the answer was to move it, not to copy it.

`src/f1_strat_manager/rcm_events.py` now holds `RCMEvent`, the flag maps, the keyword families and `classify_rcm_event`. `radio_agent` imports them. The harness is a thin field-name adapter over the same function.

Patching the port to match would have kept the drift mechanism alive for the next FIA message format.

## Verification

```
disagreements harness vs shipped : 0/1515   (was 427)
coverage the harness now reports : 0.9644
```

Report regenerated. 22 RCM/radio/NLP tests pass. Ruff check and format clean repo-wide.

## Left open on purpose

The `sector` question. The persisted schema carries it, the shipped parser decides sector-scoping from `scope` alone, and the port used both. **Which behaviour is right is a separate question** from making the harness measure what ships, and settling it here would have hidden a behaviour change inside a measurement fix.
