### PR TITLE
fix(mc): break an exact tie by a stated rule instead of by dict insertion order

### DIFF
--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -905,6 +905,55 @@ def _lap_count_or_zero(reported) -> int:
     return int(number)
 
 
+# Which candidate wins when two score EXACTLY the same. This used to be decided by
+# `max`, which returns the first item it saw, so the answer came from the order
+# `_run_mc_simulation` happens to build its dict in. That produced the right answer
+# (STAY_OUT is first, and conservative is the right default for a genuine tie) for
+# the wrong reason, and it was invisible: nothing recorded that a tie had happened.
+#
+# It is not a rare corner either. Over 415 real laps the audit found six near-ties,
+# ALL SIX on decision laps, three of them exact and falling on real pit stops (#645).
+# The margin is smallest exactly where the call is hardest, which is the opposite of
+# the usual case, so this list decides real races and deserves to be a decision.
+#
+# Conservative first: doing nothing is recoverable next lap, a stop is not.
+_TIE_BREAK_ORDER: tuple[str, ...] = ("STAY_OUT", "PIT_NOW", "UNDERCUT", "OVERCUT")
+
+
+def _scoreable(mc_results: dict) -> dict:
+    """The candidates that actually carry a finite score.
+
+    A candidate with no valid target scores None by design, and it must not be
+    silently treated as zero: that is the sentinel-collision shape this codebase
+    keeps paying for.
+    """
+    return {
+        name: cell
+        for name, cell in mc_results.items()
+        if _finite_or_none(cell.get("score")) is not None
+    }
+
+
+def mc_decision_margin(mc_results: dict) -> float | None:
+    """How far the winner beat the runner-up, or None when there is no contest.
+
+    Exists because a caller could previously not tell "the model preferred this by
+    a clear margin" from "two candidates scored identically and one was picked".
+    Both arrive as the same bare string, and the second is a materially different
+    statement about the lap: a tie means the decision is genuinely balanced, which
+    is information a strategist wants rather than noise to hide.
+
+    Returns None when fewer than two candidates are scoreable, because there is no
+    margin to report and zero would read as "a dead tie" (#645).
+    """
+    scores = sorted(
+        (cell["score"] for cell in _scoreable(mc_results).values()), reverse=True
+    )
+    if len(scores) < 2:
+        return None
+    return float(scores[0] - scores[1])
+
+
 def best_mc_candidate(mc_results: dict) -> str:
     """The argmax over scored candidates, skipping the ones never offered.
 
@@ -914,18 +963,42 @@ def best_mc_candidate(mc_results: dict) -> str:
     helper is also what stops the four from drifting apart, which is how this
     codebase acquired most of its duplicate-logic bugs.
 
+    An exact tie is broken by ``_TIE_BREAK_ORDER`` rather than by whichever key the
+    caller inserted first. Same answer as before on today's dict order, different
+    reason: it is now a stated rule instead of an accident, and the tie is logged
+    so it stops being invisible. ``mc_decision_margin`` is the companion a caller
+    should read when it needs to know how close the call was.
+
     Falls back to the first key when nothing is scoreable at all (no rivals, every
     candidate ineligible): callers need a string, and an arbitrary-but-stable pick
     beats raising inside a race.
     """
-    scored = {
-        name: cell
-        for name, cell in mc_results.items()
-        if _finite_or_none(cell.get("score")) is not None
-    }
+    scored = _scoreable(mc_results)
     if not scored:
         return next(iter(mc_results), "STAY_OUT")
-    return max(scored, key=lambda name: scored[name]["score"])
+
+    best_score = max(cell["score"] for cell in scored.values())
+    tied = [name for name, cell in scored.items() if cell["score"] == best_score]
+    if len(tied) == 1:
+        return tied[0]
+
+    winner = min(tied, key=lambda name: _tie_break_rank(name))
+    logger.info(
+        "MC tie at %.6f between %s; %s wins by the stated precedence, not by dict "
+        "order. A tie means the lap is genuinely balanced (#645).",
+        best_score,
+        ", ".join(sorted(tied)),
+        winner,
+    )
+    return winner
+
+
+def _tie_break_rank(name: str) -> int:
+    """Position in the tie-break precedence; unknown candidates sort last."""
+    try:
+        return _TIE_BREAK_ORDER.index(name)
+    except ValueError:
+        return len(_TIE_BREAK_ORDER)
 
 
 def _format_mc_row(name: str, cell: dict) -> str:

--- a/tests/mc/test_mc_is_a_real_decision.py
+++ b/tests/mc/test_mc_is_a_real_decision.py
@@ -51,8 +51,16 @@ def _score(strategy: str, state: tuple):
 
 
 def _argmax(state: tuple) -> str:
-    scores = {s: _score(s, state) for s in STRATEGIES}
-    return max(scores, key=scores.get)
+    """The winner, decided by the SHIPPED argmax rather than a second copy of it.
+
+    This used to be its own `max(scores, key=scores.get)`. That agreed with the
+    real one only because both happened to iterate STRATEGIES in the same order,
+    so a change to the shipped tie-break would have left this test still passing
+    while asserting the old behaviour. Importing it is the point (#645).
+    """
+    from src.agents.strategy_orchestrator import best_mc_candidate
+
+    return best_mc_candidate({s: {"score": _score(s, state)} for s in STRATEGIES})
 
 
 # ---------------------------------------------------------------------------
@@ -532,3 +540,55 @@ def test_the_named_target_is_the_car_we_will_be_racing_not_the_first_in_the_list
     )
     assert scores["UNDERCUT"]["eligible"]
     assert scores["UNDERCUT"]["target"] == "RACING_US"
+
+
+# ---------------------------------------------------------------------------
+# The tie-break is a stated rule, not an accident of dict order (#645)
+# ---------------------------------------------------------------------------
+
+
+def test_an_exact_tie_is_broken_by_the_stated_precedence_not_by_dict_order():
+    """The same tie must resolve the same way whichever key was inserted first.
+
+    Before #645 the winner came from `max`, which returns the first item it saw,
+    so the answer depended on the order `_run_mc_simulation` built its dict in.
+    It gave the right answer for the wrong reason, and this is the test that
+    would have caught someone reordering that list.
+    """
+    from src.agents.strategy_orchestrator import best_mc_candidate
+
+    stay_first = {"STAY_OUT": {"score": 0.0}, "PIT_NOW": {"score": 0.0}}
+    pit_first = {"PIT_NOW": {"score": 0.0}, "STAY_OUT": {"score": 0.0}}
+
+    assert best_mc_candidate(stay_first) == best_mc_candidate(pit_first)
+    assert best_mc_candidate(pit_first) == "STAY_OUT", (
+        "a genuine tie must resolve conservatively: staying out is recoverable "
+        "next lap, a stop is not"
+    )
+
+
+def test_the_margin_distinguishes_a_tie_from_a_clear_preference():
+    """A caller must be able to tell "barely won" from "won outright".
+
+    Both arrive as the same bare string from `best_mc_candidate`, and on a real
+    pit-stop lap that difference is the whole story.
+    """
+    from src.agents.strategy_orchestrator import mc_decision_margin
+
+    tie = {"STAY_OUT": {"score": 0.0}, "PIT_NOW": {"score": 0.0}}
+    clear = {"STAY_OUT": {"score": 1.0}, "PIT_NOW": {"score": 0.4}}
+
+    assert mc_decision_margin(tie) == 0.0
+    assert mc_decision_margin(clear) == pytest.approx(0.6)
+
+
+def test_the_margin_is_None_rather_than_zero_when_there_is_no_contest():
+    """One scoreable candidate is not a dead tie, and must not read as one.
+
+    Returning 0.0 here would be the sentinel-collision shape this repo keeps
+    paying for: a value the code can also legitimately find.
+    """
+    from src.agents.strategy_orchestrator import mc_decision_margin
+
+    assert mc_decision_margin({"STAY_OUT": {"score": 1.0}}) is None
+    assert mc_decision_margin({"STAY_OUT": {"score": 1.0}, "PIT_NOW": {"score": None}}) is None


### PR DESCRIPTION
Closes #645.

`best_mc_candidate` ended in `max(scored, key=...)`, and `max` returns **the first item it saw**, so an exact tie was won by whichever candidate `_run_mc_simulation` happened to insert first.

It gave the **right answer** (STAY_OUT, because it is first in that list) **for the wrong reason**, and nothing anywhere recorded that a tie had occurred.

## Not a rare corner

Over **415 real laps** the audit found six near-ties, **all six on decision laps**, three of them exact and **falling on real pit stops**.

The margin is smallest exactly where the call is hardest. That is the opposite of the usual case, where ties happen in the boring middle, so this list was deciding real races.

## What changed

**The precedence is now stated**, in `_TIE_BREAK_ORDER`, with its reason: conservative first, because staying out is recoverable next lap and a stop is not. Behaviour on today's dict order is **unchanged**; what changed is that it is a decision rather than an accident, and a broken tie is logged so it stops being invisible.

**`mc_decision_margin` is the half that matters more.** A caller could not previously tell *"the model preferred this by a clear margin"* from *"two candidates scored identically and one was picked"*, because both arrive as the same bare string. On a real pit-stop lap that difference is the whole story.

It returns **`None` rather than `0.0`** when fewer than two candidates are scoreable, because zero would read as a dead tie, and that is the sentinel-collision shape this repo keeps paying for.

## A twin, deleted

The test helper `_argmax` had **its own `max`**. It agreed with the shipped one only because both iterated the same tuple in the same order, so **changing the shipped tie-break would have left the test passing while asserting the old behaviour**. It imports the real function now.

That is the standing directive's first rule applied before writing the fix: ask whether the logic exists anywhere else. It did.

## Verification

**112 tests in `tests/mc/` pass unchanged.** Three new ones pin the rule **from both insertion orders** and pin the margin contract, including the None case. Ruff check and format clean repo-wide. A real `f1-sim --no-llm` run on Lusail completes.