### PR TITLE
fix(mc): net both sides' outstanding stops at the same horizon

### DIFF
--- a/src/agents/position_projection.py
+++ b/src/agents/position_projection.py
@@ -147,9 +147,7 @@ class RivalState:
         anyway, but stating it keeps the rule visible next to the comparison
         rather than resting on IEEE-754 happening to agree with us.
         """
-        return (
-            self.gap_s is not None and math.isfinite(float(self.gap_s)) and self.gap_s < 0
-        )
+        return self.gap_s is not None and math.isfinite(float(self.gap_s)) and self.gap_s < 0
 
     @property
     def gap_ahead_s(self) -> float | None:
@@ -235,16 +233,23 @@ class ProjectionResult:
     """Per-draw output of a projection for one candidate.
 
     Attributes:
-        positions:   Projected track position at the end of the window.
+        positions:   Projected track position at the end of the window. This is
+                     the REJOIN horizon, and it is what the 1810-stop ground
+                     truth grades, so it must keep meaning exactly that.
         margins_s:   Seconds of buffer to the nearest projected car behind,
                      clipped, and 0.0 when nothing is behind us.
-        liabilities: Cars the still-owed stop is projected to cost later.
+        terminal_positions:
+                     Projected position once every KNOWN outstanding stop has
+                     been served, ours and theirs. Scoring happens here rather
+                     than at the window end, because a candidate that skips the
+                     window has not avoided the mandatory stop, only deferred
+                     it, and a rival who still owes one has not really passed us.
         rivals_used: How many rivals had a usable gap and entered the count.
     """
 
     positions: np.ndarray
     margins_s: np.ndarray
-    liabilities: np.ndarray
+    terminal_positions: np.ndarray
     rivals_used: int
 
 
@@ -453,7 +458,9 @@ def measured_racing_laps(neutralisation: str = "sc") -> float:
     mean = (kinds.get(neutralisation) or {}).get("racing_laps_in_window", {}).get("mean")
     if mean is not None:
         return float(mean)
-    return DEFAULT_RACING_LAPS_UNDER_VSC if neutralisation == "vsc" else DEFAULT_RACING_LAPS_UNDER_SC
+    return (
+        DEFAULT_RACING_LAPS_UNDER_VSC if neutralisation == "vsc" else DEFAULT_RACING_LAPS_UNDER_SC
+    )
 
 
 def future_neutralisation_probability(rate_per_lap: float, laps_remaining: int) -> float:
@@ -480,9 +487,7 @@ def _usable_rivals(rivals: Sequence[RivalState]) -> list[RivalState]:
     ``nan`` while the payload still reports itself as scored.
     """
     return [
-        rival
-        for rival in rivals
-        if rival.gap_s is not None and math.isfinite(float(rival.gap_s))
+        rival for rival in rivals if rival.gap_s is not None and math.isfinite(float(rival.gap_s))
     ]
 
 
