### PR TITLE
feat(arcade): show the decision-memory block when the call changes

### DIFF
--- a/src/arcade/dashboard/reasoning_tabs.py
+++ b/src/arcade/dashboard/reasoning_tabs.py
@@ -12,6 +12,11 @@ when the agent did not emit a reasoning (stub path, conditional agent
 not fired, older checkpoint) the tab still surfaces the raw numbers.
 The RAG agent has no LLM reasoning; its retrieved text lives in the
 RAG card already, so it is not tabbed here.
+
+The Orchestrator tab additionally appends the DecisionMemory prompt
+block on laps where the call just changed (``plan_changed``), so the
+one lap where memory actually drives the decision is visible even
+though it leaves no trace in ``reasoning`` itself.
 """
 
 from __future__ import annotations
@@ -214,10 +219,18 @@ class ReasoningTabs(QTabWidget):
                 ed.setPlainText("")
             return
 
-        # Orchestrator: just the reasoning string.
-        self._editors["orchestrator"].setPlainText(
-            _clean(latest.get("reasoning")) or "— no reasoning —"
-        )
+        # Orchestrator: the reasoning string, plus the DecisionMemory block
+        # when this lap's call just changed. The block never shows up in
+        # `reasoning` even when it drives the call (see DecisionMemory's
+        # module docstring), so it is rendered here directly rather than
+        # trusting the LLM to narrate its own continuity. Hidden on every
+        # other lap: unconditional display was measured as wallpaper (the
+        # action changes on a small minority of laps).
+        orchestrator_text = _clean(latest.get("reasoning")) or "— no reasoning —"
+        memory_block = latest.get("memory_block")
+        if latest.get("plan_changed") and memory_block:
+            orchestrator_text += "\n\n--- why this call changed ---\n" + str(memory_block)
+        self._editors["orchestrator"].setPlainText(orchestrator_text)
 
         per = latest.get("per_agent") or {}
         for _, key in self._TABS:

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -130,6 +130,14 @@ class LapDecisionDTO:
     # dashboard can render predicted vs actual, CI bounds, cliff percentiles
     # and every other model detail that used to live only in the CLI panel).
     per_agent: PerAgentOutputsDTO | None = None
+    # DecisionMemory prompt block as it was BEFORE this lap's pipeline call
+    # (None on lap 1 or the no-llm profile, where no prompt is built at all)
+    # and whether this lap's action differs from the previous one. The block
+    # never shows up in `reasoning` even when it changes the call, so the
+    # dashboard renders it directly rather than relying on the LLM to narrate
+    # its own continuity.
+    memory_block: str | None = None
+    plan_changed: bool = False
 
 
 # --- Shared state ---------------------------------------------------------
@@ -413,12 +421,20 @@ class SimConnector(threading.Thread):
         from src.arcade.strategy_pipeline import run_strategy_pipeline
 
         race_state = self._build_race_state(lap_state, prev_lap_time)
+        # Captured BEFORE the pipeline call: this is the block as the model
+        # actually saw it. `record()` below mutates the accumulator, so reading
+        # it after would show this lap's own decision back to the dashboard
+        # instead of the plan the model was given.
+        memory_block = self._memory.block()
         rec, agent_outputs = run_strategy_pipeline(
             race_state, laps_df, lap_state, memory=self._memory
         )
         self._memory.record(race_state.lap, rec)
+        plan_changed = self._memory.last_call_changed()
         lap_time_s = lap_state.get("driver", {}).get("lap_time_s")
-        decision = _build_decision(rec, race_state, lap_time_s, agent_outputs)
+        decision = _build_decision(
+            rec, race_state, lap_time_s, agent_outputs, memory_block, plan_changed
+        )
         with self._state._lock:
             self._state.latest = decision
             self._state.history.append(decision)
@@ -789,6 +805,8 @@ def _build_decision(
     race_state: Any,
     lap_time_s: float | None,
     agent_outputs: dict[str, Any],
+    memory_block: str | None = None,
+    plan_changed: bool = False,
 ) -> LapDecisionDTO:
     """Merge the synthesised ``StrategyRecommendation`` + raw agent outputs
     into the DTO consumed by ``StrategyState.history`` / the dashboard.
@@ -796,6 +814,10 @@ def _build_decision(
     ``agent_alerts`` is rebuilt from ``radio_out.alerts`` the same way
     ``simulator._parse_lap_decision`` does it (string-or-dict tolerant)
     so the dashboard's alerts feed stays schema-stable across paths.
+
+    ``memory_block`` / ``plan_changed`` come from ``DecisionMemory`` and are
+    just carried onto the DTO here; the caller (``_step_once``) is the one
+    that decides when each is captured relative to ``record()``.
     """
     radio_out = agent_outputs.get("radio_out")
     agent_alerts: list[str] = []
@@ -826,4 +848,6 @@ def _build_decision(
         agent_alerts=agent_alerts,
         guardrail_reason=None,
         per_agent=_build_per_agent(agent_outputs),
+        memory_block=memory_block,
+        plan_changed=plan_changed,
     )


### PR DESCRIPTION
Part of #694, the arcade surface. Depends on #695 (merged).

## Why

Same reason as the CLI: the memory layer changes decisions and leaves **no trace in `reasoning`** (8 of 8 runs under a Safety Car, none mentioning the prior plan). Asking the model to narrate it was measured and made decisions worse, so the dashboard renders the block itself.

## What

- `LapDecisionDTO` (frozen dataclass) gains `memory_block` and `plan_changed` as real fields.
- `_step_once` captures the block **before** `run_strategy_pipeline` and reads the changed-flag **after** `record`, then threads both through `_build_decision`.
- The dashboard's Orchestrator tab appends the block under a `--- why this call changed ---` header, **only** when the call changed.

## Two things worth knowing

**Nothing had to change on the transport.** `StrategyState.snapshot_dict()` already does `asdict()` over the whole DTO, so the new fields ride the existing TCP JSON stream and the dashboard's `json.loads` picks them up. No schema to keep in sync on the other side.

**No new panel type was invented.** The Orchestrator tab already renders monospace, scrollable text and already composes sections conditionally, so the block reuses that. An 8-line block does not fit `OrchestratorCard`'s compact one-line convention without reflowing it, and reflowing a card to host a rarely-shown block is the wrong trade.

The block is appended raw rather than through `_clean()`, deliberately: `_clean` flattens newlines and the block's line structure is what makes it readable.

## Silence is the default, and that is measured

Over 40 lap pairs of a real race the action changed on **0** while `pit_lap_target` moved on **25 (62%)**. Unconditional display would be wallpaper.

## Checks

- `ruff check --no-cache` + `format --check` clean at the pinned 0.15.22
- `asdict` serialisation path verified in the file rather than assumed