### PR TITLE
chore(eval): re-run the memory repeat experiments on a deterministic client

### DIFF
--- a/documents/audits/AUDIT_ORCHESTRATOR_MEMORY.md
+++ b/documents/audits/AUDIT_ORCHESTRATOR_MEMORY.md
@@ -910,3 +910,108 @@ Stated so the next reader knows what does not need re-auditing.
   audit cannot attribute the effect to one of them except by the mechanism visible in §3.6,
   which points at the contingencies.
 
+
+---
+
+# GATE FOLLOW-UP 2, 2026-07-28 — the two repeat experiments, re-run on a deterministic client
+
+The first gate follow-up re-measured the whole-race passes and explicitly left this open:
+
+> Nothing here re-opens §3.5/§3.6, which were run on the shipped model with repeats. They
+> should be re-run on a deterministic client before the wiring PR, since both were measured
+> against a much noisier baseline than a fixed client would give.
+
+That is what this section does. It is the gate on Sprint 2's wiring: if memory stopped
+helping once the sampler was removed, nothing was to be wired.
+
+**Method.** Identical to §3.5/§3.6 except for the client: `--model gpt-4.1-mini` at
+`temperature=0.0`, which that family keeps. History for both experiments is `gate_none.json`,
+the deterministic no-memory pass from the first gate follow-up, so the block echoed back is
+the one a deterministic surface would actually have accumulated. 36 calls, 116k in / 13.5k out.
+
+Two variants, not three: the counterweight now ships **inside** `DecisionMemory.block()`, so
+what §3.5 called BC is what `memory` means from here on. There is no memory-without-
+counterweight configuration left to measure, by design.
+
+## Result 1 — the Safety Car experiment does NOT just survive, it sharpens
+
+**Lusail 2025 lap 42, Safety Car injected via RCM, deterministic MC = `PIT_NOW`, n=8.**
+
+| variant | takes the free stop | stays out | mean confidence | `pit_lap_target` |
+|---|---|---|---|---|
+| no memory | **0/8** | 8 | 0.856 | 57, 47, 57, 57, 50, 50, 57, 57 |
+| memory | **8/8** | 0 | 0.906 | 42 x8 |
+
+```
+Fisher two-sided, agreement with the deterministic layer: p = 0.000155
+```
+
+On the shipped sampling client this was 1/8 against 7/8 (p=0.0101). On a deterministic client
+it is total separation. **The load-bearing result is not a sampling artifact** — removing the
+sampler made it cleaner, which is the opposite of what a noise explanation predicts.
+
+The mechanism is unchanged and still legible: entering lap 42 the block carried
+`[HIGH] "SC deployed within 3 laps" -> PIT_NOW`, declared by the model itself on lap 41. The
+Safety Car then deployed. Without the echo the model does not act on its own plan; with it,
+every run does.
+
+**§3.5's severity finding also reproduces, and it got worse.** Of the 8 memory runs, **0**
+mention the prior plan, the contingency or continuity in `reasoning` — they argue from tyre
+cliff and pace delta and then pit. The one run that does reference a prior plan is in the
+**no-memory** arm. So the block changes the decision on 8 of 8 runs while leaving no trace a
+reviewer could find in the output. That is a monitoring requirement, not a reason not to ship:
+**whatever surface renders the recommendation cannot show WHY this flipped**, so the memory
+block itself has to be inspectable when a call is questioned.
+
+The §3.6 caveat stands verbatim and is not weakened by the sharper number: these SC laps route
+N28/N30 in production, so the prompts lack the pit block and the hard regulation constraint a
+`rich` run would carry. **The A-vs-B contrast is sound because both arms get the identical
+prompt; the absolute 0/8 is not a product finding** and must not be quoted as "the product
+ignores Safety Cars".
+
+## Result 2 — the anchoring experiment went DEGENERATE, and that is a limitation, not a clean bill
+
+**Lusail 2025 lap 44, Norris's real stop, deterministic MC = `UNDERCUT`, n=10.**
+
+| variant | agrees with MC (pits) | stays out | mean confidence | `pit_lap_target` |
+|---|---|---|---|---|
+| no memory | **0/10** | 10 | 0.860 | 57 x8, 50, 52 |
+| memory | **0/10** | 10 | 0.880 | 57 x10 |
+
+```
+Fisher two-sided: p = 1.0
+```
+
+**Both arms are on the floor, so this experiment measured nothing.** `gpt-4.1-mini` never takes
+the lap-44 undercut in any configuration; there is no variance for memory to move in either
+direction. Read precisely:
+
+- It does **not** show that memory is harmless at the decision lap. §3.5's 6/10 → 4/10 was
+  measured on a client where the baseline pitted at all; here the baseline never does, so the
+  harm this experiment exists to detect is undetectable by construction.
+- It does **not** reproduce §3.5's 10/10 counterweight result either. That result stays where
+  the first follow-up left it: measured on the shipped model, and not re-confirmed.
+- What it does show is that the block did not push a 0/10 baseline into a *wrong* action, and
+  that the target stopped scattering (57 x8, 50, 52 → 57 x10).
+
+Worth recording because it is the design's own worst case: this run's block reported
+**`STAY_OUT, held since lap 5 (39 laps)`** — the 39-lap hold §3.5 said it could not test,
+since that pass never left `STAY_OUT`. A 39-lap hold plus a counterweight did not produce a
+different call from no memory at all.
+
+**Residual noise at `temperature=0.0`:** the no-memory arms are not constant. Lap 44 gave
+confidences of 0.85/0.90 and targets 57/50/52; lap 42 gave 57/47/50. A kept temperature
+narrows sampling, it does not remove it — exactly as `OrchestratorCFG`'s docstring warns.
+
+## Gate verdict: PASS — wire it
+
+The gate was "if a deterministic client stops the memory improving agreement with the
+deterministic MC, or worsens it, stop". Neither happened: agreement is unchanged on the
+degenerate lap and goes 0/8 → 8/8 on the lap where the deterministic layer had a live call.
+
+Two things the wiring must carry out of this section:
+
+1. **The contingency echo is the field to ship**, confirmed twice on two clients. Field order
+   in step 4 of the plan is correct as written.
+2. **The block must be inspectable at the surface.** An intervention that flips 8 of 8
+   decisions without appearing in `reasoning` is one nobody can debug from the output alone.

