### PR TITLE
feat(eval): expose the Monte Carlo alpha so the decline rate can be swept

### DIFF
--- a/src/strategy/eval/decision_modes.py
+++ b/src/strategy/eval/decision_modes.py
@@ -98,6 +98,13 @@ SAMPLED_RACES: tuple[tuple[int, str], ...] = (
 # "unavailable" gate state invites if nobody polices it.
 MIN_SCORED_SHARE = 0.60
 
+# The `alpha` the Monte Carlo scores with: `score = alpha*E[S] + (1-alpha)*P10[S]`, taken
+# from `RaceState.risk_tolerance`. 0.5 is what every surface passes today, so it is what
+# the tier measures by default. It is exposed rather than buried because a decision layer
+# that declines 65% of real stops might simply be reading a cautious default as policy,
+# and that is answerable by sweeping it rather than by arguing about it (#715).
+DEFAULT_RISK_TOLERANCE = 0.5
+
 # Buckets that mean "the rails made agreement impossible", as opposed to
 # "the model declined to call it", which is a result and not an exclusion.
 _GUARD_RAIL_BUCKETS = frozenset({"opening_laps", "closing_laps", "min_stint"})
@@ -266,7 +273,14 @@ def lap_inputs(state: dict[str, Any]) -> dict[str, Any] | None:
     }
 
 
-def _decisions_in_window(engine, laps_df, driver: str, low: int, high: int) -> dict[int, str]:
+def _decisions_in_window(
+    engine,
+    laps_df,
+    driver: str,
+    low: int,
+    high: int,
+    risk_tolerance: float = DEFAULT_RISK_TOLERANCE,
+) -> dict[int, str]:
     """Action the deterministic stack emits on each lap of ``[low, high]``.
 
     Only the laps inside the window are pushed through ``run_lap``; the replay
@@ -286,7 +300,9 @@ def _decisions_in_window(engine, laps_df, driver: str, low: int, high: int) -> d
         if inputs["lap"] > high:
             break
 
-        race_state = RaceState(driver=driver, pace_delta_s=0.0, risk_tolerance=0.5, **inputs)
+        race_state = RaceState(
+            driver=driver, pace_delta_s=0.0, risk_tolerance=risk_tolerance, **inputs
+        )
         recommendation, _outputs, _timings = inference_engine.run_lap(
             race_state, laps_df, state, profile="no-llm", return_agent_outputs=True
         )
@@ -325,8 +341,15 @@ def _is_missing(value: Any) -> bool:
 
 def measure_decision_agreement(
     races: tuple[tuple[int, str], ...] = SAMPLED_RACES,
+    risk_tolerance: float = DEFAULT_RISK_TOLERANCE,
 ) -> tuple[DecisionAgreement, list[StopVerdict]]:
     """Drive the deterministic stack over every real green-flag stop in ``races``.
+
+    Args:
+        risk_tolerance: the Monte Carlo's ``alpha``. Exposed so the decline rate can
+            be swept against it instead of argued about: if 65% of real stops go
+            uncalled at 0.5 and the number barely moves at 0.1 or 0.9, the default is
+            not what is deciding, and the search moves to the scorer itself (#715).
 
     Raises FileNotFoundError when ``data/raw/`` is absent rather than returning an
     empty sample, because a tier that reports perfect agreement over zero stops is
@@ -387,7 +410,7 @@ def measure_decision_agreement(
             low = max(1, min(stop_laps) - DECISION_WINDOW_LAPS)
             high = min(total_laps, max(stop_laps) + DECISION_WINDOW_LAPS)
             engine = RaceReplayEngine(str(race_dir), driver, team, interval_seconds=0)
-            actions = _decisions_in_window(engine, featured, driver, low, high)
+            actions = _decisions_in_window(engine, featured, driver, low, high, risk_tolerance)
 
             for stop_lap in stop_laps:
                 compound, tyre_life = _stop_context(laps, driver, stop_lap)


### PR DESCRIPTION
Refs #715. Sprint 3, task E.

## What

`risk_tolerance` was pinned at `0.5` inside the decision tier, so *"is the cautious default what declines 65% of real stops?"* could only be argued about. Now it is a parameter and the question has an answer.

## The answer: no

Lusail 2025, 26 eligible stops:

| alpha | scored | no_call | **declined** | signed error |
| --- | --- | --- | --- | --- |
| 0.1 | 3 | 19 | **73.1%** | +0.00 |
| 0.5 | 5 | 17 | **65.4%** | −2.00 |
| 0.9 | 5 | 17 | **65.4%** | −2.00 |

Pure worst-case to pure expected value moves the decline 8 points, then **nothing at all**. The default is not what is deciding.

## Why it cannot be, and this is the real finding

**`alpha` is not silently dropped.** I checked, because this codebase has already shipped exactly that bug with `temperature=0` reaching a client that discarded it. It arrives at `strategy_orchestrator.py:1273` and `:1422`, both computing `alpha * e_val + (1 - alpha) * p10_val`. Hypothesis refuted, not assumed.

The reason is in the distributions. At Lusail lap 22:

| candidate | E | P10 | P90 |
| --- | --- | --- | --- |
| STAY_OUT | **0.3** | **0.3** | **0.3** |
| PIT_NOW | −4.248 | −4.945 | −3.941 |

**STAY_OUT is a point mass** — the same value in all 500 draws — and it is flat on 5 of 6 laps sampled across the race, outscoring PIT_NOW on every one. When one candidate dominates on both `E` and `P10`, no value of alpha can change the argmax. The risk knob is decorative in that regime.

Two hypotheses for the flatness are written up on #715 (the STAY_OUT branch not consuming the sampled uncertainty, versus integer positions swallowing the spread). They need different fixes and I have deliberately not picked one here — this PR only makes the knob measurable.

## Scope

Parameter only, defaulting to `DEFAULT_RISK_TOLERANCE = 0.5`, so every existing caller and the committed report are unchanged. No behaviour moves.