@@ -578,51 +583,77 @@ def rival_time_deltas(
     return deltas
 
 
-def terminal_liability(
-    rivals: Sequence[RivalState],
+def _stop_residual_s(stop_loss_s: np.ndarray | float, config: ProjectionConfig) -> np.ndarray:
+    """Seconds an outstanding stop still costs, after the option value of waiting.
+
+    A future neutralisation might cover the stop cheaply, and that possibility is
+    worth real seconds, so the raw pit loss is discounted by ``q_f * saving``.
+    Floored at zero: a stop cannot end up gaining time. This is what turned the
+    old flat Safety Car bonus into an option value and it is unchanged by the
+    netting; only who it is applied TO changed.
+    """
+    discounted = np.asarray(stop_loss_s, dtype=float) - (
+        config.future_neutralisation_prob * config.neutralisation_saving_s
+    )
+    return np.maximum(0.0, discounted)
+
+
+def _terminal_gaps(
+    usable: Sequence[RivalState],
     plan: DriverPlan,
+    projected_gaps: np.ndarray,
     pit_loss_s: np.ndarray,
     config: ProjectionConfig,
 ) -> np.ndarray:
-    """Cars that a still-owed stop is projected to cost us later, per draw.
+    """Window-end gaps carried forward to a race end where every KNOWN stop is served.
 
     The two-compound rule (Art. 30.5(m)) makes one stop mandatory, so a candidate
-    that skips the window has not avoided the cost, only deferred it. This counts
-    what that deferral will cost in cars: rivals close enough behind to come out
-    ahead when we finally stop, and only those who have ALREADY satisfied their
-    own obligation — a rival who must still stop pays the same price later, so
-    they are no threat.
+    that skips the window has not avoided the cost, only deferred it — and the
+    same is true of a rival. Charging our deferral while exempting theirs is what
+    made staying out look free and stopping look expensive: measured over real
+    races, 73-84% of the cars counted as passing us still owed a stop of their
+    own, and PIT_NOW won once in 110 laps.
 
-    The window is discounted by ``q_f * saving``: a future neutralisation might
-    cover the stop cheaply, and that possibility is worth real seconds. This is
-    what turns the old flat Safety Car bonus into an option value, and it is why
-    the three cases the deleted rail was patching now fall out of the arithmetic:
+    So both sides are carried to the same horizon::
 
-    - already stopped (no obligation) -> no liability, staying out is free;
-    - leading a pack that all still owe a stop -> every rival is exempt, so the
-      liability is zero and holding the lead costs nothing;
+        terminal_gap = projected_gap + their_residual - our_residual
+
+    and the three cases the deleted rail was patching still fall out of the
+    arithmetic, now by cancellation rather than by exemption:
+
+    - already stopped (no obligation) -> our residual is zero, staying out costs
+      nothing on this term;
+    - leading a pack that all still owe a stop -> their residuals and ours are
+      the same size and cancel, so holding the lead is free;
     - the race ending behind the Safety Car -> the config's racing laps go to
       zero, so nothing is gained by stopping in the first place.
 
-    An unknown obligation (``mandatory_stop_pending is None``) yields zero: the
-    liability is a claim about a fact, and without the fact we do not make it.
+    An unknown obligation contributes NOTHING in either direction, on the
+    module's standing rule that a claim needs a fact. That is deliberately
+    asymmetric with charging it: an unsettled obligation treated as a certainty
+    invents twenty-odd seconds of somebody's race.
+
+    A rival already serving their stop is excluded too: ``rival_time_deltas``
+    has charged them inside the window already, and charging the same stop twice
+    would push them a full pit cycle further back than they will ever be.
     """
-    if plan.stops_in_window or config.mandatory_stop_pending is not True:
-        return np.zeros(len(pit_loss_s), dtype=float)
+    our_residual = (
+        _stop_residual_s(pit_loss_s, config)
+        if not plan.stops_in_window and config.mandatory_stop_pending is True
+        else np.zeros(len(pit_loss_s), dtype=float)
+    )
 
-    discounted = pit_loss_s - config.future_neutralisation_prob * config.neutralisation_saving_s
-    exposure_s = np.maximum(0.0, discounted)
+    their_residual = np.array(
+        [
+            _stop_residual_s(rival.stop_loss_s, config)
+            if rival.stop_pending is True and not rival.is_pitting
+            else 0.0
+            for rival in usable
+        ],
+        dtype=float,
+    )
 
-    behind_and_settled = [
-        rival.gap_s
-        for rival in _usable_rivals(rivals)
-        if rival.gap_s > 0 and rival.stop_pending is False
-    ]
-    if not behind_and_settled:
-        return np.zeros(len(pit_loss_s), dtype=float)
-
-    gaps = np.asarray(behind_and_settled, dtype=float)
-    return (gaps[None, :] < exposure_s[:, None]).sum(axis=1).astype(float)
+    return projected_gaps + their_residual[None, :] - our_residual[:, None]
 
 
 def project_positions(
@@ -649,13 +680,14 @@ def project_positions(
     draws = len(pit_loss_s)
 
     our_delta = driver_time_delta(plan, pit_loss_s, cliff_laps, config, stop_is_neutralised)
-    liabilities = terminal_liability(rivals, plan, pit_loss_s, config)
 
     if not usable:
+        # Nobody to be passed by, at either horizon.
+        ones = np.ones(draws, dtype=float)
         return ProjectionResult(
-            positions=np.ones(draws, dtype=float),
+            positions=ones,
             margins_s=np.zeros(draws, dtype=float),
-            liabilities=liabilities,
+            terminal_positions=ones,
             rivals_used=0,
         )
 
@@ -671,26 +703,34 @@ def project_positions(
     nearest_behind = behind_gaps.min(axis=1)
     margins = np.clip(np.where(np.isinf(nearest_behind), 0.0, nearest_behind), 0.0, MARGIN_CLIP_S)
 
+    terminal_gaps = _terminal_gaps(usable, plan, projected_gaps, pit_loss_s, config)
+
     return ProjectionResult(
         positions=positions,
         margins_s=margins,
-        liabilities=liabilities,
+        terminal_positions=1.0 + (terminal_gaps < 0).sum(axis=1),
         rivals_used=len(usable),
     )
 
 
 def payoff(result: ProjectionResult, current_position: int, config: ProjectionConfig) -> np.ndarray:
-    """Per-draw payoff in positions gained, margin-adjusted and liability-charged.
+    """Per-draw payoff in positions gained at the terminal horizon, margin-adjusted.
 
     Positions are the currency, which is the point of the redesign. The margin
     term is deliberately small (a tenth of a position per second, capped): it
     breaks ties between candidates that land on the same car count and smooths
     the quantile steps that an integer-valued score would otherwise have, but it
     can never outvote an actual position.
+
+    Scored on ``terminal_positions``, not on the window-end ``positions``: both
+    sides of a comparison must be at the same horizon or the arithmetic favours
+    whichever one had its future cost left off. The margin stays on the WINDOW-end
+    gaps on purpose — it is a tie-break about track position now, not a claim
+    about the end of the race.
     """
-    gained = float(current_position) - result.positions
+    gained = float(current_position) - result.terminal_positions
     margin_bonus = config.margin_weight * result.margins_s
-    return gained + margin_bonus - result.liabilities
+    return gained + margin_bonus
 
 
 def undercut_targets(rivals: Sequence[RivalState], config: ProjectionConfig) -> list[str]:

--- a/tests/mc/test_mc_is_a_real_decision.py
+++ b/tests/mc/test_mc_is_a_real_decision.py
@@ -636,26 +636,22 @@ def _sampled_projection_draws(n: int = _DRAWS, seed: int = 42):
     )
 
 
-# The two candidates draw their variance from DIFFERENT mechanisms, which is why
-# each needs its own rival placement and why one shared state would be a
-# knife-edge. STAY_OUT varies when a settled rival behind sits near the
-# q_f-discounted liability threshold (measured support 20.72-22.65 s); PIT_NOW
-# varies when a rival sits inside the total pit-loss support, traversal 21.0 s
-# plus the sampled stop (measured 21.95-24.15 s). The centres are ~1.4 s apart.
+# One state now serves both candidates, and that is a CONSEQUENCE of the
+# race-end netting rather than a convenience.
 #
-# A shared state does exist, over a window about 0.8 s wide, but the smaller of
-# the two spreads there peaks around 0.08 — and worse, inside that window
-# STAY_OUT's spread comes ENTIRELY from the margin/cliff channel, because the
-# liability crossing fraction drops to ~3% and stops reaching P10 at all. A
-# shared state would therefore pass STAY_OUT's assertion through a mechanism its
-# own name disclaims. Two states, each comfortably inside its own band.
+# Before it, the two drew variance from different places: STAY_OUT from a
+# settled rival near the q_f-discounted liability threshold (support
+# 20.72-22.65 s), PIT_NOW from a rival inside the total pit loss, traversal
+# 21.0 s plus the sampled stop (21.95-24.15 s). Centres ~1.4 s apart, so a
+# shared state existed only over an ~0.8 s window where the smaller spread
+# peaked around 0.08 — and there STAY_OUT passed through the margin channel
+# rather than the one its name claimed. Hence two states.
 #
-# The rival is placed where the liability crossing fraction is ~0.43, near the
-# middle of the (0.10, 0.90) percentile band rather than against its edge. An
-# earlier placement sat at 0.11 — two draws from the boundary — where a numpy
-# stream change would have silently removed the liability contribution and left
-# the test green on the margin channel alone.
-_LIABILITY_CROSSING_STATE = (-3.0, 3.5, False, 6.0, False, True, 3.2)
+# Netting carries OUR outstanding stop into the terminal gaps, and our residual
+# varies with the same pit-loss draw PIT_NOW is exposed to. So both candidates
+# now cross in the same band, and a single rival inside the pit-loss support
+# exercises both honestly. Measured across six seeds at this state: STAY_OUT
+# 1.000-1.014, PIT_NOW 1.069-1.080 — each better than twice the threshold.
 _PIT_LOSS_CROSSING_STATE = (-3.0, 5.2, False, 6.0, False, True, 3.2)
 
 # A whole car crossing the threshold moves the payoff by a full position. The
@@ -669,8 +665,9 @@ def _spread(cell: dict) -> float:
     return cell["P90"] - cell["P10"]
 
 
-def test_stay_out_spreads_when_the_liability_threshold_is_crossable():
-    """P90 must exceed P10 where the deferred stop's exposure is genuinely uncertain.
+@pytest.mark.parametrize("candidate", ["STAY_OUT", "PIT_NOW"])
+def test_the_projection_spreads_when_a_rival_sits_inside_the_pit_loss_support(candidate):
+    """P90 must exceed P10 where a rival is genuinely crossable.
 
     Deliberately NOT asserted on arbitrary states, and that scoping is the
     substance of the test rather than a hedge: positions are integers and the
@@ -684,32 +681,15 @@ def test_stay_out_spreads_when_the_liability_threshold_is_crossable():
     unconditional. Without it, a candidate whose distribution had collapsed
     would be indistinguishable from a healthy one in every test this repo has.
     """
-    cell = _projection_scores(_LIABILITY_CROSSING_STATE, draws=_sampled_projection_draws())[
-        "STAY_OUT"
+    cell = _projection_scores(_PIT_LOSS_CROSSING_STATE, draws=_sampled_projection_draws())[
+        candidate
     ]
     assert cell["eligible"]
     # A whole car, not a tie-break wobble. Asserting only `> 0` would stay green
-    # if the liability channel vanished and the capped margin term was all that
-    # was left — the test would then pass through a mechanism its name disclaims.
+    # on the capped margin term alone, so the test would pass through a mechanism
+    # its own name disclaims.
     assert _spread(cell) > _A_WHOLE_CAR, (
-        f"STAY_OUT lost the liability crossing this test exists to observe: "
-        f"E={cell['E']} P10={cell['P10']} P90={cell['P90']}"
-    )
-
-
-def test_pit_now_spreads_when_a_rival_sits_inside_the_pit_loss_support():
-    """The same assertion for the stopping candidate, in the regime that is ITS own.
-
-    A rival roughly a pit cycle behind is crossed on some sampled stop times and
-    not on others, which is the only thing that puts spread into a stopping
-    candidate's payoff.
-    """
-    cell = _projection_scores(_PIT_LOSS_CROSSING_STATE, draws=_sampled_projection_draws())[
-        "PIT_NOW"
-    ]
-    assert cell["eligible"]
-    assert _spread(cell) > _A_WHOLE_CAR, (
-        f"PIT_NOW lost the pit-loss crossing this test exists to observe: "
+        f"{candidate} lost the crossing this test exists to observe: "
         f"E={cell['E']} P10={cell['P10']} P90={cell['P90']}"
     )
 

--- a/tests/mc/test_position_projection.py
+++ b/tests/mc/test_position_projection.py
@@ -3,8 +3,9 @@
 Two layers:
 
 1. Unit tests that pin the contract — the sign convention, rejoining into
-   traffic, the terminal liability's three cases, target eligibility, the
-   far-field ranker. These run everywhere and are the regression bed.
+   traffic, the three cases the deleted Safety Car rail was patching, target
+   eligibility, the far-field ranker. These run everywhere and are the
+   regression bed.
 
 2. The ground-truth test: project every real green-flag pit stop across the 71
    races and compare the projected rejoin position against what actually
@@ -179,8 +180,21 @@ def test_an_unknown_gap_keeps_a_rival_out_of_the_count():
 
 
 # ---------------------------------------------------------------------------
-# The terminal liability — the three cases the deleted rail was patching
+# The terminal horizon — the three cases the deleted rail was patching, which
+# now fall out of race-end residual netting rather than out of a one-sided
+# liability. The contracts are the same; only their arithmetic moved.
 # ---------------------------------------------------------------------------
+
+
+def _terminal_cost(result) -> float:
+    """Cars the terminal horizon costs us beyond the window end, first draw.
+
+    Replaces the old ``liabilities`` reading. The contracts below are unchanged;
+    what changed is that the correction is now computed from projected gaps with
+    BOTH sides' outstanding stops carried forward, so it can also come out
+    negative — a rival who still owes a stop ends up behind us rather than free.
+    """
+    return float(result.terminal_positions[0] - result.positions[0])
 
 
 def test_a_pending_stop_costs_the_cars_it_will_release_behind_us():
@@ -190,61 +204,83 @@ def test_a_pending_stop_costs_the_cars_it_will_release_behind_us():
     ]
     pit_loss, cliff = _draws(22.0)
     config = _flat_config(mandatory_stop_pending=True)
-    liabilities = project_positions(rivals, NO_STOP, config, pit_loss, cliff).liabilities
-    assert liabilities[0] == 1.0, "only the car inside our pit loss should count"
+    result = project_positions(rivals, NO_STOP, config, pit_loss, cliff)
+    assert _terminal_cost(result) == 1.0, "only the car inside our pit loss should count"
 
 
 def test_leading_a_pack_that_still_owes_its_stop_is_free():
-    # #470's second case: every car behind must serve the same stop, so none of
-    # them is a threat, and holding the lead costs nothing.
+    # #470's second case, and it now falls out by CANCELLATION rather than by
+    # exemption: every car behind carries the same residual we do, so the two
+    # sides net to zero and holding the lead costs nothing.
     rivals = [
-        RivalState("BEHIND_1", gap_s=5.0, stop_pending=True),
-        RivalState("BEHIND_2", gap_s=9.0, stop_pending=True),
+        RivalState("BEHIND_1", gap_s=5.0, stop_pending=True, stop_loss_s=22.0),
+        RivalState("BEHIND_2", gap_s=9.0, stop_pending=True, stop_loss_s=22.0),
     ]
     pit_loss, cliff = _draws(22.0)
     config = _flat_config(mandatory_stop_pending=True)
-    assert project_positions(rivals, NO_STOP, config, pit_loss, cliff).liabilities[0] == 0.0
+    assert _terminal_cost(project_positions(rivals, NO_STOP, config, pit_loss, cliff)) == 0.0
 
 
-def test_having_already_stopped_removes_the_liability_entirely():
+def test_having_already_stopped_removes_the_cost_entirely():
     # #470's first case: a second set buys nothing, so staying out is free.
     rivals = [RivalState("BEHIND", gap_s=5.0, stop_pending=False)]
     pit_loss, cliff = _draws(22.0)
     config = _flat_config(mandatory_stop_pending=False)
-    assert project_positions(rivals, NO_STOP, config, pit_loss, cliff).liabilities[0] == 0.0
+    assert _terminal_cost(project_positions(rivals, NO_STOP, config, pit_loss, cliff)) == 0.0
 
 
 def test_an_unknown_obligation_makes_no_claim():
     rivals = [RivalState("BEHIND", gap_s=5.0, stop_pending=False)]
     pit_loss, cliff = _draws(22.0)
     config = _flat_config(mandatory_stop_pending=None)
-    assert project_positions(rivals, NO_STOP, config, pit_loss, cliff).liabilities[0] == 0.0
+    assert _terminal_cost(project_positions(rivals, NO_STOP, config, pit_loss, cliff)) == 0.0
 
 
-def test_a_rival_whose_obligation_is_unknown_is_exempted_silently():
-    """``None`` is excluded by the same identity check that excludes ``True``.
+def test_a_rivals_unknown_obligation_makes_no_claim_either():
+    """The rule the module stated for OUR obligation now holds for theirs too.
 
-    The filter is ``rival.stop_pending is False``, so an unknown obligation
-    exempts the rival exactly as a pending one does. The module states the
-    ``None`` rule for OUR obligation and never for a rival's, and the adapter
-    hands ``None`` to any driver absent from the ``rival_stop_pending`` map — so
-    a missing verdict quietly makes a car free and biases the liability down.
+    Before the netting, ``None`` was excluded by the same ``is False`` identity
+    check that excluded ``True``, so an unknown obligation exempted a rival by
+    accident rather than by decision — and the adapter hands ``None`` to any
+    driver missing from the ``rival_stop_pending`` map.
 
-    Pinned as CURRENT behaviour, not as desired behaviour. The redesign changes
-    what happens around this, and a before-picture is what makes that diff
-    legible instead of merely green.
+    It is still exempt, but now for the stated reason: an unsettled obligation
+    contributes no residual in either direction, because treating it as a
+    certainty would invent twenty-odd seconds of somebody else's race.
     """
     pit_loss, cliff = _draws(22.0)
     config = _flat_config(mandatory_stop_pending=True)
 
     settled = [RivalState("BEHIND", gap_s=5.0, stop_pending=False)]
-    unknown = [RivalState("BEHIND", gap_s=5.0, stop_pending=None)]
+    unknown = [RivalState("BEHIND", gap_s=5.0, stop_pending=None, stop_loss_s=22.0)]
 
-    assert project_positions(settled, NO_STOP, config, pit_loss, cliff).liabilities[0] == 1.0
-    assert project_positions(unknown, NO_STOP, config, pit_loss, cliff).liabilities[0] == 0.0
+    assert _terminal_cost(project_positions(settled, NO_STOP, config, pit_loss, cliff)) == 1.0
+    assert _terminal_cost(project_positions(unknown, NO_STOP, config, pit_loss, cliff)) == 1.0, (
+        "an unknown obligation must not earn a rival a residual it may not owe"
+    )
 
 
-def test_a_likely_future_neutralisation_shrinks_the_liability():
+def test_a_rival_who_still_owes_a_stop_is_no_longer_free_to_pass_us():
+    """The defect the netting exists to fix, asserted directly.
+
+    A rival who still owes the mandatory stop used to be exempt from the cost of
+    staying out while counting in full against the cost of stopping. Now their
+    residual is carried to the same horizon as ours, so a car that only passes us
+    because it has not stopped yet does not take the place.
+    """
+    pit_loss, cliff = _draws(22.0)
+    config = _flat_config(mandatory_stop_pending=False)
+    # Two seconds ahead of us on track, but a whole pit stop still owed.
+    pending_ahead = [RivalState("AHEAD", gap_s=-2.0, stop_pending=True, stop_loss_s=22.0)]
+
+    result = project_positions(pending_ahead, NO_STOP, config, pit_loss, cliff)
+    assert result.positions[0] == 2.0, "at the window end they are genuinely ahead"
+    assert result.terminal_positions[0] == 1.0, (
+        "once their own stop is served they fall behind, so the place was never really theirs"
+    )
+
+
+def test_a_likely_future_neutralisation_shrinks_the_cost():
     # The option value: if a Safety Car is likely to cover the stop later, the
     # deferred cost is smaller, so fewer cars fit inside the exposure window.
     rivals = [RivalState("BEHIND", gap_s=16.0, stop_pending=False)]
@@ -256,15 +292,17 @@ def test_a_likely_future_neutralisation_shrinks_the_liability():
         future_neutralisation_prob=0.9,
         neutralisation_saving_s=8.0,
     )
