### PR TITLE
feat(eval): measure whether the stack picks the right lap to stop

### DIFF
--- a/documents/eval_reports/decision_modes.json
+++ b/documents/eval_reports/decision_modes.json
@@ -1,0 +1,1842 @@
+{
+  "header": {
+    "harness_sha": "80f1fa7",
+    "dataset": "data/raw laps, stratified 6-race subset (RAW, not featured)",
+    "seed_policy": "deterministic",
+    "era_tag": "2022-2025",
+    "llm": "none",
+    "schema_version": "1",
+    "generated_at": "2026-07-29T08:43:26+00:00",
+    "artifacts": {}
+  },
+  "status": "masked",
+  "window_laps": 5,
+  "sampled_races": [
+    {
+      "year": 2023,
+      "race": "Barcelona"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail"
+    },
+    {
+      "year": 2025,
+      "race": "Monza"
+    }
+  ],
+  "agreement": {
+    "sample_size": 40,
+    "eligible": 198,
+    "scored_share": 0.20202020202020202,
+    "races": 6,
+    "exact": 0.3,
+    "within_one": 0.375,
+    "within_two": 0.475,
+    "mean_signed_error": -2.225,
+    "mean_absolute_error": 2.475
+  },
+  "buckets": {
+    "closing_laps": 4,
+    "min_stint": 22,
+    "no_call_in_window": 128,
+    "opening_laps": 4,
+    "scored": 40
+  },
+  "verdicts": [
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "VER",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "VER",
+      "actual_lap": 52,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "GAS",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "GAS",
+      "actual_lap": 39,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "PER",
+      "actual_lap": 27,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "PER",
+      "actual_lap": 50,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "ALO",
+      "actual_lap": 19,
+      "chosen_lap": 24,
+      "offset_laps": 5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "ALO",
+      "actual_lap": 44,
+      "chosen_lap": 39,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "LEC",
+      "actual_lap": 16,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "LEC",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "STR",
+      "actual_lap": 14,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "STR",
+      "actual_lap": 34,
+      "chosen_lap": 34,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "SAR",
+      "actual_lap": 17,
+      "chosen_lap": 15,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "SAR",
+      "actual_lap": 36,
+      "chosen_lap": 36,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "MAG",
+      "actual_lap": 10,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "MAG",
+      "actual_lap": 24,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "MAG",
+      "actual_lap": 42,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "DEV",
+      "actual_lap": 9,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "DEV",
+      "actual_lap": 38,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "TSU",
+      "actual_lap": 10,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "TSU",
+      "actual_lap": 34,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "ALB",
+      "actual_lap": 16,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "ALB",
+      "actual_lap": 37,
+      "chosen_lap": 37,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "ZHO",
+      "actual_lap": 9,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "ZHO",
+      "actual_lap": 36,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "HUL",
+      "actual_lap": 8,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "HUL",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "HUL",
+      "actual_lap": 43,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "OCO",
+      "actual_lap": 13,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "OCO",
+      "actual_lap": 35,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "NOR",
+      "actual_lap": 1,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "opening_laps"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "NOR",
+      "actual_lap": 22,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "NOR",
+      "actual_lap": 50,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "HAM",
+      "actual_lap": 24,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "HAM",
+      "actual_lap": 50,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "SAI",
+      "actual_lap": 15,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "SAI",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "RUS",
+      "actual_lap": 25,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "RUS",
+      "actual_lap": 45,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "BOT",
+      "actual_lap": 5,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "BOT",
+      "actual_lap": 39,
+      "chosen_lap": 37,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "PIA",
+      "actual_lap": 17,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Barcelona",
+      "driver": "PIA",
+      "actual_lap": 39,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "VER",
+      "actual_lap": 55,
+      "chosen_lap": 55,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "GAS",
+      "actual_lap": 47,
+      "chosen_lap": 43,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "GAS",
+      "actual_lap": 54,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "PER",
+      "actual_lap": 1,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "opening_laps"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "PER",
+      "actual_lap": 34,
+      "chosen_lap": 30,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "PER",
+      "actual_lap": 53,
+      "chosen_lap": 48,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "PER",
+      "actual_lap": 57,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "PER",
+      "actual_lap": 70,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "ALO",
+      "actual_lap": 54,
+      "chosen_lap": 54,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "ALO",
+      "actual_lap": 55,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "LEC",
+      "actual_lap": 44,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "LEC",
+      "actual_lap": 55,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "STR",
+      "actual_lap": 51,
+      "chosen_lap": 46,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "SAR",
+      "actual_lap": 20,
+      "chosen_lap": 17,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "SAR",
+      "actual_lap": 23,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "SAR",
+      "actual_lap": 52,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "MAG",
+      "actual_lap": 56,
+      "chosen_lap": 51,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "MAG",
+      "actual_lap": 71,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "DEV",
+      "actual_lap": 53,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "TSU",
+      "actual_lap": 53,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "ALB",
+      "actual_lap": 18,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "ALB",
+      "actual_lap": 52,
+      "chosen_lap": 48,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "ZHO",
+      "actual_lap": 1,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "opening_laps"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "ZHO",
+      "actual_lap": 52,
+      "chosen_lap": 49,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "HUL",
+      "actual_lap": 1,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "opening_laps"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "HUL",
+      "actual_lap": 54,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "HUL",
+      "actual_lap": 59,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "OCO",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "OCO",
+      "actual_lap": 54,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "NOR",
+      "actual_lap": 50,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "NOR",
+      "actual_lap": 54,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "HAM",
+      "actual_lap": 31,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "HAM",
+      "actual_lap": 54,
+      "chosen_lap": 52,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "SAI",
+      "actual_lap": 33,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "SAI",
+      "actual_lap": 55,
+      "chosen_lap": 52,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "RUS",
+      "actual_lap": 54,
+      "chosen_lap": 49,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "BOT",
+      "actual_lap": 51,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "PIA",
+      "actual_lap": 54,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "VER",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "VER",
+      "actual_lap": 38,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "PER",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "PER",
+      "actual_lap": 28,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "PER",
+      "actual_lap": 37,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "PER",
+      "actual_lap": 47,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "ALO",
+      "actual_lap": 27,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "ALO",
+      "actual_lap": 38,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "LEC",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "LEC",
+      "actual_lap": 27,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "LEC",
+      "actual_lap": 37,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "STR",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "STR",
+      "actual_lap": 39,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "SAR",
+      "actual_lap": 27,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "SAR",
+      "actual_lap": 38,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "MAG",
+      "actual_lap": 27,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "MAG",
+      "actual_lap": 37,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "TSU",
+      "actual_lap": 27,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "TSU",
+      "actual_lap": 38,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "ALB",
+      "actual_lap": 27,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "ALB",
+      "actual_lap": 38,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "ZHO",
+      "actual_lap": 12,
+      "chosen_lap": 8,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "ZHO",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "ZHO",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "ZHO",
+      "actual_lap": 37,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "HUL",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "HUL",
+      "actual_lap": 39,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "RIC",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "RIC",
+      "actual_lap": 37,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "OCO",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "OCO",
+      "actual_lap": 21,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "OCO",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "OCO",
+      "actual_lap": 38,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "NOR",
+      "actual_lap": 27,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "NOR",
+      "actual_lap": 39,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "HAM",
+      "actual_lap": 27,
+      "chosen_lap": 26,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "HAM",
+      "actual_lap": 38,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "SAI",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "SAI",
+      "actual_lap": 39,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "SAI",
+      "actual_lap": 50,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "closing_laps"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "RUS",
+      "actual_lap": 27,
+      "chosen_lap": 26,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "RUS",
+      "actual_lap": 33,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "BOT",
+      "actual_lap": 26,
+      "chosen_lap": 22,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "BOT",
+      "actual_lap": 37,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "PIA",
+      "actual_lap": 28,
+      "chosen_lap": 26,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2024,
+      "race": "Silverstone",
+      "driver": "PIA",
+      "actual_lap": 38,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "VER",
+      "actual_lap": 29,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "GAS",
+      "actual_lap": 37,
+      "chosen_lap": 34,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "PER",
+      "actual_lap": 28,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "ALO",
+      "actual_lap": 25,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "LEC",
+      "actual_lap": 36,
+      "chosen_lap": 33,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "STR",
+      "actual_lap": 26,
+      "chosen_lap": 26,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "MAG",
+      "actual_lap": 28,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "MAG",
+      "actual_lap": 49,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "MAG",
+      "actual_lap": 57,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "TSU",
+      "actual_lap": 33,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "ALB",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "ALB",
+      "actual_lap": 15,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "ZHO",
+      "actual_lap": 34,
+      "chosen_lap": 30,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "HUL",
+      "actual_lap": 29,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "RIC",
+      "actual_lap": 10,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "RIC",
+      "actual_lap": 46,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "RIC",
+      "actual_lap": 58,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "OCO",
+      "actual_lap": 29,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "NOR",
+      "actual_lap": 30,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "COL",
+      "actual_lap": 29,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "HAM",
+      "actual_lap": 17,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "SAI",
+      "actual_lap": 13,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "RUS",
+      "actual_lap": 27,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "BOT",
+      "actual_lap": 33,
+      "chosen_lap": 33,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2024,
+      "race": "Marina_Bay",
+      "driver": "PIA",
+      "actual_lap": 38,
+      "chosen_lap": 37,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "VER",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "GAS",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "ANT",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "ALO",
+      "actual_lap": 32,
+      "chosen_lap": 32,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "LEC",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "STR",
+      "actual_lap": 24,
+      "chosen_lap": 19,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "STR",
+      "actual_lap": 49,
+      "chosen_lap": 44,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "STR",
+      "actual_lap": 55,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "closing_laps"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "TSU",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "ALB",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "LAW",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "OCO",
+      "actual_lap": 34,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "NOR",
+      "actual_lap": 25,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "NOR",
+      "actual_lap": 44,
+      "chosen_lap": 44,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "COL",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "HAM",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "BOR",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "SAI",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "HAD",
+      "actual_lap": 32,
+      "chosen_lap": 32,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "HAD",
+      "actual_lap": 55,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "closing_laps"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "RUS",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "PIA",
+      "actual_lap": 24,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "PIA",
+      "actual_lap": 42,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "BEA",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "BEA",
+      "actual_lap": 40,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Lusail",
+      "driver": "BEA",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "VER",
+      "actual_lap": 37,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "GAS",
+      "actual_lap": 49,
+      "chosen_lap": 44,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "ANT",
+      "actual_lap": 28,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "ALO",
+      "actual_lap": 20,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "ALO",
+      "actual_lap": 24,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "LEC",
+      "actual_lap": 33,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "STR",
+      "actual_lap": 49,
+      "chosen_lap": 49,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "TSU",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "ALB",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "LAW",
+      "actual_lap": 9,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "OCO",
+      "actual_lap": 51,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "closing_laps"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "NOR",
+      "actual_lap": 46,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "COL",
+      "actual_lap": 33,
+      "chosen_lap": 33,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "HAM",
+      "actual_lap": 38,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "BOR",
+      "actual_lap": 20,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "SAI",
+      "actual_lap": 30,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "HAD",
+      "actual_lap": 32,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "RUS",
+      "actual_lap": 27,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "PIA",
+      "actual_lap": 45,
+      "chosen_lap": 41,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monza",
+      "driver": "BEA",
+      "actual_lap": 18,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    }
+  ]
+}

