### PR TITLE
chore(strategy): measure the fresh-tyre reference and refute the pooled one

### DIFF
--- a/documents/audits/MEASURE_744a_tyre_reference.md
+++ b/documents/audits/MEASURE_744a_tyre_reference.md
@@ -1,0 +1,124 @@
+# #744a — what a fresh-tyre reference is actually worth
+
+**Date:** 2026-07-30 · **Issue:** #744 · **Instrument:** `scripts/measure_tyre_reference.py`
+**Sample:** 31,624 laps at tyre life > 3, across 2,343 stints, seasons 2023-24 (training only).
+
+**Result: the artefact #744a asked for should not be built.** A pooled per-compound reference is
+worth **+0.02 s/lap** against doing nothing, on a quantity whose zero point scatters between stints
+with a standard deviation of **5.48 s**. The reference that does work is the one this project
+**already built and reverted** — its refutation does not survive a proper sample.
+
+---
+
+## The harness, and why its numbers can be trusted
+
+Predictions come from the training parquet (`laps_tiredeg.parquet`, which already carries all 42
+features) pushed through the same scaler and the same N09 left-ZERO-pad that
+`TireAgent._build_stint_tensor` applies. Two independent checks say that is the right transform:
+
+1. **`corr(pred, target) = 0.977`** over all 42,920 predicted laps. A transform that had drifted from
+   the model would not reproduce the model's own training target. The script asserts this and raises
+   below 0.90, so the guard is permanent rather than a one-off.
+2. **No feature is a frame aggregate.** AST-scanning the ten `_add_*` builders in `tire_agent.py`
+   for `mean/std/min/max/sum/median/rolling/expanding/cumsum/quantile/var` returns **none** — every
+   feature is row-local, backward-looking, or read from `session_meta`. So slicing a stint's
+   precomputed features gives the same rows that recomputing them over the prefix would, which is
+   what lets this run offline instead of reloading 47 FastF1 sessions.
+
+## The measurement
+
+Four candidates, scored on #744's own two criteria plus a rank correlation. Spearman rather than
+Pearson because the quantity has a heavy tail — see below — and a handful of stints would otherwise
+decide the number.
+
+| reference | non-negative | spearman | pearson | median wear |
+|---|---|---|---|---|
+| `pooled` — one median per compound, **the artefact #744a proposed** | 66.3% | +0.188 | −0.055 | 0.519 |
+| `stint_first` — this stint's prediction on its first lap | 71.2% | +0.269 | +0.084 | 0.514 |
+| `stint_le3` — this stint's median prediction at tyre life ≤ 3, **the reverted design** | **73.0%** | **+0.295** | +0.090 | 0.489 |
+| `none` — the raw level, no reference at all | 65.3% | +0.191 | −0.054 | 0.519 |
+
+Median wear by tyre-life band, which is where every candidate looks fine:
+
+| band | pooled | stint_le3 | none |
+|---|---|---|---|
+| (3, 5] | 0.045 | 0.069 | 0.023 |
+| (5, 10] | 0.284 | 0.284 | 0.245 |
+| (10, 15] | 0.591 | 0.569 | 0.554 |
+| (15, 20] | 0.860 | 0.823 | 0.836 |
+| (20, 25] | 1.021 | 1.029 | 0.992 |
+| (25, 100] | 0.810 | 0.941 | 0.785 |
+
+## Reading it
+
+**The pooled reference does nothing.** Compare its row against `none`: 66.3% vs 65.3% non-negative,
+Spearman +0.188 vs **+0.191** — a hair *worse* — and band medians that differ by 0.02-0.03 s. It is a
+per-compound constant, so by construction it cannot change any ranking within a compound; the only
+thing it can move is the zero crossing, and it moves it by two hundredths of a second.
+
+**The reason is measurable.** `FuelAdjustedDegAbsolute` is defined against *each stint's own*
+baseline lap, and those baselines are not similarly biased:
+
+- the **per-stint median target has std 5.48 s**, with a 1st percentile at **−32.87 s**;
+- pooled, `corr(target, tyre_life) = −0.088` — the degradation signal is **absent** across stints;
+- **within** a stint, the median `corr(target, tyre_life)` is **+0.577**, positive on **73.8%** of the
+  2,194 stints long enough to correlate.
+
+So the signal is entirely within-stint, and the between-stint scatter is **13× the 0.411 s/lap swing**
+#744 wants to capture. No single constant per compound can normalise 2,343 different zero points.
+This is a stronger statement than the one `DESIGN_S3_option_b.md` made: that document assumed the
+per-stint baselines were *similarly* biased slow ("an out-lap or a standing start: cold and slow"), so
+that one pooled shift would correct them all. The data says they scatter over tens of seconds.
+
+**The tail is in the data, not in the model.** Predictions reach −65.3 s/lap; the training *target*
+reaches −65.3 s/lap on the same laps. Those are stints whose baseline lap was run under a Safety Car,
+a red flag, or as an out-lap. This is why Pearson is useless here and why any consumer of the per-lap
+value needs a bound.
+
+**The (25, 100] dip is a population change, not a model failure.** Stints that reach 25+ laps are the
+low-degradation ones — hard compounds in low-deg races — so the band draws from a different
+population than the ones below it. Every candidate dips there, including `none`.
+
+## What this means for the reverted design
+
+`DESIGN_S3_option_b.md` reverted the same-stint reference on **110 laps at one race**: 64.8%
+non-negative, correlation +0.291 against the raw level's +0.369. On 31,624 laps it measures **73.0%
+non-negative and Spearman +0.295 against the raw level's +0.191** — better than the raw level on both
+criteria, and better than the numbers it was reverted on.
+
+Two caveats, stated because the conclusion rests on them:
+
+- **The comparison that reverted it was not like-for-like.** +0.291 was compared against +0.369, but
+  +0.369 was itself measured over those same 110 live laps at one circuit. Pooled over the training
+  seasons the raw level correlates **+0.191**, so the reverted design was never actually behind.
+- **This measurement uses the parquet's precomputed features; the reverted implementation recomputed
+  them from raw laps over a 3-lap frame.** The AST scan above says those must agree, since no feature
+  is a frame aggregate — but the reverted code path was never measured at this scale, so #744b should
+  confirm the live values match before consuming them.
+
+## What #744a should be
+
+Do not commit a pooled per-compound table. There is no `data/tire_reference_v1.json` in this PR, and
+no accessor, because a committed constant is a permanent claim and this one measures as noise.
+
+The instrument stays: `scripts/measure_tyre_reference.py` re-runs the comparison whenever the TCN is
+retrained, and its self-check fails loudly if the transform ever drifts from the model.
+
+**#744b consumes `stint_le3`**, which needs no artefact — it is a second forward pass on the stint's
+own early laps. Its open questions are consumption-side, not measurement-side:
+
+1. the per-lap value needs a bound (the tail reaches ±15 s on real laps after referencing);
+2. 27% of laps still price negative, so the sign convention has to be decided rather than assumed;
+3. `FRESH_GAIN = 0.25` is the same quantity hardcoded and must be replaced, not added to;
+4. both scorers, including the legacy one the backend endpoint runs in production.
+
+## Reproducing
+
+```bash
+uv run python scripts/measure_tyre_reference.py --out /tmp/tyre_ref.json
+```
+
+Needs `data/processed/laps_tiredeg.parquet` and `data/models/tire_degradation/`, so it does not run
+on CI. Runtime ~4 min on CPU.
+
+Related: `DESIGN_S3_option_b.md` · `MEASURE_S3_tyre_channel.md` · `src/strategy/eval/hygiene.py`