--- a/scripts/prompt_ab/README.md
+++ b/scripts/prompt_ab/README.md
@@ -62,6 +62,14 @@ minutes and ~120 calls for the three together.
   memory, 6 with) and total `pit_lap_target` movement (311 laps against 214).
 - **Repeats**: report the count, the variant split and a Fisher exact test. n=10 cannot
   separate a 6/10 from a 4/10.
+- **Read the no-memory arm before the result.** If it is already at 0/n or n/n, the lap has
+  no room to move and the comparison measures nothing. That is what happened to the lap-44
+  anchoring experiment on `--model gpt-4.1-mini`: both arms stayed out 10 of 10, which is a
+  degenerate experiment and not evidence that memory is harmless.
+
+`--model` overrides `CFG.model_name` for one run. It exists because the shipped model
+discards `temperature`, so the only way to ask "does this survive without the sampler" is to
+measure a model that keeps it. Cross-model results are directional, never absolute.
 
 ## Deviations you must state with any result
 

--- a/scripts/prompt_ab/_common.py
+++ b/scripts/prompt_ab/_common.py
@@ -31,6 +31,37 @@ if str(REPO_ROOT) not in sys.path:
 MEMORY_ANCHOR = "RACE CONTEXT:\n"
 
 
+MODEL_FLAG_HELP = (
+    "override CFG.model_name for this run only. The reason this exists: the "
+    "shipped model discards temperature, so the only way to ask 'would a "
+    "DETERMINISTIC client behave differently' is to measure one that keeps it. "
+    "A cross-model result is suggestive, not conclusive."
+)
+
+
+def add_model_flag(parser) -> None:
+    """Register ``--model`` on a harness stage.
+
+    Shared rather than copied into each stage: the flag and the override below are
+    a pair, and a stage that grew its own copy would be one more instance of the
+    failure this repo keeps hitting - a fix landing on one twin and not the other.
+    """
+    parser.add_argument("--model", default=None, help=MODEL_FLAG_HELP)
+
+
+def apply_model_flag(model: str | None) -> str:
+    """Point ``CFG.model_name`` at ``model`` and return the model actually in use.
+
+    Must run BEFORE the first ``_get_orchestrator_llm()``, which caches the client:
+    afterwards the assignment lands on config nothing reads again.
+    """
+    from src.agents.strategy_orchestrator import CFG
+
+    if model:
+        CFG.model_name = model
+    return CFG.model_name
+
+
 def load_env() -> str:
     """Load the repo ``.env`` and return the resolved provider.
 

--- a/scripts/prompt_ab/run_pass.py
+++ b/scripts/prompt_ab/run_pass.py
@@ -24,6 +24,8 @@ from pathlib import Path
 
 from scripts.prompt_ab._common import (
     Usage,
+    add_model_flag,
+    apply_model_flag,
     assemble,
     build_prompt,
     checkpoint,
@@ -48,26 +50,15 @@ def main() -> None:
     parser.add_argument("--out", required=True, type=Path)
     parser.add_argument("--variant", choices=VARIANTS, default="none")
     parser.add_argument("--laps", default=None, help="optional sub-range, e.g. 40-45")
-    parser.add_argument(
-        "--model",
-        default=None,
-        help=(
-            "override CFG.model_name for this run only. The reason this exists: the "
-            "shipped model discards temperature, so the only way to ask 'would a "
-            "DETERMINISTIC client behave differently' is to measure one that keeps it. "
-            "A cross-model result is suggestive, not conclusive."
-        ),
-    )
+    add_model_flag(parser)
     args = parser.parse_args()
 
     provider = load_env()
 
-    from src.agents.strategy_orchestrator import CFG, _get_orchestrator_llm
+    from src.agents.strategy_orchestrator import _get_orchestrator_llm
 
-    if args.model:
-        # Must happen before the first _get_orchestrator_llm(), which caches the client.
-        CFG.model_name = args.model
-    print(f"provider={provider}  variant={args.variant}  model={CFG.model_name}")
+    model_name = apply_model_flag(args.model)
+    print(f"provider={provider}  variant={args.variant}  model={model_name}")
 
     records = pickle.loads(args.inputs.read_bytes())
     if args.laps:
@@ -104,7 +95,7 @@ def main() -> None:
             args.out,
             {
                 "variant": args.variant,
-                "model": CFG.model_name,
+                "model": model_name,
                 "usage": usage.as_dict(),
                 "rows": rows,
             },

--- a/scripts/prompt_ab/run_repeats.py
+++ b/scripts/prompt_ab/run_repeats.py
@@ -8,14 +8,20 @@ way to measure those is repetition on one lap.
 The memory block is frozen at what a source pass held ENTERING the target lap, so
 every repeat sees the same history and the only thing varying is the sampler.
 
-This is the experiment that produced the audit's two significant results: at Lusail
-2025 lap 44 memory alone agreed with the deterministic Monte Carlo on 4 of 10 runs
-against 6 of 10 without it, and 10 of 10 once the counterweight was in the block;
-under an injected Safety Car, memory took the free stop on 7 of 8 runs against 1 of 8.
+This is the experiment that produced the audit's significant result: under a Safety
+Car injected at Lusail 2025 lap 42, memory took the free stop on 7 of 8 runs against
+1 of 8 without it. Re-run on ``--model gpt-4.1-mini``, which honours ``temperature=0``,
+it separates completely: **0 of 8 against 8 of 8** (Fisher p=0.000155), so the effect
+is not the sampler.
+
+Pass ``--model`` for that check. Note the companion experiment at lap 44 went
+DEGENERATE on the deterministic client — both arms stay out 10 of 10 — so a null
+result there measures the client, not the memory. Always read the no-memory arm first.
 
 Usage:
-    python -m scripts.prompt_ab.run_repeats --inputs .../lusail_nor.pkl \\
-        --history .../pass_a.json --lap 44 --repeats 10 --out .../transition.json
+    python -m scripts.prompt_ab.run_repeats --inputs .../lusail_nor_sc.pkl \\
+        --history .../gate_none.json --lap 42 --repeats 8 --model gpt-4.1-mini \\
+        --out .../sc.json
 """
 
 from __future__ import annotations
