### PR TITLE
fix(nlp): classify the black-and-white flag, which the copy we replaced could and we could not

### DIFF
--- a/documents/eval_reports/nlp.json
+++ b/documents/eval_reports/nlp.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "81656b0",
+    "harness_sha": "02ed796",
     "dataset": "radio + intent labeled CSVs, entity annotations, 2025 RCM corpus",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-26T18:47:28+00:00",
+    "generated_at": "2026-07-26T19:30:49+00:00",
     "artifacts": {
       "roberta_sentiment": "d7d0ada739c6",
       "intent_head": "7c995ba21bc0",
@@ -81,10 +81,10 @@
     {
       "stage": "rcm",
       "metric": "coverage",
-      "value": 0.9644,
+      "value": 0.9657,
       "reference": null,
       "status": "reproduced",
-      "detail": "n=1515 across 24 2025 races; per-category [Drs 1.000, Flag 0.997, Other 0.924, SafetyCar 1.000]; vs config Flag 1.0/Other 0.928/Drs 1.0/SafetyCar 1.0 (N23 sample differs)"
+      "detail": "n=1515 across 24 2025 races; per-category [Drs 1.000, Flag 1.000, Other 0.924, SafetyCar 1.000]; vs config Flag 1.0/Other 0.928/Drs 1.0/SafetyCar 1.0 (N23 sample differs)"
     },
     {
       "stage": "ner",

--- a/documents/eval_reports/nlp.md
+++ b/documents/eval_reports/nlp.md
@@ -1,6 +1,6 @@
 # nlp
 
-- harness `81656b0` · schema v1 · generated 2026-07-26T18:47:28+00:00
+- harness `02ed796` · schema v1 · generated 2026-07-26T19:30:49+00:00
 - era 2022-2025 · dataset radio + intent labeled CSVs, entity annotations, 2025 RCM corpus · seed deterministic · llm none
 - artifacts: roberta_sentiment=`d7d0ada739c6`, intent_head=`7c995ba21bc0`, ner_bert_bio=`9e60de9bf538`
 
@@ -15,4 +15,4 @@
 | alert_precision | precision | 0.9185 | - | reproduced | n=529 (145 gold alerts); radio PROBLEM/WARNING channel from hand-labeled gold intent; R 0.855/F1 0.886; full-set optimistic |
 | intent | predict_proba_order | 1.0000 | 1 | reproduced | head.classes_=[0, 1, 2, 3, 4] map to intent_names via intent_mapping; 5/5 columns aligned (no swap) |
 | ner | entity_f1 | 0.4248 | 0.4151 | reproduced | n=529; micro entity-F1 (P 0.304/R 0.704); full-set optimistic; 4 dead classes flagged separately |
-| rcm | coverage | 0.9644 | - | reproduced | n=1515 across 24 2025 races; per-category [Drs 1.000, Flag 0.997, Other 0.924, SafetyCar 1.000]; vs config Flag 1.0/Other 0.928/Drs 1.0/SafetyCar 1.0 (N23 sample differs) |
+| rcm | coverage | 0.9657 | - | reproduced | n=1515 across 24 2025 races; per-category [Drs 1.000, Flag 1.000, Other 0.924, SafetyCar 1.000]; vs config Flag 1.0/Other 0.928/Drs 1.0/SafetyCar 1.0 (N23 sample differs) |

--- a/src/f1_strat_manager/rcm_events.py
+++ b/src/f1_strat_manager/rcm_events.py
@@ -29,6 +29,14 @@ _FLAG_MAP = {
     "CLEAR": "CLEAR_FLAG",
     "BLUE": "BLUE_FLAG",
     "CHEQUERED": "CHEQUERED_FLAG",
+    # The FIA's formal warning for unsportsmanlike driving, and the step that
+    # PRECEDES a penalty. It was missing here while the eval port #632 replaced did
+    # carry it, which is how that drift turned out to run both ways: this side was
+    # ahead on SAFETY CAR IN THIS LAP and behind on this. Two real instances in the
+    # 2025 corpus, and they were the ONLY two Flag messages falling through to
+    # OTHER, so this one key is the whole difference between Flag scoring 0.9972
+    # and 1.0000 (#641).
+    "BLACK AND WHITE": "BLACK_AND_WHITE_FLAG",
 }
 
 # NR-03 (#398) — flag values that resolve through the same scope-aware branch as


### PR DESCRIPTION
Closes #641. Found while checking whether #632 moved a figure the thesis publishes. **It did not**, but it exposed this.

## The drift ran BOTH ways, and #632 only saw one direction

#632 concluded the eval port was the older side, because #305's `SAFETY CAR IN THIS LAP` fix never crossed into it. True, and incomplete. **The port also carried a branch the shipped parser never had:**

```python
if flag_up == "BLACK AND WHITE":
    return "BLACK_AND_WHITE_FLAG"
```

So **neither copy was strictly the reference**. Each had something the other lacked, which is why that 28.2 % disagreement resolved unevenly. Pointing the harness at what ships was still right; it just also stopped reporting a capability that did not exist here.

## Measured per category, all 1515 rows

| category | n | before | after |
|---|---|---|---|
| Drs | 46 | 1.0000 | 1.0000 |
| SafetyCar | 65 | 1.0000 | 1.0000 |
| **Flag** | **719** | **0.9972** | **1.0000** |
| Other | 685 | 0.9241 | 0.9241 |

Both misses were black-and-white flags:

```
'BLACK AND WHITE FLAG FOR CAR 10 (GAS) - REJOINING UNSAFELY'
'BLACK AND WHITE FLAG FOR CAR 5 (BOR) - MOVING UNDER BRAKING'
```

**One missing key was the entire gap** on the only critical category that was not perfect.

## Why it is worth more than two rows

The thesis claims **100 % coverage on the critical categories** (flags, safety car, DRS). DRS and SafetyCar always held. **Flag now does too**, so the claim is intact and now measured against the parser that actually ships.

## Left out on purpose

A black-and-white flag is the FIA's formal warning for unsportsmanlike driving and it **precedes a penalty**, so by the argument already written into `_SAFETY_FLAGS` for `TIME_PENALTY` it is at least as strategically relevant, being the earlier signal of the same event.

**Whether it should therefore become a forwarded alert is a product decision**, with LLM cost attached and a change to what the driver is told. Deliberately not smuggled in with a classification fix.

## Verification

Per-category recount gives Flag 1.0000. Overall coverage 0.9644 to **0.9657**. 22 RCM/radio/NLP tests pass. Ruff check and format clean repo-wide.