### PR TITLE
docs(eval): regenerate the decision report on 2025 with the transition metric

### DIFF
--- a/documents/audits/MEASURE_752_metric_and_sample.md
+++ b/documents/audits/MEASURE_752_metric_and_sample.md
@@ -1,0 +1,88 @@
+# What the metric fix bought, and what moving to 2025 bought, separately
+
+**Date:** 2026-07-30 · **Issues:** #752 (the metric), #757 (the gate follow-up)
+**Instrument:** `f1-eval decision-modes`, plus one off-report run holding the code fixed and
+restoring the old race list.
+
+The committed report changed **two things at once**: the metric became a transition detector
+(#752 + #757) and the sample moved from four training-season races to six 2025 ones. Quoting
+"17.8% -> 43.4%" from those two artefacts would attribute one effect to the other. This is the
+third cell that separates them.
+
+---
+
+## The three measurements
+
+| | stops scored | **exact lap** | within 1 | mean signed | declines (`no_call`) |
+|---|---|---|---|---|---|
+| mixed 2023-25, **retired** metric | 90 of 198 (45.5%) | 17.8% | 25.6% | −3.3 | — |
+| mixed 2023-25, **current** metric | 62 of 198 (31.3%) | **30.6%** | 48.4% | −1.82 | 78 (39.4%) |
+| **2025 only, current metric** | 53 of 178 (29.8%) | **43.4%** | 52.8% | −1.72 | 82 (46.1%) |
+
+The two middle rows share a sample; the two bottom rows share a metric. Row 1 to row 2 is the
+metric alone; row 2 to row 3 is the season alone.
+
+## The metric is worth +12.8 points of exact agreement, and it costs 28 stops
+
+Scoring the transition rather than the first pit lap removes 28 of the 90 stops the retired
+scorer graded, and every one of them was graded by reporting the window's own left edge. What
+remains is a set the tier can actually locate a decision in, and on it exact agreement rises
+17.8% -> 30.6%.
+
+**Both the rate and the count improve, which is rare enough to state explicitly.** Exact
+agreements in absolute number go **16 -> 19 -> 23** across the three rows, while the scored set
+shrinks **90 -> 62 -> 53**. The tier grades fewer stops and gets more of them right, in count,
+not just in share. That is the opposite of the pattern the epic's scorecard had to explain
+earlier, where the exact-agreement rate fell while its count rose because the layer had become
+far less reluctant.
+
+## The season is worth another +12.8 points, and this was NOT the expected direction
+
+Holding the metric fixed and moving four races from 2023-24 to 2025 raises exact agreement
+30.6% -> 43.4%.
+
+**2023 and 2024 are TRAINING seasons for every model in the stack, so the naive expectation is
+that agreement would be higher there, not lower.** It is lower by the same margin the metric fix
+bought. Four of the six races changed only their year (Barcelona, Monaco, Silverstone,
+Marina_Bay); Lusail and Monza were already 2025 in both lists, so this is close to a
+year-only comparison.
+
+**No cause is claimed here.** Plausible ones — a more converged strategic meta in the
+regulation's mature year, less variable weather at those four events in 2025, better-calibrated
+degradation on 2025 car behaviour — are guesses, and this project has a scar from publishing a
+cause that was a guess wearing a fact's clothes. What is established is the magnitude and the
+direction.
+
+## What did not move, which is the consistency check
+
+`no_call_in_window` is decided by `_asks_to_stop`, which neither #752 nor #757 touches, and it
+lands at **78/198 = 39.4%** on the mixed sample and **82/178 = 46.1%** on 2025. Those are the
+two decline figures the epic scorecard already carries, reproduced here by a different code path
+after four PRs. A metric change that had silently moved them would have been a defect.
+
+## The number that must not be quoted
+
+`mean_signed_error` reads −1.82 and −1.72 above and **still moves with the window width**: the
+Fable G1 gate measured −0.33 / −1.29 / −2.50 at w=3/5/10 on one race. The mechanism is no longer
+the harness artefact #752 retired (a wider window now admits more distant, and therefore earlier,
+transitions — a real property of how far back you look), but it is still a property of the eval's
+configuration and not of the system. The report's own table now says so in its Meaning column.
+
+## Coverage is `masked`, deliberately
+
+29.8% of eligible stops are scored, against the 60% gate. The headline 43.4% describes the
+subset where a decision is locatable, and the report says so rather than promoting the figure.
+The 46.1% decline rate is the number to attack next, and it is what #744b exists for.
+
+## Reproducing
+
+```bash
+uv run python -m src.strategy.eval.cli decision-modes          # row 3, writes the report
+```
+
+Row 2 was produced by calling `measure_decision_agreement(races=...)` with the old list; it is
+not a committed configuration, deliberately, because a second committed sample is a second thing
+to keep in sync.
+
+Related: `MEASURE_S5_decision_modes_2025.md` · `FABLE_G1_transition_metric.md` ·
+`documents/eval_reports/decision_modes.md`

