### PR TITLE
release: roadmap renumbering (v2.6.0 / v2.8.0 / v3.0.0)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -634,15 +634,28 @@ Code freeze of the TFG software. Consolidates the interfaces closed in v0.12.0 (
 
 ## Next core releases (planned milestones)
 
-Post-v1.5.x core milestones, in order. Versions are targets, not commitments: directions, not deadlines. Tracked as GitHub milestones on the repo.
+Core milestones after the current release, in order. Versions are targets, not commitments: directions, not deadlines. Tracked as GitHub milestones on the repo.
+
+**Numbers here are provisional by construction.** `release-please` derives the published version
+from the commits that actually land, so a sprint that ships first consumes the next number. That
+already happened once: the milestone below was planned as v2.5.0 and v2.5.0 shipped the
+decision-memory rendering instead. When a planned number is taken, renumber here rather than
+letting the roadmap contradict the CHANGELOG.
 
 | Version | Milestone | What it adds |
 |---|---|---|
-| **v1.6.0** | Modern frontend | Replace the Streamlit UI with a faster React/Vite stack; the FastAPI backend stays. A presentation-layer swap, not a functional rewrite: menus and flows stay the same. |
-| **v1.7.0** | Rival Agent | A new, additive LangGraph node that predicts each nearby rival's next strategic move (pit window, compound, undercut/overcut) and feeds it to the orchestrator. Recommendations move from reactive to anticipatory. The six existing agents are untouched. |
-| **v1.8.0** | Live race inference | Real-time ingestion over the OpenF1 WebSocket (the `lap_state` contract is unchanged, so agents and orchestrator don't change), plus adaptation to the 2026 technical/sporting regulation (re-cluster, re-label compounds, drift monitoring). |
+| **v2.6.0** | Arcade, modernized | A web-native trackside frontend for part of the live Arcade experience, running **alongside** the pyglet 2D replay rather than replacing it. The strategy and telemetry surfaces move to a web-native view, reusing the React app's tab and URL-contract machinery from v2.0.0. The `lap_state` contract and the agents stay unchanged. |
+| **v2.8.0** | Rival Agent | A new, additive LangGraph node that predicts each nearby rival's next strategic move (pit window, compound, undercut/overcut) and feeds it to the orchestrator. Recommendations move from reactive to anticipatory. The six existing agents are untouched. |
+| **v3.0.0** | Live race inference | Real-time ingestion over the OpenF1 WebSocket (the `lap_state` contract is unchanged, so agents and orchestrator don't change), plus adaptation to the 2026 technical/sporting regulation (re-cluster, re-label compounds, drift monitoring). |
 
-### Rival Agent: the anticipatory turn (v1.7.0)
+Why that order: v2.6.0 is *same data, better face* — low risk, and it reuses what v2.0.0 already
+built. v3.0.0 is *new data, in real time*, which depends on a live source and its reliability. It
+is worth polishing the modern surface before plugging the live feed into it, so that when live
+data arrives there is somewhere good to render it.
+
+Superseded: "Modern frontend" was planned here as v1.6.0 and **shipped as v2.0.0** on 2026-07-21.
+
+### Rival Agent: the anticipatory turn (v2.8.0)
 
 Today the system reasons about our own car and treats rivals as scenery; a good pit wall decides by anticipating the cars around it. The Rival Agent closes that gap. It reuses the existing two-driver mode (which already loads a rival's public telemetry next to ours), tire age, gap, track position and history to predict what the cars in our fight will do next. Ground truth is reconstructed from real 2024–2025 pit stops cross-referenced with telemetry; the agent is validated by ablation (with/without) against the real outcome and the actual pit-wall decision on the Grands Prix already validated in the thesis. Supporting building blocks: a rival next-move classifier, a lap-by-lap rival sequence model, situation/profile clustering with anomaly detection, a scaled pit-stop ground-truth pipeline, a neural surrogate of the Monte Carlo simulator, an RL pit-stop benchmark, and analogous-race-state retrieval.
 
@@ -664,5 +677,5 @@ These map to the eight future-work lines in the thesis ([`documents/thesis/`](do
 
 ---
 
-**Last Updated:** June 28, 2026
-**Version:** 1.12 (added next-core-releases milestones v1.6.0–v1.8.0 + Rival Agent)
+**Last Updated:** July 28, 2026
+**Version:** 1.13 (renumbered the planned milestones to v2.6.0/v2.8.0/v3.0.0 after the release train overtook them; brought the wording in line with the docs-site roadmap)

--- a/docs/pages/roadmap.md
+++ b/docs/pages/roadmap.md
@@ -461,7 +461,7 @@
   <div class="rl-dot planned"></div>
   <div class="rl-card planned">
     <div class="rl-header">
-      <span class="rl-version"><span class="sr-only">Version: </span>v2.5.0</span>
+      <span class="rl-version"><span class="sr-only">Version: </span>v2.6.0</span>
       <span class="rl-badge planned-badge"><span class="sr-only">Status: </span>Planned</span>
     </div>
     <p class="rl-title">Arcade, modernized: a web-native trackside frontend</p>


### PR DESCRIPTION
Promotes the roadmap renumbering. Docs only.

## What lands

#704 — `ROADMAP.md` and `docs/pages/roadmap.md` renumbered to **v2.6.0 Arcade modernized / v2.8.0 Rival Agent / v3.0.0 Live race inference**.

## Why

Three copies of the roadmap had drifted apart: `ROADMAP.md` still listed v1.6.0-v1.8.0 while the docs site and the landing carried v2.5.0/v2.8.0/v3.0.0. And **v2.5.0 shipped on 2026-07-28** with the decision-memory rendering (#694), so the number Arcade-modernized was holding was already spent.

Recorded in the file, because it will recur: release-please derives the published version from the commits that land, so a planned number can always be consumed by a sprint that ships first. Renumber the roadmap rather than let it contradict the CHANGELOG.

The matching landing change is VforVitorio/f1stratlab-web#50, already merged.

## Checks

Docs only, no code paths touched. #704 was green on `dev` (16 checks).