### PR TITLE
fix(eval): score the decision transition instead of the first pit lap in the window

### DIFF
--- a/src/strategy/eval/decision_modes.py
+++ b/src/strategy/eval/decision_modes.py
@@ -13,11 +13,20 @@ WHAT THIS MEASURES, EXACTLY
 ---------------------------
 For every real green-flag stop in the sampled races, the stack is driven over a
 window of laps either side of the real stop lap and asked, lap by lap, what it
-would do. The first lap inside the window on which it emits a pit action is
-"the lap it would have chosen"; the signed distance to the real lap is the
-error. Signed, not absolute, for the reason ``GroundTruth.mean_signed_error``
-exists: stopping consistently early or late is a fixable bug, and a magnitude
-hides it.
+would do. The lap it would have chosen is the first **transition** — the lap
+where it stops saying "stay out" and starts saying "box" — and the signed
+distance to the real lap is the error. Signed, not absolute, for the reason
+``GroundTruth.mean_signed_error`` exists: stopping consistently early or late is
+a fixable bug, and a magnitude hides it.
+
+A transition and not simply the first pit lap, because that is what #752
+retired. A stack that would pit on *every* lap of the window has no decision
+inside it, and reporting the window's left edge as its choice made the error a
+property of the window: widening it from 5 laps to 10 moved the entire mass from
+one boundary to the other and left zero at the old one. Those stops are now
+``no_boundary_in_window`` — looked at, deliberately unscored, because the honest
+statement is that the call came earlier than we asked, not that it came on the
+lap we happened to start asking.
 
 The stack runs on ``profile="no-llm"``, so the action comes from the Monte
 Carlo layer and the guard rails **deterministically**. This is a deliberate
@@ -138,6 +147,7 @@ class DecisionAgreement:
     no_call: int
     races: int
     no_data: int = 0
+    no_boundary: int = 0
 
     @property
     def sample_size(self) -> int:
@@ -145,8 +155,13 @@ class DecisionAgreement:
 
     @property
     def eligible(self) -> int:
-        """Every stop the tier looked at, scored or not."""
-        return self.sample_size + self.guard_railed + self.no_call + self.no_data
+        """Every stop the tier looked at, scored or not.
+
+        ``no_boundary`` joined this sum in #752 and it has to: those stops WERE
+        looked at. Leaving them out would shrink the denominator and inflate the
+        scored share by exactly the stops the old code used to score wrongly.
+        """
+        return self.sample_size + self.guard_railed + self.no_call + self.no_data + self.no_boundary
 
     @property
     def exact(self) -> float:
@@ -310,10 +325,50 @@ def _decisions_in_window(
     return actions
 
 
-def _first_pit_lap(actions: dict[int, str], low: int, high: int) -> int | None:
-    """Earliest lap in the window on which the stack asked to stop, or None."""
+def _asks_to_stop(actions: dict[int, str], low: int, high: int) -> bool:
+    """Whether the stack asked to stop anywhere in the window, transition or not.
+
+    Only used to tell "it never wanted to stop" from "it already wanted to stop
+    before we started asking". Those are opposite findings and the old bucketing
+    could not distinguish them.
+    """
+    return any(actions.get(lap) in _PIT_ACTIONS for lap in range(low, high + 1))
+
+
+def _pit_decision_lap(actions: dict[int, str], low: int, high: int) -> int | None:
+    """The lap the stack DECIDED to stop on — the first non-pit → pit transition.
+
+    WHY A TRANSITION AND NOT THE FIRST PIT LAP (#752)
+    -------------------------------------------------
+    This used to return the earliest lap in the window carrying a pit action. That
+    reports the window's left edge for any stack that would pit on *every* lap of
+    it, which is not a timing estimate — it is ``window_low`` wearing one.
+
+    Measured before the change, 2025 Monza + Marina_Bay, moving only the eval's own
+    window width:
+
+        window = 5     12 offsets at -5   (the edge)   mean signed -3.08
+        window = 10     0 offsets at -5, 10 at -10     mean signed -5.04
+
+    The mass at -5 does not survive widening; it goes to **zero** and reappears at
+    the new boundary. So the published -2.23 / -3.08 / -5.04 were three readings of
+    the window, not three readings of the model.
+
+    A transition is the smallest thing that is actually a decision: the stack said
+    "stay out" and then said "box". Where no transition exists, this returns None
+    and the caller records ``no_boundary_in_window`` rather than inventing a lap —
+    which is the honest report for a stack that was already committed when the
+    window opened, and the one the old code could not make.
+
+    Requires ``lap - 1`` to have been EVALUATED, not merely absent: an unevaluated
+    predecessor cannot witness a transition, so it is not counted as one. The
+    caller widens the replay span by a lap so ``low`` itself can be judged.
+    """
     for lap in range(low, high + 1):
-        if actions.get(lap) in _PIT_ACTIONS:
+        if actions.get(lap) not in _PIT_ACTIONS:
+            continue
+        previous = actions.get(lap - 1)
+        if previous is not None and previous not in _PIT_ACTIONS:
             return lap
     return None
 
@@ -407,7 +462,11 @@ def measure_decision_agreement(
             # One replay pass per (race, driver) spanning the union of the windows.
             # Two stops twenty laps apart still cost one pass, which is where the
             # runtime budget for a stratified subset comes from.
-            low = max(1, min(stop_laps) - DECISION_WINDOW_LAPS)
+            # One lap BEFORE the earliest window, so `window_low` itself can be
+            # judged: a transition into a pit action needs its predecessor to have
+            # been evaluated, and without this the first lap of every window would
+            # be permanently unjudgeable (#752). One extra lap per (race, driver).
+            low = max(1, min(stop_laps) - DECISION_WINDOW_LAPS - 1)
             high = min(total_laps, max(stop_laps) + DECISION_WINDOW_LAPS)
             engine = RaceReplayEngine(str(race_dir), driver, team, interval_seconds=0)
             actions = _decisions_in_window(engine, featured, driver, low, high, risk_tolerance)
@@ -431,11 +490,19 @@ def measure_decision_agreement(
                     )
                     continue
 
-                chosen = _first_pit_lap(actions, window_low, window_high)
+                chosen = _pit_decision_lap(actions, window_low, window_high)
                 if chosen is None:
-                    verdicts.append(
-                        StopVerdict(year, race, driver, stop_lap, None, None, "no_call_in_window")
+                    # Two opposite findings the old bucketing merged into one. "It
+                    # never asked to stop" is the model declining; "it asked on
+                    # every lap, including the first we offered" is the model
+                    # already committed before we started looking, and reporting
+                    # the window edge as its choice is what #752 retired.
+                    unscored = (
+                        "no_boundary_in_window"
+                        if _asks_to_stop(actions, window_low, window_high)
+                        else "no_call_in_window"
                     )
+                    verdicts.append(StopVerdict(year, race, driver, stop_lap, None, None, unscored))
                     continue
 
                 verdicts.append(
@@ -449,6 +516,7 @@ def measure_decision_agreement(
         no_call=sum(1 for v in verdicts if v.bucket == "no_call_in_window"),
         races=races_measured,
         no_data=sum(1 for v in verdicts if v.bucket == "no_data"),
+        no_boundary=sum(1 for v in verdicts if v.bucket == "no_boundary_in_window"),
     )
     return agreement, verdicts
 
@@ -501,6 +569,15 @@ def _render_table(
         "number to watch: the stack looked and declined to stop anywhere near the real",
         "lap. Charging a retirement to the model as a missed call would flatter neither",
         "side honestly, so the two are never merged.",
+        "",
+        "`no_boundary_in_window` is the third case and it is the one this tier used to",
+        "get wrong (#752). The stack asked to stop on every lap offered, including the",
+        "first, so there is no STAY_OUT -> PIT transition to locate: it was already",
+        "committed before the window opened. Scoring it reported the window's left edge",
+        "as the model's choice, which is why the retired `mean_signed_error` moved with",
+        "the window width instead of with the model. A stop here is counted as looked-at",
+        "and left unscored, because the honest statement is that we do not know when it",
+        "would have called the stop, only that it was earlier than we asked.",
         "",
         "### Scope",
         "",

--- a/tests/eval/test_decision_modes.py
+++ b/tests/eval/test_decision_modes.py
@@ -26,7 +26,8 @@ from src.strategy.eval.decision_modes import (
     SAMPLED_RACES,
     DecisionAgreement,
     StopVerdict,
-    _first_pit_lap,
+    _asks_to_stop,
+    _pit_decision_lap,
     _render_table,
     coverage_verdict,
     guard_rail_block,
@@ -37,13 +38,16 @@ ROOT = Path(__file__).parent.parent.parent
 _HAS_RAW = (ROOT / "data" / "raw" / "2024").is_dir()
 
 
-def _agreement(offsets, guard_railed=0, no_call=0, races=6, no_data=0) -> DecisionAgreement:
+def _agreement(
+    offsets, guard_railed=0, no_call=0, races=6, no_data=0, no_boundary=0
+) -> DecisionAgreement:
     return DecisionAgreement(
         offsets=np.array(offsets, dtype=int),
         guard_railed=guard_railed,
         no_call=no_call,
         races=races,
         no_data=no_data,
+        no_boundary=no_boundary,
     )
 
 
@@ -140,22 +144,91 @@ def test_unknown_tyre_life_still_evaluates_the_lap_based_rails():
 
 
 # --- picking the lap the stack would have chosen ---------------------------
+#
+# These used to test `_first_pit_lap`, which returned the earliest pit action in
+# the window. #752 replaced it: that reported the window's LEFT EDGE for any
+# stack already committed when the window opened, so the reported error moved
+# with the window width instead of with the model. The tests below pin the
+# transition semantics, and the width-invariance property they were missing is
+# the last one in this group.
 
 
-def test_first_pit_lap_takes_the_earliest_call():
-    """Two pit calls in the window resolve to the first: that is the decision."""
+def test_the_decision_lap_is_the_transition_not_the_earliest_call():
+    """Two pit calls in the window resolve to the first that FOLLOWS a stay-out."""
     actions = {28: "STAY_OUT", 29: "UNDERCUT", 30: "STAY_OUT", 31: "PIT_NOW"}
-    assert _first_pit_lap(actions, 27, 32) == 29
+    assert _pit_decision_lap(actions, 27, 32) == 29
 
 
-def test_first_pit_lap_returns_none_when_the_stack_never_calls_it():
+def test_no_call_at_all_returns_none():
     """No call in the window is a result, and it must not read as lap zero."""
-    assert _first_pit_lap({lap: "STAY_OUT" for lap in range(27, 33)}, 27, 32) is None
+    assert _pit_decision_lap({lap: "STAY_OUT" for lap in range(27, 33)}, 27, 32) is None
 
 
-def test_first_pit_lap_ignores_calls_outside_the_window():
-    """A pit action two laps past the window is not agreement with this stop."""
-    assert _first_pit_lap({35: "PIT_NOW"}, 27, 32) is None
+def test_a_call_outside_the_window_is_not_agreement_with_this_stop():
+    assert _pit_decision_lap({35: "PIT_NOW"}, 27, 32) is None
+
+
+def test_a_stack_already_committed_has_no_decision_lap():
+    """THE #752 CASE. Pitting on every lap offered is not a choice of lap.
+
+    Lap 26 is the evaluated predecessor and it already says PIT, so no transition
+    exists anywhere in [27, 32]. The old helper returned 27 — the window's edge —
+    and called it the model's chosen lap.
+    """
+    actions = {lap: "PIT_NOW" for lap in range(26, 33)}
+    assert _pit_decision_lap(actions, 27, 32) is None
+    assert _asks_to_stop(actions, 27, 32) is True
+
+
+def test_an_unevaluated_predecessor_cannot_witness_a_transition():
+    """Absent is not the same as stay-out: lap 26 was never asked.
+
+    Conservative on purpose. Treating a missing predecessor as a stay-out would
+    reintroduce the edge report through the back door on the first lap of every
+    window, which is why the caller evaluates one lap before it.
+    """
+    assert _pit_decision_lap({27: "PIT_NOW", 28: "PIT_NOW"}, 27, 32) is None
+
+
+def test_the_decision_lap_does_not_move_when_only_the_window_widens():
+    """The property that was missing, and the whole point of #752.
+
+    Same actions, three window widths. A stack whose transition lies inside all
+    three must report the SAME lap, because the transition is a property of the
+    model and the window is a property of the harness. Under the old helper the
+    answer was 27, 25 and 22 for these three windows — the left edge each time.
+    """
+    actions = {lap: "STAY_OUT" for lap in range(20, 30)}
+    actions.update({lap: "PIT_NOW" for lap in range(30, 38)})
+
+    assert _pit_decision_lap(actions, 27, 32) == 30
+    assert _pit_decision_lap(actions, 25, 35) == 30
+    assert _pit_decision_lap(actions, 22, 37) == 30
+
+
+def test_the_new_bucket_counts_toward_eligible_so_the_share_is_not_inflated():
+    """#752's denominator trap: those stops WERE looked at.
+
+    Leaving `no_boundary` out of `eligible` would shrink the denominator by
+    exactly the stops the old code used to score wrongly, and the coverage share
+    would jump for a reason that is pure bookkeeping.
+    """
+    agreement = _agreement([0, -1, 1], guard_railed=2, no_call=5, no_data=1, no_boundary=9)
+
+    assert agreement.eligible == 3 + 2 + 5 + 1 + 9
+    assert agreement.scored_share == pytest.approx(3 / 20)
+
+
+def test_asks_to_stop_separates_declining_from_being_already_committed():
+    """The two findings the old bucketing merged, and they are opposites."""
+    declined = {lap: "STAY_OUT" for lap in range(27, 33)}
+    committed = {lap: "PIT_NOW" for lap in range(26, 33)}
+
+    assert _asks_to_stop(declined, 27, 32) is False
+    assert _asks_to_stop(committed, 27, 32) is True
+    # Both are unscored, and for opposite reasons.
+    assert _pit_decision_lap(declined, 27, 32) is None
+    assert _pit_decision_lap(committed, 27, 32) is None
 
 
 # --- aggregation -----------------------------------------------------------


### PR DESCRIPTION
Closes #752. PR 1 of 6 in the post-epic plan. **Lands on `dev` and stays there** — no promotion to `main` until the whole plan is done.

## The defect

The tier reported the earliest lap in the window carrying a pit action and called it the model's chosen lap. For any stack already committed when the window opened, that is `window_low` wearing a timing estimate — so the published error moved with the **harness**, not with the model.

Measured before this change on 2025 Monza + Marina_Bay, moving only the eval's own window width and touching no production code:

| | window = 5 | window = 10 |
|---|---|---|
| offsets at −5 | **12** (the edge) | **0** |
| offsets at −10 | — | **10** (the new edge) |
| mean signed | −3.08 | −5.04 |

**The mass at −5 goes to zero when the window widens.** So −2.23 / −3.08 / −5.04 were three readings of the window.

## What replaces it

The chosen lap is now the first **transition** — the lap where the stack stops saying stay-out and starts saying box. That is the smallest thing which is actually a decision.

Where no transition exists, the stop becomes **`no_boundary_in_window`** and is left unscored, because the honest statement is that the call came *earlier than we asked*, not that it came on the lap we happened to start asking.

Two details that carry weight:

- A transition needs its predecessor **evaluated**, not merely absent, so the replay span opens one lap earlier. Without it, the first lap of every window would be permanently unjudgeable and the edge report would return through the back door. One extra lap per (race, driver).
- `no_boundary_in_window` **counts toward `eligible`**. Those stops were looked at; leaving them out would shrink the denominator by exactly the stops the old code scored wrongly, inflating the coverage share for purely bookkeeping reasons.

## Measured on real data

2025 Monza, w=5: **scored 11 → 7**, the four removed becoming `no_boundary_in_window`, and the surviving offsets `[−5, −4, 0, 0, 0, 0, 0]` — **five of seven now exact**.

The property that was missing, checked at two widths on the same race: **6 of the 7 stops scored at both report the same chosen lap.** The two that move are informative rather than mechanical:

- **HAM lap 38** goes `no_boundary` → `scored` (chose 31) because the wider window *reveals* a transition the narrow one could not reach.
- **NOR lap 46** moves 42 → 38 because the model oscillates and both are real transitions.

**Stated precisely, because the issue's acceptance criterion invites overclaiming:** this metric is **not** width-invariant in general, and cannot be — a wider window is a strictly larger observation. What it no longer does is report the boundary as the answer.

## Tests

Eight new hermetic ones: the transition semantics, the already-committed case (the #752 case itself), the unevaluated-predecessor case, the width-invariance property for a transition inside every window, and the denominator trap. **`tests/eval`: 34 passed** (33 hermetic + the data-gated sample guard, which asserts `eligible == len(verdicts)` and would have caught a missed counter).

The module docstring described the old rule and now describes this one — a doc that outlives the code it documents is a defect this repo has paid for before.

## Not in this PR

The committed report is **not** regenerated here. Re-running the six-race sweep is ~30 min of wall clock and belongs with the numbers, not with the mechanism; it goes in the next commit on this branch or its own, once the sweep finishes.