@@ -30,6 +36,8 @@ from types import SimpleNamespace
 
 from scripts.prompt_ab._common import (
     Usage,
+    add_model_flag,
+    apply_model_flag,
     assemble,
     build_prompt,
     checkpoint,
@@ -91,12 +99,15 @@ def main() -> None:
     parser.add_argument("--lap", required=True, type=int)
     parser.add_argument("--repeats", type=int, default=10)
     parser.add_argument("--out", required=True, type=Path)
+    add_model_flag(parser)
     args = parser.parse_args()
 
     provider = load_env()
-    print(f"provider={provider}  lap={args.lap}  repeats={args.repeats}")
 
     from src.agents.strategy_orchestrator import _get_orchestrator_llm
+
+    model_name = apply_model_flag(args.model)
+    print(f"provider={provider}  model={model_name}  lap={args.lap}  repeats={args.repeats}")
 
     records = {r["lap"]: r for r in pickle.loads(args.inputs.read_bytes())}
     history_rows = json.loads(args.history.read_text(encoding="utf-8"))["rows"]
@@ -128,7 +139,15 @@ def main() -> None:
                 f"conf={row['confidence']:.2f} target={row['pit_lap_target']}",
                 flush=True,
             )
-            checkpoint(args.out, {"lap": args.lap, "usage": usage.as_dict(), "rows": rows})
+            checkpoint(
+                args.out,
+                {
+                    "lap": args.lap,
+                    "model": model_name,
+                    "usage": usage.as_dict(),
+                    "rows": rows,
+                },
+            )
 
     _summarise(rows, args.lap)
     print(f"\n{usage.calls} calls, {usage.prompt_tokens} in / {usage.completion_tokens} out")