--- a/documents/eval_reports/decision_modes.md
+++ b/documents/eval_reports/decision_modes.md
@@ -1,0 +1,46 @@
+# decision_modes
+
+- harness `80f1fa7` · schema v1 · generated 2026-07-29T08:43:26+00:00
+- era 2022-2025 · dataset data/raw laps, stratified 6-race subset (RAW, not featured) · seed deterministic · llm none
+- artifacts: —
+
+| Metric | Value | Meaning |
+| --- | --- | --- |
+| Stops scored | 40 of 198 (20.2%) | real green-flag stops the tier could grade |
+| Exact lap | 30.0% | chose the lap the team chose |
+| Within 1 lap | 37.5% | same call, one lap either side |
+| Within 2 laps | 47.5% | same strategic window |
+| Mean signed error | -2.23 laps | negative = stops earlier than the team |
+| Mean absolute error | 2.48 laps | magnitude |
+| Coverage verdict | **masked** | `masked` when under 60% of eligible stops were scored |
+
+### Buckets
+
+| Bucket | Stops |
+| --- | --- |
+| `closing_laps` | 4 |
+| `min_stint` | 22 |
+| `no_call_in_window` | 128 |
+| `opening_laps` | 4 |
+| `scored` | 40 |
+
+`opening_laps` / `closing_laps` / `min_stint` are stops the guard rails make
+impossible to agree with, so they are excluded from the headline rather than
+counted as misses. `no_data` is a car that had already retired, so the stack
+never evaluated the window at all. `no_call_in_window` is different and is the
+number to watch: the stack looked and declined to stop anywhere near the real
+lap. Charging a retirement to the model as a missed call would flatter neither
+side honestly, so the two are never merged.
+
+### Scope
+
+- Sampled races (6 measured): 2023 Barcelona, 2023 Monaco, 2024 Silverstone, 2024 Marina_Bay, 2025 Lusail, 2025 Monza.
+- A full sweep of the real-stop sample is roughly 11.5 h of wall clock at
+  0.51 s per lap through the stack, so this is a stratified subset by circuit
+  archetype and **not** full coverage. Read every figure above as conditional
+  on these races.
+- Decisions come from `profile="no-llm"`: the deterministic Monte Carlo layer
+  plus the guard rails, never the LLM synthesis.
+- Agreement with the real pit wall is evidence, not correctness. The team can
+  be wrong, and this tier cannot tell when it was.
+

--- a/src/strategy/eval/cli.py
+++ b/src/strategy/eval/cli.py
@@ -11,7 +11,12 @@ one-line summary of where it landed and what it flagged.
     f1-eval nlp            # NLP per-stage eval: sentiment + gated stages (#304)
     f1-eval projection     # MC projection accuracy vs real stops + the measured tables
     f1-eval alert-llm      # PROXY alert precision via an LLM judge (#304; spends API calls)
-    f1-eval all            # every report EXCEPT alert-llm (opt-in: it spends API calls)
+    f1-eval decision-modes # does the stack pick the right lap to STOP (#708; takes minutes)
+    f1-eval all            # every report EXCEPT the two opt-in ones below
+
+Two commands stay out of ``all`` because they cost something a routine run should
+not silently spend: ``alert-llm`` spends API calls, and ``decision-modes`` drives
+the whole agent stack over hundreds of laps and takes minutes.
 """
 
 from __future__ import annotations
@@ -21,6 +26,7 @@ from typing import Any, Callable
 
 from src.strategy.eval.alert_llm import build_alert_llm_report
 from src.strategy.eval.calibration import build_calibration_report
+from src.strategy.eval.decision_modes import build_decision_modes_report
 from src.strategy.eval.hygiene import build_hygiene_report
 from src.strategy.eval.nlp import build_nlp_report
 from src.strategy.eval.projection import build_projection_report
@@ -77,6 +83,20 @@ def _run_projection() -> None:
     print(f"projection -> {payload['md_path']} ({accuracy}; {len(payload['tables'])} tables)")
 
 
+def _run_decision_modes() -> None:
+    payload = build_decision_modes_report()
+    agreement = payload["agreement"]
+    accuracy = (
+        "not measured (no data/raw)"
+        if agreement is None
+        else (
+            f"{agreement.within_one:.1%} within one lap over {agreement.sample_size} "
+            f"of {agreement.eligible} real stops"
+        )
+    )
+    print(f"decision-modes -> {payload['md_path']} ({accuracy}; coverage {payload['status']})")
+
+
 def _run_alert_llm() -> None:
     payload = build_alert_llm_report()
     result = payload["result"]
@@ -104,14 +124,18 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "command",
-        choices=[*_COMMANDS, "alert-llm", "all"],
+        choices=[*_COMMANDS, "alert-llm", "decision-modes", "all"],
         help="which report to regenerate",
     )
     args = parser.parse_args(argv)
 
-    # alert-llm is opt-in only: it spends API calls, so `all` never runs it.
+    # Both of these are opt-in only, so `all` never runs them: alert-llm spends API
+    # calls, and decision-modes drives the agent stack over hundreds of laps.
     if args.command == "alert-llm":
         _run_alert_llm()
+        return 0
+    if args.command == "decision-modes":
+        _run_decision_modes()
         return 0
 
     commands = _COMMANDS.values() if args.command == "all" else [_COMMANDS[args.command]]

--- a/src/strategy/eval/decision_modes.py
+++ b/src/strategy/eval/decision_modes.py
@@ -61,13 +61,11 @@ from typing import Any
 import numpy as np
 
 from src.strategy.eval.report import build_header, write_report
-from src.strategy.inference.no_llm import (
-    _MIN_STINT_LAPS,
-    _NO_PIT_BEFORE_LAP,
-    _NO_PIT_LAST_N_LAPS,
-    _PIT_ACTIONS,
-    _DEFAULT_MIN_STINT,
-)
+
+# From the leaf module, never from ``no_llm``: that one imports the agent stack and
+# loads model weights at import time, which would make this report — and every other
+# ``f1-eval`` subcommand next to it — impossible to even import without ``data/models/``.
+from src.strategy.inference.guard_rails import _MIN_STINT_LAPS, _PIT_ACTIONS, apply_guard_rails
 
 # Laps either side of the real stop that the stack is asked about. Five matches
 # the Monte Carlo decision window, so the question posed to the model is the one
@@ -165,25 +163,44 @@ class DecisionAgreement:
         return self.sample_size / self.eligible if self.eligible else 0.0
 
 
+# Which rail fired, keyed on a stable fragment of the reason it returns. Matching
+# the message is not elegant, but re-deriving the boundaries is what produced an
+# off-by-one against the rail's own ``remaining <= 3`` the first time this was
+# written. ``test_every_bucket_is_reachable_through_the_real_rail`` fails loudly if
+# a message is ever reworded, so a silent mis-bucket is not possible.
+_RAIL_BUCKETS: tuple[tuple[str, str], ...] = (
+    ("pit window not open", "opening_laps"),
+    ("too late to pit", "closing_laps"),
+    ("minimum stint", "min_stint"),
+)
+
+
 def guard_rail_block(
     actual_lap: int, total_laps: int, compound: str | None, tyre_life: int | None
 ) -> str | None:
     """Name the guard rail that makes agreement with this stop impossible, else None.
 
-    ``apply_guard_rails`` structurally forbids a pit action in three situations. A
-    real stop inside one of them can never be agreed with no matter how good the
-    strategy is, so folding it into the headline would measure the rail rather
-    than the decision. Bucketed and reported instead of dropped in silence.
-    """
-    if actual_lap < _NO_PIT_BEFORE_LAP:
-        return "opening_laps"
-    if actual_lap > total_laps - _NO_PIT_LAST_N_LAPS:
-        return "closing_laps"
+    Asks ``apply_guard_rails`` itself whether a stop on this lap would have been
+    overridden, rather than restating its thresholds. A real stop inside a rail can
+    never be agreed with no matter how good the strategy is, so folding it into the
+    headline would measure the rail instead of the decision.
 
-    minimum = _MIN_STINT_LAPS.get((compound or "").upper(), _DEFAULT_MIN_STINT)
-    if tyre_life is not None and tyre_life < minimum:
-        return "min_stint"
-    return None
+    When tyre life is unknown the minimum-stint rail simply cannot be evaluated, so
+    the probe passes a life that satisfies every minimum and only the lap-based
+    rails apply. That is a stated assumption, not a sentinel: it never becomes a
+    value the caller can mistake for a measurement.
+    """
+    probe_life = max(_MIN_STINT_LAPS.values()) if tyre_life is None else tyre_life
+    action, reason = apply_guard_rails(
+        "PIT_NOW", actual_lap, total_laps, compound or "", probe_life
+    )
+    if action == "PIT_NOW" or reason is None:
+        return None
+
+    for marker, bucket in _RAIL_BUCKETS:
+        if marker in reason:
+            return bucket
+    raise ValueError(f"unmapped guard-rail reason: {reason!r}")
 
 
 def coverage_verdict(agreement: DecisionAgreement) -> str:

