### PR TITLE
Guard-rail Safety Car exceptions and the real stint-length measurement

### DIFF
--- a/documents/eval_reports/stint_lengths.json
+++ b/documents/eval_reports/stint_lengths.json
@@ -1,0 +1,59 @@
+{
+  "header": {
+    "harness_sha": "af96fb6",
+    "dataset": "data/raw laps 2023-2025 (RAW, not featured)",
+    "seed_policy": "deterministic",
+    "era_tag": "2022-2025",
+    "llm": "none",
+    "schema_version": "1",
+    "generated_at": "2026-07-29T09:39:31+00:00",
+    "artifacts": {}
+  },
+  "sample": {
+    "races": 71,
+    "total_counted": 1785,
+    "dropped_wet": 110,
+    "dropped_missing": 5,
+    "compounds": {
+      "SOFT": {
+        "sample_size": 341,
+        "threshold": 8,
+        "share_below_threshold": 0.15542521994134897,
+        "min": 1.0,
+        "p1": 1.0,
+        "p5": 2.0,
+        "p10": 5.0,
+        "p25": 9.0,
+        "median": 15.0,
+        "p75": 21.0,
+        "max": 50.0
+      },
+      "MEDIUM": {
+        "sample_size": 896,
+        "threshold": 12,
+        "share_below_threshold": 0.16964285714285715,
+        "min": 1.0,
+        "p1": 1.0,
+        "p5": 7.0,
+        "p10": 9.0,
+        "p25": 14.0,
+        "median": 19.0,
+        "p75": 25.0,
+        "max": 55.0
+      },
+      "HARD": {
+        "sample_size": 548,
+        "threshold": 15,
+        "share_below_threshold": 0.12226277372262774,
+        "min": 1.0,
+        "p1": 1.9399999999999995,
+        "p5": 8.0,
+        "p10": 13.0,
+        "p25": 18.0,
+        "median": 24.0,
+        "p75": 30.0,
+        "max": 72.0
+      }
+    }
+  }
+}

--- a/documents/eval_reports/stint_lengths.md
+++ b/documents/eval_reports/stint_lengths.md
@@ -1,0 +1,32 @@
+# stint_lengths
+
+- harness `af96fb6` · schema v1 · generated 2026-07-29T09:39:31+00:00
+- era 2022-2025 · dataset data/raw laps 2023-2025 (RAW, not featured) · seed deterministic · llm none
+- artifacts: —
+
+## Real green-flag stint lengths by compound (2023-2025 raw laps)
+
+Every completed stint that ended in a real green-flag pit stop, counted in
+tyre-age laps: the `TyreLife` reading at the moment of the stop, the exact
+field `apply_guard_rails` compares against `_MIN_STINT_LAPS`. A stint that
+ended because the race finished, or because the driver retired, is not a
+decision to stop and is excluded by construction: neither ever produces a
+lap with `PitInTime` set.
+
+| compound | n | threshold (laps) | shorter than threshold | min | p1 | p5 | p10 | p25 | median | p75 | max |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| SOFT | 341 | 8 | 15.5% | 1.0 | 1.0 | 2.0 | 5.0 | 9.0 | 15.0 | 21.0 | 50.0 |
+| MEDIUM | 896 | 12 | 17.0% | 1.0 | 1.0 | 7.0 | 9.0 | 14.0 | 19.0 | 25.0 | 55.0 |
+| HARD | 548 | 15 | 12.2% | 1.0 | 1.9 | 8.0 | 13.0 | 18.0 | 24.0 | 30.0 | 72.0 |
+
+"shorter than threshold" is the share of real stints the current guard rail
+would have overridden to STAY_OUT had a strategist tried to make that exact
+call: `TyreLife < _MIN_STINT_LAPS[compound]`, the same strict inequality
+`apply_guard_rails` itself uses. Close to zero means the bound sits where
+real strategy essentially never goes; anywhere else means it is vetoing
+calls a real pit wall has actually made.
+
+- real green-flag stints counted: 1785 across 71 races
+- wet-compound stops dropped (INTERMEDIATE/WET is not a dry-tyre-life question): 110
+- stops dropped for missing compound/tyre-life data: 5
+

--- a/src/strategy/eval/cli.py
+++ b/src/strategy/eval/cli.py
@@ -10,6 +10,7 @@ one-line summary of where it landed and what it flagged.
     f1-eval hygiene        # E-02 threshold provenance + leakage verdicts (#207)
     f1-eval nlp            # NLP per-stage eval: sentiment + gated stages (#304)
     f1-eval projection     # MC projection accuracy vs real stops + the measured tables
+    f1-eval stint-lengths  # real stint-length distribution vs the guard rail's bound (#716)
     f1-eval alert-llm      # PROXY alert precision via an LLM judge (#304; spends API calls)
     f1-eval decision-modes # does the stack pick the right lap to STOP (#708; takes minutes)
     f1-eval all            # every report EXCEPT the two opt-in ones below
@@ -31,6 +32,7 @@ from src.strategy.eval.hygiene import build_hygiene_report
 from src.strategy.eval.nlp import build_nlp_report
 from src.strategy.eval.projection import build_projection_report
 from src.strategy.eval.registry import build_registry
+from src.strategy.eval.stint_lengths import build_stint_lengths_report
 from src.strategy.eval.reproduce import build_reproduction_report
 
 
@@ -83,6 +85,25 @@ def _run_projection() -> None:
     print(f"projection -> {payload['md_path']} ({accuracy}; {len(payload['tables'])} tables)")
 
 
