### PR TITLE
refactor(readability): apply the four findings that earn it and close the audit

### DIFF
--- a/scripts/debug_agent.py
+++ b/scripts/debug_agent.py
@@ -147,9 +147,15 @@ def _build_lap_state(args: argparse.Namespace, laps_df: pd.DataFrame) -> dict[st
     # Try to find actual lap data from the featured parquet
     real_row = None
     if laps_df is not None and not laps_df.empty:
-        mask = (laps_df.get("Driver", laps_df.get("driver", pd.Series(dtype=str))) == driver) & (
-            laps_df.get("LapNumber", laps_df.get("lap_number", pd.Series(dtype=int))) == lap_num
-        )
+        # Named before combining. Four .get() calls joined by & hid an edge case:
+        # when neither spelling of a column exists the comparison runs against a
+        # Series with NO index, and its alignment against laps_df is easy to get
+        # wrong without noticing.
+        driver_col = laps_df.get("Driver", laps_df.get("driver", pd.Series(dtype=str)))
+        lap_col = laps_df.get("LapNumber", laps_df.get("lap_number", pd.Series(dtype=int)))
+        driver_match = driver_col == driver
+        lap_match = lap_col == lap_num
+        mask = driver_match & lap_match
         if "GrandPrix" in laps_df.columns:
             mask &= laps_df["GrandPrix"].str.contains(gp_name, case=False, na=False)
         candidates = laps_df[mask]

--- a/src/arcade/data.py
+++ b/src/arcade/data.py
@@ -650,4 +650,13 @@ class SessionLoader:
         dx = np.diff(ref_x)
         dy = np.diff(ref_y)
         length_raw = float(np.sum(np.hypot(dx, dy)))
-        return length_raw / 10000.0 if length_raw > 1e6 else length_raw
+        # ref_x/ref_y are FastF1 raw units (1/10 mm, see the module docstring), so a
+        # real circuit polyline sums into the tens of millions. The threshold exists
+        # to leave alone a caller that already handed us metres. Naming both numbers
+        # answers the question the ternary hid: what unit does this return, and can
+        # it silently return raw units instead of metres?
+        raw_units_per_metre = 10_000.0
+        looks_like_raw_units = length_raw > 1e6
+        if looks_like_raw_units:
+            return length_raw / raw_units_per_metre
+        return length_raw


### PR DESCRIPTION
Closes #643. Point 4 of the queue, under the constraint the owner stated in capitals: **surgical, only where it makes sense, never everywhere for the sake of it.**

## The result nobody planned for: the best findings were bugs

Three report-only auditors produced **23 findings** (10 HIGH, 12 MEDIUM, 1 LOW). **Four of the ten HIGHs were not readability problems at all** and became their own issues:

- **#628** — `position = d.get('position') or 1` feeding P1 into the live N06 model.
- **#629** — a branching lambda encoding an unseen team as `team_classes[0]`, which reached a published figure.

The audit paid for itself through a door it was not aiming at, for the third time in one day.

## Applied, and only this

| where | what a reader had to decode |
|---|---|
| `strategy_orchestrator.py` | a nested ternary for `gp_name` whose middle branch reads as redundant and is not |
| `bench_nlp_pipeline_cpu.py` | "is a sector present" meaning two different things by type, in one condition |
| `debug_agent.py` | a compound pandas mask with two nested column-name fallbacks, hiding an edge case where the comparison runs against a Series with **no index** |
| `arcade/data.py` | a unit conversion in an arithmetic ternary: `10000.0` is the 1/10mm-to-metres factor and nothing at the call site said so |

## What was NOT applied, which is the more important half

The rest is a tail of MEDIUMs whose rewrites add lines without adding clarity.

The auditors' own **"dense but fine"** sections are the evidence their bar was calibrated rather than exhausted. They declined the NaN-safe `int(r["X"]) if pd.notna(...) else None` idiom repeated dozens of times in `race_state_manager`, because **the repetition is what makes it recognisable**; chained comparisons like `0.0 < gap <= X`, because that is standard Python and not a trap; and the CLI's display-only `or 0` fallbacks, because **that file already documents why they are safe for a table cell and wrong for the agents**.

## One observation correctly kept out

An auditor spotted **repo-root resolution reimplemented seven times in two different shapes**, and kept it out of a readability report because it is a duplication question. That was the right call, and it is the fourteenth instance of today's dominant pattern.

## A correction inside this PR

The first commit here listed four changes and landed one: the block applying them asserted on a pattern `ruff format` had realigned, failed at the first edit and never reached the second. The second commit applies what the first claimed. That is blind-spot 7 from the standing directive, caught by reading what the commit contained rather than what it said.

## Verification

Full suite **340 passed, 4 skipped**. Ruff check and format clean repo-wide.