### PR TITLE
fix(rails): let a Safety Car suspend the pit bounds it makes pointless

### DIFF
--- a/src/strategy/inference/guard_rails.py
+++ b/src/strategy/inference/guard_rails.py
@@ -1,10 +1,24 @@
 """The deterministic pit guard rails, in a module that imports nothing heavy.
 
-Canonical re-host of the backend's ``apply_guard_rails``. Identical rule set to
-``src/telemetry/backend/services/simulation/guard_rails.py`` and the CLI's inline
-copy (``run_simulation_cli.py``). Re-hosted rather than imported because the
-parent must never depend on the submodule; the backend copy retires when P1
-migrates, the CLI copy when the P4 duplicate lands (3 -> 1).
+WHAT THESE ARE, AND WHAT THEY ARE NOT
+--------------------------------------
+These are **anti-hallucination bounds**, not a strategy model. They exist so a
+language model cannot recommend a lap-2 stop because it felt like it. The
+authoritative statement of the policy is prose, in the N28 pit agent's prompt
+(``src/agents/pit_strategy_agent.py``, "Strategic guard-rails (HARD
+constraints)"), and this module is the DETERMINISTIC MIRROR of that prose so the
+offline ``no-llm`` path behaves like the LLM path.
+
+That direction matters: **the prompt is the specification and this file is the
+copy.** When they disagree, this file is wrong until proven otherwise.
+
+They are *proscriptive* — they forbid an action. That is a different thing from
+a *prescriptive* rail that forces one (the Safety Car ``PIT_NOW`` rail, rejected
+in #464). A proscriptive bound on a generative model's output is legitimate with
+or without a regulation behind it; the test it must pass is CALIBRATION — the
+threshold has to sit where real strategy essentially never goes, so it separates
+absurd from sane rather than unusual from usual. See #716, where the
+minimum-stint threshold is measured against real stint lengths.
 
 WHY THIS IS ITS OWN MODULE (#708):
 These rules used to live in ``no_llm.py``, which imports the agent stack and
@@ -35,26 +49,60 @@ def apply_guard_rails(
     compound: str,
     tyre_life: int,
     cliff_p10: float = 99.0,
+    sc_active: bool = False,
 ) -> tuple[str, str | None]:
     """Override *action* with STAY_OUT when a hard strategic constraint fires.
 
     Rules: no pit before lap 5; no pit in the last 3 laps unless the cliff is
     imminent (cliff_p10 < 2); minimum stint SOFT 8 / MEDIUM 12 / HARD 15. Returns
     ``(action, reason)`` with ``reason=None`` when no rail fired.
