### PR TITLE
feat(surfaces): give the CLI, arcade and backend a per-race decision memory

### DIFF
--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -1589,10 +1589,14 @@ def run(args: argparse.Namespace) -> None:
     # history table was inside Live and eventually exceeded terminal height
     # (the terminal cursor cannot rewind above the topmost visible line).
     from src.nlp.rcm_state import RaceControlStateTracker
+    from src.strategy.inference.decision_memory import DecisionMemory
 
     # One Safety-Car tracker for the whole run: persists SC/VSC state across laps
     # so the deploy-once corpus message keeps the override active mid-stint (NR-02).
     sc_tracker = RaceControlStateTracker()
+    # One decision memory for the whole run: accumulates orchestrator recommendations
+    # so the Layer 3 prompt sees its own previous calls and can compose a continuous plan.
+    memory = DecisionMemory()
     with Live(
         _live_content(),
         console=console,
@@ -1744,7 +1748,10 @@ def run(args: argparse.Namespace) -> None:
                 # deterministic, zero LLM clients (fixes #166). `outs` carries the
                 # six sub-agent outputs the detail panel renders — no second pass.
                 profile = "no-llm" if args.no_llm else "rich"
-                result, outs, _ = run_lap(race_state, laps_df, lap_state, profile=profile)
+                result, outs, _ = run_lap(
+                    race_state, laps_df, lap_state, profile=profile, memory=memory
+                )
+                memory.record(lap_num, result)
                 scores = getattr(result, "scenario_scores", {})
                 action = getattr(result, "action", "?")
                 confidence = getattr(result, "confidence", 0.0)

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -231,6 +231,13 @@ class SimConnector(threading.Thread):
         from src.nlp.rcm_state import RaceControlStateTracker
 
         self._sc_tracker = RaceControlStateTracker()
+        # One DecisionMemory for the whole replay, same lifetime and shape as the
+        # SC tracker above: without it the Layer 3 prompt is stateless and
+        # re-argues an unrelated case every lap instead of building on its own
+        # previous call.
+        from src.strategy.inference.decision_memory import DecisionMemory
+
+        self._memory = DecisionMemory()
 
     def stop(self) -> None:
         self._stop_event.set()
@@ -406,7 +413,10 @@ class SimConnector(threading.Thread):
         from src.arcade.strategy_pipeline import run_strategy_pipeline
 
         race_state = self._build_race_state(lap_state, prev_lap_time)
-        rec, agent_outputs = run_strategy_pipeline(race_state, laps_df, lap_state)
+        rec, agent_outputs = run_strategy_pipeline(
+            race_state, laps_df, lap_state, memory=self._memory
+        )
+        self._memory.record(race_state.lap, rec)
         lap_time_s = lap_state.get("driver", {}).get("lap_time_s")
         decision = _build_decision(rec, race_state, lap_time_s, agent_outputs)
         with self._state._lock:

--- a/src/arcade/strategy_pipeline.py
+++ b/src/arcade/strategy_pipeline.py
@@ -24,21 +24,27 @@ from src.strategy.inference.engine import run_lap
 
 if TYPE_CHECKING:  # pragma: no cover — only for type hints
     from src.agents.strategy_orchestrator import RaceState, StrategyRecommendation
+    from src.strategy.inference.decision_memory import DecisionMemory
 
 
 def run_strategy_pipeline(
     race_state: "RaceState",
     laps_df: pd.DataFrame,
     lap_state: dict | None = None,
+    memory: "DecisionMemory | None" = None,
 ) -> tuple["StrategyRecommendation", dict]:
     """Run the full N31 pipeline; return the recommendation and per-agent outputs.
 
-    Public signature is unchanged so ``src/arcade/strategy.py`` and the dashboard
-    formatters keep working. The ``agent_outputs`` dict carries the same keys as
-    before (``pace_out``/``tire_out``/``situation_out``/``radio_out``/``pit_out``/
+    Public signature stays backward compatible: ``memory`` is optional and
+    defaults to ``None``, so ``src/arcade/strategy.py`` and the dashboard
+    formatters that already call this positionally keep working unchanged. The
+    ``agent_outputs`` dict carries the same keys as before (``pace_out``/
+    ``tire_out``/``situation_out``/``radio_out``/``pit_out``/
     ``regulation_context``/``rag``/``active``) plus ``guardrail_reason``; the
     engine's third return value (stage timings) is dropped here (a future arcade
     change may forward it on the TCP stream).
     """
-    rec, agent_outputs, _timings = run_lap(race_state, laps_df, lap_state, profile="rich")
+    rec, agent_outputs, _timings = run_lap(
+        race_state, laps_df, lap_state, profile="rich", memory=memory
+    )
     return rec, agent_outputs

--- a/src/strategy/inference/engine.py
+++ b/src/strategy/inference/engine.py
@@ -31,9 +31,19 @@ Untouchability: nothing in ``src/agents/`` is modified. Every strategy layer is 
 SAME code object the orchestrator runs (imported, never copied); the only
 engine-owned code is the call sequence itself and the default-lap_state builder.
 
-Anti-drift guards: ``tests/engine/test_engine.py``, ``tests/engine/test_engine_no_llm.py`` and
+Decision memory
+---------------
+``run_lap`` accepts an optional ``DecisionMemory`` and renders its block into the Layer 3
+prompt. The accumulator belongs to the CALLER — the CLI loop, the arcade connector, the
+backend simulator's stream — because this function has to stay pure per lap. The engine
+only ever calls ``block()``; the caller records the recommendation afterwards. The two
+stateless surfaces (``/recommend``, the MCP tool) get no memory by design, which
+``tests/engine/test_memory_scope_is_deliberate.py`` enforces.
+
+Anti-drift guards: ``tests/engine/test_engine.py``, ``tests/engine/test_engine_no_llm.py``,
 ``tests/engine/test_engine_threads_every_argument.py`` (which checks, by AST, that this path
-passes ``_assemble_recommendation`` every argument the orchestrator does).
+passes ``_assemble_recommendation`` every argument the orchestrator does) and
+``tests/engine/test_memory_scope_is_deliberate.py``.
 
 These do not assert byte-level parity with the orchestrator. An earlier docstring cited
 a ``tests/test_engine_parity.py`` that does not exist; the argument-threading test above
