### PR TITLE
feat(strategy): per-race decision memory accumulator

### DIFF
--- a/src/strategy/inference/decision_memory.py
+++ b/src/strategy/inference/decision_memory.py
@@ -1,0 +1,206 @@
+"""Per-race memory of the orchestrator's own previous recommendations.
+
+Why this exists
+---------------
+The Layer 3 prompt is stateless. Consecutive laps are 99.02% identical text and
+carry nothing that tells the model it is repeating itself, so it re-argues the
+same case in fresh prose every lap. Measured over 41 laps at Lusail 2025 with no
+memory, the orchestrator declared **80 distinct contingency triggers and reused
+almost none**: across a race that is not one plan, it is 41 unrelated plans. With
+its own previous contingencies echoed back it settles on six.
+
+That is what this class is for, and it is a narrower claim than "memory makes the
+system smarter". It does not change what the orchestrator decides on a given lap
+(``action`` differed on 0 of 41 laps in the A/B). It changes whether consecutive
+laps are the same plan.
+
+Where it lives, and why not in the engine
+-----------------------------------------
+``run_lap`` is pure per lap and ``tests/engine/test_engine_no_llm.py`` depends on
+that: it calls the engine twice on one lap and asserts identical output. So the
+accumulator lives in the CALLER (the CLI loop, the arcade connector, the backend
+simulator's stream) and reaches the engine as a value. Each surface owns one
+instance for the lifetime of one race, the same shape and lifetime as
+``RaceControlStateTracker``.
+
+``/recommend`` and the MCP tool cannot use this, and that is by design rather than
+an oversight: both are stateless per request, with no race-scoped object to hang
+an accumulator on, so the webapp Strategy tab keeps today's memoryless prompt.
+Do not "fix" that by reimplementing a per-request accumulator on the endpoint
+side; that is how ``_rcm_events_for_lap`` ended up existing twice with two
+signatures.
+
+--- WHERE TO CHANGE IF THE RECOMMENDATION SCHEMA CHANGES ---
+``record`` reads ``action``, ``pit_lap_target`` and ``contingencies`` off a
+``StrategyRecommendation``. Record from THAT object, never from a surface DTO:
+``src/arcade/strategy.py``'s ``LapDecisionDTO`` and the backend's ``LapDecision``
+both drop ``contingencies`` entirely, and the backend derives ``pit_lap_target``
+from N28 on the no-llm branch and from the LLM on the rich one, so a DTO-sourced
+memory would mean two different things on one surface.
+
+Evidence for every field choice: documents/audits/AUDIT_ORCHESTRATOR_MEMORY.md.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# The synthesis schema caps contingencies at 4 (``_LLMSynthesis.contingencies``),
+# and only the most recent lap's list is echoed, so the block cannot grow with race
+# length. The cumulative reading was rejected: a trigger is free text with no
+# evaluator, so nothing can retire one, and without memory the model produces about
+# two brand-new triggers per lap.
+MAX_CONTINGENCIES = 4
+
+# How many past targets to show. Enough to make a drifting plan visible, short
+# enough that the block stays a few lines.
+TARGET_HISTORY = 5
+
+# Appended to every block. Without it, memory measurably ANCHORED the model: at
+# Lusail 2025 lap 44 (Norris's real stop) it agreed with the deterministic Monte
+# Carlo on 4 of 10 runs against 6 of 10 with no memory at all. With this sentence,
+# 10 of 10. It is not decoration and it is not optional.
+COUNTERWEIGHT = (
+    "  This history is context, NOT a commitment. Judge this lap on its own\n"
+    "  evidence; a long hold is not itself a reason to keep holding.\n"
+)
+
+
+@dataclass(frozen=True)
+class _Entry:
+    """One recorded lap: the parts of a recommendation the next lap should see."""
+
+    lap: int
+    action: str
+    pit_lap_target: int | None
+    contingencies: tuple[dict[str, str], ...]
+
+
+@dataclass
+class DecisionMemory:
+    """Accumulates one race's recommendations and renders the prompt block.
+
+    Responsibilities:
+      * ``record`` one ``StrategyRecommendation`` per lap the surface actually
+        decided on. Laps a surface skips (retired car, incomplete lap, a lap that
+        raised) are simply not recorded, and the rendering makes the resulting gap
+        visible rather than hiding it.
+      * ``block`` renders what the LLM should see, or ``None`` before there is any
+        history at all.
+
+    Invariants:
+      * Laps are recorded in strictly increasing order. Going backwards would make
+        every span nonsense, so it raises rather than quietly accepting it.
+      * The rendered block never states a bare "held for N laps" count. N counts
+        DECISIONS; the laps that elapsed can be more. Every surface `continue`s
+        past skipped laps, so a bare count is a claim the model cannot check.
+    """
+
+    _entries: list[_Entry] = field(default_factory=list)
+
+    # ── recording ─────────────────────────────────────────────────────────
+    def record(self, lap: int, recommendation: Any) -> None:
+        """Store the parts of ``recommendation`` the next lap's prompt needs.
+
+        Raises:
+            ValueError: when ``lap`` is not after the last recorded lap. A replay
+                that seeks backwards, or a caller recording the same lap twice,
+                would otherwise produce a span that reads as a fact and is not one.
+        """
+        if self._entries and lap <= self._entries[-1].lap:
+            raise ValueError(
+                f"lap {lap} is not after the last recorded lap "
+                f"{self._entries[-1].lap}; DecisionMemory is per race and forward-only"
+            )
+        self._entries.append(
+            _Entry(
+                lap=lap,
+                action=str(getattr(recommendation, "action", "")),
+                pit_lap_target=getattr(recommendation, "pit_lap_target", None),
+                contingencies=tuple(
+                    {
+                        "trigger": str(c.trigger),
+                        "switch_to": str(c.switch_to),
+                        "priority": str(c.priority),
+                    }
+                    for c in (getattr(recommendation, "contingencies", None) or [])
+                ),
+            )
+        )
+
+    # ── derived views, each one line of the block ─────────────────────────
+    def _current_run(self) -> tuple[str, int, int]:
+        """The unbroken run of the latest action: (action, first lap, decisions)."""
+        action = self._entries[-1].action
+        decisions = 0
+        for entry in reversed(self._entries):
+            if entry.action != action:
+                break
+            decisions += 1
+        return action, self._entries[-decisions].lap, decisions
+
+    def _recent_targets(self) -> list[int | None]:
+        return [entry.pit_lap_target for entry in self._entries[-TARGET_HISTORY:]]
+
+    def _live_contingencies(self) -> tuple[dict[str, str], ...]:
+        """The most recent lap's contingencies, capped.
+
+        Deliberately the last lap only. "Everything declared and not retired" is
+        unimplementable: a trigger is prose, so no code can decide whether it fired.
+        """
+        return self._entries[-1].contingencies[:MAX_CONTINGENCIES]
+
+    # ── rendering ─────────────────────────────────────────────────────────
+    def _render_hold(self) -> str:
+        action, since_lap, decisions = self._current_run()
+        laps_spanned = self._entries[-1].lap - since_lap + 1
+        if laps_spanned == decisions:
+            return f"  Last call: {action}, held since lap {since_lap} ({decisions} laps)."
+        # The two numbers disagree, which means the surface skipped laps. Say both
+        # rather than picking one: "held for N laps" would be false, and dropping
+        # the span would hide that the race moved on without a decision.
+        return (
+            f"  Last call: {action}, held since lap {since_lap} "
+            f"({decisions} decisions across {laps_spanned} laps; the rest were not "
+            f"evaluated)."
+        )
+
+    def _render_targets(self) -> str:
+        targets = self._recent_targets()
+        shown = ", ".join("none" if t is None else str(t) for t in targets)
+        known = [t for t in targets if t is not None]
+        if len(known) < 2:
+            return f"  Your pit_lap_target over the last {len(targets)} calls: {shown}."
+        drift = known[-1] - known[0]
+        return (
+            f"  Your pit_lap_target over the last {len(targets)} calls: {shown} "
+            f"(net drift {drift:+d} laps)."
+        )
+
+    def _render_contingencies(self) -> list[str]:
+        live = self._live_contingencies()
+        if not live:
+            return ["  Contingencies you declared last lap: none."]
+        lines = ["  Contingencies you declared last lap:"]
+        lines.extend(
+            f"    - [{c['priority']}] \"{c['trigger']}\" -> {c['switch_to']}" for c in live
+        )
+        return lines
+
+    def block(self) -> str | None:
+        """The prompt block, or ``None`` when there is no history to report.
+
+        ``None`` rather than an empty string or a "held for 0 laps" line: on the
+        first lap of a race there is no previous call, and inventing a statement
+        about one is how a prompt teaches a model something untrue.
+        """
+        if not self._entries:
+            return None
+        lines = [
+            "DECISION MEMORY (your own previous calls this race):",
+            self._render_hold(),
+            self._render_targets(),
+            *self._render_contingencies(),
+        ]
+        return "\n".join(lines) + "\n" + COUNTERWEIGHT + "\n"

--- a/tests/engine/test_decision_memory.py
+++ b/tests/engine/test_decision_memory.py
@@ -1,0 +1,165 @@
+"""Contract for ``DecisionMemory``, the per-race accumulator.
+
+Hermetic: no models, no data, no LLM. ``decision_memory`` imports nothing from
+``src.agents``, which is deliberate - it is the only piece of the memory work that
+can be tested on a CI runner with no weights, so it carries the whole behavioural
+contract and the surfaces only have to be checked for wiring.
+
+Every assertion here traces to a measurement in
+``documents/audits/AUDIT_ORCHESTRATOR_MEMORY.md``; the docstrings name which.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.strategy.inference.decision_memory import (
+    COUNTERWEIGHT,
+    MAX_CONTINGENCIES,
+    DecisionMemory,
+)
+
+
+def _contingency(trigger: str, switch_to: str = "PIT_NOW", priority: str = "HIGH"):
+    return SimpleNamespace(trigger=trigger, switch_to=switch_to, priority=priority)
+
+
+def _rec(action="STAY_OUT", pit_lap_target=None, contingencies=()):
+    """A stand-in for StrategyRecommendation with only the fields memory reads."""
+    return SimpleNamespace(
+        action=action, pit_lap_target=pit_lap_target, contingencies=list(contingencies)
+    )
+
+
+@pytest.mark.unit
+def test_no_history_renders_no_block():
+    """First lap of a race: there is no previous call, so do not invent one.
+
+    A "held for 0 laps" line would be a statement about a decision that does not
+    exist, which is how a prompt teaches a model something untrue.
+    """
+    assert DecisionMemory().block() is None
+
+
+@pytest.mark.unit
+def test_a_clean_run_reports_the_span_in_laps():
+    memory = DecisionMemory()
+    for lap in range(5, 13):
+        memory.record(lap, _rec(pit_lap_target=30))
+
+    block = memory.block()
+    assert "held since lap 5 (8 laps)" in block
+    assert "decisions across" not in block, "no gap here, so do not report one"
+
+
+@pytest.mark.unit
+def test_a_gap_is_reported_as_a_gap_not_hidden_in_a_count():
+    """The bare-count bug, demonstrated in audit section 2.4.
+
+    Every surface `continue`s past laps it cannot decide on (a retired car, an
+    incomplete lap, a lap that raised). A bare "held for 7 laps" while 16 elapsed
+    is a false statement the model has no way to check, so both numbers are stated.
+    """
+    memory = DecisionMemory()
+    for lap in range(5, 11):  # 6 decisions
+        memory.record(lap, _rec())
+    memory.record(20, _rec())  # laps 11-19 skipped
+
+    block = memory.block()
+    assert "7 decisions across 16 laps" in block
+    assert "held for 7 laps" not in block
+
+
+@pytest.mark.unit
+def test_an_action_change_resets_the_run():
+    memory = DecisionMemory()
+    for lap in range(5, 10):
+        memory.record(lap, _rec(action="STAY_OUT"))
+    memory.record(10, _rec(action="UNDERCUT"))
+    memory.record(11, _rec(action="UNDERCUT"))
+
+    block = memory.block()
+    assert "Last call: UNDERCUT, held since lap 10" in block
+
+
+@pytest.mark.unit
+def test_target_drift_is_reported_with_its_sign():
+    """A target that moves every lap is a plan that does not exist (audit 1.7).
+
+    Without memory the target moved 311 laps in total across a 57-lap race, so the
+    drift is the point of the field, not the latest value.
+    """
+    memory = DecisionMemory()
+    for lap, target in zip(range(5, 10), [30, 31, 33, 35, 36]):
+        memory.record(lap, _rec(pit_lap_target=target))
+
+    assert "30, 31, 33, 35, 36 (net drift +6 laps)" in memory.block()
+
+
+@pytest.mark.unit
+def test_a_missing_target_is_rendered_as_none_not_as_a_number():
+    """`None` means "no stop planned in the visible horizon" and must stay distinct.
+
+    This repo has a scar from a sentinel colliding with a real value; rendering an
+    absent target as 0 would put a searchable lap number in the prompt.
+    """
+    memory = DecisionMemory()
+    memory.record(5, _rec(pit_lap_target=None))
+    memory.record(6, _rec(pit_lap_target=None))
+
+    block = memory.block()
+    assert "none, none" in block
+    assert "drift" not in block, "two unknowns cannot produce a drift"
+
+
+@pytest.mark.unit
+def test_only_the_last_lap_of_contingencies_is_echoed_and_it_is_capped():
+    """The block must not grow with race length (audit 1.5 / 3.3).
+
+    A trigger is free text with no evaluator, so no code can retire one. The
+    cumulative reading would have carried 80 stale lines by lap 45.
+    """
+    memory = DecisionMemory()
+    memory.record(5, _rec(contingencies=[_contingency("old trigger from lap 5")]))
+    memory.record(
+        6,
+        _rec(contingencies=[_contingency(f"trigger {i}") for i in range(MAX_CONTINGENCIES + 3)]),
+    )
+
+    block = memory.block()
+    assert "old trigger from lap 5" not in block
+    assert block.count("    - [") == MAX_CONTINGENCIES
+
+
+@pytest.mark.unit
+def test_the_counterweight_is_always_present():
+    """Without it, memory ANCHORED the model on the one lap that mattered.
+
+    At Lusail 2025 lap 44, agreement with the deterministic Monte Carlo was 6/10
+    with no memory, 4/10 with memory, and 10/10 with memory plus this sentence.
+    It is part of the block, not a caller's option.
+    """
+    memory = DecisionMemory()
+    memory.record(5, _rec())
+    assert COUNTERWEIGHT in memory.block()
+
+
+@pytest.mark.unit
+def test_recording_backwards_raises_rather_than_producing_a_false_span():
+    memory = DecisionMemory()
+    memory.record(10, _rec())
+
+    with pytest.raises(ValueError, match="forward-only"):
+        memory.record(9, _rec())
+    with pytest.raises(ValueError, match="forward-only"):
+        memory.record(10, _rec())
+
+
+@pytest.mark.unit
+def test_a_recommendation_with_no_contingencies_says_so_explicitly():
+    """Silence and "none declared" are different messages to the model."""
+    memory = DecisionMemory()
+    memory.record(5, _rec())
+    assert "Contingencies you declared last lap: none." in memory.block()


