### PR TITLE
feat(backend): bump telemetry to the lap payload carrying the decision-memory block

### DIFF
--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -49,6 +49,17 @@ _skip_no_backend = pytest.mark.skipif(
     reason="src/telemetry/backend not present in this checkout",
 )
 
+# Importing `simulator` is not free: it pulls the agent modules, which read their
+# routing config at IMPORT time. So a test that needs nothing but the module still
+# needs the weights on disk, and `_skip_no_backend` alone is not enough — that
+# combination is what made the first version of the payload tests fail on CI while
+# passing locally.
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+_skip_no_models = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="data/models/ not present (importing the simulator reads model config)",
+)
+
 
 def _ensure_backend_on_path() -> None:
     """Insert ``src/telemetry`` at the front of ``sys.path``.
@@ -238,6 +249,7 @@ def test_simulate_request_rejects_invalid_provider():
 
 
 @_skip_no_backend
+@_skip_no_models
 def test_the_memory_block_reaches_the_lap_payload():
     """The block the orchestrator was shown must survive into the wire format.
 
@@ -281,6 +293,7 @@ def test_the_memory_block_reaches_the_lap_payload():
 
 
 @_skip_no_backend
+@_skip_no_models
 def test_a_lap_with_no_memory_still_carries_both_fields():
     """Absent memory is an explicit pair of values, never missing keys.
 

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -120,6 +120,17 @@ def test_simulate_race_emits_start_lap_summary():
     assert "scenario_scores" in first_lap
     assert isinstance(first_lap["scenario_scores"], dict)
 
+    # The memory fields must be on the wire even on this branch, so the webapp can
+    # rely on their presence rather than probing for them. no-llm builds no prompt,
+    # so there is no block: the values are the explicit "no memory here" pair, not
+    # missing keys.
+    assert "memory_block" in first_lap, (
+        "LapDecision must always carry memory_block; the webapp reads it to explain "
+        "a changed recommendation and cannot branch on a key that sometimes exists"
+    )
+    assert first_lap["memory_block"] is None, "the no-llm branch builds no prompt to hold a block"
+    assert first_lap["plan_changed"] is False
+
 
 # ---------------------------------------------------------------------------
 # Integration — /api/v1/strategy/simulate SSE endpoint
@@ -224,3 +235,78 @@ def test_simulate_request_rejects_invalid_provider():
         SimulateRequest(
             year=2025, gp="Melbourne", driver="NOR", team="McLaren", provider="anthropic"
         )
+
+
+@_skip_no_backend
+def test_the_memory_block_reaches_the_lap_payload():
+    """The block the orchestrator was shown must survive into the wire format.
+
+    This is the whole point of #694: the memory layer changes decisions and leaves
+    no trace in `reasoning`, and asking the model to narrate it was measured and
+    made the decisions worse. So the explanation has to be the deterministic INPUT,
+    which means it has to reach the webapp intact.
+
+    Exercised through `_parse_lap_decision` rather than a live `rich` simulation
+    because a real run needs an LLM provider; what is under test here is the
+    transport, and the layer below it was verified on a real `f1-sim` run.
+    """
+    _ensure_backend_on_path()
+    from types import SimpleNamespace
+
+    from backend.services.simulation.simulator import _parse_lap_decision
+
+    block = "DECISION MEMORY (your own previous calls this race):\n  Last call: STAY_OUT.\n"
+    race_state = SimpleNamespace(
+        lap=42, compound="MEDIUM", tyre_life=20, position=3, gap_ahead_s=1.8
+    )
+    result = SimpleNamespace(
+        action="PIT_NOW",
+        confidence=0.9,
+        reasoning="stub",
+        scenario_scores={},
+        pace_mode=None,
+        risk_posture=None,
+        pit_lap_target=42,
+        compound_next="HARD",
+        undercut_target=None,
+    )
+
+    decision = _parse_lap_decision(
+        result, race_state, {}, 90.0, memory_block=block, plan_changed=True
+    )
+    payload = decision.model_dump()
+
+    assert payload["memory_block"] == block
+    assert payload["plan_changed"] is True
+
+
+@_skip_no_backend
+def test_a_lap_with_no_memory_still_carries_both_fields():
+    """Absent memory is an explicit pair of values, never missing keys.
+
+    The webapp has to render "no history for this call" rather than branch on a
+    key that sometimes exists. `/recommend` and the MCP tool are memoryless by
+    design, so that state is permanent, not transitional.
+    """
+    _ensure_backend_on_path()
+    from types import SimpleNamespace
+
+    from backend.services.simulation.simulator import _parse_lap_decision
+
+    race_state = SimpleNamespace(lap=1, compound="SOFT", tyre_life=1, position=5, gap_ahead_s=0.0)
+    result = SimpleNamespace(
+        action="STAY_OUT",
+        confidence=0.5,
+        reasoning="stub",
+        scenario_scores={},
+        pace_mode=None,
+        risk_posture=None,
+        pit_lap_target=None,
+        compound_next=None,
+        undercut_target=None,
+    )
+
+    payload = _parse_lap_decision(result, race_state, {}, None).model_dump()
+
+    assert payload["memory_block"] is None
+    assert payload["plan_changed"] is False


### PR DESCRIPTION
Closes #694. Picks up submodule PRs `F1_Telemetry_Manager#205` (lap payload) and `#206` (Strategy tab note), both merged.

## What lands with the bump

- `LapDecision` gains `memory_block` and `plan_changed`, always present on the wire.
- The Strategy tab states in one line that its brief has no memory of earlier calls.

## The tests live here, deliberately

The submodule's CI installs a **deps-lite** set (pytest, pydantic, fastapi, httpx) and cannot import `simulator.py`, which pulls the whole ML stack through `src.strategy.inference.engine`. This repo can. Three assertions:

- both fields are on the wire even on the **no-llm** branch, so the webapp never has to probe for a key that sometimes exists
- a supplied block survives `_parse_lap_decision` into the payload
- an absent one is an explicit `None` / `False` pair, not missing keys

## A finding worth recording

**Nothing in the webapp consumes `/simulate`.** `strategy/simulate` appears only in the generated `schema.ts` and one comment in `sse.ts`; the Strategy tab is entirely `POST /recommend`, which is stateless. So the block has no consumer on that surface today and only the note applied there. It still travels on the payload, so a future consumer gets it free rather than needing this work redone.

## Checks

- `pytest tests/simulation/` — 29 passed against the merged submodule
- `ruff check --no-cache .` + `format --check .` clean at the pinned 0.15.22