@@ -45,9 +55,14 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import pandas as pd
+
+if TYPE_CHECKING:
+    # Type-only: importing it for real would put a strategy-layer import in the
+    # engine's import graph for a value the engine never constructs.
+    from src.strategy.inference.decision_memory import DecisionMemory
 
 from src.agents.strategy_orchestrator import (
     RaceState,
@@ -163,6 +178,7 @@ def run_lap(
     *,
     profile: Profile = "rich",
     return_agent_outputs: bool = True,
+    memory: "DecisionMemory | None" = None,
 ) -> tuple[StrategyRecommendation, dict[str, Any] | None, dict[str, float]]:
     """Run one lap of the N31 strategy pipeline and return everything a surface needs.
 
@@ -176,6 +192,12 @@ def run_lap(
             (deterministic, zero LLM clients). ``"fast"`` is reserved (raises).
         return_agent_outputs: When ``False``, slot 2 is ``None`` (compute is
             unchanged; only the assembly of the outputs dict is skipped).
+        memory: This race's ``DecisionMemory``, owned by the CALLER. Read here,
+            never written: the caller records each recommendation after the lap
+            returns, which is what keeps this function pure and
+            ``tests/engine/test_engine_no_llm.py``'s twice-on-lap-6 assertion true.
+            Ignored on ``no-llm``, which builds no prompt to put it in — passing
+            one there is harmless, and silent, so it is stated here.
 
     Returns:
         ``(recommendation, agent_outputs | None, stage_timings)`` where
@@ -195,7 +217,10 @@ def run_lap(
     laps_df = _scope_laps_to_gp(laps_df, lap_state, race_state)
 
     if profile == "rich":
-        return _run_rich(race_state, laps_df, lap_state, return_agent_outputs)
+        # Rendered here rather than inside _run_rich so the engine's only contact with
+        # the accumulator is one read, at one place, of a method that cannot mutate it.
+        memory_block = memory.block() if memory is not None else ""
+        return _run_rich(race_state, laps_df, lap_state, return_agent_outputs, memory_block)
     if profile == "no-llm":
         # Imported lazily so the rich path never pays the no_llm module's agent
         # class imports, and so a circular import can never form.
@@ -212,6 +237,7 @@ def _run_rich(
     laps_df: pd.DataFrame,
     lap_state: dict[str, Any] | None,
     return_agent_outputs: bool,
+    memory_block: str | None = "",
 ) -> tuple[StrategyRecommendation, dict[str, Any] | None, dict[str, float]]:
     """The rich profile: the orchestrator's five-step sequence, outputs retained.
 
@@ -284,6 +310,12 @@ def _run_rich(
             pit_out=pit_out,
             radio_out=radio_out,
             regulation_context=regulation_context,
+            # The one argument in this call the orchestrator deliberately does NOT
+            # pass: /recommend and the MCP tool are stateless per request and have no
+            # race to accumulate over. tests/engine/test_memory_scope_is_deliberate.py
+            # holds that asymmetry open, because the threading guard next to it only
+            # looks the other way and is green on this by construction.
+            memory_block=memory_block,
         )
         synth = _get_orchestrator_llm().invoke(prompt)
         rec = _assemble_recommendation(

--- a/tests/engine/test_engine_memory.py
+++ b/tests/engine/test_engine_memory.py
@@ -1,0 +1,181 @@
+"""The memory block the caller supplies must actually reach the Layer 3 prompt.
+
+Nothing else in the suite can tell you this. `run_lap`'s parameter defaults to `None`,
+so every existing engine test passes whatever the memory path does — including doing
+nothing at all. That is the price of keeping the engine pure, and it is why this file
+exists rather than being folded into `test_engine_no_llm`.
+
+HOW IT IS CHECKED, and why not end to end. Driving `run_lap(profile="rich")` for real
+does not work as a test of this: the rich profile builds LLM clients for the always-on
+sub-agents long before the prompt is assembled, so the first attempt at this file failed
+on a connection error rather than on anything about memory. The chain is therefore
+verified as its three links instead, each one hermetically:
+
+  1. `run_lap` turns a `DecisionMemory` into a block string and hands it to `_run_rich`
+  2. `_run_rich` passes that string to `_build_orchestrator_prompt`
+  3. the builder renders it into the prompt — `tests/agents/test_orchestrator_prompt.py`
+
+Link 2 is a static check for the same reason `test_engine_threads_every_argument` is:
+the question is about a call site, and that guard cannot answer this one because it
+compares the engine against the orchestrator, which deliberately does not pass memory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from tests.engine.ast_helpers import kwargs_passed_by
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+pytestmark = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="data/models/ not present (CI runner without model weights)",
+)
+
+FIXTURE = ROOT / "tests" / "fixtures" / "mini_race.parquet"
+TRIGGER = "SC deployed within 3 laps"
+
+
+def _memory_with_one_lap(lap: int = 5):
+    from src.strategy.inference.decision_memory import DecisionMemory
+
+    memory = DecisionMemory()
+    memory.record(
+        lap,
+        SimpleNamespace(
+            action="STAY_OUT",
+            pit_lap_target=22,
+            contingencies=[SimpleNamespace(trigger=TRIGGER, switch_to="PIT_NOW", priority="HIGH")],
+        ),
+    )
+    return memory
+
+
+def _race_state(lap: int = 6):
+    from src.agents.strategy_orchestrator import RaceState
+
+    return RaceState(
+        driver="NOR",
+        lap=lap,
+        total_laps=57,
+        position=5,
+        compound="MEDIUM",
+        tyre_life=10,
+        gap_ahead_s=2.0,
+        pace_delta_s=0.0,
+        risk_tolerance=0.5,
+        air_temp=25.0,
+        track_temp=35.0,
+    )
+
+
+@pytest.fixture
+def rich_call(monkeypatch):
+    """Capture the arguments `run_lap` hands to `_run_rich`, without running it."""
+    from src.strategy.inference import engine
+
+    seen: dict = {}
+
+    def _capture(*args, **kwargs):
+        seen["args"] = args
+        seen["kwargs"] = kwargs
+        return ("rec", None, {})
+
+    monkeypatch.setattr(engine, "_run_rich", _capture)
+    return seen
+
+
+@pytest.mark.unit
+def test_run_lap_renders_the_memory_into_a_block_for_the_rich_path(rich_call):
+    """Link 1: a `DecisionMemory` in, the rendered block out.
+
+    Asserted on the contingency trigger, because the echo is the load-bearing field —
+    it is what took the Safety Car experiment from 0 of 8 to 8 of 8. A block that
+    rendered its header and dropped its contingencies would still look like memory
+    in a diff.
+    """
+    from src.strategy.inference.engine import run_lap
+
+    run_lap(_race_state(), pd.read_parquet(FIXTURE), None, memory=_memory_with_one_lap())
+
+    block = rich_call["args"][-1]
+    assert "DECISION MEMORY" in block
+    assert TRIGGER in block
+
+
+@pytest.mark.unit
+def test_run_lap_without_memory_sends_an_empty_block(rich_call):
+    """The default must be indistinguishable from before the parameter existed.
+
+    Empty string, not `None`: the two are equivalent inside the builder, but only
+    because it guards for it, and this pins which one the engine actually sends.
+    """
+    from src.strategy.inference.engine import run_lap
+
+    run_lap(_race_state(), pd.read_parquet(FIXTURE), None)
+
+    assert rich_call["args"][-1] == ""
+
+
+@pytest.mark.unit
+def test_the_rich_path_passes_the_block_to_the_prompt_builder():
+    """Link 2, statically: the argument survives the last hop.
+
+    `test_engine_threads_every_argument` cannot cover this. It asserts the engine
+    passes everything the ORCHESTRATOR passes, and the orchestrator deliberately does
+    not pass memory (see `test_memory_scope_is_deliberate`), so the block reaching the
+    builder is asserted by nothing but this line.
+    """
+    from src.strategy.inference import engine
+
+    passed = kwargs_passed_by(engine._run_rich, "_build_orchestrator_prompt")
+
+    assert "memory_block" in passed, (
+        "the rich path builds the prompt without the memory block, so every surface "
+        "that wires an accumulator is accumulating into nothing"
+    )
+
+
+@pytest.mark.unit
+def test_run_lap_does_not_record_into_the_memory_it_is_given(rich_call):
+    """Recording is the CALLER's job, and this is what keeps it that way.
+
+    If the engine recorded, `run_lap` would stop being pure per lap and
+    `test_engine_no_llm`'s twice-on-lap-6 equality would start depending on call
+    order — a failure that would surface far from its cause.
+    """
+    from src.strategy.inference.engine import run_lap
+
+    memory = _memory_with_one_lap()
+    before = memory.block()
+
+    run_lap(_race_state(), pd.read_parquet(FIXTURE), None, memory=memory)
+
+    assert memory.block() == before, (
+        "run_lap mutated the caller's DecisionMemory; the accumulator is caller-owned "
+        "and the engine must only read it"
+    )
+
+
+def test_the_no_llm_profile_accepts_a_memory_and_ignores_it():
+    """The documented behaviour, made executable.
+
+    `no-llm` builds no prompt, so there is nowhere for a block to go. Passing one has
+    to be harmless rather than a `TypeError` — surfaces switch profiles at runtime and
+    would otherwise need a conditional at every call site.
+    """
+    from src.strategy.inference.engine import run_lap
+
+    laps_df = pd.read_parquet(FIXTURE)
+    memory = _memory_with_one_lap()
+
+    with_memory = run_lap(_race_state(), laps_df, None, profile="no-llm", memory=memory)[0]
+    without = run_lap(_race_state(), laps_df, None, profile="no-llm")[0]
+
+    assert with_memory.action == without.action
+    assert memory.block() is not None

--- a/tests/engine/test_engine_threads_every_argument.py
+++ b/tests/engine/test_engine_threads_every_argument.py
@@ -97,6 +97,12 @@ def test_the_docstring_does_not_name_a_test_that_does_not_exist():
     The docstring cited a `tests/test_engine_parity.py` that was never written. Naming a
     guard that does not exist is worse than naming none, because it discourages checking.
     This scans the "Anti-drift guards" section and asserts each file it points at is real.
+
+    The pattern allows a subdirectory. It did not, and every guard the docstring names
+    now lives in `tests/engine/`, so this test matched NOTHING and passed green while
+    asserting about zero files - the same defect it was written to catch, one level up.
+    The count assertion is what stops that recurring: a pattern that stops matching is
+    indistinguishable from a docstring with nothing to check.
     """
     import re
 
@@ -104,7 +110,10 @@ def test_the_docstring_does_not_name_a_test_that_does_not_exist():
 
     doc = engine.__doc__ or ""
     section = doc.split("Anti-drift guard", 1)[-1].split("\n\n", 1)[0]
-    for name in re.findall(r"tests/test_[a-z_]+\.py", section):
+    named = re.findall(r"tests/[a-z_/]*test_[a-z_]+\.py", section)
+
+    assert named, "the engine docstring's anti-drift section names no test files at all"
+    for name in named:
         assert (ROOT / name).exists(), (
             f"the engine docstring names {name} as an anti-drift guard, but it does not exist"
         )


### PR DESCRIPTION
Closes #684. Part of #648. Backend half is submodule PR `VforVitorio/F1_Telemetry_Manager#204` (merged) plus the pointer bump here.

## What

`run_lap` gains `memory: DecisionMemory | None = None` and renders its block into the Layer 3 prompt. Each surface that owns a race owns one accumulator, created next to its existing `RaceControlStateTracker` and with the same lifetime.

| surface | accumulator | records |
|---|---|---|
| CLI | `run_simulation_cli.py:1599` | `:1755` |
| arcade | `strategy.py:240` (via `strategy_pipeline`) | `:419` |
| backend | `simulator.py:838` | `:880`, `rich` branch only |

**The engine only READS it.** One `block()` call at one place; recording is the caller's job. That is what keeps `run_lap` pure per lap, which `tests/engine/test_engine_no_llm.py:133-140` depends on — and it is also why the existing suite gives this path zero coverage by construction, so the PR brings its own.

## The two traps, and how each was closed

**Recorded from the `StrategyRecommendation`, never from a surface DTO.** Arcade's `LapDecisionDTO` and the backend's `LapDecision` both drop `contingencies` entirely — the load-bearing field — and the backend derives `pit_lap_target` from N28 on the no-llm branch and from the LLM on the rich one, so a DTO-sourced record would mean two different things on one surface. On arcade the record call sits **before** `_build_decision(...)` so it cannot reach for the DTO.

**No surface records a lap it skipped.** Every guard — lap range, DNF/incomplete, arcade's stale-seek skip, and each surface's per-lap `except` — runs before the record call on all three.

`DecisionMemory.record` raises on a non-increasing lap, deliberately. Checked rather than assumed: `RaceReplayEngine.replay()` is a single forward pass over `range(1, total_laps + 1)` with no seek, retry or reconnect; each surface iterates it once; arcade's `SimConnector` is a `Thread` whose `run()` fires once and a restart builds a fresh instance. So recorded laps are a strictly increasing subsequence and the guard cannot fire in normal operation. **No defensive `try` was added around it** — if it ever fires, that is a real bug and should be loud.

Where a surface *does* skip laps (arcade's fast-forward), `DecisionMemory` already renders the gap explicitly rather than claiming a hold it cannot support.

## Tests, and an honest note on what could not be tested

`tests/engine/test_engine_memory.py`, 5 tests. **An end-to-end `rich` run is not testable here** — the first attempt failed on a connection error, because the always-on sub-agents build LLM clients long before the prompt is assembled. The chain is therefore verified as its three links: `run_lap` renders the block (runtime), `_run_rich` passes it to the builder (static, for the same reason the sibling threading guard is static), and the builder renders it (already covered in `test_orchestrator_prompt.py`). Plus: the default sends `""`, `no-llm` accepts and ignores, and `run_lap` does not mutate the caller's accumulator.

## Unrelated fix, found while wiring

`test_the_docstring_does_not_name_a_test_that_does_not_exist` matched `tests/test_[a-z_]+\.py`, while **every guard it names now lives in `tests/engine/`**. It scanned zero files and passed green — the exact defect it was written to catch, one level up. Widened, plus a non-empty assertion so a pattern that silently stops matching fails instead of going quiet.

## Checks

- `pytest` full suite: **374 passed, 4 skipped**
- `ruff check --no-cache .` + `ruff format --check .` clean at the pinned 0.15.22
- submodule CI green on #204 (lint, test, webapp)