### PR TITLE
Render the decision-memory block on every surface that has one

### DIFF
--- a/documents/audits/AUDIT_ORCHESTRATOR_MEMORY.md
+++ b/documents/audits/AUDIT_ORCHESTRATOR_MEMORY.md
@@ -1087,3 +1087,70 @@ requirement in §2.4 holding up outside a unit test.
   last lap's list is echoed, which bounds the block rather than solving the problem.
 - **The measurement is still one circuit, one driver, one race.** Nothing in Sprint 2
   widened it.
+
+---
+
+# NEGATIVE RESULT, 2026-07-28 — asking the model to report its own continuity DESTROYS the effect
+
+§3.5 rated this HIGH and it is the one loose end Sprint 2 left: the block changes the
+decision and leaves **no trace in `reasoning`**. Under a Safety Car it flipped the call on
+8 of 8 runs and 0 of those 8 mentioned the prior plan. An effect you cannot see in the
+output is an effect you cannot debug in production, so the obvious follow-up (#691) was to
+ask for it: have `reasoning` open with `CONTINUING` or `DEPARTING`.
+
+**It does not work, and the failure is not subtle.** Three formulations, all measured on the
+same cached inputs, same deterministic client, n=8 on the Safety Car lap where the memory
+effect actually lives:
+
+| condition | takes the free stop | carries a label | says `DEPARTING` |
+|---|---|---|---|
+| **no instruction (shipped)** | **8/8** | 0/8 | 0/8 |
+| v1, label first | 6/8 | 2/8 | 0/8 |
+| v2, label first + worked examples | **0/8** | 8/8 | 0/8 |
+| v3, label LAST, explicitly after deciding | **0/8** | 7/8 | 0/8 |
+
+`8/8 → 0/8`, Fisher p = 0.000155.
+
+**The relationship is monotone in the wrong direction: the better the model complies with the
+labelling, the less it executes its own plan.** At full compliance (v2, v3) the Safety Car
+result — the entire justification for the memory layer — is gone.
+
+## Two things this rules out
+
+**It is not an ordering effect.** The first hypothesis was that classifying the call before
+reasoning forces a premature commitment to continuity. v3 tested exactly that: decide first,
+label as the last sentence, with "classify the decision you reached; do not let it steer the
+decision" stated outright. Identical damage. So it is not *when* the model is asked, it is
+*that* it is asked.
+
+**It is not a wording problem.** Three formulations spanning terse, exemplified and
+explicitly-guarded all produced the same outcome. Continuing to tune the sentence would be
+tuning against a mechanism that is not in the sentence.
+
+## What it says about how the block works
+
+`DEPARTING` was never emitted once — **0 of 65 calls** across every condition and both
+caches, including 41 green laps and 24 Safety Car runs. The model will label a call it is
+continuing and simply omits the label on a call it is changing (v1 shows this cleanly: the 2
+labels are on the 2 STAY_OUT runs, the 6 departures carry none).
+
+Read together with the decision damage, the working hypothesis is that **the echo does not
+operate through anything the model can introspect.** Asking it to describe its relationship
+to the history converts the block from context into a question about consistency, and a model
+asked whether it is being consistent answers yes — by being consistent, which on the Safety
+Car lap means not stopping.
+
+That also explains §3.5's original observation rather than merely restating it: the 8 runs
+that flipped the call did not mention the plan **because the mechanism is not available to
+them as a reason.**
+
+## Consequence for the product
+
+**Observability of this layer cannot be bought from the model.** #691 is closed unshipped.
+If a surface needs to explain why a recommendation changed, it must render **the block
+itself** next to the recommendation — the input, which is deterministic and already
+available — rather than ask the LLM to narrate it. That is a UI change, not a prompt change,
+and it costs nothing at inference.
+
+Anyone revisiting this should treat "just add an instruction asking it to say X about its own
+reasoning" as **measured and refuted for this prompt**, not untried.

--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -1748,10 +1748,15 @@ def run(args: argparse.Namespace) -> None:
                 # deterministic, zero LLM clients (fixes #166). `outs` carries the
                 # six sub-agent outputs the detail panel renders — no second pass.
                 profile = "no-llm" if args.no_llm else "rich"
+                # Captured before run_lap, not after record: this is what the prompt
+                # actually saw this lap. record() below mutates the accumulator, so
+                # reading the block afterwards would show next lap's history instead.
+                memory_block = memory.block()
                 result, outs, _ = run_lap(
                     race_state, laps_df, lap_state, profile=profile, memory=memory
                 )
                 memory.record(lap_num, result)
+                memory_changed = memory.last_call_changed()
                 scores = getattr(result, "scenario_scores", {})
                 action = getattr(result, "action", "?")
                 confidence = getattr(result, "confidence", 0.0)
@@ -1865,6 +1870,27 @@ def run(args: argparse.Namespace) -> None:
                 row_tbl.add_row(*row)
                 live.console.print(row_tbl)
                 live.console.print()  # visual breathing room between rows
+
+                # Memory only earns screen space on the lap it moved something:
+                # on an ordinary lap the call does not change (measured 0/41 at
+                # Lusail 2025) and the block would be wallpaper. --no-llm builds
+                # no prompt at all, so memory_block is None there and nothing
+                # renders, and no special case is needed for it.
+                if memory_changed and memory_block is not None:
+                    live.console.print(
+                        Panel(
+                            Text(memory_block, style=COL_DIM),
+                            title=(
+                                "[dim]why this call changed - what the orchestrator "
+                                "was told about its own previous calls[/dim]"
+                            ),
+                            title_align="left",
+                            border_style=COL_DIM,
+                            padding=(0, 1),
+                            expand=False,
+                        )
+                    )
+                    live.console.print()
 
                 # Summary counters — cheap, per-lap increments so the final
                 # "Run complete" panel can show action mix, compound stints

--- a/src/arcade/dashboard/reasoning_tabs.py
+++ b/src/arcade/dashboard/reasoning_tabs.py
@@ -12,6 +12,11 @@ when the agent did not emit a reasoning (stub path, conditional agent
 not fired, older checkpoint) the tab still surfaces the raw numbers.
 The RAG agent has no LLM reasoning; its retrieved text lives in the
 RAG card already, so it is not tabbed here.
+
+The Orchestrator tab additionally appends the DecisionMemory prompt
+block on laps where the call just changed (``plan_changed``), so the
+one lap where memory actually drives the decision is visible even
+though it leaves no trace in ``reasoning`` itself.
 """
 
 from __future__ import annotations
@@ -214,10 +219,18 @@ class ReasoningTabs(QTabWidget):
                 ed.setPlainText("")
             return
 
-        # Orchestrator: just the reasoning string.
-        self._editors["orchestrator"].setPlainText(
-            _clean(latest.get("reasoning")) or "— no reasoning —"
-        )
+        # Orchestrator: the reasoning string, plus the DecisionMemory block
+        # when this lap's call just changed. The block never shows up in
+        # `reasoning` even when it drives the call (see DecisionMemory's
+        # module docstring), so it is rendered here directly rather than
+        # trusting the LLM to narrate its own continuity. Hidden on every
+        # other lap: unconditional display was measured as wallpaper (the
+        # action changes on a small minority of laps).
+        orchestrator_text = _clean(latest.get("reasoning")) or "— no reasoning —"
+        memory_block = latest.get("memory_block")
+        if latest.get("plan_changed") and memory_block:
+            orchestrator_text += "\n\n--- why this call changed ---\n" + str(memory_block)
+        self._editors["orchestrator"].setPlainText(orchestrator_text)
 
         per = latest.get("per_agent") or {}
         for _, key in self._TABS:

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -130,6 +130,14 @@ class LapDecisionDTO:
     # dashboard can render predicted vs actual, CI bounds, cliff percentiles
     # and every other model detail that used to live only in the CLI panel).
     per_agent: PerAgentOutputsDTO | None = None
+    # DecisionMemory prompt block as it was BEFORE this lap's pipeline call
+    # (None on lap 1 or the no-llm profile, where no prompt is built at all)
+    # and whether this lap's action differs from the previous one. The block
+    # never shows up in `reasoning` even when it changes the call, so the
+    # dashboard renders it directly rather than relying on the LLM to narrate
+    # its own continuity.
+    memory_block: str | None = None
+    plan_changed: bool = False
 
 
 # --- Shared state ---------------------------------------------------------
@@ -413,12 +421,20 @@ class SimConnector(threading.Thread):
         from src.arcade.strategy_pipeline import run_strategy_pipeline
 
         race_state = self._build_race_state(lap_state, prev_lap_time)
+        # Captured BEFORE the pipeline call: this is the block as the model
+        # actually saw it. `record()` below mutates the accumulator, so reading
+        # it after would show this lap's own decision back to the dashboard
+        # instead of the plan the model was given.
+        memory_block = self._memory.block()
         rec, agent_outputs = run_strategy_pipeline(
             race_state, laps_df, lap_state, memory=self._memory
         )
         self._memory.record(race_state.lap, rec)
+        plan_changed = self._memory.last_call_changed()
         lap_time_s = lap_state.get("driver", {}).get("lap_time_s")
-        decision = _build_decision(rec, race_state, lap_time_s, agent_outputs)
+        decision = _build_decision(
+            rec, race_state, lap_time_s, agent_outputs, memory_block, plan_changed
+        )
         with self._state._lock:
             self._state.latest = decision
             self._state.history.append(decision)
@@ -789,6 +805,8 @@ def _build_decision(
     race_state: Any,
     lap_time_s: float | None,
     agent_outputs: dict[str, Any],
+    memory_block: str | None = None,
+    plan_changed: bool = False,
 ) -> LapDecisionDTO:
     """Merge the synthesised ``StrategyRecommendation`` + raw agent outputs
     into the DTO consumed by ``StrategyState.history`` / the dashboard.
@@ -796,6 +814,10 @@ def _build_decision(
     ``agent_alerts`` is rebuilt from ``radio_out.alerts`` the same way
     ``simulator._parse_lap_decision`` does it (string-or-dict tolerant)
     so the dashboard's alerts feed stays schema-stable across paths.
+
+    ``memory_block`` / ``plan_changed`` come from ``DecisionMemory`` and are
+    just carried onto the DTO here; the caller (``_step_once``) is the one
+    that decides when each is captured relative to ``record()``.
     """
     radio_out = agent_outputs.get("radio_out")
     agent_alerts: list[str] = []
@@ -826,4 +848,6 @@ def _build_decision(
         agent_alerts=agent_alerts,
         guardrail_reason=None,
         per_agent=_build_per_agent(agent_outputs),
+        memory_block=memory_block,
+        plan_changed=plan_changed,
     )

--- a/src/strategy/inference/decision_memory.py
+++ b/src/strategy/inference/decision_memory.py
@@ -146,6 +146,28 @@ class DecisionMemory:
             )
         )
 
+    # ── what a surface needs to render the block ──────────────────────────
+    def last_call_changed(self) -> bool:
+        """True when the call just recorded differs from the one before it.
+
+        Call it AFTER ``record``. Surfaces use it to decide whether to show the
+        memory block already expanded: the block explains a decision, and the
+        decision worth explaining is the one that moved.
+
+        Only ``action`` counts, and that is a measured choice rather than a
+        stylistic one. Over 40 lap pairs of a real race the action changed on
+        0 of them while ``pit_lap_target`` moved on 25 (62%), so counting the
+        target would open the panel on two laps in three and turn a signal into
+        wallpaper. A target that drifts under an unchanged call is exactly what
+        the block's drift line is for; it is not a change of plan.
+
+        False with fewer than two entries: the first decision of a race is not
+        a change, and there is nothing to compare it against.
+        """
+        if len(self._entries) < 2:
+            return False
+        return self._entries[-1].action != self._entries[-2].action
+
     # ── derived views, each one line of the block ─────────────────────────
     def _current_run(self) -> tuple[str, int, int]:
         """The unbroken run of the latest action: (action, first lap, decisions)."""

--- a/tests/engine/test_decision_memory.py
+++ b/tests/engine/test_decision_memory.py
@@ -212,6 +212,50 @@ def test_the_span_reads_as_english_for_a_single_lap():
 
 
 @pytest.mark.unit
+def test_the_first_call_of_a_race_is_not_a_change():
+    """Nothing to compare against, so a surface must not open the panel on lap one."""
+    memory = DecisionMemory()
+    memory.record(5, _rec())
+
+    assert memory.last_call_changed() is False
+
+
+@pytest.mark.unit
+def test_a_repeated_action_is_not_a_change():
+    memory = DecisionMemory()
+    memory.record(5, _rec())
+    memory.record(6, _rec())
+
+    assert memory.last_call_changed() is False
+
+
+@pytest.mark.unit
+def test_a_new_action_is_a_change():
+    """The lap the call actually moved: this is the one worth explaining."""
+    memory = DecisionMemory()
+    memory.record(5, _rec())
+    memory.record(6, _rec(action="PIT_NOW"))
+
+    assert memory.last_call_changed() is True
+
+
+@pytest.mark.unit
+def test_a_drifting_target_under_an_unchanged_call_is_NOT_a_change():
+    """Measured, not stylistic: this is what stops the signal becoming wallpaper.
+
+    Over 40 lap pairs of a real race the action changed on 0 and `pit_lap_target`
+    moved on 25 (62%). Counting the target would open the panel on two laps in
+    three. A target drifting under a held call is what the block's drift line
+    reports; it is not a change of plan.
+    """
+    memory = DecisionMemory()
+    memory.record(5, _rec(pit_lap_target=30))
+    memory.record(6, _rec(pit_lap_target=44))
+
+    assert memory.last_call_changed() is False
+
+
+@pytest.mark.unit
 def test_recording_backwards_raises_rather_than_producing_a_false_span():
     memory = DecisionMemory()
     memory.record(10, _rec())

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -49,6 +49,17 @@ _skip_no_backend = pytest.mark.skipif(
     reason="src/telemetry/backend not present in this checkout",
 )
 
+# Importing `simulator` is not free: it pulls the agent modules, which read their
+# routing config at IMPORT time. So a test that needs nothing but the module still
+# needs the weights on disk, and `_skip_no_backend` alone is not enough — that
+# combination is what made the first version of the payload tests fail on CI while
+# passing locally.
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+_skip_no_models = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="data/models/ not present (importing the simulator reads model config)",
+)
+
 
 def _ensure_backend_on_path() -> None:
     """Insert ``src/telemetry`` at the front of ``sys.path``.
@@ -238,6 +249,7 @@ def test_simulate_request_rejects_invalid_provider():
 
 
 @_skip_no_backend
+@_skip_no_models
 def test_the_memory_block_reaches_the_lap_payload():
     """The block the orchestrator was shown must survive into the wire format.
 
@@ -281,6 +293,7 @@ def test_the_memory_block_reaches_the_lap_payload():
 
 
 @_skip_no_backend
+@_skip_no_models
 def test_a_lap_with_no_memory_still_carries_both_fields():
     """Absent memory is an explicit pair of values, never missing keys.
 

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -120,6 +120,17 @@ def test_simulate_race_emits_start_lap_summary():
     assert "scenario_scores" in first_lap
     assert isinstance(first_lap["scenario_scores"], dict)
 
+    # The memory fields must be on the wire even on this branch, so the webapp can
+    # rely on their presence rather than probing for them. no-llm builds no prompt,
+    # so there is no block: the values are the explicit "no memory here" pair, not
+    # missing keys.
+    assert "memory_block" in first_lap, (
+        "LapDecision must always carry memory_block; the webapp reads it to explain "
+        "a changed recommendation and cannot branch on a key that sometimes exists"
+    )
+    assert first_lap["memory_block"] is None, "the no-llm branch builds no prompt to hold a block"
+    assert first_lap["plan_changed"] is False
+
 
 # ---------------------------------------------------------------------------
 # Integration — /api/v1/strategy/simulate SSE endpoint
@@ -224,3 +235,78 @@ def test_simulate_request_rejects_invalid_provider():
         SimulateRequest(
             year=2025, gp="Melbourne", driver="NOR", team="McLaren", provider="anthropic"
         )
+
+
+@_skip_no_backend
+def test_the_memory_block_reaches_the_lap_payload():
+    """The block the orchestrator was shown must survive into the wire format.
+
+    This is the whole point of #694: the memory layer changes decisions and leaves
+    no trace in `reasoning`, and asking the model to narrate it was measured and
+    made the decisions worse. So the explanation has to be the deterministic INPUT,
+    which means it has to reach the webapp intact.
+
+    Exercised through `_parse_lap_decision` rather than a live `rich` simulation
+    because a real run needs an LLM provider; what is under test here is the
+    transport, and the layer below it was verified on a real `f1-sim` run.
+    """
+    _ensure_backend_on_path()
+    from types import SimpleNamespace
+
+    from backend.services.simulation.simulator import _parse_lap_decision
+
+    block = "DECISION MEMORY (your own previous calls this race):\n  Last call: STAY_OUT.\n"
+    race_state = SimpleNamespace(
+        lap=42, compound="MEDIUM", tyre_life=20, position=3, gap_ahead_s=1.8
+    )
+    result = SimpleNamespace(
+        action="PIT_NOW",
+        confidence=0.9,
+        reasoning="stub",
+        scenario_scores={},
+        pace_mode=None,
+        risk_posture=None,
+        pit_lap_target=42,
+        compound_next="HARD",
+        undercut_target=None,
+    )
+
+    decision = _parse_lap_decision(
+        result, race_state, {}, 90.0, memory_block=block, plan_changed=True
+    )
+    payload = decision.model_dump()
+
+    assert payload["memory_block"] == block
+    assert payload["plan_changed"] is True
+
+
+@_skip_no_backend
+def test_a_lap_with_no_memory_still_carries_both_fields():
+    """Absent memory is an explicit pair of values, never missing keys.
+
+    The webapp has to render "no history for this call" rather than branch on a
+    key that sometimes exists. `/recommend` and the MCP tool are memoryless by
+    design, so that state is permanent, not transitional.
+    """
+    _ensure_backend_on_path()
+    from types import SimpleNamespace
+
+    from backend.services.simulation.simulator import _parse_lap_decision
+
+    race_state = SimpleNamespace(lap=1, compound="SOFT", tyre_life=1, position=5, gap_ahead_s=0.0)
+    result = SimpleNamespace(
+        action="STAY_OUT",
+        confidence=0.5,
+        reasoning="stub",
+        scenario_scores={},
+        pace_mode=None,
+        risk_posture=None,
+        pit_lap_target=None,
+        compound_next=None,
+        undercut_target=None,
+    )
+
+    payload = _parse_lap_decision(result, race_state, {}, None).model_dump()
+
+    assert payload["memory_block"] is None
+    assert payload["plan_changed"] is False


### PR DESCRIPTION
Promotes #694 to `main`. Closes #694.

## Why this exists

The decision-memory layer shipped in v2.4.0 **changes decisions and leaves no trace in `reasoning`**. Under a Safety Car it flipped the call on **8 of 8** runs and none of the 8 mentioned the prior plan. So a user asking "why did it suddenly say PIT_NOW?" had no answer available anywhere in the product.

Asking the model to narrate it was tried and **measured**: three formulations, and the better it complied the worse it decided (8/8 → 0/8, Fisher p=0.000155). That route is closed (#691, closed unshipped).

The explanation therefore has to be the deterministic **input**, which the caller already holds. It costs nothing at inference and cannot distort the decision, because it *is* the decision's input.

## What ships

| surface | what it shows |
|---|---|
| CLI | prints the block into the scrolling history on the lap the call changed |
| arcade | appends it to the Orchestrator tab under "why this call changed" |
| backend | carries `memory_block` + `plan_changed` on **every** lap payload |
| webapp Strategy tab | one line stating the brief has no memory of earlier calls |

Plus `DecisionMemory.last_call_changed()`, the shared signal, which lives on the accumulator rather than being reimplemented per surface.

## Silence is the default, and it is measured

Over 40 lap pairs of a real race:

| definition of "changed" | fires on |
|---|---|
| `action` | **0 of 40** |
| `pit_lap_target` | 25 of 40 (62%) |

Only `action` counts. Counting the target would open the panel on two laps in three and turn the signal into wallpaper. The 0% is correct, not broken: in that race the call genuinely never changed, and the signal fires on the Safety Car lap where it does.

## Two findings from doing it

**Nothing in the webapp consumes `/simulate`.** Verified by grep: it appears only in the generated `schema.ts` and one comment in `sse.ts`. The Strategy tab is entirely `POST /recommend`, which is stateless. So the block has no consumer there and only the note applied — a smaller webapp step than planned. The payload still carries it for a future consumer.

**A missing test guard that only failed on CI.** Importing `simulator.py` pulls the agent modules, which read their routing config at import time, so a test touching nothing but the module still needs the weights. Fixed with a guard naming the file actually missing, rather than borrowing a nearby parquet guard that would have passed by coincidence.

## Checks

- `pytest tests/simulation/` 29 passed · `tests/engine/` 36 passed
- `ruff check --no-cache .` + `format --check .` clean at the pinned 0.15.22
- CLI verified on a real 5-lap run: the call did not change, and nothing rendered — the correct silent case. The panel itself was rendered separately to confirm it composes.
- submodule `F1_Telemetry_Manager` #205 + #206 merged, pointer bumped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added visible “why this call changed” details to the live simulation interface when decision memory changes.
  - Orchestrator reasoning now displays the relevant decision-memory context alongside updated recommendations.
  - Lap results consistently include memory context and whether the plan changed.

- **Documentation**
  - Updated audit findings to clarify that continuity explanations should be rendered directly by the interface rather than generated through model reasoning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->