-    assert project_positions(rivals, NO_STOP, without_option, pit_loss, cliff).liabilities[0] == 1.0
-    assert project_positions(rivals, NO_STOP, with_option, pit_loss, cliff).liabilities[0] == 0.0
+    assert (
+        _terminal_cost(project_positions(rivals, NO_STOP, without_option, pit_loss, cliff)) == 1.0
+    )
+    assert _terminal_cost(project_positions(rivals, NO_STOP, with_option, pit_loss, cliff)) == 0.0
 
 
-def test_a_candidate_that_stops_carries_no_terminal_liability():
+def test_a_candidate_that_stops_carries_no_deferred_cost():
     rivals = [RivalState("BEHIND", gap_s=5.0, stop_pending=False)]
     pit_loss, cliff = _draws(22.0)
     config = _flat_config(mandatory_stop_pending=True)
-    assert project_positions(rivals, STOP_NOW, config, pit_loss, cliff).liabilities[0] == 0.0
+    assert _terminal_cost(project_positions(rivals, STOP_NOW, config, pit_loss, cliff)) == 0.0
 
 
 def test_the_future_neutralisation_probability_stays_a_probability():
@@ -422,8 +460,8 @@ def test_a_wet_race_exempts_the_mandatory_stop_so_staying_out_is_free():
     pit_loss, cliff = _draws(22.0)
     dry = _flat_config(mandatory_stop_pending=True)
     wet = _flat_config(mandatory_stop_pending=False)