--- a/scripts/measure_tyre_reference.py
+++ b/scripts/measure_tyre_reference.py
@@ -1,0 +1,243 @@
+"""Measure what a fresh-tyre reference for the TCN's own predictions is worth.
+
+The tyre channel needs *seconds per lap that staying out costs versus a fresh set*.
+The TCN supplies ``cumulative_deg_s`` — N04's ``FuelAdjustedDegAbsolute``, measured
+against **this stint's own baseline lap**. Turning that level into a cost needs a
+reference for zero, and #744 proposed a pooled per-compound one measured on the
+model's own scale.
+
+This script measures whether that reference is worth building, by scoring three
+candidates against the two criteria #744 set (non-negative on the large majority of
+laps, monotonic by tyre-life band) plus a rank correlation with tyre life:
+
+* ``pooled``      — one median per compound, the artefact #744a proposed
+* ``stint_first`` — the model's prediction on this stint's first lap
+* ``stint_le3``   — the median of this stint's predictions at tyre life <= 3
+
+Training seasons only (2023-24). ``src/strategy/eval/hygiene.py`` documents why a
+constant fitted on the 2025 test season would repeat a leak this project already paid
+for once.
+
+--- WHERE TO CHANGE IF THE MODEL CHANGES ---
+The transform below (bundle scaler, then N09's left-ZERO-pad) mirrors
+``TireAgent._build_stint_tensor``. If that changes, this changes with it, or the
+reference lands on a different scale than the value it is subtracted from — the exact
+defect CLAUDE.md records for 2026-07-27. ``--self-check`` is the guard: it correlates
+predictions against the training target and fails below the threshold.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+from scipy.stats import spearmanr
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.agents.tire_agent import TireDegTCN  # noqa: E402
+
+MODEL_DIR = Path("data/models/tire_degradation")
+LAPS_PATH = Path("data/processed/laps_tiredeg.parquet")
+TRAINING_YEARS = (2023, 2024)
+STINT_KEYS = ["Year", "GP_Name", "DriverNumber", "Stint"]
+TARGET = "FuelAdjustedDegAbsolute"
+
+# The band that stands in for "fresh". N04's baseline is the stint's lowest-tyre-life
+# lap, which is an out-lap or a standing start, so anything tighter than this leaves
+# the reference resting on a single cold lap.
+FRESH_MAX_TYRE_LIFE = 3
+
+# Below this, the transform above no longer reproduces the model and every number the
+# script prints is measuring the harness rather than the reference.
+SELF_CHECK_MIN_CORR = 0.90
+
+TYRE_LIFE_BANDS = [3, 5, 10, 15, 20, 25, 100]
+
+
+def load_bundles() -> dict[str, dict]:
+    """Load one bundle per compound, sharing the file when the routing does.
+
+    Five of the six compounds route to the same global model, so loading per compound
+    key without the cache would instantiate it five times.
+    """
+    routing = json.loads((MODEL_DIR / "routing_config.json").read_text(encoding="utf-8"))
+    by_file: dict[str, dict] = {}
+    by_compound: dict[str, dict] = {}
+    for compound, entry in routing.items():
+        filename = entry["bundle"]
+        if filename not in by_file:
+            bundle = torch.load(MODEL_DIR / filename, map_location="cpu", weights_only=False)
+            model = TireDegTCN(bundle["n_features"], **bundle["model_hparams"])
+            model.load_state_dict(bundle["state_dict"])
+            model.eval()
+            bundle["model"] = model
+            by_file[filename] = bundle
+        by_compound[compound] = by_file[filename]
+    return by_compound
+
+
+def stint_sequences(stint: pd.DataFrame, bundle: dict) -> np.ndarray:
+    """One scaled (window, n_features) sequence per lap, each from that lap's prefix.
+
+    Every feature in the manifest is row-local or backward-looking — verified by
+    AST-scanning the ten ``_add_*`` builders in ``tire_agent`` for frame aggregates —
+    so slicing the stint's precomputed features gives the same rows that recomputing
+    them over the prefix would. That equivalence is what lets this run from the
+    training parquet instead of reloading every FastF1 session.
+    """
+    window = bundle["window"]
+    raw = stint[bundle["feature_names"]].astype(float).fillna(0)
+    scaled = bundle["scaler"].transform(raw)
+
+    sequences = []
+    for length in range(1, len(scaled) + 1):
+        prefix = scaled[:length]
+        if len(prefix) >= window:
+            sequences.append(prefix[-window:])
+            continue
+        # N09's `_pad_or_truncate`, verbatim: zeros, never a tiled first lap (#443).
+        padding = np.zeros((window - len(prefix), prefix.shape[1]), dtype=prefix.dtype)
+        sequences.append(np.concatenate([padding, prefix], axis=0))
+    return np.stack(sequences)
+
+
+def predict_training_stints() -> pd.DataFrame:
+    """Run every training-season stint through its compound's TCN, lap by lap."""
+    laps = pd.read_parquet(LAPS_PATH)
+    training = laps[laps["Year"].isin(TRAINING_YEARS)]
+    bundles = load_bundles()
+
+    rows = []
+    for keys, stint in training.groupby(STINT_KEYS, sort=False):
+        absolute_id = stint["AbsoluteCompoundID"].iloc[0]
+        if pd.isna(absolute_id):
+            continue
+        compound = f"C{int(absolute_id)}"
+        if compound not in bundles:
+            continue
+
+        bundle = bundles[compound]
+        ordered = stint.sort_values("TyreLife")
+        sequences = stint_sequences(ordered, bundle)
+        with torch.no_grad():
+            batch = torch.tensor(sequences, dtype=torch.float32)
+            predictions = bundle["model"](batch).numpy().reshape(-1)
+
+        stint_id = "|".join(str(k) for k in keys)
+        for tyre_life, prediction, target in zip(
+            ordered["TyreLife"].to_numpy(), predictions, ordered[TARGET].to_numpy()
+        ):
+            rows.append((stint_id, compound, float(tyre_life), float(prediction), float(target)))
+
+    return pd.DataFrame(rows, columns=["stint", "compound", "tyre_life", "pred", "target"])
+
+
+def self_check(predictions: pd.DataFrame) -> float:
+    """Correlation against the training target — the guard on the whole harness.
+
+    A transform that no longer reproduces the model still returns numbers, and every
+    reference measured from them would look plausible. This is the one check that
+    fails loudly instead.
+    """
+    correlation = predictions["pred"].corr(predictions["target"])
+    if correlation < SELF_CHECK_MIN_CORR:
+        raise RuntimeError(
+            f"predictions correlate {correlation:.3f} with the training target, below "
+            f"{SELF_CHECK_MIN_CORR}: the tensor transform no longer reproduces the model, "
+            "so every reference below would be measured on the wrong scale"
+        )
+    return correlation
+
+
+def add_candidate_references(predictions: pd.DataFrame) -> pd.DataFrame:
+    """Attach the three candidate references as columns, one per proposal."""
+    scored = predictions.sort_values(["stint", "tyre_life"]).copy()
+    fresh = scored[scored["tyre_life"] <= FRESH_MAX_TYRE_LIFE]
+
+    scored["ref_pooled"] = scored["compound"].map(fresh.groupby("compound")["pred"].median())
+    scored["ref_stint_first"] = scored["stint"].map(scored.groupby("stint")["pred"].first())
+    scored["ref_stint_le3"] = scored["stint"].map(fresh.groupby("stint")["pred"].median())
+    return scored
+
+
+def score_candidate(scored: pd.DataFrame, reference: str | None) -> dict:
+    """The two acceptance criteria plus a rank correlation, for one reference.
+
+    Spearman rather than Pearson because the quantity has a heavy tail — the training
+    target itself reaches -65 s/lap — and a handful of stints whose baseline lap was a
+    Safety Car or an out-lap would otherwise decide the number.
+    """
+    wear = scored["pred"] if reference is None else scored["pred"] - scored[reference]
+    bands = pd.cut(scored["tyre_life"], TYRE_LIFE_BANDS)
+    by_band = wear.groupby(bands, observed=True).median()
+
+    return {
+        "non_negative_pct": round(100 * float((wear >= 0).mean()), 1),
+        "spearman": round(float(spearmanr(wear, scored["tyre_life"]).statistic), 3),
+        "pearson": round(float(wear.corr(scored["tyre_life"])), 3),
+        "median": round(float(wear.median()), 3),
+        "monotonic_bands": bool(by_band.is_monotonic_increasing),
+        "band_medians": {str(k): round(float(v), 3) for k, v in by_band.items()},
+    }
+
+
+def report(results: dict, n_laps: int, correlation: float) -> str:
+    """A copy-pasteable summary, ordered so the baseline reads last."""
+    lines = [
+        f"laps scored: {n_laps}  (tyre life > {FRESH_MAX_TYRE_LIFE}, seasons {TRAINING_YEARS})",
+        f"harness self-check: corr(pred, target) = {correlation:.3f}",
+        "",
+        f"{'reference':<16}{'non-neg':>9}{'spearman':>10}{'pearson':>9}{'monotone':>10}",
+    ]
+    for name, scores in results.items():
+        lines.append(
+            f"{name:<16}{scores['non_negative_pct']:>8.1f}%{scores['spearman']:>10.3f}"
+            f"{scores['pearson']:>9.3f}{str(scores['monotonic_bands']):>10}"
+        )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, help="write the measured scores to this JSON path")
+    args = parser.parse_args()
+
+    predictions = predict_training_stints()
+    correlation = self_check(predictions)
+
+    scored = add_candidate_references(predictions)
+    past_fresh = scored["tyre_life"] > FRESH_MAX_TYRE_LIFE
+    has_stint_reference = scored["ref_stint_le3"].notna()
+    usable = scored[past_fresh & has_stint_reference]
+
+    results = {
+        "pooled": score_candidate(usable, "ref_pooled"),
+        "stint_first": score_candidate(usable, "ref_stint_first"),
+        "stint_le3": score_candidate(usable, "ref_stint_le3"),
+        "none": score_candidate(usable, None),
+    }
+
+    summary = report(results, len(usable), correlation)
+    print(summary)
+
+    if args.out:
+        payload = {
+            "generated_by": "scripts/measure_tyre_reference.py",
+            "years": list(TRAINING_YEARS),
+            "laps_scored": len(usable),
+            "self_check_corr": round(correlation, 4),
+            "fresh_max_tyre_life": FRESH_MAX_TYRE_LIFE,
+            "candidates": results,
+        }
+        args.out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Measures what a fresh-tyre reference for the TCN's predictions is actually worth, and **refutes the artefact #744a asked for**. No table is committed.

