### PR TITLE
Sprint 2: the orchestrator decision-memory layer

### DIFF
--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -299,6 +299,26 @@ run_strategy_orchestrator_from_state(race_state, laps_df, lap_state=None)
 
 That last argument is the one worth remembering: without `lap_state` the orchestrator never sees the rival gaps, so the Monte Carlo falls back to the legacy seconds path instead of scoring in projected track position. See [agents-api.md](#/agents-api) for the full per-agent reference.
 
+## Decision memory — three surfaces, not five
+
+The Layer 3 prompt is stateless: consecutive laps are 99% identical text, so the orchestrator re-argues the same case in fresh prose every lap and never reuses a plan it made. `DecisionMemory` (`src/strategy/inference/decision_memory.py`) fixes that by echoing this race's own previous calls — the last action and how long it has been held, recent `pit_lap_target` values, and the contingencies declared last lap — back into the prompt.
+
+It lives in the **caller**, not the engine, because `run_lap` is pure per lap and a test depends on that. Each surface that owns a race owns one accumulator, the same shape and lifetime as `RaceControlStateTracker`.
+
+| Surface | Decision memory | Why |
+|---|---|---|
+| CLI (`f1-sim`) | yes | owns a race-scoped loop |
+| Arcade | yes | owns a race-scoped connector |
+| Backend `/simulate` stream, `rich` profile | yes | owns a race-scoped simulator |
+| `/recommend` | **no** | stateless per request |
+| MCP `strategy` tool, and the webapp Strategy tab | **no** | stateless per request |
+
+The bottom two rows are a **declared limitation, not a gap to close**. Neither has a race-scoped object to accumulate on, so any memory they carried would be either empty or filled from something request-scoped that resembles a race and is not. `tests/engine/test_memory_scope_is_deliberate.py` fails if that asymmetry is ever "harmonised" away.
+
+Measured effect, on a client that honours `temperature=0`: under a Safety Car at Lusail 2025 lap 42, the orchestrator acted on a contingency it had itself declared one lap earlier on **8 of 8** runs, against **0 of 8** without the block (Fisher p=0.000155). Over a full race the echo cuts distinct contingency triggers from ~27 to 5. It does not change what a given lap decides — `action` differed on 0 of 41 laps — it changes whether consecutive laps are the same plan.
+
+One consequence worth knowing before debugging a call: **the effect does not show up in `reasoning`.** In the Safety Car runs, none of the eight memory recommendations mentioned the prior plan, yet all eight flipped the call. To understand why a recommendation changed, read the memory block, not the prose.
+
 ## LLM configuration
 
 | Layer | Model | Provider |

--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -315,7 +315,9 @@ It lives in the **caller**, not the engine, because `run_lap` is pure per lap an
 
 The bottom two rows are a **declared limitation, not a gap to close**. Neither has a race-scoped object to accumulate on, so any memory they carried would be either empty or filled from something request-scoped that resembles a race and is not. `tests/engine/test_memory_scope_is_deliberate.py` fails if that asymmetry is ever "harmonised" away.
 
-Measured effect, on a client that honours `temperature=0`: under a Safety Car at Lusail 2025 lap 42, the orchestrator acted on a contingency it had itself declared one lap earlier on **8 of 8** runs, against **0 of 8** without the block (Fisher p=0.000155). Over a full race the echo cuts distinct contingency triggers from ~27 to 5. It does not change what a given lap decides — `action` differed on 0 of 41 laps — it changes whether consecutive laps are the same plan.
+Measured effect, on a client that honours `temperature=0`: under a Safety Car at Lusail 2025 lap 42, the orchestrator acted on a contingency it had itself declared one lap earlier on **8 of 8** runs, against **0 of 8** without the block (Fisher p=0.000155). Over a full race the echo cuts distinct contingency triggers from ~27 to 5.
+
+Stated precisely, because the two halves of that are easy to blur: on an **ordinary green-flag lap** the block does not change the call — `action` differed on 0 of 41 laps across a whole race — it changes whether consecutive laps are the same plan. On the lap where a **contingency the model itself declared actually fires**, it does change the call, and that is the entire point. Memory is not a nudge applied to every lap; it is a plan the model can still be holding when the trigger arrives.
 
 One consequence worth knowing before debugging a call: **the effect does not show up in `reasoning`.** In the Safety Car runs, none of the eight memory recommendations mentioned the prior plan, yet all eight flipped the call. To understand why a recommendation changed, read the memory block, not the prose.
 

--- a/documents/audits/AUDIT_ORCHESTRATOR_MEMORY.md
+++ b/documents/audits/AUDIT_ORCHESTRATOR_MEMORY.md
@@ -910,3 +910,108 @@ Stated so the next reader knows what does not need re-auditing.
   audit cannot attribute the effect to one of them except by the mechanism visible in §3.6,
   which points at the contingencies.
 
+
+---
+
+# GATE FOLLOW-UP 2, 2026-07-28 — the two repeat experiments, re-run on a deterministic client
+
+The first gate follow-up re-measured the whole-race passes and explicitly left this open:
+
+> Nothing here re-opens §3.5/§3.6, which were run on the shipped model with repeats. They
+> should be re-run on a deterministic client before the wiring PR, since both were measured
+> against a much noisier baseline than a fixed client would give.
+
+That is what this section does. It is the gate on Sprint 2's wiring: if memory stopped
+helping once the sampler was removed, nothing was to be wired.
+
+**Method.** Identical to §3.5/§3.6 except for the client: `--model gpt-4.1-mini` at
+`temperature=0.0`, which that family keeps. History for both experiments is `gate_none.json`,
+the deterministic no-memory pass from the first gate follow-up, so the block echoed back is
+the one a deterministic surface would actually have accumulated. 36 calls, 116k in / 13.5k out.
+
+Two variants, not three: the counterweight now ships **inside** `DecisionMemory.block()`, so
+what §3.5 called BC is what `memory` means from here on. There is no memory-without-
+counterweight configuration left to measure, by design.
+
+## Result 1 — the Safety Car experiment does NOT just survive, it sharpens
+
+**Lusail 2025 lap 42, Safety Car injected via RCM, deterministic MC = `PIT_NOW`, n=8.**
+
+| variant | takes the free stop | stays out | mean confidence | `pit_lap_target` |
+|---|---|---|---|---|
+| no memory | **0/8** | 8 | 0.856 | 57, 47, 57, 57, 50, 50, 57, 57 |
+| memory | **8/8** | 0 | 0.906 | 42 x8 |
+
+```
+Fisher two-sided, agreement with the deterministic layer: p = 0.000155
+```
+
+On the shipped sampling client this was 1/8 against 7/8 (p=0.0101). On a deterministic client
+it is total separation. **The load-bearing result is not a sampling artifact** — removing the
+sampler made it cleaner, which is the opposite of what a noise explanation predicts.
+
+The mechanism is unchanged and still legible: entering lap 42 the block carried
+`[HIGH] "SC deployed within 3 laps" -> PIT_NOW`, declared by the model itself on lap 41. The
+Safety Car then deployed. Without the echo the model does not act on its own plan; with it,
+every run does.
+
+**§3.5's severity finding also reproduces, and it got worse.** Of the 8 memory runs, **0**
+mention the prior plan, the contingency or continuity in `reasoning` — they argue from tyre
+cliff and pace delta and then pit. The one run that does reference a prior plan is in the
+**no-memory** arm. So the block changes the decision on 8 of 8 runs while leaving no trace a
+reviewer could find in the output. That is a monitoring requirement, not a reason not to ship:
+**whatever surface renders the recommendation cannot show WHY this flipped**, so the memory
+block itself has to be inspectable when a call is questioned.
+
+The §3.6 caveat stands verbatim and is not weakened by the sharper number: these SC laps route
+N28/N30 in production, so the prompts lack the pit block and the hard regulation constraint a
+`rich` run would carry. **The A-vs-B contrast is sound because both arms get the identical
+prompt; the absolute 0/8 is not a product finding** and must not be quoted as "the product
+ignores Safety Cars".
+
+## Result 2 — the anchoring experiment went DEGENERATE, and that is a limitation, not a clean bill
+
+**Lusail 2025 lap 44, Norris's real stop, deterministic MC = `UNDERCUT`, n=10.**
+
+| variant | agrees with MC (pits) | stays out | mean confidence | `pit_lap_target` |
+|---|---|---|---|---|
+| no memory | **0/10** | 10 | 0.860 | 57 x8, 50, 52 |
+| memory | **0/10** | 10 | 0.880 | 57 x10 |
+
+```
+Fisher two-sided: p = 1.0
+```
+
+**Both arms are on the floor, so this experiment measured nothing.** `gpt-4.1-mini` never takes
+the lap-44 undercut in any configuration; there is no variance for memory to move in either
+direction. Read precisely:
+
+- It does **not** show that memory is harmless at the decision lap. §3.5's 6/10 → 4/10 was
+  measured on a client where the baseline pitted at all; here the baseline never does, so the
+  harm this experiment exists to detect is undetectable by construction.
+- It does **not** reproduce §3.5's 10/10 counterweight result either. That result stays where
+  the first follow-up left it: measured on the shipped model, and not re-confirmed.
+- What it does show is that the block did not push a 0/10 baseline into a *wrong* action, and
+  that the target stopped scattering (57 x8, 50, 52 → 57 x10).
+
+Worth recording because it is the design's own worst case: this run's block reported
+**`STAY_OUT, held since lap 5 (39 laps)`** — the 39-lap hold §3.5 said it could not test,
+since that pass never left `STAY_OUT`. A 39-lap hold plus a counterweight did not produce a
+different call from no memory at all.
+
+**Residual noise at `temperature=0.0`:** the no-memory arms are not constant. Lap 44 gave
+confidences of 0.85/0.90 and targets 57/50/52; lap 42 gave 57/47/50. A kept temperature
+narrows sampling, it does not remove it — exactly as `OrchestratorCFG`'s docstring warns.
+
+## Gate verdict: PASS — wire it
+
+The gate was "if a deterministic client stops the memory improving agreement with the
+deterministic MC, or worsens it, stop". Neither happened: agreement is unchanged on the
+degenerate lap and goes 0/8 → 8/8 on the lap where the deterministic layer had a live call.
+
+Two things the wiring must carry out of this section:
+
+1. **The contingency echo is the field to ship**, confirmed twice on two clients. Field order
+   in step 4 of the plan is correct as written.
+2. **The block must be inspectable at the surface.** An intervention that flips 8 of 8
+   decisions without appearing in `reasoning` is one nobody can debug from the output alone.

--- a/documents/audits/AUDIT_ORCHESTRATOR_MEMORY.md
+++ b/documents/audits/AUDIT_ORCHESTRATOR_MEMORY.md
@@ -1015,3 +1015,75 @@ Two things the wiring must carry out of this section:
    in step 4 of the plan is correct as written.
 2. **The block must be inspectable at the surface.** An intervention that flips 8 of 8
    decisions without appearing in `reasoning` is one nobody can debug from the output alone.
+
+---
+
+# SPRINT 2 OUTCOME, 2026-07-28 — what was built, and what the build changed about the report
+
+The numbered plan above is now executed. This section records what shipped and, more
+usefully, the three places where building it produced a finding the audit did not have.
+
+| plan step | issue | PR | state |
+|---|---|---|---|
+| 2, re-run the harness after the temperature fix | — | #679 | done, GATE FOLLOW-UP 2 above |
+| 4, the accumulator | #672 | #676 | shipped in Sprint 1, inert |
+| the prompt seam | #680 | #682 | done |
+| 7, write the limitation down | #681 | #683 | done |
+| the three-surface wiring | #684 | #686 + submodule #204 | done |
+| 6, scope the STAY_OUT framing | #685 | #687 | done |
+
+## Three findings the wiring produced
+
+**1. An anti-drift guard in this repo was asserting nothing.**
+`test_the_docstring_does_not_name_a_test_that_does_not_exist` scans the engine docstring's
+anti-drift section and asserts each test file it names exists. Its pattern was
+`tests/test_[a-z_]+\.py`, and every guard the docstring names now lives in `tests/engine/`.
+It matched **zero files** and passed green — the same defect it was written to catch, one
+level up. Widened, plus a non-empty assertion so a pattern that silently stops matching
+fails instead of going quiet. Worth generalising: a guard whose subject can move needs an
+assertion that it still has a subject.
+
+**2. The memory path cannot be tested end to end on the `rich` profile, for a structural
+reason.** §2.7 predicted the purity test would give the memory path zero coverage, which is
+right, but the fix is not simply "write an integration test". Driving `run_lap(profile="rich")`
+in a test fails on a connection error long before the prompt exists, because the always-on
+sub-agents build LLM clients first. The chain is verified as three links instead — two at
+runtime, one static. Anyone adding to this path should expect the same wall.
+
+**3. The block rendered `(1 laps)`.** Cosmetic, but it appeared in the first held lap of
+every real run and none of the ten hermetic tests caught it, because they all record
+several laps before asserting. Fixed under #685.
+
+## What §3.1's fix actually looks like, and what it costs
+
+Step 6 said the continuation framing "can finally be conditional". It was implemented by
+moving the sentence out of the static prompt and into the memory block, rather than by
+adding a second prompt parameter — two arguments that must always travel together are two
+arguments that eventually do not.
+
+**Two consequences, stated because neither is measured:**
+
+- The block that GATE FOLLOW-UP 2 measured had **no continuation line**. The 0/8 → 8/8
+  Safety Car result was obtained on a slightly different artifact than the one that now
+  ships. The direction is not in doubt; the exact number was not re-taken.
+- `/recommend` and the MCP tool now lose the sentence entirely. That is correct — they have
+  no history, so the instruction was unconditioned there in the strongest sense — but it is
+  a behavioural change to the shipped prompt on two surfaces and nobody has measured it.
+
+## Verified on real runs, not only in tests
+
+Lusail 2025 / NOR, `rich` profile, prompts captured as sent to the provider. Lap 20 (the
+first lap decided) carries no block at all; lap 21 reports `held since lap 20 (1 lap)` with
+the counterweight and no continuation; laps 22+ carry both. The span is measured from the
+first lap the surface actually decided, not from lap 1, which is the `laps_held` honesty
+requirement in §2.4 holding up outside a unit test.
+
+## Still open from this report
+
+- **§3.7's three incidentals** are untouched: `mc_decision_margin` still has no production
+  consumer, the third `"ERROR"` default at `simulator.py:502`, and `max_retries=1` on a live
+  race surface.
+- **§3.3 stands**: nothing retires a contingency. The mitigation shipped is that only the
+  last lap's list is echoed, which bounds the block rather than solving the problem.
+- **The measurement is still one circuit, one driver, one race.** Nothing in Sprint 2
+  widened it.

--- a/scripts/prompt_ab/README.md
+++ b/scripts/prompt_ab/README.md
@@ -62,6 +62,14 @@ minutes and ~120 calls for the three together.
   memory, 6 with) and total `pit_lap_target` movement (311 laps against 214).
 - **Repeats**: report the count, the variant split and a Fisher exact test. n=10 cannot
   separate a 6/10 from a 4/10.
