### PR TITLE
feat(inference): add an operating-envelope contract for model inputs

### DIFF
--- a/src/strategy/inference/envelope.py
+++ b/src/strategy/inference/envelope.py
@@ -1,0 +1,173 @@
+"""Operating-envelope contract for ML model inputs (#709).
+
+WHY THIS EXISTS
+----------------
+Our models never refuse out-of-range input; they answer with the same
+confidence whether the call falls inside what they were trained on or not.
+N26's tire TCN did exactly that: inference skipped the notebook's per-stint
+grouping and left-padded with a repeated first lap instead of zeros, so it was
+fed sequences the training run never produced in roughly 87% of its calls, for
+two years, before anyone noticed. Two call sites have since patched the
+symptom by hand, each its own one-off, neither reusable by the next model:
+
+- ``src/agents/pit_strategy_agent.py`` clips ``tyre_life_in`` at 50 laps
+  because N15 clipped it at training time (cell 11).
+- ``src/agents/tire_agent.py`` computes a loose ``lap_out_of_range`` bool
+  inline before letting a tool proceed.
+
+This module turns that pattern into a rule instead of a habit. An
+:class:`OperatingEnvelope` names the bounds a model was actually trained on;
+:meth:`OperatingEnvelope.check` compares a feature vector against them and
+returns an :class:`EnvelopeVerdict`.
+
+LABELLING ONLY
+--------------
+A verdict is a label, nothing more. Checking a feature vector against an
+envelope must NEVER touch, clip, or refuse a prediction by itself -- it only
+tells the caller whether to trust the one it already has. Whether an agent
+skips a tool call, downgrades its confidence, or ignores the verdict entirely
+is a decision for that call site (tracked separately as #710), not for this
+module.
+
+WHY A MISSING FEATURE IS ITS OWN STATE, NOT A NUMBER
+-----------------------------------------------------
+A feature that is absent from the input (or NaN) is UNKNOWN: neither in-range
+nor out-of-range. This repo has shipped real bugs from collapsing "we do not
+know" into a numeric default that a real value could also legitimately take
+(a missing ``Position`` defaulted to 0 once matched the car that had just
+crashed, because 0 was also a valid grid position). ``check`` follows the same
+rule here: an unknown feature is tracked in ``EnvelopeVerdict.unknown`` and is
+never compared against a bound.
+
+NO MANIFEST FORMAT TO PARSE
+----------------------------
+The task behind this module expected a loader that reads ranges out of a
+``feature_manifest_*.json`` file. Both real manifests in this repo
+(``data/processed/feature_manifest_laptime.json``,
+``data/processed/tiredeg_feature_manifest.json``) and every
+``data/models/*/model_config.json`` were read before writing this: none of
+them carries a numeric min/max range, only feature name lists and categorical
+encodings (``feature_manifest_laptime.json``'s ``categorical_encoding`` maps
+compound strings to ints, for instance -- there is no bounds table anywhere).
+So there is nothing to parse. ``OperatingEnvelope`` is built directly from
+explicit bounds the caller sources itself (a notebook cell comment, a
+training-config constant such as ``_MAX_TRAINED_TYRE_LIFE`` in
+``pit_strategy_agent.py`` today). That constructor is the loader.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+# One feature's declared operating bound: (lower, upper), both inclusive.
+Bound = tuple[float, float]
+
+
+@dataclass(frozen=True)
+class FeatureViolation:
+    """One declared feature whose value fell outside its trained bound.
+
+    Carries what a caller needs to log or raise without re-deriving anything:
+    the value actually passed in, and the ``[lower, upper]`` bound it broke.
+    """
+
+    value: float
+    lower: float
+    upper: float
+
+
+@dataclass(frozen=True)
+class EnvelopeVerdict:
+    """Result of checking one feature vector against an OperatingEnvelope.
+
+    A pure label (see module docstring): nothing may use a verdict to alter a
+    prediction, only to decide whether to trust one.
+
+    Attributes:
+        envelope_name: name of the OperatingEnvelope that produced this.
+        violations: features that were present and numerically outside their
+            declared bound, keyed by feature name.
+        unknown: features the envelope declares but that were missing (or
+            NaN) in the checked input. Kept separate from ``violations`` on
+            purpose -- a model given no value for a feature was not given a
+            bad one, and the two states must stay distinguishable at the
+            call site.
+
+    ``bool(verdict)`` is True only when every declared feature was present
+    and within bounds, so a call site can write ``if not verdict: ...`` to
+    mean "do not trust this call blindly", then inspect ``.violations`` and
+    ``.unknown`` to say why.
+    """
+
+    envelope_name: str
+    violations: Mapping[str, FeatureViolation]
+    unknown: frozenset[str]
+
+    @property
+    def in_range(self) -> bool:
+        """True iff there is no violation and no unknown feature."""
+        return not self.violations and not self.unknown
+
+    def __bool__(self) -> bool:
+        return self.in_range
+
+
+def _is_unknown(value: float | None) -> bool:
+    """A value is unknown when it is None or NaN, and never coerced to a number.
+
+    Guards the rule in the module docstring: a NaN slipping in from a pandas
+    frame must be treated the same as an absent dict key, not compared
+    numerically (NaN comparisons are silently always False, which would make
+    an unknown value read as falsely in-range).
+    """
+    if value is None:
+        return True
+    return isinstance(value, float) and math.isnan(value)
+
+
+@dataclass(frozen=True)
+class OperatingEnvelope:
+    """The input range a model's answer is actually valid over.
+
+    Built directly from bounds the caller sourced from the training
+    notebook or config (see module docstring: no manifest in this repo
+    carries ranges today, so there is no separate file-loading path).
+    Checking a feature vector against an envelope never changes what the
+    model predicts; it only labels the call.
+    """
+
+    name: str
+    bounds: Mapping[str, Bound]
+
+    def __post_init__(self) -> None:
+        """Reject an envelope whose own declared bounds are inverted."""
+        for feature_name, (lower, upper) in self.bounds.items():
+            if lower > upper:
+                raise ValueError(
+                    f"{self.name}: bound for '{feature_name}' is inverted "
+                    f"(lower={lower} > upper={upper})"
+                )
+
+    def check(self, features: Mapping[str, float | None]) -> EnvelopeVerdict:
+        """Compare a feature vector against this envelope's declared bounds.
+
+        Only features this envelope declares are checked; extra keys in
+        ``features`` are ignored. Never raises on an out-of-range or missing
+        value -- what to do with the verdict is the caller's decision (#710).
+        """
+        violations: dict[str, FeatureViolation] = {}
+        unknown: set[str] = set()
+        for feature_name, (lower, upper) in self.bounds.items():
+            value = features.get(feature_name)
+            if _is_unknown(value):
+                unknown.add(feature_name)
+                continue
+            if not (lower <= value <= upper):
+                violations[feature_name] = FeatureViolation(value=value, lower=lower, upper=upper)
+        return EnvelopeVerdict(
+            envelope_name=self.name,
+            violations=violations,
+            unknown=frozenset(unknown),
+        )

--- a/src/strategy/inference/envelope.py
+++ b/src/strategy/inference/envelope.py
@@ -7,15 +7,21 @@ confidence whether the call falls inside what they were trained on or not.
 N26's tire TCN did exactly that: inference skipped the notebook's per-stint
 grouping and left-padded with a repeated first lap instead of zeros, so it was
 fed sequences the training run never produced in roughly 87% of its calls, for
-two years, before anyone noticed. Two call sites have since patched the
-symptom by hand, each its own one-off, neither reusable by the next model:
+two years, before anyone noticed.
 
-- ``src/agents/pit_strategy_agent.py`` clips ``tyre_life_in`` at 50 laps
-  because N15 clipped it at training time (cell 11).
-- ``src/agents/tire_agent.py`` computes a loose ``lap_out_of_range`` bool
-  inline before letting a tool proceed.
+Exactly ONE call site has since patched the symptom by hand:
+``src/agents/pit_strategy_agent.py`` clips ``tyre_life_in`` at 50 laps because
+N15 clipped it at training time (cell 11). That constant is an operating
+envelope written as a bare number.
 
-This module turns that pattern into a rule instead of a habit. An
+``src/agents/tire_agent.py``'s ``lap_out_of_range`` looks like a second
+instance and is **not** one, which is worth stating so nobody folds them
+together later: it tests ``1 <= lap <= total_laps`` and whether the driver is
+on track. Those are questions about whether the CALL makes sense, not about
+whether the MODEL was trained here. Data validity and operating envelope are
+different contracts, and only the second belongs in this module.
+
+This module turns the one real instance into a rule instead of a habit. An
 :class:`OperatingEnvelope` names the bounds a model was actually trained on;
 :meth:`OperatingEnvelope.check` compares a feature vector against them and
 returns an :class:`EnvelopeVerdict`.

--- a/tests/inference/test_envelope.py
+++ b/tests/inference/test_envelope.py
@@ -1,0 +1,184 @@
+"""Tests for the operating-envelope contract (#709).
+
+Pure, hermetic tests only: no ``data/models/`` weights, no agent imports. The
+contract is small on purpose (one dataclass, one check function), so the
+tests pin the three-way feature state (in-range / out-of-range / unknown),
+the inclusive boundary, multiple simultaneous violations, and the import-time
+guarantee that makes this module usable before ``data/`` even exists on disk.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from pathlib import Path
+
+import pytest
+
+from src.strategy.inference.envelope import (
+    EnvelopeVerdict,
+    FeatureViolation,
+    OperatingEnvelope,
+)
+
+ROOT = Path(__file__).parent.parent.parent
+
+
+def _tyre_life_envelope() -> OperatingEnvelope:
+    """The N15-shaped example used across most tests: one bounded feature."""
+    return OperatingEnvelope(name="n15_pit_duration", bounds={"tyre_life_in": (0, 50)})
+
+
+# --- in-range / out-of-range / boundary -------------------------------------
+
+
+def test_value_inside_bounds_is_in_range():
+    verdict = _tyre_life_envelope().check({"tyre_life_in": 25})
+    assert verdict.in_range
+    assert bool(verdict) is True
+    assert verdict.violations == {}
+    assert verdict.unknown == frozenset()
+
+
+def test_value_outside_bounds_is_a_violation_with_the_offending_bound():
+    verdict = _tyre_life_envelope().check({"tyre_life_in": 63})
+    assert not verdict
+    assert not verdict.in_range
+    assert set(verdict.violations) == {"tyre_life_in"}
+    violation = verdict.violations["tyre_life_in"]
+    assert violation == FeatureViolation(value=63, lower=0, upper=50)
+
+
+def test_lower_and_upper_bounds_are_inclusive():
+    envelope = _tyre_life_envelope()
+    assert envelope.check({"tyre_life_in": 0}).in_range
+    assert envelope.check({"tyre_life_in": 50}).in_range
+
+
+def test_just_outside_each_bound_is_a_violation():
+    envelope = _tyre_life_envelope()
+    assert not envelope.check({"tyre_life_in": -1}).in_range
+    assert not envelope.check({"tyre_life_in": 51}).in_range
+
+
+# --- the unknown state: never coerced to a number ---------------------------
+
+
+def test_missing_key_is_unknown_not_a_violation():
+    """A feature absent from the dict is UNKNOWN, distinct from out-of-range."""
+    verdict = _tyre_life_envelope().check({})
+    assert not verdict
+    assert verdict.violations == {}
+    assert verdict.unknown == frozenset({"tyre_life_in"})
+
+
+def test_explicit_none_is_unknown():
+    verdict = _tyre_life_envelope().check({"tyre_life_in": None})
+    assert verdict.unknown == frozenset({"tyre_life_in"})
+    assert verdict.violations == {}
+
+
+def test_nan_is_unknown_not_silently_in_range():
+    """NaN must never be compared numerically: NaN <= x is always False."""
+    verdict = _tyre_life_envelope().check({"tyre_life_in": math.nan})
+    assert verdict.unknown == frozenset({"tyre_life_in"})
+    assert verdict.violations == {}
+
+
+def test_unknown_alone_makes_the_verdict_falsy():
+    """Unknown is not a violation, but it still means 'do not trust this call'."""
+    verdict = _tyre_life_envelope().check({})
+    assert verdict.violations == {}
+    assert not verdict
+
+
+# --- multiple features at once ----------------------------------------------
+
+
+def test_multiple_simultaneous_violations_are_all_reported():
+    envelope = OperatingEnvelope(
+        name="two_feature_example",
+        bounds={"gap_ahead_s": (0.0, 5.0), "tyre_life_x": (0, 40)},
+    )
+    verdict = envelope.check({"gap_ahead_s": 9.4, "tyre_life_x": -3})
+    assert set(verdict.violations) == {"gap_ahead_s", "tyre_life_x"}
+    assert verdict.violations["gap_ahead_s"] == FeatureViolation(value=9.4, lower=0.0, upper=5.0)
+    assert verdict.violations["tyre_life_x"] == FeatureViolation(value=-3, lower=0, upper=40)
+
+
+def test_mixed_violation_and_unknown_are_kept_in_their_own_buckets():
+    envelope = OperatingEnvelope(
+        name="mixed_example",
+        bounds={"gap_ahead_s": (0.0, 5.0), "tyre_life_x": (0, 40)},
+    )
+    verdict = envelope.check({"gap_ahead_s": 9.4})  # tyre_life_x missing entirely
+    assert set(verdict.violations) == {"gap_ahead_s"}
+    assert verdict.unknown == frozenset({"tyre_life_x"})
+
+
+def test_extra_undeclared_features_are_ignored():
+    verdict = _tyre_life_envelope().check({"tyre_life_in": 10, "some_other_field": -999})
+    assert verdict.in_range
+
+
+# --- construction-time validation -------------------------------------------
+
+
+def test_inverted_bound_is_rejected_at_construction():
+    with pytest.raises(ValueError):
+        OperatingEnvelope(name="broken", bounds={"tyre_life_in": (50, 0)})
+
+
+# --- the contract is a label, and it is frozen -------------------------------
+
+
+def test_envelope_and_verdict_types_are_frozen():
+    envelope = _tyre_life_envelope()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        envelope.name = "mutated"  # type: ignore[misc]
+
+    verdict = envelope.check({"tyre_life_in": 10})
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        verdict.envelope_name = "mutated"  # type: ignore[misc]
+
+
+def test_verdict_carries_the_envelope_name_for_logging():
+    verdict = _tyre_life_envelope().check({"tyre_life_in": 10})
+    assert verdict.envelope_name == "n15_pit_duration"
+    assert isinstance(verdict, EnvelopeVerdict)
+
+
+# --- the import surface -----------------------------------------------------
+
+
+def test_importing_the_module_pulls_in_nothing_heavy(tmp_path):
+    """Importing envelope.py must need neither model weights nor the agent stack.
+
+    Mirrors ``tests/eval/test_decision_modes.py`` ::
+    ``test_importing_the_module_does_not_load_the_agent_stack``. Run with cwd
+    pointed at an empty temp directory (no ``data/models/`` present) so a
+    hidden filesystem read at import time would fail loudly instead of
+    silently succeeding because the real data happens to already be on disk
+    on this machine.
+    """
+    import subprocess
+    import sys
+
+    assert not (tmp_path / "data" / "models").exists()
+
+    probe = (
+        "import sys; sys.path.insert(0, r'{root}'); "
+        "import src.strategy.inference.envelope; "
+        "heavy = [m for m in sys.modules if m.split('.')[0] in "
+        "('pandas', 'numpy', 'torch', 'lightgbm', 'xgboost')]; "
+        "agents = [m for m in sys.modules if m.startswith('src.agents')]; "
+        "print(','.join(sorted(heavy + agents)))"
+    ).format(root=str(ROOT))
+    out = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        check=True,
+    )
+    assert out.stdout.strip() == "", f"unexpected imports: {out.stdout.strip()}"


