### PR TITLE
fix(agents): band threat_level on the served calibrated scale, not raw-scale operating points

### DIFF
--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -131,28 +131,45 @@ class RaceSituationConfig:
     the repo path contains non-ASCII characters that break LightGBM's native
     save_model on Windows.
 
-    Threat-level boundaries map raw calibrated probabilities to LOW/MEDIUM/HIGH
-    categorical signals for N31. high_overtake/high_sc are overwritten in
-    __post_init__ from the tuned optimal_threshold/best_threshold in each model's
-    on-disk config (#450) — the literals below are only a construction-time
-    placeholder, never the value actually used once the config has loaded.
+    Threat-level boundaries map the CALIBRATED probabilities to LOW/MEDIUM/HIGH
+    categorical signals for N31. They are pit-wall alert levels — a product
+    decision about how alarmed to be — and deliberately NOT the models' classifier
+    operating points, which live on the raw scale (see __post_init__ and #665).
+
+    Every band below was set on the served calibrated distribution, measured over
+    real 2025 laps with the models loaded, so each one is reachable and its firing
+    rate is known. The two models are banded on different terms because they are
+    not comparable: N12 is a decent ranker (AUC-PR 0.549) whose calibrated output
+    reads as a genuine probability, while N14 is weak (AUC-PR 0.072, lift 1.67x)
+    and only means something relative to its own base rate.
 
     Attributes:
         model_name: LM Studio model identifier for the ReAct agent LLM.
-        high_overtake: Probability above which threat_level is HIGH via overtake.
-            Overwritten from overtake_threshold (N12's model_config.json).
-        medium_overtake: Probability above which threat_level is MEDIUM via overtake.
-        high_sc: Probability above which threat_level is HIGH via SC risk.
-            Overwritten from sc_threshold (N14's feature_list_v1.json).
-        medium_sc: Probability above which threat_level is MEDIUM via SC risk.
+        high_overtake: Calibrated P(overtake) above which threat_level is HIGH.
+            0.65 = a strong opportunity in plain probability terms; fires on 1.36%
+            of real chaser/ahead pairs (n=8171). The calibrated output tops out at
+            0.751, so anything at or above 0.7659 is unreachable by construction.
+        medium_overtake: Calibrated P(overtake) above which threat_level is MEDIUM.
+            0.40 = a realistic shot; fires on 3.99% of pairs.
+        high_sc: Calibrated P(SC within 3 laps) above which threat_level is HIGH.
+            0.0864 = TWICE N14's 0.0432 base rate (feature_list_v1.json,
+            target_comparison['3-lap']['baseline']); fires on 1.27% of laps
+            (n=1420). The base rate is a class prevalence, not a value selected on
+            the test set, so anchoring here does not reintroduce the contamination
+            hygiene.py found in best_threshold. Retraining N14 moves the baseline —
+            move this with it, which test_sc_bands_track_the_models_base_rate
+            enforces.
+        medium_sc: Calibrated P(SC within 3 laps) above which threat_level is MEDIUM.
+            0.0432 = the base rate itself, i.e. "likelier than an average lap";
+            fires on 13.59% of laps.
     """
 
     model_name: str = 'gpt-4.1-mini'
 
-    high_overtake:   float = 0.80
+    high_overtake:   float = 0.65
     medium_overtake: float = 0.40
-    high_sc:         float = 0.30
-    medium_sc:       float = 0.15
+    high_sc:         float = 0.0864
+    medium_sc:       float = 0.0432
 
     def __post_init__(self) -> None:
         self.export_dir = _AGENTS
@@ -180,17 +197,26 @@ class RaceSituationConfig:
         self.sc_features: list[str] = sc_cfg['features']
         self.sc_threshold: float    = sc_cfg['best_threshold']
 
-        # #450: high_overtake/high_sc were dataclass literals (0.80/0.30) that this
-        # __post_init__ never touched, so the genuinely tuned thresholds loaded just
-        # above (overtake_threshold, sc_threshold) sat unused — every threat_level ever
-        # computed by RaceSituationOutput.__post_init__ was thresholded against the
-        # untuned placeholder, most visibly for SC (0.30 hardcoded vs 0.2335 tuned:
-        # a real SC risk between those two values was silently reported as MEDIUM
-        # instead of HIGH). Overwriting here means every downstream reader of
-        # CFG.high_overtake / CFG.high_sc (RaceSituationOutput, the system prompt
-        # string below) gets the value the model was actually tuned against.
-        self.high_overtake = self.overtake_threshold
-        self.high_sc       = self.sc_threshold
+        # DO NOT assign overtake_threshold/sc_threshold onto high_overtake/high_sc.
+        # #450 did exactly that and it is a unit error: both tuned thresholds are
+        # operating points on the RAW model output, while threat_level compares the
+        # CALIBRATED probability. N14 tunes best_threshold on `proba_test` (cell 20,
+        # `m.predict_proba(X_test)[:,1]`) and only calibrates afterwards in cell 32;
+        # N12 does the same in cells 22/25/26 vs cell 36. Pushed through each Platt
+        # calibrator, raw 0.2335 is calibrated 0.0158 and raw 0.7976 is calibrated
+        # 0.4183 — and the overtake calibrator's ceiling is 0.7659 at raw 1.0, so
+        # comparing a calibrated probability against 0.7976 could never be True.
+        # Measured on real 2025 laps: SC HIGH fired 0/1420, overtake HIGH 0/8171.
+        #
+        # There is a second, independent reason not to wire them: src/strategy/eval/
+        # hygiene.py already ruled BOTH thresholds test-contaminated (selected on the
+        # 2025 test set), and concluded N14 has no honest validation split for an
+        # operating threshold at all — the paper reports SC threshold-free. Promoting
+        # a leaked operating point into a runtime signal would put the contamination
+        # back into the decisions the paper's numbers describe.
+        #
+        # The bands below are deliberately NOT the classifier operating points; they
+        # are pit-wall alert levels, set on the served calibrated scale (#665).
 
         # Circuit cluster map (k=4 parquet from N05)
         _cl = pd.read_parquet(_PROCESSED / 'circuit_clustering' / 'circuit_clusters_k4.parquet')
@@ -254,12 +280,13 @@ class RaceSituationOutput:
 
     Attributes:
         overtake_prob: Calibrated P(overtake in next few laps) from N12 LightGBM
-            + Platt calibration. Above CFG.high_overtake (N12's tuned
-            optimal_threshold, ~0.80 — see RaceSituationConfig.__post_init__) =
-            strong opportunity.
+            + Platt calibration. Above CFG.high_overtake (0.65) = strong
+            opportunity. Compare only against the bands in RaceSituationConfig,
+            never against N12's optimal_threshold — that one lives on the raw
+            scale and is unreachable here (#665).
         sc_prob_3lap: Calibrated P(SC within 3 laps) from N14 LightGBM + Platt
-            calibration. Above CFG.high_sc (N14's tuned best_threshold, ~0.23 —
-            see RaceSituationConfig.__post_init__) = imminent SC risk.
+            calibration. Above CFG.high_sc (0.0864, twice the base rate) =
+            elevated SC risk. Same caveat: N14's best_threshold is raw-scale.
         threat_level: LOW / MEDIUM / HIGH derived from both probabilities in __post_init__.
         gap_ahead_s: Gap to the car directly ahead (seconds). < 1.0s = DRS range.
         pace_delta_s: 3-lap rolling pace delta vs car ahead (s/lap). Negative = faster.
@@ -762,11 +789,10 @@ except ImportError:
 # System prompt (module-level constant — interpolates CFG's loaded thresholds)
 # ─────────────────────────────────────────────────────────────────────────────
 
-# f-string, not a plain triple-quoted constant: it must read the SAME thresholds
-# RaceSituationOutput.__post_init__ actually classifies against (CFG.high_overtake /
-# CFG.high_sc, loaded from each model's tuned config in RaceSituationConfig.__post_init__),
-# not the untuned dataclass literals. CFG is fully built by the time this module-level
-# constant is evaluated (CFG is constructed above, at import time). #450.
+# f-string, not a plain triple-quoted constant: the prompt must quote the SAME bands
+# RaceSituationOutput.__post_init__ actually classifies against, or the LLM is told a
+# rule the code no longer applies. CFG is fully built by the time this module-level
+# constant is evaluated (CFG is constructed above, at import time). #450/#665.
 _RACE_SITUATION_SYSTEM_PROMPT = f"""You are a Formula 1 race situation analyst embedded in a multi-agent strategy system.
 
 Your job is to assess two dimensions of strategic threat per lap:

--- a/tests/audit/test_race_situation_hardening.py
+++ b/tests/audit/test_race_situation_hardening.py
@@ -1,15 +1,17 @@
-"""Race Situation Agent (N27) hardening — #450 tuned thresholds, #476 unvalidated LLM input.
+"""Race Situation Agent (N27) hardening — #665 threat bands, #476 unvalidated LLM input.
 
 Two independent bugs closed here, both silent (no exception, just a wrong or
 unused number):
 
-- **#450**: ``RaceSituationConfig.high_overtake``/``high_sc`` were dataclass
-  literals (0.80 / 0.30) that ``__post_init__`` loaded the REAL tuned thresholds
-  (``overtake_threshold`` from N12's ``model_config.json``, ``sc_threshold`` from
-  N14's ``feature_list_v1.json``) right next to, and then never used. Every
-  ``threat_level`` ever computed by ``RaceSituationOutput.__post_init__`` was
-  thresholded against the untuned placeholder — most visibly for SC, where the
-  hardcoded 0.30 sat nowhere near the tuned 0.2335.
+- **#665**: ``RaceSituationConfig`` compared the CALIBRATED probabilities against
+  thresholds tuned on the RAW model output. N14 tunes ``best_threshold`` on
+  ``proba_test`` (cell 20, ``m.predict_proba(X_test)[:,1]``) and only calibrates in
+  cell 32; N12 does the same in cells 22/25/26 vs cell 36. #450 wired those raw
+  operating points onto ``high_overtake``/``high_sc``, which made both bands
+  unreachable — measured over real 2025 laps, SC HIGH fired 0/1420 and overtake
+  HIGH 0/8171, so the SC model contributed nothing to ``threat_level`` at any
+  level. The bands are now pit-wall alert levels set on the served calibrated
+  scale, kept separate from the classifier operating points.
 - **#476**: ``predict_overtake_tool``/``predict_sc_tool`` take free-text driver
   codes and a free-int lap number straight from the LLM. The only guard was an
   empty-dataframe check, which does not catch a driver who is not racing THIS
@@ -55,13 +57,14 @@ pytestmark = [
 ]
 
 
-def test_thresholds_loaded_from_model_config_not_hardcoded():
-    """#450: CFG.high_overtake/high_sc must be the TUNED thresholds, not 0.80/0.30.
+def test_bands_are_never_the_raw_classifier_operating_points():
+    """#665: the threat bands must NOT be the tuned thresholds, which are raw-scale.
 
-    Reads the two on-disk configs independently of the agent module (so the test
-    does not just compare the singleton against itself) and checks CFG matches
-    what was actually written to disk by N12/N14 — and does NOT match the old
-    dataclass literals, which is exactly the bug: they were never overwritten.
+    #450 assigned overtake_threshold/sc_threshold onto high_overtake/high_sc. Both
+    are tuned on the RAW model output (N14 cell 20/23, N12 cells 22/25/26) while
+    threat_level compares the CALIBRATED probability, so neither could ever fire.
+    Reads the on-disk configs independently of the agent module so the test cannot
+    pass by comparing the singleton against itself.
     """
     from src.agents.race_situation_agent import CFG
 
@@ -70,19 +73,66 @@ def test_thresholds_loaded_from_model_config_not_hardcoded():
     with open(ROOT / "data" / "models" / "safety_car_probability" / "feature_list_v1.json") as f:
         sc_cfg = json.load(f)
 
-    loaded_overtake_threshold = ov_cfg["optimal_threshold"]
-    loaded_sc_threshold = sc_cfg["best_threshold"]
+    assert CFG.high_overtake != pytest.approx(ov_cfg["optimal_threshold"])
+    assert CFG.high_sc != pytest.approx(sc_cfg["best_threshold"])
 
-    assert CFG.high_overtake == pytest.approx(loaded_overtake_threshold)
-    assert CFG.high_sc == pytest.approx(loaded_sc_threshold)
+    # The loads themselves stay — they are exported for anyone who wants to
+    # binarise a RAW score — but they must remain separate from the bands.
+    assert CFG.overtake_threshold == pytest.approx(ov_cfg["optimal_threshold"])
+    assert CFG.sc_threshold == pytest.approx(sc_cfg["best_threshold"])
 
-    # The pre-fix hardcoded literals. If CFG ever equals these again while the
-    # loaded config differs, #450 has regressed (the loaded value stopped being
-    # the one threat_level actually thresholds against).
-    if loaded_overtake_threshold != pytest.approx(0.80):
-        assert CFG.high_overtake != pytest.approx(0.80)
-    if loaded_sc_threshold != pytest.approx(0.30):
-        assert CFG.high_sc != pytest.approx(0.30)
+
+def test_every_band_is_reachable_on_the_calibrated_scale():
+    """#665: a band above the calibrator's ceiling is a constant False, not a band.
+
+    The pre-fix high_overtake (0.7976) sat above what the Platt calibrator can
+    emit at raw=1.0, so overtake could never reach HIGH by construction. Assert the
+    property directly: push raw 1.0 through each calibrator and require every band
+    to sit strictly below that ceiling.
+    """
+    import numpy as np
+
+    from src.agents.race_situation_agent import CFG
+
+    overtake_ceiling = float(CFG.overtake_calibrator.predict_proba(np.array([[1.0]]))[:, 1][0])
+    sc_ceiling = float(CFG.sc_calibrator.predict_proba(np.array([[1.0]]))[:, 1][0])
+
+    for band, ceiling, name in (
+        (CFG.high_overtake, overtake_ceiling, "high_overtake"),
+        (CFG.medium_overtake, overtake_ceiling, "medium_overtake"),
+        (CFG.high_sc, sc_ceiling, "high_sc"),
+        (CFG.medium_sc, sc_ceiling, "medium_sc"),
+    ):
+        assert band < ceiling, (
+            f"{name}={band} is at or above the calibrator ceiling {ceiling:.4f} — "
+            "no calibrated probability can ever reach it"
+        )
+
+
+def test_sc_bands_track_the_models_base_rate():
+    """#665: high_sc/medium_sc are defined as multiples of N14's own base rate.
+
+    N14 is too weak (AUC-PR 0.072, lift 1.67x) for its absolute probability to mean
+    much, so the bands are anchored on its base rate instead: MEDIUM at 1x, HIGH at
+    2x. Retraining N14 moves that baseline, and this test is what makes the bands
+    move with it rather than silently drifting into meaninglessness.
+    """
+    from src.agents.race_situation_agent import CFG
+
+    with open(ROOT / "data" / "models" / "safety_car_probability" / "feature_list_v1.json") as f:
+        sc_cfg = json.load(f)
+    base_rate = sc_cfg["target_comparison"]["3-lap"]["baseline"]
+
+    assert CFG.medium_sc == pytest.approx(base_rate, abs=1e-4)
+    assert CFG.high_sc == pytest.approx(2 * base_rate, abs=1e-4)
+
+
+def test_bands_are_ordered():
+    """A MEDIUM band above its HIGH band makes threat_level unreachable at the top."""
+    from src.agents.race_situation_agent import CFG
+
+    assert CFG.medium_overtake < CFG.high_overtake
+    assert CFG.medium_sc < CFG.high_sc
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Promotes the #665 fix from `dev`.

Closes #665.

`RaceSituationConfig` compared the **calibrated** probabilities against thresholds tuned on the **raw** model output, so neither HIGH band could ever fire. Measured on real 2025 laps with the models loaded and zero API calls: SC HIGH fired **0 / 1420 laps**, overtake HIGH **0 / 8171 chaser/ahead pairs**. The SC model contributed nothing to `threat_level` at any level.

The bands are now pit-wall alert levels set on the served calibrated distribution, kept separate from the classifier operating points:

| band | before | after | derivation |
|---|---|---|---|
| `high_overtake` | 0.7976 | 0.65 | fires on 1.36% of pairs |
| `medium_overtake` | 0.40 | 0.40 | unchanged |
| `high_sc` | 0.2335 | 0.0864 | 2x N14's 0.0432 base rate, 1.27% of laps |
| `medium_sc` | 0.15 | 0.0432 | the base rate itself, 13.59% of laps |

`src/strategy/eval/hygiene.py` had already ruled both tuned thresholds test-contaminated, which is a second independent reason not to promote them into a runtime signal.

Tests assert the effect rather than the value: every band must sit below its calibrator's ceiling, the SC bands must track the model base rate, and the bands must stay ordered.

Detail in PR #666.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved race-situation threat classification by using calibrated probability bands.
  * Updated overtake and safety-car thresholds to provide more accurate, reachable threat levels.
  * Clarified probability-band descriptions used in race situation outputs and prompts.

* **Tests**
  * Added coverage for threshold ordering, reachability, calibration, and safety-car baseline alignment.
  * Verified threat bands remain distinct from raw model operating thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->