--- a/src/strategy/eval/decision_modes.py
+++ b/src/strategy/eval/decision_modes.py
@@ -46,11 +46,14 @@ buildable is the other half of the same idea — that the not-scored buckets mus
 not quietly absorb the failures — and that is ``coverage_verdict``.
 
 WHERE TO CHANGE IF THINGS MOVE:
-- ``src/strategy/inference/no_llm.py`` owns the guard rails and the pit-action
-  set. Both are imported here rather than restated, so a change there changes
-  this report instead of silently disagreeing with it.
+- ``src/strategy/inference/guard_rails.py`` owns the rails and the pit-action
+  set. ``guard_rail_block`` CALLS the rail rather than restating its thresholds,
+  because the first version retyped one boundary and got it wrong by one lap.
 - ``SAMPLED_RACES`` is the subset and the reason it exists; see its comment
   before widening it.
+- ``lap_inputs`` decides which laps are answerable and is deliberately free of
+  agent imports, so the two bugs that lived there stay under test on a runner
+  with no model weights.
 """
 
 from __future__ import annotations
@@ -224,6 +227,45 @@ def _team_of(laps, driver: str) -> str | None:
     return str(rows.iloc[0]) if len(rows) else None
 
 
+def lap_inputs(state: dict[str, Any]) -> dict[str, Any] | None:
+    """The primitive fields a ``RaceState`` needs from a lap state, or None to skip.
+
+    Pure and free of any agent import on purpose: this is the part that decides
+    which laps are answerable at all, it is where two real bugs lived, and keeping
+    it separate is what lets those bugs stay under test on a runner with no model
+    weights on disk.
+
+    Skips, and why each is a skip rather than a default:
+    - no ``lap_number``: a retired car keeps yielding lap states with an EMPTY
+      driver dict for the remainder of the race. Presence is the signal, never a
+      lap-number threshold — a car that finished can be missing laps too, and the
+      two ranges overlap.
+    - no ``position``: the state manager returns None deliberately, because a
+      sentinel position has already collided with a real one in this codebase. A
+      lap with no position is not a lap the stack can be asked about.
+
+    ``tyre_life`` is read the long way for the same family of reason: ``or 10``
+    would turn a legitimate fresh tyre (0) into a ten-lap-old one and quietly move
+    what the tyre agent answers.
+    """
+    car = state.get("driver") or {}
+    if "lap_number" not in car or car.get("position") is None:
+        return None
+
+    tyre_life = car.get("tyre_life")
+    weather = state.get("weather") or {}
+    return {
+        "lap": int(car["lap_number"]),
+        "total_laps": int(state["session_meta"]["total_laps"]),
+        "position": int(car["position"]),
+        "compound": car.get("compound") or "MEDIUM",
+        "tyre_life": 10 if tyre_life is None else int(tyre_life),
+        "gap_ahead_s": car.get("gap_ahead_s") or 2.0,
+        "air_temp": weather.get("air_temp") or 25.0,
+        "track_temp": weather.get("track_temp") or 35.0,
+    }
+
+
 def _decisions_in_window(engine, laps_df, driver: str, low: int, high: int) -> dict[int, str]:
     """Action the deterministic stack emits on each lap of ``[low, high]``.
 
@@ -236,48 +278,19 @@ def _decisions_in_window(engine, laps_df, driver: str, low: int, high: int) -> d
 
     actions: dict[int, str] = {}
     for state in engine.replay():
-        car = state.get("driver") or {}
-        # A retired car keeps yielding lap states with an EMPTY driver dict for the
-        # rest of the race. Presence is the signal, never a lap-number threshold:
-        # a car that finished can be missing laps too, and the two ranges overlap.
-        if "lap_number" not in car:
+        inputs = lap_inputs(state)
+        if inputs is None:
             continue
-
-        lap = int(car["lap_number"])
-        if lap < low:
+        if inputs["lap"] < low:
             continue
-        if lap > high:
+        if inputs["lap"] > high:
             break
 
-        # Position is None when the state manager could not resolve it, and it is
-        # None on purpose rather than a number: a sentinel position has already
-        # collided with a real one in this codebase. A lap with no position is not
-        # a lap the stack can be asked about, so it is skipped and never defaulted.
-        if car.get("position") is None:
-            continue
-
-        # Tyre life is read the long way for the same reason: `or 10` would turn a
-        # legitimate fresh tyre (0) into a ten-lap-old one and quietly move what the
-        # tyre agent answers.
-        tyre_life = car.get("tyre_life")
-        weather = state.get("weather") or {}
-        race_state = RaceState(
-            driver=driver,
-            lap=lap,
-            total_laps=int(state["session_meta"]["total_laps"]),
-            position=int(car["position"]),
-            compound=car.get("compound") or "MEDIUM",
-            tyre_life=10 if tyre_life is None else int(tyre_life),
-            gap_ahead_s=car.get("gap_ahead_s") or 2.0,
-            pace_delta_s=0.0,
-            risk_tolerance=0.5,
-            air_temp=weather.get("air_temp") or 25.0,
-            track_temp=weather.get("track_temp") or 35.0,
-        )
+        race_state = RaceState(driver=driver, pace_delta_s=0.0, risk_tolerance=0.5, **inputs)
         recommendation, _outputs, _timings = inference_engine.run_lap(
             race_state, laps_df, state, profile="no-llm", return_agent_outputs=True
         )
-        actions[lap] = recommendation.action
+        actions[inputs["lap"]] = recommendation.action
     return actions
 
 