+- **Read the no-memory arm before the result.** If it is already at 0/n or n/n, the lap has
+  no room to move and the comparison measures nothing. That is what happened to the lap-44
+  anchoring experiment on `--model gpt-4.1-mini`: both arms stayed out 10 of 10, which is a
+  degenerate experiment and not evidence that memory is harmless.
+
+`--model` overrides `CFG.model_name` for one run. It exists because the shipped model
+discards `temperature`, so the only way to ask "does this survive without the sampler" is to
+measure a model that keeps it. Cross-model results are directional, never absolute.
 
 ## Deviations you must state with any result
 

--- a/scripts/prompt_ab/_common.py
+++ b/scripts/prompt_ab/_common.py
@@ -6,12 +6,10 @@ calls ``_build_orchestrator_prompt``, ``_get_orchestrator_llm`` and
 that measures a private copy of the code is a recorded failure in this repo, and
 two published numbers were produced that way.
 
---- WHERE TO CHANGE IF THE PROMPT GAINS A MEMORY PARAMETER ---
-``inject_memory_block`` splices the block in by string surgery, above the
-``RACE CONTEXT:`` heading. That is a harness-only workaround for the fact that
-``_build_orchestrator_prompt`` has no ``memory_block`` argument yet. The moment it
-gains one, delete the splice and pass the argument, or this harness starts
-measuring a prompt assembled differently from the one production builds.
+Earlier versions spliced the memory block in by string surgery above the
+``RACE CONTEXT:`` heading, because the builder had no parameter for it. It has one
+now and the splice is gone: every measurement here assembles the prompt through the
+same code path production uses, which is the whole point of this module.
 """
 
 from __future__ import annotations
@@ -25,11 +23,6 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
-
-# The heading the memory block is spliced above: after the guard-rails and the
-# STAY_OUT framing, immediately before the per-lap facts.
-MEMORY_ANCHOR = "RACE CONTEXT:\n"
-
 
 MODEL_FLAG_HELP = (
     "override CFG.model_name for this run only. The reason this exists: the "
@@ -144,19 +137,11 @@ def invoke_with_retry(llm, prompt: str, usage: Usage, attempts: int = 4):
     raise AssertionError("unreachable")
 
 
-def inject_memory_block(prompt: str, block: str | None) -> str:
-    """Splice the memory block above ``RACE CONTEXT:``; a falsy block is a no-op."""
-    if not block:
-        return prompt
-    index = prompt.index(MEMORY_ANCHOR)
-    return prompt[:index] + block + prompt[index:]
-
-
 def build_prompt(record: dict[str, Any], memory_block: str | None = None) -> str:
     """Build one lap's orchestrator prompt from a cached record."""
     from src.agents.strategy_orchestrator import _build_orchestrator_prompt
 
