### PR TITLE
docs(memory): say precisely when the block does and does not change the call

### DIFF
--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -315,7 +315,9 @@ It lives in the **caller**, not the engine, because `run_lap` is pure per lap an
 
 The bottom two rows are a **declared limitation, not a gap to close**. Neither has a race-scoped object to accumulate on, so any memory they carried would be either empty or filled from something request-scoped that resembles a race and is not. `tests/engine/test_memory_scope_is_deliberate.py` fails if that asymmetry is ever "harmonised" away.
 
-Measured effect, on a client that honours `temperature=0`: under a Safety Car at Lusail 2025 lap 42, the orchestrator acted on a contingency it had itself declared one lap earlier on **8 of 8** runs, against **0 of 8** without the block (Fisher p=0.000155). Over a full race the echo cuts distinct contingency triggers from ~27 to 5. It does not change what a given lap decides — `action` differed on 0 of 41 laps — it changes whether consecutive laps are the same plan.
+Measured effect, on a client that honours `temperature=0`: under a Safety Car at Lusail 2025 lap 42, the orchestrator acted on a contingency it had itself declared one lap earlier on **8 of 8** runs, against **0 of 8** without the block (Fisher p=0.000155). Over a full race the echo cuts distinct contingency triggers from ~27 to 5.
+
+Stated precisely, because the two halves of that are easy to blur: on an **ordinary green-flag lap** the block does not change the call — `action` differed on 0 of 41 laps across a whole race — it changes whether consecutive laps are the same plan. On the lap where a **contingency the model itself declared actually fires**, it does change the call, and that is the entire point. Memory is not a nudge applied to every lap; it is a plan the model can still be holding when the trigger arrives.
 
 One consequence worth knowing before debugging a call: **the effect does not show up in `reasoning`.** In the Safety Car runs, none of the eight memory recommendations mentioned the prior plan, yet all eight flipped the call. To understand why a recommendation changed, read the memory block, not the prose.
 

--- a/src/strategy/inference/decision_memory.py
+++ b/src/strategy/inference/decision_memory.py
@@ -10,9 +10,15 @@ almost none**: across a race that is not one plan, it is 41 unrelated plans. Wit
 its own previous contingencies echoed back it settles on six.
 
 That is what this class is for, and it is a narrower claim than "memory makes the
-system smarter". It does not change what the orchestrator decides on a given lap
-(``action`` differed on 0 of 41 laps in the A/B). It changes whether consecutive
-laps are the same plan.
+system smarter" - but do not narrow it too far either, because the two halves blur
+easily. On an ORDINARY green-flag lap the block does not change the call:
+``action`` differed on 0 of 41 laps across a whole race. On the lap where a
+contingency the model itself declared actually FIRES, it does, and that is the
+entire point - under a Safety Car at Lusail 2025 lap 42 the orchestrator executed
+its own one-lap-old plan on 8 of 8 runs against 0 of 8 without the block.
+
+So: not a nudge applied to every lap, but a plan the model can still be holding
+when the trigger arrives.
 
 Where it lives, and why not in the engine
 -----------------------------------------


### PR DESCRIPTION
Part of #648. A correction to prose I wrote in #683 and #676.

## The problem

Both `docs/pages/multi-agent.md` and `DecisionMemory`'s own docstring said:

> It does not change what the orchestrator decides on a given lap (`action` differed on 0 of 41 laps).

and then, separately, reported the Safety Car result where the block **flipped the call on 8 of 8 runs**. Read together, those contradict each other, and the docs page had both sentences in the same paragraph.

## The fix

Both halves are true of different laps, and the distinction is the whole mechanism:

- On an **ordinary green-flag lap**, the block does not change the call. It changes whether consecutive laps are the same plan.
- On the lap where a **contingency the model itself declared actually fires**, it does change the call — and that is the point.

Stated as: not a nudge applied to every lap, but a plan the model can still be holding when the trigger arrives.

Caught by re-reading my own merged prose against the gate numbers. Docs and a docstring only, no behaviour change.

## Checks

- `pytest tests/engine/test_decision_memory.py` — 15 passed
- `ruff check --no-cache .` + `ruff format --check .` clean at the pinned 0.15.22