@@ -380,9 +393,7 @@ def measure_decision_agreement(
                 compound, tyre_life = _stop_context(laps, driver, stop_lap)
                 blocked = guard_rail_block(stop_lap, total_laps, compound, tyre_life)
                 if blocked is not None:
-                    verdicts.append(
-                        StopVerdict(year, race, driver, stop_lap, None, None, blocked)
-                    )
+                    verdicts.append(StopVerdict(year, race, driver, stop_lap, None, None, blocked))
                     continue
 
                 window_low = max(1, stop_lap - DECISION_WINDOW_LAPS)
@@ -405,14 +416,10 @@ def measure_decision_agreement(
                     continue
 
                 verdicts.append(
-                    StopVerdict(
-                        year, race, driver, stop_lap, chosen, chosen - stop_lap, "scored"
-                    )
+                    StopVerdict(year, race, driver, stop_lap, chosen, chosen - stop_lap, "scored")
                 )
 
-    offsets = np.array(
-        [v.offset_laps for v in verdicts if v.offset_laps is not None], dtype=int
-    )
+    offsets = np.array([v.offset_laps for v in verdicts if v.offset_laps is not None], dtype=int)
     agreement = DecisionAgreement(
         offsets=offsets,
         guard_railed=sum(1 for v in verdicts if v.bucket in _GUARD_RAIL_BUCKETS),
@@ -479,7 +486,7 @@ def _render_table(
         "  0.51 s per lap through the stack, so this is a stratified subset by circuit",
         "  archetype and **not** full coverage. Read every figure above as conditional",
         "  on these races.",
-        "- Decisions come from `profile=\"no-llm\"`: the deterministic Monte Carlo layer",
+        '- Decisions come from `profile="no-llm"`: the deterministic Monte Carlo layer',
         "  plus the guard rails, never the LLM synthesis.",
         "- Agreement with the real pit wall is evidence, not correctness. The team can",
         "  be wrong, and this tier cannot tell when it was.",

--- a/src/strategy/eval/decision_modes.py
+++ b/src/strategy/eval/decision_modes.py
@@ -1,0 +1,525 @@
+"""Eval report for the DECISION, not the rejoin: does the stack pick the right lap to stop?
+
+``projection.py`` answers "given that the driver stopped on lap L, where does he
+rejoin" — 86.5% within one place over 1810 real stops. That is pit-cycle
+geometry, and it is the number this project has been quoting. It is not the
+claim the system actually makes. The claim is *when to stop*, and until this
+report existed nobody had measured it.
+
+The gap survived because the projection number is good. A strong metric is
+effective camouflage for the adjacent claim nobody tested.
+
+WHAT THIS MEASURES, EXACTLY
+---------------------------
+For every real green-flag stop in the sampled races, the stack is driven over a
+window of laps either side of the real stop lap and asked, lap by lap, what it
+would do. The first lap inside the window on which it emits a pit action is
+"the lap it would have chosen"; the signed distance to the real lap is the
+error. Signed, not absolute, for the reason ``GroundTruth.mean_signed_error``
+exists: stopping consistently early or late is a fixable bug, and a magnitude
+hides it.
+
+The stack runs on ``profile="no-llm"``, so the action comes from the Monte
+Carlo layer and the guard rails **deterministically**. This is a deliberate
+scope choice, not a shortcut: the LLM synthesis is stochastic and has been
+shown to be steerable by the prompt, so measuring it would measure the sampler
+as much as the strategy. What is under test here is the deterministic decision
+layer.
+
+WHAT THIS DOES NOT MEASURE (do not let a reader assume it does)
+---------------------------------------------------------------
+It is **not** counterfactual. It never claims "stopping on lap 28 instead of 32
+would have finished higher" — answering that needs a full-field propagator, and
+``RaceReplayEngine`` replays real laps by design while rivals get timing-only
+data. Agreement with what the team actually did is also not proof of
+correctness: the team can be wrong. This measures whether the decision layer
+lands in the same place as a professional pit wall, which is evidence, not a
+verdict.
+
+WHY THERE IS NO CROSS-TIER MONOTONICITY GUARD
+----------------------------------------------
+The intended guard was "a freer tier must not score better than a constrained
+one, or two errors are cancelling". It is not buildable across these two tiers:
+projection error is in POSITIONS and decision error is in LAPS, and converting
+the second into the first requires the counterfactual ruled out above. What is
+buildable is the other half of the same idea — that the not-scored buckets must
+not quietly absorb the failures — and that is ``coverage_verdict``.
+
+WHERE TO CHANGE IF THINGS MOVE:
+- ``src/strategy/inference/no_llm.py`` owns the guard rails and the pit-action
+  set. Both are imported here rather than restated, so a change there changes
+  this report instead of silently disagreeing with it.
+- ``SAMPLED_RACES`` is the subset and the reason it exists; see its comment
+  before widening it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from src.strategy.eval.report import build_header, write_report
+from src.strategy.inference.no_llm import (
+    _MIN_STINT_LAPS,
+    _NO_PIT_BEFORE_LAP,
+    _NO_PIT_LAST_N_LAPS,
+    _PIT_ACTIONS,
+    _DEFAULT_MIN_STINT,
+)
+
+# Laps either side of the real stop that the stack is asked about. Five matches
+# the Monte Carlo decision window, so the question posed to the model is the one
+# it was built to answer rather than a horizon it never considers.
+DECISION_WINDOW_LAPS = 5
+
+# A full sweep is not affordable. Measured on this machine: 0.51 s per lap through
+# the no-llm stack, 28.8 s for one (race, driver) pair, and the real-stop sample
+# spans roughly 1440 pairs — about 11.5 hours for one report. So the tier runs on a
+# named, stratified subset instead, chosen for circuit archetype rather than
+# convenience: two conventional high-degradation circuits, two street circuits where
+# track position dominates, one low-downforce low-stop circuit and one fast circuit
+# with variable weather. Widening this is a runtime decision, not a correctness one —
+# but the report must keep saying which races it used.
+SAMPLED_RACES: tuple[tuple[int, str], ...] = (
+    (2023, "Barcelona"),  # conventional, high degradation
+    (2023, "Monaco"),  # street, track position is everything
+    (2024, "Silverstone"),  # fast, weather-variable
+    (2024, "Marina_Bay"),  # street, high degradation
+    (2025, "Lusail"),  # high degradation, stint-limited history
+    (2025, "Monza"),  # low downforce, fewest stops
+)
+
+# Share of eligible stops that must actually be scored before the headline
+# agreement figure means anything. Below this the not-scored buckets are large
+# enough to be hiding the answer, which is exactly the failure mode a fourth
+# "unavailable" gate state invites if nobody polices it.
+MIN_SCORED_SHARE = 0.60
+
+# Buckets that mean "the rails made agreement impossible", as opposed to
+# "the model declined to call it", which is a result and not an exclusion.
+_GUARD_RAIL_BUCKETS = frozenset({"opening_laps", "closing_laps", "min_stint"})
+
+
+@dataclass(frozen=True)
+class StopVerdict:
+    """One real stop, and what the decision layer would have done about it.
+
+    ``offset_laps`` is signed (chosen minus actual) and is ``None`` whenever the
+    stop was not scored, in which case ``bucket`` says why. None means "not
+    measured" and never zero — a zero offset is perfect agreement, which is the
+    opposite conclusion.
+    """
+
+    year: int
+    race: str
+    driver: str
+    actual_lap: int
+    chosen_lap: int | None
+    offset_laps: int | None
+    bucket: str
+
+
+@dataclass(frozen=True)
+class DecisionAgreement:
+    """Aggregate agreement between the decision layer and the real pit wall."""
+
+    offsets: np.ndarray
+    guard_railed: int
+    no_call: int
+    races: int
+    no_data: int = 0
+
+    @property
+    def sample_size(self) -> int:
+        return int(self.offsets.size)
+
+    @property
+    def eligible(self) -> int:
+        """Every stop the tier looked at, scored or not."""
+        return self.sample_size + self.guard_railed + self.no_call + self.no_data
+
+    @property
+    def exact(self) -> float:
+        return float((self.offsets == 0).mean()) if self.sample_size else 0.0
+
+    @property
+    def within_one(self) -> float:
+        return float((np.abs(self.offsets) <= 1).mean()) if self.sample_size else 0.0
+
+    @property
+    def within_two(self) -> float:
+        return float((np.abs(self.offsets) <= 2).mean()) if self.sample_size else 0.0
+
+    @property
+    def mean_signed_error(self) -> float:
+        return float(self.offsets.mean()) if self.sample_size else 0.0
+
+    @property
+    def mean_absolute_error(self) -> float:
+        return float(np.abs(self.offsets).mean()) if self.sample_size else 0.0
+
+    @property
+    def scored_share(self) -> float:
+        return self.sample_size / self.eligible if self.eligible else 0.0
+
+
+def guard_rail_block(
+    actual_lap: int, total_laps: int, compound: str | None, tyre_life: int | None
+) -> str | None:
+    """Name the guard rail that makes agreement with this stop impossible, else None.
+
+    ``apply_guard_rails`` structurally forbids a pit action in three situations. A
+    real stop inside one of them can never be agreed with no matter how good the
+    strategy is, so folding it into the headline would measure the rail rather
+    than the decision. Bucketed and reported instead of dropped in silence.
+    """
+    if actual_lap < _NO_PIT_BEFORE_LAP:
+        return "opening_laps"
+    if actual_lap > total_laps - _NO_PIT_LAST_N_LAPS:
+        return "closing_laps"
+
+    minimum = _MIN_STINT_LAPS.get((compound or "").upper(), _DEFAULT_MIN_STINT)
+    if tyre_life is not None and tyre_life < minimum:
+        return "min_stint"
+    return None
+
+
+def coverage_verdict(agreement: DecisionAgreement) -> str:
+    """``ok`` when enough stops were actually scored, ``masked`` when they were not.
+
+    The adapted form of the compensation guard. A tier that quietly routes most
+    of its sample into "could not evaluate" reports a headline drawn from
+    whatever is left, and the shape of what is left is not random: guard-railed
+    and no-call stops are systematically the awkward ones. Surfacing this as a
+    status is the whole point — an "unavailable" bucket that nobody polices is
+    just a failure with better manners.
+    """
+    if agreement.eligible == 0:
+        return "unavailable"
+    return "ok" if agreement.scored_share >= MIN_SCORED_SHARE else "masked"
+
+
+def _team_of(laps, driver: str) -> str | None:
+    """The Team string this driver raced under, exactly as the parquet spells it."""
+    rows = laps[laps["Driver"] == driver]["Team"].dropna()
+    return str(rows.iloc[0]) if len(rows) else None
+
+
+def _decisions_in_window(engine, laps_df, driver: str, low: int, high: int) -> dict[int, str]:
+    """Action the deterministic stack emits on each lap of ``[low, high]``.
+
+    Only the laps inside the window are pushed through ``run_lap``; the replay
+    generator itself is cheap and the agent stack is not, so skipping the rest of
+    the race is where the runtime budget comes from.
+    """
+    from src.agents.strategy_orchestrator import RaceState
+    import src.strategy.inference.engine as inference_engine
+
+    actions: dict[int, str] = {}
+    for state in engine.replay():
+        car = state.get("driver") or {}
+        # A retired car keeps yielding lap states with an EMPTY driver dict for the
+        # rest of the race. Presence is the signal, never a lap-number threshold:
+        # a car that finished can be missing laps too, and the two ranges overlap.
+        if "lap_number" not in car:
+            continue
+
+        lap = int(car["lap_number"])
+        if lap < low:
+            continue
+        if lap > high:
+            break
+
+        # Position is None when the state manager could not resolve it, and it is
+        # None on purpose rather than a number: a sentinel position has already
+        # collided with a real one in this codebase. A lap with no position is not
+        # a lap the stack can be asked about, so it is skipped and never defaulted.
+        if car.get("position") is None:
+            continue
+
+        # Tyre life is read the long way for the same reason: `or 10` would turn a
+        # legitimate fresh tyre (0) into a ten-lap-old one and quietly move what the
+        # tyre agent answers.
+        tyre_life = car.get("tyre_life")
+        weather = state.get("weather") or {}
+        race_state = RaceState(
+            driver=driver,
+            lap=lap,
+            total_laps=int(state["session_meta"]["total_laps"]),
+            position=int(car["position"]),
+            compound=car.get("compound") or "MEDIUM",
+            tyre_life=10 if tyre_life is None else int(tyre_life),
+            gap_ahead_s=car.get("gap_ahead_s") or 2.0,
+            pace_delta_s=0.0,
+            risk_tolerance=0.5,
+            air_temp=weather.get("air_temp") or 25.0,
+            track_temp=weather.get("track_temp") or 35.0,
+        )
+        recommendation, _outputs, _timings = inference_engine.run_lap(
+            race_state, laps_df, state, profile="no-llm", return_agent_outputs=True
+        )
+        actions[lap] = recommendation.action
+    return actions
+
+
+def _first_pit_lap(actions: dict[int, str], low: int, high: int) -> int | None:
+    """Earliest lap in the window on which the stack asked to stop, or None."""
+    for lap in range(low, high + 1):
+        if actions.get(lap) in _PIT_ACTIONS:
+            return lap
+    return None
+
+
+def _stop_context(laps, driver: str, lap: int) -> tuple[str | None, int | None]:
+    """Compound and tyre life on the lap the car actually pitted."""
+    row = laps[(laps["Driver"] == driver) & (laps["LapNumber"] == lap)]
+    if not len(row):
+        return None, None
+    compound = row["Compound"].iloc[0]
+    tyre_life = row["TyreLife"].iloc[0]
+    return (
+        None if compound is None or _is_missing(compound) else str(compound),
+        None if _is_missing(tyre_life) else int(tyre_life),
+    )
+
+
+def _is_missing(value: Any) -> bool:
+    """True for NaN/NaT/None, without assuming the value is numeric."""
+    try:
+        return bool(np.isnan(value))
+    except (TypeError, ValueError):
+        return value is None
+
+
+def measure_decision_agreement(
+    races: tuple[tuple[int, str], ...] = SAMPLED_RACES,
+) -> tuple[DecisionAgreement, list[StopVerdict]]:
+    """Drive the deterministic stack over every real green-flag stop in ``races``.
+
+    Raises FileNotFoundError when ``data/raw/`` is absent rather than returning an
+    empty sample, because a tier that reports perfect agreement over zero stops is
+    worse than one that reports nothing.
+    """
+    import pandas as pd
+
+    from src.f1_strat_manager.laps_augment import augment_featured_laps
+    from src.simulation.replay_engine import RaceReplayEngine
+
+    # The sample definition comes from projection.py rather than being restated,
+    # so both tiers grade the same stops. That identity is the only reason the two
+    # sets of numbers can sit in the same sentence.
+    from src.strategy.eval.projection import (
+        _neutralised_laps,
+        _raw_data_root,
+        green_flag_stops,
+    )
+
+    raw = _raw_data_root()
+    if raw is None:
+        raise FileNotFoundError(
+            "data/raw/ is not present; the decision tier needs the raw laps from the "
+            "Hugging Face dataset (the featured parquet drops the pit laps it is keyed on)"
+        )
+
+    featured_by_year: dict[int, Any] = {}
+    verdicts: list[StopVerdict] = []
+    races_measured = 0
+
+    for year, race in races:
+        race_dir = raw / str(year) / race
+        laps_path = race_dir / "laps.parquet"
+        if not laps_path.exists():
+            continue
+
+        laps = pd.read_parquet(laps_path)
+        if "PitInTime" not in laps.columns:
+            continue
+
+        if year not in featured_by_year:
+            featured_path = f"data/processed/laps_featured_{year}.parquet"
+            featured_by_year[year] = augment_featured_laps(pd.read_parquet(featured_path), year)
+        featured = featured_by_year[year]
+
+        neutralised = _neutralised_laps(laps)
+        total_laps = int(laps["LapNumber"].max())
+        races_measured += 1
+
+        for driver, stop_laps in green_flag_stops(laps, neutralised).items():
+            team = _team_of(laps, driver)
+            if team is None:
+                continue
+
+            # One replay pass per (race, driver) spanning the union of the windows.
+            # Two stops twenty laps apart still cost one pass, which is where the
+            # runtime budget for a stratified subset comes from.
+            low = max(1, min(stop_laps) - DECISION_WINDOW_LAPS)
+            high = min(total_laps, max(stop_laps) + DECISION_WINDOW_LAPS)
+            engine = RaceReplayEngine(str(race_dir), driver, team, interval_seconds=0)
+            actions = _decisions_in_window(engine, featured, driver, low, high)
+
+            for stop_lap in stop_laps:
+                compound, tyre_life = _stop_context(laps, driver, stop_lap)
+                blocked = guard_rail_block(stop_lap, total_laps, compound, tyre_life)
+                if blocked is not None:
+                    verdicts.append(
+                        StopVerdict(year, race, driver, stop_lap, None, None, blocked)
+                    )
+                    continue
+
+                window_low = max(1, stop_lap - DECISION_WINDOW_LAPS)
+                window_high = min(total_laps, stop_lap + DECISION_WINDOW_LAPS)
+
+                # "The stack never evaluated this window" and "the stack looked and
+                # declined to stop" are different findings, and collapsing them would
+                # charge a retirement to the model as a missed call.
+                if not any(lap in actions for lap in range(window_low, window_high + 1)):
+                    verdicts.append(
+                        StopVerdict(year, race, driver, stop_lap, None, None, "no_data")
+                    )
+                    continue
+
+                chosen = _first_pit_lap(actions, window_low, window_high)
+                if chosen is None:
+                    verdicts.append(
+                        StopVerdict(year, race, driver, stop_lap, None, None, "no_call_in_window")
+                    )
+                    continue
+
+                verdicts.append(
+                    StopVerdict(
+                        year, race, driver, stop_lap, chosen, chosen - stop_lap, "scored"
+                    )
+                )
+
+    offsets = np.array(
+        [v.offset_laps for v in verdicts if v.offset_laps is not None], dtype=int
+    )
+    agreement = DecisionAgreement(
+        offsets=offsets,
+        guard_railed=sum(1 for v in verdicts if v.bucket in _GUARD_RAIL_BUCKETS),
+        no_call=sum(1 for v in verdicts if v.bucket == "no_call_in_window"),
+        races=races_measured,
+        no_data=sum(1 for v in verdicts if v.bucket == "no_data"),
+    )
+    return agreement, verdicts
+
+
+def _bucket_counts(verdicts: list[StopVerdict]) -> dict[str, int]:
+    """How many stops landed in each bucket, so the exclusions stay countable."""
+    counts: dict[str, int] = {}
+    for verdict in verdicts:
+        counts[verdict.bucket] = counts.get(verdict.bucket, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _render_table(
+    agreement: DecisionAgreement | None, verdicts: list[StopVerdict], status: str
+) -> str:
+    """Markdown body: the headline agreement, the buckets, and the caveats."""
+    if agreement is None:
+        return (
+            "Not measured: `data/raw/` is absent, so there are no real stops to "
+            "compare against. Pull the Hugging Face dataset and re-run.\n"
+        )
+
+    races = ", ".join(f"{year} {race}" for year, race in SAMPLED_RACES)
+    lines = [
+        "| Metric | Value | Meaning |",
+        "| --- | --- | --- |",
+        f"| Stops scored | {agreement.sample_size} of {agreement.eligible} "
+        f"({agreement.scored_share:.1%}) | real green-flag stops the tier could grade |",
+        f"| Exact lap | {agreement.exact:.1%} | chose the lap the team chose |",
+        f"| Within 1 lap | {agreement.within_one:.1%} | same call, one lap either side |",
+        f"| Within 2 laps | {agreement.within_two:.1%} | same strategic window |",
+        f"| Mean signed error | {agreement.mean_signed_error:+.2f} laps | "
+        "negative = stops earlier than the team |",
+        f"| Mean absolute error | {agreement.mean_absolute_error:.2f} laps | magnitude |",
+        f"| Coverage verdict | **{status}** | `masked` when under "
+        f"{MIN_SCORED_SHARE:.0%} of eligible stops were scored |",
+        "",
+        "### Buckets",
+        "",
+        "| Bucket | Stops |",
+        "| --- | --- |",
+    ]
+    lines += [f"| `{name}` | {count} |" for name, count in _bucket_counts(verdicts).items()]
+    lines += [
+        "",
+        "`opening_laps` / `closing_laps` / `min_stint` are stops the guard rails make",
+        "impossible to agree with, so they are excluded from the headline rather than",
+        "counted as misses. `no_data` is a car that had already retired, so the stack",
+        "never evaluated the window at all. `no_call_in_window` is different and is the",
+        "number to watch: the stack looked and declined to stop anywhere near the real",
+        "lap. Charging a retirement to the model as a missed call would flatter neither",
+        "side honestly, so the two are never merged.",
+        "",
+        "### Scope",
+        "",
+        f"- Sampled races ({agreement.races} measured): {races}.",
+        "- A full sweep of the real-stop sample is roughly 11.5 h of wall clock at",
+        "  0.51 s per lap through the stack, so this is a stratified subset by circuit",
+        "  archetype and **not** full coverage. Read every figure above as conditional",
+        "  on these races.",
+        "- Decisions come from `profile=\"no-llm\"`: the deterministic Monte Carlo layer",
+        "  plus the guard rails, never the LLM synthesis.",
+        "- Agreement with the real pit wall is evidence, not correctness. The team can",
+        "  be wrong, and this tier cannot tell when it was.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def build_decision_modes_report() -> dict[str, Any]:
+    """Write ``documents/eval_reports/decision_modes.{md,json}`` and return the payload."""
+    try:
+        agreement, verdicts = measure_decision_agreement()
+    except FileNotFoundError:
+        agreement, verdicts = None, []
+
+    status = coverage_verdict(agreement) if agreement is not None else "unavailable"
+    header = build_header(dataset="data/raw laps, stratified 6-race subset (RAW, not featured)")
+    md_path, json_path = write_report(
+        "decision_modes",
+        header,
+        _render_table(agreement, verdicts, status),
+        {
+            "status": status,
+            "window_laps": DECISION_WINDOW_LAPS,
+            "sampled_races": [{"year": year, "race": race} for year, race in SAMPLED_RACES],
+            "agreement": None
+            if agreement is None
+            else {
+                "sample_size": agreement.sample_size,
+                "eligible": agreement.eligible,
+                "scored_share": agreement.scored_share,
+                "races": agreement.races,
+                "exact": agreement.exact,
+                "within_one": agreement.within_one,
+                "within_two": agreement.within_two,
+                "mean_signed_error": agreement.mean_signed_error,
+                "mean_absolute_error": agreement.mean_absolute_error,
+            },
+            "buckets": _bucket_counts(verdicts),
+            "verdicts": [
+                {
+                    "year": v.year,
+                    "race": v.race,
+                    "driver": v.driver,
+                    "actual_lap": v.actual_lap,
+                    "chosen_lap": v.chosen_lap,
+                    "offset_laps": v.offset_laps,
+                    "bucket": v.bucket,
+                }
+                for v in verdicts
+            ],
+        },
+    )
+    return {
+        "md_path": str(md_path),
+        "json_path": str(json_path),
+        "status": status,
+        "agreement": agreement,
+        "verdicts": verdicts,
+    }

--- a/src/strategy/eval/projection.py
+++ b/src/strategy/eval/projection.py
@@ -157,6 +157,30 @@ def _neutralised_laps(laps) -> set[int]:
     return neutralised
 
 
+def green_flag_stops(laps, neutralised: set[int]) -> dict[str, list[int]]:
+    """Green-flag stop laps per driver, in lap order.
+
+    Public because it is the definition of the SAMPLE, and more than one eval
+    tier has to grade the same stops or their numbers are not comparable with
+    each other. ``decision_modes.py`` consumes it for exactly that reason;
+    restating the rule there would make a second copy of a filter this repo
+    already pays to keep correct, and the two would drift apart the first time
+    either moved.
+
+    Note this is not every stop: ``pitters`` (rival geometry) still wants the
+    neutralised ones, because a rival pitting under a Safety Car changes where
+    our car comes out even though it is not a decision worth grading.
+    """
+    stops = laps[laps["PitInTime"].notna()][["Driver", "LapNumber"]]
+    by_driver: dict[str, list[int]] = {}
+    for _, row in stops.iterrows():
+        lap = int(row["LapNumber"])
+        if lap in neutralised or lap + 1 in neutralised:
+            continue
+        by_driver.setdefault(str(row["Driver"]), []).append(lap)
+    return {driver: sorted(stop_laps) for driver, stop_laps in by_driver.items()}
+
+
 def _rivals_around(pivot, medians, pitters, driver, lap, row_before, row_after, ours_before):
     """Every car with a lap either side of the stop, with its own stop loss if it pitted."""
     rivals: list[RivalState] = []
@@ -283,13 +307,11 @@ def measure_projection_ground_truth(years: tuple[int, ...] = (2023, 2024, 2025))
             for _, row in stops.iterrows():
                 pitters.setdefault(int(row["LapNumber"]), set()).add(str(row["Driver"]))
 
-            for _, stop in stops.iterrows():
-                lap = int(stop["LapNumber"])
-                if lap in neutralised or lap + 1 in neutralised:
-                    continue
-                error = project_one_stop(pivot, medians, pitters, str(stop["Driver"]), lap)
-                if error is not None:
-                    errors.append(error)
+            for driver, stop_laps in green_flag_stops(laps, neutralised).items():
+                for lap in stop_laps:
+                    error = project_one_stop(pivot, medians, pitters, driver, lap)
+                    if error is not None:
+                        errors.append(error)
 
     return GroundTruth(errors=np.array(errors, dtype=int), races=races)
 

--- a/src/strategy/inference/guard_rails.py
+++ b/src/strategy/inference/guard_rails.py
@@ -1,0 +1,63 @@
+"""The deterministic pit guard rails, in a module that imports nothing heavy.
+
+Canonical re-host of the backend's ``apply_guard_rails``. Identical rule set to
+``src/telemetry/backend/services/simulation/guard_rails.py`` and the CLI's inline
+copy (``run_simulation_cli.py``). Re-hosted rather than imported because the
+parent must never depend on the submodule; the backend copy retires when P1
+migrates, the CLI copy when the P4 duplicate lands (3 -> 1).
+
+WHY THIS IS ITS OWN MODULE (#708):
+These rules used to live in ``no_llm.py``, which imports the agent stack and
+therefore loads model weights at import time. That made "what is the minimum
+stint?" a question you could not ask without ``data/models/`` on disk — it broke
+``f1-eval`` on any install without the weights, and it broke CI. A policy
+constant should not cost a LightGBM load, so the rules live here and ``no_llm``
+imports them. Anything that needs to MIRROR a rail must import it from here and,
+better still, call ``apply_guard_rails`` rather than re-derive its boundaries:
+the eval tier initially retyped ``remaining < 3`` against the rail's
+``remaining <= 3`` and shipped a test that encoded the off-by-one.
+"""
+
+from __future__ import annotations
+
+_PIT_ACTIONS = frozenset({"PIT_NOW", "UNDERCUT", "OVERCUT", "REACTIVE_SC"})
+_NO_PIT_BEFORE_LAP = 5
+_NO_PIT_LAST_N_LAPS = 3
+_CLIFF_P10_SAFE = 2
+_MIN_STINT_LAPS = {"SOFT": 8, "MEDIUM": 12, "HARD": 15}
+_DEFAULT_MIN_STINT = 10
+
+
+def apply_guard_rails(
+    action: str,
+    lap: int,
+    total_laps: int,
+    compound: str,
+    tyre_life: int,
+    cliff_p10: float = 99.0,
+) -> tuple[str, str | None]:
+    """Override *action* with STAY_OUT when a hard strategic constraint fires.
+
+    Rules: no pit before lap 5; no pit in the last 3 laps unless the cliff is
+    imminent (cliff_p10 < 2); minimum stint SOFT 8 / MEDIUM 12 / HARD 15. Returns
+    ``(action, reason)`` with ``reason=None`` when no rail fired.
+    """
+    if action not in _PIT_ACTIONS:
+        return action, None
+
+    remaining_laps = total_laps - lap
+
+    if lap < _NO_PIT_BEFORE_LAP:
+        return "STAY_OUT", f"guard-rail: pit window not open (lap < {_NO_PIT_BEFORE_LAP})"
+
+    if remaining_laps <= _NO_PIT_LAST_N_LAPS and cliff_p10 >= _CLIFF_P10_SAFE:
+        return "STAY_OUT", f"guard-rail: too late to pit (<={_NO_PIT_LAST_N_LAPS} laps left)"
+
+    min_life = _MIN_STINT_LAPS.get(compound, _DEFAULT_MIN_STINT)
+    if tyre_life < min_life:
+        return (
+            "STAY_OUT",
+            f"guard-rail: minimum stint not reached ({compound} {tyre_life}/{min_life} laps)",
+        )
+
+    return action, None

--- a/src/strategy/inference/no_llm.py
+++ b/src/strategy/inference/no_llm.py
@@ -53,53 +53,22 @@ from src.strategy.inference.engine import (
 )
 
 # ---------------------------------------------------------------------------
-# Guard-rails — canonical re-host of the backend's apply_guard_rails.
-# Identical rule set to src/telemetry/backend/services/simulation/guard_rails.py
-# and the CLI's inline copy (run_simulation_cli.py L1504-L1535). Re-hosted rather
-# than imported because the parent must never depend on the submodule; the backend
-# copy retires when P1 migrates, the CLI copy when the P4 duplicate lands (3 -> 1).
+# Guard-rails now live in src/strategy/inference/guard_rails.py, which imports
+# nothing heavy, so a caller can read a rail without loading the agent stack's
+# model weights (#708). Re-exported here because this module was their published
+# home and existing importers must keep working.
 # ---------------------------------------------------------------------------
-_PIT_ACTIONS = frozenset({"PIT_NOW", "UNDERCUT", "OVERCUT", "REACTIVE_SC"})
-_NO_PIT_BEFORE_LAP = 5
-_NO_PIT_LAST_N_LAPS = 3
-_CLIFF_P10_SAFE = 2
-_MIN_STINT_LAPS = {"SOFT": 8, "MEDIUM": 12, "HARD": 15}
-_DEFAULT_MIN_STINT = 10
+from src.strategy.inference.guard_rails import (  # noqa: E402
+    _CLIFF_P10_SAFE,
+    _DEFAULT_MIN_STINT,
+    _MIN_STINT_LAPS,
+    _NO_PIT_BEFORE_LAP,
+    _NO_PIT_LAST_N_LAPS,
+    _PIT_ACTIONS,
+    apply_guard_rails,
+)
 
-
-def apply_guard_rails(
-    action: str,
-    lap: int,
-    total_laps: int,
-    compound: str,
-    tyre_life: int,
-    cliff_p10: float = 99.0,
-) -> tuple[str, str | None]:
-    """Override *action* with STAY_OUT when a hard strategic constraint fires.
-
-    Rules: no pit before lap 5; no pit in the last 3 laps unless the cliff is
-    imminent (cliff_p10 < 2); minimum stint SOFT 8 / MEDIUM 12 / HARD 15. Returns
-    ``(action, reason)`` with ``reason=None`` when no rail fired.
-    """
-    if action not in _PIT_ACTIONS:
-        return action, None
-
-    remaining_laps = total_laps - lap
-
-    if lap < _NO_PIT_BEFORE_LAP:
-        return "STAY_OUT", f"guard-rail: pit window not open (lap < {_NO_PIT_BEFORE_LAP})"
-
-    if remaining_laps <= _NO_PIT_LAST_N_LAPS and cliff_p10 >= _CLIFF_P10_SAFE:
-        return "STAY_OUT", f"guard-rail: too late to pit (<={_NO_PIT_LAST_N_LAPS} laps left)"
-
-    min_life = _MIN_STINT_LAPS.get(compound, _DEFAULT_MIN_STINT)
-    if tyre_life < min_life:
-        return (
-            "STAY_OUT",
-            f"guard-rail: minimum stint not reached ({compound} {tyre_life}/{min_life} laps)",
-        )
-
-    return action, None
+__all__ = ["apply_guard_rails", "run_no_llm_lap"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/eval/test_decision_modes.py
+++ b/tests/eval/test_decision_modes.py
@@ -1,0 +1,279 @@
+"""Tests for the decision-agreement tier (#708).
+
+Two layers, deliberately split the same way ``test_position_projection.py`` splits:
+
+1. Pure tests that pin the contract — which stops the guard rails make
+   unanswerable, how an agreement is aggregated, when coverage is untrustworthy,
+   and that the report keeps saying it is a subset. These run everywhere.
+
+2. One data-tier test that refuses to believe a sample it has not counted. It
+   needs ``data/raw`` and skips without it.
+
+The report's honesty is itself under test here. ``test_render_states_the_subset``
+exists because the single most damaging edit anyone could make to this module is
+deleting the sentence that says the figures are conditional on six races.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.strategy.eval.decision_modes import (
+    MIN_SCORED_SHARE,
+    SAMPLED_RACES,
+    DecisionAgreement,
+    StopVerdict,
+    _first_pit_lap,
+    _render_table,
+    coverage_verdict,
+    guard_rail_block,
+)
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_RAW = (ROOT / "data" / "raw" / "2024").is_dir()
+
+
+def _agreement(offsets, guard_railed=0, no_call=0, races=6, no_data=0) -> DecisionAgreement:
+    return DecisionAgreement(
+        offsets=np.array(offsets, dtype=int),
+        guard_railed=guard_railed,
+        no_call=no_call,
+        races=races,
+        no_data=no_data,
+    )
+
+
+# --- guard rails: which stops can never be agreed with ---------------------
+
+
+@pytest.mark.parametrize(
+    ("lap", "total", "compound", "tyre_life", "expected"),
+    [
+        (3, 57, "MEDIUM", 20, "opening_laps"),
+        (56, 57, "MEDIUM", 20, "closing_laps"),
+        (30, 57, "SOFT", 5, "min_stint"),
+        (30, 57, None, 9, "min_stint"),
+        (30, 57, "SOFT", 20, None),
+        (30, 57, "MEDIUM", None, None),
+    ],
+)
+def test_guard_rail_block_names_the_rule(lap, total, compound, tyre_life, expected):
+    """Each rail is named, so an exclusion can be counted instead of vanishing."""
+    assert guard_rail_block(lap, total, compound, tyre_life) == expected
+
+
+def test_guard_rail_thresholds_track_the_rails_they_mirror():
+    """The boundary is the rail's, not a number retyped here.
+
+    If ``no_llm`` moves a threshold this test moves with it; a hardcoded 5 or 3
+    would let this module drift away from the rails it claims to mirror.
+    """
+    from src.strategy.inference.no_llm import _NO_PIT_BEFORE_LAP, _NO_PIT_LAST_N_LAPS
+
+    assert guard_rail_block(_NO_PIT_BEFORE_LAP - 1, 57, "HARD", 30) == "opening_laps"
+    assert guard_rail_block(_NO_PIT_BEFORE_LAP, 57, "HARD", 30) is None
+    assert guard_rail_block(57 - _NO_PIT_LAST_N_LAPS, 57, "HARD", 30) is None
+    assert guard_rail_block(57 - _NO_PIT_LAST_N_LAPS + 1, 57, "HARD", 30) == "closing_laps"
+
+
+# --- picking the lap the stack would have chosen ---------------------------
+
+
+def test_first_pit_lap_takes_the_earliest_call():
+    """Two pit calls in the window resolve to the first: that is the decision."""
+    actions = {28: "STAY_OUT", 29: "UNDERCUT", 30: "STAY_OUT", 31: "PIT_NOW"}
+    assert _first_pit_lap(actions, 27, 32) == 29
+
+
+def test_first_pit_lap_returns_none_when_the_stack_never_calls_it():
+    """No call in the window is a result, and it must not read as lap zero."""
+    assert _first_pit_lap({lap: "STAY_OUT" for lap in range(27, 33)}, 27, 32) is None
+
+
+def test_first_pit_lap_ignores_calls_outside_the_window():
+    """A pit action two laps past the window is not agreement with this stop."""
+    assert _first_pit_lap({35: "PIT_NOW"}, 27, 32) is None
+
+
+# --- aggregation -----------------------------------------------------------
+
+
+def test_agreement_reports_signed_bias_not_just_magnitude():
+    """A stack that always stops two laps early must not look unbiased."""
+    agreement = _agreement([-2, -2, -2, -2])
+    assert agreement.mean_signed_error == -2.0
+    assert agreement.mean_absolute_error == 2.0
+    assert agreement.exact == 0.0
+
+
+def test_agreement_tolerance_bands_are_nested():
+    offsets = [0, 1, -1, 2, 4]
+    agreement = _agreement(offsets)
+    assert agreement.exact == pytest.approx(0.2)
+    assert agreement.within_one == pytest.approx(0.6)
+    assert agreement.within_two == pytest.approx(0.8)
+
+
+def test_retired_cars_are_counted_apart_from_declined_calls():
+    """`no_data` and `no_call_in_window` must never be merged.
+
+    A car that had already retired gave the stack nothing to evaluate; a car the
+    stack looked at and declined to stop is a finding. Folding the first into the
+    second charges a retirement to the model as a missed call — the same shape as
+    the sentinel bugs this repo has paid for before.
+    """
+    agreement = _agreement([0, 1], no_call=3, no_data=5)
+    assert agreement.eligible == 10
+    assert agreement.no_call == 3
+    assert agreement.no_data == 5
+
+
+def test_no_data_counts_against_coverage():
+    """Stops the tier could not look at still shrink the share it can vouch for."""
+    assert coverage_verdict(_agreement([0] * 5, no_data=5)) == "masked"
+
+
+def test_empty_agreement_reports_zero_rather_than_dividing_by_zero():
+    """An empty sample is a reporting state, not a crash and not a perfect score."""
+    agreement = _agreement([])
+    assert agreement.sample_size == 0
+    assert agreement.within_one == 0.0
+    assert agreement.scored_share == 0.0
+
+
+# --- the coverage guard ----------------------------------------------------
+
+
+def test_coverage_ok_when_most_stops_were_scored():
+    assert coverage_verdict(_agreement([0] * 9, guard_railed=1)) == "ok"
+
+
+def test_coverage_masked_when_the_unscored_buckets_dominate():
+    """The adapted compensation guard: a headline drawn from a third of the sample
+    is a headline about whatever survived, and the survivors are not random."""
+    agreement = _agreement([0] * 3, guard_railed=4, no_call=3)
+    assert agreement.scored_share < MIN_SCORED_SHARE
+    assert coverage_verdict(agreement) == "masked"
+
+
+def test_coverage_unavailable_when_nothing_was_eligible():
+    assert coverage_verdict(_agreement([])) == "unavailable"
+
+
+# --- which laps are evaluable at all ---------------------------------------
+
+
+class _FakeEngine:
+    """Replay stub: yields the lap states it was handed, nothing else."""
+
+    def __init__(self, states):
+        self._states = states
+
+    def replay(self):
+        return iter(self._states)
+
+
+def _lap_state(lap, position=4, tyre_life=12):
+    return {
+        "driver": {
+            "lap_number": lap,
+            "position": position,
+            "compound": "MEDIUM",
+            "tyre_life": tyre_life,
+            "gap_ahead_s": 2.0,
+        },
+        "weather": {"air_temp": 25.0, "track_temp": 35.0},
+        "session_meta": {"total_laps": 57},
+    }
+
+
+def test_laps_without_a_position_are_skipped_not_defaulted(monkeypatch):
+    """A None position skips the lap; it must never become a number.
+
+    This crashed the first real run. The state manager returns None on purpose
+    because a sentinel position has already collided with a real one here, so the
+    fix is to skip the lap, not to invent a plausible place.
+    """
+    import src.strategy.inference.engine as inference_engine
+    from src.strategy.eval.decision_modes import _decisions_in_window
+
+    seen: list[int] = []
+
+    def _fake_run_lap(race_state, laps_df, lap_state, **kwargs):
+        seen.append(race_state.lap)
+        return type("R", (), {"action": "STAY_OUT"})(), None, {}
+
+    monkeypatch.setattr(inference_engine, "run_lap", _fake_run_lap)
+
+    states = [
+        _lap_state(10, position=None),
+        _lap_state(11),
+        {"driver": {}},  # retired: empty driver dict for the rest of the race
+    ]
+    actions = _decisions_in_window(_FakeEngine(states), None, "NOR", 1, 57)
+
+    assert seen == [11]
+    assert actions == {11: "STAY_OUT"}
+
+
+def test_fresh_tyre_is_not_rounded_up_to_ten_laps(monkeypatch):
+    """`tyre_life=0` is a real reading, and `or 10` would silently age the tyre."""
+    import src.strategy.inference.engine as inference_engine
+    from src.strategy.eval.decision_modes import _decisions_in_window
+
+    captured: list[int] = []
+
+    def _fake_run_lap(race_state, laps_df, lap_state, **kwargs):
+        captured.append(race_state.tyre_life)
+        return type("R", (), {"action": "STAY_OUT"})(), None, {}
+
+    monkeypatch.setattr(inference_engine, "run_lap", _fake_run_lap)
+    _decisions_in_window(_FakeEngine([_lap_state(11, tyre_life=0)]), None, "NOR", 1, 57)
+
+    assert captured == [0]
+
+
+# --- the report's honesty --------------------------------------------------
+
+
+def test_render_states_the_subset_and_refuses_to_imply_full_coverage():
+    """The scope caveats are part of the artifact, not decoration."""
+    body = _render_table(
+        _agreement([0, 1], guard_railed=1),
+        [StopVerdict(2025, "Lusail", "NOR", 30, 30, 0, "scored")],
+        "ok",
+    )
+    assert "not** full coverage" in body
+    assert "stratified subset" in body
+    assert "no-llm" in body
+    for _year, race in SAMPLED_RACES:
+        assert race in body
+
+
+def test_render_without_data_says_so_instead_of_printing_zeros():
+    body = _render_table(None, [], "unavailable")
+    assert "Not measured" in body
+    assert "0.0%" not in body
+
+
+# --- the one test that checks against the world ----------------------------
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_RAW, reason="data/raw absent (CI runner without the dataset)")
+def test_measured_sample_is_non_empty_before_any_figure_is_believed():
+    """Guard against a green run that quietly graded nothing.
+
+    A tier iterating a DISCOVERED set can pass every assertion about the empty
+    set. This asserts the set exists first; the repo has shipped that bug before.
+    """
+    from src.strategy.eval.decision_modes import measure_decision_agreement
+
+    agreement, verdicts = measure_decision_agreement(races=((2025, "Lusail"),))
+    assert verdicts, "no real stops enumerated: the sample is empty, not accurate"
+    assert agreement.eligible == len(verdicts)
+    assert agreement.races == 1
+    assert all(v.offset_laps is None for v in verdicts if v.bucket != "scored")

--- a/tests/eval/test_decision_modes.py
+++ b/tests/eval/test_decision_modes.py
@@ -30,6 +30,7 @@ from src.strategy.eval.decision_modes import (
     _render_table,
     coverage_verdict,
     guard_rail_block,
+    lap_inputs,
 )
 
 ROOT = Path(__file__).parent.parent.parent
@@ -225,16 +226,6 @@ def test_coverage_unavailable_when_nothing_was_eligible():
 # --- which laps are evaluable at all ---------------------------------------
 
 
-class _FakeEngine:
-    """Replay stub: yields the lap states it was handed, nothing else."""
-
-    def __init__(self, states):
-        self._states = states
-
-    def replay(self):
-        return iter(self._states)
-
-
 def _lap_state(lap, position=4, tyre_life=12):
     return {
         "driver": {
@@ -249,50 +240,31 @@ def _lap_state(lap, position=4, tyre_life=12):
     }
 
 
-def test_laps_without_a_position_are_skipped_not_defaulted(monkeypatch):
+def test_laps_without_a_position_are_skipped_not_defaulted():
     """A None position skips the lap; it must never become a number.
 
-    This crashed the first real run. The state manager returns None on purpose
-    because a sentinel position has already collided with a real one here, so the
-    fix is to skip the lap, not to invent a plausible place.
+    This crashed the first real measurement run. The state manager returns None on
+    purpose because a sentinel position has already collided with a real one here,
+    so the fix is to skip the lap, not to invent a plausible place.
     """
-    import src.strategy.inference.engine as inference_engine
-    from src.strategy.eval.decision_modes import _decisions_in_window
-
-    seen: list[int] = []
-
-    def _fake_run_lap(race_state, laps_df, lap_state, **kwargs):
-        seen.append(race_state.lap)
-        return type("R", (), {"action": "STAY_OUT"})(), None, {}
-
-    monkeypatch.setattr(inference_engine, "run_lap", _fake_run_lap)
-
-    states = [
-        _lap_state(10, position=None),
-        _lap_state(11),
-        {"driver": {}},  # retired: empty driver dict for the rest of the race
-    ]
-    actions = _decisions_in_window(_FakeEngine(states), None, "NOR", 1, 57)
-
-    assert seen == [11]
-    assert actions == {11: "STAY_OUT"}
+    assert lap_inputs(_lap_state(10, position=None)) is None
+    assert lap_inputs(_lap_state(11))["position"] == 4
 
 
-def test_fresh_tyre_is_not_rounded_up_to_ten_laps(monkeypatch):
+def test_retired_cars_yield_nothing_to_evaluate():
+    """An empty driver dict is how a retirement shows up for the rest of the race."""
+    assert lap_inputs({"driver": {}}) is None
+    assert lap_inputs({}) is None
+
+
+def test_fresh_tyre_is_not_rounded_up_to_ten_laps():
     """`tyre_life=0` is a real reading, and `or 10` would silently age the tyre."""
-    import src.strategy.inference.engine as inference_engine
-    from src.strategy.eval.decision_modes import _decisions_in_window
+    assert lap_inputs(_lap_state(11, tyre_life=0))["tyre_life"] == 0
 
-    captured: list[int] = []
 
-    def _fake_run_lap(race_state, laps_df, lap_state, **kwargs):
-        captured.append(race_state.tyre_life)
-        return type("R", (), {"action": "STAY_OUT"})(), None, {}
-
-    monkeypatch.setattr(inference_engine, "run_lap", _fake_run_lap)
-    _decisions_in_window(_FakeEngine([_lap_state(11, tyre_life=0)]), None, "NOR", 1, 57)
-
-    assert captured == [0]
+def test_unknown_tyre_life_falls_back_but_a_known_one_never_does():
+    assert lap_inputs(_lap_state(11, tyre_life=None))["tyre_life"] == 10
+    assert lap_inputs(_lap_state(11, tyre_life=3))["tyre_life"] == 3
 
 
 # --- the report's honesty --------------------------------------------------

--- a/tests/eval/test_decision_modes.py
+++ b/tests/eval/test_decision_modes.py
@@ -46,6 +46,35 @@ def _agreement(offsets, guard_railed=0, no_call=0, races=6, no_data=0) -> Decisi
     )
 
 
+# --- the import surface ----------------------------------------------------
+
+
+def test_importing_the_module_does_not_load_the_agent_stack():
+    """Importing this report must not require model weights on disk.
+
+    ``no_llm`` pulls in the agent stack, which loads LightGBM weights at import
+    time. Importing the guard rails from there turned every `f1-eval` subcommand
+    into something that could not even be COLLECTED without `data/models/`, and it
+    is what turned CI red on the first push of this tier.
+    """
+    import subprocess
+    import sys
+
+    probe = (
+        "import sys; import src.strategy.eval.decision_modes; "
+        "loaded = [m for m in sys.modules if m.startswith('src.agents')]; "
+        "print(','.join(sorted(loaded)))"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        check=True,
+    )
+    assert out.stdout.strip() == "", f"agent modules imported eagerly: {out.stdout.strip()}"
+
+
 # --- guard rails: which stops can never be agreed with ---------------------
 
 
@@ -65,18 +94,48 @@ def test_guard_rail_block_names_the_rule(lap, total, compound, tyre_life, expect
     assert guard_rail_block(lap, total, compound, tyre_life) == expected
 
 
-def test_guard_rail_thresholds_track_the_rails_they_mirror():
-    """The boundary is the rail's, not a number retyped here.
+def test_block_agrees_with_the_rail_on_every_lap_of_a_race():
+    """The bucketer must agree with the rail itself, lap by lap, never re-derive it.
 
-    If ``no_llm`` moves a threshold this test moves with it; a hardcoded 5 or 3
-    would let this module drift away from the rails it claims to mirror.
+    The first version of ``guard_rail_block`` retyped the closing-laps boundary as
+    ``remaining < 3`` against the rail's ``remaining <= 3``, and the test that was
+    supposed to catch it re-derived the same boundary and so agreed with the bug.
+    Asserting equivalence with ``apply_guard_rails`` is the only formulation that
+    cannot drift, because there is nothing left to retype.
     """
-    from src.strategy.inference.no_llm import _NO_PIT_BEFORE_LAP, _NO_PIT_LAST_N_LAPS
+    from src.strategy.inference.guard_rails import apply_guard_rails
 
-    assert guard_rail_block(_NO_PIT_BEFORE_LAP - 1, 57, "HARD", 30) == "opening_laps"
-    assert guard_rail_block(_NO_PIT_BEFORE_LAP, 57, "HARD", 30) is None
-    assert guard_rail_block(57 - _NO_PIT_LAST_N_LAPS, 57, "HARD", 30) is None
-    assert guard_rail_block(57 - _NO_PIT_LAST_N_LAPS + 1, 57, "HARD", 30) == "closing_laps"
+    total = 57
+    for lap in range(1, total + 1):
+        for compound, tyre_life in (("SOFT", 20), ("MEDIUM", 4), ("HARD", 30)):
+            rail_action, _reason = apply_guard_rails("PIT_NOW", lap, total, compound, tyre_life)
+            blocked = guard_rail_block(lap, total, compound, tyre_life)
+            assert (rail_action == "STAY_OUT") == (blocked is not None), (
+                f"disagreement at lap {lap} on {compound}/{tyre_life}"
+            )
+
+
+def test_every_bucket_is_reachable_through_the_real_rail():
+    """Each named bucket is produced by a real rail firing, not by a stale string.
+
+    The bucketer keys on a fragment of the rail's reason. If a message is ever
+    reworded this fails here instead of silently raising in the middle of a
+    twenty-minute measurement run.
+    """
+    assert guard_rail_block(2, 57, "HARD", 30) == "opening_laps"
+    assert guard_rail_block(55, 57, "HARD", 30) == "closing_laps"
+    assert guard_rail_block(30, 57, "HARD", 2) == "min_stint"
+
+
+def test_closing_rail_includes_the_boundary_lap():
+    """Exactly three laps remaining is blocked: the rail is `<=`, not `<`."""
+    assert guard_rail_block(54, 57, "HARD", 30) == "closing_laps"
+
+
+def test_unknown_tyre_life_still_evaluates_the_lap_based_rails():
+    """A missing tyre life suspends only the stint rail, never the lap ones."""
+    assert guard_rail_block(2, 57, "SOFT", None) == "opening_laps"
+    assert guard_rail_block(30, 57, "SOFT", None) is None
 
 
 # --- picking the lap the stack would have chosen ---------------------------


### PR DESCRIPTION
Closes #708. Part of #707.

## What

`f1-eval projection` measures **86.5% within one position over 1810 real green-flag stops** — given that the driver stopped on lap L, where does he rejoin. That is pit-cycle geometry, and it is the number this project quotes. It is not the claim the system makes.

The claim is *when to stop*. This adds the tier that measures it.

## How it works

For every real green-flag stop in the sampled races, the deterministic stack is driven over a window of ±5 laps (the Monte Carlo decision window) and asked, lap by lap, what it would do. The first lap inside the window carrying a pit action is the lap it would have chosen; the **signed** distance to the real lap is the error — signed for the same reason `GroundTruth.mean_signed_error` exists, because stopping consistently early or late is a fixable bug that a magnitude hides.

## What it deliberately does not claim

- **Not counterfactual.** It never says "stopping on lap 28 would have finished higher" — that needs a full-field propagator, and `RaceReplayEngine` replays real laps by design.
- **Not correctness.** Agreement with the real pit wall is evidence; the team can be wrong and this tier cannot tell when it was.
- **Not full coverage.** A full sweep is ~11.5 h of wall clock (measured: 0.51 s/lap through the stack, ~1440 race-driver pairs), so it runs a stratified six-race subset chosen by circuit archetype. The report states this, and a test asserts the report keeps stating it.
- **Not the LLM.** Decisions come from `profile="no-llm"` — the Monte Carlo layer plus the guard rails. The LLM synthesis is stochastic and has been shown to be steerable by the prompt, so measuring it would measure the sampler.

## Buckets, and why they are separate

- `opening_laps` / `closing_laps` / `min_stint` — the guard rails structurally forbid a pit action there, so a real stop inside one can never be agreed with. Excluded from the headline and counted, never dropped in silence.
- `no_data` — the car had already retired, so the stack never evaluated the window.
- `no_call_in_window` — the stack looked and declined. This is a finding, not an exclusion, and merging it with `no_data` would charge a retirement to the model as a missed call.

## The coverage guard

The guard originally planned for #708 was cross-tier monotonicity ("a freer tier must not score better, or two errors are cancelling"). It is **not buildable across these two tiers**: projection error is in positions, decision error is in laps, and converting one to the other needs the counterfactual ruled out above. The buildable half of the same idea ships instead — `coverage_verdict` reports `masked` when under 60% of eligible stops were scored, because a headline drawn from whatever survived the exclusions is a headline about the survivors, and the survivors are not random.

## Sample identity

`green_flag_stops` moves into `projection.py` and both tiers consume it. The two sets of numbers can only appear in the same sentence if they grade the same stops, and this repo has already paid for one parallel implementation drifting from the reference it copied.

**The published ground truth is unchanged to the last digit**: 1810 stops, 71 races, `within_one=0.8646408839779005`, verified before and after the extraction.

## Two bugs the first real run surfaced

- `position` comes back `None` on purpose (a sentinel position has collided with a real one here before) and `int(None)` crashed the run. Laps without a resolved position are now skipped, never defaulted.
- `tyre_life or 10` turned a legitimate fresh tyre (0) into a ten-lap-old one, silently moving what the tyre agent answers.

Both have regression tests.

## Checks

- 22 pure tests, run everywhere
- 1 data-tier test that asserts the sample is non-empty *before* believing any figure
- full suite: 376 passed, 4 skipped (optional deps)
- `ruff@0.15.22` (the pinned CI version) check + format clean; `mypy src/rag/` clean

## Out of scope

The operating-envelope work (#709, #710) is separate and touches `src/agents/`; nothing here does.
