### PR TITLE
feat(agents): carry the TCN's own prediction to TireOutput and the prompt

### DIFF
--- a/documents/audits/DESIGN_S3_option_b.md
+++ b/documents/audits/DESIGN_S3_option_b.md
@@ -1,0 +1,131 @@
+# Sprint 3 option B — consuming the tyre prediction without inventing a constant
+
+**Date:** 2026-07-29 · **Issue:** #727 · **Status:** design settled, pending empirical validation of the reference
+
+Companion to `MEASURE_S3_tyre_channel.md`, which refuted the sprint's original premise. That document
+established what to consume; this one establishes **how**, and records two designs that were worked
+out and rejected before the third.
+
+---
+
+## The problem in one line
+
+The scorer needs *seconds per lap that staying out costs versus having a fresh set*. The model
+supplies `cumulative_deg_s` — seconds per lap slower than **this stint's baseline lap**. Those are
+not the same zero.
+
+N04 fixes the baseline:
+
+```python
+baseline_tyrelife = group['TyreLife'].min()
+baseline_laptime  = group.loc[group['TyreLife'] == baseline_tyrelife, 'LapTime_s'].mean()
+FuelAdjustedDegAbsolute = adjusted - baseline_laptime
+```
+
+The stint's freshest lap is an out-lap or a standing-start lap: cold tyres, slow. So the reference is
+biased slow, and the level comes out **negative on most laps** — median −0.161 over 110 measured
+laps, and −0.308 in the 0-5 tyre-life band where construction says it should be ≈0.
+
+**The slope is trustworthy; the intercept is not.** Charging the level directly would pay STAY_OUT a
+negative cost on most laps, which is worse than the flat constant it replaces.
+
+## Rejected: a pooled per-compound floor measured from the data column
+
+Measured on 2023-2024 (45,327 laps, training seasons only, deliberately excluding the 2025 test
+season for the reason `src/strategy/eval/hygiene.py` already documents):
+
+| tyre life | SOFT | MEDIUM | HARD |
+|---|---|---|---|
+| 3 | −0.212 | −0.129 | 0.000 |
+| 10 | +0.191 | +0.101 | +0.207 |
+| 15 | +0.496 | +0.486 | +0.472 |
+| 20 | +0.634 | +0.839 | +0.676 |
+
+Clean, monotonic, physically sensible, and the floor of each curve is an obvious fresh reference
+(SOFT −0.212 at life 3, MEDIUM −0.141 at life 4, HARD 0.000 at life 2).
+
+**Rejected anyway, and this is the important part.** Those numbers come from the **data column**. The
+code would subtract them from the **model's prediction**, and the two are not on the same scale: over
+the same laps the model reports +0.103 at 20+ tyre life where the data says +0.68 to +0.84. Mixing
+them is precisely the defect `CLAUDE.md` §11 records for 2026-07-27 — *"un umbral tuneado y una banda
+de alerta no viven en la misma escala; confundirlos convierte una señal en una constante"*. That one
+cost a whole signal (0/1420 and 0/8171 firings). Paying for the same mistake twice would be
+indefensible.
+
+## Rejected: a per-compound floor measured from the model's own predictions
+
+Correct on the scale question, and it fits the repo's existing measured-table pattern
+(`scripts/measure_mc_tables.py` → `data/mc_measured_v1.json`, with a test asserting the committed file
+matches a fresh run).
+
+Rejected on cost and on fit: that script is deliberately raw-parquet pandas and would have to grow a
+TCN-loading dependency, and a **pooled cross-season constant is a worse reference than one this car
+already provides** — see below.
+
+## Chosen: the model against itself, same stint
+
+Ask the TCN for its prediction at the current tyre life **and** at a fresh tyre life on the same
+stint, and take the difference:
+
+```
+deg_cost_s_per_lap = pred(stint, tyre_life=now) - pred(stint, tyre_life≈3)
+```
+
+Why this is the right shape:
+
+- **The baseline cancels exactly.** Both terms carry the same `baseline_laptime`, so the subtraction
+  removes it algebraically rather than approximately. No calibration constant exists to be wrong.
+- **Same scale by construction.** Both sides are model output, so the scale question cannot arise.
+- **A better reference than any pooled table.** It is *this car's own fresh pace, on this set, at this
+  circuit, in these conditions* — not a cross-season average over every driver and track.
+- **No new artefact.** No JSON, no script, no committed table to regenerate and drift.
+- **Cheap.** One extra deterministic forward pass (`model.eval()`, no MC sampling) per lap.
+
+### The one real risk, and why it is acceptable
+
+At tyre life ≈3 the stint tensor is mostly padding. That was a genuine defect once — inference padded
+by replicating the first lap while N09 trained with `np.zeros` (`CLAUDE.md` §11) — and it is fixed, so
+inference now pads the way training did. Every stint in training also contains its own laps 1-3, so
+the model has seen that regime rather than being extrapolated into it.
+
+**This must be validated before the code lands, not asserted.** The check: over the same 110 laps,
+`pred(now) − pred(3)` should be (a) non-negative on the large majority and (b) rising with tyre life.
+If it is not, the padding concern is real and the rejected model-scale table becomes the fallback.
+
+## What happens to FRESH_GAIN
+
+`FRESH_GAIN = 0.25  # s/lap advantage of fresh vs degraded tyre` is **the same quantity**, hardcoded.
+So this is a replacement, not an addition, and the double-count trap the plan warned about is avoided
+by that fact rather than by a correction term.
+
+The arithmetic, worked out rather than assumed:
+
+- today, no stop: `worn·cliff_loss`
+- today, stop at offset *k*: `pit_loss + worn·cliff_loss − (racing−k)·0.25 − …`
+
+Charging `deg_cost` on the laps run on the old set and dropping the post-stop fresh credit shifts
+**every plan by the same `racing·deg_cost`** when `deg_cost = 0.25`. A uniform shift across all four
+candidates cancels in every comparison, so **the no-signal fallback path is argmax-identical to
+today** — which is exactly the property that makes the change safe to ship and testable against the
+existing goldens.
+
+`FRESH_GAIN` therefore survives as the fallback when `cumulative_deg_s` is `None`, in the same spirit
+as the module's other `DEFAULT_*` constants: not an invented number, but the value the system held
+before the measurement existed.
+
+## Both scorers, and why that is not optional
+
+`simulate_lap_window` is not a golden-pinned relic. Three shipping builders hardcode `"rivals": []` —
+`engine.py:449`, `strategy_orchestrator.py:2356`, and **`src/telemetry/backend/api/v1/endpoints/
+strategy.py:882`** — and `_has_usable_gaps` also demotes to the legacy path when every gap is NaN. So
+**the backend endpoint runs the legacy scorer in production.**
+
+Connecting only the projection branch would fix arcade and the CLI and silently leave the backend on
+the old behaviour: the twin defect this repo keeps paying for. Both move, and the legacy golden is
+re-frozen deliberately rather than treated as breakage.
+
+## Out of scope, stated so it is not mistaken for an oversight
+
+The 5-lap window still prices 100% of a stop's cost against ~5 laps of its benefit. That is the third
+cause from the epic and it is #729's subject, to be decided with a measurement rather than folded in
+here.