Adds `scripts/measure_tyre_reference.py` (the instrument) and `documents/audits/MEASURE_744a_tyre_reference.md` (the finding). No production code changes.

## The measurement

31,624 laps at tyre life > 3, across 2,343 stints, seasons 2023-24 only (`hygiene.py` documents the 2025 contamination).

| reference | non-negative | spearman |
|---|---|---|
| `pooled` — one median per compound, **the proposed artefact** | 66.3% | +0.188 |
| `stint_first` — this stint's prediction on its first lap | 71.2% | +0.269 |
| `stint_le3` — this stint's median at tyre life ≤ 3, **the reverted design** | **73.0%** | **+0.295** |
| `none` — no reference at all | 65.3% | +0.191 |

The pooled reference is a hair *worse* than doing nothing on Spearman and shifts the band medians by 0.02-0.03 s. A per-compound constant cannot change any ranking within a compound.

## Why

`FuelAdjustedDegAbsolute` is defined against **each stint's own** baseline lap, and those baselines are not similarly biased:

- per-stint median target: **std 5.48 s**, 1st percentile **−32.87 s**
- pooled `corr(target, tyre_life)` = **−0.088** — no signal across stints
- **within** a stint, median `corr(target, tyre_life)` = **+0.577**, positive on 73.8% of 2,194 stints