### PR DESCRIPTION
Closes #709. Sprint 4 of the plan from the `f1-eval decision-modes` findings.

## Why

Models never refuse out-of-range input. They answer with the same confidence whether the call falls inside what they were trained on or not. N26's tire TCN did exactly that in roughly **87% of its calls, for two years**, because inference skipped the notebook's per-stint grouping and left-padded with a repeated first lap instead of zeros.

The pattern is already patched twice by hand, each a one-off neither reusable by the next model:

- `pit_strategy_agent.py` clips `tyre_life_in` at 50 laps because N15 clipped it at training time
- `tire_agent.py` computes a loose `lap_out_of_range` bool inline

This turns the habit into a rule.

## The contract

`OperatingEnvelope(name, bounds)` declares the range a model was trained on. `check(features)` returns an `EnvelopeVerdict`, and **that is all it does** — a verdict is a label. Nothing here clips, refuses or alters a prediction; what a call site does with the verdict is #710's decision.

Three design points that matter more than the code:

1. **A missing or NaN feature is UNKNOWN, not a violation.** They are separate buckets and an unknown is never coerced to a number. This repo has shipped the opposite: a missing `Position` defaulted to 0 once matched the car that had just crashed, because 0 was also a valid position.
2. **NaN needs its own path.** A NaN comparison is silently `False`, so `lower <= nan <= upper` would report an unknown value as in-range.
3. `bool(verdict)` is `True` only when everything declared was present *and* inside, so a call site reads `if not verdict:` and then inspects `.violations` / `.unknown` for why.

