### PR TITLE
feat(memory): expose whether the last recorded call changed

### DIFF
--- a/src/strategy/inference/decision_memory.py
+++ b/src/strategy/inference/decision_memory.py
@@ -146,6 +146,28 @@ class DecisionMemory:
             )
         )
 
+    # ── what a surface needs to render the block ──────────────────────────
+    def last_call_changed(self) -> bool:
+        """True when the call just recorded differs from the one before it.
+
+        Call it AFTER ``record``. Surfaces use it to decide whether to show the
+        memory block already expanded: the block explains a decision, and the
+        decision worth explaining is the one that moved.
+
+        Only ``action`` counts, and that is a measured choice rather than a
+        stylistic one. Over 40 lap pairs of a real race the action changed on
+        0 of them while ``pit_lap_target`` moved on 25 (62%), so counting the
+        target would open the panel on two laps in three and turn a signal into
+        wallpaper. A target that drifts under an unchanged call is exactly what
+        the block's drift line is for; it is not a change of plan.
+
+        False with fewer than two entries: the first decision of a race is not
+        a change, and there is nothing to compare it against.
+        """
+        if len(self._entries) < 2:
+            return False
+        return self._entries[-1].action != self._entries[-2].action
+
     # ── derived views, each one line of the block ─────────────────────────
     def _current_run(self) -> tuple[str, int, int]:
         """The unbroken run of the latest action: (action, first lap, decisions)."""

--- a/tests/engine/test_decision_memory.py
+++ b/tests/engine/test_decision_memory.py
@@ -212,6 +212,50 @@ def test_the_span_reads_as_english_for_a_single_lap():
 
 
 @pytest.mark.unit
+def test_the_first_call_of_a_race_is_not_a_change():
+    """Nothing to compare against, so a surface must not open the panel on lap one."""
+    memory = DecisionMemory()
+    memory.record(5, _rec())
+
+    assert memory.last_call_changed() is False
+
+
+@pytest.mark.unit
+def test_a_repeated_action_is_not_a_change():
+    memory = DecisionMemory()
+    memory.record(5, _rec())
+    memory.record(6, _rec())
+
+    assert memory.last_call_changed() is False
+
+
+@pytest.mark.unit
+def test_a_new_action_is_a_change():
+    """The lap the call actually moved: this is the one worth explaining."""
+    memory = DecisionMemory()
+    memory.record(5, _rec())
+    memory.record(6, _rec(action="PIT_NOW"))
+
+    assert memory.last_call_changed() is True
+
+
+@pytest.mark.unit
+def test_a_drifting_target_under_an_unchanged_call_is_NOT_a_change():
+    """Measured, not stylistic: this is what stops the signal becoming wallpaper.
+
+    Over 40 lap pairs of a real race the action changed on 0 and `pit_lap_target`
+    moved on 25 (62%). Counting the target would open the panel on two laps in
+    three. A target drifting under a held call is what the block's drift line
+    reports; it is not a change of plan.
+    """
+    memory = DecisionMemory()
+    memory.record(5, _rec(pit_lap_target=30))
+    memory.record(6, _rec(pit_lap_target=44))
+
+    assert memory.last_call_changed() is False
+
+
+@pytest.mark.unit
 def test_recording_backwards_raises_rather_than_producing_a_false_span():
     memory = DecisionMemory()
     memory.record(10, _rec())


### PR DESCRIPTION
Part of #694, step 0 of 4. The shared piece every surface needs before any of them can render the block.

## What

`DecisionMemory.last_call_changed()` — true when the call just recorded differs from the one before it. Called after `record`.

Surfaces use it for the **auto-expand** decision agreed on the issue: the block explains a decision, and the decision worth explaining is the one that moved.

## Why it lives here

`DecisionMemory` is the object that knows the previous call. Reimplementing the comparison in the CLI, the arcade dashboard and the backend would be three copies of one rule — the defect this repo keeps paying for, and the reason `_rcm_events_for_lap` exists twice with two signatures.

## Only `action` counts, and that is measured

Over 40 lap pairs of a real race:

| definition of "changed" | fires on |
|---|---|
| `action` | **0 of 40 (0%)** |
| `pit_lap_target` | 25 of 40 (62%) |
| either | 25 of 40 (62%) |

Counting the target would open the panel on **two laps in three** and turn the signal into wallpaper. A target drifting under a held call is exactly what the block's own drift line reports; it is not a change of plan.

The 0% is the correct outcome, not a broken one: in that race the call genuinely never changed. It fires on the lap that matters — the Safety Car lap, where the action does flip.

## Checks

- `pytest tests/engine/` — 36 passed
- `ruff check --no-cache .` + `format --check` clean at the pinned 0.15.22