### PR TITLE
feat(orchestrator): render a decision-memory block in the Layer 3 prompt

### DIFF
--- a/scripts/prompt_ab/_common.py
+++ b/scripts/prompt_ab/_common.py
@@ -6,12 +6,10 @@ calls ``_build_orchestrator_prompt``, ``_get_orchestrator_llm`` and
 that measures a private copy of the code is a recorded failure in this repo, and
 two published numbers were produced that way.
 
---- WHERE TO CHANGE IF THE PROMPT GAINS A MEMORY PARAMETER ---
-``inject_memory_block`` splices the block in by string surgery, above the
-``RACE CONTEXT:`` heading. That is a harness-only workaround for the fact that
-``_build_orchestrator_prompt`` has no ``memory_block`` argument yet. The moment it
-gains one, delete the splice and pass the argument, or this harness starts
-measuring a prompt assembled differently from the one production builds.
+Earlier versions spliced the memory block in by string surgery above the
+``RACE CONTEXT:`` heading, because the builder had no parameter for it. It has one
+now and the splice is gone: every measurement here assembles the prompt through the
+same code path production uses, which is the whole point of this module.
 """
 
 from __future__ import annotations
@@ -25,11 +23,6 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
-
-# The heading the memory block is spliced above: after the guard-rails and the
-# STAY_OUT framing, immediately before the per-lap facts.
-MEMORY_ANCHOR = "RACE CONTEXT:\n"
-
 
 MODEL_FLAG_HELP = (
     "override CFG.model_name for this run only. The reason this exists: the "
@@ -144,19 +137,11 @@ def invoke_with_retry(llm, prompt: str, usage: Usage, attempts: int = 4):
     raise AssertionError("unreachable")
 
 
-def inject_memory_block(prompt: str, block: str | None) -> str:
-    """Splice the memory block above ``RACE CONTEXT:``; a falsy block is a no-op."""
-    if not block:
-        return prompt
-    index = prompt.index(MEMORY_ANCHOR)
-    return prompt[:index] + block + prompt[index:]
-
-
 def build_prompt(record: dict[str, Any], memory_block: str | None = None) -> str:
     """Build one lap's orchestrator prompt from a cached record."""
     from src.agents.strategy_orchestrator import _build_orchestrator_prompt
 