+def _run_stint_lengths() -> None:
+    payload = build_stint_lengths_report()
+    sample = payload["sample"]
+    if sample is None:
+        print(f"stint-lengths -> {payload['md_path']} (not measured; no data/raw)")
+        return
+
+    # The share below the bound IS the finding, so it leads the line: a bound meant to
+    # catch absurdity should be near zero here, and it is not.
+    shares = ", ".join(
+        f"{compound} {stats.share_below_threshold:.1%}"
+        for compound, stats in sample.by_compound.items()
+    )
+    print(
+        f"stint-lengths -> {payload['md_path']} ({sample.total_counted} stints, "
+        f"{sample.races} races; below the guard-rail bound: {shares})"
+    )
+
+
 def _run_decision_modes() -> None:
     payload = build_decision_modes_report()
     agreement = payload["agreement"]
@@ -114,6 +135,7 @@ _COMMANDS: dict[str, Callable[[], None]] = {
     "hygiene": _run_hygiene,
     "nlp": _run_nlp,
     "projection": _run_projection,
+    "stint-lengths": _run_stint_lengths,
 }
 
 

--- a/src/strategy/eval/stint_lengths.py
+++ b/src/strategy/eval/stint_lengths.py
@@ -1,0 +1,333 @@
+"""Eval report for the guard rail's own bound: how long do real stints actually run?
+
+``guard_rails.py`` refuses a pit call when ``tyre_life < _MIN_STINT_LAPS[compound]``
+(SOFT 8, MEDIUM 12, HARD 15 laps). Those numbers have never been checked against a
+single real race. This report answers the question that decides whether they are
+doing their job: over every green-flag pit stop in 2023-2025, what share of real
+stints were shorter than the bound that would have overridden them?
+
+If the answer is close to zero, the bound sits where professional strategy never
+goes and is a cheap safety net. If it is not close to zero, the bound is quietly
+vetoing calls a real pit wall has made, which is a very different finding from
+"the rail never fires" — this report exists because nobody had counted it either
+way.
+
+WHAT COUNTS AS A STINT LENGTH
+------------------------------
+The length recorded for a completed stint is the ``TyreLife`` reading on the lap
+of the stop, not the number of race laps run on that tyre set within this race.
+The two usually agree, but ``TyreLife`` also counts laps a set ran before the
+race (most commonly tyres carried over from qualifying), and it is exactly the
+field ``apply_guard_rails`` reads at decision time. Measuring anything else would
+answer a question the guard rail does not ask.
+
+A stint that ended because the race finished, or because the driver retired, is
+not a decision to stop, and both are excluded by construction rather than by an
+extra filter: neither ever produces a lap with ``PitInTime`` set, so neither ever
+appears in ``green_flag_stops``.
+
+WHERE TO CHANGE IF THINGS MOVE:
+- ``src/strategy/inference/guard_rails.py`` owns ``_MIN_STINT_LAPS``. It is
+  imported here rather than restated, for the reason its own module docstring
+  gives: a retyped boundary has shipped wrong in this codebase before.
+- ``src/strategy/eval/projection.py`` owns ``green_flag_stops``, the definition
+  of a real, gradeable pit stop that every eval tier in this package shares.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from src.strategy.eval.projection import _neutralised_laps, _raw_data_root, green_flag_stops
+from src.strategy.eval.report import build_header, write_report
+from src.strategy.inference.guard_rails import _MIN_STINT_LAPS
+
+# Dry compounds the guard rail actually gates. Order also fixes the report's
+# row order, so a reader sees the softest, shortest-lived compound first.
+_COMPOUNDS: tuple[str, ...] = ("SOFT", "MEDIUM", "HARD")
+
+# Wet compounds run no minimum-stint rule at all (`_MIN_STINT_LAPS.get(compound,
+# _DEFAULT_MIN_STINT)` never fires the SOFT/MEDIUM/HARD boundaries for them), so a
+# wet stint answers a different question than the one this report asks.
+_WET_COMPOUNDS: frozenset[str] = frozenset({"INTERMEDIATE", "WET"})
+
+# The eight points the task and the report both read: the extremes, the tails
+# that matter for a minimum-bound question, and the median. Kept as one ordered
+# table so `CompoundStints.summary()` and the markdown header can share it
+# instead of each hand-listing the same eight numbers.
+_PERCENTILE_POINTS: tuple[tuple[str, float], ...] = (
+    ("min", 0),
+    ("p1", 1),
+    ("p5", 5),
+    ("p10", 10),
+    ("p25", 25),
+    ("median", 50),
+    ("p75", 75),
+    ("max", 100),
+)
+
+
+@dataclass(frozen=True)
+class CompoundStints:
+    """Completed green-flag stint lengths for one dry compound, in tyre-age laps.
+
+    ``threshold`` travels with the sample rather than being looked up again at
+    render time, so a report and a test reading the same ``CompoundStints`` can
+    never disagree about which bound they are comparing against.
+    """
+
+    compound: str
+    lengths: np.ndarray
+    threshold: int
+
+    @property
+    def sample_size(self) -> int:
+        return int(self.lengths.size)
+
+    def percentile(self, q: float) -> float:
+        """The q-th percentile of stint length in laps, or 0.0 over an empty sample.
+
+        0.0 rather than NaN so a report or a JSON payload never has to special-case
+        the empty compound: it reads as "no data", not as a stint of zero laps,
+        because ``sample_size`` is the field that actually says whether there was
+        a sample at all.
+        """
+        if self.sample_size == 0:
+            return 0.0
+        return float(np.percentile(self.lengths, q))
+
+    @property
+    def share_below_threshold(self) -> float:
+        """Share of real stints strictly SHORTER than the guard rail's own minimum.
+
+        Strict, matching ``apply_guard_rails``'s own ``tyre_life < min_life``: a
+        stint that ended exactly on the boundary is a stint the rail would have
+        allowed, not one it would have blocked, and folding it into "below" would
+        overstate how often the rail actually binds.
+        """
+        if self.sample_size == 0:
+            return 0.0
+        return float((self.lengths < self.threshold).mean())
+
+    def summary(self) -> dict[str, float]:
+        """The eight percentile points in `_PERCENTILE_POINTS`, by label."""
+        return {label: self.percentile(q) for label, q in _PERCENTILE_POINTS}
+
+
+@dataclass(frozen=True)
+class StintLengthSample:
+    """Completed green-flag stint lengths across the sampled seasons, by compound."""
+
+    by_compound: dict[str, CompoundStints]
+    dropped_wet: int
+    dropped_missing: int
+    races: int
+
+    @property
+    def total_counted(self) -> int:
+        """Real green-flag stints that fed one of the three dry-compound samples."""
+        return sum(stats.sample_size for stats in self.by_compound.values())
+
+
+def _compound_bucket(compound: str) -> str:
+    """Which counting bucket a raw ``Compound`` reading belongs in.
+
+    Returns the compound name itself for a dry compound, ``"wet"`` for
+    INTERMEDIATE/WET, or ``"unknown"`` for anything else (there is no other label
+    on a real green-flag pit lap; this is a defensive catch-all, not a case this
+    dataset is expected to hit). Dataframe-free on purpose: this is the whole
+    rule behind "ignore wet compounds but report how many you dropped", and it
+    needs to be checkable without a parquet file.
+    """
+    if compound in _COMPOUNDS:
+        return compound
+    if compound in _WET_COMPOUNDS:
+        return "wet"
+    return "unknown"
+
+
+def _stop_tyre(laps, driver: str, lap: int) -> tuple[str | None, float | None]:
+    """Compound and TyreLife on the lap a driver actually pitted, or (None, None).
+
+    The ``PitInTime`` row IS the last lap of the ending stint, so its own
+    ``Compound`` and ``TyreLife`` are exactly the reading ``apply_guard_rails``
+    would have seen at that moment; no ``Stint``-group aggregation is needed.
+    Either field missing marks the stop unusable rather than guessing at a bucket
+    for it, the same choice ``decision_modes._stop_context`` makes for the same
+    two columns.
+    """
+    import pandas as pd
+
+    row = laps[(laps["Driver"] == driver) & (laps["LapNumber"] == lap)]
+    if not len(row):
+        return None, None
+
+    compound = row["Compound"].iloc[0]
+    tyre_life = row["TyreLife"].iloc[0]
+    if pd.isna(compound) or pd.isna(tyre_life):
+        return None, None
+    return str(compound), float(tyre_life)
+
+
+def measure_stint_lengths(years: tuple[int, ...] = (2023, 2024, 2025)) -> StintLengthSample:
+    """Completed green-flag stint lengths for every driver in every sampled race.
+
+    Raises FileNotFoundError when ``data/raw/`` is absent, since a silently empty
+    sample would report a 0% below-threshold share that means nothing rather than
+    the honest "not measured".
+    """
+    import pandas as pd
+
+    raw = _raw_data_root()
+    if raw is None:
+        raise FileNotFoundError(
+            "data/raw/ is not present; the stint-length distribution needs the raw "
+            "laps from the Hugging Face dataset (Stint/Compound/TyreLife are dropped "
+            "from the featured parquet)"
+        )
+
+    lengths_by_compound: dict[str, list[float]] = {compound: [] for compound in _COMPOUNDS}
+    dropped_wet = 0
+    dropped_missing = 0
+    races = 0
+
+    for year in years:
+        year_dir = raw / str(year)
+        if not year_dir.is_dir():
+            continue
+
+        for race_dir in sorted(path for path in year_dir.iterdir() if path.is_dir()):
+            laps_path = race_dir / "laps.parquet"
+            if not laps_path.exists():
+                continue
+
+            laps = pd.read_parquet(laps_path)
+            if "PitInTime" not in laps.columns:
+                continue
+
+            races += 1
+            neutralised = _neutralised_laps(laps)
+
+            for driver, stop_laps in green_flag_stops(laps, neutralised).items():
+                for lap in stop_laps:
+                    compound, tyre_life = _stop_tyre(laps, driver, lap)
+                    if compound is None:
+                        dropped_missing += 1
+                        continue
+
+                    bucket = _compound_bucket(compound)
+                    if bucket == "wet":
+                        dropped_wet += 1
+                    elif bucket == "unknown":
+                        dropped_missing += 1
+                    else:
+                        lengths_by_compound[bucket].append(tyre_life)
+
+    by_compound = {
+        compound: CompoundStints(
+            compound=compound,
+            lengths=np.array(lengths_by_compound[compound], dtype=float),
+            threshold=_MIN_STINT_LAPS[compound],
+        )
+        for compound in _COMPOUNDS
+    }
+    return StintLengthSample(
+        by_compound=by_compound,
+        dropped_wet=dropped_wet,
+        dropped_missing=dropped_missing,
+        races=races,
+    )
+
+
+def _compound_row(stats: CompoundStints) -> str:
+    """One markdown table row: sample size, threshold, the headline share, then the percentiles."""
+    summary = stats.summary()
+    percentile_cells = " | ".join(f"{summary[label]:.1f}" for label, _ in _PERCENTILE_POINTS)
+    return (
+        f"| {stats.compound} | {stats.sample_size} | {stats.threshold} | "
+        f"{stats.share_below_threshold:.1%} | {percentile_cells} |"
+    )
+
+
+def _render_table(sample: StintLengthSample | None) -> str:
+    """Per-compound percentile table plus the drop counts, or a not-measured note."""
+    if sample is None:
+        return (
+            "Not measured: `data/raw/` is absent from this checkout. Pull the "
+            "Hugging Face dataset and re-run.\n"
+        )
+
+    header_cells = " | ".join(label for label, _ in _PERCENTILE_POINTS)
+    divider_cells = "---|" * len(_PERCENTILE_POINTS)
+    lines = [
+        "## Real green-flag stint lengths by compound (2023-2025 raw laps)",
+        "",
+        "Every completed stint that ended in a real green-flag pit stop, counted in",
+        "tyre-age laps: the `TyreLife` reading at the moment of the stop, the exact",
+        "field `apply_guard_rails` compares against `_MIN_STINT_LAPS`. A stint that",
+        "ended because the race finished, or because the driver retired, is not a",
+        "decision to stop and is excluded by construction: neither ever produces a",
+        "lap with `PitInTime` set.",
+        "",
+        f"| compound | n | threshold (laps) | shorter than threshold | {header_cells} |",
+        f"|---|---|---|---|{divider_cells}",
+    ]
+    lines += [_compound_row(sample.by_compound[compound]) for compound in _COMPOUNDS]
+    lines += [
+        "",
+        '"shorter than threshold" is the share of real stints the current guard rail',
+        "would have overridden to STAY_OUT had a strategist tried to make that exact",
+        "call: `TyreLife < _MIN_STINT_LAPS[compound]`, the same strict inequality",
+        "`apply_guard_rails` itself uses. Close to zero means the bound sits where",
+        "real strategy essentially never goes; anywhere else means it is vetoing",
+        "calls a real pit wall has actually made.",
+        "",
+        f"- real green-flag stints counted: {sample.total_counted} across {sample.races} races",
+        "- wet-compound stops dropped (INTERMEDIATE/WET is not a dry-tyre-life "
+        f"question): {sample.dropped_wet}",
+        f"- stops dropped for missing compound/tyre-life data: {sample.dropped_missing}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def build_stint_lengths_report() -> dict[str, Any]:
+    """Write ``documents/eval_reports/stint_lengths.{md,json}`` and return the payload."""
+    try:
+        sample: StintLengthSample | None = measure_stint_lengths()
+    except FileNotFoundError:
+        sample = None
+
+    header = build_header(dataset="data/raw laps 2023-2025 (RAW, not featured)")
+    md_path, json_path = write_report(
+        "stint_lengths",
+        header,
+        _render_table(sample),
+        {
+            "sample": None
+            if sample is None
+            else {
+                "races": sample.races,
+                "total_counted": sample.total_counted,
+                "dropped_wet": sample.dropped_wet,
+                "dropped_missing": sample.dropped_missing,
+                "compounds": {
+                    compound: {
+                        "sample_size": stats.sample_size,
+                        "threshold": stats.threshold,
+                        "share_below_threshold": stats.share_below_threshold,
+                        **stats.summary(),
+                    }
+                    for compound, stats in sample.by_compound.items()
+                },
+            }
+        },
+    )
+    return {
+        "md_path": str(md_path),
+        "json_path": str(json_path),
+        "sample": sample,
+    }

--- a/src/strategy/inference/guard_rails.py
+++ b/src/strategy/inference/guard_rails.py
@@ -1,10 +1,24 @@
 """The deterministic pit guard rails, in a module that imports nothing heavy.
 
