### PR TITLE
test(mc): give the projection branch teeth before anything else moves

### DIFF
--- a/tests/mc/test_mc_is_a_real_decision.py
+++ b/tests/mc/test_mc_is_a_real_decision.py
@@ -149,12 +149,24 @@ _PROJECTION_STATES = tuple(
 )
 
 
-def _projection_scores(state: tuple, gp_name: str | None = None) -> dict:
+def _projection_scores(
+    state: tuple,
+    gp_name: str | None = None,
+    rival_stop_pending: dict | None = None,
+    draws: tuple[np.ndarray, np.ndarray] | None = None,
+) -> dict:
     """Score one projected race state, returning the four candidates' dicts.
 
     ``gp_name`` is left unset for the main sweep so the invariants below hold on
     the pooled measurements rather than on any one circuit's quirks. The
     clean-air tests pass it, because that is the only term that is per circuit.
+
+    ``rival_stop_pending`` and ``draws`` both default to what the sweep has
+    always passed, so every existing state scores exactly as before. They exist
+    because the defaults are two blind spots: the sweep only ever ran the
+    all-settled obligation map, in which the pending-rival asymmetry cannot
+    occur at all, and only ever passed identical draws, in which a distribution
+    cannot be seen to collapse.
     """
     from src.agents.strategy_orchestrator import _run_projection_mc
 
@@ -175,12 +187,14 @@ def _projection_scores(state: tuple, gp_name: str | None = None) -> dict:
             # No neutralisation_rate override: with no circuit the layer falls
             # back to the pooled measurement anyway, and pinning it here meant a
             # named circuit silently kept the pooled hazard instead of its own.
-            "rival_stop_pending": {"B": False, "C": False},
+            "rival_stop_pending": (
+                {"B": False, "C": False} if rival_stop_pending is None else rival_stop_pending
+            ),
             "rival_pit_loss_s": 23.8,
         },
-        cliff_s=np.full(_DRAWS, cliff),
+        cliff_s=np.full(_DRAWS, cliff) if draws is None else draws[1],
         sc_s=np.full(_DRAWS, neutralised),
-        pit_s=np.full(_DRAWS, stop_s),
+        pit_s=np.full(_DRAWS, stop_s) if draws is None else draws[0],
         ucut_s=(np.arange(_DRAWS) % 2 == 0),
         alpha=0.5,
         neutralisation_saving_s=8.0,
@@ -592,3 +606,138 @@ def test_the_margin_is_None_rather_than_zero_when_there_is_no_contest():
 
     assert mc_decision_margin({"STAY_OUT": {"score": 1.0}}) is None
     assert mc_decision_margin({"STAY_OUT": {"score": 1.0}, "PIT_NOW": {"score": None}}) is None