+
+    Args:
+        sc_active: A neutralisation (Safety Car or VSC) is deployed right now.
+            It suspends the two bounds whose premise it falsifies, and NOT the
+            third. Both of those exist because a stop costs ~22-25 s; under a
+            neutralisation the field is delta-limited and queued, the relative
+            loss collapses, and a bound written to catch nonsense must not be what
+            blocks the most valuable stop in racing (#716).
+
+    THE ONE BOUND A SAFETY CAR DOES NOT SUSPEND is the end-of-race one, and this
+    is a DELIBERATE divergence from the prompt, which does exempt it. The prompt's
+    stated rationale there is cost, but cost is not the binding objection so late:
+    Art. 55.17 ends the race behind the Safety Car if it is still deployed on the
+    final lap, so the position surrendered by stopping is unrecoverable **by
+    regulation** rather than merely expensive. A neutralisation makes that more
+    true, not less. Suspending this bound under SC would re-create the exact defect
+    corrected in #464, where the system emitted PIT_NOW with the reason "too late
+    to pit". Raised on #716 as a question for the prompt, not settled unilaterally.
+
+    KNOWN REMAINING DIVERGENCE, also tracked in #716: the prompt exempts the
+    early-race bound when "radio confirms damage/puncture/mechanical failure".
+    That is not wired here, because mapping radio alerts onto a damage semantic is
+    its own source of error and is not worth guessing at. The gap is narrow (it
+    costs a legitimate early stop after first-lap contact) and it is documented
+    rather than faked.
     """
     if action not in _PIT_ACTIONS:
         return action, None
 
     remaining_laps = total_laps - lap
 
-    if lap < _NO_PIT_BEFORE_LAP:
+    # Suspended under a neutralisation: the ~22-25 s premise behind this bound is
+    # false while the field is queued behind the Safety Car.
+    if lap < _NO_PIT_BEFORE_LAP and not sc_active:
         return "STAY_OUT", f"guard-rail: pit window not open (lap < {_NO_PIT_BEFORE_LAP})"
 
+    # NOT suspended under a neutralisation. See the docstring: Art. 55.17 makes the
+    # ceded position unrecoverable rather than expensive, which a Safety Car
+    # aggravates. Only an imminent tyre failure still overrides it.
     if remaining_laps <= _NO_PIT_LAST_N_LAPS and cliff_p10 >= _CLIFF_P10_SAFE:
         return "STAY_OUT", f"guard-rail: too late to pit (<={_NO_PIT_LAST_N_LAPS} laps left)"
 
+    # Suspended under a neutralisation, matching the prompt: a cheap stop makes a
+    # short stint affordable, so "the set still has useful life" stops being the
+    # deciding consideration.
     min_life = _MIN_STINT_LAPS.get(compound, _DEFAULT_MIN_STINT)
-    if tyre_life < min_life:
+    if tyre_life < min_life and not sc_active:
         return (
             "STAY_OUT",
             f"guard-rail: minimum stint not reached ({compound} {tyre_life}/{min_life} laps)",

--- a/src/strategy/inference/no_llm.py
+++ b/src/strategy/inference/no_llm.py
@@ -297,6 +297,11 @@ def run_no_llm_lap(
             race_state.compound,
             race_state.tyre_life,
             tire_out.laps_to_cliff_p10,
+            # Without this the offline path is STRICTER than the prompt it mirrors and
+            # refuses the cheapest stop in racing (#716). `sc_currently_active` is the
+            # flag every other consumer already reads, and it covers VSC as well as a
+            # full SC — both make the stop cheap, which is what the bounds are about.
+            sc_active=situation_out.sc_currently_active,
         )
         synth = _deterministic_synthesis(action, guardrail_reason)
         rec = _assemble_recommendation(

--- a/tests/mc/test_guard_rails.py
+++ b/tests/mc/test_guard_rails.py
@@ -1,0 +1,116 @@
+"""The pit bounds, and exactly which of them a Safety Car suspends.
+
+These run everywhere. The rails moved to a leaf module in #708 precisely so that
+reading a bound costs no model load, and this file is the payoff: until now the
+only tests covering them sat behind a `data/models/` gate and therefore never ran
+on a push.
+
+The subject under test is a **proscriptive** bound — it forbids an action so a
+generative model cannot emit nonsense. That is a different object from a
+prescriptive rail that forces one, and the two are judged differently: a
+proscriptive bound needs calibration, not a regulation. See #716.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.strategy.inference.guard_rails import (
+    _MIN_STINT_LAPS,
+    _NO_PIT_BEFORE_LAP,
+    _NO_PIT_LAST_N_LAPS,
+    apply_guard_rails,
+)
+
+_GREEN_TOTAL_LAPS = 57
+
+
+def _pit(
+    lap, *, total_laps=_GREEN_TOTAL_LAPS, compound="MEDIUM", tyre_life=30, cliff=99.0, sc=False
+):
+    """Ask the bounds whether a PIT_NOW on this lap survives."""
+    return apply_guard_rails("PIT_NOW", lap, total_laps, compound, tyre_life, cliff, sc_active=sc)
+
+
+# --- the bounds fire on green ----------------------------------------------
+
+
+def test_the_three_bounds_fire_on_a_green_lap():
+    """The baseline the exceptions are exceptions to."""
+    assert _pit(_NO_PIT_BEFORE_LAP - 1)[0] == "STAY_OUT"
+    assert _pit(_GREEN_TOTAL_LAPS - _NO_PIT_LAST_N_LAPS)[0] == "STAY_OUT"
+    assert _pit(30, tyre_life=_MIN_STINT_LAPS["MEDIUM"] - 1)[0] == "STAY_OUT"
+
+
+def test_a_non_pit_action_is_never_touched():
+    """The bounds only ever veto a stop; they never manufacture one."""
+    for lap in (1, 30, 57):
+        assert apply_guard_rails("STAY_OUT", lap, 57, "MEDIUM", 1)[0] == "STAY_OUT"
+
+
+# --- what a neutralisation suspends -----------------------------------------
+
+
+def test_a_safety_car_suspends_the_early_race_bound():
+    """The bound defends against a ~22-25 s cost that a neutralisation removes.
+
+    A first-lap stop under a Safety Car is ordinary racing, not a hallucination.
+    """
+    assert _pit(2)[0] == "STAY_OUT"
+    assert _pit(2, sc=True)[0] == "PIT_NOW"
+
+
+def test_a_safety_car_suspends_the_minimum_stint_bound():
+    """A cheap stop makes a short stint affordable, which is the whole premise.
+
+    This was the divergence found in #716: the N28 prompt has always exempted an
+    active SC here and the deterministic mirror did not, so the offline path
+    refused the cheapest stop in racing.
+    """
+    short = {"tyre_life": _MIN_STINT_LAPS["MEDIUM"] - 1}
+    assert _pit(30, **short)[0] == "STAY_OUT"
+    assert _pit(30, sc=True, **short)[0] == "PIT_NOW"
+
+
+def test_a_safety_car_does_NOT_suspend_the_end_of_race_bound():
+    """Deliberate divergence from the prompt, and the one that must not regress.
+
+    Art. 55.17 ends the race behind the Safety Car if it is still deployed on the
+    final lap, so track position surrendered in the closing laps is unrecoverable
+    **by regulation** rather than merely expensive. A neutralisation makes that
+    more true, not less. Suspending this bound would re-create the #464 defect,
+    where the pipeline shipped PIT_NOW carrying the reason "too late to pit".
+    """
+    late = _GREEN_TOTAL_LAPS - _NO_PIT_LAST_N_LAPS
+    assert _pit(late)[0] == "STAY_OUT"
+
+    action, reason = _pit(late, sc=True)
+    assert action == "STAY_OUT", (
+        "a Safety Car must not unlock a stop Art. 55.17 makes unrecoverable"
+    )
+    assert "too late to pit" in (reason or "")
+
+
+def test_an_imminent_cliff_still_overrides_the_end_of_race_bound():
+    """The one exception the end-of-race bound does keep: the tyre is about to fail."""
+    late = _GREEN_TOTAL_LAPS - _NO_PIT_LAST_N_LAPS
+    assert _pit(late, cliff=99.0)[0] == "STAY_OUT"
+    assert _pit(late, cliff=1.0)[0] == "PIT_NOW"
+
+
+# --- the exception is opt-in ------------------------------------------------
+
+
+def test_sc_active_defaults_to_false_so_existing_callers_are_unchanged():
+    """Adding the parameter must not have moved behaviour for anyone not passing it."""
+    with_default = apply_guard_rails("PIT_NOW", 2, 57, "MEDIUM", 30)
+    explicit_green = apply_guard_rails("PIT_NOW", 2, 57, "MEDIUM", 30, 99.0, sc_active=False)
+    assert with_default == explicit_green
+
+
+@pytest.mark.parametrize("compound", ["SOFT", "MEDIUM", "HARD"])
+def test_every_compound_minimum_is_suspended_by_a_neutralisation(compound):
+    """No compound keeps a minimum stint while the field is queued behind the SC."""
+    one_short = _MIN_STINT_LAPS[compound] - 1
+    assert _pit(30, compound=compound, tyre_life=one_short)[0] == "STAY_OUT"
+    assert _pit(30, compound=compound, tyre_life=one_short, sc=True)[0] == "PIT_NOW"