### PR DESCRIPTION
Closes #671

## What

`DecisionMemory`, a per-race accumulator of the orchestrator's own previous
recommendations, plus the block it renders for the Layer 3 prompt.

**Nothing consumes it yet.** No prompt change, no surface change, no behaviour change. It
is inert until a later PR wires it, and it is deliberately inert so it can be measured
first.

## Why now, before the wiring is approved

The gate measurement needs a memory-block implementation to measure. Putting a prototype in
`scripts/` would have created a second implementation that drifts from the eventual one -
this repo's dominant defect, and three surfaces is exactly where it strikes. Building the
real class first and having the harness import it kills the twin before it exists. If the
wiring is never approved, this is one file to delete.

## Why memory at all

Measured over 41 laps at Lusail 2025: without memory the orchestrator declares **80
distinct contingency triggers** and reuses almost none. That is not one plan across a race,
it is 41 unrelated plans. With its own contingencies echoed back: **6**. The gate
measurement on a temperature-honouring model confirms this is not a sampling artifact
(28 and 26 distinct triggers without memory, 5 with).

It does **not** change what the orchestrator decides on a lap - `action` differed on 0 of
41 laps. It changes whether consecutive laps are the same plan.

## Design, and why each field is the way it is

- **Lives in the caller, not the engine.** `run_lap` is pure per lap and
  `tests/engine/test_engine_no_llm.py:133-140` depends on that.
