### PR TITLE
refactor(agents): declare the N15 tyre-life ceiling as an operating envelope

### DIFF
--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -25,6 +25,10 @@ import numpy as np
 import pandas as pd
 from sklearn.preprocessing import LabelEncoder
 
+# Safe in this direction: envelope.py is a leaf that imports nothing from src.agents, so
+# there is no cycle even though src/strategy/inference/no_llm.py imports this package.
+from src.strategy.inference.envelope import OperatingEnvelope
+
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent
 while not (_REPO_ROOT / '.git').exists():
@@ -106,6 +110,18 @@ _N15_COMPOUND_UNKNOWN: int = -1  # matches the notebook's .fillna(-1)
 # N15 clipped tyre_life_in at 50 laps in training (cell 11); mirror that ceiling here so
 # an absurd stint cannot extrapolate outside the fitted range (#450).
 _MAX_TRAINED_TYRE_LIFE: int = 50
+
+# The same ceiling, declared rather than left as a bare number (#710). The envelope does
+# not clip and does not change what N15 is fed: the clip below still does that, byte for
+# byte. What it adds is that exceeding the trained range stops being SILENT, which is the
+# failure this contract exists for — N26 spent two years answering out-of-range calls
+# with full confidence because nothing ever said so out loud.
+#
+# The lower bound is 1 because a tyre on its first lap reads 1, never 0.
+_N15_TYRE_LIFE_ENVELOPE = OperatingEnvelope(
+    name="n15_pit_duration",
+    bounds={"tyre_life_in": (1.0, float(_MAX_TRAINED_TYRE_LIFE))},
+)
 
 # N15's tight_pit_box feature (notebook cell 4): {"Monaco Grand Prix", "Singapore Grand
 # Prix", "Hungarian Grand Prix"} — circuits with narrow/short pit boxes that cause minor
@@ -793,6 +809,19 @@ class PitStrategyAgent:
         if value is None or pd.isna(value):
             logger.warning('TyreLife missing on the lap row; N15 reads it as a fresh set')
             return 1