--- a/documents/eval_reports/decision_modes.json
+++ b/documents/eval_reports/decision_modes.json
@@ -1,31 +1,31 @@
 {
   "header": {
-    "harness_sha": "1f0ec9d",
+    "harness_sha": "99a663d",
     "dataset": "data/raw laps, stratified 6-race subset (RAW, not featured)",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-30T08:37:07+00:00",
+    "generated_at": "2026-07-31T07:13:39+00:00",
     "artifacts": {}
   },
   "status": "masked",
   "window_laps": 5,
   "sampled_races": [
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Monaco"
     },
     {
-      "year": 2024,
+      "year": 2025,
       "race": "Silverstone"
     },
     {
-      "year": 2024,
+      "year": 2025,
       "race": "Marina_Bay"
     },
     {
@@ -38,1391 +38,1211 @@
     }
   ],
   "agreement": {
-    "sample_size": 90,
-    "eligible": 198,
-    "scored_share": 0.45454545454545453,
+    "sample_size": 53,
+    "eligible": 178,
+    "scored_share": 0.29775280898876405,
     "races": 6,
-    "exact": 0.17777777777777778,
-    "within_one": 0.25555555555555554,
-    "within_two": 0.35555555555555557,
-    "mean_signed_error": -3.3,
-    "mean_absolute_error": 3.3
+    "exact": 0.4339622641509434,
+    "within_one": 0.5283018867924528,
+    "within_two": 0.6226415094339622,
+    "mean_signed_error": -1.7169811320754718,
+    "mean_absolute_error": 1.8679245283018868
   },
   "buckets": {
     "closing_laps": 4,
-    "min_stint": 22,
-    "no_call_in_window": 78,
-    "opening_laps": 4,
-    "scored": 90
+    "min_stint": 17,
+    "no_boundary_in_window": 22,
+    "no_call_in_window": 82,
+    "scored": 53
   },
   "verdicts": [
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
       "driver": "VER",
-      "actual_lap": 26,
+      "actual_lap": 13,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "bucket": "no_boundary_in_window"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
       "driver": "VER",
-      "actual_lap": 52,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "GAS",
-      "actual_lap": 19,
-      "chosen_lap": 15,
-      "offset_laps": -4,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "GAS",
-      "actual_lap": 39,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "PER",
-      "actual_lap": 27,
+      "actual_lap": 29,
       "chosen_lap": 27,
-      "offset_laps": 0,
+      "offset_laps": -2,
       "bucket": "scored"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "PER",
-      "actual_lap": 50,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "ALO",
-      "actual_lap": 19,
-      "chosen_lap": 14,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "ALO",
-      "actual_lap": 44,
-      "chosen_lap": 39,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "LEC",
-      "actual_lap": 16,
-      "chosen_lap": 15,
+      "driver": "VER",
+      "actual_lap": 47,
+      "chosen_lap": 46,
       "offset_laps": -1,
       "bucket": "scored"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "LEC",
-      "actual_lap": 41,
+      "driver": "GAS",
+      "actual_lap": 10,
+      "chosen_lap": 6,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "GAS",
+      "actual_lap": 31,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "bucket": "no_boundary_in_window"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "STR",
-      "actual_lap": 14,
-      "chosen_lap": 9,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "STR",
-      "actual_lap": 34,
-      "chosen_lap": 29,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "SAR",
-      "actual_lap": 17,
-      "chosen_lap": 15,
-      "offset_laps": -2,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "SAR",
-      "actual_lap": 36,
-      "chosen_lap": 36,
+      "driver": "ANT",
+      "actual_lap": 21,
+      "chosen_lap": 21,
       "offset_laps": 0,
       "bucket": "scored"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "MAG",
-      "actual_lap": 10,
-      "chosen_lap": 8,
-      "offset_laps": -2,
+      "driver": "ANT",
+      "actual_lap": 49,
+      "chosen_lap": 49,
+      "offset_laps": 0,
       "bucket": "scored"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "MAG",
-      "actual_lap": 24,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "driver": "ALO",
+      "actual_lap": 15,
+      "chosen_lap": 11,
+      "offset_laps": -4,
+      "bucket": "scored"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "MAG",
+      "driver": "ALO",
       "actual_lap": 42,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "DEV",
-      "actual_lap": 9,
-      "chosen_lap": 9,
-      "offset_laps": 0,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "DEV",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "TSU",
-      "actual_lap": 10,
-      "chosen_lap": 8,
-      "offset_laps": -2,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "TSU",
-      "actual_lap": 34,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "ALB",
-      "actual_lap": 16,
-      "chosen_lap": 11,
+      "driver": "LEC",
+      "actual_lap": 17,
+      "chosen_lap": 12,
       "offset_laps": -5,
       "bucket": "scored"
     },
     {
-      "year": 2023,
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "LEC",
+      "actual_lap": 40,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "TSU",
+      "actual_lap": 8,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "TSU",
+      "actual_lap": 24,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "TSU",
+      "actual_lap": 44,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
       "race": "Barcelona",
       "driver": "ALB",
-      "actual_lap": 37,
-      "chosen_lap": 37,
-      "offset_laps": 0,
+      "actual_lap": 6,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "ALB",
+      "actual_lap": 26,
+      "chosen_lap": 23,
+      "offset_laps": -3,
       "bucket": "scored"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "ZHO",
+      "driver": "ALB",
+      "actual_lap": 27,
+      "chosen_lap": 23,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "HUL",
       "actual_lap": 9,
       "chosen_lap": 8,
       "offset_laps": -1,
       "bucket": "scored"
     },
     {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "ZHO",
-      "actual_lap": 36,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
       "driver": "HUL",
-      "actual_lap": 8,
-      "chosen_lap": 5,
-      "offset_laps": -3,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "HUL",
-      "actual_lap": 26,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "HUL",
-      "actual_lap": 43,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "OCO",
-      "actual_lap": 13,
-      "chosen_lap": 8,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "OCO",
-      "actual_lap": 35,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "NOR",
-      "actual_lap": 1,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "opening_laps"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "NOR",
-      "actual_lap": 22,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "NOR",
-      "actual_lap": 50,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "HAM",
-      "actual_lap": 24,
-      "chosen_lap": 22,
-      "offset_laps": -2,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "HAM",
-      "actual_lap": 50,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "SAI",
-      "actual_lap": 15,
-      "chosen_lap": 12,
-      "offset_laps": -3,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "SAI",
-      "actual_lap": 41,
-      "chosen_lap": 41,
-      "offset_laps": 0,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "RUS",
-      "actual_lap": 25,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "RUS",
       "actual_lap": 45,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "BOT",
-      "actual_lap": 5,
+      "driver": "LAW",
+      "actual_lap": 18,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "min_stint"
+      "bucket": "no_boundary_in_window"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "BOT",
+      "driver": "LAW",
+      "actual_lap": 44,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "OCO",
+      "actual_lap": 20,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "OCO",
+      "actual_lap": 43,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "NOR",
+      "actual_lap": 21,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "NOR",
+      "actual_lap": 48,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "COL",
+      "actual_lap": 14,
+      "chosen_lap": 9,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "COL",
       "actual_lap": 39,
       "chosen_lap": 37,
       "offset_laps": -2,
       "bucket": "scored"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "PIA",
-      "actual_lap": 17,
-      "chosen_lap": 12,
-      "offset_laps": -5,
-      "bucket": "scored"
+      "driver": "HAM",
+      "actual_lap": 16,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "PIA",
-      "actual_lap": 39,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "VER",
-      "actual_lap": 55,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "GAS",
-      "actual_lap": 47,
-      "chosen_lap": 43,
-      "offset_laps": -4,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "GAS",
-      "actual_lap": 54,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "PER",
-      "actual_lap": 1,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "opening_laps"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "PER",
-      "actual_lap": 34,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "PER",
-      "actual_lap": 53,
-      "chosen_lap": 53,
-      "offset_laps": 0,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "PER",
-      "actual_lap": 57,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "PER",
-      "actual_lap": 70,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "ALO",
-      "actual_lap": 54,
-      "chosen_lap": 54,
-      "offset_laps": 0,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "ALO",
-      "actual_lap": 55,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "LEC",
-      "actual_lap": 44,
-      "chosen_lap": 39,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "LEC",
-      "actual_lap": 55,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "STR",
-      "actual_lap": 51,
-      "chosen_lap": 46,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "SAR",
-      "actual_lap": 20,
-      "chosen_lap": 17,
-      "offset_laps": -3,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "SAR",
-      "actual_lap": 23,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "SAR",
-      "actual_lap": 52,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "MAG",
-      "actual_lap": 56,
-      "chosen_lap": 51,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "MAG",
-      "actual_lap": 71,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "DEV",
-      "actual_lap": 53,
-      "chosen_lap": 48,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "TSU",
-      "actual_lap": 53,
-      "chosen_lap": 51,
-      "offset_laps": -2,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "ALB",
-      "actual_lap": 18,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "ALB",
-      "actual_lap": 52,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "ZHO",
-      "actual_lap": 1,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "opening_laps"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "ZHO",
-      "actual_lap": 52,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "HUL",
-      "actual_lap": 1,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "opening_laps"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "HUL",
-      "actual_lap": 54,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "HUL",
-      "actual_lap": 59,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "OCO",
-      "actual_lap": 32,
-      "chosen_lap": 31,
-      "offset_laps": -1,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "OCO",
-      "actual_lap": 54,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "NOR",
-      "actual_lap": 50,
-      "chosen_lap": 47,
-      "offset_laps": -3,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "NOR",
-      "actual_lap": 54,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
       "driver": "HAM",
-      "actual_lap": 31,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "HAM",
-      "actual_lap": 54,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "SAI",
-      "actual_lap": 33,
-      "chosen_lap": 29,
-      "offset_laps": -4,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "SAI",
-      "actual_lap": 55,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "RUS",
-      "actual_lap": 54,
-      "chosen_lap": 49,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "BOT",
-      "actual_lap": 51,
-      "chosen_lap": 46,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "PIA",
-      "actual_lap": 54,
-      "chosen_lap": 49,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "VER",
-      "actual_lap": 26,
-      "chosen_lap": 21,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "VER",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "PER",
-      "actual_lap": 19,
-      "chosen_lap": 15,
-      "offset_laps": -4,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "PER",
-      "actual_lap": 28,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "PER",
-      "actual_lap": 37,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "PER",
-      "actual_lap": 47,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "ALO",
-      "actual_lap": 27,
-      "chosen_lap": 22,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "ALO",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "LEC",
-      "actual_lap": 19,
-      "chosen_lap": 17,
-      "offset_laps": -2,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "LEC",
-      "actual_lap": 27,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "LEC",
-      "actual_lap": 37,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "STR",
-      "actual_lap": 26,
-      "chosen_lap": 21,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "STR",
-      "actual_lap": 39,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "SAR",
-      "actual_lap": 27,
-      "chosen_lap": 22,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "SAR",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "MAG",
-      "actual_lap": 27,
-      "chosen_lap": 22,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "MAG",
-      "actual_lap": 37,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "TSU",
-      "actual_lap": 27,
-      "chosen_lap": 22,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "TSU",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "ALB",
-      "actual_lap": 27,
-      "chosen_lap": 22,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "ALB",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "ZHO",
-      "actual_lap": 12,
-      "chosen_lap": 8,
-      "offset_laps": -4,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "ZHO",
-      "actual_lap": 19,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "ZHO",
-      "actual_lap": 26,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "ZHO",
-      "actual_lap": 37,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "HUL",
-      "actual_lap": 26,
-      "chosen_lap": 21,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "HUL",
-      "actual_lap": 39,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "RIC",
-      "actual_lap": 26,
-      "chosen_lap": 21,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "RIC",
-      "actual_lap": 37,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "OCO",
-      "actual_lap": 19,
-      "chosen_lap": 14,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "OCO",
-      "actual_lap": 21,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "OCO",
-      "actual_lap": 26,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "OCO",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "NOR",
-      "actual_lap": 27,
-      "chosen_lap": 22,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "NOR",
-      "actual_lap": 39,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "HAM",
-      "actual_lap": 27,
-      "chosen_lap": 22,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "HAM",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "SAI",
-      "actual_lap": 26,
-      "chosen_lap": 21,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "SAI",
-      "actual_lap": 39,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "SAI",
-      "actual_lap": 50,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "closing_laps"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "RUS",
-      "actual_lap": 27,
-      "chosen_lap": 22,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "RUS",
-      "actual_lap": 33,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "BOT",
-      "actual_lap": 26,
-      "chosen_lap": 22,
-      "offset_laps": -4,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "BOT",
-      "actual_lap": 37,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "PIA",
-      "actual_lap": 28,
-      "chosen_lap": 23,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "PIA",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "VER",
-      "actual_lap": 29,
-      "chosen_lap": 29,
-      "offset_laps": 0,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "GAS",
-      "actual_lap": 37,
-      "chosen_lap": 32,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "PER",
-      "actual_lap": 28,
-      "chosen_lap": 23,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "ALO",
-      "actual_lap": 25,
-      "chosen_lap": 21,
-      "offset_laps": -4,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "LEC",
-      "actual_lap": 36,
-      "chosen_lap": 31,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "STR",
-      "actual_lap": 26,
-      "chosen_lap": 22,
-      "offset_laps": -4,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "MAG",
-      "actual_lap": 28,
-      "chosen_lap": 26,
-      "offset_laps": -2,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "MAG",
-      "actual_lap": 49,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "MAG",
-      "actual_lap": 57,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "TSU",
-      "actual_lap": 33,
-      "chosen_lap": 28,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "ALB",
-      "actual_lap": 11,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "ALB",
-      "actual_lap": 15,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "ZHO",
-      "actual_lap": 34,
-      "chosen_lap": 29,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "HUL",
-      "actual_lap": 29,
-      "chosen_lap": 28,
-      "offset_laps": -1,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "RIC",
-      "actual_lap": 10,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "RIC",
       "actual_lap": 46,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "RIC",
-      "actual_lap": 58,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "OCO",
-      "actual_lap": 29,
-      "chosen_lap": 27,
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "BOR",
+      "actual_lap": 19,
+      "chosen_lap": 17,
       "offset_laps": -2,
       "bucket": "scored"
     },
     {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "NOR",
-      "actual_lap": 30,
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "BOR",
+      "actual_lap": 49,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "COL",
-      "actual_lap": 29,
-      "chosen_lap": 24,
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "SAI",
+      "actual_lap": 9,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "SAI",
+      "actual_lap": 34,
+      "chosen_lap": 34,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "HAD",
+      "actual_lap": 19,
+      "chosen_lap": 19,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "HAD",
+      "actual_lap": 48,
+      "chosen_lap": 47,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "RUS",
+      "actual_lap": 20,
+      "chosen_lap": 17,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "RUS",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "PIA",
+      "actual_lap": 22,
+      "chosen_lap": 22,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "PIA",
+      "actual_lap": 49,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "BEA",
+      "actual_lap": 8,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "BEA",
+      "actual_lap": 35,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "VER",
+      "actual_lap": 28,
+      "chosen_lap": 27,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "VER",
+      "actual_lap": 77,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "closing_laps"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "GAS",
+      "actual_lap": 8,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "ANT",
+      "actual_lap": 69,
+      "chosen_lap": 64,
       "offset_laps": -5,
       "bucket": "scored"
     },
     {
-      "year": 2024,
-      "race": "Marina_Bay",
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "ANT",
+      "actual_lap": 71,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "ALO",
+      "actual_lap": 16,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "LEC",
+      "actual_lap": 22,
+      "chosen_lap": 22,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "LEC",
+      "actual_lap": 49,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "STR",
+      "actual_lap": 17,
+      "chosen_lap": 14,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "STR",
+      "actual_lap": 64,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "TSU",
+      "actual_lap": 73,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "ALB",
+      "actual_lap": 32,
+      "chosen_lap": 36,
+      "offset_laps": 4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "ALB",
+      "actual_lap": 40,
+      "chosen_lap": 36,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "HUL",
+      "actual_lap": 12,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "HUL",
+      "actual_lap": 44,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "LAW",
+      "actual_lap": 31,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "LAW",
+      "actual_lap": 40,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "OCO",
+      "actual_lap": 16,
+      "chosen_lap": 12,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "OCO",
+      "actual_lap": 28,
+      "chosen_lap": 24,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "NOR",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "NOR",
+      "actual_lap": 50,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "COL",
+      "actual_lap": 13,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "COL",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
       "driver": "HAM",
+      "actual_lap": 18,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "HAM",
+      "actual_lap": 56,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "BOR",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "BOR",
+      "actual_lap": 35,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "SAI",
+      "actual_lap": 48,
+      "chosen_lap": 44,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "SAI",
+      "actual_lap": 53,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "HAD",
+      "actual_lap": 14,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "HAD",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "RUS",
+      "actual_lap": 53,
+      "chosen_lap": 49,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "RUS",
+      "actual_lap": 62,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "RUS",
+      "actual_lap": 68,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "PIA",
+      "actual_lap": 20,
+      "chosen_lap": 15,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "PIA",
+      "actual_lap": 48,
+      "chosen_lap": 48,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "BEA",
       "actual_lap": 17,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
-      "year": 2024,
-      "race": "Marina_Bay",
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "VER",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "VER",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "GAS",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "GAS",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "ANT",
+      "actual_lap": 9,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "ANT",
+      "actual_lap": 23,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "ALO",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "ALO",
+      "actual_lap": 37,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "LEC",
+      "actual_lap": 10,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "LEC",
+      "actual_lap": 42,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "STR",
+      "actual_lap": 10,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "STR",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "TSU",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "TSU",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "ALB",
+      "actual_lap": 42,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "HUL",
+      "actual_lap": 9,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "HUL",
+      "actual_lap": 42,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "OCO",
+      "actual_lap": 42,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "NOR",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "NOR",
+      "actual_lap": 44,
+      "chosen_lap": 39,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "HAM",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "HAM",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
       "driver": "SAI",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "SAI",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "HAD",
+      "actual_lap": 10,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "RUS",
+      "actual_lap": 10,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "RUS",
+      "actual_lap": 38,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "PIA",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "PIA",
+      "actual_lap": 43,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "BEA",
+      "actual_lap": 10,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "BEA",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "VER",
+      "actual_lap": 19,
+      "chosen_lap": 19,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "GAS",
+      "actual_lap": 24,
+      "chosen_lap": 24,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "GAS",
+      "actual_lap": 51,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "ANT",
+      "actual_lap": 25,
+      "chosen_lap": 25,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "ALO",
+      "actual_lap": 27,
+      "chosen_lap": 27,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "LEC",
+      "actual_lap": 21,
+      "chosen_lap": 21,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "STR",
+      "actual_lap": 38,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "TSU",
       "actual_lap": 13,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
-      "year": 2024,
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "ALB",
+      "actual_lap": 42,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "HUL",
+      "actual_lap": 25,
+      "chosen_lap": 23,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "HUL",
+      "actual_lap": 44,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "LAW",
+      "actual_lap": 48,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "OCO",
+      "actual_lap": 30,
+      "chosen_lap": 30,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "NOR",
+      "actual_lap": 26,
+      "chosen_lap": 26,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "COL",
+      "actual_lap": 14,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "HAM",
+      "actual_lap": 24,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "HAM",
+      "actual_lap": 46,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "BOR",
+      "actual_lap": 13,
+      "chosen_lap": 13,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "SAI",
+      "actual_lap": 50,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "HAD",
+      "actual_lap": 20,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
       "race": "Marina_Bay",
       "driver": "RUS",
-      "actual_lap": 27,
-      "chosen_lap": 26,
-      "offset_laps": -1,
-      "bucket": "scored"
+      "actual_lap": 25,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "BOT",
-      "actual_lap": 33,
-      "chosen_lap": 29,
-      "offset_laps": -4,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
+      "year": 2025,
       "race": "Marina_Bay",
       "driver": "PIA",
-      "actual_lap": 38,
-      "chosen_lap": 37,
-      "offset_laps": -1,
+      "actual_lap": 27,
+      "chosen_lap": 25,
+      "offset_laps": -2,
       "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "BEA",
+      "actual_lap": 23,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -1483,9 +1303,9 @@
       "race": "Lusail",
       "driver": "STR",
       "actual_lap": 49,
-      "chosen_lap": 44,
-      "offset_laps": -5,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -1501,9 +1321,9 @@
       "race": "Lusail",
       "driver": "TSU",
       "actual_lap": 32,
-      "chosen_lap": 27,
-      "offset_laps": -5,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -1573,9 +1393,9 @@
       "race": "Lusail",
       "driver": "BOR",
       "actual_lap": 32,
-      "chosen_lap": 27,
-      "offset_laps": -5,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -1672,9 +1492,9 @@
       "race": "Monza",
       "driver": "GAS",
       "actual_lap": 49,
-      "chosen_lap": 44,
-      "offset_laps": -5,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -1717,9 +1537,9 @@
       "race": "Monza",
       "driver": "STR",
       "actual_lap": 49,
-      "chosen_lap": 44,
-      "offset_laps": -5,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -1780,9 +1600,9 @@
       "race": "Monza",
       "driver": "HAM",
       "actual_lap": 38,
-      "chosen_lap": 33,
-      "offset_laps": -5,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -1825,9 +1645,9 @@
       "race": "Monza",
       "driver": "PIA",
       "actual_lap": 45,
-      "chosen_lap": 40,
-      "offset_laps": -5,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,

--- a/documents/eval_reports/decision_modes.md
+++ b/documents/eval_reports/decision_modes.md
@@ -1,17 +1,17 @@
 # decision_modes
 
-- harness `1f0ec9d` · schema v1 · generated 2026-07-30T08:37:07+00:00
+- harness `99a663d` · schema v1 · generated 2026-07-31T07:13:39+00:00
 - era 2022-2025 · dataset data/raw laps, stratified 6-race subset (RAW, not featured) · seed deterministic · llm none
 - artifacts: —
 
 | Metric | Value | Meaning |
 | --- | --- | --- |
-| Stops scored | 90 of 198 (45.5%) | real green-flag stops the tier could grade |
-| Exact lap | 17.8% | chose the lap the team chose |
-| Within 1 lap | 25.6% | same call, one lap either side |
-| Within 2 laps | 35.6% | same strategic window |
-| Mean signed error | -3.30 laps | negative = stops earlier than the team |
-| Mean absolute error | 3.30 laps | magnitude |
+| Stops scored | 53 of 178 (29.8%) | real green-flag stops the tier could grade |
+| Exact lap | 43.4% | chose the lap the team chose |
+| Within 1 lap | 52.8% | same call, one lap either side |
+| Within 2 laps | 62.3% | same strategic window |
+| Mean signed error | -1.72 laps | negative = earlier than the team. **Do not quote as a system property** — still moves with `DECISION_WINDOW_LAPS` (measured -0.33 / -1.29 / -2.50 at w=3/5/10 on one race), because a wider window admits more distant, and therefore earlier, transitions |
+| Mean absolute error | 1.87 laps | magnitude, same width caveat |
 | Coverage verdict | **masked** | `masked` when under 60% of eligible stops were scored |
 
 ### Buckets
@@ -19,10 +19,10 @@
 | Bucket | Stops |
 | --- | --- |
 | `closing_laps` | 4 |
-| `min_stint` | 22 |
-| `no_call_in_window` | 78 |
-| `opening_laps` | 4 |
-| `scored` | 90 |
+| `min_stint` | 17 |
+| `no_boundary_in_window` | 22 |
+| `no_call_in_window` | 82 |
+| `scored` | 53 |
 
 `opening_laps` / `closing_laps` / `min_stint` are stops the guard rails make
 impossible to agree with, so they are excluded from the headline rather than
@@ -32,9 +32,34 @@ number to watch: the stack looked and declined to stop anywhere near the real
 lap. Charging a retirement to the model as a missed call would flatter neither
 side honestly, so the two are never merged.
 
+`no_boundary_in_window` is the third case and it is the one this tier used to
+get wrong (#752). It means only this: the stack asked to stop somewhere in the
+window, but no STAY_OUT -> PIT transition could be located inside it. Read it
+as **no locatable decision**, never as a description of what the stack did.
+Three different shapes land here and they are not the same finding:
+
+- already asking when the window opened, and still asking on every lap;
+- already asking when the window opened, then **withdrawing** later - on the
+  measured 2025 Monza sample this was 4 of 4 occupants, one of them flipping to
+  STAY_OUT on the exact lap the team really stopped;
+- a lap inside the window that was never evaluated, so the only pit ask has no
+  witness for its predecessor.
+
+What they share is that the earliest pit ask has no evaluated non-pit lap before
+it, so any lap reported would be the window's left edge rather than the model's
+choice - which is why `mean_signed_error` used to move with the window width
+instead of with the model. A stop here is counted as looked-at and left unscored.
+The same applies at the opening guard rail: a transition on lap
+5 or earlier is the rail releasing, not the model deciding,
+so it is bucketed here too.
+
 ### Scope
 
-- Sampled races (6 measured): 2023 Barcelona, 2023 Monaco, 2024 Silverstone, 2024 Marina_Bay, 2025 Lusail, 2025 Monza.
+- Sampled races (6 measured): 2025 Barcelona, 2025 Monaco, 2025 Silverstone, 2025 Marina_Bay, 2025 Lusail, 2025 Monza.
+- **All six are 2025, deliberately.** 2023 and 2024 are training seasons for
+  every model in the stack, so a decision tier scored there is partly reading
+  back its own training data. An earlier version of this list took four of its
+  six races from those seasons; the archetypes are unchanged, only the year.
 - A full sweep of the real-stop sample is roughly 11.5 h of wall clock at
   0.51 s per lap through the stack, so this is a stratified subset by circuit
   archetype and **not** full coverage. Read every figure above as conditional

--- a/src/strategy/eval/decision_modes.py
+++ b/src/strategy/eval/decision_modes.py
@@ -103,11 +103,18 @@ DECISION_WINDOW_LAPS = 5
 # track position dominates, one low-downforce low-stop circuit and one fast circuit
 # with variable weather. Widening this is a runtime decision, not a correctness one —
 # but the report must keep saying which races it used.
+#
+# ALL SIX ARE 2025, AND THAT IS THE CORRECTNESS HALF. The first version of this list
+# took four of its six races from 2023-24, which are TRAINING seasons for every model
+# in the stack. A decision tier scored there is partly reading back its own training
+# data, and the whole point of this report is what the shipped system does on the
+# season it actually infers on. The archetypes are unchanged; only the year moved, so
+# the stratification argument above still holds.
 SAMPLED_RACES: tuple[tuple[int, str], ...] = (
-    (2023, "Barcelona"),  # conventional, high degradation
-    (2023, "Monaco"),  # street, track position is everything
-    (2024, "Silverstone"),  # fast, weather-variable
-    (2024, "Marina_Bay"),  # street, high degradation
+    (2025, "Barcelona"),  # conventional, high degradation
+    (2025, "Monaco"),  # street, track position is everything
+    (2025, "Silverstone"),  # fast, weather-variable
+    (2025, "Marina_Bay"),  # street, high degradation
     (2025, "Lusail"),  # high degradation, stint-limited history
     (2025, "Monza"),  # low downforce, fewest stops
 )
@@ -594,8 +601,12 @@ def _render_table(
         f"| Within 1 lap | {agreement.within_one:.1%} | same call, one lap either side |",
         f"| Within 2 laps | {agreement.within_two:.1%} | same strategic window |",
         f"| Mean signed error | {agreement.mean_signed_error:+.2f} laps | "
-        "negative = stops earlier than the team |",
-        f"| Mean absolute error | {agreement.mean_absolute_error:.2f} laps | magnitude |",
+        "negative = earlier than the team. **Do not quote as a system property** "
+        f"— still moves with `DECISION_WINDOW_LAPS` (measured -0.33 / -1.29 / -2.50 "
+        "at w=3/5/10 on one race), because a wider window admits more distant, and "
+        "therefore earlier, transitions |",
+        f"| Mean absolute error | {agreement.mean_absolute_error:.2f} laps | magnitude, "
+        "same width caveat |",
         f"| Coverage verdict | **{status}** | `masked` when under "
         f"{MIN_SCORED_SHARE:.0%} of eligible stops were scored |",
         "",
@@ -630,7 +641,7 @@ def _render_table(
         "",
         "What they share is that the earliest pit ask has no evaluated non-pit lap before",
         "it, so any lap reported would be the window's left edge rather than the model's",
-        "choice - which is why the retired `mean_signed_error` moved with the window width",
+        "choice - which is why `mean_signed_error` used to move with the window width",
         "instead of with the model. A stop here is counted as looked-at and left unscored.",
         "The same applies at the opening guard rail: a transition on lap",
         f"{_NO_PIT_BEFORE_LAP} or earlier is the rail releasing, not the model deciding,",
@@ -639,6 +650,10 @@ def _render_table(
         "### Scope",
         "",
         f"- Sampled races ({agreement.races} measured): {races}.",
+        "- **All six are 2025, deliberately.** 2023 and 2024 are training seasons for",
+        "  every model in the stack, so a decision tier scored there is partly reading",
+        "  back its own training data. An earlier version of this list took four of its",
+        "  six races from those seasons; the archetypes are unchanged, only the year.",
         "- A full sweep of the real-stop sample is roughly 11.5 h of wall clock at",
         "  0.51 s per lap through the stack, so this is a stratified subset by circuit",
         "  archetype and **not** full coverage. Read every figure above as conditional",


### PR DESCRIPTION
Refs #752, #757

Closes #752's last acceptance criterion and the **F1 finding of gate G1**: the committed report was still publishing numbers from the retired scorer, in the artefact position a reader trusts most.

## The sample moves to 2025, and that is a correctness change

The old list took **four of its six races from 2023-24 — training seasons for every model in the stack**, so the decision tier was partly being scored against its own training data. The archetypes are unchanged; only the year moved, on four of six. That reason existed nowhere in the repo and is now next to the list and in the report's Scope section.

## The report

| | now | was |
|---|---|---|
| Stops scored | 53 of 178 (29.8%) | 90 of 198 (45.5%) |
| **Exact lap** | **43.4%** | 17.8% |
| Within 1 lap | 52.8% | 25.6% |
| Coverage verdict | `masked` | `masked` |
| `no_call_in_window` | 82 (46.1%) | — |
| `no_boundary_in_window` | 22 | — |

**Do not read those two columns as a before/after.** Two things changed between them. The third cell that separates them is in `documents/audits/MEASURE_752_metric_and_sample.md`:

| | scored | exact | declines |
|---|---|---|---|
| mixed 2023-25, retired metric | 90/198 (45.5%) | 17.8% | — |
| mixed 2023-25, **current** metric | 62/198 (31.3%) | **30.6%** | 39.4% |
| **2025 only, current metric** | 53/178 (29.8%) | **43.4%** | 46.1% |

The metric is worth **+12.8 points**, the season another **+12.8**. And both the rate and the count improve: exact agreements go **16 → 19 → 23** while the scored set shrinks **90 → 62 → 53** — fewer stops graded, more of them right in absolute number.

The season effect is **not** the direction a training season predicts. No cause is claimed for it; four of six races changed only their year, and that is all that is established.

## The consistency check that makes the rest trustworthy

`no_call_in_window` is decided by `_asks_to_stop`, which neither #752 nor #757 touches. It reproduced at **39.4%** and **46.1%** after four PRs by a different code path — the two decline figures the epic already carried. A metric change that had silently moved them would have been a defect.

And the report **reproduced exactly on a second run a day later** — same 53/178, same 43.4%, same buckets. That is what #740 bought and it is what makes any of this quotable.

## Two self-contradictions fixed

- The table published `mean_signed_error` with a clean Meaning while the prose three paragraphs below called it retired. The Meaning column now says **do not quote it as a system property** and why: gate G1 measured **−0.33 / −1.29 / −2.50 at w=3/5/10**. The mechanism is no longer the harness artefact #752 retired — a wider window admits more distant, and therefore earlier, transitions — but it remains a property of the eval's configuration.
- `no_boundary_in_window`'s prose claimed the stack "asked to stop on every lap offered". Measured false for 4 of 4 real occupants (#758); it now names all three shapes that land there without claiming any universally.

## Scope

Coverage is `masked` at 29.8% against the 60% gate, deliberately: 43.4% describes the subset where a decision is locatable, and the report says so rather than promoting the figure. **The 46.1% decline rate is the number to attack next, and that is #744b.**

## Checks

`ruff check` + `ruff format --check` clean; 37 hermetic and 84 across `tests/eval` on the code this report was generated from (#758). The report itself is a generated artefact — the check that matters is that it reproduced.