- **Contingencies: last recorded lap only, capped at 4.** The cumulative reading is
  unimplementable - a trigger is free text with no evaluator, so no code can retire one -
  and it would have carried 80 stale lines by lap 45.
- **`last_action` renders a SPAN, never a bare count.** Every surface skips laps (retired
  car, incomplete lap, a lap that raised), so "held for 7 laps" while 16 elapsed is a false
  statement the model cannot check. When the two numbers disagree the block says both.
- **The counterweight sentence is part of the block, not a caller option.** Without it,
  memory measurably anchored the model: at the real stop lap, agreement with the
  deterministic Monte Carlo was 4/10 with memory alone against 6/10 with none, and 10/10
  with the counterweight (Fisher p=0.011 against memory alone).
- **Forward-only.** Recording a lap that is not after the last one raises, because a
  backwards seek would produce a span that reads as a fact and is not one.
- **`None` when there is no history.** On lap 1 there is no previous call, and a "held for 0
  laps" line is a statement about a decision that does not exist.

## Tests

`tests/engine/test_decision_memory.py`, 10 cases, fully hermetic (no models, no data, no
LLM, 0.12 s). Every assertion traces to a measurement in the audit and the docstrings name
which. It carries the whole behavioural contract, so the surfaces will only need checking
for wiring.

## Out of scope

Rendering it in the prompt, wiring any surface, and scoping the STAY_OUT framing. Each is
its own PR and the wiring one needs central verification across three surfaces.

## Checks

- `pytest` full suite: 364 passed, 4 skipped
- `ruff@0.15.22 check .` and `format --check .`: clean
- `mypy src/rag/`: clean
