### PR TITLE
fix(orchestrator): warn when the client discards the requested temperature

### DIFF
--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -103,7 +103,21 @@ class OrchestratorCFG:
     risk_tolerance_default (α) weights expected value vs worst-case in the MC
     score: score(S) = α·E[S] + (1−α)·P10[S]. α=1.0 aggressive, α=0.0 conservative.
 
-    temperature=0.0 ensures deterministic structured output from Layer 3 LLM.
+    temperature is REQUESTED, not guaranteed. Whether it survives depends on the
+    model family: langchain_openai keeps it for gpt-4.1-mini (what the sub-agents
+    run) and silently discards it for the gpt-5.x family — the client attribute
+    comes back None and the key never reaches the request payload. So with the
+    default model_name below, Layer 3 samples at the provider default and this
+    value does nothing. Measured 2026-07-27 over 41 laps: two identical passes
+    disagreed on confidence in 36, on pit_lap_target in 23, and produced opposite
+    actions on the one lap where the call actually changed. An earlier version of
+    this docstring promised the setting guaranteed determinism here, which was
+    false for every model this project has shipped with.
+
+    _get_orchestrator_llm warns when the request is dropped rather than papering
+    over it. Do NOT read a surviving temperature as a promise of determinism
+    either — it narrows sampling, it does not remove it.
+    See documents/audits/AUDIT_ORCHESTRATOR_MEMORY.md §1.1.
     """
 
     model_name:             str   = "gpt-5.4-mini"
@@ -120,11 +134,31 @@ CFG = OrchestratorCFG()
 _orchestrator_llm = None
 
 
+def _temperature_was_dropped(llm, requested: float | None) -> bool:
+    """True when the client did not keep the temperature we asked it for.
+
+    Split out from _get_orchestrator_llm so the check is testable without an API
+    key, a network call or a provider: it only reads an attribute off whatever
+    object the client library handed back.
+
+    langchain_openai does not raise when a model family rejects the parameter, it
+    nulls the attribute and omits the key from the payload. So `None` on a client
+    we explicitly gave a number is the signal, and it is the only one available
+    short of inspecting the request.
+    """
+    return requested is not None and getattr(llm, "temperature", None) is None
+
+
 def _get_orchestrator_llm():
     """Return the cached structured-output LLM, creating it on first call.
 
     Checks F1_LLM_PROVIDER env var: 'openai' uses the real OpenAI API
     (requires OPENAI_API_KEY); anything else defaults to LM Studio at CFG.base_url.
+
+    Warns once, on creation, when CFG.temperature does not survive into the
+    client — see OrchestratorCFG. The warning is deliberately not a raise: the
+    project ships on a model that drops it, so raising would take the whole
+    orchestrator down over a setting Layer 3 has never actually had.
 
     Returns a Runnable that produces StrategyRecommendation Pydantic objects.
     Raises ImportError when langchain_openai is not installed.
@@ -150,6 +184,17 @@ def _get_orchestrator_llm():
                 model_kwargs={"parallel_tool_calls": False},
                 timeout=120,
                 max_retries=1,
+            )
+        if _temperature_was_dropped(llm, CFG.temperature):
+            # ASCII only: this line lands on Windows terminals, where the repo's
+            # cp1252 console renders an em-dash or a section sign as '?'.
+            logger.warning(
+                "Layer 3 temperature=%s was discarded by the client for model %r. The "
+                "orchestrator is sampling at the provider default, not running "
+                "deterministically: consecutive laps will disagree on confidence, "
+                "pit_lap_target and reasoning even when the prompt is identical. "
+                "See documents/audits/AUDIT_ORCHESTRATOR_MEMORY.md, section 1.1.",
+                CFG.temperature, CFG.model_name,
             )
         # _LLMSynthesis only has the 3 fields the LLM actually fills —
         # scenario_scores (dict) and regulation_context are attached in code after.