+
+
+# ---------------------------------------------------------------------------
+# The distribution itself — the layer's two structural blind spots
+#
+# Everything above varies the STATE and holds the draws identical, so a
+# candidate whose distribution has collapsed into a point mass scores exactly
+# as a healthy one does and no assertion notices. And every state above runs
+# the all-settled obligation map, in which a rival who still owes their stop
+# never appears. These two sections close those gaps.
+# ---------------------------------------------------------------------------
+
+# A rival gap inside this support is what makes different draws land
+# differently; outside it the projection is a point mass no matter how the
+# draws vary, which is correct behaviour and not a defect.
+_PIT_SUPPORT = (2.2, 3.2, 4.4)
+# A cliff straddling the five-lap window, so the tyre term is live rather than
+# clipped to zero on every draw.
+_CLIFF_STRADDLING_THE_WINDOW = (1.5, 3.0, 4.5)
+
+
+def _sampled_projection_draws(n: int = _DRAWS, seed: int = 42):
+    """Genuinely varying (pit, cliff) draws for the projection path."""
+    rng = np.random.default_rng(seed)
+    return (
+        rng.triangular(*_PIT_SUPPORT, n),
+        rng.triangular(*_CLIFF_STRADDLING_THE_WINDOW, n),
+    )
+
+
+# The two candidates draw their variance from DIFFERENT mechanisms, which is why
+# each needs its own rival placement and why one shared state would be a
+# knife-edge. STAY_OUT varies when a settled rival behind sits near the
+# q_f-discounted liability threshold; PIT_NOW varies when a rival sits inside the
+# total pit-loss support (traversal 21.0 s plus the sampled stop). Measured, the
+# two bands are about 1.2 s apart: at C=22.2 s STAY_OUT spreads 1.000 and PIT_NOW
+# 0.000; at C=23.2 s it is 0.002 and 1.076. A single state can catch both only at
+# a margin of 0.06, which is not a test, it is a coincidence waiting to break.
+_LIABILITY_CROSSING_STATE = (-3.0, 4.2, False, 6.0, False, True, 3.2)
+_PIT_LOSS_CROSSING_STATE = (-3.0, 5.2, False, 6.0, False, True, 3.2)
+
+
+def _spread(cell: dict) -> float:
+    return cell["P90"] - cell["P10"]
+
+
+def test_stay_out_spreads_when_the_liability_threshold_is_crossable():
+    """P90 must exceed P10 where the deferred stop's exposure is genuinely uncertain.
+
+    Deliberately NOT asserted on arbitrary states, and that scoping is the
+    substance of the test rather than a hedge: positions are integers and the
+    margin saturates at its clip, so a CORRECT implementation returns a point
+    mass whenever nothing sits inside the draw support. Proved next door in
+    ``test_position_projection.py`` — the same varying draws give 250 distinct
+    payoffs against a rival inside the support and exactly 1 against one 60 s
+    away.
+
+    So the fixture constructs the regime and inside it the assertion is
+    unconditional. Without it, a candidate whose distribution had collapsed
+    would be indistinguishable from a healthy one in every test this repo has.
+    """
+    cell = _projection_scores(_LIABILITY_CROSSING_STATE, draws=_sampled_projection_draws())[
+        "STAY_OUT"
+    ]
+    assert cell["eligible"]
+    assert _spread(cell) > 0.0, (
+        f"STAY_OUT collapsed to a point mass under varying draws: "
+        f"E={cell['E']} P10={cell['P10']} P90={cell['P90']}"
+    )
+
+
+def test_pit_now_spreads_when_a_rival_sits_inside_the_pit_loss_support():
+    """The same assertion for the stopping candidate, in the regime that is ITS own.
+
+    A rival roughly a pit cycle behind is crossed on some sampled stop times and
+    not on others, which is the only thing that puts spread into a stopping
+    candidate's payoff.
+    """
+    cell = _projection_scores(_PIT_LOSS_CROSSING_STATE, draws=_sampled_projection_draws())[
+        "PIT_NOW"
+    ]
+    assert cell["eligible"]
+    assert _spread(cell) > 0.0, (
+        f"PIT_NOW collapsed to a point mass under varying draws: "
+        f"E={cell['E']} P10={cell['P10']} P90={cell['P90']}"
+    )
+
+
+def test_identical_draws_still_collapse_the_spread():
+    """The control: the suite's own default draws produce no spread at all.
+
+    Without this, the test above could pass for a reason unrelated to sampling
+    and nobody would know the default fixtures were blind.
+    """
+    state = (-3.0, 2.5, False, 6.0, False, True, 3.2)
+    scores = _projection_scores(state)
+
+    assert scores["STAY_OUT"]["P90"] == scores["STAY_OUT"]["P10"]
+
+
+@pytest.mark.parametrize("pending", [True, False, None])
+def test_the_layer_scores_every_rival_obligation_state(pending):
+    """A rival's obligation may be owed, settled or unknown, and all three ship.
+
+    The sweep has only ever run the settled map, which is the one configuration
+    in which a pending rival cannot affect anything. Real races put most passing
+    cars in the other two states, so an entire regime went unexercised.
+
+    This asserts the layer stays coherent across all three rather than pinning a
+    number: the numbers are what the redesign is about to change deliberately.
+    """
+    state = (-3.0, 2.5, False, 6.0, False, True, 3.2)
+    scores = _projection_scores(
+        state, rival_stop_pending={"A": pending, "B": pending, "C": pending}
+    )
+
+    live = [cell["score"] for cell in scores.values() if cell["score"] is not None]
+    assert live, "every obligation state must leave at least one scoreable candidate"
+    assert all(np.isfinite(score) for score in live)
+
+
+def test_a_pending_rival_obligation_changes_the_score_it_is_supposed_to_change():
+    """Settled and pending must not produce identical numbers.
+
+    If they did, the obligation channel would be decorative — and that is
+    exactly the class of defect this file failed to catch before, so the
+    assertion is worth making explicitly rather than assuming.
+    """
+    state = (-3.0, 2.5, False, 6.0, False, True, 3.2)
+    settled = _projection_scores(state, rival_stop_pending={"B": False, "C": False})
+    pending = _projection_scores(state, rival_stop_pending={"B": True, "C": True})
+
+    assert settled["STAY_OUT"]["score"] != pending["STAY_OUT"]["score"], (
+        "a rival who still owes their stop must not score the same as one who has taken it"
+    )