--- a/documents/audits/DESIGN_S3_option_b.md
+++ b/documents/audits/DESIGN_S3_option_b.md
@@ -1,6 +1,8 @@
 # Sprint 3 option B — consuming the tyre prediction without inventing a constant
 
-**Date:** 2026-07-29 · **Issue:** #727 · **Status:** design settled, pending empirical validation of the reference
+**Date:** 2026-07-29 · **Issue:** #727 · **Status:** ⛔ **the chosen reference was BUILT, MEASURED and REFUTED.** See §Result. The
+approach it was chosen over — a per-compound reference measured on the MODEL's own scale — is the
+remaining work, and it is a measurement task rather than a wiring one.
 
 Companion to `MEASURE_S3_tyre_channel.md`, which refuted the sprint's original premise. That document
 established what to consume; this one establishes **how**, and records two designs that were worked
@@ -98,16 +100,36 @@ If it is not, the padding concern is real and the rejected model-scale table bec
 So this is a replacement, not an addition, and the double-count trap the plan warned about is avoided
 by that fact rather than by a correction term.
 
-The arithmetic, worked out rather than assumed:
+### ⚠️ Correction to an earlier draft of this section
 
-- today, no stop: `worn·cliff_loss`
-- today, stop at offset *k*: `pit_loss + worn·cliff_loss − (racing−k)·0.25 − …`
+The first version of this document claimed that charging `deg_cost` on the old-set laps and dropping
+the fresh credit shifts **every** plan by the same `racing·deg_cost`, making the no-signal path
+argmax-identical to today. **Worked out properly, that is true for three of the four candidates and
+false for the fourth.**
 
-Charging `deg_cost` on the laps run on the old set and dropping the post-stop fresh credit shifts
-**every plan by the same `racing·deg_cost`** when `deg_cost = 0.25`. A uniform shift across all four
-candidates cancels in every comparison, so **the no-signal fallback path is argmax-identical to
-today** — which is exactly the property that makes the change safe to ship and testable against the
-existing goldens.
+Per candidate, with `c` the per-lap rate and `window = 5`: today's fresh credit covers `fresh_laps`,
+and the new charge covers `old_laps`, so each plan shifts by `−c·(old_laps + fresh_laps)`.
+
+| candidate | old laps | fresh laps today | shift |
+|---|---|---|---|
+| STAY_OUT | 5 | 0 | −5c |
+| PIT_NOW | 0 | 5 | −5c |
+| UNDERCUT | 0 | 5 | −5c |
+| OVERCUT, neutralised | 0 | 5 | −5c |
+| **OVERCUT, green** | **2** | **2** | **−4c** |
+
+The green overcut branch prices only **4 of the 5 window laps** — it charges the cliff over
+`window // 2 = 2` laps and credits freshness over `window // 2 = 2` — so it gains `+c` relative to
+the other three. At the fallback rate that is +0.25 s, or +0.167 positions.
+
+That asymmetry is **pre-existing**, not introduced here: it is a property of how OVERCUT-green counts
+its laps, and it is left alone deliberately rather than folded into a sprint about the tyre channel.
+Its practical weight is small — after #470 charged the stop in that branch, OVERCUT takes **0%** of
+the argmax on the documented sweep.
+
+So the honest claim is narrower than the original one, and it is the one the tests assert: with no
+tyre signal the fallback path is argmax-identical to today for STAY_OUT, PIT_NOW and UNDERCUT, and
+shifts OVERCUT-green by a known `+c`.
 
 `FRESH_GAIN` therefore survives as the fallback when `cumulative_deg_s` is `None`, in the same spirit
 as the module's other `DEFAULT_*` constants: not an invented number, but the value the system held
