### PR TITLE
Operating envelopes, and the alpha sweep that closed the risk-knob hypothesis

### DIFF
--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -25,6 +25,10 @@ import numpy as np
 import pandas as pd
 from sklearn.preprocessing import LabelEncoder
 
+# Safe in this direction: envelope.py is a leaf that imports nothing from src.agents, so
+# there is no cycle even though src/strategy/inference/no_llm.py imports this package.
+from src.strategy.inference.envelope import OperatingEnvelope
+
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent
 while not (_REPO_ROOT / '.git').exists():
@@ -106,6 +110,18 @@ _N15_COMPOUND_UNKNOWN: int = -1  # matches the notebook's .fillna(-1)
 # N15 clipped tyre_life_in at 50 laps in training (cell 11); mirror that ceiling here so
 # an absurd stint cannot extrapolate outside the fitted range (#450).
 _MAX_TRAINED_TYRE_LIFE: int = 50
+
+# The same ceiling, declared rather than left as a bare number (#710). The envelope does
+# not clip and does not change what N15 is fed: the clip below still does that, byte for
+# byte. What it adds is that exceeding the trained range stops being SILENT, which is the
+# failure this contract exists for — N26 spent two years answering out-of-range calls
+# with full confidence because nothing ever said so out loud.
+#
+# The lower bound is 1 because a tyre on its first lap reads 1, never 0.
+_N15_TYRE_LIFE_ENVELOPE = OperatingEnvelope(
+    name="n15_pit_duration",
+    bounds={"tyre_life_in": (1.0, float(_MAX_TRAINED_TYRE_LIFE))},
+)
 
 # N15's tight_pit_box feature (notebook cell 4): {"Monaco Grand Prix", "Singapore Grand
 # Prix", "Hungarian Grand Prix"} — circuits with narrow/short pit boxes that cause minor
@@ -793,6 +809,19 @@ class PitStrategyAgent:
         if value is None or pd.isna(value):
             logger.warning('TyreLife missing on the lap row; N15 reads it as a fresh set')
             return 1