The between-stint scatter is **13× the 0.411 s/lap swing** #744 wants. `DESIGN_S3_option_b.md` assumed those baselines were similarly biased slow, so one pooled shift would correct them all. They scatter over tens of seconds instead.

## The reverted design was never behind

It was reverted on 64.8% / +0.291 measured over **110 laps at one race**, against a raw level quoted at +0.369 **from those same 110 laps**. Pooled over the training seasons the raw level is **+0.191**. The comparison was not like-for-like. At scale the reverted design is the best of the four on both criteria.

## Trust

Two checks say the harness measures the model and not itself:

1. **`corr(pred, target) = 0.977`** over 42,920 laps — and the script *raises* below 0.90, so this is a permanent guard, not a one-off.
2. **No feature is a frame aggregate** — AST-scanning the ten `_add_*` builders in `tire_agent.py` for `mean/std/min/max/sum/median/rolling/expanding/cumsum/quantile/var` returns none. That is what makes slicing the training parquet equivalent to recomputing features over the prefix, and it is why this runs offline instead of reloading 47 FastF1 sessions.

## Out of scope

Consumption. #744b threads `stint_le3` into both scorers — including the legacy one the backend endpoint runs in production — and has to settle a bound for the tail (±15 s on real laps), the sign convention for the 27% of laps that still price negative, and replacing rather than adding to `FRESH_GAIN = 0.25`. It should also confirm the live recomputed features match these, since the reverted code path was never measured at this scale.

## Checks

`ruff check` + `ruff format --check` clean. The script is data-gated (needs `data/processed/` and `data/models/`) so it does not run on CI; it is verified by the 0.977 self-check on a real run.

Refs #744