-Canonical re-host of the backend's ``apply_guard_rails``. Identical rule set to
-``src/telemetry/backend/services/simulation/guard_rails.py`` and the CLI's inline
-copy (``run_simulation_cli.py``). Re-hosted rather than imported because the
-parent must never depend on the submodule; the backend copy retires when P1
-migrates, the CLI copy when the P4 duplicate lands (3 -> 1).
+WHAT THESE ARE, AND WHAT THEY ARE NOT
+--------------------------------------
+These are **anti-hallucination bounds**, not a strategy model. They exist so a
+language model cannot recommend a lap-2 stop because it felt like it. The
+authoritative statement of the policy is prose, in the N28 pit agent's prompt
+(``src/agents/pit_strategy_agent.py``, "Strategic guard-rails (HARD
+constraints)"), and this module is the DETERMINISTIC MIRROR of that prose so the
+offline ``no-llm`` path behaves like the LLM path.
+
+That direction matters: **the prompt is the specification and this file is the
+copy.** When they disagree, this file is wrong until proven otherwise.
+
+They are *proscriptive* — they forbid an action. That is a different thing from
+a *prescriptive* rail that forces one (the Safety Car ``PIT_NOW`` rail, rejected
+in #464). A proscriptive bound on a generative model's output is legitimate with
+or without a regulation behind it; the test it must pass is CALIBRATION — the
+threshold has to sit where real strategy essentially never goes, so it separates
+absurd from sane rather than unusual from usual. See #716, where the
+minimum-stint threshold is measured against real stint lengths.
 
 WHY THIS IS ITS OWN MODULE (#708):
 These rules used to live in ``no_llm.py``, which imports the agent stack and
@@ -35,26 +49,60 @@ def apply_guard_rails(
     compound: str,
     tyre_life: int,
     cliff_p10: float = 99.0,
+    sc_active: bool = False,
 ) -> tuple[str, str | None]:
     """Override *action* with STAY_OUT when a hard strategic constraint fires.
 
     Rules: no pit before lap 5; no pit in the last 3 laps unless the cliff is
     imminent (cliff_p10 < 2); minimum stint SOFT 8 / MEDIUM 12 / HARD 15. Returns
     ``(action, reason)`` with ``reason=None`` when no rail fired.
+
+    Args:
+        sc_active: A neutralisation (Safety Car or VSC) is deployed right now.
+            It suspends the two bounds whose premise it falsifies, and NOT the
+            third. Both of those exist because a stop costs ~22-25 s; under a
+            neutralisation the field is delta-limited and queued, the relative
+            loss collapses, and a bound written to catch nonsense must not be what
+            blocks the most valuable stop in racing (#716).
+
+    THE ONE BOUND A SAFETY CAR DOES NOT SUSPEND is the end-of-race one, and this
+    is a DELIBERATE divergence from the prompt, which does exempt it. The prompt's
+    stated rationale there is cost, but cost is not the binding objection so late:
+    Art. 55.17 ends the race behind the Safety Car if it is still deployed on the
+    final lap, so the position surrendered by stopping is unrecoverable **by
+    regulation** rather than merely expensive. A neutralisation makes that more
+    true, not less. Suspending this bound under SC would re-create the exact defect
+    corrected in #464, where the system emitted PIT_NOW with the reason "too late
+    to pit". Raised on #716 as a question for the prompt, not settled unilaterally.
+
+    KNOWN REMAINING DIVERGENCE, also tracked in #716: the prompt exempts the
+    early-race bound when "radio confirms damage/puncture/mechanical failure".
+    That is not wired here, because mapping radio alerts onto a damage semantic is
+    its own source of error and is not worth guessing at. The gap is narrow (it
+    costs a legitimate early stop after first-lap contact) and it is documented
+    rather than faked.
     """
     if action not in _PIT_ACTIONS:
         return action, None
 
     remaining_laps = total_laps - lap
 
-    if lap < _NO_PIT_BEFORE_LAP:
+    # Suspended under a neutralisation: the ~22-25 s premise behind this bound is
+    # false while the field is queued behind the Safety Car.
+    if lap < _NO_PIT_BEFORE_LAP and not sc_active:
         return "STAY_OUT", f"guard-rail: pit window not open (lap < {_NO_PIT_BEFORE_LAP})"
 
+    # NOT suspended under a neutralisation. See the docstring: Art. 55.17 makes the
+    # ceded position unrecoverable rather than expensive, which a Safety Car
+    # aggravates. Only an imminent tyre failure still overrides it.
     if remaining_laps <= _NO_PIT_LAST_N_LAPS and cliff_p10 >= _CLIFF_P10_SAFE:
         return "STAY_OUT", f"guard-rail: too late to pit (<={_NO_PIT_LAST_N_LAPS} laps left)"
 
+    # Suspended under a neutralisation, matching the prompt: a cheap stop makes a
+    # short stint affordable, so "the set still has useful life" stops being the
+    # deciding consideration.
     min_life = _MIN_STINT_LAPS.get(compound, _DEFAULT_MIN_STINT)
-    if tyre_life < min_life:
+    if tyre_life < min_life and not sc_active:
         return (
             "STAY_OUT",
             f"guard-rail: minimum stint not reached ({compound} {tyre_life}/{min_life} laps)",

--- a/src/strategy/inference/no_llm.py
+++ b/src/strategy/inference/no_llm.py
@@ -297,6 +297,11 @@ def run_no_llm_lap(
             race_state.compound,
             race_state.tyre_life,
             tire_out.laps_to_cliff_p10,
+            # Without this the offline path is STRICTER than the prompt it mirrors and
+            # refuses the cheapest stop in racing (#716). `sc_currently_active` is the
+            # flag every other consumer already reads, and it covers VSC as well as a
+            # full SC — both make the stop cheap, which is what the bounds are about.
+            sc_active=situation_out.sc_currently_active,
         )
         synth = _deterministic_synthesis(action, guardrail_reason)
         rec = _assemble_recommendation(

--- a/tests/eval/test_stint_lengths.py
+++ b/tests/eval/test_stint_lengths.py
@@ -1,0 +1,211 @@
+"""Tests for the guard-rail stint-length evidence tier (#708 family).
+
+Two layers, the same split ``test_decision_modes.py`` and
+``test_position_projection.py`` use:
+
+1. Pure tests that pin the contract: percentile maths, the strict "shorter than
+   threshold" comparison, the wet/dry/unknown compound split, and that the
+   thresholds are imported from the guard rail rather than retyped. These run
+   everywhere, no dataset required.
+
+2. One data-tier test that refuses to believe a sample it has not counted. It
+   needs ``data/raw`` and skips without it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.strategy.eval.stint_lengths import (
+    _MIN_STINT_LAPS,
+    _PERCENTILE_POINTS,
+    CompoundStints,
+    StintLengthSample,
+    _compound_bucket,
+    _render_table,
+)
+from src.strategy.inference.guard_rails import _MIN_STINT_LAPS as RAIL_MIN_STINT_LAPS
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_RAW = (ROOT / "data" / "raw" / "2025").is_dir()
+
+
+def _stints(compound: str, lengths: list[float], threshold: int) -> CompoundStints:
+    return CompoundStints(
+        compound=compound, lengths=np.array(lengths, dtype=float), threshold=threshold
+    )
+
+
+# --- percentile maths --------------------------------------------------------
+
+
+def test_summary_matches_numpy_percentile_directly():
+    """The report's own percentile points must agree with numpy, point for point."""
+    lengths = [3, 5, 8, 9, 11, 14, 15, 18, 22, 30]
+    stats = _stints("MEDIUM", lengths, threshold=12)
+    summary = stats.summary()
+    for label, q in _PERCENTILE_POINTS:
+        assert summary[label] == pytest.approx(float(np.percentile(lengths, q))), label
+
+
+def test_min_and_max_are_the_extremes_of_the_sample():
+    stats = _stints("HARD", [15, 20, 40, 9], threshold=15)
+    summary = stats.summary()
+    assert summary["min"] == 9.0
+    assert summary["max"] == 40.0
+
+
+def test_percentile_over_an_empty_sample_is_zero_not_nan():
+    """An empty compound must read as 'no data' via sample_size, never as NaN."""
+    stats = _stints("SOFT", [], threshold=8)
+    assert stats.sample_size == 0
+    for value in stats.summary().values():
+        assert value == 0.0
+        assert not np.isnan(value)
+
+
+# --- the headline: share strictly shorter than the guard rail's bound -------
+
+
+def test_share_below_threshold_is_strict_not_inclusive():
+    """A stint exactly on the boundary is one the rail would allow, not block."""
+    stats = _stints("SOFT", [5, 8, 8, 10, 15], threshold=8)
+    # Only the single 5-lap stint is strictly shorter than 8.
+    assert stats.share_below_threshold == pytest.approx(0.2)
+
+
+def test_share_below_threshold_is_zero_when_nothing_runs_that_short():
+    stats = _stints("HARD", [15, 20, 25, 30], threshold=15)
+    assert stats.share_below_threshold == 0.0
+
+
+def test_share_below_threshold_is_one_when_every_stint_undercuts_the_rail():
+    stats = _stints("MEDIUM", [3, 4, 5], threshold=12)
+    assert stats.share_below_threshold == 1.0
+
+
+def test_share_below_threshold_over_an_empty_sample_is_zero():
+    stats = _stints("SOFT", [], threshold=8)
+    assert stats.share_below_threshold == 0.0
+
+
+# --- classifying a raw Compound reading --------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("compound", "expected"),
+    [
+        ("SOFT", "SOFT"),
+        ("MEDIUM", "MEDIUM"),
+        ("HARD", "HARD"),
+        ("INTERMEDIATE", "wet"),
+        ("WET", "wet"),
+        ("UNKNOWN_TYRE", "unknown"),
+        ("", "unknown"),
+    ],
+)
+def test_compound_bucket_classifies_dry_wet_and_unknown(compound, expected):
+    """The wet/dry split is pure and dataframe-free: no parquet needed to check it."""
+    assert _compound_bucket(compound) == expected
+
+
+# --- the thresholds must come from the guard rail, never be retyped ---------
+
+
+def test_thresholds_are_imported_from_the_guard_rail_not_restated():
+    """A retyped boundary has shipped wrong in this codebase before (#708).
+
+    Asserting identity, not just equal values, is what actually catches a
+    future edit that hardcodes ``{"SOFT": 8, ...}`` here instead of importing it:
+    two equal-but-separate dicts would pass an equality check and still drift the
+    day only one of them is edited.
+    """
+    assert _MIN_STINT_LAPS is RAIL_MIN_STINT_LAPS
+
+
+def test_every_dry_compound_has_a_rail_threshold():
+    for compound in ("SOFT", "MEDIUM", "HARD"):
+        assert compound in _MIN_STINT_LAPS
+
+
+# --- rendering ----------------------------------------------------------------
+
+
+def _sample(
+    by_compound: dict[str, CompoundStints], dropped_wet=0, dropped_missing=0, races=1
+) -> StintLengthSample:
+    return StintLengthSample(
+        by_compound=by_compound,
+        dropped_wet=dropped_wet,
+        dropped_missing=dropped_missing,
+        races=races,
+    )
+
+
+def test_render_without_data_says_so_instead_of_printing_zeros():
+    body = _render_table(None)
+    assert "Not measured" in body
+    assert "0.0%" not in body
+
+
+def test_render_reports_the_headline_share_and_the_drop_counts():
+    sample = _sample(
+        {
+            "SOFT": _stints("SOFT", [5, 8, 10, 20], threshold=8),
+            "MEDIUM": _stints("MEDIUM", [10, 12, 20], threshold=12),
+            "HARD": _stints("HARD", [15, 18, 22], threshold=15),
+        },
+        dropped_wet=7,
+        dropped_missing=2,
+        races=3,
+    )
+    body = _render_table(sample)
+
+    assert "SOFT" in body and "MEDIUM" in body and "HARD" in body
+    # One of four SOFT stints (the 5-lap one) undercuts the 8-lap rail: 25.0%.
+    assert "25.0%" in body
+    assert "dropped" in body
+    assert "7" in body
+    assert "2" in body
+
+
+def test_render_states_the_field_it_measures():
+    """The 'not race laps, TyreLife' choice is part of the artifact, not a comment."""
+    sample = _sample(
+        {
+            "SOFT": _stints("SOFT", [10], threshold=8),
+            "MEDIUM": _stints("MEDIUM", [], threshold=12),
+            "HARD": _stints("HARD", [], threshold=15),
+        }
+    )
+    body = _render_table(sample)
+    assert "TyreLife" in body
+    assert "PitInTime" in body
+
+
+# --- the one test that checks against the world -----------------------------
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_RAW, reason="data/raw absent (CI runner without the dataset)")
+def test_measured_sample_is_non_empty_before_any_figure_is_believed():
+    """Guard against a green run that quietly counted zero real stints.
+
+    A report iterating a DISCOVERED set can pass every assertion about the empty
+    set. This asserts the set exists first, the same guard
+    ``test_decision_modes.py`` keeps for its own discovered sample.
+    """
+    from src.strategy.eval.stint_lengths import measure_stint_lengths
+
+    sample = measure_stint_lengths(years=(2025,))
+
+    assert sample.races > 0, "no races found under data/raw/2025"
+    assert sample.total_counted > 0, "no real green-flag stints were counted: sample is empty"
+    for compound, stats in sample.by_compound.items():
+        assert stats.threshold == RAIL_MIN_STINT_LAPS[compound]
+        # Not every compound need appear at every circuit, but at least one must,
+        # or this "distribution by compound" report has nothing to report.
+    assert any(stats.sample_size > 0 for stats in sample.by_compound.values())

--- a/tests/mc/test_guard_rails.py
+++ b/tests/mc/test_guard_rails.py
@@ -1,0 +1,116 @@
+"""The pit bounds, and exactly which of them a Safety Car suspends.
+
+These run everywhere. The rails moved to a leaf module in #708 precisely so that
+reading a bound costs no model load, and this file is the payoff: until now the
+only tests covering them sat behind a `data/models/` gate and therefore never ran
+on a push.
+
+The subject under test is a **proscriptive** bound — it forbids an action so a
+generative model cannot emit nonsense. That is a different object from a
+prescriptive rail that forces one, and the two are judged differently: a
+proscriptive bound needs calibration, not a regulation. See #716.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.strategy.inference.guard_rails import (
+    _MIN_STINT_LAPS,
+    _NO_PIT_BEFORE_LAP,
+    _NO_PIT_LAST_N_LAPS,
+    apply_guard_rails,
+)
+
+_GREEN_TOTAL_LAPS = 57
+
+
+def _pit(
+    lap, *, total_laps=_GREEN_TOTAL_LAPS, compound="MEDIUM", tyre_life=30, cliff=99.0, sc=False
+):
+    """Ask the bounds whether a PIT_NOW on this lap survives."""
+    return apply_guard_rails("PIT_NOW", lap, total_laps, compound, tyre_life, cliff, sc_active=sc)
+
+
+# --- the bounds fire on green ----------------------------------------------
+
+
+def test_the_three_bounds_fire_on_a_green_lap():
+    """The baseline the exceptions are exceptions to."""
+    assert _pit(_NO_PIT_BEFORE_LAP - 1)[0] == "STAY_OUT"
+    assert _pit(_GREEN_TOTAL_LAPS - _NO_PIT_LAST_N_LAPS)[0] == "STAY_OUT"
+    assert _pit(30, tyre_life=_MIN_STINT_LAPS["MEDIUM"] - 1)[0] == "STAY_OUT"
+
+
+def test_a_non_pit_action_is_never_touched():
+    """The bounds only ever veto a stop; they never manufacture one."""
+    for lap in (1, 30, 57):
+        assert apply_guard_rails("STAY_OUT", lap, 57, "MEDIUM", 1)[0] == "STAY_OUT"
+
+
+# --- what a neutralisation suspends -----------------------------------------
+
+
+def test_a_safety_car_suspends_the_early_race_bound():
+    """The bound defends against a ~22-25 s cost that a neutralisation removes.
+
+    A first-lap stop under a Safety Car is ordinary racing, not a hallucination.
+    """
+    assert _pit(2)[0] == "STAY_OUT"
+    assert _pit(2, sc=True)[0] == "PIT_NOW"
+
+
+def test_a_safety_car_suspends_the_minimum_stint_bound():
+    """A cheap stop makes a short stint affordable, which is the whole premise.
+
+    This was the divergence found in #716: the N28 prompt has always exempted an
+    active SC here and the deterministic mirror did not, so the offline path
+    refused the cheapest stop in racing.
+    """
+    short = {"tyre_life": _MIN_STINT_LAPS["MEDIUM"] - 1}
+    assert _pit(30, **short)[0] == "STAY_OUT"
+    assert _pit(30, sc=True, **short)[0] == "PIT_NOW"
+
+
+def test_a_safety_car_does_NOT_suspend_the_end_of_race_bound():
+    """Deliberate divergence from the prompt, and the one that must not regress.
+
+    Art. 55.17 ends the race behind the Safety Car if it is still deployed on the
+    final lap, so track position surrendered in the closing laps is unrecoverable
+    **by regulation** rather than merely expensive. A neutralisation makes that
+    more true, not less. Suspending this bound would re-create the #464 defect,
+    where the pipeline shipped PIT_NOW carrying the reason "too late to pit".
+    """
+    late = _GREEN_TOTAL_LAPS - _NO_PIT_LAST_N_LAPS
+    assert _pit(late)[0] == "STAY_OUT"
+
+    action, reason = _pit(late, sc=True)
+    assert action == "STAY_OUT", (
+        "a Safety Car must not unlock a stop Art. 55.17 makes unrecoverable"
+    )
+    assert "too late to pit" in (reason or "")
+
+
+def test_an_imminent_cliff_still_overrides_the_end_of_race_bound():
+    """The one exception the end-of-race bound does keep: the tyre is about to fail."""
+    late = _GREEN_TOTAL_LAPS - _NO_PIT_LAST_N_LAPS
+    assert _pit(late, cliff=99.0)[0] == "STAY_OUT"
+    assert _pit(late, cliff=1.0)[0] == "PIT_NOW"
+
+
+# --- the exception is opt-in ------------------------------------------------
+
+
+def test_sc_active_defaults_to_false_so_existing_callers_are_unchanged():
+    """Adding the parameter must not have moved behaviour for anyone not passing it."""
+    with_default = apply_guard_rails("PIT_NOW", 2, 57, "MEDIUM", 30)
+    explicit_green = apply_guard_rails("PIT_NOW", 2, 57, "MEDIUM", 30, 99.0, sc_active=False)
+    assert with_default == explicit_green
+
+
+@pytest.mark.parametrize("compound", ["SOFT", "MEDIUM", "HARD"])
+def test_every_compound_minimum_is_suspended_by_a_neutralisation(compound):
+    """No compound keeps a minimum stint while the field is queued behind the SC."""
+    one_short = _MIN_STINT_LAPS[compound] - 1
+    assert _pit(30, compound=compound, tyre_life=one_short)[0] == "STAY_OUT"
+    assert _pit(30, compound=compound, tyre_life=one_short, sc=True)[0] == "PIT_NOW"

--- a/tests/mc/test_sc_regulatory_rails.py
+++ b/tests/mc/test_sc_regulatory_rails.py
@@ -50,6 +50,10 @@ def test_sc_in_the_last_laps_does_not_force_a_stop():
     The guard-rail already knows this and returns STAY_OUT. This asserts that nothing
     downstream overrides it. Before the rail was removed, the pipeline shipped
     ``action=PIT_NOW`` carrying the reason "too late to pit".
+
+    ``sc_active=True`` is passed explicitly since #716 gave the bounds that parameter.
+    Until then this test named a Safety Car it never actually declared, so it was
+    asserting about a green lap while claiming to be about a neutralised one.
     """
     from src.strategy.inference.no_llm import apply_guard_rails
 
@@ -60,6 +64,7 @@ def test_sc_in_the_last_laps_does_not_force_a_stop():
         compound="MEDIUM",
         tyre_life=30,
         cliff_p10=99.0,
+        sc_active=True,
     )
     assert action == "STAY_OUT", "the guard-rail itself changed; this test's premise is gone"
     assert "too late to pit" in (reason or "")
@@ -90,6 +95,7 @@ def test_the_shipped_action_never_contradicts_its_own_reason():
         compound="MEDIUM",
         tyre_life=30,
         cliff_p10=99.0,
+        sc_active=True,
     )
     rec = _recommend_under_sc(action, reason)
 


