### PR TITLE
feat(orchestrator): scope the STAY_OUT continuation framing to actual holds

### DIFF
--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -1611,15 +1611,18 @@ def _build_orchestrator_prompt(
         # "no pit action". Measured on real races it is the call on the large majority
         # of green-flag laps (39/41 at Lusail 2025, 414/415 across the projection set),
         # so the prompt was teaching the LLM to treat its own most frequent output as a
-        # failure to decide. The prompt is also stateless: consecutive laps are 99.0%
-        # identical text, so nothing tells the model it is repeating itself and it
-        # re-argues the same case from scratch every lap (#646).
+        # failure to decide.
+        #
+        # What stays here is what is true on EVERY lap. The instruction to treat a
+        # repeated STAY_OUT as a continuing plan used to sit in this block, where it
+        # fired on lap 1, when there was nothing to continue, and on the lap the call
+        # changed, when continuing was wrong. It now lives in the memory block, which
+        # is the only place that knows whether anything is being repeated.
         f"WHEN THE CALL IS STAY_OUT (the majority call, by design):\n"
         f"  STAY_OUT is an ACTIVE monitoring posture, not the absence of a decision and\n"
-        f"  not merely what is left when a pit is blocked. Treat a repeated STAY_OUT as\n"
-        f"  CONTINUING a plan rather than making a fresh one, and do not re-argue the same\n"
-        f"  case from scratch. State (a) what you are watching, (b) the concrete threshold\n"
-        f"  that would change the call, and (c) how far the current numbers sit from it.\n"
+        f"  not merely what is left when a pit is blocked. State (a) what you are watching,\n"
+        f"  (b) the concrete threshold that would change the call, and (c) how far the\n"
+        f"  current numbers sit from it.\n"
         f"  Carry the lap you are watching towards in pit_lap_target whenever the tyre\n"
         f"  data supports one, so a hold reads as a plan with a horizon, not indecision.\n\n"
         # Placed after the framing and before the per-lap facts, so the model reads

--- a/src/strategy/inference/decision_memory.py
+++ b/src/strategy/inference/decision_memory.py
@@ -66,6 +66,17 @@ COUNTERWEIGHT = (
     "  evidence; a long hold is not itself a reason to keep holding.\n"
 )
 
+# Emitted only on a genuine repeated STAY_OUT. It used to live in the static
+# prompt, where it fired on every lap: on lap 1, when there was no previous call
+# to continue, and on the lap the call changed, when continuing was the wrong
+# answer. Nothing could condition it there because the prompt had no idea what the
+# last call was. Here the object that knows owns the claim, which is also why this
+# is not a second parameter on the prompt builder travelling next to the block.
+CONTINUATION = (
+    "  This is a CONTINUING plan, not a fresh one: do not re-argue the same case\n"
+    "  from scratch.\n"
+)
+
 
 @dataclass(frozen=True)
 class _Entry:
@@ -152,11 +163,24 @@ class DecisionMemory:
         return self._entries[-1].contingencies[:MAX_CONTINGENCIES]
 
     # ── rendering ─────────────────────────────────────────────────────────
+    def _is_continuing_a_hold(self) -> bool:
+        """True when the last call repeated a STAY_OUT, which is the only real hold.
+
+        Two decisions minimum: one STAY_OUT is a call, not a continuation. Restricted
+        to STAY_OUT because it is the only action a race can sit on. Repeating
+        PIT_NOW is not a plan being continued, it is a stop that has not happened.
+        """
+        if len(self._entries) < 2:
+            return False
+        action, _since_lap, decisions = self._current_run()
+        return action == "STAY_OUT" and decisions >= 2
+
     def _render_hold(self) -> str:
         action, since_lap, decisions = self._current_run()
         laps_spanned = self._entries[-1].lap - since_lap + 1
         if laps_spanned == decisions:
-            return f"  Last call: {action}, held since lap {since_lap} ({decisions} laps)."
+            unit = "lap" if decisions == 1 else "laps"
+            return f"  Last call: {action}, held since lap {since_lap} ({decisions} {unit})."
         # The two numbers disagree, which means the surface skipped laps. Say both
         # rather than picking one: "held for N laps" would be false, and dropping
         # the span would hide that the race moved on without a decision.
@@ -203,4 +227,9 @@ class DecisionMemory:
             self._render_targets(),
             *self._render_contingencies(),
         ]
-        return "\n".join(lines) + "\n" + COUNTERWEIGHT + "\n"
+        # CONTINUATION and COUNTERWEIGHT are deliberately adjacent and deliberately
+        # in this order: carry the plan, but do not treat carrying it as a promise.
+        # Shipping the first without the second is the configuration that measurably
+        # anchored the model at the decision lap.
+        tail = (CONTINUATION if self._is_continuing_a_hold() else "") + COUNTERWEIGHT
+        return "\n".join(lines) + "\n" + tail + "\n"

