### PR TITLE
feat(cli): show the decision-memory block when the call changes

### DIFF
--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -1748,10 +1748,15 @@ def run(args: argparse.Namespace) -> None:
                 # deterministic, zero LLM clients (fixes #166). `outs` carries the
                 # six sub-agent outputs the detail panel renders — no second pass.
                 profile = "no-llm" if args.no_llm else "rich"
+                # Captured before run_lap, not after record: this is what the prompt
+                # actually saw this lap. record() below mutates the accumulator, so
+                # reading the block afterwards would show next lap's history instead.
+                memory_block = memory.block()
                 result, outs, _ = run_lap(
                     race_state, laps_df, lap_state, profile=profile, memory=memory
                 )
                 memory.record(lap_num, result)
+                memory_changed = memory.last_call_changed()
                 scores = getattr(result, "scenario_scores", {})
                 action = getattr(result, "action", "?")
                 confidence = getattr(result, "confidence", 0.0)
@@ -1865,6 +1870,27 @@ def run(args: argparse.Namespace) -> None:
                 row_tbl.add_row(*row)
                 live.console.print(row_tbl)
                 live.console.print()  # visual breathing room between rows
+
+                # Memory only earns screen space on the lap it moved something:
+                # on an ordinary lap the call does not change (measured 0/41 at
+                # Lusail 2025) and the block would be wallpaper. --no-llm builds
+                # no prompt at all, so memory_block is None there and nothing
+                # renders, and no special case is needed for it.
+                if memory_changed and memory_block is not None:
+                    live.console.print(
+                        Panel(
+                            Text(memory_block, style=COL_DIM),
+                            title=(
+                                "[dim]why this call changed - what the orchestrator "
+                                "was told about its own previous calls[/dim]"
+                            ),
+                            title_align="left",
+                            border_style=COL_DIM,
+                            padding=(0, 1),
+                            expand=False,
+                        )
+                    )
+                    live.console.print()
 
                 # Summary counters — cheap, per-lap increments so the final
                 # "Run complete" panel can show action mix, compound stints


### PR DESCRIPTION
Part of #694, the CLI surface. Depends on #695 (merged).

## Why

The memory layer changes decisions and leaves **no trace in `reasoning`** — under a Safety Car it flipped the call on 8 of 8 runs and none of them mentioned the prior plan. Asking the model to narrate it was measured and made decisions worse (8/8 → 0/8), so the surface renders the deterministic block itself.

## What

On the lap where the call changed, the CLI prints the block into the scrolling history, above the fixed Live panel, titled "why this call changed - what the orchestrator was told about its own previous calls".

Two orderings are load-bearing and both are asserted by reading, not assumed:

- **`memory.block()` is captured BEFORE `run_lap`.** `record()` afterwards mutates the accumulator, so reading it later would show the *next* lap's history. What is printed is what the model was actually given.
- **`last_call_changed()` is read AFTER `record`**, which is that method's contract.

## Silence is the default, and that is measured

Over 40 lap pairs of a real race the action changed on **0** of them while `pit_lap_target` moved on **25 (62%)**. Rendering every lap would be wallpaper; the block exists to explain the lap that moved. `--no-llm` builds no prompt, so the block is `None` there and nothing renders without a special case.

## Checks

- `ruff check --no-cache` + `format --check` clean at the pinned 0.15.22
- `Panel`, `Text` and `COL_DIM` verified to exist in the file rather than taken on trust
- The printing mechanism copies the existing history-row pattern (`live.console.print(...)` then a bare `live.console.print()` for spacing), not `live.update`