### PR DESCRIPTION
## What

Closes the gate the first follow-up left open. Sections 3.5 and 3.6 of `AUDIT_ORCHESTRATOR_MEMORY.md` were measured on the shipped sampling model, so neither could be separated from the sampler. Both are re-run here on `gpt-4.1-mini` at `temperature=0.0`, the family that keeps the parameter.

36 API calls, 116k in / 13.5k out.

## Result

| experiment | no memory | memory | Fisher |
|---|---|---|---|
| Safety Car lap 42, det MC `PIT_NOW` | **0/8** | **8/8** | p = 0.000155 |
| Anchoring lap 44, det MC `UNDERCUT` | 0/10 | 0/10 | p = 1.0 |

- **The Safety Car result sharpens.** On the sampling client it was 1/8 against 7/8 (p=0.0101); deterministic, it separates completely. A noise explanation predicts the opposite, so the contingency echo is confirmed as the field to ship.
- **The anchoring experiment went degenerate.** `gpt-4.1-mini` never takes the lap-44 undercut in either arm, so there is no variance for memory to move. Written up as a limitation, explicitly **not** as evidence that memory is harmless at the decision lap. The block in that run reported a 39-lap hold, the design's own worst case, and still changed nothing.
- **The effect is invisible in the prose.** 0 of 8 memory reasonings mention the prior plan while all 8 flip the call. That becomes a requirement on the wiring: the block has to be inspectable at the surface, because nobody can debug this from `reasoning`.

Section 3.6's caveat is restated and stands: these SC laps route N28/N30 in production, so the absolute 0/8 is not a product finding.

## Gate verdict

**PASS.** Memory does not worsen agreement with the deterministic layer on the degenerate lap and goes 0/8 to 8/8 on the lap where the deterministic layer had a live call. Sprint 2's wiring proceeds.

## Also

`run_repeats` gains `--model`, shared with `run_pass` through `_common` rather than copied. A second copy of the flag plus its `CFG` assignment is exactly how this repo grows twins.

## Checks

- `ruff check --no-cache .` and `ruff format --check .` clean at the pinned 0.15.22
- both harness stages verified to still start
- outputs land under `data/eval/prompt_ab/`, which is gitignored