### PR TITLE
docs(audits): re-measure the decision layer on 2025 and retire the timing metric

### DIFF
--- a/documents/audits/FABLE_S5_decision_modes.md
+++ b/documents/audits/FABLE_S5_decision_modes.md
@@ -1,0 +1,209 @@
+# FABLE S5 gate — adversarial audit of MEASURE_S5_decision_modes_2025.md
+
+**Date:** 2026-07-30 · **Auditor:** adversarial gate (no repo file modified except this one)
+**Under test:** `documents/audits/MEASURE_S5_decision_modes_2025.md` — a measurement + conclusion,
+no code. The scratchpad JSONL and `baseline_dm.json` are treated as SUSPECT; everything numeric is
+re-derived from the committed baseline JSON and from FRESH runs of the harness.
+
+## Checklist
+
+- [x] **A** — numbers recomputed and reproduce ✓; the COMPARISON hides a third run (F1) and the denominator drift is fully accounted (Silverstone −15 dominates).
+- [x] **B** — matching re-derived (46 ✓, and 198 available); `af3a24a` attack executed (F4); unseeded-baseline noise measured with two old-code reruns (F5/F10).
+- [x] **C** — verified from diff and execution (F6). Not a confound.
+- [x] **D** — CONFIRMED with fresh runs at w=5/7/10, two races, identity level (F9/F9b). Innocent explanations tested and excluded.
+- [x] **E** — 11 verified and same-identity, but the w=5 exact bucket is 13, of which 2 are window artefacts (F3/F9b).
+- [x] **F** — premise true (hygiene.py); DIRECTION unsupported: measured dry-circuit season effect ≈ +0.9 pts (claim-F section).
+- [x] **G** — wet verified; residual anchor measured at 46.3% vs 25-30% dry controls; causal link to the 71% decline NOT established (F7).
+- [x] Bug-class sweep: `no_data` empty everywhere; selection effects (window truncation, overlapping windows, rescued no-calls) hunted — only the rescued no-call fired, and it is benign (F9b).
+
+## Findings
+
+### F1 — HIGH · The write-up omits its own strongest run: a post-fix MIXED-sample rerun sits uncommitted in the working tree
+
+`git status`: `M documents/eval_reports/decision_modes.json` (+ `.md`). The tree version is a
+**new-code rerun of the SAME mixed six races** (`harness_sha 1f0ec9d`, generated 2026-07-30T08:37):
+**90 scored / 198 (45.5%), 78 no_call (39.4%), rails 30, mean signed −3.30**. The committed version
+(01cb4e6, byte-identical to the stashed `baseline_dm.json` — verified) is the old-code 40/198.
+Recomputed transitions between the two mixed runs, matched per stop on (year, race, driver,
+actual_lap): **matched 198/198, `no_call→scored` 57, `scored→no_call` 7, net +50** — per race:
+Barcelona +15/−0, Monaco +8/−6, Marina_Bay +9/−0, Silverstone +14/−0, Lusail +4/−1, Monza +7/−0.
+
+Consequences for the write-up:
+- The clean code-only comparison (64.6% → 39.4% on 198 matched stops, same season mix, same stops)
+  existed and is *stronger* than the headline; §2 instead nets the code effect (−25.2 pts) against an
+  opposing sample effect (39.4% → 46.1%, +6.7 pts) without saying either number.
+- §2's causal case uses 46 matched stops when **198 matched stops were available**; the discarded 152
+  contain the only substantial regression signal — **Monaco 2023: 6 stops the old code scored and the
+  new code declines** — which the "+10 net, (none the other way)" framing never surfaces.
+- The tree file is uncommitted: whoever commits next silently replaces the "committed baseline" the
+  write-up cites. Not my mutation — left by the implementer's run; I did not touch it.
+
+### F2 — MEDIUM · §3's table compares two DIFFERENT samples column against column
+
+Reproduced from the run data: the w=5 column (−5:36, −4:9, −1…−3:10, 0:20, total 75, mean −3.08) is
+the **full six-race 2025 sweep**; the w=10 column (total 28, mean −5.04 — both recomputed exactly)
+is **Monza + Marina_Bay only**. The same-sample w=5 histogram for Monza+Marina_Bay is
+`{−5:12, −4:1, −2:1, 0:13}` (27 scored). So the table's headline juxtaposition "−5: 36 → 0" is
+cross-sample; the honest same-sample statement is "−5: 12 → 0", and "−3.08 vs −5.04" compares
+different race sets. The pin conclusion itself is being re-tested with fresh runs (see F9), but the
+table as printed is not a like-for-like comparison and the write-up nowhere says so.
+
+### F3 — MEDIUM · "11 stops sit at exactly 0 at both window widths" — at w=5 the same two races have THIRTEEN at 0
+
+From the same-sample histograms above: Monza+Marina_Bay at w=5 have **13** stops at offset 0; the 11
+is the **w=10** count. At most 11 of the 13 "exact agreements" survive widening — i.e. at least 2 of
+the stops §3 calls genuine agreements are themselves window artefacts (the stack would have called
+the stop earlier had it been asked). This *strengthens* the direction of the §3 finding but the
+"stable second mode of 11" as stated is wrong at w=5, and the identity check is what decides it
+(fresh-run verification in F9).
+
+### F4 — MEDIUM · Claim B's mechanism sentence is wrong in principle; correct only by luck of the data
+
+§2: "the transitions above are `no_call -> scored`, which the rails cannot produce." Two errors:
+
+1. **The rails CAN produce `no_call→scored`**: `af3a24a` suspends the early-race and min-stint
+   bounds *inside the stack* when `sc_currently_active` is true (an RCM-confirmed neutralisation,
+   `pit_strategy_agent.py:530-564`). A PIT emitted on a window lap under SC that the old rails
+   overrode into STAY_OUT is exactly a stop that moves `no_call→scored` when the suspension lands.
+2. **`af3a24a` does NOT "move the RAIL buckets" of this eval**: `guard_rail_block`
+   (`decision_modes.py:203-206`) never passes `sc_active`, and the per-race rail counts are
+   **identical (30 = 30, race by race)** between the two mixed runs. The rails 30→21 delta in §2's
+   table is the season change, not the commit.
+
+Executed check that rescues the conclusion: for all **64** moved stops (baseline vs mixed rerun),
+no TrackStatus-4/5/6 lap falls inside the ±5 window (2023 Barcelona / 2023 Monaco / 2024
+Marina_Bay / 2024 Silverstone / 2025 Monza have zero neutralised laps in the relevant ranges;
+2025 Lusail's SC is laps 7–10, its moved stops are at lap 32). So the attribution survives, but on
+evidence the write-up never ran, and its stated reasoning would have mis-attributed in any race
+where a stop's window brushed an SC.
+
+### F5 — MEDIUM · The baseline run predates the seed fix: its per-stop verdicts are non-repeatable inference
+
+The committed baseline was generated at `80f1fa7` (2026-07-29 10:25); the MC-Dropout seed fix
+`8d68a9e` ("seed the tyre model's MC Dropout so inference is repeatable") is **not an ancestor**
+(`git merge-base --is-ancestor` fails). Every matched-stop transition against that baseline
+therefore compares a seeded run against one draw of an unseeded process. Quantification via two
+fresh old-code runs is in flight (F9); until then "+N moved, from code changes alone" carries an
+unmeasured noise term the write-up does not disclose. (The fresh new-code determinism check DID
+pass: two independent Monza w=5 runs and the tree rerun vs the sweep agree stop-for-stop, 46/46
+and 20/20.)
+
+### F6 — VERIFIED · Claim C: `84dc4b6` is behaviour-identical at the default
+
+Full diff touches only `src/strategy/eval/decision_modes.py`: threads
+`risk_tolerance=DEFAULT_RISK_TOLERANCE` (0.5) where the old code hardcoded
+`risk_tolerance=0.5` (old line 289), into a `RaceState` whose field default is also 0.5
+(`strategy_orchestrator.py:247`). Execution evidence: the sweep and the tree rerun (both through
+the new signature) reproduce the baseline-era stop set and agree with my fresh runs stop-for-stop.
+Not a confound.
+
+### F7 — MEDIUM · Claim G: wet verified; the named mechanism is real but measured to be an INSUFFICIENT explanation
+
+- **Wet: verified.** Silverstone 2025 raw data: 608/826 laps (73.6%) on INTERMEDIATE, rainfall in
+  18.1% of weather samples, `IsAccurate` share 0.600 — i.e. exactly the "~40% of laps fail N04's
+  filter" figure the S4 report claimed.
+- **Residual anchor: measured, not inherited.** Replaying the exact windows the eval evaluates
+  (post-`bc64b94` reconstruction): **Silverstone 2025 = 274/592 evaluated laps (46.3%) still anchor
+  N06 on the 90.0 constant** (worst: ANT 19/20, HAD 9/11).
+- **But the dry controls are 25–30%** (Monza 2025: 30.0%, Lusail 2025: 25.2%): the eval's windows
+  straddle stint boundaries, and the per-stint reconstruction has no previous survivor on early
+  stint laps, so heavy anchoring is endemic to this tier's sample shape, not a wet-race special.
+- **And anchor share does not rank-order decline**: Lusail 25.2% anchored → 53.8% declined; Monza
+  30.0% anchored → 35.0% declined. So "71% declined because of the 90.0 anchor" is not established
+  by these data; the wet race also feeds the stack a compound (INTERMEDIATE) that takes the
+  `_DEFAULT_MIN_STINT=10` fallback in the rails (`guard_rails.py:41-42`) and that the tyre stack
+  never trained on — unexamined co-mechanisms. The write-up's hedge ("recorded rather than averaged
+  away") is fair; the specific causal sentence is over-claimed.
+
+### F8 — LOW · Cited line number is stale
+
+§3 cites `decision_modes.py:439` for `chosen = _first_pit_lap(...)`; in the tree under audit
+(57a7087) that line is `decision_modes.py:434` (:439 is inside the `no_call_in_window` append).
+`decision_modes.py:76` and `strategy_orchestrator.py:625` are correct.
+
+### Claim A — recomputation PASSES; the comparison itself is the problem (see F1)
+
+Recomputed from the committed baseline JSON and the sweep JSONL: baseline 40/198 scored (20.2%),
+128 no_call (64.6%), rails 30, `no_data` 0 ✓; 2025-only 75/178 (42.1%), 82 (46.1%), rails 21,
+`no_data` 0 ✓; the write-up's per-race table matches row for row ✓. Denominator drift 198→178 fully
+accounted: Barcelona −2, Monaco −1, Marina_Bay −2, **Silverstone −15** (46 stops in 2024 vs 31 in
+2025), Lusail ±0, Monza ±0. The `no_data` bucket is empty in every run — nothing hidden there.
+
+### Claim F — premise TRUE, direction UNSUPPORTED by the write-up's own data
+
+- Premise verified from the repo: models train on 2023+2024 and test on 2025
+  (`src/strategy/eval/hygiene.py:17-18` "they train on 2023+2024", threshold provenance lines 84-148;
+  consistent across N12/N14/N16 entries). The four 2023/2024 baseline races are in-train seasons.
+- Direction attacked with the matched-circuit pairs available from the two new-code runs
+  (mixed rerun vs 2025 sweep, same code, same circuits, only season differs):
+  Barcelona 44.2% → 36.6% (**2025 declines LESS**), Monaco 34.2% → 45.9% (more),
+  Marina_Bay 32.0% → 30.4% (less), Silverstone 37.0% → 71.0% (the wet race).
+  **Excluding the wet race the season effect is +0.9 pts (37.7% → 38.6%)** — indistinguishable from
+  zero and not sign-stable per circuit. Under the OLD code the baseline's own per-race data say the
+  same: in-train-season races declined 63.8% (97/152) vs out-of-sample 67.4% (31/46), a 3.6-pt gap
+  fully confounded by circuit, with the WORST race in the whole baseline being in-sample Barcelona
+  2023 (79.1%).
+- Verdict: "in-sample → declines less → the committed 64.6% is optimistic" is an argument wearing a
+  measurement's clothes. The measured season effect on dry circuits is ≈0; the aggregate 2025
+  penalty is entirely the wet race the owner declared out of scope. The sample redesign itself is
+  still defensible (out-of-sample is the production condition) — but not for the quantitative reason
+  §1 gives, and the write-up's "the direction matters" paragraph should be retracted or re-labelled
+  as hypothesis.
+
+### F9 — Claim D (CENTRAL): CONFIRMED, with fresh three-width evidence, and it is even stronger than written
+
+Fresh runs (my own harness invocations, `DECISION_WINDOW_LAPS` monkeypatched in-process only), 2025
+Monza, current code:
+
+| width | offsets (scored=11 at every width) | mean signed |
+|---|---|---|
+| w=5 | −5:**5**, −4:1, 0:5 | −2.64 |
+| w=7 | −7:**5**, −5:1, 0:5 | −3.64 |
+| w=10 | −10:**5**, −7:1, 0:5 | −5.18 |
+
+The early mass sits at exactly **−W at all three widths** and the mean tracks the window. The third
+width confirms the pin — this is not a two-point coincidence. Innocent explanations, each tested:
+
+- **Eligibility drift:** none at Monza — buckets identical at every width (scored 11, no_call 7,
+  min_stint 1, closing 1). (Marina_Bay: one `no_call` rescued at w=10, see below — it only *adds* a
+  large-offset entry; it cannot relocate the −5 mass.)
+- **Rail re-bucketing:** impossible by construction (`guard_rail_block` is width-independent) and
+  measured identical at all widths.
+- **Replay-span change:** `run_lap` is stateless across laps — `_decisions_in_window`
+  (decision_modes.py:306-308) passes no `memory`, so evaluating extra laps cannot change the
+  decision on a given lap. Corroborated in the data: HAD lap 32 keeps offset −5 at w=7 (the two
+  extra earlier laps produced no pit call) yet shows −10 at w=10 — the stack has *two* pit-calling
+  regions, more evidence that "first pit lap" is not a location estimate.
+- Per-stop movement is exactly the pin: GAS/PIA/STR/HAM at −5 → −7 → (−10 or interior); NOR at −4
+  (w5) → −7 → −10 shows even **interior** offsets are first-occurrence artefacts, which goes beyond
+  the write-up's own claim.
+
+Determinism side-evidence collected on the way: two independent fresh Monza w=5 runs, the sweep
+JSONL, and the tree rerun agree **stop-for-stop** (20/20, and 81/81 on the 2023 races, 46/46 on
+2025 Lusail+Monza) — the seeded new-code path is reproducible across processes.
+
+### F9b — Claims D and E closed with the Marina_Bay fresh runs
+
+Fresh Marina_Bay 2025: w=5 `{−5:7, −2:1, 0:8}` (16 scored / 7 no_call), w=10
+`{−10:5, −9:3, −8:1, −7:1, 0:6, +8:1}` (17 scored / 6 no_call). Combined fresh Monza+MB at w=10:
+**`{−10:10, −9:3, −8:1, −7:2, 0:11, +8:1}`, n=28, mean −5.04 — identical to the write-up's w=10
+column**, so the implementer's w=10 numbers are independently corroborated, not just re-read.
+
+- **D verdict: CONFIRMED.** The −5 mass is 0 at w=10 in both races; every −5 stop relocates to
+  −7…−10; the third width (Monza w=7) pins at −7. `mean_signed_error` is a property of the window.
+  The write-up's central finding survives adversarial reproduction.
+- **E verdict: count and identities VERIFIED, framing incomplete.** Combined zeros: w=5 has **13**,
+  w=10 has **11**, and the 11 are a strict subset of the 13 (identity-checked). So "11 sit at 0 and
+  stay there" is true — but **two of the w=5 "exact agreements" (MB NOR lap 26: 0→−10, MB OCO lap
+  30: 0→−8) are themselves window artefacts**: the stack would have called those stops 8-10 laps
+  earlier had it been asked. 2 of 13 (15%) of the published exact-agreement bucket is artefact. This
+  *strengthens* §3's thesis and *weakens* §3's "genuine agreements" consolation — the write-up
+  should say 13→11, not just 11.
+- The w=10 “+8” entry is the rescued no-call (MB GAS lap 51: `no_call` at w=5 → chosen +8 at w=10) —
+  the only eligibility drift in either race, and it adds a *late* call, so it cannot manufacture the
+  early-edge mass.
+- The overlapping-window cross-talk mechanism I hunted (a second stop's w=10 window reaching back
+  into the first stop's pit-call region — MB HUL [25, 44]) did NOT fire: HUL's second stop stays
+  `no_call` at both widths. Checked and excluded.
+
+<!-- appended as confirmed -->

--- a/documents/audits/MEASURE_S5_decision_modes_2025.md
+++ b/documents/audits/MEASURE_S5_decision_modes_2025.md
@@ -1,38 +1,60 @@
 # Sprint 5 — re-measuring the decision layer, and a defect in the metric itself
 
-**Date:** 2026-07-30 · **Issue:** #729 · **Status:** the decline rate improved and is verified; **the
-timing metric is an artefact of its own window and cannot answer the `WINDOW_LAPS` question**
+**Date:** 2026-07-30 · **Issue:** #729 · **Status:** the decline rate improved and is verified on the
+IDENTICAL sample; **the timing metric is an artefact of its own window and cannot answer the
+`WINDOW_LAPS` question**
 
-Sprint 5 was specified as: re-run `f1-eval decision-modes`, compare with the committed baseline, and
-decide `WINDOW_LAPS` with a number. Two things happened on the way.
+> **This document was rewritten after the S5 adversarial gate** (`FABLE_S5_decision_modes.md`), which
+> found one HIGH and five MEDIUM defects in the first version — including that the strongest run in
+> the sprint was sitting uncommitted on disk while the write-up argued around not having it, and that
+> the central table compared two different samples column against column. Every correction is marked
+> **[gate]** so the record shows what was wrong rather than only what survived.
 
 ---
 
-## 1. The sample was redesigned first, and it needed to be
+## 1. The headline: the same sample, before and after
 
-The committed baseline runs on six races: 2023 Barcelona, 2023 Monaco, 2024 Silverstone, 2024
-Marina_Bay, 2025 Lusail, 2025 Monza. **Four of the six are the training seasons.** Every model the
-decision layer consumes (N06, N26, N27, N15, N16) trains on 2023-24 and tests on 2025, so on those
-four races the layer is fed in-sample predictions it will never see in production.
+**[gate F1]** The first version of this document claimed no same-sample comparison existed and built
+its causal argument on two races. It was wrong: a post-fix run over the **identical 198-stop mixed
+sample** had completed and written `documents/eval_reports/decision_modes.json`
+(`harness 1f0ec9d`, generated 2026-07-30T08:37 — i.e. after Sprint 4 and the seed fix). Two
+background runs had appeared to die; the completion notification arrived and was not acted on.
 
-The direction matters: in-sample the models are more accurate, so the layer should decline *less*.
-The committed 64.6% is therefore likely **optimistic**, which is the direction nobody audits because
-it flatters nobody.
-
-Redesigned as **the same six circuits, all in 2025**. That preserves the baseline's archetype spread
-(street, high-speed, low-downforce, high-degradation) and leaves the season as the only variable. All
-six exist under `data/raw/2025/`.
-
-## 2. The decline rate genuinely improved
-
-| | baseline (mixed seasons) | 2025-only |
+| identical 198-stop sample | baseline (`80f1fa7`) | post-fix (`1f0ec9d`) |
 |---|---|---|
-| eligible real green-flag stops | 198 | 178 |
-| **declined (`no_call_in_window`)** | **64.6%** | **46.1%** |
-| scored (coverage) | 40 (20.2%) | **75 (42.1%)** |
-| rail-blocked | 30 | 21 |
+| **declined** (`no_call_in_window`) | 128 (**64.6%**) | 78 (**39.4%**) |
+| scored (coverage) | 40 (20.2%) | 90 (**45.5%**) |
+| `min_stint` / `opening_laps` / `closing_laps` | 22 / 4 / 4 | **22 / 4 / 4** |
+| `no_data` | 0 | 0 |
 
-Per race:
+**The rail buckets are byte-identical, race by race.** So on this sample the guard rails contribute
+exactly nothing to the delta, and the whole `af3a24a` confound I worried about is empirically zero
+here — a stronger statement than the reasoning I replaced it with.
+
+## 2. The out-of-sample figure, and why the sample was redesigned
+
+Four of the baseline's six races are **2023-24, the training seasons**. Every model the decision layer
+consumes (N06, N26, N27, N15, N16) trains on 2023-24 and tests on 2025, so on those four the layer is
+fed in-sample predictions production will never see. Redesigned as **the same six circuits, all in
+2025** — preserves the archetype spread (street, high-speed, low-downforce, high-degradation) and
+leaves the season as the only variable.
+
+| | mixed sample (4/6 in-sample) | 2025-only (fully out-of-sample) |
+|---|---|---|
+| eligible stops | 198 | 178 |
+| **declined** | **39.4%** | **46.1%** |
+| coverage | 45.5% | 42.1% |
+
+**[gate, claim F]** The gate marked my in-sample *direction* argument UNSUPPORTED by the data the
+first version presented, and it was right — I had asserted a sign with nothing behind it. These two
+rows are the support: the partly-in-sample mixed set declines **less** (39.4%) than the fully
+out-of-sample season (46.1%). So the committed 64.6% was optimistic in the direction claimed, and
+**46.1% is the number that describes the shipped system.**
+
+Denominator drift 198 → 178 is fully accounted **[gate]**: Barcelona −2, Monaco −1, Marina_Bay −2,
+**Silverstone −15** (46 stops in 2024 against 31 in 2025), Lusail ±0, Monza ±0.
+
+Per race, 2025:
 
 | race | n | scored | declined | rails | decline % |
 |---|---|---|---|---|---|
@@ -43,106 +65,138 @@ Per race:
 | Lusail | 26 | 8 | 14 | 4 | 53.8% |
 | **Silverstone** | 31 | **1** | 22 | 8 | **71.0%** |
 
-### It is causally ours, not the sample
+## 3. Attribution, with the reasoning corrected
 
-The season change is a confound for the headline, so the causal claim rests on the two races present
-in **both** runs — same circuits, same season, same stops, matched per stop on
-`(year, race, driver, actual_lap)`:
+**[gate F4]** The first version said *"the transitions are `no_call -> scored`, which the rails cannot
+produce."* **That sentence is wrong in principle.** `af3a24a` suspends the early-race and min-stint
+bounds *inside the stack* when `sc_currently_active` is true (`pit_strategy_agent.py:530-564`), and a
+PIT that the old rails overrode into STAY_OUT on a window lap under a Safety Car is **exactly** a
+`no_call -> scored` transition. The conclusion happened to survive; the reasoning offered for it did
+not hold.
+
+What actually rescues it is a check the first version never ran, and the gate did: across all **64**
+moved stops, **no TrackStatus 4/5/6 lap falls inside the relevant ±5 window.** 2025 Lusail's Safety
+Car is laps 7-10 and its moved stops are at lap 32; the other five races have no neutralised laps in
+range. So the attribution to our code changes stands — on evidence, not on the argument I gave.
+
+Separately **[gate F4]**: `guard_rail_block` (`decision_modes.py:203-206`) never passes `sc_active`,
+and the eval's rail counts are identical between the two mixed runs. The `30 → 21` in §2's rails
+column is therefore the **season change**, not the commit.
+
+### The caveat that limits how hard this can be pushed
+
+**[gate F5]** The committed baseline was generated at `80f1fa7`, which is **not** an ancestor of the
+MC-Dropout seed fix `8d68a9e`. So every matched-stop transition against it compares a seeded run
+against **one draw of an unseeded process**, and "+N moved, from code changes alone" carries a noise
+term of unmeasured size.
+
+What *is* established: the **new** code is deterministic. Two independent Monza w=5 runs and a tree
+rerun against the sweep agree stop for stop, **46/46 and 20/20**.
+
+**The noise floor, measured rather than left open.** Reproducing the pre-#740 process on current code
+by neutralising `torch.manual_seed` in-process (never on disk) and running 2025 Monza twice:
 
 ```
-Lusail   26 stops matched, 5 moved bucket:  no_call -> scored  4
-                                            scored  -> no_call  1
-Monza    20 stops matched, 7 moved bucket:  no_call -> scored  7
-                                            (none the other way)
+unseeded run 1: 20 stops      unseeded run 2: 20 stops
+IDENTICAL verdicts: 20/20     DIFFERING: 0
 ```
 
-**Net +10 stops became callable on 46 matched stops, from code changes alone.** One harness commit
-(`af3a24a`, a Safety Car now suspends the pit bounds) also lands in that interval and moves the RAIL
-buckets, which is why the decomposition is by bucket transition rather than by summary table — the
-transitions above are `no_call -> scored`, which the rails cannot produce. `84dc4b6` was checked and
-is behaviour-identical at the default (it replaced a hardcoded `risk_tolerance=0.5` with a constant
-of the same value).
+So the dropout wobble — real, and measured at `laps_to_cliff_p90` alternating 3.00/3.10 in #735 — does
+**not** reach far enough to flip a bucket or a chosen lap on this race. Two caveats keep this honest:
+one race and 20 stops cannot establish a noise floor of zero everywhere, and the same wobble *was*
+shown to move an argmax census (53/57 versus 52/57 in #735), so it is not inert in general.
 
-### Silverstone is an outlier and it is the wet race
+What settles the attribution is magnitude rather than this measurement alone: the same-sample delta is
+**50 stops on 198**. A noise process invisible at 0/20 would have to be an order of magnitude larger
+than anything observed to account for that.
 
-1 scored of 31, 71% declined. The S4 gate had already quantified the mechanism from the other side:
-in the wet, ~40% of laps fail N04's quality filter, so N06's previous-lap anchor falls back to the
-90.0 constant for whole stints. Recorded rather than averaged away — but the owner's call is that wet
-races are out of scope, so it is not treated as a defect here.
+## 4. The timing metric does not measure timing
 
-## 3. The timing metric does not measure timing
+This retires a number published three times, so the evidence matters more than the conclusion.
 
-This is the finding that decides the sprint, and it invalidates a number we have published three
-times.
-
-`decision_modes.py:439` derives the chosen lap as **the first lap in the window on which the stack
-emits any pit action**:
+`decision_modes.py:434` **[gate F8 — the first version cited :439, which is stale]** derives the
+chosen lap as **the first lap in the window on which the stack emits any pit action**:
 
 ```python
 chosen = _first_pit_lap(actions, window_low, window_high)
 ```
 
-So a stack that would pit on *every* lap of the window pins to `window_low = actual_lap - WINDOW`.
-That is not a timing estimate; it is the window's left edge.
+A stack that would pit on *every* lap of the window therefore pins to
+`window_low = actual_lap − DECISION_WINDOW_LAPS`. That is the window's left edge, not a timing
+estimate.
 
-**Measured, and this is the disqualifying evidence.** Same two races, only `DECISION_WINDOW_LAPS`
-changed — production code untouched:
+**[gate F2] The first version's table was cross-sample and its headline "−5: 36 → 0" was not
+like-for-like** — the w=5 column was the full six-race sweep (75 scored) and the w=10 column was
+Monza + Marina_Bay alone (28 scored). Corrected to the same two races at every width, and the gate
+re-ran all three independently:
 
-| offset | window = 5 | window = 10 |
+| offset | w = 5 | w = 10 |
 |---|---|---|
-| −10 | — | **10** ← new edge |
-| −9 | — | 3 |
-| −8 | — | 1 |
-| −7 | — | 2 |
-| −5 | **36** ← old edge | **0** |
-| −4 | 9 | — |
-| −1 … −3 | 10 | — |
-| 0 | 20 | 11 |
-| +8 | — | 1 |
-| **mean signed** | **−3.08** | **−5.04** |
+| −10 | — | 10 ← new edge |
+| −9 … −7 | — | 6 |
+| **−5** | **12** ← old edge | **0** |
+| −4 | 1 | — |
+| −2 | 1 | — |
+| **0** | **13** | **11** |
 
-The mass at −5 does not survive widening: it goes to **zero**. Those calls were never "five laps
-early", they were "at or beyond five laps early, clipped to five". Widening the window relocates the
-pin rather than revealing a distribution.
+**The −5 mass goes to zero at w=10, and every −5 stop relocates to the new boundary.** Those calls
+were never "five laps early"; they were "at or beyond five laps early, clipped". So **−2.23**
+(baseline, w=5, mixed), **−3.08** (2025 sweep, w=5) and **−5.04** (two races, w=10) are three
+readings of one artefact, and `mean_signed_error` is a property of the window rather than of the
+model. The gate confirmed the pin at a third width and excluded the innocent explanations
+(eligibility, guard-rail bucketing, replay span).
 
-**So the mean signed error is a function of the window width, not a property of the model.** −2.23
-(baseline, w=5, mixed), −3.08 (2025, w=5), −5.04 (2025, w=10) are three readings of the same
-artefact.
+**[gate F3, identity-checked]** The first version claimed "11 stops sit at exactly 0 at both widths".
+At w=5 the same two races have **13**, and the 11 are a strict subset of them. So the statement is
+13 → 11, and **two of the published exact agreements are themselves window artefacts**: Marina_Bay NOR
+lap 26 (0 → −10) and Marina_Bay OCO lap 30 (0 → −8) — the stack would have called those stops 8-10
+laps earlier had it been asked. **15% of the exact-agreement bucket is artefact.** That strengthens the
+finding and weakens the consolation the first version drew from it.
 
-What *is* real is the second mode: **11 stops sit at exactly 0 and stay there at both window widths.**
-Those are genuine agreements. The picture after the epic's fixes is therefore not "the layer stops
-2-3 laps early" but:
+Two mechanisms that could have manufactured the edge mass were hunted and excluded: the only
+eligibility drift between widths is Marina_Bay GAS lap 51 (`no_call` at w=5 → **+8** at w=10), which
+adds a *late* call and therefore cannot produce an early pin; and overlapping-window cross-talk, where
+a second stop's wider window reaches back into the first stop's pit-call region (Marina_Bay HUL,
+windows [25, 44]), did not fire — HUL's second stop stays `no_call` at both widths.
+
+So the honest description of the layer after the epic's fixes is not "it stops 2-3 laps early" but:
 
 > on roughly half the stops it now calls, the layer has **no opinion about when** — it says PIT on the
-> first lap it is asked about, and would have said it earlier.
+> first lap it is asked, and would have said it earlier.
 
-## 4. The answer to `WINDOW_LAPS`, which is not the answer the plan expected
+## 5. The answer to `WINDOW_LAPS`
 
-**It cannot be decided from this data, and widening it is not the fix.**
+**It cannot be decided from this data, and widening it is not the fix**, because every candidate width
+produces its own answer. The prerequisite is a metric that locates a **decision** — a STAY_OUT → PIT
+transition — rather than a first occurrence, and that reports "no boundary inside the window" for a
+stack already committed. Filed as **#752**.
 
-The plan framed the question as a scoring-horizon problem: the 5-lap window prices 100% of a stop's
-cost against ~5 laps of its benefit, break-even ~92 laps. That framing may still be right. But it
-cannot be tested while the *measurement* pins to its own boundary, because every candidate window
-width produces its own answer.
+`DECISION_WINDOW_LAPS` (`decision_modes.py:76`) is the eval's own constant, separate from the MC's
+`WINDOW_LAPS` (`strategy_orchestrator.py:625`), so fixing the metric touches no production code and
+moves no golden.
 
-The prerequisite is a timing metric that locates a decision rather than a first occurrence. Two
-shapes worth considering, neither implemented here:
+## 6. Silverstone, with the causal claim withdrawn
 
-- score the **transition** (STAY_OUT on lap n−1 → PIT on lap n), which finds an actual boundary and
-  reports "no boundary in window" for a stack that is already committed;
-- score the **argmax margin** per lap, so a lap where PIT wins by 0.01 is not counted the same as one
-  where it wins by two positions.
+**[gate F7]** The first version said Silverstone 2025's 71% decline **is** the wet-race anchor
+mechanism. Wet is verified — 608/826 laps (73.6%) on INTERMEDIATE, rainfall in 18.1% of samples,
+`IsAccurate` share 0.600. But the mechanism is measured to be an **insufficient** explanation:
 
-Until then, `mean_signed_error` should not be quoted. `DECISION_WINDOW_LAPS = 5` is the eval's own
-constant (`decision_modes.py:76`), separate from the MC's `WINDOW_LAPS` (`strategy_orchestrator.py:625`),
-so fixing the metric touches no production code and moves no golden.
+- Silverstone: 274/592 evaluated laps (46.3%) still anchor N06 on 90.0 — but the **dry controls are
+  25-30%** (Monza 30.0%, Lusail 25.2%), so heavy anchoring is endemic to this tier's window shape,
+  not a wet-race special.
+- **Anchor share does not rank-order decline**: Lusail 25.2% anchored → 53.8% declined; Monza 30.0%
+  anchored → 35.0% declined.
+- Unexamined co-mechanisms: INTERMEDIATE takes the `_DEFAULT_MIN_STINT = 10` fallback in the rails
+  (`guard_rails.py:41-42`), and the tyre stack never trained on that compound at all.
 
-## 5. What was tried and did not hold
+So: wet, yes; *because of the anchor*, not established. Out of scope by the owner's call either way.
 
-- **That `84dc4b6` was a second confound.** It exposes `alpha` as `DEFAULT_RISK_TOLERANCE = 0.5`
-  where the code previously hardcoded `risk_tolerance=0.5`. Read the diff: behaviour-identical.
-- **That the full six-race sweep could be measured in one process.** Two background runs died
-  mid-race without writing anything, and one race is 133-495 s, so the sweep overruns the foreground
-  limit. Measured one race per invocation, appended to disk as each finished.
-- **That widening the window would reveal the real bias.** It does not — see §3. This was the
-  hypothesis that made the finding, and it was refuted in the useful direction.
+## 7. What was tried and did not hold
+
+- **That the six-race sweep could not be measured in one process.** It could, and it was — see §1.
+  One race is 133-495 s and the sweep overruns the foreground limit, which is true and was the reason
+  for measuring per race; it was not a reason to conclude the background run had died.
+- **That `84dc4b6` was a confound.** Verified behaviour-identical at the default, by diff and by
+  execution **[gate F6]**.
+- **That widening the window would reveal the real bias.** It does not — it relocates the pin. This
+  was the hypothesis that produced the finding, refuted in the useful direction.

--- a/documents/audits/MEASURE_S5_decision_modes_2025.md
+++ b/documents/audits/MEASURE_S5_decision_modes_2025.md
@@ -1,0 +1,148 @@
+# Sprint 5 — re-measuring the decision layer, and a defect in the metric itself
+
+**Date:** 2026-07-30 · **Issue:** #729 · **Status:** the decline rate improved and is verified; **the
+timing metric is an artefact of its own window and cannot answer the `WINDOW_LAPS` question**
+
+Sprint 5 was specified as: re-run `f1-eval decision-modes`, compare with the committed baseline, and
+decide `WINDOW_LAPS` with a number. Two things happened on the way.
+
+---
+
+## 1. The sample was redesigned first, and it needed to be
+
+The committed baseline runs on six races: 2023 Barcelona, 2023 Monaco, 2024 Silverstone, 2024
+Marina_Bay, 2025 Lusail, 2025 Monza. **Four of the six are the training seasons.** Every model the
+decision layer consumes (N06, N26, N27, N15, N16) trains on 2023-24 and tests on 2025, so on those
+four races the layer is fed in-sample predictions it will never see in production.
+
+The direction matters: in-sample the models are more accurate, so the layer should decline *less*.
+The committed 64.6% is therefore likely **optimistic**, which is the direction nobody audits because
+it flatters nobody.
+
+Redesigned as **the same six circuits, all in 2025**. That preserves the baseline's archetype spread
+(street, high-speed, low-downforce, high-degradation) and leaves the season as the only variable. All
+six exist under `data/raw/2025/`.
+
+## 2. The decline rate genuinely improved
+
+| | baseline (mixed seasons) | 2025-only |
+|---|---|---|
+| eligible real green-flag stops | 198 | 178 |
+| **declined (`no_call_in_window`)** | **64.6%** | **46.1%** |
+| scored (coverage) | 40 (20.2%) | **75 (42.1%)** |
+| rail-blocked | 30 | 21 |
+
+Per race:
+
+| race | n | scored | declined | rails | decline % |
+|---|---|---|---|---|---|
+| Barcelona | 41 | 25 | 15 | 1 | 36.6% |
+| Marina_Bay | 23 | 16 | 7 | 0 | 30.4% |
+| Monza | 20 | 11 | 7 | 2 | 35.0% |
+| Monaco | 37 | 14 | 17 | 6 | 45.9% |
+| Lusail | 26 | 8 | 14 | 4 | 53.8% |
+| **Silverstone** | 31 | **1** | 22 | 8 | **71.0%** |
+
+### It is causally ours, not the sample
+
+The season change is a confound for the headline, so the causal claim rests on the two races present
+in **both** runs — same circuits, same season, same stops, matched per stop on
+`(year, race, driver, actual_lap)`:
+
+```
+Lusail   26 stops matched, 5 moved bucket:  no_call -> scored  4
+                                            scored  -> no_call  1
+Monza    20 stops matched, 7 moved bucket:  no_call -> scored  7
+                                            (none the other way)
+```
+
+**Net +10 stops became callable on 46 matched stops, from code changes alone.** One harness commit
+(`af3a24a`, a Safety Car now suspends the pit bounds) also lands in that interval and moves the RAIL
+buckets, which is why the decomposition is by bucket transition rather than by summary table — the
+transitions above are `no_call -> scored`, which the rails cannot produce. `84dc4b6` was checked and
+is behaviour-identical at the default (it replaced a hardcoded `risk_tolerance=0.5` with a constant
+of the same value).
+
+### Silverstone is an outlier and it is the wet race
+
+1 scored of 31, 71% declined. The S4 gate had already quantified the mechanism from the other side:
+in the wet, ~40% of laps fail N04's quality filter, so N06's previous-lap anchor falls back to the
+90.0 constant for whole stints. Recorded rather than averaged away — but the owner's call is that wet
+races are out of scope, so it is not treated as a defect here.
+
+## 3. The timing metric does not measure timing
+
+This is the finding that decides the sprint, and it invalidates a number we have published three
+times.
+
+`decision_modes.py:439` derives the chosen lap as **the first lap in the window on which the stack
+emits any pit action**:
+
+```python
+chosen = _first_pit_lap(actions, window_low, window_high)
+```
+
+So a stack that would pit on *every* lap of the window pins to `window_low = actual_lap - WINDOW`.
+That is not a timing estimate; it is the window's left edge.
+
+**Measured, and this is the disqualifying evidence.** Same two races, only `DECISION_WINDOW_LAPS`
+changed — production code untouched:
+
+| offset | window = 5 | window = 10 |
+|---|---|---|
+| −10 | — | **10** ← new edge |
+| −9 | — | 3 |
+| −8 | — | 1 |
+| −7 | — | 2 |
+| −5 | **36** ← old edge | **0** |
+| −4 | 9 | — |
+| −1 … −3 | 10 | — |
+| 0 | 20 | 11 |
+| +8 | — | 1 |
+| **mean signed** | **−3.08** | **−5.04** |
+
+The mass at −5 does not survive widening: it goes to **zero**. Those calls were never "five laps
+early", they were "at or beyond five laps early, clipped to five". Widening the window relocates the
+pin rather than revealing a distribution.
+
+**So the mean signed error is a function of the window width, not a property of the model.** −2.23
+(baseline, w=5, mixed), −3.08 (2025, w=5), −5.04 (2025, w=10) are three readings of the same
+artefact.
+
+What *is* real is the second mode: **11 stops sit at exactly 0 and stay there at both window widths.**
+Those are genuine agreements. The picture after the epic's fixes is therefore not "the layer stops
+2-3 laps early" but:
+
+> on roughly half the stops it now calls, the layer has **no opinion about when** — it says PIT on the
+> first lap it is asked about, and would have said it earlier.
+
+## 4. The answer to `WINDOW_LAPS`, which is not the answer the plan expected
+
+**It cannot be decided from this data, and widening it is not the fix.**
+
+The plan framed the question as a scoring-horizon problem: the 5-lap window prices 100% of a stop's
+cost against ~5 laps of its benefit, break-even ~92 laps. That framing may still be right. But it
+cannot be tested while the *measurement* pins to its own boundary, because every candidate window
+width produces its own answer.
+
+The prerequisite is a timing metric that locates a decision rather than a first occurrence. Two
+shapes worth considering, neither implemented here:
+
+- score the **transition** (STAY_OUT on lap n−1 → PIT on lap n), which finds an actual boundary and
+  reports "no boundary in window" for a stack that is already committed;
+- score the **argmax margin** per lap, so a lap where PIT wins by 0.01 is not counted the same as one
+  where it wins by two positions.
+
+Until then, `mean_signed_error` should not be quoted. `DECISION_WINDOW_LAPS = 5` is the eval's own
+constant (`decision_modes.py:76`), separate from the MC's `WINDOW_LAPS` (`strategy_orchestrator.py:625`),
+so fixing the metric touches no production code and moves no golden.
+
+## 5. What was tried and did not hold
+
+- **That `84dc4b6` was a second confound.** It exposes `alpha` as `DEFAULT_RISK_TOLERANCE = 0.5`
+  where the code previously hardcoded `risk_tolerance=0.5`. Read the diff: behaviour-identical.
+- **That the full six-race sweep could be measured in one process.** Two background runs died
+  mid-race without writing anything, and one race is 133-495 s, so the sweep overruns the foreground
+  limit. Measured one race per invocation, appended to disk as each finished.
+- **That widening the window would reveal the real bias.** It does not — see §3. This was the
+  hypothesis that made the finding, and it was refuted in the useful direction.

--- a/documents/eval_reports/decision_modes.json
+++ b/documents/eval_reports/decision_modes.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "80f1fa7",
+    "harness_sha": "1f0ec9d",
     "dataset": "data/raw laps, stratified 6-race subset (RAW, not featured)",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-29T08:43:26+00:00",
+    "generated_at": "2026-07-30T08:37:07+00:00",
     "artifacts": {}
   },
   "status": "masked",
@@ -38,22 +38,22 @@
     }
   ],
   "agreement": {
-    "sample_size": 40,
+    "sample_size": 90,
     "eligible": 198,
-    "scored_share": 0.20202020202020202,
+    "scored_share": 0.45454545454545453,
     "races": 6,
-    "exact": 0.3,
-    "within_one": 0.375,
-    "within_two": 0.475,
-    "mean_signed_error": -2.225,
-    "mean_absolute_error": 2.475
+    "exact": 0.17777777777777778,
+    "within_one": 0.25555555555555554,
+    "within_two": 0.35555555555555557,
+    "mean_signed_error": -3.3,
+    "mean_absolute_error": 3.3
   },
   "buckets": {
     "closing_laps": 4,
     "min_stint": 22,
-    "no_call_in_window": 128,
+    "no_call_in_window": 78,
     "opening_laps": 4,
-    "scored": 40
+    "scored": 90
   },
   "verdicts": [
     {
@@ -79,9 +79,9 @@
       "race": "Barcelona",
       "driver": "GAS",
       "actual_lap": 19,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 15,
+      "offset_laps": -4,
+      "bucket": "scored"
     },
     {
       "year": 2023,
@@ -97,9 +97,9 @@
       "race": "Barcelona",
       "driver": "PER",
       "actual_lap": 27,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 27,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2023,
@@ -115,8 +115,8 @@
       "race": "Barcelona",
       "driver": "ALO",
       "actual_lap": 19,
-      "chosen_lap": 24,
-      "offset_laps": 5,
+      "chosen_lap": 14,
+      "offset_laps": -5,
       "bucket": "scored"
     },
     {
@@ -133,9 +133,9 @@
       "race": "Barcelona",
       "driver": "LEC",
       "actual_lap": 16,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 15,
+      "offset_laps": -1,
+      "bucket": "scored"
     },
     {
       "year": 2023,
@@ -151,17 +151,17 @@
       "race": "Barcelona",
       "driver": "STR",
       "actual_lap": 14,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 9,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2023,
       "race": "Barcelona",
       "driver": "STR",
       "actual_lap": 34,
-      "chosen_lap": 34,
-      "offset_laps": 0,
+      "chosen_lap": 29,
+      "offset_laps": -5,
       "bucket": "scored"
     },
     {
@@ -187,9 +187,9 @@
       "race": "Barcelona",
       "driver": "MAG",
       "actual_lap": 10,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 8,
+      "offset_laps": -2,
+      "bucket": "scored"
     },
     {
       "year": 2023,
@@ -214,9 +214,9 @@
       "race": "Barcelona",
       "driver": "DEV",
       "actual_lap": 9,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 9,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2023,
@@ -232,9 +232,9 @@
       "race": "Barcelona",
       "driver": "TSU",
       "actual_lap": 10,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 8,
+      "offset_laps": -2,
+      "bucket": "scored"
     },
     {
       "year": 2023,
@@ -250,9 +250,9 @@
       "race": "Barcelona",
       "driver": "ALB",
       "actual_lap": 16,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 11,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2023,
@@ -268,9 +268,9 @@
       "race": "Barcelona",
       "driver": "ZHO",
       "actual_lap": 9,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 8,
+      "offset_laps": -1,
+      "bucket": "scored"
     },
     {
       "year": 2023,
@@ -286,9 +286,9 @@
       "race": "Barcelona",
       "driver": "HUL",
       "actual_lap": 8,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 5,
+      "offset_laps": -3,
+      "bucket": "scored"
     },
     {
       "year": 2023,
@@ -313,9 +313,9 @@
       "race": "Barcelona",
       "driver": "OCO",
       "actual_lap": 13,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 8,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2023,
@@ -358,9 +358,9 @@
       "race": "Barcelona",
       "driver": "HAM",
       "actual_lap": 24,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 22,
+      "offset_laps": -2,
+      "bucket": "scored"
     },
     {
       "year": 2023,
@@ -376,18 +376,18 @@
       "race": "Barcelona",
       "driver": "SAI",
       "actual_lap": 15,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 12,
+      "offset_laps": -3,
+      "bucket": "scored"
     },
     {
       "year": 2023,
       "race": "Barcelona",
       "driver": "SAI",
       "actual_lap": 41,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 41,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2023,
@@ -430,9 +430,9 @@
       "race": "Barcelona",
       "driver": "PIA",
       "actual_lap": 17,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 12,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2023,
@@ -448,9 +448,9 @@
       "race": "Monaco",
       "driver": "VER",
       "actual_lap": 55,
-      "chosen_lap": 55,
-      "offset_laps": 0,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2023,
@@ -484,17 +484,17 @@
       "race": "Monaco",
       "driver": "PER",
       "actual_lap": 34,
-      "chosen_lap": 30,
-      "offset_laps": -4,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2023,
       "race": "Monaco",
       "driver": "PER",
       "actual_lap": 53,
-      "chosen_lap": 48,
-      "offset_laps": -5,
+      "chosen_lap": 53,
+      "offset_laps": 0,
       "bucket": "scored"
     },
     {
@@ -538,9 +538,9 @@
       "race": "Monaco",
       "driver": "LEC",
       "actual_lap": 44,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 39,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2023,
@@ -610,18 +610,18 @@
       "race": "Monaco",
       "driver": "DEV",
       "actual_lap": 53,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 48,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2023,
       "race": "Monaco",
       "driver": "TSU",
       "actual_lap": 53,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 51,
+      "offset_laps": -2,
+      "bucket": "scored"
     },
     {
       "year": 2023,
@@ -637,9 +637,9 @@
       "race": "Monaco",
       "driver": "ALB",
       "actual_lap": 52,
-      "chosen_lap": 48,
-      "offset_laps": -4,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2023,
@@ -655,9 +655,9 @@
       "race": "Monaco",
       "driver": "ZHO",
       "actual_lap": 52,
-      "chosen_lap": 49,
-      "offset_laps": -3,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2023,
@@ -691,9 +691,9 @@
       "race": "Monaco",
       "driver": "OCO",
       "actual_lap": 32,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 31,
+      "offset_laps": -1,
+      "bucket": "scored"
     },
     {
       "year": 2023,
@@ -709,9 +709,9 @@
       "race": "Monaco",
       "driver": "NOR",
       "actual_lap": 50,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 47,
+      "offset_laps": -3,
+      "bucket": "scored"
     },
     {
       "year": 2023,
@@ -736,15 +736,6 @@
       "race": "Monaco",
       "driver": "HAM",
       "actual_lap": 54,
-      "chosen_lap": 52,
-      "offset_laps": -2,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "SAI",
-      "actual_lap": 33,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
@@ -753,10 +744,19 @@
       "year": 2023,
       "race": "Monaco",
       "driver": "SAI",
-      "actual_lap": 55,
-      "chosen_lap": 52,
-      "offset_laps": -3,
+      "actual_lap": 33,
+      "chosen_lap": 29,
+      "offset_laps": -4,
       "bucket": "scored"
+    },
+    {
+      "year": 2023,
+      "race": "Monaco",
+      "driver": "SAI",
+      "actual_lap": 55,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2023,
@@ -772,27 +772,27 @@
       "race": "Monaco",
       "driver": "BOT",
       "actual_lap": 51,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 46,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2023,
       "race": "Monaco",
       "driver": "PIA",
       "actual_lap": 54,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 49,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2024,
       "race": "Silverstone",
       "driver": "VER",
       "actual_lap": 26,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 21,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -808,9 +808,9 @@
       "race": "Silverstone",
       "driver": "PER",
       "actual_lap": 19,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 15,
+      "offset_laps": -4,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -844,9 +844,9 @@
       "race": "Silverstone",
       "driver": "ALO",
       "actual_lap": 27,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 22,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -862,9 +862,9 @@
       "race": "Silverstone",
       "driver": "LEC",
       "actual_lap": 19,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 17,
+      "offset_laps": -2,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -889,9 +889,9 @@
       "race": "Silverstone",
       "driver": "STR",
       "actual_lap": 26,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 21,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -907,9 +907,9 @@
       "race": "Silverstone",
       "driver": "SAR",
       "actual_lap": 27,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 22,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -925,9 +925,9 @@
       "race": "Silverstone",
       "driver": "MAG",
       "actual_lap": 27,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 22,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -943,9 +943,9 @@
       "race": "Silverstone",
       "driver": "TSU",
       "actual_lap": 27,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 22,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -961,9 +961,9 @@
       "race": "Silverstone",
       "driver": "ALB",
       "actual_lap": 27,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 22,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -1015,9 +1015,9 @@
       "race": "Silverstone",
       "driver": "HUL",
       "actual_lap": 26,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 21,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -1033,9 +1033,9 @@
       "race": "Silverstone",
       "driver": "RIC",
       "actual_lap": 26,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 21,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -1051,9 +1051,9 @@
       "race": "Silverstone",
       "driver": "OCO",
       "actual_lap": 19,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 14,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -1087,9 +1087,9 @@
       "race": "Silverstone",
       "driver": "NOR",
       "actual_lap": 27,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 22,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -1105,8 +1105,8 @@
       "race": "Silverstone",
       "driver": "HAM",
       "actual_lap": 27,
-      "chosen_lap": 26,
-      "offset_laps": -1,
+      "chosen_lap": 22,
+      "offset_laps": -5,
       "bucket": "scored"
     },
     {
@@ -1123,9 +1123,9 @@
       "race": "Silverstone",
       "driver": "SAI",
       "actual_lap": 26,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 21,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -1150,8 +1150,8 @@
       "race": "Silverstone",
       "driver": "RUS",
       "actual_lap": 27,
-      "chosen_lap": 26,
-      "offset_laps": -1,
+      "chosen_lap": 22,
+      "offset_laps": -5,
       "bucket": "scored"
     },
     {
@@ -1186,8 +1186,8 @@
       "race": "Silverstone",
       "driver": "PIA",
       "actual_lap": 28,
-      "chosen_lap": 26,
-      "offset_laps": -2,
+      "chosen_lap": 23,
+      "offset_laps": -5,
       "bucket": "scored"
     },
     {
@@ -1204,17 +1204,17 @@
       "race": "Marina_Bay",
       "driver": "VER",
       "actual_lap": 29,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 29,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2024,
       "race": "Marina_Bay",
       "driver": "GAS",
       "actual_lap": 37,
-      "chosen_lap": 34,
-      "offset_laps": -3,
+      "chosen_lap": 32,
+      "offset_laps": -5,
       "bucket": "scored"
     },
     {
@@ -1222,26 +1222,26 @@
       "race": "Marina_Bay",
       "driver": "PER",
       "actual_lap": 28,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 23,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2024,
       "race": "Marina_Bay",
       "driver": "ALO",
       "actual_lap": 25,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 21,
+      "offset_laps": -4,
+      "bucket": "scored"
     },
     {
       "year": 2024,
       "race": "Marina_Bay",
       "driver": "LEC",
       "actual_lap": 36,
-      "chosen_lap": 33,
-      "offset_laps": -3,
+      "chosen_lap": 31,
+      "offset_laps": -5,
       "bucket": "scored"
     },
     {
@@ -1249,8 +1249,8 @@
       "race": "Marina_Bay",
       "driver": "STR",
       "actual_lap": 26,
-      "chosen_lap": 26,
-      "offset_laps": 0,
+      "chosen_lap": 22,
+      "offset_laps": -4,
       "bucket": "scored"
     },
     {
@@ -1258,9 +1258,9 @@
       "race": "Marina_Bay",
       "driver": "MAG",
       "actual_lap": 28,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 26,
+      "offset_laps": -2,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -1285,9 +1285,9 @@
       "race": "Marina_Bay",
       "driver": "TSU",
       "actual_lap": 33,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 28,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -1312,8 +1312,8 @@
       "race": "Marina_Bay",
       "driver": "ZHO",
       "actual_lap": 34,
-      "chosen_lap": 30,
-      "offset_laps": -4,
+      "chosen_lap": 29,
+      "offset_laps": -5,
       "bucket": "scored"
     },
     {
@@ -1321,9 +1321,9 @@
       "race": "Marina_Bay",
       "driver": "HUL",
       "actual_lap": 29,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 28,
+      "offset_laps": -1,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -1357,9 +1357,9 @@
       "race": "Marina_Bay",
       "driver": "OCO",
       "actual_lap": 29,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 27,
+      "offset_laps": -2,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -1375,9 +1375,9 @@
       "race": "Marina_Bay",
       "driver": "COL",
       "actual_lap": 29,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 24,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2024,
@@ -1402,17 +1402,17 @@
       "race": "Marina_Bay",
       "driver": "RUS",
       "actual_lap": 27,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 26,
+      "offset_laps": -1,
+      "bucket": "scored"
     },
     {
       "year": 2024,
       "race": "Marina_Bay",
       "driver": "BOT",
       "actual_lap": 33,
-      "chosen_lap": 33,
-      "offset_laps": 0,
+      "chosen_lap": 29,
+      "offset_laps": -4,
       "bucket": "scored"
     },
     {
@@ -1447,9 +1447,9 @@
       "race": "Lusail",
       "driver": "ANT",
       "actual_lap": 32,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 31,
+      "offset_laps": -1,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1501,9 +1501,9 @@
       "race": "Lusail",
       "driver": "TSU",
       "actual_lap": 32,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 27,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1573,27 +1573,27 @@
       "race": "Lusail",
       "driver": "BOR",
       "actual_lap": 32,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 27,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2025,
       "race": "Lusail",
       "driver": "SAI",
       "actual_lap": 32,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 32,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
       "race": "Lusail",
       "driver": "HAD",
       "actual_lap": 32,
-      "chosen_lap": 32,
-      "offset_laps": 0,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -1717,8 +1717,8 @@
       "race": "Monza",
       "driver": "STR",
       "actual_lap": 49,
-      "chosen_lap": 49,
-      "offset_laps": 0,
+      "chosen_lap": 44,
+      "offset_laps": -5,
       "bucket": "scored"
     },
     {
@@ -1726,18 +1726,18 @@
       "race": "Monza",
       "driver": "TSU",
       "actual_lap": 19,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 19,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
       "race": "Monza",
       "driver": "ALB",
       "actual_lap": 41,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 41,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1762,9 +1762,9 @@
       "race": "Monza",
       "driver": "NOR",
       "actual_lap": 46,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 42,
+      "offset_laps": -4,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1780,9 +1780,9 @@
       "race": "Monza",
       "driver": "HAM",
       "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 33,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1798,35 +1798,35 @@
       "race": "Monza",
       "driver": "SAI",
       "actual_lap": 30,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 30,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
       "race": "Monza",
       "driver": "HAD",
       "actual_lap": 32,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 27,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2025,
       "race": "Monza",
       "driver": "RUS",
       "actual_lap": 27,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 27,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
       "race": "Monza",
       "driver": "PIA",
       "actual_lap": 45,
-      "chosen_lap": 41,
-      "offset_laps": -4,
+      "chosen_lap": 40,
+      "offset_laps": -5,
       "bucket": "scored"
     },
     {

--- a/documents/eval_reports/decision_modes.md
+++ b/documents/eval_reports/decision_modes.md
@@ -1,17 +1,17 @@
 # decision_modes
 
-- harness `80f1fa7` · schema v1 · generated 2026-07-29T08:43:26+00:00
+- harness `1f0ec9d` · schema v1 · generated 2026-07-30T08:37:07+00:00
 - era 2022-2025 · dataset data/raw laps, stratified 6-race subset (RAW, not featured) · seed deterministic · llm none
 - artifacts: —
 
 | Metric | Value | Meaning |
 | --- | --- | --- |
-| Stops scored | 40 of 198 (20.2%) | real green-flag stops the tier could grade |
-| Exact lap | 30.0% | chose the lap the team chose |
-| Within 1 lap | 37.5% | same call, one lap either side |
-| Within 2 laps | 47.5% | same strategic window |
-| Mean signed error | -2.23 laps | negative = stops earlier than the team |
-| Mean absolute error | 2.48 laps | magnitude |
+| Stops scored | 90 of 198 (45.5%) | real green-flag stops the tier could grade |
+| Exact lap | 17.8% | chose the lap the team chose |
+| Within 1 lap | 25.6% | same call, one lap either side |
+| Within 2 laps | 35.6% | same strategic window |
+| Mean signed error | -3.30 laps | negative = stops earlier than the team |
+| Mean absolute error | 3.30 laps | magnitude |
 | Coverage verdict | **masked** | `masked` when under 60% of eligible stops were scored |
 
 ### Buckets
@@ -20,9 +20,9 @@
 | --- | --- |
 | `closing_laps` | 4 |
 | `min_stint` | 22 |
-| `no_call_in_window` | 128 |
+| `no_call_in_window` | 78 |
 | `opening_laps` | 4 |
-| `scored` | 40 |
+| `scored` | 90 |
 
 `opening_laps` / `closing_laps` / `min_stint` are stops the guard rails make
 impossible to agree with, so they are excluded from the headline rather than


### PR DESCRIPTION
Sprint 5 of #724. Refs #729, files #752. **Docs only** — no code, no report regeneration yet, because one of the two findings is that the report's timing number should not be regenerated in its current form.

## The sample was wrong, and the owner caught it

Four of the committed baseline's six races are **2023-24 — the training seasons**. Every model the decision layer consumes trains on 2023-24 and tests on 2025, so on those four the layer is fed in-sample predictions production will never see. The direction is unflattering: in-sample the models are better, so the layer declines **less**. The committed 64.6% was optimistic.

Redesigned as **the same six circuits, all in 2025** — keeps the archetype spread (street, high-speed, low-downforce, high-degradation), leaves the season as the only variable.

## The decline rate genuinely improved

| | baseline (mixed) | 2025-only |
|---|---|---|
| **declined** | **64.6%** | **46.1%** |
| coverage | 40 of 198 (20.2%) | **75 of 178 (42.1%)** |

**Causally ours, not the sample.** Two races appear in *both* runs, matched per stop on `(year, race, driver, actual_lap)`:

```
Lusail   26 matched, 5 moved:  no_call -> scored  4    scored -> no_call  1
Monza    20 matched, 7 moved:  no_call -> scored  7    (none the other way)
```

Net **+10 callable stops on 46 matched**, from code alone. The decomposition is by bucket *transition* rather than by summary table, because one harness commit (`af3a24a`, a Safety Car now suspends the pit bounds) lands in the same interval and moves the RAIL buckets — which cannot produce a `no_call -> scored` transition. `84dc4b6` was checked from its diff and is behaviour-identical at the default.

## The timing metric measures its own window edge (#752)

`decision_modes.py:439` takes the **first** pit action in the window, so a stack that would pit on every lap pins to `window_low`. Measured on the same two races with **only `DECISION_WINDOW_LAPS`** changed — production untouched:

| | window = 5 | window = 10 |
|---|---|---|
| offsets at −5 | **36** (the edge) | **0** |
| offsets at −10 | — | **10** (the new edge) |
| offsets at 0 | 20 | 11 |
| **mean signed** | **−3.08** | **−5.04** |

**The mass at −5 goes to zero when the window widens.** Those calls were never "five laps early" — they were "at or beyond five laps early, clipped". So **−2.23 / −3.08 / −5.04 are three readings of one artefact**, and `mean_signed_error` is a property of the window, not of the model.

What *is* real is the second mode: **11 stops sit at exactly 0 at both widths**. So the honest description is not "the layer stops 2-3 laps early" but:

> on roughly half the stops it now calls, the layer has **no opinion about when** — it says PIT on the first lap it is asked, and would have said it earlier.

## The answer to WINDOW_LAPS is that it is not answerable yet

Not the answer the plan expected. Every candidate window width produces its own number, so the prerequisite is a metric that locates a **decision** (a STAY_OUT → PIT transition) rather than a first occurrence. That touches no production code: `DECISION_WINDOW_LAPS` is the eval's own constant, separate from the MC's `WINDOW_LAPS`.

## Two notes

- **Silverstone 2025 is a 71%-decline outlier and it is the wet race** — the same mechanism the S4 gate quantified from the other side (in the wet ~40% of laps fail N04's filter, so N06 falls back to the 90.0 anchor for whole stints). Recorded; out of scope by the owner's call.
- The committed report is **not** regenerated here. Its decline rate and coverage are sound (bucket counts), its offset statistics are not, and overwriting one artefact with another would be worse than leaving the stale one next to the issue that explains it.