@@ -123,6 +145,57 @@ strategy.py:882`** — and `_has_usable_gaps` also demotes to the legacy path wh
 Connecting only the projection branch would fix arcade and the CLI and silently leave the backend on
 the old behaviour: the twin defect this repo keeps paying for. Both move, and the legacy golden is
 re-frozen deliberately rather than treated as breakage.
+
+## Result — the self-referential design was built, measured, and refuted
+
+The code was written (a `_fresh_reference_degradation` pass on the agent, the second number printed
+into the tool string, `TireOutput.fresh_deg_s` and a derived `wear_vs_fresh_s`) and measured through
+the production path over the same 110 laps. **Both acceptance criteria failed**, and it was reverted
+before any scorer consumed it.
+
+| criterion | required | measured |
+|---|---|---|
+| (a) non-negative on the large majority | — | **64.8%** (68 of 105) |
+| (b) rising with tyre life | > +0.369, the raw level | **+0.291 — WORSE than the level** |
+
+Median by tyre-life band, and this is the disqualifying line:
+
+```
+ 0-5    0.000
+ 5-10  +0.076
+10-15  -0.125     <- non-monotonic
+15-20  +0.054
+20+    +0.331
+```
+
+**Why it failed, exactly as flagged in the risk section above.** The fresh reference is a prediction
+on a 3-lap stint tensor that is mostly padding, so it is itself noisy. Subtracting one noisy quantity
+from another raises the variance of the result, and here that noise swamped the trend the difference
+was supposed to isolate — the correlation *fell* from +0.369 to +0.291. The algebra that cancels the
+baseline is sound; the estimator on one side of it is not.
+
+Reverted rather than shipped with a caveat. A non-monotonic wear signal in the scorer would be the
+same mistake as wiring `deg_rate`, made a second time and with more machinery behind it.
+
+## What remains for option B
+
+The approach rejected above on cost grounds: **a per-compound fresh reference measured on the MODEL's
+own predictions**, pooled over the 2023-24 training seasons. Pooling is precisely what fixes the
+failure — thousands of stints average away the padding noise that one prediction cannot.
+
+It is a measurement task, not a wiring one:
+
+- a pass that runs the per-compound TCN bundles over training-season stints and takes the median
+  prediction at low tyre life, per compound;
+- a committed artefact plus accessor, following the `data/mc_measured_v1.json` /
+  `measured_tables()` / "a test asserts the committed file matches a fresh run" pattern already in
+  the repo;
+- **2023-24 only.** `src/strategy/eval/hygiene.py` already documents the 2025 test-season
+  contamination, and a calibration constant fitted on the test season would repeat it.
+
+The scorer side is unaffected by the choice and stays as designed: `deg_cost_s` threaded into
+**both** scorers, charged on old-set laps with the cliff term's own lap counts, replacing the
+`FRESH_GAIN` credit, with `FRESH_GAIN` surviving as the no-signal fallback.
 
 ## Out of scope, stated so it is not mistaken for an oversight
 

--- a/documents/audits/MEASURE_S3_tyre_channel.md
+++ b/documents/audits/MEASURE_S3_tyre_channel.md
@@ -1,0 +1,124 @@
+# Sprint 3 pre-measurement — the tyre channel is disconnected at a different seam than planned
+
+**Date:** 2026-07-29 · **Issue:** #727 · **Status:** the sprint's premise is REFUTED; the diagnosis survives
+
+Sprint 3 was specified as *"consume `TireOutput.deg_rate` as a per-lap cost"*. Before writing it, the
+field was measured on the same 110 laps the epic uses (Lusail/NOR + Monza/LEC, `profile="no-llm"`,
+zero LLM calls via `_NullReActRunner`). **The field named in the plan cannot carry the channel.**
+
+The diagnosis behind the sprint is unaffected: the tyre channel really is disconnected, the
+consequence really is that a worn tyre scores like a fresh one, and a properly connected channel
+really would move the decision. Only the *seam* was wrong.
+
+---
+
+## 1. `TireOutput.deg_rate` is not the quantity a scorer needs
+
+Measured over 110 laps:
+
+| statistic | value |
+|---|---|
+| median | **+0.0058 s/lap** |
+| mean | −0.0006 s/lap |
+| negative | 43 of 110 laps |
+| exactly `0.0` (also the parse-miss sentinel) | 12 of 110 |
+| above `FRESH_GAIN = 0.25` | 6 of 110 |
+| correlation with tyre life | **+0.115** |
+
+Median by tyre-life band — **non-monotonic**, so it does not separate a worn tyre from a fresh one:
+
+```
+ 0-5 laps   0.0000
+ 5-10      -0.0245
+10-15      -0.0175
+15-20      +0.0605
+20+        +0.0478
+```
+
+Over the 5-lap window the median contributes **0.03 s = 0.02 positions**. Wiring it in would connect
+a noise channel and let us report the tyre channel as "connected" while nothing changed.
+
+**Why it looks like a degradation rate and is not one:** `predict_tire_deg_tool` reads
+`feat_df['DegradationRate'].iloc[-1]` — the last row of a raw lap-to-lap derivative. Fuel burn-off
+makes lap times *fall* through a stint at roughly the rate tyre wear makes them rise, so the raw
+derivative sits on zero. Every other tyre quantity in the system is computed on the **fuel-adjusted**
+series; this one is not.
+
+## 2. The signal exists, is computed on every lap, and is thrown away
+
+`predict_tire_deg_tool` (`src/agents/tire_agent.py:1054`) runs the TCN and produces `pred`, then
+prints it:
+
+```python
+pred = model(tensor).item()
+...
+f'Cumulative degradation: {pred:.3f} s | Degradation rate: {deg_rate:.4f} s/lap'
+```
+
+`_parse_tool_outputs` (`:658-668`) has regexes for `Degradation rate`, `P10`, `P50`, `P90` — and
+**none for `Cumulative degradation`**. `TireOutput` has **no field** for it. So the TCN's actual
+prediction — the model N07-N10 exists to produce — reaches nothing: not the Monte Carlo, not the
+orchestrator prompt, not the UI.
+
+Measured, same 110 laps, captured by spying on the tool string:
+
+| statistic | `cum_deg` | `deg_rate` |
+|---|---|---|
+| correlation with tyre life | **+0.369** | +0.133 |
+| median, 0-5 laps | −0.308 | 0.000 |
+| median, 20+ laps | **+0.103** | +0.048 |
+| swing across a stint | **0.411 s/lap** | ~0.07 s/lap |
+
+**0.411 s/lap across a stint is 2.06 s over the window = 1.37 positions** — larger than the flat
+`FRESH_GAIN` term it would refine (0.83 positions). A correctly connected tyre channel moves the
+decision materially, which is exactly why connecting the wrong one is worth avoiding.
+
+## 3. The complication that stops this being a drop-in
+
+`N04_feature_engineering.ipynb` defines the target the TCN predicts:
+
+```python
+baseline_tyrelife = group['TyreLife'].min()
+baseline_laptime  = group.loc[group['TyreLife'] == baseline_tyrelife, 'LapTime_s'].mean()
+FuelAdjustedDegAbsolute = adjusted - baseline_laptime
+```
+
+The baseline is **the freshest lap of that stint** — so the semantics are right ("seconds per lap
+slower than this tyre was when new", fuel-corrected). But that lap is an out-lap or a standing-start
+lap, and it is slow. The reference is therefore biased slow, and the measured level comes out
+**negative on most laps** (median −0.161; −0.308 in the 0-5 band, where construction says it should
+be ~0).
+
+**The slope is trustworthy; the intercept is not.** Charging the level directly would pay STAY_OUT a
+*negative* cost on most laps — rewarding staying out, the opposite of the fix.
+
+## 4. Where that leaves the sprint
+
+**Unambiguous, no decision needed:** carry `pred` onto `TireOutput` (new field + regex) and into the
+orchestrator prompt. A model output that is computed and discarded is a defect independent of how the
+scorer eventually uses it, and it unblocks every option below. Give it a `None` default, **never
+`0.0`** — `deg_rate` already demonstrates the collision, with 12 of 110 laps carrying a parse-miss
+that is indistinguishable from a real zero.
+
+**Needs a decision, because the options differ materially:**
+
+| option | what it costs | what it needs |
+|---|---|---|
+| **A. Ship the plan as written** (`deg_rate`) | ~0.02 positions | nothing — but it connects noise and lets a false claim into the record |
+| **B. Consume `pred` relative to a fresh reference** | ~1.37 positions | a defensible fresh reference, i.e. a calibration step, not a code change |
+| **C. Grade the cliff term instead of adding a rate** | unmeasured | uses only already-calibrated quantities (`laps_to_cliff_*`), but the ramp shape is an invented opinion |
+
+Option B is the one that matches the diagnosis. Its blocker is real: the per-stint baseline
+contamination is a modelling question, and inventing a correction constant would be exactly the
+"rails encode opinions" failure this project has already paid for once.
+
+## 5. What was tried and did not hold
+
+- **That `FRESH_GAIN` and `deg_rate` double-count.** They do not, because `deg_rate` is not the same
+  quantity — the double-count trap in the plan applies to option B, not to the plan's own option A.
+- **That the raw parquet would answer the semantics question.** `FuelAdjustedDegAbsolute` and
+  `CumulativeDeg` are the same column by different names (identical median and mean), which was worth
+  confirming before treating them as two channels.
+- **That the probe was cheap because of the profile name.** It was cheap because `no_llm.py` injects
+  `_NullReActRunner`; `_run_always_on_agents_from_state` itself has no profile switch and calls the
+  tyre agent unconditionally. Checked rather than assumed, because the provider is `openai`.

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -1458,6 +1458,40 @@ def _build_rag_question(
     return "What are the mandatory tyre compound regulations for a dry race?"
 
 
+def _build_tire_block(tire_out) -> str:
+    """N26's numeric block for the prompt, verbatim so the LLM can cite it.
+
+    Extracted from the prompt builder when the wear term was added (#727), so the
+    formatting decision below can be tested without assembling a whole prompt.
+
+    ``wear`` leads because it is the model's actual output — seconds per lap this
+    set is slower than it was fresh, fuel-corrected. ``deg_rate`` stays because
+    the LLM has cited it for two years and removing it silently would change the
+    synthesis for reasons unrelated to this change; it is the raw, uncorrected
+    lap-to-lap derivative and is close to noise (median +0.006 s/lap over 110
+    measured laps, negative on 43 of them).
+
+    A missing prediction prints ``unknown``, never ``0.000``. Zero is a real
+    reading for this quantity — a set sitting at its fresh baseline — so printing
+    it for an absent one would tell the LLM the tyre is pristine at the exact
+    moment the model failed to say anything.
+    """
+    if tire_out is None:
+        return "  [N26 Tire]      not activated"
+
+    cumulative = getattr(tire_out, "cumulative_deg_s", None)
+    wear = f"{cumulative:+.3f}s/lap vs fresh" if cumulative is not None else "unknown"
+    return (
+        f"  [N26 Tire]      wear={wear}  "
+        f"deg_rate={tire_out.deg_rate:.3f}s/lap  "
+        f"cliff P10={tire_out.laps_to_cliff_p10:.1f}  "
+        f"P50={tire_out.laps_to_cliff_p50:.1f}  "
+        f"P90={tire_out.laps_to_cliff_p90:.1f}  "
+        f"[{tire_out.warning_level}]\n"
+        f"                  reasoning: {tire_out.reasoning or '(empty)'}"
+    )
+
+
 def _build_orchestrator_prompt(
     race_state:          "RaceState",
     mc_results:          dict,
@@ -1527,17 +1561,7 @@ def _build_orchestrator_prompt(
     else:
         pace_block = "  [N25 Pace]      not activated"
 
-    if tire_out is not None:
-        tire_block = (
-            f"  [N26 Tire]      deg_rate={tire_out.deg_rate:.3f}s/lap  "
-            f"cliff P10={tire_out.laps_to_cliff_p10:.1f}  "
-            f"P50={tire_out.laps_to_cliff_p50:.1f}  "
-            f"P90={tire_out.laps_to_cliff_p90:.1f}  "
-            f"[{tire_out.warning_level}]\n"
-            f"                  reasoning: {tire_out.reasoning or '(empty)'}"
-        )
-    else:
-        tire_block = "  [N26 Tire]      not activated"
+    tire_block = _build_tire_block(tire_out)
 
     if situation_out is not None:
         sit_block = (

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -394,6 +394,32 @@ class TireOutput:
         current_tyre_life: Laps completed on this tyre set at inference time.
             Used by N28 Pit Strategy as baseline for undercut feature construction.
         deg_rate: Predicted degradation rate in seconds per lap (median of MC passes).
+
+            Read this before using it as a tyre-wear signal: it is the last row of
+            the RAW lap-to-lap derivative, not a fuel-corrected one, and fuel
+            burn-off pushes lap times down at roughly the rate wear pushes them
+            up. Measured over 110 real laps it has median +0.006 s/lap, is
+            negative on 43 of them, and correlates +0.115 with tyre life — its
+            median by tyre-life band is not even monotonic. It does not separate
+            a worn tyre from a fresh one. ``cumulative_deg_s`` is the field that
+            does (#727).
+        cumulative_deg_s: The TCN's own prediction — seconds per lap this set is
+            slower than it was when fresh, fuel-corrected (N04's
+            ``FuelAdjustedDegAbsolute``). ``None`` when no TCN ran or the tool
+            output did not parse.
+
+            ``None`` and not ``0.0``, deliberately: 0.0 is a legitimate reading
+            here (a tyre at its baseline pace), so a sentinel of 0.0 would be a
+            value the code can also genuinely find. ``deg_rate`` already
+            demonstrates the collision — 12 of those 110 laps carry a parse miss
+            indistinguishable from a real zero.
+
+            This is the scalar the whole tyre-degradation model family exists to
+            produce, and until #727 it was computed on every call, printed into
+            the tool string, and dropped at the parser — so it reached neither
+            the Monte Carlo, nor the orchestrator prompt, nor any UI. Measured
+            over the same 110 laps it correlates +0.369 with tyre life and swings
+            0.411 s/lap across a stint.
         laps_to_cliff_p10: Pessimistic estimate (P10) of laps before the cliff.
             Drives PIT_SOON warning — conservative to avoid running too long.
         laps_to_cliff_p50: Median estimate of laps before the cliff.
@@ -415,6 +441,7 @@ class TireOutput:
     laps_to_cliff_p50: float
     laps_to_cliff_p90: float
     gp_name: str   = ''
+    cumulative_deg_s: float | None = None
     warning_level: str = field(init=False)
     reasoning: str = ''
 
@@ -682,6 +709,11 @@ def _parse_tool_outputs(messages: list) -> dict:
             # leading minus, so a negative degradation rate — real and expected
             # per the system prompt ("track evolution or fuel load reduction")
             # — silently failed to parse and fell through to the 0.0 default.
+            # predict_tire_deg_tool has printed this since the tool existed and
+            # nothing ever read it, so the TCN's actual output stopped at the
+            # parser (#727). The same `-?` applies for the same reason as below:
+            # a set faster than its own fresh baseline is real early in a stint.
+            (r'Cumulative degradation:\s*(-?[\d.]+)', 'cum_deg'),
             (r'Degradation rate:\s*(-?[\d.]+)', 'deg_rate'),
             (r'P10:\s*(-?[\d.]+)',              'p10'),
             (r'P50:\s*(-?[\d.]+)',              'p50'),
@@ -1476,6 +1508,12 @@ class TireAgent:
             current_tyre_life = tyre_life,
             gp_name           = gp_name,
             deg_rate          = round(parsed.get('deg_rate', 0.0), 4),
+            # `.get(...)` then an explicit None, rather than a numeric default:
+            # predict_tire_deg_tool can legitimately be skipped while the cliff
+            # tool ran, and 0.0 is a real reading for this quantity.
+            cumulative_deg_s  = (
+                round(parsed['cum_deg'], 4) if 'cum_deg' in parsed else None
+            ),
             laps_to_cliff_p10 = round(parsed['p10'], 1),
             laps_to_cliff_p50 = round(parsed.get('p50', 0.0), 1),
             laps_to_cliff_p90 = round(parsed.get('p90', 0.0), 1),

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -33,6 +33,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from src.agents.tire_parsing import parse_tool_outputs
+
 # ── Repo root (module-relative) ───────────────────────────────────────────────
 # Walker with a root-stop guard so we don't spin forever when the module is
 # imported from outside a git checkout (e.g. uv tool install).
@@ -686,43 +688,11 @@ def _add_session_cols(df: pd.DataFrame, session_meta: dict) -> pd.DataFrame:
 # Stateless helpers
 # ─────────────────────────────────────────────────────────────────────────────
 
-def _parse_tool_outputs(messages: list) -> dict:
-    """Extract numeric fields from ToolMessage strings in the agent message history.
-
-    Parses the structured output lines produced by predict_tire_deg_tool and
-    estimate_laps_to_cliff_tool rather than the LLM's free-text final answer,
-    guaranteeing the returned values are the exact numbers computed by inference.
-
-    Args:
-        messages: LangChain message objects from the agent's invoke result.
-
-    Returns:
-        Dict with keys deg_rate, p10, p50, p90 (all floats, defaulting to 0.0).
-    """
-    result: dict[str, float] = {}
-    for msg in messages:
-        content = getattr(msg, 'content', '')
-        if not isinstance(content, str):
-            continue
-        for pattern, key in [
-            # -?[\d.]+ (was [\d.]+, #477): the bare digit class can't match a
-            # leading minus, so a negative degradation rate — real and expected
-            # per the system prompt ("track evolution or fuel load reduction")
-            # — silently failed to parse and fell through to the 0.0 default.
-            # predict_tire_deg_tool has printed this since the tool existed and
-            # nothing ever read it, so the TCN's actual output stopped at the
-            # parser (#727). The same `-?` applies for the same reason as below:
-            # a set faster than its own fresh baseline is real early in a stint.
-            (r'Cumulative degradation:\s*(-?[\d.]+)', 'cum_deg'),
-            (r'Degradation rate:\s*(-?[\d.]+)', 'deg_rate'),
-            (r'P10:\s*(-?[\d.]+)',              'p10'),
-            (r'P50:\s*(-?[\d.]+)',              'p50'),
-            (r'P90:\s*(-?[\d.]+)',              'p90'),
-        ]:
-            m = re.search(pattern, content)
-            if m and key not in result:
-                result[key] = float(m.group(1))
-    return result
+# Kept importable under its original private name so existing callers and the
+# hardening tests do not move. The body lives in the leaf module because importing
+# THIS module builds TireAgentConfig() and therefore needs data/models/ on disk,
+# which is what left a pure string parser with no CI coverage (#727).
+_parse_tool_outputs = parse_tool_outputs
 
 
 def _compound_name_to_id(compound_name: str, gp_name: str, year: int) -> str:

--- a/src/agents/tire_parsing.py
+++ b/src/agents/tire_parsing.py
@@ -1,0 +1,77 @@
+"""Pure parsing of the tyre tools' output strings — no models, no I/O, no weights.
+
+A leaf module so that reading a number the tools printed costs nothing. ``tire_agent``
+builds ``TireAgentConfig()`` at import time, which reads
+``data/models/tire_degradation/routing_config.json`` — a file that comes from Hugging
+Face and is not in git. So importing the parser from there requires the model bundles
+to be on disk, and ``tests/audit/test_tire_agent_hardening.py`` skips its **entire
+module** for that reason, taking its pure-parser test down with it.
+
+That is how this function ended up with no CI coverage while being the single point
+where every numeric field of ``TireOutput`` is produced. Splitting it out is the same
+move ``src/strategy/inference/guard_rails.py`` made for the pit bounds, for the same
+reason: a value that is cheap to read should not be behind an import that is expensive.
+
+--- WHERE TO CHANGE IF A TOOL'S OUTPUT FORMAT CHANGES ---
+The patterns below are contracts with the f-strings in ``tire_agent``'s
+``_build_tools`` — ``predict_tire_deg_tool`` and ``estimate_laps_to_cliff_tool``.
+Change a printed label there and the matching pattern here has to move with it, or the
+field silently reverts to "absent" and its consumer sees ``None``.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Ordered (pattern, key) pairs, applied to every ToolMessage in the history.
+#
+# `-?[\d.]+` rather than `[\d.]+` (#477): the bare digit class cannot match a leading
+# minus, so a negative degradation rate — real and expected per the tyre agent's own
+# system prompt ("track evolution or fuel load reduction") — silently failed to parse
+# and fell through to a 0.0 default.
+#
+# `Cumulative degradation` (#727) is the TCN's own scalar. predict_tire_deg_tool has
+# printed it since the tool existed and nothing ever read it, so the prediction the
+# whole N07-N10 family exists to produce stopped here. It takes the same `-?` for the
+# same reason: a set faster than its own fresh baseline is real early in a stint.
+_PATTERNS: tuple[tuple[str, str], ...] = (
+    (r'Cumulative degradation:\s*(-?[\d.]+)', 'cum_deg'),
+    (r'Degradation rate:\s*(-?[\d.]+)',       'deg_rate'),
+    (r'P10:\s*(-?[\d.]+)',                    'p10'),
+    (r'P50:\s*(-?[\d.]+)',                    'p50'),
+    (r'P90:\s*(-?[\d.]+)',                    'p90'),
+)
+
+
+def parse_tool_outputs(messages: list) -> dict:
+    """Extract the numeric fields the tyre tools printed, keyed only when matched.
+
+    Reads the structured lines the tools emit rather than the LLM's free-text answer,
+    so the values returned are the exact numbers inference computed regardless of how
+    the model phrased its summary.
+
+    A key is present **only if its pattern matched**. That is the contract callers
+    depend on: an absent key means "the tool was skipped or its output did not parse",
+    which is a different fact from a present 0.0, and collapsing the two turned a
+    silent regex miss into a confident call to box (#436). The first match wins, so a
+    field printed by both tools is read from whichever ran first.
+
+    Args:
+        messages: LangChain message objects from the agent's invoke result. Anything
+            without a string ``.content`` is skipped rather than coerced.
+
+    Returns:
+        Dict of matched field name to float. Possibly empty; never padded with
+        defaults, because choosing a default is the caller's decision and it differs
+        per field.
+    """
+    result: dict[str, float] = {}
+    for msg in messages:
+        content = getattr(msg, 'content', '')
+        if not isinstance(content, str):
+            continue
+        for pattern, key in _PATTERNS:
+            match = re.search(pattern, content)
+            if match and key not in result:
+                result[key] = float(match.group(1))
+    return result

--- a/tests/agents/test_tire_cumulative_deg.py
+++ b/tests/agents/test_tire_cumulative_deg.py
@@ -20,12 +20,20 @@ median-by-band that is not even monotonic.
 The discarded scalar is fuel-corrected (N04's ``FuelAdjustedDegAbsolute``),
 correlates +0.369 with tyre life, and swings 0.411 s/lap across a stint.
 
-THE TWO CHEAP TESTS RUN WITHOUT MODEL WEIGHTS, ON PURPOSE
----------------------------------------------------------
-``_parse_tool_outputs`` is a pure string parser. Keeping its tests ungated means CI
-covers the new field on a runner with no ``data/`` — unlike
-``tests/audit/test_tire_agent_hardening.py``, whose module-level skip takes its own
-parser test down with the rest of the file.
+THE PARSER TESTS RUN WITHOUT MODEL WEIGHTS, AND THAT TOOK A SECOND ATTEMPT
+--------------------------------------------------------------------------
+The parser is pure, so its tests were written ungated — and CI failed, because
+**importing** it was not pure: ``tire_agent`` builds ``TireAgentConfig()`` at module
+scope, which reads ``data/models/tire_degradation/routing_config.json``, a file that
+comes from Hugging Face and is not in git. That is precisely why
+``tests/audit/test_tire_agent_hardening.py`` skips its **entire module** and takes its
+own pure-parser test down with it.
+
+The fix is the one ``src/strategy/inference/guard_rails.py`` already made for the pit
+bounds: the parser moved to ``src/agents/tire_parsing.py``, a leaf module with nothing
+but ``re``. Now the ungated tests genuinely run on a bare runner. Anything touching
+``TireOutput`` itself still has to be gated, since the dataclass lives behind that
+import.
 """
 
 from __future__ import annotations
@@ -76,17 +84,44 @@ class _FakeToolMessage:
 # ---------------------------------------------------------------------------
 
 
+def test_the_parser_module_stays_a_leaf():
+    """Guards the whole point of the split: importing it must stay cheap.
+
+    A subprocess, not ``sys.modules`` in-process, because by the time this test runs
+    the suite has already imported torch for other reasons and the check would pass
+    on someone else's import. Same technique as
+    ``tests/eval/test_decision_modes.py``'s eager-import guard.
+
+    If this fails, the parser has grown a dependency and CI has silently lost its
+    only ungated coverage of the field extraction — which is the exact state #727
+    found it in.
+    """
+    import subprocess
+    import sys
+
+    probe = (
+        "import sys; import src.agents.tire_parsing; "
+        "heavy = [m for m in ('torch', 'pandas', 'numpy') if m in sys.modules]; "
+        "print(','.join(heavy))"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, cwd=ROOT, check=True
+    )
+
+    assert out.stdout.strip() == "", f"tire_parsing pulled in heavy deps: {out.stdout.strip()}"
+
+
 @pytest.mark.parametrize("printed", ["-1.200", "0.000", "2.345"])
 def test_the_parser_captures_the_cumulative_prediction(printed):
     """Including a negative one: a set faster than its fresh baseline is real early."""
-    from src.agents.tire_agent import _parse_tool_outputs
+    from src.agents.tire_parsing import parse_tool_outputs
 
     message = _FakeToolMessage(
         "Driver NOR | Compound C2 | TyreLife 12\n"
         f"Cumulative degradation: {printed} s | Degradation rate: -0.05 s/lap"
     )
 
-    assert _parse_tool_outputs([message])["cum_deg"] == float(printed)
+    assert parse_tool_outputs([message])["cum_deg"] == float(printed)
 
 
 def test_an_absent_line_writes_no_key_at_all():
@@ -95,16 +130,21 @@ def test_an_absent_line_writes_no_key_at_all():
     ``estimate_laps_to_cliff_tool`` prints the quantiles and the rate but not the
     cumulative prediction, so the cliff tool alone must not manufacture one.
     """
-    from src.agents.tire_agent import _parse_tool_outputs
+    from src.agents.tire_parsing import parse_tool_outputs
 
     message = _FakeToolMessage(
         "Laps to cliff — P10: 3.0 | P50: 5.0 | P90: 7.0\n"
         "Degradation rate: 0.0400 s/lap | MC std: 0.1 s | Calibrated sigma: 0.2 s"
     )
 
-    assert "cum_deg" not in _parse_tool_outputs([message])
+    assert "cum_deg" not in parse_tool_outputs([message])
 
 
+@pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="TireOutput lives in tire_agent, whose import builds TireAgentConfig() and "
+    "reads data/models/tire_degradation/ (HF, not git)",
+)
 def test_the_field_defaults_to_none_and_never_to_zero():
     """0.0 is a real reading here — a set at its fresh baseline — so it cannot double
     as the sentinel. ``deg_rate`` already shows the collision this avoids: 12 of 110

--- a/tests/agents/test_tire_cumulative_deg.py
+++ b/tests/agents/test_tire_cumulative_deg.py
@@ -1,0 +1,172 @@
+"""#727 — the TCN's own prediction must reach TireOutput instead of stopping at the parser.
+
+``predict_tire_deg_tool`` has always run the TCN and printed its scalar:
+
+    Cumulative degradation: -1.200 s | Degradation rate: -0.05 s/lap
+
+``_parse_tool_outputs`` had regexes for the rate and the three cliff quantiles and
+**none for the first half of that line**, and ``TireOutput`` had no field to put it
+in. So the number the whole N07-N10 model family exists to produce reached nothing:
+not the Monte Carlo, not the orchestrator prompt, not any UI.
+
+WHY IT WAS THE WRONG FIELD THAT GOT WIRED
+-----------------------------------------
+``deg_rate`` looks like the tyre signal and is not one. It is the last row of the
+RAW lap-to-lap derivative, uncorrected for fuel, and fuel burn-off drives lap times
+down at roughly the rate wear drives them up. Measured over 110 real laps: median
++0.006 s/lap, negative on 43 of them, correlation with tyre life +0.115, and a
+median-by-band that is not even monotonic.
+
+The discarded scalar is fuel-corrected (N04's ``FuelAdjustedDegAbsolute``),
+correlates +0.369 with tyre life, and swings 0.411 s/lap across a stint.
+
+THE TWO CHEAP TESTS RUN WITHOUT MODEL WEIGHTS, ON PURPOSE
+---------------------------------------------------------
+``_parse_tool_outputs`` is a pure string parser. Keeping its tests ungated means CI
+covers the new field on a runner with no ``data/`` — unlike
+``tests/audit/test_tire_agent_hardening.py``, whose module-level skip takes its own
+parser test down with the rest of the file.
+"""
+
+from __future__ import annotations
+
+from itertools import islice
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+RACE_DIR = ROOT / "data" / "raw" / "2025" / "Lusail"
+FEATURED = ROOT / "data" / "processed" / "laps_featured_2025.parquet"
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+_HAS_DATA = (RACE_DIR / "laps.parquet").exists() and FEATURED.exists()
+
+
+def _scoped_lusail_lap_30():
+    """A real lap_state plus the laps frame **scoped to this GP**, as engine.py feeds it.
+
+    The scoping is not incidental. ``engine.py`` narrows the season-wide featured
+    parquet through ``_scope_laps_to_gp`` before any agent sees it (#429), because
+    the agents' lookups filter by Driver and LapNumber and never by GP. Handing
+    ``_tire_no_llm`` the unscoped frame is a configuration nothing runs, and it does
+    not merely add noise: measured here it returned a cumulative degradation of
+    **-33.840 s/lap**, against a real range of roughly -0.9 to +0.5. A test written
+    against that would be green and meaningless.
+    """
+    from src.f1_strat_manager.laps_augment import augment_featured_laps
+    from src.simulation.replay_engine import RaceReplayEngine
+    from src.strategy.inference.engine import _scope_laps_to_gp
+
+    replay = RaceReplayEngine(RACE_DIR, driver_code="NOR", team="McLaren", interval_seconds=0.0)
+    lap_state = next(islice(replay.replay(), 29, 30))  # 0-indexed 29 -> lap 30
+    laps = augment_featured_laps(pd.read_parquet(FEATURED), 2025)
+    return lap_state, _scope_laps_to_gp(laps, lap_state)
+
+
+class _FakeToolMessage:
+    """Minimal stand-in for a LangChain ToolMessage — only ``.content`` is read."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+# ---------------------------------------------------------------------------
+# The parser — no model weights needed, so CI actually runs these
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("printed", ["-1.200", "0.000", "2.345"])
+def test_the_parser_captures_the_cumulative_prediction(printed):
+    """Including a negative one: a set faster than its fresh baseline is real early."""
+    from src.agents.tire_agent import _parse_tool_outputs
+
+    message = _FakeToolMessage(
+        "Driver NOR | Compound C2 | TyreLife 12\n"
+        f"Cumulative degradation: {printed} s | Degradation rate: -0.05 s/lap"
+    )
+
+    assert _parse_tool_outputs([message])["cum_deg"] == float(printed)
+
+
+def test_an_absent_line_writes_no_key_at_all():
+    """The parser's contract: a key exists only when its regex matched.
+
+    ``estimate_laps_to_cliff_tool`` prints the quantiles and the rate but not the
+    cumulative prediction, so the cliff tool alone must not manufacture one.
+    """
+    from src.agents.tire_agent import _parse_tool_outputs
+
+    message = _FakeToolMessage(
+        "Laps to cliff — P10: 3.0 | P50: 5.0 | P90: 7.0\n"
+        "Degradation rate: 0.0400 s/lap | MC std: 0.1 s | Calibrated sigma: 0.2 s"
+    )
+
+    assert "cum_deg" not in _parse_tool_outputs([message])
+
+
+def test_the_field_defaults_to_none_and_never_to_zero():
+    """0.0 is a real reading here — a set at its fresh baseline — so it cannot double
+    as the sentinel. ``deg_rate`` already shows the collision this avoids: 12 of 110
+    measured laps carry a parse miss indistinguishable from a genuine zero.
+    """
+    from src.agents.tire_agent import TireOutput
+
+    stub = TireOutput(
+        compound="C2",
+        current_tyre_life=10,
+        deg_rate=0.03,
+        laps_to_cliff_p10=20.0,
+        laps_to_cliff_p50=30.0,
+        laps_to_cliff_p90=40.0,
+    )
+
+    assert stub.cumulative_deg_s is None
+
+
+# ---------------------------------------------------------------------------
+# The production seam — needs the weights the prediction comes from
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not (_HAS_MODELS and _HAS_DATA),
+    reason="needs data/models/tire_degradation/ and data/{raw/2025/Lusail,processed} (HF, not git)",
+)
+def test_a_real_lap_carries_the_prediction_end_to_end():
+    """Through ``_tire_no_llm`` — the path ``engine.py`` runs — not a re-implementation.
+
+    Asserts a plausible range rather than a value: pinning a number here would break
+    on any legitimate model refresh while saying nothing about whether the field is
+    connected. The band is wide on purpose; what is being tested is that a real
+    number arrives at all, where ``None`` arrived before.
+
+    It is not so wide that it passes for the wrong reason, though — the unscoped
+    frame this fixture exists to avoid returns -33.840, well outside it.
+    """
+    from src.strategy.inference.no_llm import _tire_no_llm
+
+    lap_state, laps = _scoped_lusail_lap_30()
+
+    tire_out = _tire_no_llm(lap_state, laps)
+
+    assert tire_out.cumulative_deg_s is not None
+    assert -5.0 < tire_out.cumulative_deg_s < 5.0
+
+
+@pytest.mark.skipif(
+    not (_HAS_MODELS and _HAS_DATA),
+    reason="needs data/models/tire_degradation/ and data/{raw/2025/Lusail,processed} (HF, not git)",
+)
+def test_the_prompt_shows_the_wear_and_says_unknown_when_it_is_missing():
+    """A missing prediction must not print as 0.000, which reads as a pristine tyre."""
+    from dataclasses import replace
+
+    from src.agents.strategy_orchestrator import _build_tire_block
+    from src.strategy.inference.no_llm import _tire_no_llm
+
+    lap_state, laps = _scoped_lusail_lap_30()
+    tire_out = _tire_no_llm(lap_state, laps)
+
+    assert "vs fresh" in _build_tire_block(tire_out)
+    assert "wear=unknown" in _build_tire_block(replace(tire_out, cumulative_deg_s=None))

--- a/tests/audit/test_tire_mc_determinism.py
+++ b/tests/audit/test_tire_mc_determinism.py
@@ -61,14 +61,22 @@ def lusail_lap_30():
     Mid-stint on purpose. The first laps of a stint are where the degradation
     rate's own floor fires, so a lap chosen there could be repeatable for a
     reason that has nothing to do with the dropout seed.
+
+    Scoped to the GP the way ``engine.py`` scopes it (#429) before any agent sees
+    the frame. The first version of this fixture passed the season-wide parquet
+    straight in — the assertions held either way, because determinism does not
+    care, but it was measuring a configuration nothing runs. Unscoped, this same
+    lap reports a cumulative degradation of -33.840 s/lap against a real range of
+    roughly -0.9 to +0.5.
     """
     from src.f1_strat_manager.laps_augment import augment_featured_laps
     from src.simulation.replay_engine import RaceReplayEngine
+    from src.strategy.inference.engine import _scope_laps_to_gp
 
     replay = RaceReplayEngine(RACE_DIR, driver_code="NOR", team="McLaren", interval_seconds=0.0)
     lap_state = next(islice(replay.replay(), 29, 30))  # 0-indexed 29 -> lap 30
     laps = augment_featured_laps(pd.read_parquet(FEATURED), 2025)
-    return lap_state, laps
+    return lap_state, _scope_laps_to_gp(laps, lap_state)
 
 
 def test_two_identical_calls_return_an_identical_tyre_output(lusail_lap_30):


### PR DESCRIPTION
Part of #727. **Plumbing only** — no score changes, no golden moves. How the Monte Carlo consumes the field is the second half, and it needed a design decision this PR unblocks.

## The defect

`predict_tire_deg_tool` has run the TCN and printed its scalar since the tool existed:

```
Cumulative degradation: -1.200 s | Degradation rate: -0.05 s/lap
```

`_parse_tool_outputs` had regexes for the rate and the three cliff quantiles and **none for the first half of that line**. `TireOutput` had no field to put it in. So the number the whole N07-N10 family exists to produce reached nothing: not the Monte Carlo, not the orchestrator prompt, not any UI.

## The field that did get wired is the wrong one

This is the part worth keeping. Sprint 3 was specified as *"consume `TireOutput.deg_rate`"*, and measuring it first is what stopped that shipping. Over 110 real laps through the production entry point:

| | `deg_rate` | the discarded scalar |
|---|---|---|
| correlation with tyre life | **+0.115** | **+0.369** |
| median | +0.006 s/lap | — |
| negative | 43 of 110 laps | — |
| swing across a stint | ~0.07 s/lap | **0.411 s/lap** |

`deg_rate` is the last row of the **raw** lap-to-lap derivative, uncorrected for fuel — and fuel burn-off drives lap times down at roughly the rate wear drives them up, so it sits on zero. Its median by tyre-life band is not even monotonic, so it cannot separate a worn tyre from a fresh one.

The discarded scalar is fuel-corrected (N04's `FuelAdjustedDegAbsolute`), and **0.411 s/lap across a stint is 2.06 s over the five-lap window — larger than the flat `FRESH_GAIN` term the layer uses today.**

Written up in `documents/audits/MEASURE_S3_tyre_channel.md`; the consumption design, including two approaches worked out and rejected, is in `DESIGN_S3_option_b.md`.

## `None`, never `0.0`

Zero is a **legitimate reading** for this quantity — a set sitting at its fresh baseline — so a `0.0` sentinel would be a value the code can also genuinely find. `deg_rate` already demonstrates the collision: 12 of those 110 laps carry a parse miss indistinguishable from a real zero.

The prompt prints `wear=unknown` for the same reason. `0.000` would tell the LLM the tyre is pristine at the exact moment the model failed to say anything.

`deg_rate` **stays** in the prompt block: the LLM has cited it for two years, and removing it silently would change the synthesis for reasons unrelated to this change.

## Two of four tests are ungated, on purpose

`_parse_tool_outputs` is a pure string parser, so CI covers the new field on a runner with no `data/` — unlike `tests/audit/test_tire_agent_hardening.py`, whose module-level skip takes its own parser test down with the rest of the file.

## A defect in my own test from an hour ago

#740's determinism test fed `_tire_no_llm` the **season-wide** parquet, skipping the per-GP scoping `engine.py` applies before any agent sees the frame (#429). The assertions held either way — determinism does not care — but it was measuring a configuration nothing runs.

Unscoped, that same lap reports a cumulative degradation of **−33.840 s/lap** against a real range of roughly −0.9 to +0.5. Both tyre test files now scope the way production does, and the new end-to-end assertion band is deliberately narrow enough that the unscoped value falls outside it.

## Checks

`ruff` clean, `ruff format` clean, `tests/agents` + `tests/audit` + `tests/mc`: **248 passed**.
