### PR TITLE
fix(orchestrator): frame a held STAY_OUT as monitoring, not as a blocked pit

### DIFF
--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -1547,6 +1547,21 @@ def _build_orchestrator_prompt(
         f"     Discount them one tier (HIGH→MEDIUM, MEDIUM→LOW) for decision-making.\n"
         f"  If a sub-agent recommends an action that violates these rules, override to\n"
         f"  STAY_OUT and explain why in reasoning.\n\n"
+        # Everything above reaches STAY_OUT by subtraction: "force", "override to",
+        # "no pit action". Measured on real races it is the call on the large majority
+        # of green-flag laps (39/41 at Lusail 2025, 414/415 across the projection set),
+        # so the prompt was teaching the LLM to treat its own most frequent output as a
+        # failure to decide. The prompt is also stateless: consecutive laps are 99.0%
+        # identical text, so nothing tells the model it is repeating itself and it
+        # re-argues the same case from scratch every lap (#646).
+        f"WHEN THE CALL IS STAY_OUT (the majority call, by design):\n"
+        f"  STAY_OUT is an ACTIVE monitoring posture, not the absence of a decision and\n"
+        f"  not merely what is left when a pit is blocked. Treat a repeated STAY_OUT as\n"
+        f"  CONTINUING a plan rather than making a fresh one, and do not re-argue the same\n"
+        f"  case from scratch. State (a) what you are watching, (b) the concrete threshold\n"
+        f"  that would change the call, and (c) how far the current numbers sit from it.\n"
+        f"  Carry the lap you are watching towards in pit_lap_target whenever the tyre\n"
+        f"  data supports one, so a hold reads as a plan with a horizon, not indecision.\n\n"
         f"RACE CONTEXT:\n"
         f"  Driver: {race_state.driver} | Lap: {race_state.lap}/{race_state.total_laps}\n"
         f"  Position: P{race_state.position} | Compound: {race_state.compound} "

--- a/tests/agents/test_orchestrator_prompt.py
+++ b/tests/agents/test_orchestrator_prompt.py
@@ -1,0 +1,78 @@
+"""Guards on the Layer 3 synthesis prompt.
+
+The prompt is the whole of the LLM's instruction surface: 12 of the 14
+``StrategyRecommendation`` fields come from it (6 verbatim from the synthesis,
+6 synthesis-then-clamped) and only ``scenario_scores`` and
+``regulation_context`` are assembled deterministically. A silent edit here
+changes every recommendation the system emits and no other test would notice,
+because nothing else asserts on prompt text.
+
+--- WHERE TO CHANGE IF THE PROMPT CHANGES ---
+``_build_orchestrator_prompt`` in ``src/agents/strategy_orchestrator.py`` is
+the only producer. If a block below is deliberately reworded, update the
+assertion rather than deleting it.
+"""
+
+import pytest
+
+from src.agents.strategy_orchestrator import RaceState, _build_orchestrator_prompt
+
+
+@pytest.fixture
+def prompt() -> str:
+    """A prompt with no sub-agent outputs, so only the static blocks remain."""
+    race_state = RaceState(
+        driver="NOR",
+        lap=25,
+        total_laps=57,
+        position=2,
+        compound="MEDIUM",
+        tyre_life=25,
+        gap_ahead_s=2.4,
+        pace_delta_s=0.15,
+        risk_tolerance=0.5,
+        air_temp=22.7,
+        track_temp=28.1,
+    )
+    return _build_orchestrator_prompt(race_state, {}, "STAY_OUT")
+
+
+@pytest.mark.unit
+def test_stay_out_is_framed_as_an_active_posture_not_a_fallback(prompt: str) -> None:
+    """STAY_OUT is the majority call, so the prompt must not define it by subtraction.
+
+    Measured before the fix: 39 of 41 green-flag laps at Lusail 2025 and 414 of
+    415 across the projection set resolve to STAY_OUT, while every mention of it
+    in the guard-rails arrived as "force" or "override to". The model was being
+    taught to read its own most frequent output as a failure to decide (#646).
+    """
+    assert "ACTIVE monitoring posture" in prompt
+    assert "not merely what is left when a pit is blocked" in prompt
+
+
+@pytest.mark.unit
+def test_a_held_stay_out_asks_for_a_threshold_rather_than_the_same_case_again(
+    prompt: str,
+) -> None:
+    """Consecutive prompts are 99.0% identical text and carry no memory of the last lap.
+
+    Nothing in the prompt says an action has been held, so the LLM re-argues the
+    same case in fresh prose every lap. The block cannot add memory the prompt
+    does not have, but it can ask for the shape that makes a hold legible: what
+    is watched, what would change it, and how far away that is.
+    """
+    # Matched as fragments, not as one phrase: the block is a wrapped f-string
+    # and every demand below straddles a line break in the source.
+    for demand in ("what you are watching", "the concrete threshold", "would change the call"):
+        assert demand in prompt, f"the held-STAY_OUT block no longer asks for: {demand}"
+
+
+@pytest.mark.unit
+def test_the_regulation_example_still_cites_no_hardcoded_article(prompt: str) -> None:
+    """The two-compound article is renumbered between seasons, so the example must not name one.
+
+    30.5(n) in 2023, 30.5(m) in 2024, 30.5(i) in 2025. The prompt asks the LLM to
+    quote article numbers, so any number hardcoded in the worked example gets
+    echoed into the output and is wrong for two seasons out of three.
+    """
+    assert "30.5(" not in prompt

--- a/tests/agents/test_orchestrator_prompt.py
+++ b/tests/agents/test_orchestrator_prompt.py
@@ -13,14 +13,29 @@ the only producer. If a block below is deliberately reworded, update the
 assertion rather than deleting it.
 """
 
+from pathlib import Path
+
 import pytest
 
-from src.agents.strategy_orchestrator import RaceState, _build_orchestrator_prompt
+# Importing the orchestrator pulls in the tire agent, which reads its routing
+# config at import time, so the whole module is unimportable without the HF
+# weights. That is why the import below lives inside the fixture rather than at
+# module scope: a module-level import raises during COLLECTION, which no skipif
+# can catch. Same guard as tests/agents/test_agents.py, same reason.
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="data/models/ not present (CI environment without model weights)",
+)
 
 
 @pytest.fixture
 def prompt() -> str:
     """A prompt with no sub-agent outputs, so only the static blocks remain."""
+    from src.agents.strategy_orchestrator import RaceState, _build_orchestrator_prompt
+
     race_state = RaceState(
         driver="NOR",
         lap=25,


### PR DESCRIPTION
Closes #646.

## The measurement, first

The plan for this issue said measure before writing any prompt. Done on the `no-llm` profile over Lusail 2025 (NOR, laps 5-45), so it costs zero API calls: real sub-agent outputs and a real Monte Carlo, with the orchestrator prompt built from them and diffed lap to lap.

| | |
|---|---|
| consecutive prompt pairs | 40 |
| identical byte for byte | 0 |
| **median similarity** | **0.9902** (min 0.9616) |
| median lines changing | 20 of 104 (max 24) |
| where the churn is | 254 lines in `SUB-AGENT OUTPUTS`, 116 in `RACE CONTEXT` |
| deterministic MC action | **STAY_OUT on 39 of 41 laps**, UNDERCUT on 2 |

Two things follow, and the second is the one that decided the fix.

**The question barely changes.** 99% identical text, and what does move is numeric drift: lap number, tyre life, track temperature, agent predictions shifting by fractions.

**The prompt has no memory.** There is no `last_action`, no laps-held counter, nothing. Every lap is presented as an isolated first decision. So the LLM cannot know it is repeating itself, and it re-argues the same case in fresh prose 39 times.

## The defect that measurement exposed

Every mention of STAY_OUT in the guard-rails block arrives by subtraction:

- "Force STAY_OUT."
- "override to STAY_OUT (current set has life left)"
- "If a sub-agent recommends an action that violates these rules, override to STAY_OUT"

STAY_OUT is defined as what is left when a pit is illegal. It is also the system's majority output, on 39/41 laps here and 414/415 across the projection set. The prompt was teaching the model to read its most frequent call as a failure to decide.

## The change

Prompt-only. No signature change, no caller state, no engine change, which is the scope agreed for this issue. A block after the guard-rails frames a held STAY_OUT as an active monitoring posture and asks for the shape that makes a hold legible: **what is being watched**, **the threshold that would change the call**, and **how far the current numbers sit from it**, plus carrying `pit_lap_target` as the lap being watched towards.

It cannot add memory the prompt does not have. It can stop the model from treating a continuing plan as a fresh one.

## Tests

`tests/agents/test_orchestrator_prompt.py` is new and is the first test in the repo to assert on prompt text at all. 12 of the 14 `StrategyRecommendation` fields come from this prompt, so an edit here changes every recommendation the system emits and until now nothing would have caught it.

The third test pins a deliberate absence: the two-compound article is renumbered every season (30.5(n) in 2023, 30.5(m) in 2024, 30.5(i) in 2025), the prompt asks the LLM to quote article numbers, so a number hardcoded in the worked example would be echoed out and wrong two seasons in three.

## Checks

- `pytest tests/agents` 45 passed
- `ruff check .` clean, `ruff format --check .` 103 files already formatted