### PR TITLE
fix(tests): correct a golden that was born red, and say why CI could never tell us

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,13 @@ these safeguards trigger there. They are no-ops on POSIX.
 
 - [ ] Branch off `dev` (`main` is release-only).
 - [ ] `pytest tests/ -x` green.
+- [ ] **`pytest tests/eval/ -q` green, run LOCALLY.** CI cannot run this
+      directory: it needs `data/models/` and the labeled holdouts, which the
+      runners do not have, so those tests are skipped there and **a failure in
+      them is invisible to every pull request**. This is not hypothetical: a
+      golden asserting a pit coverage of 0.7047 sat red for months after the
+      holdout was regenerated to 0.7024, with every PR passing over it (#634).
+      A green CI means these did not run, not that they passed.
 - [ ] If you touched `src/telemetry/*`, commit inside the submodule and
       bump the submodule pointer in the parent repo.
 - [ ] `ROADMAP.md` and the relevant `docs/` file updated when behaviour

--- a/tests/eval/test_registry_golden.py
+++ b/tests/eval/test_registry_golden.py
@@ -6,11 +6,18 @@ tests) and run locally where the weights are present. They lock the harness's
 retro-validation contract - the three claims #206 must keep true:
 
 - the registry reconciles the pace 0.392 -> 0.4104 divergence to the canonical;
-- calibration "finds" the known-broken pit P05-P95 coverage (0.7047) as drift;
+- calibration "finds" the known-broken pit P05-P95 coverage (177/252) as drift;
 - reproduction re-derives overtake AUC-PR back to its published 0.5491.
 
 They call the ``collect_*`` functions (pure, no report I/O) so the assertions
 test the harness logic, not the markdown writer.
+
+WARNING, and it has already cost this repo once. Because CI cannot run these, a
+red test here is INVISIBLE to every pull request. The pit-coverage golden was
+written against 0.7047, the holdout was regenerated to 0.7024 in the same week,
+and the assertion sat failing for months with every PR going green over it
+(#634). **Run this directory locally before promoting to main.** A green CI is
+not evidence that these passed; it is evidence that they did not run.
 """
 
 from __future__ import annotations
@@ -42,14 +49,26 @@ def test_registry_reconciles_pace_divergence():
 
 
 def test_calibration_flags_pit_coverage_drift():
-    """The pit P05-P95 coverage (0.7047) surfaces and is flagged as drift."""
+    """The pit P05-P95 coverage surfaces and is flagged as drift.
+
+    The drift assertion is what this test is FOR. The exact value is provenance,
+    and it moved once: this test was written against 0.7047, then `ccc213d`
+    regenerated the N15 holdout from raw laps, computed 0.7024, wrote that into
+    the report, and left the assertion on the old number. So the golden was born
+    red and stayed red, because `tests/eval/` is data-gated and CI runners have
+    no dataset to run it with. Nobody was ever told (#634).
+
+    177/252 is the current value, re-derived here rather than copied: the alias
+    fix in #629 was checked against it and moves it by exactly nothing (it moved
+    P50 MAE by -0.0045 s instead).
+    """
     from src.strategy.eval.calibration import collect_results
 
     pit = [
         r for r in collect_results() if r.model == "pit_duration" and r.metric == "p05_p95_coverage"
     ]
     assert len(pit) == 1
-    assert pit[0].value == pytest.approx(0.7047)
+    assert pit[0].value == pytest.approx(177 / 252, abs=1e-6)
     assert pit[0].status == "drift", "coverage below 0.90 nominal must flag drift"
 
 


### PR DESCRIPTION
Closes #634.

`test_calibration_flags_pit_coverage_drift` asserted a pit P05-P95 coverage of **0.7047**. The real value is **177/252 = 0.70238**, and has been since `ccc213d` regenerated the N15 holdout from raw laps. That commit computed 0.7024, wrote it into the calibration report, and **left the assertion on the old number**. The golden was red from that day.

## Established, not assumed

The obvious suspect was the #629 team-alias fix, since `calibration.py` recomputes this straight from `load_pit_holdout()`. **It is not.**

- Monkeypatching `canonical_team` to the identity, which reproduces the pre-fix lambda exactly, gives **the same 177/252 either way**. The alias fix moved P50 MAE by -0.0045 s and moved this by nothing.
- Checked out `dev` and ran the test there: **fails identically.**

The assertion now uses `177 / 252` with its provenance in the docstring, and keeps the drift check, which is what the test is actually for. The exact value is evidence; **the drift is the contract**.

## The half that matters more

`tests/eval/` is data-gated. CI runners have no dataset, so these tests **skip** there, and a red one is **invisible to every pull request**. Months of green PRs passed over this one.

The module docstring and the `CONTRIBUTING` pre-merge checklist now say it plainly:

> A green CI is not evidence that these passed. It is evidence that they did not run.

with the instruction to run `pytest tests/eval/ -q` locally before promoting.

## The pattern, for the thirteenth time today

One artefact was updated and its twin was not, and nothing was watching the twin. Same shape as #620, #566, #628, #629, #632, #633.

## Verification

`tests/eval/test_registry_golden.py`: **3 passed**. Ruff check and format clean repo-wide.