### PR TITLE
fix(mc): stop crediting a rival's fall-back when our own obligation is unknown

### DIFF
--- a/src/agents/position_projection.py
+++ b/src/agents/position_projection.py
@@ -624,7 +624,12 @@ def _terminal_gaps(
     - already stopped (no obligation) -> our residual is zero, staying out costs
       nothing on this term;
     - leading a pack that all still owe a stop -> their residuals and ours are
-      the same size and cancel, so holding the lead is free;
+      the same size and cancel, so holding the lead is free. The cancellation is
+      EXACT only when the two losses match; in production ours is sampled and
+      theirs is a per-rival prior, so a tight pack costs a fraction of a position
+      on the draws where the sampled loss runs longer than the prior. That is a
+      real difference between two cars' pit stops, not a modelling artefact, but
+      "free" is the round-number version of it;
     - the race ending behind the Safety Car -> the config's racing laps go to
       zero, so nothing is gained by stopping in the first place.
 
@@ -633,10 +638,22 @@ def _terminal_gaps(
     asymmetric with charging it: an unsettled obligation treated as a certainty
     invents twenty-odd seconds of somebody's race.
 
+    **And that rule binds BOTH sides of the subtraction.** If we do not know
+    whether WE still owe a stop, then crediting a rival's fall-back is not a
+    claim about them, it is a claim that we will not fall back with them — a
+    fact we do not have. The first version applied their residual anyway and
+    handed a candidate that stays out a full terminal place on that bet: it
+    scored an unknown obligation exactly like a known-discharged one. A plan
+    that STOPS inside the window is settled either way, so the suppression is
+    narrow, covering only the deferring case.
+
     A rival already serving their stop is excluded too: ``rival_time_deltas``
     has charged them inside the window already, and charging the same stop twice
     would push them a full pit cycle further back than they will ever be.
     """
+    if not plan.stops_in_window and config.mandatory_stop_pending is None:
+        return projected_gaps
+
     our_residual = (
         _stop_residual_s(pit_loss_s, config)
         if not plan.stops_in_window and config.mandatory_stop_pending is True

--- a/tests/mc/test_position_projection.py
+++ b/tests/mc/test_position_projection.py
@@ -280,6 +280,61 @@ def test_a_rival_who_still_owes_a_stop_is_no_longer_free_to_pass_us():
     )
 
 
+def test_an_unknown_obligation_of_OURS_suppresses_the_credit_too():
+    """The no-fact-no-claim rule binds both sides of the subtraction.
+
+    A rival ahead who still owes a stop will fall behind us when they take it —
+    but only if WE are not about to fall back with them. With our own obligation
+    unknown, crediting their fall-back is not a claim about them, it is a claim
+    that we do not owe one either, and we have no fact for that.
+
+    The first version of the netting credited it anyway and scored an unknown
+    obligation exactly like a known-discharged one, handing a full terminal
+    place to a bet. Found by the A-2 gate; prevalence was 0 of 110 replay laps,
+    so nothing but this test would have caught it before it mattered.
+    """
+    pit_loss, cliff = _draws(22.0)
+    ahead_owing = [RivalState("AHEAD", gap_s=-2.0, stop_pending=True, stop_loss_s=22.0)]
+
+    settled = _flat_config(mandatory_stop_pending=False)
+    unknown = _flat_config(mandatory_stop_pending=None)
+
+    earned = project_positions(ahead_owing, NO_STOP, settled, pit_loss, cliff)
+    assert earned.terminal_positions[0] == 1.0, (
+        "we have stopped and they have not: the place is ours"
+    )
+
+    claimed = project_positions(ahead_owing, NO_STOP, unknown, pit_loss, cliff)
+    assert claimed.terminal_positions[0] == claimed.positions[0], (
+        "an unknown obligation of ours must make no terminal claim in either direction"
+    )
+
+
+def test_a_candidate_that_stops_keeps_the_credit_even_when_our_obligation_is_unknown():
+    """Stopping settles us either way, so the suppression above must not reach it.
+
+    The case that matters is a car BEHIND us that our own stop lets past: at the
+    window end they are genuinely ahead, but they only got there by not having
+    stopped yet, and when they do they drop back behind. Suppressing their
+    residual here would leave the projection believing a stop costs a place it
+    does not really cost.
+
+    Note the arithmetic, because it is the reason the suppression is narrow: when
+    both cars stop, both pay, and the order is simply preserved — there is no
+    credit to win. The credit exists only against a car whose pass is entirely an
+    artefact of its own outstanding stop.
+    """
+    pit_loss, cliff = _draws(22.0)
+    behind_owing = [RivalState("BEHIND", gap_s=5.0, stop_pending=True, stop_loss_s=22.0)]
+    unknown = _flat_config(mandatory_stop_pending=None)
+
+    result = project_positions(behind_owing, STOP_NOW, unknown, pit_loss, cliff)
+    assert result.positions[0] == 2.0, "our stop lets them past inside the window"
+    assert result.terminal_positions[0] == 1.0, (
+        "they only passed us because they had not stopped; once they do, the place comes back"
+    )
+
+
 def test_a_likely_future_neutralisation_shrinks_the_cost():
     # The option value: if a Safety Car is likely to cover the stop later, the
     # deferred cost is smaller, so fewer cars fit inside the exposure window.


### PR DESCRIPTION
Closes #736.

The A-2 gate was pointed at #726 — my own fix, not the bug it fixed. It found one defect there (**D1**) plus two claims of mine that were overstated. This PR carries the defect fix; the corrections are recorded on their issues.

## What changed

Race-end netting reads the mandatory stop as a three-state fact — owed / settled / unknown — and the module's doctrine is *no fact, no claim*. I stated that rule in the docstring for **our** side and implemented it on **one side of the subtraction only**. With our own obligation unknown, a rival who still owed a stop was credited with falling back behind us.

That credit is not a claim about them. It is a claim that **we will not fall back alongside them** — the exact fact we do not have.

```
rival 30 s ahead, still owes a 22 s stop, plan STAY_OUT

  ours=True  -> window pos 2.0   terminal pos 2.0   +0.0   residuals cancel
  ours=False -> window pos 2.0   terminal pos 1.0   +1.0   place earned
  ours=None  -> window pos 2.0   terminal pos 1.0   +1.0   scored as settled  <-- defect
```

Unknown resolved to the **most optimistic** of the three readings rather than the neutral one, biasing STAY_OUT upward exactly where the layer already over-prefers it.

## The scope is narrow, and the reason is worth reading

The suppression covers **deferral only**. A plan that takes the stop has discharged whatever it may have owed, so the rival's residual still applies there — and it must, because that term is what restores a place lost only to a car that had not stopped yet.

I know this because the first version of the second test asserted the opposite and failed. **When both cars stop, both pay, and the order is simply preserved.** There is no credit to win in the symmetric case; the credit exists only against a pass that is an artefact of the rival's outstanding stop. The test now pins that geometry — a car *behind* us that our stop lets past, and that drops back when it takes its own.

## What did not move

- **`f1-eval projection`: 1810 stops / 71 races / 86.4640883977%, unchanged to the last digit.** It must be — every `RivalState` the projection eval builds leaves `stop_pending` as `None`, so this is the branch it always took.
- `positions`, `margins_s`, the legacy scorer, eligibility, the N16 bonus, CRN.
- Full `tests/mc` suite: **144 passed**.

## Corrections the gate forced, carried on their issues rather than here

- **The "52/57 argmax" figure on #726 is not reproducible** and I have corrected it there. The cause is bigger than the number: N26's MC Dropout is **unseeded at inference** (`tire_agent.py:1094`) while its eval twin **is** seeded (`tire_holdout.py:225`) — filed as #735. Two identical captures at the same commit gave 53/57 and 52/57. The `decision-modes` headline figures (65% declined, −2.23 laps) therefore carry an unmeasured error bar.
- The docstring claimed the residuals "cancel". They cancel **when the two stop losses are equal** — the common case, not the rule. Corrected in this diff.

## What the gate tried to break and could not

The mirror-image phantom, C3 in its mandate: the refuted A-1 fix would have let a pending rival gain us a place we never earn, and the gate constructed the state to force it. Absent. It found D1 while looking for it.

<!-- add new entries above this line -->