### PR DESCRIPTION
Promotes #717 and #718 to `main`. Both refs #716.

## #717 — a Safety Car now suspends the bounds it makes pointless

The pit bounds are **anti-hallucination guards**; their authoritative statement is the N28 prompt and `apply_guard_rails` is the deterministic mirror. They had drifted, and the mirror was stricter: the prompt exempts an active Safety Car from all three bounds, the mirror exempted nothing. So `f1-sim --no-llm` refused the cheapest stop in racing.

- early-race and minimum-stint bounds are now suspended under a neutralisation
- the end-of-race bound deliberately is **not**, diverging from the prompt: Art. 55.17 ends the race behind the Safety Car if it is still out on the final lap, so the position surrendered is unrecoverable *by regulation* rather than merely expensive. Suspending it would re-create the #464 defect that shipped `PIT_NOW` reasoned "too late to pit"
- `sc_active` defaults to `False`, so no existing caller moved
- `tests/mc/test_guard_rails.py` is new and runs on **every push**; the only coverage of these bounds until now sat behind a `data/models/` gate, which is how the divergence survived

## #718 — the minimum-stint bound is not calibrated

Measured over **1785 real green-flag stints across 71 races**: 15.5% of SOFT, 17.0% of MEDIUM and 12.2% of HARD stints ended shorter than the bound that would have vetoed them. All three sit between p10 and p25 of the real distribution, so they separate unusual from usual rather than absurd from sane.

`f1-eval stint-lengths` is added, in `all` since it is cheap. The headline percentages were independently recounted with a throwaway implementation before landing and match to three decimals.

## Not settled, deliberately

Lowering the thresholds to p1 is not obviously right either: p1 is **1.0 lap** for SOFT and MEDIUM, which is a puncture, not strategy. There is no stint length that is absurd in isolation, so the bound cannot be calibrated from this distribution alone. Options carried to #716 rather than actioned: wire the damage exception the prompt has and the mirror lacks, or move the minimum-stint preference into the Monte Carlo cost where a short stint can be expensive without being forbidden.

## Checks

- `tests/mc/`: 125 passed locally with `data/` present, strategy goldens included
- both PRs green on their own CI before merge