--- a/tests/mc/test_sc_regulatory_rails.py
+++ b/tests/mc/test_sc_regulatory_rails.py
@@ -50,6 +50,10 @@ def test_sc_in_the_last_laps_does_not_force_a_stop():
     The guard-rail already knows this and returns STAY_OUT. This asserts that nothing
     downstream overrides it. Before the rail was removed, the pipeline shipped
     ``action=PIT_NOW`` carrying the reason "too late to pit".
+
+    ``sc_active=True`` is passed explicitly since #716 gave the bounds that parameter.
+    Until then this test named a Safety Car it never actually declared, so it was
+    asserting about a green lap while claiming to be about a neutralised one.
     """
     from src.strategy.inference.no_llm import apply_guard_rails
 
@@ -60,6 +64,7 @@ def test_sc_in_the_last_laps_does_not_force_a_stop():
         compound="MEDIUM",
         tyre_life=30,
         cliff_p10=99.0,
+        sc_active=True,
     )
     assert action == "STAY_OUT", "the guard-rail itself changed; this test's premise is gone"
     assert "too late to pit" in (reason or "")
@@ -90,6 +95,7 @@ def test_the_shipped_action_never_contradicts_its_own_reason():
         compound="MEDIUM",
         tyre_life=30,
         cliff_p10=99.0,
+        sc_active=True,
     )
     rec = _recommend_under_sc(action, reason)
 


### PR DESCRIPTION
Refs #716. Sprint 1 of the plan that came out of the first `f1-eval decision-modes` run.

## The divergence

The pit bounds are **anti-hallucination guards**, not a strategy model: they exist so a language model cannot recommend a lap-2 stop because it felt like it. Their authoritative statement is prose, in the N28 prompt (`src/agents/pit_strategy_agent.py`, "Strategic guard-rails (HARD constraints)"). `apply_guard_rails` is the deterministic **mirror**, so the offline `no-llm` path behaves like the LLM path.

They had drifted apart, and the mirror was the stricter one:

| Bound | Prompt exempts | Mirror exempted |
| --- | --- | --- |
| before lap 5 | SC, or damage/puncture/mechanical | nothing |
| last 3 laps | cliff P10 < 2, or SC | cliff only |
| minimum stint | SC active | nothing |

So `f1-sim --no-llm` refused the single most valuable stop in racing.

## What changed

`sc_active` is added, **defaulting to `False` so no existing caller moves**, and wired at the one production call site from `situation_out.sc_currently_active` (the flag every other consumer already reads; it covers VSC too, and both make the stop cheap).

- **Early-race and minimum-stint bounds: suspended** under a neutralisation. Both exist because a stop costs ~22-25 s, and a queued delta-limited field falsifies that premise.
- **End-of-race bound: deliberately NOT suspended**, diverging from the prompt. The prompt's rationale there is cost, but cost is not the binding objection so late: **Art. 55.17** ends the race behind the Safety Car if it is still deployed on the final lap, so the position surrendered is unrecoverable *by regulation* rather than merely expensive. A neutralisation makes that more true, not less. Suspending it would re-create the #464 defect that shipped `PIT_NOW` carrying the reason "too late to pit". Raised on #716 as a question for the prompt rather than settled unilaterally.

## Tests

`tests/mc/test_guard_rails.py` is new and **runs on every push**. Until now the only coverage of these bounds sat behind a `data/models/` gate, so it never ran in CI — which is exactly how the divergence survived.

Two existing tests in `test_sc_regulatory_rails.py` named a Safety Car they never actually declared, because the parameter did not exist. They now pass it, so they test what their names claim.

## Also

The module docstring described a three-copy consolidation (backend + CLI inline + this one) as still pending. Verified: **no rail copy survives in `scripts/` or in the submodule at its current commit.** The consolidation already happened, so the docstring is corrected rather than left describing a repo that no longer exists.

## Checks

- `tests/mc/`: **125 passed** locally with `data/` present, strategy goldens included, so no shipped green-flag behaviour moved
- `ruff@0.15.22` check + format clean

## Not in scope

The prompt also exempts the early bound on radio-confirmed damage. Not wired: mapping radio alerts onto a damage semantic is its own source of error and is not worth guessing at. Documented in the docstring and tracked on #716.
