### PR TITLE
docs(mc): price the lap-number neutralisation union in all three places it lives

### DIFF
--- a/scripts/measure_mc_tables.py
+++ b/scripts/measure_mc_tables.py
@@ -292,6 +292,25 @@ def _status_by_lap(laps: pd.DataFrame) -> dict[int, str]:
     lap: at ~90 s per lap, race control escalates inside the same lap, and this
     function labels it by the stronger flag. Only 27% of onsets are preceded by a
     lap that was yellow and nothing else.
+
+    THE PRICE OF THE UNION, so the choice above stays deliberate rather than
+    invisible. Heilmeier et al. (Applied Sciences 2020, 10(21):4229) warn that
+    neutralisations belong on race TIME, not race PROGRESS: a driver a lap down
+    is somewhere else on the circuit than the leader sharing his lap number, so
+    a union over lap numbers hands him a flag he never drove through. Measured
+    over all 72 races of 2023-2025 (79032 driver-laps, flags 4/5/6/7):
+
+        carrying a flag on their own row     4993 (6.32%)
+        marked by the lap-number union       5575 (7.05%)
+        marked without having seen it         663 (0.84%)
+        over-marking factor                  1.135x
+
+    Keyed on the session clock the cost would be near zero, since FastF1 rows
+    carry ``Time``. It is not worth doing here: these tables are committed and
+    a golden test pins their values, so regenerating for 0.84% would move
+    published numbers for no decision-relevant gain. Measure the delta first if
+    that ever changes (#647). The same union, and the same price, applies in
+    ``src/strategy/eval/projection.py::_neutralised_laps``.
     """
     statuses: dict[int, str] = {}
     for lap, group in laps.groupby("LapNumber"):

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -499,6 +499,13 @@ def _compute_track_status_features(all_laps: pd.DataFrame, lap_number: int) -> d
             'laps_since_last_yellow':  10,
         }
 
+    # Grouped by lap NUMBER across every car, so a driver a lap down inherits the
+    # leader's flag. #647 prices that union at 0.84% of driver-laps over 2023-2025
+    # and cites Heilmeier et al. 2020, who argue neutralisations belong on race
+    # TIME. DO NOT "fix" it here: N13 builds the training features with the same
+    # `groupby("LapNumber")` union, so keying this on the clock would feed N14 a
+    # distribution it never saw. Inference has to reproduce its notebook, and this
+    # repo has already paid for three bugs that were exactly that divergence.
     lap_status = (
         causal_laps
         .groupby('LapNumber')

--- a/src/strategy/eval/projection.py
+++ b/src/strategy/eval/projection.py
@@ -132,7 +132,23 @@ def _elapsed_pivot(laps):
 
 
 def _neutralised_laps(laps) -> set[int]:
-    """Lap numbers showing a Safety Car, VSC or red flag on any car's status."""
+    """Lap numbers showing a Safety Car, VSC or red flag on any car's status.
+
+    Keyed on lap NUMBER, which is a deliberate choice with a measured price.
+    Heilmeier et al. (Applied Sciences 2020, 10(21):4229) warn that
+    neutralisations belong on race TIME: a driver a lap down sits elsewhere on
+    the circuit than the leader sharing his lap number, so a union over lap
+    numbers attributes a flag to a car that never drove through it. Measured
+    over all 72 races of 2023-2025 (79032 driver-laps, flags 4/5/6): 692
+    driver-laps marked without having seen the flag, 0.88%, a 1.142x
+    over-marking factor.
+
+    Kept because this function exists to EXCLUDE neutralised laps from the
+    projection ground truth, and over-exclusion is the safe direction: it drops
+    a few clean stops rather than scoring the model on laps where nobody raced.
+    The same union, priced the same way, is in
+    ``scripts/measure_mc_tables.py::_status_by_lap`` (#647).
+    """
     neutralised = set()
     for lap, group in laps.groupby("LapNumber"):
         joined = "".join(group["TrackStatus"].dropna().astype(str))


### PR DESCRIPTION
Closes #647.

Heilmeier et al. (*Applied Sciences* 2020, 10(21):4229) warn that neutralisations must trigger on race **TIME**, not race **PROGRESS**. A driver a lap down is somewhere else on the circuit than the leader sharing his lap number, so a union over lap numbers hands him a flag he never drove through.

The docstring already argued for the union. What it never said is what the union costs, and a reader cannot weigh a trade-off whose price is unstated.

## Re-measured, wider than the issue

The issue quoted 0.89% and 1.18x from a 12-race 2024 sample. I re-ran it over **all 72 races of 2023-2025 (79032 driver-laps)** before writing anything into a docstring, and split it by flag set, because the two call sites do not use the same one.

| call site | flags | over-marked | factor |
|---|---|---|---|
| `measure_mc_tables._status_by_lap` | 4/5/6/7 | 663 driver-laps (**0.84%**) | 1.135x |
| `projection._neutralised_laps` | 4/5/6 | 692 driver-laps (**0.88%**) | 1.142x |

Per season the cost tracks how eventful the year was: 0.63% in 2023, 0.75% in 2024, 1.14% in 2025.

## The issue named one call site. There are three.

This is the repo's dominant defect shape, so I checked for twins before writing the fix.

1. **`scripts/measure_mc_tables.py::_status_by_lap`** — the one the issue found. Priced, plus why it is not worth regenerating: the tables are committed and a golden test pins them, so moving published numbers for 0.84% buys nothing a decision would notice.

2. **`src/strategy/eval/projection.py::_neutralised_laps`** — the same union, the same silence, and I wrote it myself in #609. Priced, and kept deliberately: this function exists to *exclude* neutralised laps from the ground truth, so over-exclusion is the safe direction. It drops a few clean stops rather than scoring the model on laps where nobody raced.

3. **`src/agents/race_situation_agent.py`** — the live one, and the reason this PR matters beyond documentation. It groups by `LapNumber` across every car at inference time. It now carries a **DO NOT FIX** note: I verified that N13 builds N14's training features with the identical `groupby("LapNumber")` union, so keying inference on the session clock would feed the model a distribution it never saw. Without that note, the next reader greps for the pattern, finds this, and introduces exactly the train/inference divergence this repo has already paid for three times.

## No behaviour change

Docstrings and one comment. Nothing regenerated, nothing recomputed.

## Checks

- `pytest tests/engine tests/agents` 54 passed
- `ruff check .` clean, `ruff format --check .` 103 files already formatted