## The issue's estimate was wrong, and this corrects it

#709 claimed the ranges *already existed* in `feature_manifest_*.json` and that declaring an envelope was "mostly reading a file we already ship". **It is not.** Every manifest and `model_config.json` in the repo was read: they carry feature name lists and categorical encodings, and **not one numeric range**. The only `min`/`max` strings anywhere are `max_length`, a tokenizer setting on the NLP models.

So there is nothing to parse; the constructor is the loader, and the caller supplies bounds it sourced. Sourcing them honestly (measuring the actual trained range per feature, as an eval artifact rather than a retyped constant) is now the expensive half of #710. Documented on the issue.

## Scope

This lands the contract with **no caller yet**, which is deliberate but should not linger: `src/agents/` is load-bearing and each agent earns its own real-run verification, which is why #710 is separate. #710 is the next PR in this sequence, so the contract does not sit unused.

## Checks

- 15 pure tests: inside / outside / both boundaries, unknown-vs-violation, NaN, multiple simultaneous violations, frozen-instance mutation, inverted-bound rejection
- one test asserts the module imports without pulling `src.agents` or any ML library, run in a subprocess with the working directory pointed at an empty dir
- behaviour independently probed after review, not just read: in/out/NaN/missing/both-edges all behave as documented
- `ruff@0.15.22` check + format clean
