### PR TITLE
fix(dashboard): the orchestrator tab was losing the memory block below the fold

### DIFF
--- a/src/arcade/dashboard/orchestrator_card.py
+++ b/src/arcade/dashboard/orchestrator_card.py
@@ -74,7 +74,15 @@ class OrchestratorCard(QFrame):
     def __init__(self) -> None:
         super().__init__()
         self.setProperty("card", True)
-        self.setMinimumHeight(220)
+        # 170, not 220. The rows below add up to roughly 165px (a 70px badge, the
+        # chip row, the plan line, the guardrail line, plus margins and spacing), so
+        # a 220 floor reserved around 50px of dead space under the plan line and took
+        # it from the only widget in this column that stretches: the reasoning tabs.
+        # With the decision-memory block appended on a changed lap, those 50px were
+        # the difference between the block fitting and being scrolled below the fold.
+        # The vertical policy stays Fixed, so a long wrapped guardrail line still
+        # grows the card past this floor. Lowering a MINIMUM cannot clip content.
+        self.setMinimumHeight(170)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
         outer = QVBoxLayout(self)


### PR DESCRIPTION
Promotes the one fix that came out of screenshotting #694's work instead of trusting a green build.

## What was wrong

`OrchestratorCard` floored itself at **220px** while its rows add up to about **165** (70px badge, chip row, plan line, guardrail line, margins). Roughly **50px sat dead** under the plan line.

The left column's only stretching widget is `ReasoningTabs`, so that dead space came straight out of it. With the decision-memory block appended on a changed lap, it was the difference between the block fitting and being scrolled out of view: in the default 1280x720 window the **counterweight sentence fell below the fold**, and reading it needed noticing a scrollbar and dragging it.

## The fix

`setMinimumHeight(220)` → `170`. The vertical policy stays `Fixed`, so a long wrapped guardrail line still grows the card past this floor. Lowering a minimum cannot clip content; it only stops the card reserving space it never uses.

## Verified by looking

The real `MainWindow` at default size, before and after, fed a realistic broadcast with `plan_changed=True`:

- **before** — scrollbar present, block truncated after the MEDIUM contingency
- **after** — no scrollbar, block whole including the counterweight

The card is unchanged to the eye; only the dead space is gone.

## Worth stating

The build was green and the tests passed while this defect was live. It only surfaced by rendering the window. That is the standing rule about not shipping visual work on a build-pass alone, and it earned its keep here.

## Checks

- `pytest tests/surfaces/` 15 passed
- `ruff check --no-cache` + `format --check` clean at the pinned 0.15.22
- CI green on #701

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the minimum height of the orchestrator dashboard card to improve layout fit and prevent unnecessary scrolling or content being pushed below the fold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->