### PR TITLE
docs(orchestrator): declare that /recommend and MCP have no decision memory

### DIFF
--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -299,6 +299,26 @@ run_strategy_orchestrator_from_state(race_state, laps_df, lap_state=None)
 
 That last argument is the one worth remembering: without `lap_state` the orchestrator never sees the rival gaps, so the Monte Carlo falls back to the legacy seconds path instead of scoring in projected track position. See [agents-api.md](#/agents-api) for the full per-agent reference.
 
+## Decision memory — three surfaces, not five
+
+The Layer 3 prompt is stateless: consecutive laps are 99% identical text, so the orchestrator re-argues the same case in fresh prose every lap and never reuses a plan it made. `DecisionMemory` (`src/strategy/inference/decision_memory.py`) fixes that by echoing this race's own previous calls — the last action and how long it has been held, recent `pit_lap_target` values, and the contingencies declared last lap — back into the prompt.
+
+It lives in the **caller**, not the engine, because `run_lap` is pure per lap and a test depends on that. Each surface that owns a race owns one accumulator, the same shape and lifetime as `RaceControlStateTracker`.
+
+| Surface | Decision memory | Why |
+|---|---|---|
+| CLI (`f1-sim`) | yes | owns a race-scoped loop |
+| Arcade | yes | owns a race-scoped connector |
+| Backend `/simulate` stream, `rich` profile | yes | owns a race-scoped simulator |
+| `/recommend` | **no** | stateless per request |
+| MCP `strategy` tool, and the webapp Strategy tab | **no** | stateless per request |
+
+The bottom two rows are a **declared limitation, not a gap to close**. Neither has a race-scoped object to accumulate on, so any memory they carried would be either empty or filled from something request-scoped that resembles a race and is not. `tests/engine/test_memory_scope_is_deliberate.py` fails if that asymmetry is ever "harmonised" away.
+
+Measured effect, on a client that honours `temperature=0`: under a Safety Car at Lusail 2025 lap 42, the orchestrator acted on a contingency it had itself declared one lap earlier on **8 of 8** runs, against **0 of 8** without the block (Fisher p=0.000155). Over a full race the echo cuts distinct contingency triggers from ~27 to 5. It does not change what a given lap decides — `action` differed on 0 of 41 laps — it changes whether consecutive laps are the same plan.
+
+One consequence worth knowing before debugging a call: **the effect does not show up in `reasoning`.** In the Safety Car runs, none of the eight memory recommendations mentioned the prior plan, yet all eight flipped the call. To understand why a recommendation changed, read the memory block, not the prose.
+
 ## LLM configuration
 
 | Layer | Model | Provider |

--- a/tests/engine/ast_helpers.py
+++ b/tests/engine/ast_helpers.py
@@ -1,0 +1,37 @@
+"""Static inspection of what one function passes to another.
+
+Shared by the two anti-drift guards in this directory, which ask opposite
+questions of the same call sites: ``test_engine_threads_every_argument`` asserts
+the engine passes everything the orchestrator does, and
+``test_memory_scope_is_deliberate`` asserts one specific argument goes only one
+way. A second copy of this parser is exactly the shape of defect both files exist
+to catch, so it lives here instead.
+
+Static rather than runtime because the alternative is calling the layer functions
+for real, which needs the model weights, an LLM client and a race state. The
+question is about the call site, not the result.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+
+def kwargs_passed_by(func, callee: str) -> set[str]:
+    """The keyword names ``func`` passes to ``callee``.
+
+    Returns an empty set when ``func`` never calls ``callee``, which callers must
+    distinguish from "calls it with no keywords" themselves — assert the call
+    exists first, or an empty set reads as a passing test for a function that was
+    renamed out from under it.
+    """
+    tree = ast.parse(inspect.getsource(func).lstrip())
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == callee
+        ):
+            return {kw.arg for kw in node.keywords if kw.arg}
+    return set()

--- a/tests/engine/test_engine_threads_every_argument.py
+++ b/tests/engine/test_engine_threads_every_argument.py
@@ -26,10 +26,11 @@ enforced one.
 
 from __future__ import annotations
 
-import inspect
 from pathlib import Path
 
 import pytest
+
+from tests.engine.ast_helpers import kwargs_passed_by
 
 ROOT = Path(__file__).parent.parent.parent
 _HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
@@ -48,18 +49,8 @@ _THREADED_CALLEES = ("_assemble_recommendation", "_build_orchestrator_prompt")
 
 
 def _kwargs_passed_by(func, callee: str = "_assemble_recommendation") -> set[str]:
-    """The keyword names `func` passes to `callee`."""
-    import ast
-
-    tree = ast.parse(inspect.getsource(func).lstrip())
-    for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == callee
-        ):
-            return {kw.arg for kw in node.keywords if kw.arg}
-    return set()
+    """The keyword names `func` passes to `callee`, with this file's default callee."""
+    return kwargs_passed_by(func, callee)
 
 
 @pytest.mark.parametrize("callee", _THREADED_CALLEES)

--- a/tests/engine/test_memory_scope_is_deliberate.py
+++ b/tests/engine/test_memory_scope_is_deliberate.py
@@ -1,0 +1,90 @@
+"""The decision-memory block reaches three surfaces and deliberately not the other two.
+
+`run_lap`'s callers own a race — the CLI loop, the arcade connector, the backend
+simulator's stream — so each can hold one `DecisionMemory` for its lifetime and pass
+the rendered block down. `/recommend` and the MCP tool cannot: both are stateless per
+request, with no race-scoped object to accumulate on, so the webapp Strategy tab keeps
+the memoryless prompt. That is a declared limitation, not an oversight.
+
+WHY THIS NEEDS ITS OWN FILE, when an anti-drift guard already exists next door.
+`test_engine_threads_every_argument` asserts `orch_kwargs - engine_kwargs`: the
+ORCHESTRATOR has an argument the ENGINE lacks. That is the direction both real
+failures took (#462, and the prompt builder in #675), and it is the direction that
+file was widened to cover.
+
+Memory goes the other way. The engine passes it; the orchestrator's stateless entry
+point deliberately does not. The existing guard is green on that by construction — its
+own docstring says so — so without this file the asymmetry is protected by nothing, and
+a later "make these two call sites consistent" cleanup would pass the whole suite while
+silently giving `/recommend` a memory it has no way to populate.
+
+The failure this prevents is not hypothetical in shape: `_rcm_events_for_lap` already
+exists twice with two signatures because a second surface grew its own copy of
+something the engine already had.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.engine.ast_helpers import kwargs_passed_by
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+pytestmark = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="data/models/ not present (CI runner without model weights)",
+)
+
+_PROMPT_BUILDER = "_build_orchestrator_prompt"
+_MEMORY_ARG = "memory_block"
+
+
+def test_the_stateless_entry_point_does_not_pass_a_memory_block():
+    """`/recommend` and the MCP tool must keep the memoryless prompt.
+
+    Both reach the orchestrator through `run_strategy_orchestrator_from_state`, one
+    request at a time, with nothing that survives between laps. A memory block there
+    could only ever be empty or, worse, filled from something request-scoped that
+    looks like a race and is not.
+
+    If this test fails because someone threaded memory into the orchestrator, the fix
+    is NOT to update the assertion. It is to give that surface a real race-scoped
+    accumulator or leave it alone.
+    """
+    import src.agents.strategy_orchestrator as orch
+
+    passed = kwargs_passed_by(orch.run_strategy_orchestrator_from_state, _PROMPT_BUILDER)
+
+    assert passed, (
+        f"no call to {_PROMPT_BUILDER} found in run_strategy_orchestrator_from_state; "
+        f"this guard is inspecting a call site that no longer exists"
+    )
+    assert _MEMORY_ARG not in passed, (
+        f"run_strategy_orchestrator_from_state now passes {_MEMORY_ARG!r}, but it is the "
+        f"entry point for /recommend and the MCP tool, which are stateless per request "
+        f"and have no race-scoped object to accumulate one on. Whatever it is passing "
+        f"is not this race's history. See src/strategy/inference/decision_memory.py."
+    )
+
+
+def test_the_prompt_builder_still_accepts_a_memory_block():
+    """The parameter has to exist for the asymmetry to mean anything.
+
+    Without this, deleting `memory_block` from the builder entirely would leave the
+    test above passing green and reporting a scope decision about an argument that no
+    longer exists.
+    """
+    import inspect
+
+    import src.agents.strategy_orchestrator as orch
+
+    signature = inspect.signature(orch._build_orchestrator_prompt)
+
+    assert _MEMORY_ARG in signature.parameters
+    assert signature.parameters[_MEMORY_ARG].default == "", (
+        "the memory block must default to empty: the stateless surfaces call the "
+        "builder without it and have to keep the prompt they had"
+    )


### PR DESCRIPTION
Closes #681. Part of #648.

## What

The memory block reaches the three surfaces that own a race and **deliberately not** the two that are stateless per request. Written down in `docs/pages/multi-agent.md` and enforced by `tests/engine/test_memory_scope_is_deliberate.py`.

| Surface | memory | why |
|---|---|---|
| CLI `f1-sim` | yes | race-scoped loop |
| arcade | yes | race-scoped connector |
| backend `/simulate` stream, `rich` | yes | race-scoped simulator |
| `/recommend` | **no** | stateless per request |
| MCP `strategy` tool, webapp Strategy tab | **no** | stateless per request |

## Why this needs its own test file

`test_engine_threads_every_argument` asserts `orch_kwargs - engine_kwargs` — **the orchestrator has an argument the engine lacks**. That is the direction both real drift failures took (#462, and the prompt builder in #675), and it is what that file was widened to cover.

**Memory goes the other way.** The engine will pass it; `run_strategy_orchestrator_from_state` deliberately will not. The existing guard is green on that by construction and its own docstring says so at line 73-78. So today the asymmetry is protected by nothing, and a later "make these two call sites consistent" cleanup would pass the entire suite while handing `/recommend` a memory it has no way to populate.

Two assertions, because one alone is a trap:

- the stateless entry point does not pass `memory_block`, with the reason in the assert message so a red run explains itself
- the builder still **has** the parameter, defaulting to `""` — otherwise deleting it outright would leave the first test green while reporting a scope decision about an argument that no longer exists

## Also

The AST helper both guards need moves to `tests/engine/ast_helpers.py` instead of being copied. A duplicated checker is the precise defect these two files exist to catch; `_rcm_events_for_lap` already exists twice with two signatures for the same reason.

## Docs

`docs/pages/multi-agent.md` gains a "Decision memory" section: the surface table, the measured effect (Safety Car lap 42, 0/8 → 8/8, Fisher p=0.000155; contingency triggers ~27 → 5 over a race), and one operational warning — **the effect does not appear in `reasoning`**, so a call that changed has to be debugged from the memory block, not the prose.

## Checks

- `pytest tests/engine/` — 22 passed
- `ruff check --no-cache .` + `ruff format --check .` clean at the pinned 0.15.22