### PR TITLE
Promote dev to main: the black-and-white flag and the readability tail

### DIFF
--- a/documents/eval_reports/nlp.json
+++ b/documents/eval_reports/nlp.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "81656b0",
+    "harness_sha": "02ed796",
     "dataset": "radio + intent labeled CSVs, entity annotations, 2025 RCM corpus",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-26T18:47:28+00:00",
+    "generated_at": "2026-07-26T19:30:49+00:00",
     "artifacts": {
       "roberta_sentiment": "d7d0ada739c6",
       "intent_head": "7c995ba21bc0",
@@ -81,10 +81,10 @@
     {
       "stage": "rcm",
       "metric": "coverage",
-      "value": 0.9644,
+      "value": 0.9657,
       "reference": null,
       "status": "reproduced",
-      "detail": "n=1515 across 24 2025 races; per-category [Drs 1.000, Flag 0.997, Other 0.924, SafetyCar 1.000]; vs config Flag 1.0/Other 0.928/Drs 1.0/SafetyCar 1.0 (N23 sample differs)"
+      "detail": "n=1515 across 24 2025 races; per-category [Drs 1.000, Flag 1.000, Other 0.924, SafetyCar 1.000]; vs config Flag 1.0/Other 0.928/Drs 1.0/SafetyCar 1.0 (N23 sample differs)"
     },
     {
       "stage": "ner",

--- a/documents/eval_reports/nlp.md
+++ b/documents/eval_reports/nlp.md
@@ -1,6 +1,6 @@
 # nlp
 
-- harness `81656b0` · schema v1 · generated 2026-07-26T18:47:28+00:00
+- harness `02ed796` · schema v1 · generated 2026-07-26T19:30:49+00:00
 - era 2022-2025 · dataset radio + intent labeled CSVs, entity annotations, 2025 RCM corpus · seed deterministic · llm none
 - artifacts: roberta_sentiment=`d7d0ada739c6`, intent_head=`7c995ba21bc0`, ner_bert_bio=`9e60de9bf538`
 
@@ -15,4 +15,4 @@
 | alert_precision | precision | 0.9185 | - | reproduced | n=529 (145 gold alerts); radio PROBLEM/WARNING channel from hand-labeled gold intent; R 0.855/F1 0.886; full-set optimistic |
 | intent | predict_proba_order | 1.0000 | 1 | reproduced | head.classes_=[0, 1, 2, 3, 4] map to intent_names via intent_mapping; 5/5 columns aligned (no swap) |
 | ner | entity_f1 | 0.4248 | 0.4151 | reproduced | n=529; micro entity-F1 (P 0.304/R 0.704); full-set optimistic; 4 dead classes flagged separately |
-| rcm | coverage | 0.9644 | - | reproduced | n=1515 across 24 2025 races; per-category [Drs 1.000, Flag 0.997, Other 0.924, SafetyCar 1.000]; vs config Flag 1.0/Other 0.928/Drs 1.0/SafetyCar 1.0 (N23 sample differs) |
+| rcm | coverage | 0.9657 | - | reproduced | n=1515 across 24 2025 races; per-category [Drs 1.000, Flag 1.000, Other 0.924, SafetyCar 1.000]; vs config Flag 1.0/Other 0.928/Drs 1.0/SafetyCar 1.0 (N23 sample differs) |

--- a/scripts/debug_agent.py
+++ b/scripts/debug_agent.py
@@ -147,9 +147,15 @@ def _build_lap_state(args: argparse.Namespace, laps_df: pd.DataFrame) -> dict[st
     # Try to find actual lap data from the featured parquet
     real_row = None
     if laps_df is not None and not laps_df.empty:
-        mask = (laps_df.get("Driver", laps_df.get("driver", pd.Series(dtype=str))) == driver) & (
-            laps_df.get("LapNumber", laps_df.get("lap_number", pd.Series(dtype=int))) == lap_num
-        )
+        # Named before combining. Four .get() calls joined by & hid an edge case:
+        # when neither spelling of a column exists the comparison runs against a
+        # Series with NO index, and its alignment against laps_df is easy to get
+        # wrong without noticing.
+        driver_col = laps_df.get("Driver", laps_df.get("driver", pd.Series(dtype=str)))
+        lap_col = laps_df.get("LapNumber", laps_df.get("lap_number", pd.Series(dtype=int)))
+        driver_match = driver_col == driver
+        lap_match = lap_col == lap_num
+        mask = driver_match & lap_match
         if "GrandPrix" in laps_df.columns:
             mask &= laps_df["GrandPrix"].str.contains(gp_name, case=False, na=False)
         candidates = laps_df[mask]

--- a/src/arcade/data.py
+++ b/src/arcade/data.py
@@ -650,4 +650,13 @@ class SessionLoader:
         dx = np.diff(ref_x)
         dy = np.diff(ref_y)
         length_raw = float(np.sum(np.hypot(dx, dy)))
-        return length_raw / 10000.0 if length_raw > 1e6 else length_raw
+        # ref_x/ref_y are FastF1 raw units (1/10 mm, see the module docstring), so a
+        # real circuit polyline sums into the tens of millions. The threshold exists
+        # to leave alone a caller that already handed us metres. Naming both numbers
+        # answers the question the ternary hid: what unit does this return, and can
+        # it silently return raw units instead of metres?
+        raw_units_per_metre = 10_000.0
+        looks_like_raw_units = length_raw > 1e6
+        if looks_like_raw_units:
+            return length_raw / raw_units_per_metre
+        return length_raw

--- a/src/f1_strat_manager/rcm_events.py
+++ b/src/f1_strat_manager/rcm_events.py
@@ -29,6 +29,14 @@ _FLAG_MAP = {
     "CLEAR": "CLEAR_FLAG",
     "BLUE": "BLUE_FLAG",
     "CHEQUERED": "CHEQUERED_FLAG",
+    # The FIA's formal warning for unsportsmanlike driving, and the step that
+    # PRECEDES a penalty. It was missing here while the eval port #632 replaced did
+    # carry it, which is how that drift turned out to run both ways: this side was
+    # ahead on SAFETY CAR IN THIS LAP and behind on this. Two real instances in the
+    # 2025 corpus, and they were the ONLY two Flag messages falling through to
+    # OTHER, so this one key is the whole difference between Flag scoring 0.9972
+    # and 1.0000 (#641).
+    "BLACK AND WHITE": "BLACK_AND_WHITE_FLAG",
 }
 
 # NR-03 (#398) — flag values that resolve through the same scope-aware branch as


### PR DESCRIPTION
Three commits the open 2.2.2 release PR does not yet contain. Promoting first so the release picks them up rather than shipping without them.

## #642 — the black-and-white flag, and the drift that ran both ways

#632 concluded the eval port was the older side of the RCM parser, because #305's `SAFETY CAR IN THIS LAP` fix never crossed into it. True, and incomplete: **the port also carried a branch the shipped parser never had**, for the FIA black-and-white flag. So neither copy was strictly the reference.

Measured per category over all 1515 rows: Drs 46/46 and SafetyCar 65/65 at 1.0000, **Flag 717 of 719**. Both misses were black-and-white flags, so **one missing key was the entire gap** on the only critical category that was not perfect.

That matters because the thesis claims 100 % coverage on the critical categories. **Flag now holds too**, measured against the parser that actually ships.

## #644 — the readability audit, closed

23 findings, **4 applied**, the rest deliberately not. Four of the ten HIGHs turned out not to be readability problems at all and became #628 and #629, one of which reached a published figure.

The auditors' own "dense but fine" sections are the evidence their bar was calibrated: they declined the NaN-safe extraction idiom repeated dozens of times in `race_state_manager` because **the repetition is what makes it recognisable**, and the CLI's display-only fallbacks because that file already documents why they are safe for a table cell and wrong for the agents.

## A correction inside it

The first readability commit listed four changes and landed one: the block applying them asserted on a pattern `ruff format` had realigned, failed at the first edit and never reached the second. The follow-up applies what the first claimed, and says so. That is blind-spot 7 from the standing directive, caught by reading what the commit contained rather than what it said.

## Verification

Full local suite **340 passed, 4 skipped**, run the way #634 now demands, since CI cannot execute the data-gated tests. Ruff check and format clean repo-wide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recognition for FIA “BLACK AND WHITE” flag messages as a distinct event type.

* **Bug Fixes**
  * Improved event and circuit data handling for more reliable race information.
  * Refreshed NLP evaluation results with updated coverage measurements and run metadata.

* **Refactor**
  * Clarified internal data-processing logic without changing expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->