--- a/tests/agents/test_orchestrator_prompt.py
+++ b/tests/agents/test_orchestrator_prompt.py
@@ -90,6 +90,24 @@ def test_a_held_stay_out_asks_for_a_threshold_rather_than_the_same_case_again(
 
 
 @pytest.mark.unit
+def test_the_continuation_instruction_is_not_in_the_unconditioned_prompt(prompt: str) -> None:
+    """ "Do not re-argue the same case" is only true when there IS a previous case.
+
+    It used to sit in the static block, so it fired on lap 1, when there was nothing
+    to continue, and on the lap the call changed, when continuing was the wrong
+    answer. It now lives in `DecisionMemory`'s block, which is the only place that
+    knows whether anything is being repeated. `/recommend` and the MCP tool are
+    stateless per request, so for them this instruction is now correctly absent
+    rather than unconditionally present.
+
+    If this fails, check whether the sentence was reintroduced here instead of being
+    conditioned there.
+    """
+    assert "CONTINUING a plan" not in prompt
+    assert "re-argue the same case" not in prompt
+
+
+@pytest.mark.unit
 def test_the_default_memory_block_leaves_the_prompt_byte_identical(race_state) -> None:
     """The memoryless surfaces must get exactly the prompt they got before the parameter existed.
 

--- a/tests/engine/test_decision_memory.py
+++ b/tests/engine/test_decision_memory.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 import pytest
 
 from src.strategy.inference.decision_memory import (
+    CONTINUATION,
     COUNTERWEIGHT,
     MAX_CONTINGENCIES,
     DecisionMemory,
@@ -144,6 +145,70 @@ def test_the_counterweight_is_always_present():
     memory = DecisionMemory()
     memory.record(5, _rec())
     assert COUNTERWEIGHT in memory.block()
+
+
+@pytest.mark.unit
+def test_a_single_call_is_not_a_continuation():
+    """One STAY_OUT is a call, not a plan being carried.
+
+    This is the case that made the instruction wrong in the static prompt: it also
+    fired on the very first decision of a race, telling the model not to re-argue a
+    case it had never argued.
+    """
+    memory = DecisionMemory()
+    memory.record(5, _rec())
+
+    block = memory.block()
+    assert CONTINUATION not in block
+    assert COUNTERWEIGHT in block, "the counterweight is unconditional; only this line is not"
+
+
+@pytest.mark.unit
+def test_a_repeated_stay_out_is_told_it_is_continuing_a_plan():
+    """The one case the instruction was always meant for (audit section 3.1)."""
+    memory = DecisionMemory()
+    memory.record(5, _rec())
+    memory.record(6, _rec())
+
+    assert CONTINUATION in memory.block()
+
+
+@pytest.mark.unit
+def test_a_changed_call_is_not_a_continuation():
+    """The other case it was wrong in: the lap the plan actually changed.
+
+    A STAY_OUT that follows an UNDERCUT is a new decision. Telling the model not to
+    re-argue it is telling it not to think about the only lap that moved.
+    """
+    memory = DecisionMemory()
+    memory.record(5, _rec())
+    memory.record(6, _rec(action="UNDERCUT"))
+    memory.record(7, _rec())
+
+    assert CONTINUATION not in memory.block()
+
+
+@pytest.mark.unit
+def test_a_repeated_pit_call_is_not_a_continuing_plan():
+    """STAY_OUT is the only action a race can sit on.
+
+    A repeated PIT_NOW is not a plan being carried, it is a stop that has not
+    happened, and it is the last thing that should be discouraged from re-arguing.
+    """
+    memory = DecisionMemory()
+    memory.record(5, _rec(action="PIT_NOW"))
+    memory.record(6, _rec(action="PIT_NOW"))
+
+    assert CONTINUATION not in memory.block()
+
+
+@pytest.mark.unit
+def test_the_span_reads_as_english_for_a_single_lap():
+    """It rendered "(1 laps)" on the first held lap of every real run."""
+    memory = DecisionMemory()
+    memory.record(20, _rec())
+
+    assert "held since lap 20 (1 lap)." in memory.block()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #685. Part of #648. Depends on #684 (merged).

## The problem

The prompt told the model, on **every lap**:

> Treat a repeated STAY_OUT as CONTINUING a plan rather than making a fresh one, and do not re-argue the same case from scratch.

It said that on lap 1, when there was nothing to continue. On the lap the call changed, when continuing was the wrong answer. And to `/recommend` and the MCP tool, which are stateless per request and can never know whether anything is being repeated.

The intent was right (#646). Nothing could condition it, because until #684 the prompt had no idea what the previous call was.

## The fix

The sentence moves into the block `DecisionMemory` renders, emitted only when the last call genuinely repeated a `STAY_OUT` (two decisions minimum, and `STAY_OUT` only — a repeated `PIT_NOW` is not a plan being carried, it is a stop that has not happened).

**Why not a second prompt parameter:** it would have to travel next to `memory_block` at every call site forever, and two arguments that must always move together are two arguments that eventually do not. The conditionality belongs to the object that knows.

What stays unconditioned is what is true on every lap: STAY_OUT is an active monitoring posture, plus the demand for a threshold and a distance to it.

The continuation line sits immediately **above** the counterweight, deliberately — carry the plan, but do not read carrying it as a promise. Shipping the first without the second is the configuration that measurably anchored the model at the decision lap.

## Verified on a real `f1-sim` run

Lusail 2025, NOR, laps 20-23, `rich` profile, prompts tapped as sent:

| lap | block | continuation | counterweight |
|---|---|---|---|
| 20 | — (first decision) | — | — |
| 21 | `held since lap 20 (1 lap)` | **no** | yes |
| 22 | `held since lap 20 (2 laps)` | **yes** | yes |
| 23 | `held since lap 20 (3 laps)` | **yes** | yes |

The old sentence is absent from all four.

## Two things to state rather than let someone discover

1. **This changes the block that was measured.** `GATE FOLLOW-UP 2` measured a block without a continuation line, so the 0/8 → 8/8 Safety Car result was obtained on a slightly different artifact. This is the audit's own step 6, but the numbers were not re-taken on the new block.
2. **`/recommend` and MCP lose the sentence entirely.** Correct — they have no history and the instruction is meaningless there — but it is a behavioural change to the shipped prompt on two surfaces, and it is unmeasured.

## Also

The block rendered `(1 laps)` on the first held lap of every real run. Fixed.

## Checks

- `pytest tests/engine/ tests/agents/` — 84 passed; full suite running
- `ruff check --no-cache .` + `ruff format --check .` clean at the pinned 0.15.22