-    assert project_positions(rivals, NO_STOP, dry, pit_loss, cliff).liabilities[0] == 1.0
-    assert project_positions(rivals, NO_STOP, wet, pit_loss, cliff).liabilities[0] == 0.0
+    assert _terminal_cost(project_positions(rivals, NO_STOP, dry, pit_loss, cliff)) == 1.0
+    assert _terminal_cost(project_positions(rivals, NO_STOP, wet, pit_loss, cliff)) == 0.0
 
 
 def test_the_undercut_band_covers_the_drs_range_and_stops_well_short_of_a_pit_cycle():

--- a/tests/mc/test_projection_golden.py
+++ b/tests/mc/test_projection_golden.py
@@ -13,17 +13,23 @@ edit that broke its VALUES failed loudly on the legacy side and silently on this
 one — which is exactly the asymmetry that let a distribution collapse into a
 point mass without a single test noticing.
 
-WHAT THIS GOLDEN DELIBERATELY FREEZES
---------------------------------------
-Today's numbers, defect included. ``STAY_OUT`` below is a point mass
-(``E == P10 == P90``), because the layer's only tyre signal is a cliff that
-almost never falls inside the five-lap window and because a rival who still owes
-the mandatory stop is exempt from the cost of staying out while counting against
-the cost of stopping. Both are being fixed (#726, #727).
+WHAT THIS GOLDEN FREEZES, AND WHAT IT ALREADY CAUGHT
+-----------------------------------------------------
+It was created (#725) pinning the defect on purpose: ``STAY_OUT`` was a strict
+point mass, ``E == P10 == P90 == 1.3``. That was the whole design — a golden
+recording what we wished were true would prove nothing, while one recording the
+defect turns the next fix into a visible diff.
 
-Freezing the defect is the point. When those land, **the diff in this file is
-the fix**, stated in numbers rather than in a commit message. A golden that
-recorded what we wished were true would prove nothing.
+It worked. Race-end residual netting (#726) moved ``STAY_OUT``'s expected value
+off the point mass to 1.276 and lifted PIT_NOW from 0.582 to 0.678, and the
+tripwire below fired rather than the change slipping through.
+
+``P10`` and ``P90`` are still equal for STAY_OUT here, and that is honest rather
+than a leftover: in THIS geometry only a minority of draws see the correction,
+so the middle of the distribution does not move even though its mean does. The
+remaining flatness belongs to the tyre channel, which is #727's subject: the
+layer's only tyre signal is still a cliff that almost never falls inside the
+five-lap window.
 
 WHERE TO CHANGE IF THE PROJECTION CHANGES:
 - Regenerate by calling the same function with the same arguments and pasting
@@ -68,29 +74,40 @@ _RIVALS = [
     {"driver": "FAR", "interval_to_driver_s": 22.6, "is_pitting": False},
 ]
 
+# AHEAD still owes its stop, and that is the point of the entry: the race-end
+# netting only does anything when at least one rival carries an outstanding
+# obligation. An all-settled map would leave the branch that changed in #726
+# unpinned by the only golden that covers this path.
 _PIT_CONTEXT = {
     "gp_name": None,
     "traversal_s": 21.0,
     "mandatory_stop_pending": True,
-    "rival_stop_pending": {"BEHIND": False, "FAR": False},
+    "rival_stop_pending": {"AHEAD": True, "BEHIND": False, "FAR": False},
     "rival_pit_loss_s": 23.8,
 }
 
 _GOLDEN_PROJECTION_ALPHA_05 = {
-    "STAY_OUT": {"E": 1.3, "P10": 1.3, "P90": 1.3, "score": 1.3, "eligible": True, "target": None},
+    "STAY_OUT": {
+        "E": 1.276,
+        "P10": 1.3,
+        "P90": 1.3,
+        "score": 1.288,
+        "eligible": True,
+        "target": None,
+    },
     "PIT_NOW": {
-        "E": 0.582,
+        "E": 0.678,
         "P10": 0.0,
         "P90": 1.056,
-        "score": 0.291,
+        "score": 0.339,
         "eligible": True,
         "target": None,
     },
     "UNDERCUT": {
-        "E": 1.114,
+        "E": 1.21,
         "P10": 0.0,
-        "P90": 2.023,
-        "score": 0.557,
+        "P90": 2.049,
+        "score": 0.605,
         "eligible": True,
         "target": "AHEAD",
     },
@@ -148,16 +165,24 @@ def test_an_ineligible_candidate_carries_no_numbers_at_all():
     assert all(overcut[key] is None for key in ("E", "P10", "P90", "score"))
 
 
-def test_the_frozen_state_still_records_the_defect_being_fixed():
-    """STAY_OUT is a point mass here, and that is on purpose.
+def test_the_frozen_state_records_how_far_the_collapse_has_been_undone():
+    """A tripwire on the defect, updated once it partly fired.
 
-    If this assertion ever fails it means the collapse is gone — which is the
-    goal of #726/#727 and should arrive as a deliberate golden update, not as a
-    surprise. Keeping it explicit stops a future reader mistaking the frozen
-    numbers for a healthy distribution.
+    It began as ``E == P10 == P90``, the strict point mass #726 set out to
+    break. Netting broke it: the mean now differs from the quantiles. The
+    quantiles themselves are still equal, because in this geometry the
+    correction reaches only a minority of draws — that residual flatness is the
+    tyre channel, and it belongs to #727.
+
+    Kept as a tripwire rather than deleted, so the NEXT change to the collapse
+    also has to arrive as a deliberate golden update rather than as a surprise.
     """
     stay_out = _GOLDEN_PROJECTION_ALPHA_05["STAY_OUT"]
-    assert stay_out["E"] == stay_out["P10"] == stay_out["P90"]
+    assert stay_out["E"] != stay_out["P10"], "the netting's effect on the mean has vanished"
+    assert stay_out["P10"] == stay_out["P90"], (
+        "the quantile band has moved: the tyre channel (#727) is the expected cause, "
+        "and it should arrive as a deliberate update here"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #726. Sprint 2 of #724. **Changes shipped behaviour — the measured before/after is below.**

## The defect

`payoff()` summed a **window-end** quantity (`positions`) and a **race-end** correction (`liabilities`) at parity, and applied the correction to **one candidate only**: `terminal_liability` returned zeros for anything that stopped inside the window.

So a rival who still owed the mandatory stop was **exempt from the cost of staying out** while **counting in full against the cost of stopping**.

The liability's own docstring already carried the argument for the mirror it never applied — *"a rival who must still stop pays the same price later, so they are no threat"*. True symmetrically. Applied one-sidedly. Measured over real races it covered **73-84%** of the cars counted as passing us, and **PIT_NOW won once in 110 laps**.

## The change

```
terminal_gap = projected_gap + their_residual − our_residual
residual     = max(0, stop_loss − q_f × neutralisation_saving)
```

- **ours** only when the plan defers a stop we *know* we owe;
- **theirs** only when they owe one and are not already serving it — charging a car already in the pit lane would double-count what `rival_time_deltas` has charged inside the window;
- an **unknown obligation contributes nothing in either direction**, on the module's standing rule that a claim needs a fact.

`terminal_liability` is subsumed — it was exactly the we-owe / they-settled / they-behind quadrant — and deleted with its call site. The margin term deliberately stays on **window-end** gaps: it is a tie-break about track position *now*, not a claim about the end of the race.

## Measured on 110 real laps, against a baseline captured before the change

| lap | before | after |
| --- | --- | --- |
| Lusail 25 (NOR's real stop) | PIT **−5.424** | PIT **+0.039** |
| Lusail 44 (real stop) | −2.700 / −2.689 / −2.434 | **unchanged** — negative control |
| Monza 33 (LEC's real stop) | PIT **−3.959** | PIT **+0.010** |
| Monza 13 | +0.057 / −13.655 | **flips to UNDERCUT** |
| Lusail STAY−PIT margin | median 3.98 / max 17.1 | median **1.12** / max **9.2** |
| Lusail argmax STAY_OUT | 54/57 | **52/57** |

Every row reproduces the independently predicted value. The negative control held.

**Method note:** the baseline was captured through the production path before touching anything, and the first attempt used the wrong driver at Monza — Lusail matched to the digit and Monza did not, which reads as a scorer disagreement and was **a different car**. The published rows are NOR at Lusail and LEC at Monza. Worth stating because a partial match is a louder warning than a total mismatch.

## The must-not-move, verified

`f1-eval projection` still reports **1810 stops / 71 races / 0.8646408839779005**, unchanged to the last digit. `positions` and `margins_s` keep meaning the rejoin horizon the eval grades; the netting is a **separate** term. That is not luck — the ground truth never populates `stop_pending`, so it could not have moved.

## What this does NOT do

**It does not make the layer prefer a stop.** It produces near-ties on the real stop laps (+0.039 against STAY_OUT's +0.300). The remaining causes are the five-lap window, which prices 100% of a stop's cost against ~5 laps of its benefit, and the unpriced tyre channel (#727). Any claim that this alone fixes the 65% decline would be wrong, and #729 exists to measure it rather than argue about it.

## Explicitly not done

The refuted implementation — charging `rival.stop_loss_s` inside `rival_time_deltas` — is **not** here. It creates the mirror-image phantom (a pending rival 5 s ahead becomes +18 and STAY_OUT gains a place it never earns) and violates the module's own v1 doctrine of trusting facts over guesses about rival strategy.

## Tests

The eight liability tests were **rewritten, not deleted**: every contract they encoded still holds, through the new arithmetic. `#470`'s "leading a pack that all owe a stop is free" now falls out by **cancellation** rather than by exemption, which is a better reason for the same answer. Two are new:

- a rival who still owes a stop no longer takes a place they only hold because they have not stopped;
- an unknown rival obligation still makes no claim, now for the stated reason rather than by an accidental `is False` identity check.

**The two spread tests collapsed into one parametrised test**, and that is a consequence of the change: netting exposes STAY_OUT to the same pit-loss draw PIT_NOW sees, so both now cross in the same band. Before, they needed separate states 1.4 s apart. Measured across six seeds at the shared state: STAY_OUT 1.000-1.014, PIT_NOW 1.069-1.080.

**The projection golden moved, deliberately** — that is what #725 built it for. It also gained a pending rival, because an all-settled map would have left the branch this PR changes unpinned by the only golden covering that path.

## Checks

- `tests/mc/`: **142 passed** locally with `data/` present
- `ruff@0.15.22` check + format clean
