### PR TITLE
test(mc): act on the A-1 gate — a comment that taught the wrong mechanism

### DIFF
--- a/tests/mc/test_mc_is_a_real_decision.py
+++ b/tests/mc/test_mc_is_a_real_decision.py
@@ -639,13 +639,30 @@ def _sampled_projection_draws(n: int = _DRAWS, seed: int = 42):
 # The two candidates draw their variance from DIFFERENT mechanisms, which is why
 # each needs its own rival placement and why one shared state would be a
 # knife-edge. STAY_OUT varies when a settled rival behind sits near the
-# q_f-discounted liability threshold; PIT_NOW varies when a rival sits inside the
-# total pit-loss support (traversal 21.0 s plus the sampled stop). Measured, the
-# two bands are about 1.2 s apart: at C=22.2 s STAY_OUT spreads 1.000 and PIT_NOW
-# 0.000; at C=23.2 s it is 0.002 and 1.076. A single state can catch both only at
-# a margin of 0.06, which is not a test, it is a coincidence waiting to break.
-_LIABILITY_CROSSING_STATE = (-3.0, 4.2, False, 6.0, False, True, 3.2)
+# q_f-discounted liability threshold (measured support 20.72-22.65 s); PIT_NOW
+# varies when a rival sits inside the total pit-loss support, traversal 21.0 s
+# plus the sampled stop (measured 21.95-24.15 s). The centres are ~1.4 s apart.
+#
+# A shared state does exist, over a window about 0.8 s wide, but the smaller of
+# the two spreads there peaks around 0.08 — and worse, inside that window
+# STAY_OUT's spread comes ENTIRELY from the margin/cliff channel, because the
+# liability crossing fraction drops to ~3% and stops reaching P10 at all. A
+# shared state would therefore pass STAY_OUT's assertion through a mechanism its
+# own name disclaims. Two states, each comfortably inside its own band.
+#
+# The rival is placed where the liability crossing fraction is ~0.43, near the
+# middle of the (0.10, 0.90) percentile band rather than against its edge. An
+# earlier placement sat at 0.11 — two draws from the boundary — where a numpy
+# stream change would have silently removed the liability contribution and left
+# the test green on the margin channel alone.
+_LIABILITY_CROSSING_STATE = (-3.0, 3.5, False, 6.0, False, True, 3.2)
 _PIT_LOSS_CROSSING_STATE = (-3.0, 5.2, False, 6.0, False, True, 3.2)
+
+# A whole car crossing the threshold moves the payoff by a full position. The
+# margin channel is capped at 0.3 by MARGIN_CLIP_S and in practice contributes
+# ~0.1, so requiring more than half a position is what separates "the liability
+# actually varied" from "a tie-break wobbled".
+_A_WHOLE_CAR = 0.5
 
 
 def _spread(cell: dict) -> float:
@@ -671,8 +688,11 @@ def test_stay_out_spreads_when_the_liability_threshold_is_crossable():
         "STAY_OUT"
     ]
     assert cell["eligible"]
-    assert _spread(cell) > 0.0, (
-        f"STAY_OUT collapsed to a point mass under varying draws: "
+    # A whole car, not a tie-break wobble. Asserting only `> 0` would stay green
+    # if the liability channel vanished and the capped margin term was all that
+    # was left — the test would then pass through a mechanism its name disclaims.
+    assert _spread(cell) > _A_WHOLE_CAR, (
+        f"STAY_OUT lost the liability crossing this test exists to observe: "
         f"E={cell['E']} P10={cell['P10']} P90={cell['P90']}"
     )
 
@@ -688,8 +708,8 @@ def test_pit_now_spreads_when_a_rival_sits_inside_the_pit_loss_support():
         "PIT_NOW"
     ]
     assert cell["eligible"]
