### PR TITLE
fix(simulation): reconstruct N04's previous-lap time so N06 stops anchoring on 90.0

### DIFF
--- a/src/simulation/race_state_manager.py
+++ b/src/simulation/race_state_manager.py
@@ -137,6 +137,11 @@ class RaceStateManager:
         # same reason as the leader times: get_lap_state must stay an O(1) lookup.
         self._stint_baselines: dict[int, int] = self._precompute_stint_baselines()
 
+        # N04's Prev_LapTime, reconstructed for frames that do not carry it.
+        # Precomputed for the same reason as the two above: get_driver_state is an
+        # O(1) lookup and a per-lap rescan would break that promise.
+        self._derived_prev_lap: dict[int, float] = self._precompute_prev_lap_times()
+
         # Art. 30.5(m) flags, one timeline per driver, built on first ask.
         # `get_lap_state` needs ours plus one per rival, and the per-lap helper
         # rescans the whole frame each time, so a lap cost about twenty full
@@ -145,6 +150,75 @@ class RaceStateManager:
         # pass brings it back to 3.9 ms. Lazy per driver, because a caller asking
         # about three cars should not pay for twenty.
         self._stint_flags: dict[str, dict[int, dict[str, Any]]] = {}
+
+    def _precompute_prev_lap_times(self) -> dict[int, float]:
+        """Reconstruct N04's ``Prev_LapTime`` for a frame that has no such column.
+
+        The featured parquet carries the column; the RAW per-race parquet this class
+        is normally built from does not, and ``get_driver_state`` had no fallback.
+        The pace agent then substituted ``90.0`` (``pace_agent.py``), and because
+        ``_predict`` uses that value as an ANCHOR — the prediction is
+        ``prev + delta``, with no NaN branch — every absolute lap-time prediction
+        was pinned to 90 s regardless of circuit. Measured, the fallback fired on
+        100% of laps on the replay path (#728).
+
+        RECONSTRUCTION, NOT REINTERPRETATION
+        ------------------------------------
+        This applies N04's own transform rather than an equivalent-looking rule,
+        because two details of it are load-bearing and neither is guessable:
+
+        - the shift is grouped by ``Stint`` (N04 groups by
+          ``['Year','GP_Name','DriverNumber','Stint']``, and the first three are
+          constant for one driver in one race), so the first lap of a stint has no
+          previous lap and stays unknown;
+        - it runs AFTER ``filter_baseline_laps``: ``IsAccurate & ~Deleted &
+          LapTime_s < 180 & LapNumber > 1``. So the previous lap is the previous
+          SURVIVING one, not simply ``lap_number - 1``.
+
+        That second point decides the whole helper. An out-lap is excluded by
+        ``IsAccurate``, and it is not a rounding difference: measured at Lusail 2025,
+        NOR's out-lap is 107.6 s against 85.3 s on the lap that follows it. Anchoring
+        the lap after a stop on the out-lap would be **22 s wrong** — worse than the
+        90.0 it replaces. The same filter is what keeps a Safety Car lap from
+        becoming the anchor for a green one.
+
+        A cross-stint fallback is wrong for the same measured reason, not merely on
+        training-semantics grounds: the last lap of a stint is the in-lap, so it is
+        slow in exactly the same way.
+
+        Returns:
+            ``{lap_number: previous lap time in seconds}``, holding only laps whose
+            previous lap is known. An absent key means unknown, and the caller
+            keeps that as ``None`` rather than inventing a number. An empty map is
+            the honest result for a frame lacking the columns this needs.
+        """
+        needed = {"LapNumber", "LapTime", "Stint"}
+        if self._driver.empty or not needed <= set(self._driver.columns):
+            return {}
+
+        laps = self._driver.copy()
+        laps["_lap_time_s"] = laps["LapTime"].map(_to_seconds)
+
+        # N04's filter_baseline_laps, term for term. IsAccurate and Deleted are
+        # FastF1 quality flags absent from some hand-built frames, so a missing
+        # column is treated as "nothing excluded" rather than excluding everything.
+        surviving = laps["_lap_time_s"].notna() & (laps["_lap_time_s"] < 180)
+        surviving &= laps["LapNumber"] > 1
+        if "IsAccurate" in laps.columns:
+            surviving &= laps["IsAccurate"].fillna(False).astype(bool)
+        if "Deleted" in laps.columns:
+            surviving &= ~laps["Deleted"].fillna(False).astype(bool)
+
+        ordered = laps[surviving].sort_values("LapNumber")
+        if ordered.empty:
+            return {}
+
+        previous = ordered.groupby("Stint", sort=False)["_lap_time_s"].shift(1)
+        return {
+            int(lap): float(value)
+            for lap, value in zip(ordered["LapNumber"], previous, strict=True)
+            if pd.notna(value)
+        }
 
     def _precompute_stint_baselines(self) -> dict[int, int]:
         """Return our driver's TyreLife at the first lap of each stint.
@@ -255,7 +329,19 @@ class RaceStateManager:
             # same as every other optional column read via ``r.get(...)`` below.
             # NaN (no earlier lap, e.g. the first lap of a stint) -> None, same
             # handling as every other timing field in this method.
-            "prev_lap_time": _to_seconds(r.get("Prev_LapTime")),
+            #
+            # Falls back to the reconstruction when the column is absent OR its
+            # value is NaN. Both, deliberately: `Series.get` returns a stored NaN
+            # rather than the default, so a column-presence test alone would leave
+            # the RAW frame — which has no such column at all — on 90.0 forever,
+            # and that is exactly the state #728 found (the fallback fired on 100%
+            # of laps). See _precompute_prev_lap_times for why a reconstruction is
+            # not simply `lap_number - 1`.
+            "prev_lap_time": (
+                _to_seconds(r.get("Prev_LapTime"))
+                if pd.notna(r.get("Prev_LapTime"))
+                else self._derived_prev_lap.get(int(lap_number))
+            ),
             "sector1_s": _to_seconds(r.get("Sector1Time")),
             "sector2_s": _to_seconds(r.get("Sector2Time")),
             "sector3_s": _to_seconds(r.get("Sector3Time")),

--- a/tests/simulation/test_rsm_prev_lap_time.py
+++ b/tests/simulation/test_rsm_prev_lap_time.py
@@ -1,0 +1,266 @@
+"""#728 — RaceStateManager must reconstruct N04's Prev_LapTime for a RAW frame.
+
+The featured parquet carries a ``Prev_LapTime`` column. The RAW per-race parquet this
+class is normally built from does not, and ``get_driver_state`` had no fallback, so it
+emitted ``None`` on every lap. The pace agent then substituted ``90.0``, and since
+``_predict`` uses that value as an ANCHOR — the prediction is ``prev + delta``, with no
+NaN branch — every absolute lap-time prediction was pinned near 90 s regardless of
+circuit.
+
+Measured on the real raw parquets, median |anchor − this lap|:
+
+    Monaco  78 laps   14.686 s  ->  0.480 s
+    Monza   53 laps    6.889 s  ->  0.191 s
+    Lusail  57 laps    4.955 s  ->  0.158 s
+
+WHY THE TESTS BELOW LOOK THE WAY THEY DO
+----------------------------------------
+The naive fix — take ``lap_number - 1`` — is worse than the bug on the lap after a
+stop. N04 computes the shift AFTER ``filter_baseline_laps``
+(``IsAccurate & ~Deleted & LapTime_s < 180 & LapNumber > 1``) and groups by ``Stint``,
+so the previous lap is the previous **surviving** one. An out-lap is excluded by
+``IsAccurate``, and measured at Lusail 2025 NOR's out-lap is 107.6 s against 85.3 s on
+the lap that follows: anchoring there would be 22 s wrong, against the 5 s the 90.0
+default was wrong by at that circuit.
+
+So most of these tests are about what must NOT become the anchor.
+
+Hermetic: the frames are built here, since the cases that matter (an out-lap, a
+stint boundary, a deleted lap) are structural and a real slice may contain none of
+them. One data-gated test at the bottom checks the real raw schema, because a
+synthetic frame cannot prove the column names match production.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.simulation.race_state_manager import RaceStateManager
+
+ROOT = Path(__file__).parent.parent.parent
+RACE_DIR = ROOT / "data" / "raw" / "2025" / "Monaco"
+
+OUR_DRIVER = "NOR"
+
+
+def _raw_frame(laps: list[dict]) -> pd.DataFrame:
+    """A minimal RAW-schema frame: the required columns, and no ``Prev_LapTime``.
+
+    ``LapTime`` and ``Time`` are timedeltas because ``validate_laps_df`` requires that
+    of a raw frame — the featured parquet's float ``LapTime_s`` is a different schema
+    and a different code path.
+    """
+    rows = []
+    for lap in laps:
+        rows.append(
+            {
+                "Driver": OUR_DRIVER,
+                "Team": "McLaren",
+                "LapNumber": float(lap["lap"]),
+                "LapTime": pd.to_timedelta(lap["seconds"], unit="s"),
+                "Time": pd.to_timedelta(lap["lap"] * 90.0, unit="s"),
+                "Position": 1.0,
+                "Compound": "MEDIUM",
+                "TyreLife": float(lap.get("tyre_life", lap["lap"])),
+                "TrackStatus": lap.get("status", "1"),
+                "Stint": float(lap.get("stint", 1)),
+                "IsAccurate": lap.get("accurate", True),
+                "Deleted": lap.get("deleted", False),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _manager(frame: pd.DataFrame) -> RaceStateManager:
+    return RaceStateManager(
+        frame, driver_code=OUR_DRIVER, team="McLaren", gp_name="Monaco", year=2025
+    )
+
+
+# ---------------------------------------------------------------------------
+# The reconstruction
+# ---------------------------------------------------------------------------
+
+
+def test_a_raw_frame_gets_the_previous_lap_instead_of_nothing():
+    """The whole point: no Prev_LapTime column, and the value still arrives."""
+    rsm = _manager(
+        _raw_frame(
+            [
+                {"lap": 1, "seconds": 80.0},
+                {"lap": 2, "seconds": 76.0},
+                {"lap": 3, "seconds": 75.5},
+                {"lap": 4, "seconds": 75.2},
+            ]
+        )
+    )
+
+    assert rsm.get_driver_state(3)["prev_lap_time"] == pytest.approx(76.0)
+    assert rsm.get_driver_state(4)["prev_lap_time"] == pytest.approx(75.5)
+
+
+def test_lap_one_and_the_lap_after_it_stay_unknown():
+    """N04's filter drops ``LapNumber <= 1``, so lap 2 has no surviving predecessor.
+
+    Reproduced rather than smoothed over: lap 1 of a race is a standing start and is
+    not a lap the model was trained to read as "previous".
+    """
+    rsm = _manager(
+        _raw_frame(
+            [
+                {"lap": 1, "seconds": 80.0},
+                {"lap": 2, "seconds": 76.0},
+                {"lap": 3, "seconds": 75.5},
+            ]
+        )
+    )
+
+    assert rsm.get_driver_state(1)["prev_lap_time"] is None
+    assert rsm.get_driver_state(2)["prev_lap_time"] is None
+
+
+def test_an_out_lap_never_becomes_the_anchor():
+    """The trap that makes ``lap_number - 1`` worse than the bug.
+
+    Lap 11 is the out-lap: a real one is ~22 s slower than the lap after it. It is
+    excluded by ``IsAccurate``, so lap 12 has no surviving predecessor inside its own
+    stint and stays unknown — which falls back to the pre-existing 90.0 rather than
+    introducing a new, larger error.
+    """
+    rsm = _manager(
+        _raw_frame(
+            [
+                {"lap": 9, "seconds": 75.5, "stint": 1, "tyre_life": 9},
+                {"lap": 10, "seconds": 95.0, "stint": 1, "tyre_life": 10, "accurate": False},
+                {"lap": 11, "seconds": 97.6, "stint": 2, "tyre_life": 1, "accurate": False},
+                {"lap": 12, "seconds": 75.3, "stint": 2, "tyre_life": 2},
+                {"lap": 13, "seconds": 75.1, "stint": 2, "tyre_life": 3},
+            ]
+        )
+    )
+
+    assert rsm.get_driver_state(12)["prev_lap_time"] is None, (
+        "anchored on the out-lap: 22 s wrong, worse than the 90.0 it replaces"
+    )
+    assert rsm.get_driver_state(13)["prev_lap_time"] == pytest.approx(75.3)
+
+
+def test_the_shift_does_not_cross_a_stint_boundary():
+    """Even when both laps survive the filter, the previous stint is out of reach.
+
+    N04 groups by ``Stint``, and the reason is measured rather than formal: the last
+    lap of a stint is the in-lap, so it is slow in exactly the way an out-lap is.
+    """
+    rsm = _manager(
+        _raw_frame(
+            [
+                {"lap": 5, "seconds": 75.5, "stint": 1, "tyre_life": 5},
+                {"lap": 6, "seconds": 75.4, "stint": 1, "tyre_life": 6},
+                {"lap": 7, "seconds": 75.0, "stint": 2, "tyre_life": 1},
+                {"lap": 8, "seconds": 74.8, "stint": 2, "tyre_life": 2},
+            ]
+        )
+    )
+
+    assert rsm.get_driver_state(7)["prev_lap_time"] is None
+    assert rsm.get_driver_state(8)["prev_lap_time"] == pytest.approx(75.0)
+
+
+def test_a_deleted_lap_is_skipped_and_the_shift_reaches_past_it():
+    """``Deleted`` is the other half of N04's filter, and the shift reaches back.
+
+    This is the case that distinguishes "previous surviving lap" from "previous lap":
+    lap 8's anchor is lap 6, not the deleted lap 7.
+    """
+    rsm = _manager(
+        _raw_frame(
+            [
+                {"lap": 6, "seconds": 75.5},
+                {"lap": 7, "seconds": 75.4, "deleted": True},
+                {"lap": 8, "seconds": 75.2},
+            ]
+        )
+    )
+
+    assert rsm.get_driver_state(8)["prev_lap_time"] == pytest.approx(75.5)
+
+
+def test_the_featured_column_wins_when_it_carries_a_value():
+    """Featured-parquet callers must be untouched: their own column takes precedence."""
+    frame = _raw_frame(
+        [
+            {"lap": 6, "seconds": 75.5},
+            {"lap": 7, "seconds": 75.4},
+            {"lap": 8, "seconds": 75.2},
+        ]
+    )
+    frame["Prev_LapTime"] = [float("nan"), 61.0, 62.0]
+
+    rsm = _manager(frame)
+
+    assert rsm.get_driver_state(8)["prev_lap_time"] == pytest.approx(62.0)
+    # A NaN in the column is not a value, so lap 6 falls through to the
+    # reconstruction rather than being trusted. `Series.get` returns the stored NaN
+    # rather than a default, which is the trap this branch exists to avoid.
+    assert rsm.get_driver_state(6)["prev_lap_time"] is None
+
+
+def test_a_frame_without_stint_yields_no_reconstruction_rather_than_a_wrong_one():
+    """``Stint`` is not a required column, and without it the grouping is unknowable.
+
+    An empty map is the honest answer; the consumer keeps its existing default. The
+    alternative — group everything as one stint — would silently anchor across pit
+    stops, which is the error this whole helper exists to avoid.
+    """
+    frame = _raw_frame([{"lap": 6, "seconds": 75.5}, {"lap": 7, "seconds": 75.4}])
+    frame = frame.drop(columns=["Stint"])
+
+    rsm = _manager(frame)
+
+    assert rsm._derived_prev_lap == {}
+    assert rsm.get_driver_state(7)["prev_lap_time"] is None
+
+
+# ---------------------------------------------------------------------------
+# The real raw schema — a synthetic frame cannot prove the column names match
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not (RACE_DIR / "laps.parquet").exists(),
+    reason="needs data/raw/2025/Monaco/ (HF, not git)",
+)
+def test_the_real_monaco_parquet_gets_a_plausible_anchor_on_most_laps():
+    """Monaco on purpose: it is where the 90.0 anchor is visible.
+
+    Real Monaco pace is ~75 s, so the old default was ~15 s out on every lap. Lusail
+    would be a false negative — its pace is ~85.7 s, so the same bug reads as ~5 s and
+    could pass for noise.
+
+    Asserts a band and a coverage floor, not values: a model or data refresh may move
+    the numbers, but if the anchor stops landing near the real lap time the
+    reconstruction has broken.
+    """
+    raw = pd.read_parquet(RACE_DIR / "laps.parquet")
+    rsm = RaceStateManager(raw, OUR_DRIVER, "McLaren", gp_name="Monaco", year=2025)
+
+    anchored, errors = 0, []
+    for lap in range(1, rsm.total_laps + 1):
+        state = rsm.get_driver_state(lap)
+        if not state or state.get("lap_time_s") is None:
+            continue
+        previous = state.get("prev_lap_time")
+        if previous is None:
+            continue
+        anchored += 1
+        errors.append(abs(previous - state["lap_time_s"]))
+
+    assert anchored >= 50, f"only {anchored} laps anchored; the reconstruction is not firing"
+    assert max(errors) < 25.0, "an out-lap or a cross-stint lap leaked in as the anchor"
+    assert sorted(errors)[len(errors) // 2] < 2.0, (
+        "median anchor error above 2 s at Monaco, where consecutive green laps sit "
+        "within a few tenths — the shift is reaching the wrong lap"
+    )


### PR DESCRIPTION
Closes #728. Sprint 4 of #724, and the one finding in the epic with **visible user damage**.

## The defect

The featured parquet carries a `Prev_LapTime` column. The **RAW** per-race parquet this class is normally built from does not, and `get_driver_state` had no fallback — so it emitted `None` on every lap. `pace_agent` then substituted `90.0`, and because `_predict` uses that value as an **anchor** (the prediction is `prev + delta`, with no NaN branch), every absolute lap-time prediction was pinned near 90 s regardless of circuit.

Measured on the real raw parquets, median `|anchor − this lap|`:

| race | laps | anchored | before | after | real pace |
|---|---|---|---|---|---|
| **Monaco** | 78 | 86% | **14.686 s** | **0.480 s** | 75.40 |
| Monza | 53 | 89% | 6.889 s | 0.191 s | 83.15 |
| Lusail | 57 | 75% | 4.955 s | 0.158 s | 85.70 |

**A correction to the plan while I'm here:** Lusail was described as the circuit where the bug hides, because its pace is "~89.5 s". Its real median lap is **85.70**, so the old anchor was 4.955 s out there too. Still 30× smaller than Monaco and still the wrong place to verify — but not harmless, which is how it was written.

## The obvious fix is worse than the bug

Taking `lap n − 1` anchors the lap after every stop on the **out-lap**:

```
Lusail 2025, NOR
  lap 26   out-lap   107.589 s
  lap 27             85.304 s    <- lap n-1 would anchor this on 107.589
  lap 28             85.065 s
```

That is **22 s wrong** exactly where the 90.0 default was 5 s wrong. Measuring what the *fix* would produce, not just what the *defect* produces, is the only reason this PR does something else.

## Reproduce the transform, don't reimplement the intent

The right rule was only recoverable from N04 itself: the shift runs **after** `filter_baseline_laps` (`IsAccurate & ~Deleted & LapTime_s < 180 & LapNumber > 1`) and groups by `Stint`. So the trained-on value is the previous **surviving** lap inside the same stint.

This applies those exact terms. That is what keeps an out-lap, a Safety Car lap, and the previous stint's in-lap out of the anchor — and where no surviving predecessor exists the value stays `None`, so a stint's first racing lap degrades to today's 90.0 rather than to a new, larger error.

The column still wins when it carries a value, so featured-parquet callers are untouched. The fallback also triggers on a **NaN**, not only on an absent column — `Series.get` returns a stored NaN rather than the default, the trap #428/#446/#462 keep finding.

Precomputed once in `__init__`, beside the leader times and stint baselines, so `get_driver_state` stays the O(1) lookup this class promises.

## Blast radius: displays and the prompt, not the decision layer

**Verified, not assumed.** `pace_s` appears exactly once in `strategy_orchestrator.py` — assigned from `lap_time_pred` and never read (`# noqa: F841`) — and `rng.normal` consumes the same stream state whatever its mean, so the later draws are unmoved and the recommendation goldens do not shift.

The arcade's own `prev_lap_time` accumulator is untouched and correctly so: it feeds `pace_delta` in `_build_race_state`, a different quantity from N06's feature, which comes from the `lap_state` this PR fixes.

## Tests

Eight, seven of them hermetic. **Most assert what must NOT become the anchor** — the out-lap, the in-lap across a stint boundary, a deleted lap, lap 1 — because that is precisely where the naive fix fails and a test of the happy path would not notice.

The eighth is gated on the real Monaco parquet, since a synthetic frame cannot prove the column names match production. Monaco on purpose; Lusail would be a 30× weaker signal. Verified with `-v` that it runs rather than skipping.

`tests/simulation`: **37 passed**. `ruff` and `ruff format` clean.

## Filed separately

**#746** — the backend's own twin still derives from `lap_number - 1` with no stint scope and no filter, so it walks straight into the out-lap trap. The plan called that implementation *"already correct"*; verified against the code, it is not. `src/telemetry/` is a submodule, so it needs its own commit plus a pointer bump.
