### PR TITLE
fix(dashboard): give the orchestrator tab the height the card was hoarding

### DIFF
--- a/src/arcade/dashboard/orchestrator_card.py
+++ b/src/arcade/dashboard/orchestrator_card.py
@@ -74,7 +74,15 @@ class OrchestratorCard(QFrame):
     def __init__(self) -> None:
         super().__init__()
         self.setProperty("card", True)
-        self.setMinimumHeight(220)
+        # 170, not 220. The rows below add up to roughly 165px (a 70px badge, the
+        # chip row, the plan line, the guardrail line, plus margins and spacing), so
+        # a 220 floor reserved around 50px of dead space under the plan line and took
+        # it from the only widget in this column that stretches: the reasoning tabs.
+        # With the decision-memory block appended on a changed lap, those 50px were
+        # the difference between the block fitting and being scrolled below the fold.
+        # The vertical policy stays Fixed, so a long wrapped guardrail line still
+        # grows the card past this floor. Lowering a MINIMUM cannot clip content.
+        self.setMinimumHeight(170)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
         outer = QVBoxLayout(self)


### PR DESCRIPTION
Found by actually screenshotting the dashboard after #697, instead of trusting a green build.

## The bug

`OrchestratorCard` floored itself at **220px** while its rows add up to about **165** (a 70px badge, the chip row, the plan line, the guardrail line, margins and spacing). Roughly **50px sat dead** under the plan line.

The left column's only stretching widget is `ReasoningTabs`, so those 50px came straight out of it. With the decision-memory block appended on a changed lap, that was the difference between the block fitting and being scrolled below the fold: in the default 1280x720 window the **counterweight sentence fell out of view**, and a user had to notice the scrollbar and drag it.

## The fix

One number: `setMinimumHeight(220)` → `170`.

The vertical size policy stays `Fixed`, so a long wrapped guardrail line still grows the card past this floor. **Lowering a minimum cannot clip content** — it only stops the card reserving space it never uses.

## Verified visually, not by build

Screenshotted the **real** `MainWindow` at its default size, before and after, feeding it a realistic broadcast with `plan_changed=True`:

- **before:** scrollbar present, block truncated after the MEDIUM contingency
- **after:** no scrollbar, block renders whole including the counterweight

The card itself is unchanged to the eye — badge, chips and plan line all sit where they did; only the dead space below them is gone.

## Note for future Qt screenshots

Under `QT_QPA_PLATFORM=offscreen` on Windows the font database comes back **empty** and everything renders as tofu boxes until `QT_QPA_FONTDIR=C:/Windows/Fonts` is also set.

## Checks

- `pytest tests/surfaces/` — 15 passed
- `ruff check --no-cache` + `format --check` clean at the pinned 0.15.22