-    assert _spread(cell) > 0.0, (
-        f"PIT_NOW collapsed to a point mass under varying draws: "
+    assert _spread(cell) > _A_WHOLE_CAR, (
+        f"PIT_NOW lost the pit-loss crossing this test exists to observe: "
         f"E={cell['E']} P10={cell['P10']} P90={cell['P90']}"
     )
 

--- a/tests/mc/test_projection_golden.py
+++ b/tests/mc/test_projection_golden.py
@@ -42,10 +42,26 @@ from tests.mc.test_strategy_goldens import _canned_outputs
 ROOT = Path(__file__).parent.parent.parent
 _HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
 
-# The rival geometry is chosen, not arbitrary: one car just ahead (a live
-# undercut target), one close behind, and one a pit cycle behind so the terminal
-# liability has something to charge. A field with nothing near the pit-loss
-# support would pin a set of point masses and hide any future collapse.
+# The rival geometry is chosen, not arbitrary, and the roles are the opposite of
+# the intuitive reading — measured, not assumed:
+#
+#   AHEAD  (-2.4 s)  a live undercut target, which is why UNDERCUT names it.
+#   BEHIND ( 4.6 s)  charged by the terminal liability on 100% of draws. Being
+#                    charged CONSTANTLY it contributes no spread at all; it pins
+#                    the level, not the distribution.
+#   FAR    (22.6 s)  sits inside the total pit-loss support and is crossed on
+#                    exactly 50% of draws. THIS is what gives PIT_NOW and
+#                    UNDERCUT their P10/P90 spread.
+#
+# So the pit-cycle-behind car is not here "so the liability has something to
+# charge" — that is BEHIND's job, and it is a constant. Stating it the wrong way
+# round would teach a false mechanism to whoever edits this next.
+#
+# Far-field control, executed: move BEHIND to 40 s and FAR to 60 s and STAY_OUT
+# and PIT_NOW both collapse to point masses (2.3/2.3/2.3). UNDERCUT does not,
+# because the N16 bonus is a Bernoulli draw that spreads regardless of geometry
+# and is not part of the projection. So the geometry is load-bearing for the
+# projection channels specifically, which is the claim worth making.
 _RIVALS = [
     {"driver": "AHEAD", "interval_to_driver_s": -2.4, "is_pitting": False},
     {"driver": "BEHIND", "interval_to_driver_s": 4.6, "is_pitting": False},


### PR DESCRIPTION
Refs #725. Follow-up to #730, acting on Fable audit **A-1** — the gate the plan attaches to every PR in #724.

The gate was pointed at **my own work**, not at the original bug, and it found three things. All three are the same class of defect these tests exist to catch, which is exactly the argument for auditing the fix rather than the bug.

## 1. The golden's comment had the rival roles backwards

I wrote that the pit-cycle-behind car was there *"so the terminal liability has something to charge"*. Measured:

| rival | measured role |
| --- | --- |
| `BEHIND` (4.6 s) | charged by the liability on **100%** of draws — being constant it contributes **no spread at all** |
| `FAR` (22.6 s) | inside the total pit-loss support, crossed on exactly **50%** of draws — **this** is what gives PIT_NOW and UNDERCUT their distribution |

The geometry is load-bearing, but for the opposite reason to the one I documented. A comment that names the wrong mechanism is worse than no comment: it is what stops the next reader checking.

## 2. The STAY_OUT test sat two draws from silently losing its own mechanism

Its rival was placed where the liability crossing fraction was **0.11**, against a P10 boundary of 0.10. A numpy stream change would have dropped the liability contribution out of `P90 − P10` entirely and the test would have stayed **green** on the capped margin channel alone — passing through a mechanism its own name disclaims.

Moved to a crossing fraction of **0.43**, mid-band.

## 3. `> 0` is satisfied by a tie-break wobble

Both spread assertions now require **`> 0.5`** — a whole car crossing, not a margin twitch, since `MARGIN_CLIP_S` caps that channel at 0.3 and in practice it contributes ~0.1. Measured headroom:

| seed | STAY_OUT | PIT_NOW |
| --- | --- | --- |
| 0 | 1.084 | 1.080 |
| 1 | 1.071 | 1.071 |
| 7 | 1.094 | 1.079 |
| 42 | 1.091 | 1.076 |
| 99 | 1.066 | 1.069 |

Better than 2× the threshold on every seed.

## Also corrected

The claim that a far field "would pin a set of point masses" is **overstated** and now names its exception: STAY_OUT and PIT_NOW do collapse, but UNDERCUT keeps spreading because the N16 bonus is a Bernoulli draw and is not part of the projection.

## What the gate confirmed

The "250 distinct payoffs inside the support vs exactly 1 at 60 s" figure reproduced **exactly**. The ~1.2 s band-gap claim holds (measured centres 1.4 s apart). `_draws` and every pre-existing assertion are unchanged — that file's diff is pure addition, `+73/−0`. And the shared-state window it found is ~0.8 s wide with a best-case smaller spread of ~0.08, so the two-state design is justified **more strongly** than my comment argued.

## One operational note worth recording

The gate **died mid-run and left its mutation applied** to `position_projection.py`. It never reached a commit — verified with `git log -S` and against `dev` HEAD — but the working tree needed reverting by hand. Any audit licensed to mutate production code needs its revert checked by the orchestrator rather than trusted to the agent's own report.

## Checks

- `tests/mc/test_mc_is_a_real_decision.py` + `test_projection_golden.py`: 38 passed
- `ruff@0.15.22` check + format clean