+
+        # Label the call BEFORE clipping, because after the clip the evidence is gone:
+        # every value reads as in-range once it has been forced there. The clip is what
+        # keeps N15 inside its fitted range and it is unchanged; this only makes the
+        # moment it bites visible instead of silent (#710).
+        verdict = _N15_TYRE_LIFE_ENVELOPE.check({'tyre_life_in': float(value)})
+        if not verdict:
+            logger.warning(
+                'N15 called outside its trained range: %s; the value is clipped to %d, '
+                'so the prediction is an extrapolation to the boundary rather than a fit',
+                dict(verdict.violations),
+                _MAX_TRAINED_TYRE_LIFE,
+            )
         return min(int(value), _MAX_TRAINED_TYRE_LIFE)
 
     def _build_pit_duration_features(

--- a/src/strategy/eval/decision_modes.py
+++ b/src/strategy/eval/decision_modes.py
@@ -98,6 +98,13 @@ SAMPLED_RACES: tuple[tuple[int, str], ...] = (
 # "unavailable" gate state invites if nobody polices it.
 MIN_SCORED_SHARE = 0.60
 
+# The `alpha` the Monte Carlo scores with: `score = alpha*E[S] + (1-alpha)*P10[S]`, taken
+# from `RaceState.risk_tolerance`. 0.5 is what every surface passes today, so it is what
+# the tier measures by default. It is exposed rather than buried because a decision layer
+# that declines 65% of real stops might simply be reading a cautious default as policy,
+# and that is answerable by sweeping it rather than by arguing about it (#715).
+DEFAULT_RISK_TOLERANCE = 0.5
+
 # Buckets that mean "the rails made agreement impossible", as opposed to
 # "the model declined to call it", which is a result and not an exclusion.
 _GUARD_RAIL_BUCKETS = frozenset({"opening_laps", "closing_laps", "min_stint"})
@@ -266,7 +273,14 @@ def lap_inputs(state: dict[str, Any]) -> dict[str, Any] | None:
     }
 
 
-def _decisions_in_window(engine, laps_df, driver: str, low: int, high: int) -> dict[int, str]:
+def _decisions_in_window(
+    engine,
+    laps_df,
+    driver: str,
+    low: int,
+    high: int,
+    risk_tolerance: float = DEFAULT_RISK_TOLERANCE,
+) -> dict[int, str]:
     """Action the deterministic stack emits on each lap of ``[low, high]``.
 
     Only the laps inside the window are pushed through ``run_lap``; the replay
@@ -286,7 +300,9 @@ def _decisions_in_window(engine, laps_df, driver: str, low: int, high: int) -> d
         if inputs["lap"] > high:
             break
 
-        race_state = RaceState(driver=driver, pace_delta_s=0.0, risk_tolerance=0.5, **inputs)
+        race_state = RaceState(
+            driver=driver, pace_delta_s=0.0, risk_tolerance=risk_tolerance, **inputs
+        )
         recommendation, _outputs, _timings = inference_engine.run_lap(
             race_state, laps_df, state, profile="no-llm", return_agent_outputs=True
         )
@@ -325,8 +341,15 @@ def _is_missing(value: Any) -> bool:
 
 def measure_decision_agreement(
     races: tuple[tuple[int, str], ...] = SAMPLED_RACES,
+    risk_tolerance: float = DEFAULT_RISK_TOLERANCE,
 ) -> tuple[DecisionAgreement, list[StopVerdict]]:
     """Drive the deterministic stack over every real green-flag stop in ``races``.
+
+    Args:
+        risk_tolerance: the Monte Carlo's ``alpha``. Exposed so the decline rate can
+            be swept against it instead of argued about: if 65% of real stops go
+            uncalled at 0.5 and the number barely moves at 0.1 or 0.9, the default is
+            not what is deciding, and the search moves to the scorer itself (#715).
 
     Raises FileNotFoundError when ``data/raw/`` is absent rather than returning an
     empty sample, because a tier that reports perfect agreement over zero stops is
@@ -387,7 +410,7 @@ def measure_decision_agreement(
             low = max(1, min(stop_laps) - DECISION_WINDOW_LAPS)
             high = min(total_laps, max(stop_laps) + DECISION_WINDOW_LAPS)
             engine = RaceReplayEngine(str(race_dir), driver, team, interval_seconds=0)
-            actions = _decisions_in_window(engine, featured, driver, low, high)
+            actions = _decisions_in_window(engine, featured, driver, low, high, risk_tolerance)
 
             for stop_lap in stop_laps:
                 compound, tyre_life = _stop_context(laps, driver, stop_lap)

--- a/src/strategy/inference/envelope.py
+++ b/src/strategy/inference/envelope.py
@@ -1,0 +1,173 @@
+"""Operating-envelope contract for ML model inputs (#709).
+
+WHY THIS EXISTS
+----------------
+Our models never refuse out-of-range input; they answer with the same
+confidence whether the call falls inside what they were trained on or not.
+N26's tire TCN did exactly that: inference skipped the notebook's per-stint
+grouping and left-padded with a repeated first lap instead of zeros, so it was
+fed sequences the training run never produced in roughly 87% of its calls, for
+two years, before anyone noticed. Two call sites have since patched the
+symptom by hand, each its own one-off, neither reusable by the next model:
+
+- ``src/agents/pit_strategy_agent.py`` clips ``tyre_life_in`` at 50 laps
+  because N15 clipped it at training time (cell 11).
+- ``src/agents/tire_agent.py`` computes a loose ``lap_out_of_range`` bool
+  inline before letting a tool proceed.
+
+This module turns that pattern into a rule instead of a habit. An
+:class:`OperatingEnvelope` names the bounds a model was actually trained on;
+:meth:`OperatingEnvelope.check` compares a feature vector against them and
+returns an :class:`EnvelopeVerdict`.
+
+LABELLING ONLY
+--------------
+A verdict is a label, nothing more. Checking a feature vector against an
+envelope must NEVER touch, clip, or refuse a prediction by itself -- it only
+tells the caller whether to trust the one it already has. Whether an agent
+skips a tool call, downgrades its confidence, or ignores the verdict entirely
+is a decision for that call site (tracked separately as #710), not for this
+module.
+
+WHY A MISSING FEATURE IS ITS OWN STATE, NOT A NUMBER
+-----------------------------------------------------
+A feature that is absent from the input (or NaN) is UNKNOWN: neither in-range
+nor out-of-range. This repo has shipped real bugs from collapsing "we do not
+know" into a numeric default that a real value could also legitimately take
+(a missing ``Position`` defaulted to 0 once matched the car that had just
+crashed, because 0 was also a valid grid position). ``check`` follows the same
+rule here: an unknown feature is tracked in ``EnvelopeVerdict.unknown`` and is
+never compared against a bound.
+
+NO MANIFEST FORMAT TO PARSE
+----------------------------
+The task behind this module expected a loader that reads ranges out of a
+``feature_manifest_*.json`` file. Both real manifests in this repo
+(``data/processed/feature_manifest_laptime.json``,
+``data/processed/tiredeg_feature_manifest.json``) and every
+``data/models/*/model_config.json`` were read before writing this: none of
+them carries a numeric min/max range, only feature name lists and categorical
+encodings (``feature_manifest_laptime.json``'s ``categorical_encoding`` maps
+compound strings to ints, for instance -- there is no bounds table anywhere).
+So there is nothing to parse. ``OperatingEnvelope`` is built directly from
+explicit bounds the caller sources itself (a notebook cell comment, a
+training-config constant such as ``_MAX_TRAINED_TYRE_LIFE`` in
+``pit_strategy_agent.py`` today). That constructor is the loader.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+# One feature's declared operating bound: (lower, upper), both inclusive.
+Bound = tuple[float, float]
+
+
+@dataclass(frozen=True)
+class FeatureViolation:
+    """One declared feature whose value fell outside its trained bound.
+
+    Carries what a caller needs to log or raise without re-deriving anything:
+    the value actually passed in, and the ``[lower, upper]`` bound it broke.
+    """
+
+    value: float
+    lower: float
+    upper: float
+
+
+@dataclass(frozen=True)
+class EnvelopeVerdict:
+    """Result of checking one feature vector against an OperatingEnvelope.
+
+    A pure label (see module docstring): nothing may use a verdict to alter a
+    prediction, only to decide whether to trust one.
+
+    Attributes:
+        envelope_name: name of the OperatingEnvelope that produced this.
+        violations: features that were present and numerically outside their
+            declared bound, keyed by feature name.
+        unknown: features the envelope declares but that were missing (or
+            NaN) in the checked input. Kept separate from ``violations`` on
+            purpose -- a model given no value for a feature was not given a
+            bad one, and the two states must stay distinguishable at the
+            call site.
+
+    ``bool(verdict)`` is True only when every declared feature was present
+    and within bounds, so a call site can write ``if not verdict: ...`` to
+    mean "do not trust this call blindly", then inspect ``.violations`` and
+    ``.unknown`` to say why.
+    """
+
+    envelope_name: str
+    violations: Mapping[str, FeatureViolation]
+    unknown: frozenset[str]
+
+    @property
+    def in_range(self) -> bool:
+        """True iff there is no violation and no unknown feature."""
+        return not self.violations and not self.unknown
+
+    def __bool__(self) -> bool:
+        return self.in_range
+
+
+def _is_unknown(value: float | None) -> bool:
+    """A value is unknown when it is None or NaN, and never coerced to a number.
+
+    Guards the rule in the module docstring: a NaN slipping in from a pandas
+    frame must be treated the same as an absent dict key, not compared
+    numerically (NaN comparisons are silently always False, which would make
+    an unknown value read as falsely in-range).
+    """
+    if value is None:
+        return True
+    return isinstance(value, float) and math.isnan(value)
+
+
+@dataclass(frozen=True)
+class OperatingEnvelope:
+    """The input range a model's answer is actually valid over.
+
+    Built directly from bounds the caller sourced from the training
+    notebook or config (see module docstring: no manifest in this repo
+    carries ranges today, so there is no separate file-loading path).
+    Checking a feature vector against an envelope never changes what the
+    model predicts; it only labels the call.
+    """
+
+    name: str
+    bounds: Mapping[str, Bound]
+
+    def __post_init__(self) -> None:
+        """Reject an envelope whose own declared bounds are inverted."""
+        for feature_name, (lower, upper) in self.bounds.items():
+            if lower > upper:
+                raise ValueError(
+                    f"{self.name}: bound for '{feature_name}' is inverted "
+                    f"(lower={lower} > upper={upper})"
+                )
+
+    def check(self, features: Mapping[str, float | None]) -> EnvelopeVerdict:
+        """Compare a feature vector against this envelope's declared bounds.
+
+        Only features this envelope declares are checked; extra keys in
+        ``features`` are ignored. Never raises on an out-of-range or missing
+        value -- what to do with the verdict is the caller's decision (#710).
+        """
+        violations: dict[str, FeatureViolation] = {}
+        unknown: set[str] = set()
+        for feature_name, (lower, upper) in self.bounds.items():
+            value = features.get(feature_name)
+            if _is_unknown(value):
+                unknown.add(feature_name)
+                continue
+            if not (lower <= value <= upper):
+                violations[feature_name] = FeatureViolation(value=value, lower=lower, upper=upper)
+        return EnvelopeVerdict(
+            envelope_name=self.name,
+            violations=violations,
+            unknown=frozenset(unknown),
+        )

--- a/src/strategy/inference/envelope.py
+++ b/src/strategy/inference/envelope.py
@@ -7,15 +7,21 @@ confidence whether the call falls inside what they were trained on or not.
 N26's tire TCN did exactly that: inference skipped the notebook's per-stint
 grouping and left-padded with a repeated first lap instead of zeros, so it was
 fed sequences the training run never produced in roughly 87% of its calls, for
-two years, before anyone noticed. Two call sites have since patched the
-symptom by hand, each its own one-off, neither reusable by the next model:
+two years, before anyone noticed.
 
-- ``src/agents/pit_strategy_agent.py`` clips ``tyre_life_in`` at 50 laps
-  because N15 clipped it at training time (cell 11).
-- ``src/agents/tire_agent.py`` computes a loose ``lap_out_of_range`` bool
-  inline before letting a tool proceed.
+Exactly ONE call site has since patched the symptom by hand:
+``src/agents/pit_strategy_agent.py`` clips ``tyre_life_in`` at 50 laps because
+N15 clipped it at training time (cell 11). That constant is an operating
+envelope written as a bare number.
 
-This module turns that pattern into a rule instead of a habit. An
+``src/agents/tire_agent.py``'s ``lap_out_of_range`` looks like a second
+instance and is **not** one, which is worth stating so nobody folds them
+together later: it tests ``1 <= lap <= total_laps`` and whether the driver is
+on track. Those are questions about whether the CALL makes sense, not about
+whether the MODEL was trained here. Data validity and operating envelope are
+different contracts, and only the second belongs in this module.
+
+This module turns the one real instance into a rule instead of a habit. An
 :class:`OperatingEnvelope` names the bounds a model was actually trained on;
 :meth:`OperatingEnvelope.check` compares a feature vector against them and
 returns an :class:`EnvelopeVerdict`.

--- a/tests/agents/test_n15_envelope.py
+++ b/tests/agents/test_n15_envelope.py
@@ -1,0 +1,83 @@
+"""N15's tyre-life ceiling, now declared as an operating envelope (#710).
+
+The contract this pins is narrow and it is the whole point: **the envelope
+labels, the clip decides.** Wiring a verdict in must not move a single value
+N15 is fed, or the strategy goldens would shift and there would be no way to
+tell a real regression from this change.
+
+The second thing under test is that the label is emitted BEFORE the clip. After
+clipping, every value reads as in-range by construction, so a check placed after
+it would be permanently silent and would look like it worked.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+pytestmark = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="data/models/ not present (importing the pit agent reads model config)",
+)
+
+
+def _tyre_life_in(value):
+    """Call the real feature builder with a one-field pandas row."""
+    import pandas as pd
+
+    from src.agents.pit_strategy_agent import PitStrategyAgent
+
+    return PitStrategyAgent._tyre_life_in(pd.Series({"TyreLife": value}))
+
+
+def test_the_clip_still_returns_exactly_what_it_returned_before():
+    """Values in range pass through; values above the ceiling come back clipped."""
+    from src.agents.pit_strategy_agent import _MAX_TRAINED_TYRE_LIFE
+
+    assert _tyre_life_in(1) == 1
+    assert _tyre_life_in(25) == 25
+    assert _tyre_life_in(_MAX_TRAINED_TYRE_LIFE) == _MAX_TRAINED_TYRE_LIFE
+    assert _tyre_life_in(_MAX_TRAINED_TYRE_LIFE + 1) == _MAX_TRAINED_TYRE_LIFE
+    assert _tyre_life_in(999) == _MAX_TRAINED_TYRE_LIFE
+
+
+def test_an_out_of_range_call_is_announced(caplog):
+    """Exceeding the trained range must stop being silent.
+
+    This is the failure the contract exists for: N26 answered out-of-range calls
+    with full confidence for two years because nothing ever said so out loud.
+    """
+    from src.agents.pit_strategy_agent import _MAX_TRAINED_TYRE_LIFE
+
+    with caplog.at_level(logging.WARNING):
+        _tyre_life_in(_MAX_TRAINED_TYRE_LIFE + 20)
+
+    assert any("outside its trained range" in record.message for record in caplog.records)
+
+
+def test_an_in_range_call_says_nothing(caplog):
+    """A normal stint must not produce a warning, or the signal is worthless."""
+    with caplog.at_level(logging.WARNING):
+        _tyre_life_in(20)
+
+    assert not [r for r in caplog.records if "trained range" in r.message]
+
+
+def test_the_envelope_bound_is_the_clip_constant_not_a_second_number():
+    """One source for the ceiling. A retyped boundary has shipped wrong here before."""
+    from src.agents.pit_strategy_agent import _MAX_TRAINED_TYRE_LIFE, _N15_TYRE_LIFE_ENVELOPE
+
+    _lower, upper = _N15_TYRE_LIFE_ENVELOPE.bounds["tyre_life_in"]
+    assert upper == float(_MAX_TRAINED_TYRE_LIFE)
+
+
+def test_a_missing_tyre_life_is_still_read_as_a_fresh_set():
+    """The NaN path predates the envelope and must be untouched by it."""
+    import numpy as np
+
+    assert _tyre_life_in(np.nan) == 1
+    assert _tyre_life_in(None) == 1

--- a/tests/inference/test_envelope.py
+++ b/tests/inference/test_envelope.py
@@ -1,0 +1,184 @@
+"""Tests for the operating-envelope contract (#709).
+
+Pure, hermetic tests only: no ``data/models/`` weights, no agent imports. The
+contract is small on purpose (one dataclass, one check function), so the
+tests pin the three-way feature state (in-range / out-of-range / unknown),
+the inclusive boundary, multiple simultaneous violations, and the import-time
+guarantee that makes this module usable before ``data/`` even exists on disk.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from pathlib import Path
+
+import pytest
+
+from src.strategy.inference.envelope import (
+    EnvelopeVerdict,
+    FeatureViolation,
+    OperatingEnvelope,
+)
+
+ROOT = Path(__file__).parent.parent.parent
+
+
+def _tyre_life_envelope() -> OperatingEnvelope:
+    """The N15-shaped example used across most tests: one bounded feature."""
+    return OperatingEnvelope(name="n15_pit_duration", bounds={"tyre_life_in": (0, 50)})
+
+
+# --- in-range / out-of-range / boundary -------------------------------------
+
+
+def test_value_inside_bounds_is_in_range():
+    verdict = _tyre_life_envelope().check({"tyre_life_in": 25})
+    assert verdict.in_range
+    assert bool(verdict) is True
+    assert verdict.violations == {}
+    assert verdict.unknown == frozenset()
+
+
+def test_value_outside_bounds_is_a_violation_with_the_offending_bound():
+    verdict = _tyre_life_envelope().check({"tyre_life_in": 63})
+    assert not verdict
+    assert not verdict.in_range
+    assert set(verdict.violations) == {"tyre_life_in"}
+    violation = verdict.violations["tyre_life_in"]
+    assert violation == FeatureViolation(value=63, lower=0, upper=50)
+
+
+def test_lower_and_upper_bounds_are_inclusive():
+    envelope = _tyre_life_envelope()
+    assert envelope.check({"tyre_life_in": 0}).in_range
+    assert envelope.check({"tyre_life_in": 50}).in_range
+
+
+def test_just_outside_each_bound_is_a_violation():
+    envelope = _tyre_life_envelope()
+    assert not envelope.check({"tyre_life_in": -1}).in_range
+    assert not envelope.check({"tyre_life_in": 51}).in_range
+
+
+# --- the unknown state: never coerced to a number ---------------------------
+
+
+def test_missing_key_is_unknown_not_a_violation():
+    """A feature absent from the dict is UNKNOWN, distinct from out-of-range."""
+    verdict = _tyre_life_envelope().check({})
+    assert not verdict
+    assert verdict.violations == {}
+    assert verdict.unknown == frozenset({"tyre_life_in"})
+
+
+def test_explicit_none_is_unknown():
+    verdict = _tyre_life_envelope().check({"tyre_life_in": None})
+    assert verdict.unknown == frozenset({"tyre_life_in"})
+    assert verdict.violations == {}
+
+
+def test_nan_is_unknown_not_silently_in_range():
+    """NaN must never be compared numerically: NaN <= x is always False."""
+    verdict = _tyre_life_envelope().check({"tyre_life_in": math.nan})
+    assert verdict.unknown == frozenset({"tyre_life_in"})
+    assert verdict.violations == {}
+
+
+def test_unknown_alone_makes_the_verdict_falsy():
+    """Unknown is not a violation, but it still means 'do not trust this call'."""
+    verdict = _tyre_life_envelope().check({})
+    assert verdict.violations == {}
+    assert not verdict
+
+
+# --- multiple features at once ----------------------------------------------
+
+
+def test_multiple_simultaneous_violations_are_all_reported():
+    envelope = OperatingEnvelope(
+        name="two_feature_example",
+        bounds={"gap_ahead_s": (0.0, 5.0), "tyre_life_x": (0, 40)},
+    )
+    verdict = envelope.check({"gap_ahead_s": 9.4, "tyre_life_x": -3})
+    assert set(verdict.violations) == {"gap_ahead_s", "tyre_life_x"}
+    assert verdict.violations["gap_ahead_s"] == FeatureViolation(value=9.4, lower=0.0, upper=5.0)
+    assert verdict.violations["tyre_life_x"] == FeatureViolation(value=-3, lower=0, upper=40)
+
+
+def test_mixed_violation_and_unknown_are_kept_in_their_own_buckets():
+    envelope = OperatingEnvelope(
+        name="mixed_example",
+        bounds={"gap_ahead_s": (0.0, 5.0), "tyre_life_x": (0, 40)},
+    )
+    verdict = envelope.check({"gap_ahead_s": 9.4})  # tyre_life_x missing entirely
+    assert set(verdict.violations) == {"gap_ahead_s"}
+    assert verdict.unknown == frozenset({"tyre_life_x"})
+
+
+def test_extra_undeclared_features_are_ignored():
+    verdict = _tyre_life_envelope().check({"tyre_life_in": 10, "some_other_field": -999})
+    assert verdict.in_range
+
+
+# --- construction-time validation -------------------------------------------
+
+
+def test_inverted_bound_is_rejected_at_construction():
+    with pytest.raises(ValueError):
+        OperatingEnvelope(name="broken", bounds={"tyre_life_in": (50, 0)})
+
+
+# --- the contract is a label, and it is frozen -------------------------------
+
+
+def test_envelope_and_verdict_types_are_frozen():
+    envelope = _tyre_life_envelope()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        envelope.name = "mutated"  # type: ignore[misc]
+
+    verdict = envelope.check({"tyre_life_in": 10})
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        verdict.envelope_name = "mutated"  # type: ignore[misc]
+
+
+def test_verdict_carries_the_envelope_name_for_logging():
+    verdict = _tyre_life_envelope().check({"tyre_life_in": 10})
+    assert verdict.envelope_name == "n15_pit_duration"
+    assert isinstance(verdict, EnvelopeVerdict)
+
+
+# --- the import surface -----------------------------------------------------
+
+
+def test_importing_the_module_pulls_in_nothing_heavy(tmp_path):
+    """Importing envelope.py must need neither model weights nor the agent stack.
+
+    Mirrors ``tests/eval/test_decision_modes.py`` ::
+    ``test_importing_the_module_does_not_load_the_agent_stack``. Run with cwd
+    pointed at an empty temp directory (no ``data/models/`` present) so a
+    hidden filesystem read at import time would fail loudly instead of
+    silently succeeding because the real data happens to already be on disk
+    on this machine.
+    """
+    import subprocess
+    import sys
+
+    assert not (tmp_path / "data" / "models").exists()
+
+    probe = (
+        "import sys; sys.path.insert(0, r'{root}'); "
+        "import src.strategy.inference.envelope; "
+        "heavy = [m for m in sys.modules if m.split('.')[0] in "
+        "('pandas', 'numpy', 'torch', 'lightgbm', 'xgboost')]; "
+        "agents = [m for m in sys.modules if m.startswith('src.agents')]; "
+        "print(','.join(sorted(heavy + agents)))"
+    ).format(root=str(ROOT))
+    out = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        check=True,
+    )
+    assert out.stdout.strip() == "", f"unexpected imports: {out.stdout.strip()}"


### PR DESCRIPTION
Promotes #720, #721 and #722 to `main`.

## #720 — the operating-envelope contract (closes #709)

`OperatingEnvelope(name, bounds)` declares the range a model was trained on; `check()` returns a verdict that **labels and never alters a prediction**. A missing or NaN feature is UNKNOWN, tracked apart from a violation and never coerced to a number, and NaN gets its own path because a NaN comparison is silently `False` and would read as in-range.

Corrected the issue's estimate while building it: the ranges do **not** already exist in `feature_manifest_*.json`. Every manifest and model config in the repo carries feature names and categorical encodings and not one numeric range, so the constructor is the loader and sourcing bounds is measurement work.

## #721 — N15's ceiling becomes a declared envelope (refs #710)

The bound was a bare constant and the clip built on it was silent. The check now runs **before** the clip, because after clipping every value reads as in-range by construction and a check placed after it would be permanently quiet while looking like it worked.

**Behaviour byte-identical**: 125 tests in `tests/mc` pass with the strategy goldens, and 400 real Lusail rows go through the feature builder with no warning while a forced 88-lap stint announces itself.

Scope corrected: `tire_agent.lap_out_of_range` is **not** a second instance and is left alone. It asks whether the call makes sense, not whether the model was trained there.

## #722 — the alpha sweep (refs #715)

`risk_tolerance` is now measurable instead of pinned at 0.5. Sweeping it answers the open question:

| alpha | declined |
| --- | --- |
| 0.1 | 73.1% |
| 0.5 | 65.4% |
| 0.9 | 65.4% |

**The cautious default is not what declines 65% of real stops.** And `alpha` is not silently dropped — checked, because this codebase has shipped that exact bug with `temperature=0`.

The mechanism is that **STAY_OUT comes back as a point mass** (`E = P10 = P90`) on 5 of 6 sampled laps and outscores PIT_NOW on every one. No alpha can move an argmax when a candidate dominates on both terms, so the risk knob is decorative in that regime. Two competing explanations for the flatness are written up on #715 and deliberately not chosen here.

## Checks

All three green on their own CI before merge; `tests/mc` run locally with `data/` present at each agent-touching step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added operating-envelope validation for model inputs, identifying values outside trained ranges and unknown inputs.
  * Added warnings when tyre-life inputs exceed the trained range, while preserving existing clipping and missing-value behavior.
  * Added configurable risk tolerance for decision-agreement evaluation, with the existing default retained.

* **Bug Fixes**
  * Out-of-range tyre-life values are now explicitly surfaced instead of being silently clipped.

* **Tests**
  * Added coverage for envelope boundaries, unknown values, warnings, clipping, immutability, and lightweight module loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->