-    prompt = _build_orchestrator_prompt(
+    return _build_orchestrator_prompt(
         race_state=record["race_state"],
         mc_results=record["mc_results"],
         best_mc=record["best_mc"],
@@ -166,8 +151,8 @@ def build_prompt(record: dict[str, Any], memory_block: str | None = None) -> str
         pit_out=record["pit_out"],
         radio_out=record["radio_out"],
         regulation_context=record["regulation_context"],
+        memory_block=memory_block,
     )
-    return inject_memory_block(prompt, memory_block)
 
 
 def assemble(record: dict[str, Any], synthesis):

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -1468,6 +1468,7 @@ def _build_orchestrator_prompt(
     pit_out              = None,
     radio_out            = None,
     regulation_context:  str = "",
+    memory_block:        str = "",
 ) -> str:
     """Build the LLM synthesis prompt for Layer 3.
 
@@ -1485,6 +1486,20 @@ def _build_orchestrator_prompt(
     best_mc is the MC argmax passed as a hint. The LLM may override it if
     regulation context, radio alerts, or a planned contingency justify a
     different action.
+
+    memory_block is what this race's own previous recommendations looked like,
+    rendered by DecisionMemory and empty by default. Empty is not a degraded
+    mode: two of the three call sites (/recommend and the MCP tool) are
+    stateless per request and have no race-scoped object to accumulate on, so
+    they keep this prompt exactly as it was. The default therefore has to
+    produce a byte-identical prompt, which tests/agents/test_orchestrator_prompt
+    asserts.
+
+    Measured effect when it IS supplied, on a client that honours temperature=0:
+    under a Safety Car at Lusail 2025 lap 42, the model acted on a contingency it
+    had itself declared one lap earlier on 8 of 8 runs, against 0 of 8 without
+    the block (Fisher p=0.000155). It changes whether consecutive laps are the
+    same plan, not what any single lap decides.
     """
     mc_table = "\n".join(_format_mc_row(name, cell) for name, cell in mc_results.items())
 
@@ -1607,6 +1622,11 @@ def _build_orchestrator_prompt(
         f"  that would change the call, and (c) how far the current numbers sit from it.\n"
         f"  Carry the lap you are watching towards in pit_lap_target whenever the tyre\n"
         f"  data supports one, so a hold reads as a plan with a horizon, not indecision.\n\n"
+        # Placed after the framing and before the per-lap facts, so the model reads
+        # what it decided before it reads this lap's numbers. `or ""` because the
+        # producer, DecisionMemory.block(), returns None before there is any history
+        # and an unguarded f-string would render the literal "None" into the prompt.
+        f"{memory_block or ''}"
         f"RACE CONTEXT:\n"
         f"  Driver: {race_state.driver} | Lap: {race_state.lap}/{race_state.total_laps}\n"
         f"  Position: P{race_state.position} | Compound: {race_state.compound} "

--- a/tests/agents/test_orchestrator_prompt.py
+++ b/tests/agents/test_orchestrator_prompt.py
@@ -32,11 +32,11 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture
-def prompt() -> str:
-    """A prompt with no sub-agent outputs, so only the static blocks remain."""
-    from src.agents.strategy_orchestrator import RaceState, _build_orchestrator_prompt
+def race_state():
+    """The one RaceState every prompt in this file is built from."""
+    from src.agents.strategy_orchestrator import RaceState
 
-    race_state = RaceState(
+    return RaceState(
         driver="NOR",
         lap=25,
         total_laps=57,
@@ -49,6 +49,13 @@ def prompt() -> str:
         air_temp=22.7,
         track_temp=28.1,
     )
+
+
+@pytest.fixture
+def prompt(race_state) -> str:
+    """A prompt with no sub-agent outputs, so only the static blocks remain."""
+    from src.agents.strategy_orchestrator import _build_orchestrator_prompt
+
     return _build_orchestrator_prompt(race_state, {}, "STAY_OUT")
 
 
@@ -80,6 +87,85 @@ def test_a_held_stay_out_asks_for_a_threshold_rather_than_the_same_case_again(
     # and every demand below straddles a line break in the source.
     for demand in ("what you are watching", "the concrete threshold", "would change the call"):
         assert demand in prompt, f"the held-STAY_OUT block no longer asks for: {demand}"
+
+
+@pytest.mark.unit
+def test_the_default_memory_block_leaves_the_prompt_byte_identical(race_state) -> None:
+    """The memoryless surfaces must get exactly the prompt they got before the parameter existed.
+
+    ``/recommend`` and the MCP tool are stateless per request, so they will never
+    pass a block and must not be changed by the fact that others can. Byte
+    equality is the only assertion that proves it: a prompt that gained a stray
+    blank line still returns a well-formed recommendation, so nothing else in the
+    suite would notice.
+
+    Both spellings of "no memory" are checked, because ``DecisionMemory.block()``
+    returns ``None`` before there is any history and a caller passing it straight
+    through is the natural way to use it. Without the guard in the builder that
+    renders the literal string "None" above ``RACE CONTEXT:``, which equality with
+    the empty-block prompt is what catches. (A bare "None" not in prompt would not
+    work here: the field-schema instructions use the word legitimately.)
+    """
+    from src.agents.strategy_orchestrator import _build_orchestrator_prompt
+
+    baseline = _build_orchestrator_prompt(race_state, {}, "STAY_OUT")
+
+    assert _build_orchestrator_prompt(race_state, {}, "STAY_OUT", memory_block="") == baseline
+    assert _build_orchestrator_prompt(race_state, {}, "STAY_OUT", memory_block=None) == baseline
+
+
+@pytest.mark.unit
+def test_a_supplied_memory_block_lands_between_the_framing_and_the_facts(race_state) -> None:
+    """Position is the point: the model reads what it decided before it reads this lap.
+
+    Above ``RACE CONTEXT:`` and below the held-STAY_OUT framing, which is the anchor
+    the A/B harness spliced at while measuring this. If the block moves, the measured
+    result stops applying to the shipped prompt.
+    """
+    from src.agents.strategy_orchestrator import _build_orchestrator_prompt
+
+    block = "DECISION MEMORY (your own previous calls this race):\n  Last call: STAY_OUT.\n\n"
+    prompt = _build_orchestrator_prompt(race_state, {}, "STAY_OUT", memory_block=block)
+
+    assert block in prompt
+    assert prompt.index("ACTIVE monitoring posture") < prompt.index(block)
+    assert prompt.index(block) < prompt.index("RACE CONTEXT:")
+
+
+@pytest.mark.unit
+def test_the_real_decision_memory_block_renders_into_the_prompt(race_state) -> None:
+    """Against the shipping producer, not a hand-written string.
+
+    The two objects are wired together by nothing but a string, so a change to
+    ``DecisionMemory``'s rendering that broke the placement would otherwise be
+    caught by no test in either file.
+    """
+    from types import SimpleNamespace
+
+    from src.agents.strategy_orchestrator import _build_orchestrator_prompt
+    from src.strategy.inference.decision_memory import DecisionMemory
+
+    memory = DecisionMemory()
+    memory.record(
+        5,
+        SimpleNamespace(
+            action="STAY_OUT",
+            pit_lap_target=22,
+            contingencies=[
+                SimpleNamespace(
+                    trigger="SC deployed within 3 laps", switch_to="PIT_NOW", priority="HIGH"
+                )
+            ],
+        ),
+    )
+    prompt = _build_orchestrator_prompt(race_state, {}, "STAY_OUT", memory_block=memory.block())
+
+    assert "DECISION MEMORY" in prompt
+    assert "SC deployed within 3 laps" in prompt
+    # The counterweight is not optional decoration: without it the block measurably
+    # anchored the model at the decision lap.
+    assert "NOT a commitment" in prompt
+    assert prompt.index("DECISION MEMORY") < prompt.index("RACE CONTEXT:")
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #680. Part of #648.

## What

`_build_orchestrator_prompt` gains `memory_block: str = ""`, rendered between the held-STAY_OUT framing and the `RACE CONTEXT:` heading. **Nothing passes a non-empty block yet** — wiring the CLI, arcade and backend is the next PR. This is the rendering seam alone, so the byte-identity claim below can be reviewed on its own.

## The default renders nothing, and that is the point

`/recommend` and the MCP tool (and therefore the webapp Strategy tab) are stateless per request and will never pass a block. They must keep the prompt they had.

**Verified against the pre-change builder, not just against itself:** dumped the prompt from this branch and from `dev` for identical inputs — 6729 bytes each, byte-identical. The test in the suite asserts the forward-looking property instead (the default and an explicit `""` and `None` all produce the same prompt), because a golden snapshot would break on every future prompt edit and stop meaning anything.

The builder absorbs a `None` block deliberately: `DecisionMemory.block()` returns `None` before there is any history, and passing it straight through is the natural call. Unguarded, that renders the literal string `None` above `RACE CONTEXT:`.

## Tests

| test | claim |
|---|---|
| `..._byte_identical` | the default changes nothing for the memoryless surfaces |
| `..._lands_between_the_framing_and_the_facts` | placement, which is where the measurement was taken |
| `..._the_real_decision_memory_block_renders` | built from the shipping `DecisionMemory`, not a hand-written string, including the counterweight |

The third exists because the two objects are wired together by nothing but a string; a rendering change in `DecisionMemory` would otherwise be caught by no test in either file.

## Harness

`scripts/prompt_ab/_common.py` drops `inject_memory_block` and passes the argument, as its own docstring instructed. Measurements now assemble the prompt through the same code path production uses — an eval harness measuring a private copy of the code is a recorded failure in this repo.

## Why this ships at all

`documents/audits/AUDIT_ORCHESTRATOR_MEMORY.md`, GATE FOLLOW-UP 2: on a client that honours `temperature=0`, under a Safety Car at Lusail 2025 lap 42, the model acted on a contingency it had declared one lap earlier on **8 of 8** runs against **0 of 8** without the block (Fisher p=0.000155).

## Checks

- `pytest tests/agents/test_orchestrator_prompt.py tests/engine/` — 26 passed
- `ruff check --no-cache .` + `ruff format --check .` clean at the pinned 0.15.22