-    prompt = _build_orchestrator_prompt(
+    return _build_orchestrator_prompt(
         race_state=record["race_state"],
         mc_results=record["mc_results"],
         best_mc=record["best_mc"],
@@ -166,8 +151,8 @@ def build_prompt(record: dict[str, Any], memory_block: str | None = None) -> str
         pit_out=record["pit_out"],
         radio_out=record["radio_out"],
         regulation_context=record["regulation_context"],
+        memory_block=memory_block,
     )
-    return inject_memory_block(prompt, memory_block)
 
 
 def assemble(record: dict[str, Any], synthesis):

--- a/scripts/prompt_ab/_common.py
+++ b/scripts/prompt_ab/_common.py
@@ -31,6 +31,37 @@ if str(REPO_ROOT) not in sys.path:
 MEMORY_ANCHOR = "RACE CONTEXT:\n"
 
 
+MODEL_FLAG_HELP = (
+    "override CFG.model_name for this run only. The reason this exists: the "
+    "shipped model discards temperature, so the only way to ask 'would a "
+    "DETERMINISTIC client behave differently' is to measure one that keeps it. "
+    "A cross-model result is suggestive, not conclusive."
+)
+
+
+def add_model_flag(parser) -> None:
+    """Register ``--model`` on a harness stage.
+
+    Shared rather than copied into each stage: the flag and the override below are
+    a pair, and a stage that grew its own copy would be one more instance of the
+    failure this repo keeps hitting - a fix landing on one twin and not the other.
+    """
+    parser.add_argument("--model", default=None, help=MODEL_FLAG_HELP)
+
+
+def apply_model_flag(model: str | None) -> str:
+    """Point ``CFG.model_name`` at ``model`` and return the model actually in use.
+
+    Must run BEFORE the first ``_get_orchestrator_llm()``, which caches the client:
+    afterwards the assignment lands on config nothing reads again.
+    """
+    from src.agents.strategy_orchestrator import CFG
+
+    if model:
+        CFG.model_name = model
+    return CFG.model_name
+
+
 def load_env() -> str:
     """Load the repo ``.env`` and return the resolved provider.
 

--- a/scripts/prompt_ab/run_pass.py
+++ b/scripts/prompt_ab/run_pass.py
@@ -24,6 +24,8 @@ from pathlib import Path
 
 from scripts.prompt_ab._common import (
     Usage,
+    add_model_flag,
+    apply_model_flag,
     assemble,
     build_prompt,
     checkpoint,
@@ -48,26 +50,15 @@ def main() -> None:
     parser.add_argument("--out", required=True, type=Path)
     parser.add_argument("--variant", choices=VARIANTS, default="none")
     parser.add_argument("--laps", default=None, help="optional sub-range, e.g. 40-45")
-    parser.add_argument(
-        "--model",
-        default=None,
-        help=(
-            "override CFG.model_name for this run only. The reason this exists: the "
-            "shipped model discards temperature, so the only way to ask 'would a "
-            "DETERMINISTIC client behave differently' is to measure one that keeps it. "
-            "A cross-model result is suggestive, not conclusive."
-        ),
-    )
+    add_model_flag(parser)
     args = parser.parse_args()
 
     provider = load_env()
 
-    from src.agents.strategy_orchestrator import CFG, _get_orchestrator_llm
+    from src.agents.strategy_orchestrator import _get_orchestrator_llm
 
-    if args.model:
-        # Must happen before the first _get_orchestrator_llm(), which caches the client.
-        CFG.model_name = args.model
-    print(f"provider={provider}  variant={args.variant}  model={CFG.model_name}")
+    model_name = apply_model_flag(args.model)
+    print(f"provider={provider}  variant={args.variant}  model={model_name}")
 
     records = pickle.loads(args.inputs.read_bytes())
     if args.laps:
@@ -104,7 +95,7 @@ def main() -> None:
             args.out,
             {
                 "variant": args.variant,
-                "model": CFG.model_name,
+                "model": model_name,
                 "usage": usage.as_dict(),
                 "rows": rows,
             },

--- a/scripts/prompt_ab/run_repeats.py
+++ b/scripts/prompt_ab/run_repeats.py
@@ -8,14 +8,20 @@ way to measure those is repetition on one lap.
 The memory block is frozen at what a source pass held ENTERING the target lap, so
 every repeat sees the same history and the only thing varying is the sampler.
 
-This is the experiment that produced the audit's two significant results: at Lusail
-2025 lap 44 memory alone agreed with the deterministic Monte Carlo on 4 of 10 runs
-against 6 of 10 without it, and 10 of 10 once the counterweight was in the block;
-under an injected Safety Car, memory took the free stop on 7 of 8 runs against 1 of 8.
+This is the experiment that produced the audit's significant result: under a Safety
+Car injected at Lusail 2025 lap 42, memory took the free stop on 7 of 8 runs against
+1 of 8 without it. Re-run on ``--model gpt-4.1-mini``, which honours ``temperature=0``,
+it separates completely: **0 of 8 against 8 of 8** (Fisher p=0.000155), so the effect
+is not the sampler.
+
+Pass ``--model`` for that check. Note the companion experiment at lap 44 went
+DEGENERATE on the deterministic client — both arms stay out 10 of 10 — so a null
+result there measures the client, not the memory. Always read the no-memory arm first.
 
 Usage:
-    python -m scripts.prompt_ab.run_repeats --inputs .../lusail_nor.pkl \\
-        --history .../pass_a.json --lap 44 --repeats 10 --out .../transition.json
+    python -m scripts.prompt_ab.run_repeats --inputs .../lusail_nor_sc.pkl \\
+        --history .../gate_none.json --lap 42 --repeats 8 --model gpt-4.1-mini \\
+        --out .../sc.json
 """
 
 from __future__ import annotations
@@ -30,6 +36,8 @@ from types import SimpleNamespace
 
 from scripts.prompt_ab._common import (
     Usage,
+    add_model_flag,
+    apply_model_flag,
     assemble,
     build_prompt,
     checkpoint,
@@ -91,12 +99,15 @@ def main() -> None:
     parser.add_argument("--lap", required=True, type=int)
     parser.add_argument("--repeats", type=int, default=10)
     parser.add_argument("--out", required=True, type=Path)
+    add_model_flag(parser)
     args = parser.parse_args()
 
     provider = load_env()
-    print(f"provider={provider}  lap={args.lap}  repeats={args.repeats}")
 
     from src.agents.strategy_orchestrator import _get_orchestrator_llm
+
+    model_name = apply_model_flag(args.model)
+    print(f"provider={provider}  model={model_name}  lap={args.lap}  repeats={args.repeats}")
 
     records = {r["lap"]: r for r in pickle.loads(args.inputs.read_bytes())}
     history_rows = json.loads(args.history.read_text(encoding="utf-8"))["rows"]
@@ -128,7 +139,15 @@ def main() -> None:
                 f"conf={row['confidence']:.2f} target={row['pit_lap_target']}",
                 flush=True,
             )
-            checkpoint(args.out, {"lap": args.lap, "usage": usage.as_dict(), "rows": rows})
+            checkpoint(
+                args.out,
+                {
+                    "lap": args.lap,
+                    "model": model_name,
+                    "usage": usage.as_dict(),
+                    "rows": rows,
+                },
+            )
 
     _summarise(rows, args.lap)
     print(f"\n{usage.calls} calls, {usage.prompt_tokens} in / {usage.completion_tokens} out")

--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -1589,10 +1589,14 @@ def run(args: argparse.Namespace) -> None:
     # history table was inside Live and eventually exceeded terminal height
     # (the terminal cursor cannot rewind above the topmost visible line).
     from src.nlp.rcm_state import RaceControlStateTracker
+    from src.strategy.inference.decision_memory import DecisionMemory
 
     # One Safety-Car tracker for the whole run: persists SC/VSC state across laps
     # so the deploy-once corpus message keeps the override active mid-stint (NR-02).
     sc_tracker = RaceControlStateTracker()
+    # One decision memory for the whole run: accumulates orchestrator recommendations
+    # so the Layer 3 prompt sees its own previous calls and can compose a continuous plan.
+    memory = DecisionMemory()
     with Live(
         _live_content(),
         console=console,
@@ -1744,7 +1748,10 @@ def run(args: argparse.Namespace) -> None:
                 # deterministic, zero LLM clients (fixes #166). `outs` carries the
                 # six sub-agent outputs the detail panel renders — no second pass.
                 profile = "no-llm" if args.no_llm else "rich"
-                result, outs, _ = run_lap(race_state, laps_df, lap_state, profile=profile)
+                result, outs, _ = run_lap(
+                    race_state, laps_df, lap_state, profile=profile, memory=memory
+                )
+                memory.record(lap_num, result)
                 scores = getattr(result, "scenario_scores", {})
                 action = getattr(result, "action", "?")
                 confidence = getattr(result, "confidence", 0.0)

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -1468,6 +1468,7 @@ def _build_orchestrator_prompt(
     pit_out              = None,
     radio_out            = None,
     regulation_context:  str = "",
+    memory_block:        str = "",
 ) -> str:
     """Build the LLM synthesis prompt for Layer 3.
 
@@ -1485,6 +1486,20 @@ def _build_orchestrator_prompt(
     best_mc is the MC argmax passed as a hint. The LLM may override it if
     regulation context, radio alerts, or a planned contingency justify a
     different action.
+
+    memory_block is what this race's own previous recommendations looked like,
+    rendered by DecisionMemory and empty by default. Empty is not a degraded
+    mode: two of the three call sites (/recommend and the MCP tool) are
+    stateless per request and have no race-scoped object to accumulate on, so
+    they keep this prompt exactly as it was. The default therefore has to
+    produce a byte-identical prompt, which tests/agents/test_orchestrator_prompt
+    asserts.
+
+    Measured effect when it IS supplied, on a client that honours temperature=0:
+    under a Safety Car at Lusail 2025 lap 42, the model acted on a contingency it
+    had itself declared one lap earlier on 8 of 8 runs, against 0 of 8 without
+    the block (Fisher p=0.000155). It changes whether consecutive laps are the
+    same plan, not what any single lap decides.
     """
     mc_table = "\n".join(_format_mc_row(name, cell) for name, cell in mc_results.items())
 
@@ -1607,6 +1622,11 @@ def _build_orchestrator_prompt(
         f"  that would change the call, and (c) how far the current numbers sit from it.\n"
         f"  Carry the lap you are watching towards in pit_lap_target whenever the tyre\n"
         f"  data supports one, so a hold reads as a plan with a horizon, not indecision.\n\n"
+        # Placed after the framing and before the per-lap facts, so the model reads
+        # what it decided before it reads this lap's numbers. `or ""` because the
+        # producer, DecisionMemory.block(), returns None before there is any history
+        # and an unguarded f-string would render the literal "None" into the prompt.
+        f"{memory_block or ''}"
         f"RACE CONTEXT:\n"
         f"  Driver: {race_state.driver} | Lap: {race_state.lap}/{race_state.total_laps}\n"
         f"  Position: P{race_state.position} | Compound: {race_state.compound} "

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -1611,15 +1611,18 @@ def _build_orchestrator_prompt(
         # "no pit action". Measured on real races it is the call on the large majority
         # of green-flag laps (39/41 at Lusail 2025, 414/415 across the projection set),
         # so the prompt was teaching the LLM to treat its own most frequent output as a
-        # failure to decide. The prompt is also stateless: consecutive laps are 99.0%
-        # identical text, so nothing tells the model it is repeating itself and it
-        # re-argues the same case from scratch every lap (#646).
+        # failure to decide.
+        #
+        # What stays here is what is true on EVERY lap. The instruction to treat a
+        # repeated STAY_OUT as a continuing plan used to sit in this block, where it
+        # fired on lap 1, when there was nothing to continue, and on the lap the call
+        # changed, when continuing was wrong. It now lives in the memory block, which
+        # is the only place that knows whether anything is being repeated.
         f"WHEN THE CALL IS STAY_OUT (the majority call, by design):\n"
         f"  STAY_OUT is an ACTIVE monitoring posture, not the absence of a decision and\n"
-        f"  not merely what is left when a pit is blocked. Treat a repeated STAY_OUT as\n"
-        f"  CONTINUING a plan rather than making a fresh one, and do not re-argue the same\n"
-        f"  case from scratch. State (a) what you are watching, (b) the concrete threshold\n"
-        f"  that would change the call, and (c) how far the current numbers sit from it.\n"
+        f"  not merely what is left when a pit is blocked. State (a) what you are watching,\n"
+        f"  (b) the concrete threshold that would change the call, and (c) how far the\n"
+        f"  current numbers sit from it.\n"
         f"  Carry the lap you are watching towards in pit_lap_target whenever the tyre\n"
         f"  data supports one, so a hold reads as a plan with a horizon, not indecision.\n\n"
         # Placed after the framing and before the per-lap facts, so the model reads

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -231,6 +231,13 @@ class SimConnector(threading.Thread):
         from src.nlp.rcm_state import RaceControlStateTracker
 
         self._sc_tracker = RaceControlStateTracker()
+        # One DecisionMemory for the whole replay, same lifetime and shape as the
+        # SC tracker above: without it the Layer 3 prompt is stateless and
+        # re-argues an unrelated case every lap instead of building on its own
+        # previous call.
+        from src.strategy.inference.decision_memory import DecisionMemory
+
+        self._memory = DecisionMemory()
 
     def stop(self) -> None:
         self._stop_event.set()
@@ -406,7 +413,10 @@ class SimConnector(threading.Thread):
         from src.arcade.strategy_pipeline import run_strategy_pipeline
 
         race_state = self._build_race_state(lap_state, prev_lap_time)
-        rec, agent_outputs = run_strategy_pipeline(race_state, laps_df, lap_state)
+        rec, agent_outputs = run_strategy_pipeline(
+            race_state, laps_df, lap_state, memory=self._memory
+        )
+        self._memory.record(race_state.lap, rec)
         lap_time_s = lap_state.get("driver", {}).get("lap_time_s")
         decision = _build_decision(rec, race_state, lap_time_s, agent_outputs)
         with self._state._lock:

--- a/src/arcade/strategy_pipeline.py
+++ b/src/arcade/strategy_pipeline.py
@@ -24,21 +24,27 @@ from src.strategy.inference.engine import run_lap
 
 if TYPE_CHECKING:  # pragma: no cover — only for type hints
     from src.agents.strategy_orchestrator import RaceState, StrategyRecommendation
+    from src.strategy.inference.decision_memory import DecisionMemory
 
 
 def run_strategy_pipeline(
     race_state: "RaceState",
     laps_df: pd.DataFrame,
     lap_state: dict | None = None,
+    memory: "DecisionMemory | None" = None,
 ) -> tuple["StrategyRecommendation", dict]:
     """Run the full N31 pipeline; return the recommendation and per-agent outputs.
 
-    Public signature is unchanged so ``src/arcade/strategy.py`` and the dashboard
-    formatters keep working. The ``agent_outputs`` dict carries the same keys as
-    before (``pace_out``/``tire_out``/``situation_out``/``radio_out``/``pit_out``/
+    Public signature stays backward compatible: ``memory`` is optional and
+    defaults to ``None``, so ``src/arcade/strategy.py`` and the dashboard
+    formatters that already call this positionally keep working unchanged. The
+    ``agent_outputs`` dict carries the same keys as before (``pace_out``/
+    ``tire_out``/``situation_out``/``radio_out``/``pit_out``/
     ``regulation_context``/``rag``/``active``) plus ``guardrail_reason``; the
     engine's third return value (stage timings) is dropped here (a future arcade
     change may forward it on the TCP stream).
     """
-    rec, agent_outputs, _timings = run_lap(race_state, laps_df, lap_state, profile="rich")
+    rec, agent_outputs, _timings = run_lap(
+        race_state, laps_df, lap_state, profile="rich", memory=memory
+    )
     return rec, agent_outputs

--- a/src/strategy/inference/decision_memory.py
+++ b/src/strategy/inference/decision_memory.py
@@ -10,9 +10,15 @@ almost none**: across a race that is not one plan, it is 41 unrelated plans. Wit
 its own previous contingencies echoed back it settles on six.
 
 That is what this class is for, and it is a narrower claim than "memory makes the
-system smarter". It does not change what the orchestrator decides on a given lap
-(``action`` differed on 0 of 41 laps in the A/B). It changes whether consecutive
-laps are the same plan.
+system smarter" - but do not narrow it too far either, because the two halves blur
+easily. On an ORDINARY green-flag lap the block does not change the call:
+``action`` differed on 0 of 41 laps across a whole race. On the lap where a
+contingency the model itself declared actually FIRES, it does, and that is the
+entire point - under a Safety Car at Lusail 2025 lap 42 the orchestrator executed
+its own one-lap-old plan on 8 of 8 runs against 0 of 8 without the block.
+
+So: not a nudge applied to every lap, but a plan the model can still be holding
+when the trigger arrives.
 
 Where it lives, and why not in the engine
 -----------------------------------------

--- a/src/strategy/inference/decision_memory.py
+++ b/src/strategy/inference/decision_memory.py
@@ -66,6 +66,17 @@ COUNTERWEIGHT = (
     "  evidence; a long hold is not itself a reason to keep holding.\n"
 )
 
+# Emitted only on a genuine repeated STAY_OUT. It used to live in the static
+# prompt, where it fired on every lap: on lap 1, when there was no previous call
+# to continue, and on the lap the call changed, when continuing was the wrong
+# answer. Nothing could condition it there because the prompt had no idea what the
+# last call was. Here the object that knows owns the claim, which is also why this
+# is not a second parameter on the prompt builder travelling next to the block.
+CONTINUATION = (
+    "  This is a CONTINUING plan, not a fresh one: do not re-argue the same case\n"
+    "  from scratch.\n"
+)
+
 
 @dataclass(frozen=True)
 class _Entry:
@@ -152,11 +163,24 @@ class DecisionMemory:
         return self._entries[-1].contingencies[:MAX_CONTINGENCIES]
 
     # ── rendering ─────────────────────────────────────────────────────────
+    def _is_continuing_a_hold(self) -> bool:
+        """True when the last call repeated a STAY_OUT, which is the only real hold.
+
+        Two decisions minimum: one STAY_OUT is a call, not a continuation. Restricted
+        to STAY_OUT because it is the only action a race can sit on. Repeating
+        PIT_NOW is not a plan being continued, it is a stop that has not happened.
+        """
+        if len(self._entries) < 2:
+            return False
+        action, _since_lap, decisions = self._current_run()
+        return action == "STAY_OUT" and decisions >= 2
+
     def _render_hold(self) -> str:
         action, since_lap, decisions = self._current_run()
         laps_spanned = self._entries[-1].lap - since_lap + 1
         if laps_spanned == decisions:
-            return f"  Last call: {action}, held since lap {since_lap} ({decisions} laps)."
+            unit = "lap" if decisions == 1 else "laps"
+            return f"  Last call: {action}, held since lap {since_lap} ({decisions} {unit})."
         # The two numbers disagree, which means the surface skipped laps. Say both
         # rather than picking one: "held for N laps" would be false, and dropping
         # the span would hide that the race moved on without a decision.
@@ -203,4 +227,9 @@ class DecisionMemory:
             self._render_targets(),
             *self._render_contingencies(),
         ]
-        return "\n".join(lines) + "\n" + COUNTERWEIGHT + "\n"
+        # CONTINUATION and COUNTERWEIGHT are deliberately adjacent and deliberately
+        # in this order: carry the plan, but do not treat carrying it as a promise.
+        # Shipping the first without the second is the configuration that measurably
+        # anchored the model at the decision lap.
+        tail = (CONTINUATION if self._is_continuing_a_hold() else "") + COUNTERWEIGHT
+        return "\n".join(lines) + "\n" + tail + "\n"

--- a/src/strategy/inference/engine.py
+++ b/src/strategy/inference/engine.py
@@ -31,9 +31,19 @@ Untouchability: nothing in ``src/agents/`` is modified. Every strategy layer is 
 SAME code object the orchestrator runs (imported, never copied); the only
 engine-owned code is the call sequence itself and the default-lap_state builder.
 
-Anti-drift guards: ``tests/engine/test_engine.py``, ``tests/engine/test_engine_no_llm.py`` and
+Decision memory
+---------------
+``run_lap`` accepts an optional ``DecisionMemory`` and renders its block into the Layer 3
+prompt. The accumulator belongs to the CALLER — the CLI loop, the arcade connector, the
+backend simulator's stream — because this function has to stay pure per lap. The engine
+only ever calls ``block()``; the caller records the recommendation afterwards. The two
+stateless surfaces (``/recommend``, the MCP tool) get no memory by design, which
+``tests/engine/test_memory_scope_is_deliberate.py`` enforces.
+
+Anti-drift guards: ``tests/engine/test_engine.py``, ``tests/engine/test_engine_no_llm.py``,
 ``tests/engine/test_engine_threads_every_argument.py`` (which checks, by AST, that this path
-passes ``_assemble_recommendation`` every argument the orchestrator does).
+passes ``_assemble_recommendation`` every argument the orchestrator does) and
+``tests/engine/test_memory_scope_is_deliberate.py``.
 
 These do not assert byte-level parity with the orchestrator. An earlier docstring cited
 a ``tests/test_engine_parity.py`` that does not exist; the argument-threading test above
@@ -45,9 +55,14 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import pandas as pd
+
+if TYPE_CHECKING:
+    # Type-only: importing it for real would put a strategy-layer import in the
+    # engine's import graph for a value the engine never constructs.
+    from src.strategy.inference.decision_memory import DecisionMemory
 
 from src.agents.strategy_orchestrator import (
     RaceState,
@@ -163,6 +178,7 @@ def run_lap(
     *,
     profile: Profile = "rich",
     return_agent_outputs: bool = True,
+    memory: "DecisionMemory | None" = None,
 ) -> tuple[StrategyRecommendation, dict[str, Any] | None, dict[str, float]]:
     """Run one lap of the N31 strategy pipeline and return everything a surface needs.
 
@@ -176,6 +192,12 @@ def run_lap(
             (deterministic, zero LLM clients). ``"fast"`` is reserved (raises).
         return_agent_outputs: When ``False``, slot 2 is ``None`` (compute is
             unchanged; only the assembly of the outputs dict is skipped).
+        memory: This race's ``DecisionMemory``, owned by the CALLER. Read here,
+            never written: the caller records each recommendation after the lap
+            returns, which is what keeps this function pure and
+            ``tests/engine/test_engine_no_llm.py``'s twice-on-lap-6 assertion true.
+            Ignored on ``no-llm``, which builds no prompt to put it in — passing
+            one there is harmless, and silent, so it is stated here.
 
     Returns:
         ``(recommendation, agent_outputs | None, stage_timings)`` where
@@ -195,7 +217,10 @@ def run_lap(
     laps_df = _scope_laps_to_gp(laps_df, lap_state, race_state)
 
     if profile == "rich":
-        return _run_rich(race_state, laps_df, lap_state, return_agent_outputs)
+        # Rendered here rather than inside _run_rich so the engine's only contact with
+        # the accumulator is one read, at one place, of a method that cannot mutate it.
+        memory_block = memory.block() if memory is not None else ""
+        return _run_rich(race_state, laps_df, lap_state, return_agent_outputs, memory_block)
     if profile == "no-llm":
         # Imported lazily so the rich path never pays the no_llm module's agent
         # class imports, and so a circular import can never form.
@@ -212,6 +237,7 @@ def _run_rich(
     laps_df: pd.DataFrame,
     lap_state: dict[str, Any] | None,
     return_agent_outputs: bool,
+    memory_block: str | None = "",
 ) -> tuple[StrategyRecommendation, dict[str, Any] | None, dict[str, float]]:
     """The rich profile: the orchestrator's five-step sequence, outputs retained.
 
@@ -284,6 +310,12 @@ def _run_rich(
             pit_out=pit_out,
             radio_out=radio_out,
             regulation_context=regulation_context,
+            # The one argument in this call the orchestrator deliberately does NOT
+            # pass: /recommend and the MCP tool are stateless per request and have no
+            # race to accumulate over. tests/engine/test_memory_scope_is_deliberate.py
+            # holds that asymmetry open, because the threading guard next to it only
+            # looks the other way and is green on this by construction.
+            memory_block=memory_block,
         )
         synth = _get_orchestrator_llm().invoke(prompt)
         rec = _assemble_recommendation(

--- a/tests/agents/test_orchestrator_prompt.py
+++ b/tests/agents/test_orchestrator_prompt.py
@@ -90,6 +90,24 @@ def test_a_held_stay_out_asks_for_a_threshold_rather_than_the_same_case_again(
 
 
 @pytest.mark.unit
+def test_the_continuation_instruction_is_not_in_the_unconditioned_prompt(prompt: str) -> None:
+    """ "Do not re-argue the same case" is only true when there IS a previous case.
+
+    It used to sit in the static block, so it fired on lap 1, when there was nothing
+    to continue, and on the lap the call changed, when continuing was the wrong
+    answer. It now lives in `DecisionMemory`'s block, which is the only place that
+    knows whether anything is being repeated. `/recommend` and the MCP tool are
+    stateless per request, so for them this instruction is now correctly absent
+    rather than unconditionally present.
+
+    If this fails, check whether the sentence was reintroduced here instead of being
+    conditioned there.
+    """
+    assert "CONTINUING a plan" not in prompt
+    assert "re-argue the same case" not in prompt
+
+
+@pytest.mark.unit
 def test_the_default_memory_block_leaves_the_prompt_byte_identical(race_state) -> None:
     """The memoryless surfaces must get exactly the prompt they got before the parameter existed.
 

--- a/tests/agents/test_orchestrator_prompt.py
+++ b/tests/agents/test_orchestrator_prompt.py
@@ -32,11 +32,11 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture
-def prompt() -> str:
-    """A prompt with no sub-agent outputs, so only the static blocks remain."""
-    from src.agents.strategy_orchestrator import RaceState, _build_orchestrator_prompt
+def race_state():
+    """The one RaceState every prompt in this file is built from."""
+    from src.agents.strategy_orchestrator import RaceState
 
-    race_state = RaceState(
+    return RaceState(
         driver="NOR",
         lap=25,
         total_laps=57,
@@ -49,6 +49,13 @@ def prompt() -> str:
         air_temp=22.7,
         track_temp=28.1,
     )
+
+
+@pytest.fixture
+def prompt(race_state) -> str:
+    """A prompt with no sub-agent outputs, so only the static blocks remain."""
+    from src.agents.strategy_orchestrator import _build_orchestrator_prompt
+
     return _build_orchestrator_prompt(race_state, {}, "STAY_OUT")
 
 
@@ -80,6 +87,85 @@ def test_a_held_stay_out_asks_for_a_threshold_rather_than_the_same_case_again(
     # and every demand below straddles a line break in the source.
     for demand in ("what you are watching", "the concrete threshold", "would change the call"):
         assert demand in prompt, f"the held-STAY_OUT block no longer asks for: {demand}"
+
+
+@pytest.mark.unit
+def test_the_default_memory_block_leaves_the_prompt_byte_identical(race_state) -> None:
+    """The memoryless surfaces must get exactly the prompt they got before the parameter existed.
+
+    ``/recommend`` and the MCP tool are stateless per request, so they will never
+    pass a block and must not be changed by the fact that others can. Byte
+    equality is the only assertion that proves it: a prompt that gained a stray
+    blank line still returns a well-formed recommendation, so nothing else in the
+    suite would notice.
+
+    Both spellings of "no memory" are checked, because ``DecisionMemory.block()``
+    returns ``None`` before there is any history and a caller passing it straight
+    through is the natural way to use it. Without the guard in the builder that
+    renders the literal string "None" above ``RACE CONTEXT:``, which equality with
+    the empty-block prompt is what catches. (A bare "None" not in prompt would not
+    work here: the field-schema instructions use the word legitimately.)
+    """
+    from src.agents.strategy_orchestrator import _build_orchestrator_prompt
+
+    baseline = _build_orchestrator_prompt(race_state, {}, "STAY_OUT")
+
+    assert _build_orchestrator_prompt(race_state, {}, "STAY_OUT", memory_block="") == baseline
+    assert _build_orchestrator_prompt(race_state, {}, "STAY_OUT", memory_block=None) == baseline
+
+
+@pytest.mark.unit
+def test_a_supplied_memory_block_lands_between_the_framing_and_the_facts(race_state) -> None:
+    """Position is the point: the model reads what it decided before it reads this lap.
+
+    Above ``RACE CONTEXT:`` and below the held-STAY_OUT framing, which is the anchor
+    the A/B harness spliced at while measuring this. If the block moves, the measured
+    result stops applying to the shipped prompt.
+    """
+    from src.agents.strategy_orchestrator import _build_orchestrator_prompt
+
+    block = "DECISION MEMORY (your own previous calls this race):\n  Last call: STAY_OUT.\n\n"
+    prompt = _build_orchestrator_prompt(race_state, {}, "STAY_OUT", memory_block=block)
+
+    assert block in prompt
+    assert prompt.index("ACTIVE monitoring posture") < prompt.index(block)
+    assert prompt.index(block) < prompt.index("RACE CONTEXT:")
+
+
+@pytest.mark.unit
+def test_the_real_decision_memory_block_renders_into_the_prompt(race_state) -> None:
+    """Against the shipping producer, not a hand-written string.
+
+    The two objects are wired together by nothing but a string, so a change to
+    ``DecisionMemory``'s rendering that broke the placement would otherwise be
+    caught by no test in either file.
+    """
+    from types import SimpleNamespace
+
+    from src.agents.strategy_orchestrator import _build_orchestrator_prompt
+    from src.strategy.inference.decision_memory import DecisionMemory
+
+    memory = DecisionMemory()
+    memory.record(
+        5,
+        SimpleNamespace(
+            action="STAY_OUT",
+            pit_lap_target=22,
+            contingencies=[
+                SimpleNamespace(
+                    trigger="SC deployed within 3 laps", switch_to="PIT_NOW", priority="HIGH"
+                )
+            ],
+        ),
+    )
+    prompt = _build_orchestrator_prompt(race_state, {}, "STAY_OUT", memory_block=memory.block())
+
+    assert "DECISION MEMORY" in prompt
+    assert "SC deployed within 3 laps" in prompt
+    # The counterweight is not optional decoration: without it the block measurably
+    # anchored the model at the decision lap.
+    assert "NOT a commitment" in prompt
+    assert prompt.index("DECISION MEMORY") < prompt.index("RACE CONTEXT:")
 
 
 @pytest.mark.unit

--- a/tests/engine/ast_helpers.py
+++ b/tests/engine/ast_helpers.py
@@ -1,0 +1,37 @@
+"""Static inspection of what one function passes to another.
+
+Shared by the two anti-drift guards in this directory, which ask opposite
+questions of the same call sites: ``test_engine_threads_every_argument`` asserts
+the engine passes everything the orchestrator does, and
+``test_memory_scope_is_deliberate`` asserts one specific argument goes only one
+way. A second copy of this parser is exactly the shape of defect both files exist
+to catch, so it lives here instead.
+
+Static rather than runtime because the alternative is calling the layer functions
+for real, which needs the model weights, an LLM client and a race state. The
+question is about the call site, not the result.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+
+def kwargs_passed_by(func, callee: str) -> set[str]:
+    """The keyword names ``func`` passes to ``callee``.
+
+    Returns an empty set when ``func`` never calls ``callee``, which callers must
+    distinguish from "calls it with no keywords" themselves — assert the call
+    exists first, or an empty set reads as a passing test for a function that was
+    renamed out from under it.
+    """
+    tree = ast.parse(inspect.getsource(func).lstrip())
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == callee
+        ):
+            return {kw.arg for kw in node.keywords if kw.arg}
+    return set()

--- a/tests/engine/test_decision_memory.py
+++ b/tests/engine/test_decision_memory.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 import pytest
 
 from src.strategy.inference.decision_memory import (
+    CONTINUATION,
     COUNTERWEIGHT,
     MAX_CONTINGENCIES,
     DecisionMemory,
@@ -144,6 +145,70 @@ def test_the_counterweight_is_always_present():
     memory = DecisionMemory()
     memory.record(5, _rec())
     assert COUNTERWEIGHT in memory.block()
+
+
+@pytest.mark.unit
+def test_a_single_call_is_not_a_continuation():
+    """One STAY_OUT is a call, not a plan being carried.
+
+    This is the case that made the instruction wrong in the static prompt: it also
+    fired on the very first decision of a race, telling the model not to re-argue a
+    case it had never argued.
+    """
+    memory = DecisionMemory()
+    memory.record(5, _rec())
+
+    block = memory.block()
+    assert CONTINUATION not in block
+    assert COUNTERWEIGHT in block, "the counterweight is unconditional; only this line is not"
+
+
+@pytest.mark.unit
+def test_a_repeated_stay_out_is_told_it_is_continuing_a_plan():
+    """The one case the instruction was always meant for (audit section 3.1)."""
+    memory = DecisionMemory()
+    memory.record(5, _rec())
+    memory.record(6, _rec())
+
+    assert CONTINUATION in memory.block()
+
+
+@pytest.mark.unit
+def test_a_changed_call_is_not_a_continuation():
+    """The other case it was wrong in: the lap the plan actually changed.
+
+    A STAY_OUT that follows an UNDERCUT is a new decision. Telling the model not to
+    re-argue it is telling it not to think about the only lap that moved.
+    """
+    memory = DecisionMemory()
+    memory.record(5, _rec())
+    memory.record(6, _rec(action="UNDERCUT"))
+    memory.record(7, _rec())
+
+    assert CONTINUATION not in memory.block()
+
+
+@pytest.mark.unit
+def test_a_repeated_pit_call_is_not_a_continuing_plan():
+    """STAY_OUT is the only action a race can sit on.
+
+    A repeated PIT_NOW is not a plan being carried, it is a stop that has not
+    happened, and it is the last thing that should be discouraged from re-arguing.
+    """
+    memory = DecisionMemory()
+    memory.record(5, _rec(action="PIT_NOW"))
+    memory.record(6, _rec(action="PIT_NOW"))
+
+    assert CONTINUATION not in memory.block()
+
+
+@pytest.mark.unit
+def test_the_span_reads_as_english_for_a_single_lap():
+    """It rendered "(1 laps)" on the first held lap of every real run."""
+    memory = DecisionMemory()
+    memory.record(20, _rec())
+
+    assert "held since lap 20 (1 lap)." in memory.block()
 
 
 @pytest.mark.unit

--- a/tests/engine/test_engine_memory.py
+++ b/tests/engine/test_engine_memory.py
@@ -1,0 +1,181 @@
+"""The memory block the caller supplies must actually reach the Layer 3 prompt.
+
+Nothing else in the suite can tell you this. `run_lap`'s parameter defaults to `None`,
+so every existing engine test passes whatever the memory path does — including doing
+nothing at all. That is the price of keeping the engine pure, and it is why this file
+exists rather than being folded into `test_engine_no_llm`.
+
+HOW IT IS CHECKED, and why not end to end. Driving `run_lap(profile="rich")` for real
+does not work as a test of this: the rich profile builds LLM clients for the always-on
+sub-agents long before the prompt is assembled, so the first attempt at this file failed
+on a connection error rather than on anything about memory. The chain is therefore
+verified as its three links instead, each one hermetically:
+
+  1. `run_lap` turns a `DecisionMemory` into a block string and hands it to `_run_rich`
+  2. `_run_rich` passes that string to `_build_orchestrator_prompt`
+  3. the builder renders it into the prompt — `tests/agents/test_orchestrator_prompt.py`
+
+Link 2 is a static check for the same reason `test_engine_threads_every_argument` is:
+the question is about a call site, and that guard cannot answer this one because it
+compares the engine against the orchestrator, which deliberately does not pass memory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from tests.engine.ast_helpers import kwargs_passed_by
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+pytestmark = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="data/models/ not present (CI runner without model weights)",
+)
+
+FIXTURE = ROOT / "tests" / "fixtures" / "mini_race.parquet"
+TRIGGER = "SC deployed within 3 laps"
+
+
+def _memory_with_one_lap(lap: int = 5):
+    from src.strategy.inference.decision_memory import DecisionMemory
+
+    memory = DecisionMemory()
+    memory.record(
+        lap,
+        SimpleNamespace(
+            action="STAY_OUT",
+            pit_lap_target=22,
+            contingencies=[SimpleNamespace(trigger=TRIGGER, switch_to="PIT_NOW", priority="HIGH")],
+        ),
+    )
+    return memory
+
+
+def _race_state(lap: int = 6):
+    from src.agents.strategy_orchestrator import RaceState
+
+    return RaceState(
+        driver="NOR",
+        lap=lap,
+        total_laps=57,
+        position=5,
+        compound="MEDIUM",
+        tyre_life=10,
+        gap_ahead_s=2.0,
+        pace_delta_s=0.0,
+        risk_tolerance=0.5,
+        air_temp=25.0,
+        track_temp=35.0,
+    )
+
+
+@pytest.fixture
+def rich_call(monkeypatch):
+    """Capture the arguments `run_lap` hands to `_run_rich`, without running it."""
+    from src.strategy.inference import engine
+
+    seen: dict = {}
+
+    def _capture(*args, **kwargs):
+        seen["args"] = args
+        seen["kwargs"] = kwargs
+        return ("rec", None, {})
+
+    monkeypatch.setattr(engine, "_run_rich", _capture)
+    return seen
+
+
+@pytest.mark.unit
+def test_run_lap_renders_the_memory_into_a_block_for_the_rich_path(rich_call):
+    """Link 1: a `DecisionMemory` in, the rendered block out.
+
+    Asserted on the contingency trigger, because the echo is the load-bearing field —
+    it is what took the Safety Car experiment from 0 of 8 to 8 of 8. A block that
+    rendered its header and dropped its contingencies would still look like memory
+    in a diff.
+    """
+    from src.strategy.inference.engine import run_lap
+
+    run_lap(_race_state(), pd.read_parquet(FIXTURE), None, memory=_memory_with_one_lap())
+
+    block = rich_call["args"][-1]
+    assert "DECISION MEMORY" in block
+    assert TRIGGER in block
+
+
+@pytest.mark.unit
+def test_run_lap_without_memory_sends_an_empty_block(rich_call):
+    """The default must be indistinguishable from before the parameter existed.
+
+    Empty string, not `None`: the two are equivalent inside the builder, but only
+    because it guards for it, and this pins which one the engine actually sends.
+    """
+    from src.strategy.inference.engine import run_lap
+
+    run_lap(_race_state(), pd.read_parquet(FIXTURE), None)
+
+    assert rich_call["args"][-1] == ""
+
+
+@pytest.mark.unit
+def test_the_rich_path_passes_the_block_to_the_prompt_builder():
+    """Link 2, statically: the argument survives the last hop.
+
+    `test_engine_threads_every_argument` cannot cover this. It asserts the engine
+    passes everything the ORCHESTRATOR passes, and the orchestrator deliberately does
+    not pass memory (see `test_memory_scope_is_deliberate`), so the block reaching the
+    builder is asserted by nothing but this line.
+    """
+    from src.strategy.inference import engine
+
+    passed = kwargs_passed_by(engine._run_rich, "_build_orchestrator_prompt")
+
+    assert "memory_block" in passed, (
+        "the rich path builds the prompt without the memory block, so every surface "
+        "that wires an accumulator is accumulating into nothing"
+    )
+
+
+@pytest.mark.unit
+def test_run_lap_does_not_record_into_the_memory_it_is_given(rich_call):
+    """Recording is the CALLER's job, and this is what keeps it that way.
+
+    If the engine recorded, `run_lap` would stop being pure per lap and
+    `test_engine_no_llm`'s twice-on-lap-6 equality would start depending on call
+    order — a failure that would surface far from its cause.
+    """
+    from src.strategy.inference.engine import run_lap
+
+    memory = _memory_with_one_lap()
+    before = memory.block()
+
+    run_lap(_race_state(), pd.read_parquet(FIXTURE), None, memory=memory)
+
+    assert memory.block() == before, (
+        "run_lap mutated the caller's DecisionMemory; the accumulator is caller-owned "
+        "and the engine must only read it"
+    )
+
+
+def test_the_no_llm_profile_accepts_a_memory_and_ignores_it():
+    """The documented behaviour, made executable.
+
+    `no-llm` builds no prompt, so there is nowhere for a block to go. Passing one has
+    to be harmless rather than a `TypeError` — surfaces switch profiles at runtime and
+    would otherwise need a conditional at every call site.
+    """
+    from src.strategy.inference.engine import run_lap
+
+    laps_df = pd.read_parquet(FIXTURE)
+    memory = _memory_with_one_lap()
+
+    with_memory = run_lap(_race_state(), laps_df, None, profile="no-llm", memory=memory)[0]
+    without = run_lap(_race_state(), laps_df, None, profile="no-llm")[0]
+
+    assert with_memory.action == without.action
+    assert memory.block() is not None

--- a/tests/engine/test_engine_threads_every_argument.py
+++ b/tests/engine/test_engine_threads_every_argument.py
@@ -26,10 +26,11 @@ enforced one.
 
 from __future__ import annotations
 
-import inspect
 from pathlib import Path
 
 import pytest
+
+from tests.engine.ast_helpers import kwargs_passed_by
 
 ROOT = Path(__file__).parent.parent.parent
 _HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
@@ -48,18 +49,8 @@ _THREADED_CALLEES = ("_assemble_recommendation", "_build_orchestrator_prompt")
 
 
 def _kwargs_passed_by(func, callee: str = "_assemble_recommendation") -> set[str]:
-    """The keyword names `func` passes to `callee`."""
-    import ast
-
-    tree = ast.parse(inspect.getsource(func).lstrip())
-    for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == callee
-        ):
-            return {kw.arg for kw in node.keywords if kw.arg}
-    return set()
+    """The keyword names `func` passes to `callee`, with this file's default callee."""
+    return kwargs_passed_by(func, callee)
 
 
 @pytest.mark.parametrize("callee", _THREADED_CALLEES)

--- a/tests/engine/test_engine_threads_every_argument.py
+++ b/tests/engine/test_engine_threads_every_argument.py
@@ -97,6 +97,12 @@ def test_the_docstring_does_not_name_a_test_that_does_not_exist():
     The docstring cited a `tests/test_engine_parity.py` that was never written. Naming a
     guard that does not exist is worse than naming none, because it discourages checking.
     This scans the "Anti-drift guards" section and asserts each file it points at is real.
+
+    The pattern allows a subdirectory. It did not, and every guard the docstring names
+    now lives in `tests/engine/`, so this test matched NOTHING and passed green while
+    asserting about zero files - the same defect it was written to catch, one level up.
+    The count assertion is what stops that recurring: a pattern that stops matching is
+    indistinguishable from a docstring with nothing to check.
     """
     import re
 
@@ -104,7 +110,10 @@ def test_the_docstring_does_not_name_a_test_that_does_not_exist():
 
     doc = engine.__doc__ or ""
     section = doc.split("Anti-drift guard", 1)[-1].split("\n\n", 1)[0]
-    for name in re.findall(r"tests/test_[a-z_]+\.py", section):
+    named = re.findall(r"tests/[a-z_/]*test_[a-z_]+\.py", section)
+
+    assert named, "the engine docstring's anti-drift section names no test files at all"
+    for name in named:
         assert (ROOT / name).exists(), (
             f"the engine docstring names {name} as an anti-drift guard, but it does not exist"
         )

--- a/tests/engine/test_memory_scope_is_deliberate.py
+++ b/tests/engine/test_memory_scope_is_deliberate.py
@@ -1,0 +1,90 @@
+"""The decision-memory block reaches three surfaces and deliberately not the other two.
+
+`run_lap`'s callers own a race — the CLI loop, the arcade connector, the backend
+simulator's stream — so each can hold one `DecisionMemory` for its lifetime and pass
+the rendered block down. `/recommend` and the MCP tool cannot: both are stateless per
+request, with no race-scoped object to accumulate on, so the webapp Strategy tab keeps
+the memoryless prompt. That is a declared limitation, not an oversight.
+
+WHY THIS NEEDS ITS OWN FILE, when an anti-drift guard already exists next door.
+`test_engine_threads_every_argument` asserts `orch_kwargs - engine_kwargs`: the
+ORCHESTRATOR has an argument the ENGINE lacks. That is the direction both real
+failures took (#462, and the prompt builder in #675), and it is the direction that
+file was widened to cover.
+
+Memory goes the other way. The engine passes it; the orchestrator's stateless entry
+point deliberately does not. The existing guard is green on that by construction — its
+own docstring says so — so without this file the asymmetry is protected by nothing, and
+a later "make these two call sites consistent" cleanup would pass the whole suite while
+silently giving `/recommend` a memory it has no way to populate.
+
+The failure this prevents is not hypothetical in shape: `_rcm_events_for_lap` already
+exists twice with two signatures because a second surface grew its own copy of
+something the engine already had.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.engine.ast_helpers import kwargs_passed_by
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+pytestmark = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="data/models/ not present (CI runner without model weights)",
+)
+
+_PROMPT_BUILDER = "_build_orchestrator_prompt"
+_MEMORY_ARG = "memory_block"
+
+
+def test_the_stateless_entry_point_does_not_pass_a_memory_block():
+    """`/recommend` and the MCP tool must keep the memoryless prompt.
+
+    Both reach the orchestrator through `run_strategy_orchestrator_from_state`, one
+    request at a time, with nothing that survives between laps. A memory block there
+    could only ever be empty or, worse, filled from something request-scoped that
+    looks like a race and is not.
+
+    If this test fails because someone threaded memory into the orchestrator, the fix
+    is NOT to update the assertion. It is to give that surface a real race-scoped
+    accumulator or leave it alone.
+    """
+    import src.agents.strategy_orchestrator as orch
+
+    passed = kwargs_passed_by(orch.run_strategy_orchestrator_from_state, _PROMPT_BUILDER)
+
+    assert passed, (
+        f"no call to {_PROMPT_BUILDER} found in run_strategy_orchestrator_from_state; "
+        f"this guard is inspecting a call site that no longer exists"
+    )
+    assert _MEMORY_ARG not in passed, (
+        f"run_strategy_orchestrator_from_state now passes {_MEMORY_ARG!r}, but it is the "
+        f"entry point for /recommend and the MCP tool, which are stateless per request "
+        f"and have no race-scoped object to accumulate one on. Whatever it is passing "
+        f"is not this race's history. See src/strategy/inference/decision_memory.py."
+    )
+
+
+def test_the_prompt_builder_still_accepts_a_memory_block():
+    """The parameter has to exist for the asymmetry to mean anything.
+
+    Without this, deleting `memory_block` from the builder entirely would leave the
+    test above passing green and reporting a scope decision about an argument that no
+    longer exists.
+    """
+    import inspect
+
+    import src.agents.strategy_orchestrator as orch
+
+    signature = inspect.signature(orch._build_orchestrator_prompt)
+
+    assert _MEMORY_ARG in signature.parameters
+    assert signature.parameters[_MEMORY_ARG].default == "", (
+        "the memory block must default to empty: the stateless surfaces call the "
+        "builder without it and have to keep the prompt they had"
+    )


### PR DESCRIPTION
Promotes Sprint 2 of epic #648 to `main`. Closes #680, #681, #684, #685.

## What ships

The Layer 3 prompt was stateless: consecutive laps are 99% identical text, so the orchestrator re-argued an unrelated case every lap and never reused a plan it had made. `DecisionMemory` echoes this race's own previous calls back into the prompt — last action and its span, recent `pit_lap_target`s with drift, and the contingencies declared last lap — plus a counterweight, and a continuation line when there is a genuine hold.

The accumulator is owned by the **caller**, not the engine, so `run_lap` stays pure per lap.

| surface | memory |
|---|---|
| CLI `f1-sim` | yes |
| arcade | yes |
| backend `/simulate` stream, `rich` branch | yes |
| `/recommend`, MCP tool, webapp Strategy tab | **no, by design** |

## The measurement that justifies it

Re-run on `gpt-4.1-mini` at `temperature=0.0`, the client that honours the parameter:

| experiment | no memory | memory | Fisher |
|---|---|---|---|
| Safety Car, Lusail 2025 lap 42 | **0/8** | **8/8** | **p = 0.000155** |

The model had declared "SC deployed within 3 laps -> PIT_NOW" one lap earlier. The SC deployed. Without the echo it forgets its own plan; with it, every run executes it. On the sampling client this was 1/8 vs 7/8 — **removing the sampler sharpened the result**, which is the opposite of what a noise explanation predicts.

Over a full race the echo cuts distinct contingency triggers from ~27 to 5. On ordinary green laps it does **not** change the call (`action` differed on 0 of 41 laps); it changes whether consecutive laps are the same plan. On the lap a declared contingency fires, it does — and that is the mechanism.

## Verified on real runs

`f1-sim Lusail NOR McLaren --laps 20-26`, `rich`, prompts captured as sent. Lap 20 (first decided) carries no block; lap 21 reports `held since lap 20 (1 lap)` with no continuation; laps 22+ carry both. The span starts at the first lap actually decided, not lap 1.

## Known limits, stated rather than buried

- **The companion anchoring experiment went degenerate** — both arms stay out 10/10 on the deterministic client, so it measured nothing. Not evidence that memory is harmless at the decision lap.
- **The effect does not appear in `reasoning`.** 0 of 8 memory runs mentioned the prior plan while all 8 flipped the call. A changed recommendation must be debugged from the block, not the prose. Follow-up work.
- The continuation line was added **after** the gate measurement, so the shipped block differs slightly from the measured one. Direction not in doubt; the exact number was not re-taken.
- `/recommend` and MCP also lose that sentence — correct, since they can never know a call repeats, but unmeasured.
- The SC experiment's absolute 0/8 is **not** a product finding: those laps route N28/N30 in production and the harness prompts lack the pit block.
- Still one circuit, one driver, one race. `laps_held` remains the field with no demonstrated effect.
- Nothing retires a contingency (audit §3.3); the shipped mitigation bounds the block rather than solving it.

## Incidental fix

`test_the_docstring_does_not_name_a_test_that_does_not_exist` scanned for `tests/test_*.py` while every guard it names lives in `tests/engine/`. It matched **zero files** and passed green — the defect it exists to catch, one level up. Widened, plus a non-empty assertion.

## Checks

- full suite **380 passed, 4 skipped**
- ruff 0.15.22 `--no-cache` check + format clean
- `dev` CI green after the final merge
- submodule `VforVitorio/F1_Telemetry_Manager#204` merged, pointer bumped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added race-scoped decision memory to the CLI, Arcade, and backend simulation streams, allowing planning context and contingencies to carry across laps.
  * Improved continuation guidance when repeated stay-out decisions indicate an ongoing plan.
* **Documentation**
  * Documented supported memory surfaces, known limitations, and guidance for interpreting simulation results.
* **Bug Fixes**
  * Corrected singular and plural lap wording in decision-memory displays.
* **Tests**
  * Added coverage for memory rendering, continuation behavior, and stateless entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->