### PR TITLE
chore: promote #646 and #647 to main

### DIFF
--- a/scripts/measure_mc_tables.py
+++ b/scripts/measure_mc_tables.py
@@ -292,6 +292,25 @@ def _status_by_lap(laps: pd.DataFrame) -> dict[int, str]:
     lap: at ~90 s per lap, race control escalates inside the same lap, and this
     function labels it by the stronger flag. Only 27% of onsets are preceded by a
     lap that was yellow and nothing else.
+
+    THE PRICE OF THE UNION, so the choice above stays deliberate rather than
+    invisible. Heilmeier et al. (Applied Sciences 2020, 10(21):4229) warn that
+    neutralisations belong on race TIME, not race PROGRESS: a driver a lap down
+    is somewhere else on the circuit than the leader sharing his lap number, so
+    a union over lap numbers hands him a flag he never drove through. Measured
+    over all 72 races of 2023-2025 (79032 driver-laps, flags 4/5/6/7):
+
+        carrying a flag on their own row     4993 (6.32%)
+        marked by the lap-number union       5575 (7.05%)
+        marked without having seen it         663 (0.84%)
+        over-marking factor                  1.135x
+
+    Keyed on the session clock the cost would be near zero, since FastF1 rows
+    carry ``Time``. It is not worth doing here: these tables are committed and
+    a golden test pins their values, so regenerating for 0.84% would move
+    published numbers for no decision-relevant gain. Measure the delta first if
+    that ever changes (#647). The same union, and the same price, applies in
+    ``src/strategy/eval/projection.py::_neutralised_laps``.
     """
     statuses: dict[int, str] = {}
     for lap, group in laps.groupby("LapNumber"):

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -499,6 +499,13 @@ def _compute_track_status_features(all_laps: pd.DataFrame, lap_number: int) -> d
             'laps_since_last_yellow':  10,
         }
 
+    # Grouped by lap NUMBER across every car, so a driver a lap down inherits the
+    # leader's flag. #647 prices that union at 0.84% of driver-laps over 2023-2025
+    # and cites Heilmeier et al. 2020, who argue neutralisations belong on race
+    # TIME. DO NOT "fix" it here: N13 builds the training features with the same
+    # `groupby("LapNumber")` union, so keying this on the clock would feed N14 a
+    # distribution it never saw. Inference has to reproduce its notebook, and this
+    # repo has already paid for three bugs that were exactly that divergence.
     lap_status = (
         causal_laps
         .groupby('LapNumber')

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -1547,6 +1547,21 @@ def _build_orchestrator_prompt(
         f"     Discount them one tier (HIGH→MEDIUM, MEDIUM→LOW) for decision-making.\n"
         f"  If a sub-agent recommends an action that violates these rules, override to\n"
         f"  STAY_OUT and explain why in reasoning.\n\n"
+        # Everything above reaches STAY_OUT by subtraction: "force", "override to",
+        # "no pit action". Measured on real races it is the call on the large majority
+        # of green-flag laps (39/41 at Lusail 2025, 414/415 across the projection set),
+        # so the prompt was teaching the LLM to treat its own most frequent output as a
+        # failure to decide. The prompt is also stateless: consecutive laps are 99.0%
+        # identical text, so nothing tells the model it is repeating itself and it
+        # re-argues the same case from scratch every lap (#646).
+        f"WHEN THE CALL IS STAY_OUT (the majority call, by design):\n"
+        f"  STAY_OUT is an ACTIVE monitoring posture, not the absence of a decision and\n"
+        f"  not merely what is left when a pit is blocked. Treat a repeated STAY_OUT as\n"
+        f"  CONTINUING a plan rather than making a fresh one, and do not re-argue the same\n"
+        f"  case from scratch. State (a) what you are watching, (b) the concrete threshold\n"
+        f"  that would change the call, and (c) how far the current numbers sit from it.\n"
+        f"  Carry the lap you are watching towards in pit_lap_target whenever the tyre\n"
+        f"  data supports one, so a hold reads as a plan with a horizon, not indecision.\n\n"
         f"RACE CONTEXT:\n"
         f"  Driver: {race_state.driver} | Lap: {race_state.lap}/{race_state.total_laps}\n"
         f"  Position: P{race_state.position} | Compound: {race_state.compound} "

--- a/src/strategy/eval/projection.py
+++ b/src/strategy/eval/projection.py
@@ -132,7 +132,23 @@ def _elapsed_pivot(laps):
 
 
 def _neutralised_laps(laps) -> set[int]:
-    """Lap numbers showing a Safety Car, VSC or red flag on any car's status."""
+    """Lap numbers showing a Safety Car, VSC or red flag on any car's status.
+
+    Keyed on lap NUMBER, which is a deliberate choice with a measured price.
+    Heilmeier et al. (Applied Sciences 2020, 10(21):4229) warn that
+    neutralisations belong on race TIME: a driver a lap down sits elsewhere on
+    the circuit than the leader sharing his lap number, so a union over lap
+    numbers attributes a flag to a car that never drove through it. Measured
+    over all 72 races of 2023-2025 (79032 driver-laps, flags 4/5/6): 692
+    driver-laps marked without having seen the flag, 0.88%, a 1.142x
+    over-marking factor.
+
+    Kept because this function exists to EXCLUDE neutralised laps from the
+    projection ground truth, and over-exclusion is the safe direction: it drops
+    a few clean stops rather than scoring the model on laps where nobody raced.
+    The same union, priced the same way, is in
+    ``scripts/measure_mc_tables.py::_status_by_lap`` (#647).
+    """
     neutralised = set()
     for lap, group in laps.groupby("LapNumber"):
         joined = "".join(group["TrackStatus"].dropna().astype(str))

--- a/tests/agents/test_orchestrator_prompt.py
+++ b/tests/agents/test_orchestrator_prompt.py
@@ -1,0 +1,78 @@
+"""Guards on the Layer 3 synthesis prompt.
+
+The prompt is the whole of the LLM's instruction surface: 12 of the 14
+``StrategyRecommendation`` fields come from it (6 verbatim from the synthesis,
+6 synthesis-then-clamped) and only ``scenario_scores`` and
+``regulation_context`` are assembled deterministically. A silent edit here
+changes every recommendation the system emits and no other test would notice,
+because nothing else asserts on prompt text.
+
+--- WHERE TO CHANGE IF THE PROMPT CHANGES ---
+``_build_orchestrator_prompt`` in ``src/agents/strategy_orchestrator.py`` is
+the only producer. If a block below is deliberately reworded, update the
+assertion rather than deleting it.
+"""
+
+import pytest
+
+from src.agents.strategy_orchestrator import RaceState, _build_orchestrator_prompt
+
+
+@pytest.fixture
+def prompt() -> str:
+    """A prompt with no sub-agent outputs, so only the static blocks remain."""
+    race_state = RaceState(
+        driver="NOR",
+        lap=25,
+        total_laps=57,
+        position=2,
+        compound="MEDIUM",
+        tyre_life=25,
+        gap_ahead_s=2.4,
+        pace_delta_s=0.15,
+        risk_tolerance=0.5,
+        air_temp=22.7,
+        track_temp=28.1,
+    )
+    return _build_orchestrator_prompt(race_state, {}, "STAY_OUT")
+
+
+@pytest.mark.unit
+def test_stay_out_is_framed_as_an_active_posture_not_a_fallback(prompt: str) -> None:
+    """STAY_OUT is the majority call, so the prompt must not define it by subtraction.
+
+    Measured before the fix: 39 of 41 green-flag laps at Lusail 2025 and 414 of
+    415 across the projection set resolve to STAY_OUT, while every mention of it
+    in the guard-rails arrived as "force" or "override to". The model was being
+    taught to read its own most frequent output as a failure to decide (#646).
+    """
+    assert "ACTIVE monitoring posture" in prompt
+    assert "not merely what is left when a pit is blocked" in prompt
+
+
+@pytest.mark.unit
+def test_a_held_stay_out_asks_for_a_threshold_rather_than_the_same_case_again(
+    prompt: str,
+) -> None:
+    """Consecutive prompts are 99.0% identical text and carry no memory of the last lap.
+
+    Nothing in the prompt says an action has been held, so the LLM re-argues the
+    same case in fresh prose every lap. The block cannot add memory the prompt
+    does not have, but it can ask for the shape that makes a hold legible: what
+    is watched, what would change it, and how far away that is.
+    """
+    # Matched as fragments, not as one phrase: the block is a wrapped f-string
+    # and every demand below straddles a line break in the source.
+    for demand in ("what you are watching", "the concrete threshold", "would change the call"):
+        assert demand in prompt, f"the held-STAY_OUT block no longer asks for: {demand}"
+
+
+@pytest.mark.unit
+def test_the_regulation_example_still_cites_no_hardcoded_article(prompt: str) -> None:
+    """The two-compound article is renumbered between seasons, so the example must not name one.
+
+    30.5(n) in 2023, 30.5(m) in 2024, 30.5(i) in 2025. The prompt asks the LLM to
+    quote article numbers, so any number hardcoded in the worked example gets
+    echoed into the output and is wrong for two seasons out of three.
+    """
+    assert "30.5(" not in prompt

--- a/tests/agents/test_orchestrator_prompt.py
+++ b/tests/agents/test_orchestrator_prompt.py
@@ -13,14 +13,29 @@ the only producer. If a block below is deliberately reworded, update the
 assertion rather than deleting it.
 """
 
+from pathlib import Path
+
 import pytest
 
-from src.agents.strategy_orchestrator import RaceState, _build_orchestrator_prompt
+# Importing the orchestrator pulls in the tire agent, which reads its routing
+# config at import time, so the whole module is unimportable without the HF
+# weights. That is why the import below lives inside the fixture rather than at
+# module scope: a module-level import raises during COLLECTION, which no skipif
+# can catch. Same guard as tests/agents/test_agents.py, same reason.
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="data/models/ not present (CI environment without model weights)",
+)
 
 
 @pytest.fixture
 def prompt() -> str:
     """A prompt with no sub-agent outputs, so only the static blocks remain."""
+    from src.agents.strategy_orchestrator import RaceState, _build_orchestrator_prompt
+
     race_state = RaceState(
         driver="NOR",
         lap=25,


### PR DESCRIPTION
Promotes `dev` to `main`. Two changes, both landed green on `dev`.

## #646 — a held STAY_OUT is monitoring, not a blocked pit

PR #661. Measured first on the `no-llm` profile over Lusail 2025 (zero API calls): consecutive orchestrator prompts are **99.02% identical text**, the deterministic MC action is **STAY_OUT on 39 of 41 laps**, and the prompt is **stateless** — no `last_action`, no laps-held counter, so the LLM re-argues the same case in fresh prose every lap.

Meanwhile every mention of STAY_OUT in the guard-rails arrived by subtraction ("force", "override to"), teaching the model to read its own majority output as a failure to decide. Prompt-only fix, plus `tests/agents/test_orchestrator_prompt.py`, the first test in the repo to assert on prompt text at all.

## #647 — the lap-number neutralisation union, priced

PR #662. Heilmeier et al. 2020 warn neutralisations belong on race TIME. Re-measured over **all 72 races of 2023-2025 (79032 driver-laps)** rather than the issue's 12-race sample: 0.84% over-marked at 1.135x for `_status_by_lap`, 0.88% at 1.142x for `_neutralised_laps`.

The issue named one call site; there are three. The third is live (`race_situation_agent`) and now carries a **DO NOT FIX** note, because N13 builds N14's training features with the identical union and keying inference on the clock would feed the model a distribution it never saw.

No behaviour change beyond the prompt text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved strategy guidance for “Stay Out” decisions, emphasizing active monitoring, measurable thresholds, and clear conditions for changing course.
  * Enhanced staged pit-stop planning when tire data supports continued running.
  * Clarified track-status handling and neutralisation-lap analysis for more consistent race strategy evaluation.

* **Tests**
  * Added coverage to verify “Stay Out” guidance remains actionable and avoids season-specific regulation assumptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->