--- a/tests/mc/test_position_projection.py
+++ b/tests/mc/test_position_projection.py
@@ -58,6 +58,28 @@ def _draws(pit_loss: float, cliff: float = 99.0, n: int = 1) -> tuple[np.ndarray
     return np.full(n, pit_loss), np.full(n, cliff)
 
 
+def _sampled_draws(
+    pit_loss: tuple[float, float, float],
+    cliff: tuple[float, float, float],
+    n: int = 500,
+    seed: int = 42,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Genuinely varying draws, for tests that care about the DISTRIBUTION.
+
+    The sibling of ``_draws``, which is degenerate on purpose. Until this
+    existed, every call into the primitive in the whole suite passed identical
+    draws, so no test could see a distribution collapse into a point mass — and
+    that is exactly the shape of the defect the projection layer turned out to
+    have. A suite that only ever asks about geometry cannot notice that the
+    sampling stopped mattering.
+
+    Each argument is the ``(left, mode, right)`` triple ``triangular`` wants, so
+    a caller states the support it needs rather than a spread it hopes for.
+    """
+    rng = np.random.default_rng(seed)
+    return rng.triangular(*pit_loss, n), rng.triangular(*cliff, n)
+
+
 def _flat_config(**overrides) -> ProjectionConfig:
     """Config with the tyre terms switched off, isolating the gap geometry."""
     settings = {
@@ -197,6 +219,29 @@ def test_an_unknown_obligation_makes_no_claim():
     pit_loss, cliff = _draws(22.0)
     config = _flat_config(mandatory_stop_pending=None)
     assert project_positions(rivals, NO_STOP, config, pit_loss, cliff).liabilities[0] == 0.0
+
+
+def test_a_rival_whose_obligation_is_unknown_is_exempted_silently():
+    """``None`` is excluded by the same identity check that excludes ``True``.
+
+    The filter is ``rival.stop_pending is False``, so an unknown obligation
+    exempts the rival exactly as a pending one does. The module states the
+    ``None`` rule for OUR obligation and never for a rival's, and the adapter
+    hands ``None`` to any driver absent from the ``rival_stop_pending`` map — so
+    a missing verdict quietly makes a car free and biases the liability down.
+
+    Pinned as CURRENT behaviour, not as desired behaviour. The redesign changes
+    what happens around this, and a before-picture is what makes that diff
+    legible instead of merely green.
+    """
+    pit_loss, cliff = _draws(22.0)
+    config = _flat_config(mandatory_stop_pending=True)
+
+    settled = [RivalState("BEHIND", gap_s=5.0, stop_pending=False)]
+    unknown = [RivalState("BEHIND", gap_s=5.0, stop_pending=None)]
+
+    assert project_positions(settled, NO_STOP, config, pit_loss, cliff).liabilities[0] == 1.0
+    assert project_positions(unknown, NO_STOP, config, pit_loss, cliff).liabilities[0] == 0.0
 
 
 def test_a_likely_future_neutralisation_shrinks_the_liability():
@@ -392,6 +437,34 @@ def test_the_undercut_band_covers_the_drs_range_and_stops_well_short_of_a_pit_cy
 # ---------------------------------------------------------------------------
 # Payoff
 # ---------------------------------------------------------------------------
+
+
+def test_varying_draws_reach_the_payoff_when_a_rival_sits_inside_the_pit_loss():
+    """Draw spread must survive into payoff spread, or P10 and P90 are decoration.
+
+    The regime has to be CONSTRUCTED and that is the point of the test, not a
+    weakness in it. Positions are integers and the margin saturates at
+    ``MARGIN_CLIP_S``, so a rival parked far from the pit-loss support returns
+    the same answer on every draw however wildly the draws vary — a correct
+    implementation produces point masses all the time. What makes different
+    draws land differently is a rival sitting INSIDE the support, so that some
+    draws cross them and others do not.
+
+    Asserting spread on an arbitrary state would therefore be false. Asserting
+    it here, where crossing is possible, is the strong form.
+    """
+    config = _flat_config(mandatory_stop_pending=False)
+    # 23.2 s sits inside the 22.0-24.4 s support: some draws clear this car, some
+    # do not, which is precisely the condition the assertion needs.
+    rivals = [RivalState("INSIDE_THE_SUPPORT", gap_s=23.2, stop_pending=False)]
+    pit_loss, cliff = _sampled_draws(pit_loss=(22.0, 23.2, 24.4), cliff=(1.5, 3.0, 4.5))
+
+    payoffs = payoff(project_positions(rivals, STOP_NOW, config, pit_loss, cliff), 2, config)
+
+    assert len(set(payoffs.tolist())) > 1, (
+        "identical payoffs across varying draws means the sampling is not reaching the score"
+    )
+    assert np.percentile(payoffs, 90) > np.percentile(payoffs, 10)
 
 
 def test_the_margin_can_break_a_tie_but_never_outvote_a_position():

--- a/tests/mc/test_projection_golden.py
+++ b/tests/mc/test_projection_golden.py
@@ -1,0 +1,174 @@
+"""A frozen golden for the PROJECTION branch — the one every real surface takes.
+
+``test_strategy_goldens.py`` pins ``simulate_lap_window``, the legacy seconds
+path, and says so: *"This IS the thesis-defended math."* It reaches that path by
+calling ``_run_mc_simulation`` with **no** ``rivals`` kwarg, so
+``_has_usable_gaps(None)`` is False and the dispatch at
+``strategy_orchestrator.py:1396`` routes away from the projection entirely.
+
+The consequence went unnoticed for as long as the branch has existed: **the
+projection path had no golden at all.** It was guarded only by structural
+invariants with wide tolerance bands and by unit asserts on the primitive. An
+edit that broke its VALUES failed loudly on the legacy side and silently on this
+one — which is exactly the asymmetry that let a distribution collapse into a
+point mass without a single test noticing.
+
+WHAT THIS GOLDEN DELIBERATELY FREEZES
+--------------------------------------
+Today's numbers, defect included. ``STAY_OUT`` below is a point mass
+(``E == P10 == P90``), because the layer's only tyre signal is a cliff that
+almost never falls inside the five-lap window and because a rival who still owes
+the mandatory stop is exempt from the cost of staying out while counting against
+the cost of stopping. Both are being fixed (#726, #727).
+
+Freezing the defect is the point. When those land, **the diff in this file is
+the fix**, stated in numbers rather than in a commit message. A golden that
+recorded what we wished were true would prove nothing.
+
+WHERE TO CHANGE IF THE PROJECTION CHANGES:
+- Regenerate by calling the same function with the same arguments and pasting
+  the result. Do NOT hand-edit an entry to make a test pass; the whole value of
+  this file is that it moves only when someone decided it should.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.mc.test_strategy_goldens import _canned_outputs
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+
+# The rival geometry is chosen, not arbitrary: one car just ahead (a live
+# undercut target), one close behind, and one a pit cycle behind so the terminal
+# liability has something to charge. A field with nothing near the pit-loss
+# support would pin a set of point masses and hide any future collapse.
+_RIVALS = [
+    {"driver": "AHEAD", "interval_to_driver_s": -2.4, "is_pitting": False},
+    {"driver": "BEHIND", "interval_to_driver_s": 4.6, "is_pitting": False},
+    {"driver": "FAR", "interval_to_driver_s": 22.6, "is_pitting": False},
+]
+
+_PIT_CONTEXT = {
+    "gp_name": None,
+    "traversal_s": 21.0,
+    "mandatory_stop_pending": True,
+    "rival_stop_pending": {"BEHIND": False, "FAR": False},
+    "rival_pit_loss_s": 23.8,
+}
+
+_GOLDEN_PROJECTION_ALPHA_05 = {
+    "STAY_OUT": {"E": 1.3, "P10": 1.3, "P90": 1.3, "score": 1.3, "eligible": True, "target": None},
+    "PIT_NOW": {
+        "E": 0.582,
+        "P10": 0.0,
+        "P90": 1.056,
+        "score": 0.291,
+        "eligible": True,
+        "target": None,
+    },
+    "UNDERCUT": {
+        "E": 1.114,
+        "P10": 0.0,
+        "P90": 2.023,
+        "score": 0.557,
+        "eligible": True,
+        "target": "AHEAD",
+    },
+    "OVERCUT": {
+        "E": None,
+        "P10": None,
+        "P90": None,
+        "score": None,
+        "eligible": False,
+        "target": None,
+    },
+}
+
+
+def _projection_scores(alpha: float = 0.5) -> dict:
+    """Score the frozen state through the real production entry point."""
+    from src.agents.strategy_orchestrator import _run_mc_simulation
+
+    pace, tire, situation, pit = _canned_outputs()
+    return _run_mc_simulation(
+        pace,
+        tire,
+        situation,
+        pit,
+        alpha=alpha,
+        rivals=_RIVALS,
+        position=4,
+        laps_remaining=22,
+        pit_context=_PIT_CONTEXT,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shape — runs everywhere, including a CI runner with no model weights
+# ---------------------------------------------------------------------------
+
+
+def test_the_golden_carries_the_projection_only_keys():
+    """The projection returns two keys the legacy branch never does.
+
+    Asserted on the frozen dict rather than on a live call so it survives
+    without ``data/models/``. Both MC test files are gated on model weights, so
+    without this the entire projection branch would again have zero coverage on
+    CI — the precise gap this file exists to close.
+    """
+    assert set(_GOLDEN_PROJECTION_ALPHA_05) == {"STAY_OUT", "PIT_NOW", "UNDERCUT", "OVERCUT"}
+    for cell in _GOLDEN_PROJECTION_ALPHA_05.values():
+        assert set(cell) == {"E", "P10", "P90", "score", "eligible", "target"}
+
+
+def test_an_ineligible_candidate_carries_no_numbers_at_all():
+    """``None`` everywhere, never 0.0 — a zero score is a real, findable value."""
+    overcut = _GOLDEN_PROJECTION_ALPHA_05["OVERCUT"]
+    assert overcut["eligible"] is False
+    assert all(overcut[key] is None for key in ("E", "P10", "P90", "score"))
+
+
+def test_the_frozen_state_still_records_the_defect_being_fixed():
+    """STAY_OUT is a point mass here, and that is on purpose.
+
+    If this assertion ever fails it means the collapse is gone — which is the
+    goal of #726/#727 and should arrive as a deliberate golden update, not as a
+    surprise. Keeping it explicit stops a future reader mistaking the frozen
+    numbers for a healthy distribution.
+    """
+    stay_out = _GOLDEN_PROJECTION_ALPHA_05["STAY_OUT"]
+    assert stay_out["E"] == stay_out["P10"] == stay_out["P90"]
+
+
+# ---------------------------------------------------------------------------
+# Values — needs the model weights the canned outputs are shaped against
+# ---------------------------------------------------------------------------
+
+pytestmark_values = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="data/models/ not present (CI runner without model weights)",
+)
+
+
+@pytestmark_values
+def test_projection_scores_match_the_frozen_golden():
+    assert _projection_scores() == _GOLDEN_PROJECTION_ALPHA_05
+
+
+@pytestmark_values
+def test_the_projection_is_deterministic_across_calls():
+    assert _projection_scores() == _projection_scores()
+
+
+@pytestmark_values
+@pytest.mark.parametrize(("alpha", "key"), [(1.0, "E"), (0.0, "P10")])
+def test_alpha_collapses_the_score_onto_a_single_quantile(alpha, key):
+    """Alpha 1 is pure expected value, alpha 0 is pure worst case."""
+    for name, cell in _projection_scores(alpha=alpha).items():
+        if cell["score"] is None:
+            continue
+        assert cell["score"] == pytest.approx(cell[key]), name


### PR DESCRIPTION
Closes #725. Sprint 1 of #724. **Tests only, zero production risk.**

## Why this is first

The projection branch — the one every RaceStateManager-backed surface takes — had:

- **no golden at all.** The frozen `_GOLDEN_ALPHA_05` calls `_run_mc_simulation` with **no `rivals` kwarg**, so `_has_usable_gaps(None)` is False and it pins the **legacy** path instead.
- **no test where the draws vary.** Every call passed `np.full`.
- **nothing anywhere asserting `P90 > P10`.**

So a defect whose signature is *a distribution collapsing into a point mass* was invisible to the whole suite — which is exactly the defect #726 and #727 exist to fix. Landing them without this first would mean shipping a change whose effect nothing can see.

## The `P90 > P10` assertion is conditional, and that is the substance

The property is **not universal.** Positions are integers and the margin saturates at `MARGIN_CLIP_S`, so a **correct** implementation returns a point mass whenever nothing sits inside the draw support. Measured directly:

| rival placement | unique payoffs | P90 − P10 |
| --- | --- | --- |
| **inside the pit-loss support (23.2 s)** | **250** | **1.0643** |
| far behind (60 s) | 1 | 0.0000 |
| far ahead (−60 s) | 1 | 0.0000 |

So the fixture **constructs** the regime and inside it the assertion is unconditional. Asserting it on arbitrary states would be false; this is the strong form, not a hedge.

## Two candidates, two mechanisms, two placements

STAY_OUT's variance comes from the **liability threshold** being crossable; PIT_NOW's from a rival sitting inside the **total pit loss** (traversal 21.0 s plus the sampled stop). Measured, the bands are ~1.2 s apart:

| rival at | STAY_OUT spread | PIT_NOW spread |
| --- | --- | --- |
| 22.2 s | **1.000** | 0.000 |
| 22.6 s | 0.064 | 1.016 |
| 23.2 s | 0.002 | **1.076** |

A single shared state catches both only at a 0.06 margin. That is a coincidence waiting to break, not a test — so each candidate gets the regime that is genuinely its own, and the reason is written down.

## Mutation-checked, because a test that cannot fail is the same disease

| mutation | result |
| --- | --- |
| `terminal_liability`'s filter: `is False` → `is not True` (so `None` is charged) | **exactly one** test red — the new `None` pin — and no others |
| `MARGIN_WEIGHT` 0.1 → 0.2 | new projection golden **red** |
| same mutation, existing legacy golden | **12/12 still green** |

That last row is the justification for the new file in one line: **a change to the projection layer was completely invisible to the only golden this repo had.**

## The golden freezes the defect on purpose

`STAY_OUT` is frozen as a point mass (`E == P10 == P90 == 1.3`), and there is an explicit test asserting it still is. When #726 and #727 land, **the diff in that file is the fix**, stated in numbers rather than in a commit message. A golden recording what we wish were true would prove nothing.

## Also

Rival obligations now run in all three states (`True` / `False` / `None`). The sweep only ever ran the all-settled map — the one configuration in which the pending-rival asymmetry structurally cannot occur, while real races put 73-84% of passing cars in the states it never touched.

## Must-not-move, respected

`_draws` itself (degenerate by design, and the geometry tests depend on it), every existing assertion, the legacy golden.

## Known limitation, stated rather than papered over

Both MC test files are gated on `data/models/`, so **the value assertions do not run on CI**. The new golden's *shape* assertions are deliberately written against the frozen dict rather than a live call, so at least those survive without model weights. This gating is how the projection branch ended up ungoldened in the first place and it deserves its own issue.

## Checks

- `tests/mc/`: **141 passed** locally with `data/` present
- `ruff@0.15.22` check + format clean