--- a/tests/agents/test_agent_llm_timeout.py
+++ b/tests/agents/test_agent_llm_timeout.py
@@ -1,4 +1,4 @@
-"""Agent-side provider-timeout contract (LLM-cost L-1 / #263).
+"""Agent-side provider-kwarg contract (LLM-cost L-1 / #263, plus the temperature drop).
 
 The sub-agents construct their own ``ChatOpenAI`` clients; without a finite
 timeout a stalled provider (a hung LM Studio, a dead socket) can pin a lap for
@@ -7,16 +7,32 @@ the SDK's full ~30-min retry budget. Every construction now passes
 contract - the kwargs are still honored by langchain-openai, and no agent
 construction silently loses the timeout - without importing the agents (which
 would load the model configs) or hitting the network.
+
+The second half of the file covers the kwarg that is NOT honored. langchain-openai
+accepts ``temperature`` for gpt-4.1-mini and silently discards it for the gpt-5.x
+family, nulling the attribute instead of raising, so the orchestrator has been
+sampling at the provider default while its config said 0.0. These tests live here
+rather than in a file of their own because the subject is identical - what the
+client library does with the kwargs we pass - and a second file on the same subject
+is how the two copies drift apart.
+
+Everything here stays source-level or uses a dummy api key, so it runs on a CI
+runner with no weights and no key. That matters more than usual for the
+temperature canary: the whole premise of
+``documents/audits/AUDIT_ORCHESTRATOR_MEMORY.md`` is that the parameter is dropped,
+and if a library upgrade starts honoring it, this file is what tells us.
 """
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
 import pytest
 
 _AGENTS_DIR = Path(__file__).parent.parent.parent / "src" / "agents"
+_ORCHESTRATOR = _AGENTS_DIR / "strategy_orchestrator.py"
 _AGENT_FILES = [
     "pace_agent.py",
     "tire_agent.py",
@@ -57,3 +73,101 @@ def test_every_agent_chatopenai_has_a_timeout(filename: str):
             i += 1
         construction = source[match.start() : i]
         assert "timeout=" in construction, f"{filename}: a ChatOpenAI(...) has no timeout="
+
+
+# ── The temperature the orchestrator asks for and does not get ────────────────
+
+
+def _orchestrator_cfg_defaults() -> dict[str, object]:
+    """Read OrchestratorCFG's field defaults without importing the orchestrator.
+
+    Importing ``src.agents.strategy_orchestrator`` pulls in the tire agent, which
+    reads its routing config at import time, so it is unimportable without the HF
+    weights. Parsing the dataclass keeps these tests running on a CI runner that
+    has none - and it reads the SAME values the module will, instead of restating
+    them here where they would quietly go stale.
+    """
+    tree = ast.parse(_ORCHESTRATOR.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "OrchestratorCFG":
+            fields = {}
+            for stmt in node.body:
+                if isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
+                    fields[stmt.target.id] = ast.literal_eval(stmt.value)
+            return fields
+    raise AssertionError("OrchestratorCFG not found in strategy_orchestrator.py")
+
+
+def test_the_orchestrator_model_still_discards_temperature():
+    """Canary: the audit's central premise is that this kwarg does not survive.
+
+    Not a bug being asserted as correct - a fact being pinned. If a langchain-openai
+    or provider upgrade starts honoring temperature for this model, Layer 3 becomes
+    materially more deterministic overnight and every number in
+    AUDIT_ORCHESTRATOR_MEMORY.md (the 36/41 confidence disagreements between two
+    identical passes, the coin flip on the one decision lap) is measured on a
+    configuration that no longer exists.
+
+    When this fails: re-run scripts/prompt_ab, then update the audit and the
+    OrchestratorCFG docstring. Do not just flip the assertion.
+    """
+    ChatOpenAI = pytest.importorskip("langchain_openai").ChatOpenAI
+    cfg = _orchestrator_cfg_defaults()
+
+    dropped = ChatOpenAI(model=cfg["model_name"], api_key="test-key", temperature=0.0)
+    kept = ChatOpenAI(model="gpt-4.1-mini", api_key="test-key", temperature=0.0)
+
+    assert kept.temperature == 0.0, (
+        "gpt-4.1-mini stopped honoring temperature; the sub-agents relied on it"
+    )
+    assert dropped.temperature is None, (
+        f"{cfg['model_name']} now KEEPS temperature - this is good news and it "
+        "invalidates the audit's measurements; see this test's docstring"
+    )
+
+
+def test_the_orchestrator_warns_when_its_temperature_is_discarded():
+    """``_get_orchestrator_llm`` must call the check, not construct and hope.
+
+    Source-level (AST) rather than behavioural, for the import cost above. The
+    failure this guards is silent by construction: the client returns a working
+    object either way, so nothing downstream can notice the setting evaporated.
+    """
+    tree = ast.parse(_ORCHESTRATOR.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_get_orchestrator_llm":
+            called = {
+                n.func.id
+                for n in ast.walk(node)
+                if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+            }
+            assert "_temperature_was_dropped" in called, (
+                "_get_orchestrator_llm no longer checks whether the client kept "
+                "CFG.temperature, so Layer 3 can silently go back to sampling"
+            )
+            return
+    raise AssertionError("_get_orchestrator_llm not found in strategy_orchestrator.py")
+
+
+def test_the_config_docstring_does_not_promise_determinism():
+    """The docstring claimed the opposite of what happens, for every shipped model.
+
+    It read "temperature=0.0 ensures deterministic structured output from Layer 3
+    LLM" while the parameter was being discarded. A docstring that asserts a
+    guarantee the code does not provide is worse than no docstring: it is why
+    nobody checked for years.
+    """
+    tree = ast.parse(_ORCHESTRATOR.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "OrchestratorCFG":
+            doc = (ast.get_docstring(node) or "").lower()
+            assert "ensures deterministic" not in doc, (
+                "OrchestratorCFG's docstring promises determinism again; the client "
+                "discards temperature for the gpt-5.x family"
+            )
+            assert "requested, not guaranteed" in doc, (
+                "OrchestratorCFG's docstring must say temperature is requested, not "
+                "guaranteed, so the next reader does not trust it"
+            )
+            return
+    raise AssertionError("OrchestratorCFG not found in strategy_orchestrator.py")


### PR DESCRIPTION
Closes #669

## What

`_get_orchestrator_llm` now warns when the client discards the temperature it was given,
and `OrchestratorCFG`'s docstring says what actually happens instead of promising the
opposite.

## Why

`CFG.temperature = 0.0` is passed to `ChatOpenAI` at `strategy_orchestrator.py:143` and
`langchain_openai` drops it for the `gpt-5.x` family. It does not raise: it nulls the
attribute and omits the key from the request payload. Measured:

```
CFG.temperature = 0.0
client temperature = None
ChatOpenAI('gpt-5.4-mini', temperature=0.0).temperature -> None    (payload: key absent)
ChatOpenAI('gpt-4.1-mini', temperature=0.0).temperature -> 0.0     (the sub-agent model)
```

So Layer 3 samples at the provider default while the config says deterministic. The
docstring asserted a guarantee the code never provided, which is why it went unnoticed.

Effect, measured over 41 laps at Lusail 2025 with two identical passes: `confidence`
differed on 36 laps, `pit_lap_target` on 23, `reasoning` on 41 (median similarity 0.30),
and the action on lap 44 - Norris's real stop, the only significant action change in the
415-lap projection set - came out UNDERCUT once and STAY_OUT once from the same prompt.

## How

- `_temperature_was_dropped(llm, requested)`, a one-expression helper split out so the
  check is testable with no API key, no network and no provider.
- One `logger.warning` on client creation, ASCII only because the line lands on Windows
  terminals where the console renders an em-dash as `?`.
- The docstring now states that temperature is requested, not guaranteed, and which model
  families keep it.

**Deliberately not a behaviour change.** Whether Layer 3 should be deterministic is a
separate product question; swapping to a model that honours the parameter changes output
quality everywhere and needs its own before/after. A config value that is read, passed and
discarded is wrong either way, so this makes it loud.

## Tests

Extended `tests/agents/test_agent_llm_timeout.py` rather than adding a second file on the
same subject - what the client library does with the kwargs we pass. All hermetic
(source-level or a dummy api key), so they run on a CI runner with no weights and no key:

- a **canary** asserting the model still discards it, with instructions not to just flip
  the assertion if it fails
- an AST guard that `_get_orchestrator_llm` calls the check
- an AST guard that the docstring does not promise determinism again

## Checks

- `pytest` full suite: 364 passed, 4 skipped
- `ruff@0.15.22 check .` and `format --check .`: clean
- `mypy src/rag/`: clean
- Verified by hand that the warning fires exactly once on a real client build (the second
  call hits the cached singleton).