+
+        # Label the call BEFORE clipping, because after the clip the evidence is gone:
+        # every value reads as in-range once it has been forced there. The clip is what
+        # keeps N15 inside its fitted range and it is unchanged; this only makes the
+        # moment it bites visible instead of silent (#710).
+        verdict = _N15_TYRE_LIFE_ENVELOPE.check({'tyre_life_in': float(value)})
+        if not verdict:
+            logger.warning(
+                'N15 called outside its trained range: %s; the value is clipped to %d, '
+                'so the prediction is an extrapolation to the boundary rather than a fit',
+                dict(verdict.violations),
+                _MAX_TRAINED_TYRE_LIFE,
+            )
         return min(int(value), _MAX_TRAINED_TYRE_LIFE)
 
     def _build_pit_duration_features(

--- a/tests/agents/test_n15_envelope.py
+++ b/tests/agents/test_n15_envelope.py
@@ -1,0 +1,83 @@
+"""N15's tyre-life ceiling, now declared as an operating envelope (#710).
+
+The contract this pins is narrow and it is the whole point: **the envelope
+labels, the clip decides.** Wiring a verdict in must not move a single value
+N15 is fed, or the strategy goldens would shift and there would be no way to
+tell a real regression from this change.
+
+The second thing under test is that the label is emitted BEFORE the clip. After
+clipping, every value reads as in-range by construction, so a check placed after
+it would be permanently silent and would look like it worked.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+pytestmark = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="data/models/ not present (importing the pit agent reads model config)",
+)
+
+
+def _tyre_life_in(value):
+    """Call the real feature builder with a one-field pandas row."""
+    import pandas as pd
+
+    from src.agents.pit_strategy_agent import PitStrategyAgent
+
+    return PitStrategyAgent._tyre_life_in(pd.Series({"TyreLife": value}))
+
+
+def test_the_clip_still_returns_exactly_what_it_returned_before():
+    """Values in range pass through; values above the ceiling come back clipped."""
+    from src.agents.pit_strategy_agent import _MAX_TRAINED_TYRE_LIFE
+
+    assert _tyre_life_in(1) == 1
+    assert _tyre_life_in(25) == 25
+    assert _tyre_life_in(_MAX_TRAINED_TYRE_LIFE) == _MAX_TRAINED_TYRE_LIFE
+    assert _tyre_life_in(_MAX_TRAINED_TYRE_LIFE + 1) == _MAX_TRAINED_TYRE_LIFE
+    assert _tyre_life_in(999) == _MAX_TRAINED_TYRE_LIFE
+
+
+def test_an_out_of_range_call_is_announced(caplog):
+    """Exceeding the trained range must stop being silent.
+
+    This is the failure the contract exists for: N26 answered out-of-range calls
+    with full confidence for two years because nothing ever said so out loud.
+    """
+    from src.agents.pit_strategy_agent import _MAX_TRAINED_TYRE_LIFE
+
+    with caplog.at_level(logging.WARNING):
+        _tyre_life_in(_MAX_TRAINED_TYRE_LIFE + 20)
+
+    assert any("outside its trained range" in record.message for record in caplog.records)
+
+
+def test_an_in_range_call_says_nothing(caplog):
+    """A normal stint must not produce a warning, or the signal is worthless."""
+    with caplog.at_level(logging.WARNING):
+        _tyre_life_in(20)
+
+    assert not [r for r in caplog.records if "trained range" in r.message]
+
+
+def test_the_envelope_bound_is_the_clip_constant_not_a_second_number():
+    """One source for the ceiling. A retyped boundary has shipped wrong here before."""
+    from src.agents.pit_strategy_agent import _MAX_TRAINED_TYRE_LIFE, _N15_TYRE_LIFE_ENVELOPE
+
+    _lower, upper = _N15_TYRE_LIFE_ENVELOPE.bounds["tyre_life_in"]
+    assert upper == float(_MAX_TRAINED_TYRE_LIFE)
+
+
+def test_a_missing_tyre_life_is_still_read_as_a_fresh_set():
+    """The NaN path predates the envelope and must be untouched by it."""
+    import numpy as np
+
+    assert _tyre_life_in(np.nan) == 1
+    assert _tyre_life_in(None) == 1


### PR DESCRIPTION
Refs #710. Sprint 5, the first caller of the contract landed in #720.

## What

`_MAX_TRAINED_TYRE_LIFE = 50` was a bare constant and the clip built on it was **silent**. That is the exact shape of the failure the contract exists for: N26 answered out-of-range calls with full confidence for two years because nothing ever said so out loud.

- `_N15_TYRE_LIFE_ENVELOPE` declares the bound, derived from `_MAX_TRAINED_TYRE_LIFE` so there is **one source** rather than a retyped boundary. A test asserts they agree.
- The check runs **before** the clip. This is the part worth reviewing: after clipping, every value reads as in-range by construction, so a check placed after it would be permanently silent and would still look like it worked.
- An out-of-range call now logs what broke and by how much. The clip, and the value N15 is fed, are untouched.

## Behaviour is unchanged, and that is the gate

- **125 tests in `tests/mc` pass**, strategy goldens included. The goldens pin the Monte Carlo to the digit, so a moved value would have shown.
- Real-data check: 400 real rows from Lusail 2025 go through the feature builder with **no warning** (max real `TyreLife` there is 25), while a forced 88-lap stint announces itself with the violation and the bound it broke.
- 5 new tests: pass-through, both boundaries, the clip, the warning firing, the warning **not** firing on a normal stint, single-source of the ceiling, and the pre-existing NaN path untouched.

## Scope correction carried from the issue

#710 listed `tire_agent.lap_out_of_range` as a second instance of this pattern. **It is not, and it is left alone.** It tests `1 <= lap <= total_laps` and whether the driver is on track: whether the *call* makes sense. An operating envelope asks whether the *model was trained here*. Different contracts; folding them together would put a race-structure bound in a training-range module.

That leaves the rest of #710 as measurement work rather than refactoring: no `feature_manifest_*.json` or `model_config.json` in this repo carries a numeric range, so every other gated feature needs its trained range **measured off the training split** and recorded as a regenerable eval artifact. Never a constant retyped from a notebook comment, which is what produced the original N26 bug. Detailed on the issue; it likely deserves its own.

## Import direction

`src/agents/` importing `src/strategy/inference/envelope.py` is safe and non-circular: `envelope.py` is a leaf that imports nothing from `src.agents`, even though `no_llm.py` imports this package. Noted at the import site.
