### PR TITLE
feat(mc): charge measured tyre wear in both scorers, replacing the flat fresh credit

### DIFF
--- a/scripts/measure_tyre_reference.py
+++ b/scripts/measure_tyre_reference.py
@@ -13,6 +13,10 @@ laps, monotonic by tyre-life band) plus a rank correlation with tyre life:
 * ``pooled``      — one median per compound, the artefact #744a proposed
 * ``stint_first`` — the model's prediction on this stint's first lap
 * ``stint_le3``   — the median of this stint's predictions at tyre life <= 3
+* ``stint_live``  — the prediction at the LAST lap with tyre life <= 3, which is the
+  only one the live path can produce: ``_get_driver_stint(driver, 3)`` returns the
+  whole prefix and ``_build_stint_tensor`` predicts from it once. It is what #744b
+  ships, so it is measured rather than assumed equivalent to ``stint_le3``.
 
 Training seasons only (2023-24). ``src/strategy/eval/hygiene.py`` documents why a
 constant fitted on the 2025 test season would repeat a leak this project already paid
@@ -163,6 +167,7 @@ def add_candidate_references(predictions: pd.DataFrame) -> pd.DataFrame:
     scored["ref_pooled"] = scored["compound"].map(fresh.groupby("compound")["pred"].median())
     scored["ref_stint_first"] = scored["stint"].map(scored.groupby("stint")["pred"].first())
     scored["ref_stint_le3"] = scored["stint"].map(fresh.groupby("stint")["pred"].median())
+    scored["ref_stint_live"] = scored["stint"].map(fresh.groupby("stint")["pred"].last())
     return scored
 
 
@@ -184,6 +189,14 @@ def score_candidate(scored: pd.DataFrame, reference: str | None) -> dict:
         "median": round(float(wear.median()), 3),
         "monotonic_bands": bool(by_band.is_monotonic_increasing),
         "band_medians": {str(k): round(float(v), 3) for k, v in by_band.items()},
+        # The bound a consumer needs, measured rather than chosen. The raw quantity
+        # reaches +-15 s/lap on real laps because a handful of stints have a Safety Car
+        # or an out-lap as their N04 baseline, and a scorer fed one of those prices a
+        # single lap like ten positions. Do NOT bound this at CLIFF_LOSS = 0.80: the
+        # measured median at 20-25 laps of tyre life is already above it, so that would
+        # delete the signal instead of the outliers.
+        "p1": round(float(wear.quantile(0.01)), 3),
+        "p99": round(float(wear.quantile(0.99)), 3),
     }
 
 
@@ -193,12 +206,12 @@ def report(results: dict, n_laps: int, correlation: float) -> str:
         f"laps scored: {n_laps}  (tyre life > {FRESH_MAX_TYRE_LIFE}, seasons {TRAINING_YEARS})",
         f"harness self-check: corr(pred, target) = {correlation:.3f}",
         "",
-        f"{'reference':<16}{'non-neg':>9}{'spearman':>10}{'pearson':>9}{'monotone':>10}",
+        f"{'reference':<16}{'non-neg':>9}{'spearman':>10}{'pearson':>9}{'p1':>8}{'p99':>8}",
     ]
     for name, scores in results.items():
         lines.append(
             f"{name:<16}{scores['non_negative_pct']:>8.1f}%{scores['spearman']:>10.3f}"
-            f"{scores['pearson']:>9.3f}{str(scores['monotonic_bands']):>10}"
+            f"{scores['pearson']:>9.3f}{scores['p1']:>8.2f}{scores['p99']:>8.2f}"
         )
     return "\n".join(lines)
 
@@ -220,6 +233,7 @@ def main() -> None:
         "pooled": score_candidate(usable, "ref_pooled"),
         "stint_first": score_candidate(usable, "ref_stint_first"),
         "stint_le3": score_candidate(usable, "ref_stint_le3"),
+        "stint_live": score_candidate(usable, "ref_stint_live"),
         "none": score_candidate(usable, None),
     }
 

--- a/src/agents/position_projection.py
+++ b/src/agents/position_projection.py
@@ -187,8 +187,21 @@ class ProjectionConfig:
                           zero under a neutralisation, which is what makes the
                           Art. 55.17 endgame fall out of the arithmetic: with no
                           racing laps left, fresh tyres buy nothing.
-        fresh_gain_s:     Seconds per lap a fresh tyre gains.
-        cliff_loss_s:     Seconds per lap lost past the tyre cliff.
+        fresh_gain_s:     Seconds per lap a fresh tyre gains. The FALLBACK for
+                          ``deg_cost_s``, used only when the tyre model gave no
+                          reading; the two are the same quantity and are never
+                          charged together.
+        deg_cost_s:       Seconds per lap the CURRENT set costs versus fresh, read
+                          from the tyre model rather than assumed. ``None`` when
+                          the model had no reference to subtract, which leaves
+                          ``fresh_gain_s`` in charge. Measured, not tuned: this is
+                          a fact about the car's tyres, so it belongs here, whereas
+                          a hand-picked weight on it would not.
+        cliff_loss_s:     Seconds per lap lost past the tyre cliff. Charged only on
+                          laps run PAST the cliff, so it does not overlap
+                          ``deg_cost_s``, which is charged on every old-set lap.
+                          A tyre ten laps from the cliff but 0.4 s off the pace was
+                          previously priced identically to a fresh one.
         neutralisation_saving_s: Seconds a stop saves when taken under a
                           neutralisation (the field is queued, so the pit loss
                           costs less).
@@ -217,6 +230,7 @@ class ProjectionConfig:
     window_laps: int = 5
     racing_laps: float = 5.0
     fresh_gain_s: float = 0.25
+    deg_cost_s: float | None = None
     cliff_loss_s: float = 0.80
     neutralisation_saving_s: float = 8.0
     undercut_band_s: float = DEFAULT_UNDERCUT_BAND_S
@@ -491,6 +505,38 @@ def _usable_rivals(rivals: Sequence[RivalState]) -> list[RivalState]:
     ]
 
 
+def _tyre_cost_s(config: ProjectionConfig, *, old_laps: float, fresh_laps: float) -> float:
+    """Seconds this plan's tyre state costs, positive = worse for us.
+
+    Sign convention differs from ``strategy_orchestrator._tyre_term`` because this
+    module accumulates a LOSS while that one accumulates a gain. Same two mutually
+    exclusive prices for the same physical thing: a measured cost on the laps spent
+    on the old set, or the hardcoded fresh credit when the model gave no reading.
+
+    THE ASYMMETRY WITH RIVALS IS REAL, AND IT IS A LIMITATION, NOT A CORRECTION
+    ---------------------------------------------------------------------------
+    This scorer works in gaps, and ``rival_time_deltas`` moves each rival by
+    ``pace_delta_s * racing_laps``. That is not a reason to skip our own wear: a
+    pace delta is a SNAPSHOT of the rival's relative pace at the current lap, and it
+    says nothing about how the gap moves as our set degrades across the window.
+    Charging our wear is exactly that extrapolation, and without it the projection
+    prices a twenty-lap-old set identically to a fresh one for every lap it holds.
+
+    What is genuinely missing is the mirror: **their** degradation is not modelled,
+    because the single-driver boundary gives rivals timing-screen data only and there
+    is no per-rival tyre state to run a TCN on. So a rival on older tyres than ours
+    is credited with holding their current pace. That biases the comparison toward
+    stopping, in the same direction and for a different reason than the term above,
+    and it is a known limitation of the projection rather than something this
+    function should compensate for by silently halving a measured cost.
+
+    The legacy path has no rivals and never faced the question.
+    """
+    if config.deg_cost_s is None:
+        return -fresh_laps * config.fresh_gain_s
+    return old_laps * config.deg_cost_s
+
+
 def driver_time_delta(
     plan: DriverPlan,
     pit_loss_s: np.ndarray,
@@ -544,7 +590,7 @@ def driver_time_delta(
         worn_laps = np.maximum(0.0, laps_before_stop - cliff_laps)
         delta += effective_loss
         delta += worn_laps * config.cliff_loss_s
-        delta -= laps_after_stop * config.fresh_gain_s
+        delta += _tyre_cost_s(config, old_laps=laps_before_stop, fresh_laps=laps_after_stop)
         delta -= laps_before_stop * config.clean_air_gain_s
 
         waiting_pays = laps_before_stop * config.neutralisation_onset_rate * saving_if_it_comes
@@ -552,6 +598,7 @@ def driver_time_delta(
     else:
         worn_laps = np.maximum(0.0, racing - cliff_laps)
         delta += worn_laps * config.cliff_loss_s
+        delta += _tyre_cost_s(config, old_laps=racing, fresh_laps=0.0)
 
     return delta
 

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -664,6 +664,28 @@ VSC_PIT_BONUS = 3.0  # seconds saved by pitting under a Virtual Safety Car (Art.
                      # measured.
 
 
+def _tyre_term(deg_cost_s: float | None, old_laps: int, fresh_laps: int) -> float:
+    """Seconds the tyre state is worth over one plan's window.
+
+    Two mutually exclusive ways of pricing the same physical thing, so this is a
+    REPLACEMENT and not an addition, and the double-count trap is avoided by that
+    fact rather than by a correction term.
+
+    With a measured signal, charge the laps spent on the OLD set: a tyre 0.4 s off
+    the pace costs 0.4 s every lap you keep it, whether or not the cliff is near.
+    Without one, fall back to ``FRESH_GAIN``, the hardcoded 0.25 s/lap credit for
+    the laps spent on the NEW set, which is the same quantity guessed at instead of
+    read. Both are seconds, applied before the conversion to positions.
+
+    ``None`` is a real state, not a defect: a stint whose early laps are outside the
+    replay has no reference to subtract, and the fallback keeps that case scoring
+    exactly as it did before #744b.
+    """
+    if deg_cost_s is None:
+        return FRESH_GAIN * fresh_laps
+    return -deg_cost_s * old_laps
+
+
 def simulate_lap_window(
     strategy: str,
     cliff_i:  float,
@@ -672,6 +694,7 @@ def simulate_lap_window(
     ucut_i:   bool,
     window:   int = WINDOW_LAPS,
     sc_pit_bonus: float = SC_PIT_BONUS,
+    deg_cost_s: float | None = None,
 ) -> float:
     """Estimate position gain vs STAY_OUT baseline over a W-lap window.
 
@@ -711,16 +734,16 @@ def simulate_lap_window(
     """
     if strategy == "STAY_OUT":
         cliff_laps = max(0.0, window - cliff_i)
-        time_delta = -cliff_laps * CLIFF_LOSS
+        time_delta = -cliff_laps * CLIFF_LOSS + _tyre_term(deg_cost_s, window, 0)
 
     elif strategy == "PIT_NOW":
         sc_saving  = sc_pit_bonus if sc_i else 0.0
-        time_delta = -pit_i + sc_saving + FRESH_GAIN * window
+        time_delta = -pit_i + sc_saving + _tyre_term(deg_cost_s, 0, window)
 
     elif strategy == "UNDERCUT":
         sc_saving  = sc_pit_bonus if sc_i else 0.0
         ucut_bonus = POS_GAP_S if ucut_i else 0.0
-        time_delta = -pit_i + sc_saving + FRESH_GAIN * window + ucut_bonus
+        time_delta = -pit_i + sc_saving + _tyre_term(deg_cost_s, 0, window) + ucut_bonus
 
     elif strategy == "OVERCUT":
         # An overcut still makes the stop, just later, so it pays for it like the others.
@@ -738,10 +761,17 @@ def simulate_lap_window(
         # -14 positions against a worst-case STAY_OUT of about -2.7 and suppresses pitting.
         # See tests/mc/test_mc_is_a_real_decision.py.
         if sc_i:
-            time_delta = -pit_i + sc_pit_bonus + FRESH_GAIN * window
+            time_delta = -pit_i + sc_pit_bonus + _tyre_term(deg_cost_s, 0, window)
         else:
             cliff_laps = max(0.0, (window // 2) - cliff_i)
-            time_delta = -pit_i + FRESH_GAIN * (window // 2) - cliff_laps * CLIFF_LOSS
+            # The only branch that splits the window: half on the old set, half on the
+            # new one. Getting these two counts wrong makes the wear term a constant
+            # offset that cancels in the argmax and looks like it did nothing.
+            time_delta = (
+                -pit_i
+                + _tyre_term(deg_cost_s, window // 2, window // 2)
+                - cliff_laps * CLIFF_LOSS
+            )
 
     else:
         time_delta = 0.0
@@ -1077,6 +1107,7 @@ def _run_projection_mc(
     ucut_s,
     alpha: float,
     neutralisation_saving_s: float,
+    deg_cost_s: float | None = None,
 ) -> dict:
     """Score the four candidates in projected track position instead of seconds.
 
@@ -1182,6 +1213,10 @@ def _run_projection_mc(
             window_laps=WINDOW_LAPS,
             racing_laps=racing_laps,
             fresh_gain_s=FRESH_GAIN,
+            # Set on BOTH configs the closure builds, green and neutralised. Setting
+            # only the green one would leave every Safety Car lap on the old constant
+            # while the report claimed the channel was connected.
+            deg_cost_s=deg_cost_s,
             cliff_loss_s=CLIFF_LOSS,
             neutralisation_saving_s=neutralisation_saving_s,
             undercut_band_s=measured_undercut_band_s(),
@@ -1349,6 +1384,11 @@ def _run_mc_simulation(
         tire_out.laps_to_cliff_p90,
     )
 
+    # `getattr` because a caller may still pass a stub TireOutput built before this
+    # field existed; `None` then keeps both scorers on the FRESH_GAIN fallback, which
+    # is the pre-#744b behaviour rather than a zero cost.
+    deg_cost_s = getattr(tire_out, "deg_cost_s", None)
+
     sc_prob = situation_out.sc_prob_3lap
 
     # A VSC is a neutralisation too (N27 forces sc_prob_3lap to 1.0, so every draw sees
@@ -1405,6 +1445,7 @@ def _run_mc_simulation(
             ucut_s=ucut_s,
             alpha=alpha,
             neutralisation_saving_s=sc_pit_bonus,
+            deg_cost_s=deg_cost_s,
         )
 
     strategies = ["STAY_OUT", "PIT_NOW", "UNDERCUT", "OVERCUT"]
@@ -1413,7 +1454,7 @@ def _run_mc_simulation(
     for s in strategies:
         outcomes = np.array([
             simulate_lap_window(s, cliff_s[i], sc_s[i], pit_s[i], ucut_s[i],
-                                sc_pit_bonus=sc_pit_bonus)
+                                sc_pit_bonus=sc_pit_bonus, deg_cost_s=deg_cost_s)
             for i in range(n)
         ])
         e_val   = float(np.mean(outcomes))

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -219,6 +219,24 @@ class TireAgentConfig:
             is PIT_SOON. Per-cluster values take precedence when available.
         cliff_monitor_laps: Global fallback threshold below which warning_level
             is MONITOR. Per-cluster values take precedence when available.
+        fresh_reference_tyre_life: Tyre life that stands in for "fresh" when asking
+            the model what this set was worth before it wore. N04 defines the target
+            against the stint's own lowest-tyre-life lap, which is an out-lap or a
+            standing start, so the level is biased slow and cannot be charged as a
+            cost directly. Asking the same model on the same stint's early laps
+            cancels that baseline algebraically instead of approximately.
+        deg_cost_floor_s / deg_cost_ceiling_s: Bounds on the referenced wear, in
+            seconds per lap. MEASURED, not chosen: they are the 1st and 99th
+            percentiles over 31,624 training-season laps
+            (``scripts/measure_tyre_reference.py``). The raw quantity reaches
+            +-15 s/lap because a handful of stints have a Safety Car or an out-lap
+            as their N04 baseline, and one of those reaching the scorer prices a
+            single lap like ten positions.
+
+            Do NOT tighten these to ``CLIFF_LOSS = 0.80``. The measured median at
+            20-25 laps of tyre life is 1.03 s/lap, so that bound would delete the
+            signal rather than the outliers. These are a guard against nonsense,
+            not an opinion about how much a worn tyre costs.
     """
 
     n_mc: int = 50
@@ -226,6 +244,9 @@ class TireAgentConfig:
     model_name: str = 'gpt-4.1-mini'
     cliff_pit_soon_laps: int = 3
     cliff_monitor_laps: int  = 7
+    fresh_reference_tyre_life: int = 3
+    deg_cost_floor_s: float   = -2.33
+    deg_cost_ceiling_s: float = 3.67
 
     def __post_init__(self) -> None:
         self._model_dir = _MODEL_DIR
@@ -377,6 +398,21 @@ CLIFF_THRESHOLD: dict[str, int] = {
 MAX_RACE_LAPS: int = 78
 
 
+def _referenced_wear(parsed: dict) -> Optional[float]:
+    """Seconds per lap this set costs versus fresh, bounded, or ``None``.
+
+    Both halves must have parsed. ``.get`` with a numeric default would turn a
+    missing reference into "this tyre is exactly at its fresh pace", which is a
+    reading the scorer can also legitimately receive.
+    """
+    if 'cum_deg' not in parsed or 'fresh_ref' not in parsed:
+        return None
+
+    wear = parsed['cum_deg'] - parsed['fresh_ref']
+    bounded = min(max(wear, CFG.deg_cost_floor_s), CFG.deg_cost_ceiling_s)
+    return round(bounded, 4)
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # TireOutput
 # ─────────────────────────────────────────────────────────────────────────────
@@ -422,6 +458,20 @@ class TireOutput:
             the Monte Carlo, nor the orchestrator prompt, nor any UI. Measured
             over the same 110 laps it correlates +0.369 with tyre life and swings
             0.411 s/lap across a stint.
+        deg_cost_s: Seconds per lap staying out costs versus a fresh set, bounded.
+            This is ``cumulative_deg_s`` minus the model's own prediction on this
+            stint's early laps, which cancels N04's per-stint baseline instead of
+            approximating it — see ``TireAgent._fresh_reference`` for why a pooled
+            per-compound table was measured and refused.
+
+            **This is the field the scorers consume**, not ``cumulative_deg_s``:
+            the level carries a per-stint offset whose standard deviation across
+            stints is 5.48 s, so it is not comparable between cars or laps.
+
+            ``None`` when either side is missing, never 0.0, for the same reason
+            given above for ``cumulative_deg_s``: a genuinely fresh set reads 0.0
+            here, so the sentinel would collide with a real value. A ``None``
+            leaves both scorers on the ``FRESH_GAIN`` fallback.
         laps_to_cliff_p10: Pessimistic estimate (P10) of laps before the cliff.
             Drives PIT_SOON warning — conservative to avoid running too long.
         laps_to_cliff_p50: Median estimate of laps before the cliff.
@@ -444,6 +494,7 @@ class TireOutput:
     laps_to_cliff_p90: float
     gp_name: str   = ''
     cumulative_deg_s: float | None = None
+    deg_cost_s: float | None = None
     warning_level: str = field(init=False)
     reasoning: str = ''
 
@@ -858,6 +909,40 @@ class TireAgent:
 
         return df[self.bundles[compound_id]['feature_names']].astype(float)
 
+    def _fresh_reference(self, driver: str, compound_id: str) -> Optional[float]:
+        """What the model said about this same set before it wore, in seconds.
+
+        A second deterministic pass over the stint's own early laps. Subtracting it
+        from the current prediction gives *seconds per lap this set costs versus
+        fresh*, which is what a scorer needs and what the raw level is not: N04
+        measures against the stint's slowest lap, so the level is negative on most
+        laps and charging it directly would pay a car for staying out.
+
+        WHY THIS AND NOT A COMMITTED PER-COMPOUND TABLE
+        -----------------------------------------------
+        Because the baseline is per stint, not per compound. Measured over 2,343
+        training-season stints, the per-stint median target has a standard deviation
+        of 5.48 s and a 1st percentile of -32.87 s: 13x the 0.411 s/lap signal being
+        chased. A pooled constant cannot normalise 2,343 different zero points, and
+        measurement put it at Spearman +0.188 against +0.191 for having no reference
+        at all. This one measures +0.308 and 73.9% non-negative
+        (``scripts/measure_tyre_reference.py``, ``documents/audits/MEASURE_744a_*``).
+
+        Returns ``None``, never 0.0, when the stint has no lap at the reference tyre
+        life — a replay that starts mid-stint. Zero is a legitimate reading of the
+        wear it feeds, so collapsing "unknown" into it would be the same sentinel
+        collision that #436 fixed for the cliff.
+        """
+        early_laps = self._get_driver_stint(driver, self.cfg.fresh_reference_tyre_life)
+        if early_laps is None or not len(early_laps):
+            return None
+
+        tensor = self._build_stint_tensor(early_laps, compound_id, self.session_meta)
+        model = self.bundles[compound_id]['model']
+        with torch.no_grad():
+            model.eval()
+            return float(model(tensor).item())
+
     def _build_stint_tensor(
         self,
         stint_laps: pd.DataFrame,
@@ -1080,9 +1165,15 @@ class TireAgent:
             feat_df  = agent._build_stint_features(stint, compound_id, agent.session_meta)
             deg_rate = float(feat_df['DegradationRate'].iloc[-1])
 
+            reference = agent._fresh_reference(driver, compound_id)
+            reference_line = (
+                '' if reference is None else f' | Fresh reference: {reference:.3f} s'
+            )
+
             return (
                 f'Driver {driver} | Compound {compound_id} | TyreLife {tyre_life}\n'
                 f'Cumulative degradation: {pred:.3f} s | Degradation rate: {deg_rate:.4f} s/lap'
+                f'{reference_line}'
             )
 
         @lc_tool
@@ -1484,6 +1575,7 @@ class TireAgent:
             cumulative_deg_s  = (
                 round(parsed['cum_deg'], 4) if 'cum_deg' in parsed else None
             ),
+            deg_cost_s        = _referenced_wear(parsed),
             laps_to_cliff_p10 = round(parsed['p10'], 1),
             laps_to_cliff_p50 = round(parsed.get('p50', 0.0), 1),
             laps_to_cliff_p90 = round(parsed.get('p90', 0.0), 1),

--- a/src/agents/tire_parsing.py
+++ b/src/agents/tire_parsing.py
@@ -34,7 +34,13 @@ import re
 # printed it since the tool existed and nothing ever read it, so the prediction the
 # whole N07-N10 family exists to produce stopped here. It takes the same `-?` for the
 # same reason: a set faster than its own fresh baseline is real early in a stint.
+#
+# `Fresh reference` (#744b) is the same model on the same stint's early laps. It is
+# printed only when those laps exist, so an absent key means "no reference could be
+# taken" and the wear it feeds stays None. Same `-?` for the same reason: the fresh
+# reference is itself measured against N04's slow baseline and is routinely negative.
 _PATTERNS: tuple[tuple[str, str], ...] = (
+    (r'Fresh reference:\s*(-?[\d.]+)',        'fresh_ref'),
     (r'Cumulative degradation:\s*(-?[\d.]+)', 'cum_deg'),
     (r'Degradation rate:\s*(-?[\d.]+)',       'deg_rate'),
     (r'P10:\s*(-?[\d.]+)',                    'p10'),

--- a/tests/agents/test_tire_cumulative_deg.py
+++ b/tests/agents/test_tire_cumulative_deg.py
@@ -210,3 +210,134 @@ def test_the_prompt_shows_the_wear_and_says_unknown_when_it_is_missing():
 
     assert "vs fresh" in _build_tire_block(tire_out)
     assert "wear=unknown" in _build_tire_block(replace(tire_out, cumulative_deg_s=None))
+
+
+# ===========================================================================
+# #744b — the level becomes a COST by subtracting the model's own fresh reading
+# ===========================================================================
+#
+# `cumulative_deg_s` is measured against N04's per-stint baseline, and those
+# baselines are not comparable between stints: over 2,343 training-season stints
+# the per-stint median has std 5.48 s and a 1st percentile of -32.87 s, against
+# the 0.411 s/lap signal being chased. So the level cannot be charged as a cost,
+# and a pooled per-compound table cannot fix it either — measured at Spearman
+# +0.188 against +0.191 for having no reference at all.
+#
+# Subtracting the model's own prediction on the same stint's early laps cancels
+# that baseline algebraically. Measured: 73.9% non-negative, Spearman +0.308.
+
+
+def test_the_parser_captures_the_fresh_reference_including_a_negative_one():
+    """The reference is itself measured against N04's slow baseline, so it is
+    routinely negative — the same reason the other patterns carry `-?`."""
+    from src.agents.tire_parsing import parse_tool_outputs
+
+    message = _FakeToolMessage(
+        "Driver NOR | Compound C2 | TyreLife 18\n"
+        "Cumulative degradation: 0.412 s | Degradation rate: 0.02 s/lap"
+        " | Fresh reference: -0.308 s"
+    )
+
+    parsed = parse_tool_outputs([message])
+
+    assert parsed["fresh_ref"] == -0.308
+    assert parsed["cum_deg"] == 0.412
+
+
+def test_no_reference_line_writes_no_reference_key():
+    """A replay starting mid-stint has no laps at the reference tyre life, so the
+    tool prints no reference at all. That must stay distinguishable from one that
+    happens to be zero."""
+    from src.agents.tire_parsing import parse_tool_outputs
+
+    message = _FakeToolMessage(
+        "Driver NOR | Compound C2 | TyreLife 18\n"
+        "Cumulative degradation: 0.412 s | Degradation rate: 0.02 s/lap"
+    )
+
+    assert "fresh_ref" not in parse_tool_outputs([message])
+
+
+@pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="_referenced_wear reads the measured bounds off TireAgentConfig, whose "
+    "construction needs data/models/tire_degradation/ (HF, not git)",
+)
+class TestReferencedWear:
+    """The arithmetic that turns two model readings into one charge."""
+
+    def test_a_set_at_its_own_fresh_pace_costs_exactly_zero(self):
+        """The reference IS the current prediction on a stint's first laps, so the
+        wear is 0.0 — correct, and pinned so nobody "fixes" it into a fallback."""
+        from src.agents.tire_agent import _referenced_wear
+
+        assert _referenced_wear({"cum_deg": -0.308, "fresh_ref": -0.308}) == 0.0
+
+    def test_a_missing_half_is_none_and_never_zero(self):
+        """Zero is a legitimate reading of this field — see the test above — so it
+        cannot double as the sentinel. This is the collision #436 fixed for the
+        cliff, where a parse miss became a confident call to box."""
+        from src.agents.tire_agent import _referenced_wear
+
+        assert _referenced_wear({"cum_deg": 0.412}) is None
+        assert _referenced_wear({"fresh_ref": -0.308}) is None
+        assert _referenced_wear({}) is None
+
+    def test_the_baseline_cancels_rather_than_being_approximated(self):
+        """Both readings carry the same per-stint offset, so it subtracts out
+        exactly. Shift both by a 30 s Safety-Car baseline and the cost is unmoved."""
+        from src.agents.tire_agent import _referenced_wear
+
+        normal = _referenced_wear({"cum_deg": 0.412, "fresh_ref": -0.308})
+        shifted = _referenced_wear({"cum_deg": -29.588, "fresh_ref": -30.308})
+
+        assert normal == shifted == 0.72
+
+    def test_the_tail_is_bounded_by_the_measured_percentiles(self):
+        """The raw quantity reaches +-15 s/lap because a few stints have an out-lap
+        or a Safety Car as their N04 baseline, and one of those reaching the scorer
+        prices a single lap like ten positions."""
+        from src.agents.tire_agent import CFG, _referenced_wear
+
+        assert _referenced_wear({"cum_deg": 60.0, "fresh_ref": 0.0}) == CFG.deg_cost_ceiling_s
+        assert _referenced_wear({"cum_deg": -60.0, "fresh_ref": 0.0}) == CFG.deg_cost_floor_s
+
+    def test_the_bound_does_not_clip_a_genuinely_worn_tyre(self):
+        """The measured median at 20-25 laps of tyre life is 1.03 s/lap, which is
+        already above CLIFF_LOSS. A bound set there would delete the signal instead
+        of the outliers, so this pins that the real range survives."""
+        from src.agents.tire_agent import _referenced_wear
+
+        assert _referenced_wear({"cum_deg": 1.03, "fresh_ref": 0.0}) == 1.03
+        assert _referenced_wear({"cum_deg": 2.5, "fresh_ref": 0.0}) == 2.5
+
+
+@pytest.mark.skipif(
+    not (_HAS_MODELS and _HAS_DATA),
+    reason="needs data/models/tire_degradation/ and data/{raw/2025/Lusail,processed} (HF, not git)",
+)
+def test_a_real_lap_carries_a_cost_that_the_raw_level_could_not_have_given():
+    """The whole point of #744b, on a real lap rather than an arithmetic fixture.
+
+    Lusail 2025 lap 30, five laps into the stint. The raw level reads NEGATIVE
+    because N04 measures it against this stint's own out-lap; charged directly it
+    would have PAID the car for staying out, which is why the level was never
+    consumable. The referenced cost is a small positive, which is what a nearly
+    fresh set should cost.
+
+    Ranges, not values: pinning a number here would break on any legitimate model
+    refresh while saying nothing about whether the reference is connected. What is
+    pinned is the SIGN RELATIONSHIP the fix exists to create.
+    """
+    from src.strategy.inference.no_llm import _tire_no_llm
+
+    lap_state, laps = _scoped_lusail_lap_30()
+
+    tire_out = _tire_no_llm(lap_state, laps)
+
+    assert tire_out.cumulative_deg_s is not None
+    assert tire_out.deg_cost_s is not None
+    # The level is measured against a slow baseline, so it is below the cost.
+    assert tire_out.cumulative_deg_s < tire_out.deg_cost_s
+    # A five-lap-old set costs something small and non-negative, not a credit.
+    assert 0.0 <= tire_out.deg_cost_s < 1.0

--- a/tests/mc/test_tyre_wear_term.py
+++ b/tests/mc/test_tyre_wear_term.py
@@ -1,0 +1,337 @@
+"""#744b — the tyre channel reaches BOTH scorers, and it is charged on the right laps.
+
+Until now the Monte Carlo's only tyre signal was the cliff, a discrete event that
+falls inside the 5-lap window on 4 of 110 measured laps. A set 0.4 s off the pace but
+ten laps from the cliff scored identically to a fresh one, which is most of why the
+decision layer declines to call 46% of real stops.
+
+WHAT IS BEING REPLACED, AND WHY IT IS A REPLACEMENT
+----------------------------------------------------
+``FRESH_GAIN = 0.25  # s/lap advantage of fresh vs degraded tyre`` is the same
+quantity, hardcoded and applied identically at tyre life 3 and tyre life 25. So the
+measured cost REPLACES it rather than adding to it, and the double-count trap is
+avoided by that fact rather than by a correction term. ``FRESH_GAIN`` survives as the
+no-signal fallback, which is what keeps a stint with no reference scoring exactly as
+it did before.
+
+THE LAP COUNTS ARE THE WHOLE THING
+-----------------------------------
+The two prices sit on opposite sides of the stop: the old credit paid for laps on the
+NEW set, the new charge bills laps on the OLD one. Get those counts wrong and the term
+becomes a constant offset that cancels in the argmax and looks like it did nothing at
+all. Per candidate, with ``window = 5``:
+
+    STAY_OUT              5 old, 0 fresh
+    PIT_NOW / UNDERCUT    0 old, 5 fresh
+    OVERCUT under SC      0 old, 5 fresh
+    OVERCUT green         2 old, 2 fresh   <- the only split, and window // 2
+
+The projection scorer counts differently because it knows when in the window the stop
+falls: ``laps_before_stop`` on the old set, ``laps_after_stop`` on the new one, and the
+whole window on the old set for a plan that does not stop at all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.agents.position_projection import DriverPlan, ProjectionConfig, driver_time_delta
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").is_file()
+
+DRAWS = 4
+
+
+def _config(**overrides) -> ProjectionConfig:
+    """A config with every term but the tyre ones zeroed, so the charge is readable."""
+    base = {
+        "window_laps": 5,
+        "racing_laps": 5.0,
+        "fresh_gain_s": 0.25,
+        "cliff_loss_s": 0.0,
+        "neutralisation_saving_s": 0.0,
+        "clean_air_gain_s": 0.0,
+        "neutralisation_onset_rate": 0.0,
+    }
+    base.update(overrides)
+    return ProjectionConfig(**base)
+
+
+def _zeros() -> np.ndarray:
+    return np.zeros(DRAWS, dtype=float)
+
+
+def _no_cliff() -> np.ndarray:
+    """Cliff far outside the window, so the cliff term contributes nothing."""
+    return np.full(DRAWS, 99.0, dtype=float)
+
+
+# ---------------------------------------------------------------------------
+# The projection scorer — hermetic, so CI sees these
+# ---------------------------------------------------------------------------
+
+
+def test_staying_out_pays_the_wear_on_every_racing_lap():
+    """A plan that never stops runs the whole window on the old set."""
+    config = _config(deg_cost_s=0.4)
+
+    delta = driver_time_delta(
+        DriverPlan(name="STAY_OUT", stops_in_window=False, stop_offset_laps=0),
+        _zeros(),
+        _no_cliff(),
+        config,
+    )
+
+    assert delta == pytest.approx(np.full(DRAWS, 5.0 * 0.4))
+
+
+def test_pitting_immediately_pays_no_wear_at_all():
+    """Zero laps on the old set, so the charge vanishes without needing a branch."""
+    config = _config(deg_cost_s=0.4)
+
+    delta = driver_time_delta(
+        DriverPlan(name="PIT_NOW", stops_in_window=True, stop_offset_laps=0),
+        _zeros(),
+        _no_cliff(),
+        config,
+    )
+
+    assert delta == pytest.approx(_zeros())
+
+
+def test_an_overcut_pays_for_the_laps_it_waits_and_no_more():
+    """The term has to track WHEN the stop falls, not just whether it happens.
+
+    A stop deferred two laps runs two laps on the old set. If this were charged over
+    the whole window instead, every candidate would shift by the same amount and the
+    argmax would not move — the term would be invisible while looking connected.
+    """
+    config = _config(deg_cost_s=0.4)
+
+    delta = driver_time_delta(
+        DriverPlan(name="OVERCUT", stops_in_window=True, stop_offset_laps=2),
+        _zeros(),
+        _no_cliff(),
+        config,
+    )
+
+    assert delta == pytest.approx(np.full(DRAWS, 2.0 * 0.4))
+
+
+def test_a_worn_tyre_makes_staying_out_worse_than_stopping():
+    """The behaviour the whole issue exists for, stated as an inequality.
+
+    Nothing here says by how much; it says the sign is right. A term wired with the
+    wrong sign still moves the numbers and would pass every count test above.
+    """
+    config = _config(deg_cost_s=0.4)
+    stay = driver_time_delta(
+        DriverPlan(name="STAY_OUT", stops_in_window=False, stop_offset_laps=0),
+        _zeros(),
+        _no_cliff(),
+        config,
+    )
+    pit = driver_time_delta(
+        DriverPlan(name="PIT_NOW", stops_in_window=True, stop_offset_laps=0),
+        _zeros(),
+        _no_cliff(),
+        config,
+    )
+
+    assert stay.mean() > pit.mean()
+
+
+def test_a_fresh_set_costs_nothing_and_is_not_the_same_as_no_reading():
+    """0.0 is a real reading: the wear term vanishes, and the FRESH_GAIN fallback
+    must NOT come back to life instead. That distinction is the sentinel rule this
+    field is built on, checked here at the consuming end rather than the producing
+    one."""
+    measured_zero = _config(deg_cost_s=0.0)
+    no_reading = _config(deg_cost_s=None)
+    plan = DriverPlan(name="PIT_NOW", stops_in_window=True, stop_offset_laps=0)
+
+    with_zero = driver_time_delta(plan, _zeros(), _no_cliff(), measured_zero)
+    without = driver_time_delta(plan, _zeros(), _no_cliff(), no_reading)
+
+    assert with_zero == pytest.approx(_zeros())
+    assert without == pytest.approx(np.full(DRAWS, -5.0 * 0.25))
+
+
+def test_with_no_reading_the_scorer_is_byte_identical_to_the_old_credit():
+    """The fallback is not an approximation of the previous behaviour, it IS it."""
+    config = _config(deg_cost_s=None)
+
+    for plan in (
+        DriverPlan(name="STAY_OUT", stops_in_window=False, stop_offset_laps=0),
+        DriverPlan(name="PIT_NOW", stops_in_window=True, stop_offset_laps=0),
+        DriverPlan(name="OVERCUT", stops_in_window=True, stop_offset_laps=2),
+    ):
+        delta = driver_time_delta(plan, _zeros(), _no_cliff(), config)
+        laps_after_stop = 0.0 if not plan.stops_in_window else 5.0 - plan.stop_offset_laps
+        assert delta == pytest.approx(np.full(DRAWS, -laps_after_stop * 0.25))
+
+
+def test_the_cliff_term_and_the_wear_term_do_not_overlap():
+    """They price different laps: the cliff bills only laps run PAST it, the wear
+    bills every old-set lap. A tyre ten laps from the cliff used to cost nothing."""
+    config = _config(deg_cost_s=0.4, cliff_loss_s=0.8)
+    plan = DriverPlan(name="STAY_OUT", stops_in_window=False, stop_offset_laps=0)
+
+    before_cliff = driver_time_delta(plan, _zeros(), _no_cliff(), config)
+    past_cliff = driver_time_delta(plan, _zeros(), np.zeros(DRAWS), config)
+
+    assert before_cliff == pytest.approx(np.full(DRAWS, 5.0 * 0.4))
+    assert past_cliff == pytest.approx(np.full(DRAWS, 5.0 * 0.4 + 5.0 * 0.8))
+
+
+# ---------------------------------------------------------------------------
+# The legacy scorer — the one the backend endpoint runs in production
+# ---------------------------------------------------------------------------
+#
+# Not a relic. Three shipping builders hardcode `"rivals": []`, which routes to it:
+# `engine.py`, `strategy_orchestrator.py`, and the backend's own
+# `api/v1/endpoints/strategy.py`. A fix that reached only the projection branch would
+# have connected the tyre channel for arcade and the CLI while leaving the backend on
+# the old constant.
+
+
+@pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="strategy_orchestrator imports the agent stack, which loads model bundles",
+)
+class TestLegacyScorer:
+    """Charged in seconds, before the conversion to positions."""
+
+    def test_each_candidate_is_charged_for_its_own_old_set_laps(self):
+        from src.agents.strategy_orchestrator import _tyre_term
+
+        assert _tyre_term(0.4, old_laps=5, fresh_laps=0) == pytest.approx(-2.0)
+        assert _tyre_term(0.4, old_laps=0, fresh_laps=5) == pytest.approx(0.0)
+        assert _tyre_term(0.4, old_laps=2, fresh_laps=2) == pytest.approx(-0.8)
+
+    def test_without_a_reading_it_is_the_old_fresh_credit_unchanged(self):
+        from src.agents.strategy_orchestrator import FRESH_GAIN, _tyre_term
+
+        assert _tyre_term(None, old_laps=5, fresh_laps=0) == pytest.approx(0.0)
+        assert _tyre_term(None, old_laps=0, fresh_laps=5) == pytest.approx(FRESH_GAIN * 5)
+        assert _tyre_term(None, old_laps=2, fresh_laps=2) == pytest.approx(FRESH_GAIN * 2)
+
+    def test_the_two_prices_are_never_charged_together(self):
+        """The double-count trap, closed by construction rather than by a correction:
+        with a reading, the fresh credit is not merely offset, it is absent."""
+        from src.agents.strategy_orchestrator import _tyre_term
+
+        assert _tyre_term(0.4, old_laps=0, fresh_laps=5) == pytest.approx(0.0)
+
+    def test_a_worn_set_makes_staying_out_score_worse(self):
+        """Same inequality as the projection branch, on the other implementation.
+
+        The two scorers have opposite sign conventions — this one accumulates a gain,
+        the other a loss — so a term copied across without flipping it would pass the
+        count tests on both and fail exactly here.
+        """
+        from src.agents.strategy_orchestrator import simulate_lap_window
+
+        kwargs = dict(cliff_i=99.0, sc_i=False, pit_i=22.0, ucut_i=False)
+        fresh = simulate_lap_window("STAY_OUT", deg_cost_s=0.0, **kwargs)
+        worn = simulate_lap_window("STAY_OUT", deg_cost_s=0.4, **kwargs)
+
+        assert worn < fresh
+
+    def test_the_overcut_green_branch_splits_the_window(self):
+        """The only candidate that runs on both sets, and the one whose counts are
+        easiest to get wrong: `window // 2` on each side, not the whole window."""
+        from src.agents.strategy_orchestrator import WINDOW_LAPS, _tyre_term
+
+        half = WINDOW_LAPS // 2
+        assert _tyre_term(0.4, old_laps=half, fresh_laps=half) == pytest.approx(-0.4 * half)
+
+
+def _rivals_with_usable_gaps() -> list[dict]:
+    """Rivals the projection branch will actually accept.
+
+    The key is `interval_to_driver_s`, and getting it wrong is not a loud failure:
+    `_has_usable_gaps` simply returns False and `_run_mc_simulation` falls through to
+    the LEGACY scorer. A test that thought it was exercising the projection branch
+    would then pass while proving nothing about it, which is what the first version of
+    this file did — caught by mutating the projection call site and watching all
+    fifteen tests stay green.
+    """
+    return [
+        {"driver": "VER", "interval_to_driver_s": -2.0, "is_pitting": False},
+        {"driver": "LEC", "interval_to_driver_s": 3.5, "is_pitting": False},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The wiring itself — the part a comment cannot assert
+# ---------------------------------------------------------------------------
+#
+# Everything above tests the two leaf functions. Neither one proves the value
+# actually TRAVELS from TireOutput through `_run_mc_simulation` into each branch,
+# and that is precisely the defect gate G1 found in the previous PR of this epic:
+# the mechanism a commit calls essential, protected by a comment and nothing else.
+#
+# `_run_projection_mc` did not receive `tire_out` in any form before #744b, so the
+# projection branch needed a new kwarg. A change that added it to one branch and not
+# the other would leave every existing test green: the goldens run with no reading at
+# all and take the fallback.
+
+
+@pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="_run_mc_simulation imports the agent stack, which loads model bundles",
+)
+class TestTheValueReachesBothBranches:
+    """One canned scenario, scored twice, differing only in the tyre reading."""
+
+    @staticmethod
+    def _score(rivals, deg_cost_s):
+        from dataclasses import replace
+
+        from src.agents.strategy_orchestrator import _run_mc_simulation
+
+        from .test_strategy_goldens import _canned_outputs
+
+        pace, tire, situation, pit = _canned_outputs()
+        return _run_mc_simulation(
+            pace_out=pace,
+            tire_out=replace(tire, deg_cost_s=deg_cost_s),
+            situation_out=situation,
+            pit_out=pit,
+            alpha=0.5,
+            rivals=rivals,
+            position=5,
+            laps_remaining=25,
+            pit_context=None,
+        )
+
+    def test_the_legacy_branch_receives_it(self):
+        """Reached whenever a caller passes no usable gaps, which three shipping
+        builders do by hardcoding an empty rival list — including the backend's own
+        endpoint. This is the branch that runs in production behind the API."""
+        without = self._score([], None)
+        with_wear = self._score([], 0.4)
+
+        assert with_wear["STAY_OUT"]["E"] != without["STAY_OUT"]["E"]
+        assert with_wear["STAY_OUT"]["E"] < without["STAY_OUT"]["E"]
+
+    def test_the_projection_branch_receives_it(self):
+        """Reached when rivals carry usable gaps: arcade, the CLI, the eval harness."""
+        rivals = _rivals_with_usable_gaps()
+        without = self._score(rivals, None)
+        with_wear = self._score(rivals, 0.4)
+
+        assert with_wear["STAY_OUT"]["E"] != without["STAY_OUT"]["E"]
+
+    def test_neither_branch_moves_when_there_is_no_reading(self):
+        """The fallback keeps every pre-#744b caller on exactly its old numbers,
+        which is why the frozen goldens did not need re-freezing."""
+        rivals = _rivals_with_usable_gaps()
+
+        assert self._score([], None) == self._score([], None)
+        assert self._score(rivals, None) == self._score(rivals, None)


### PR DESCRIPTION
Refs #744 — the consumption half (#744a's measurement landed in #756).

Connects the largest term still missing from the decision layer. The Monte Carlo's only tyre signal was the **cliff**, a discrete event that falls inside the 5-lap window on **4 of 110** measured laps, so a set 0.4 s off the pace but ten laps from the cliff scored identically to a fresh one.

## Why the raw level could not just be charged

`cumulative_deg_s` is measured against **each stint's own** baseline lap. Those baselines are not comparable — over 2,343 training-season stints the per-stint median has **std 5.48 s** and a 1st percentile of **−32.87 s**, against the 0.411 s/lap signal being chased.

`TireAgent._fresh_reference` asks the same model on the same stint's early laps, so the baseline cancels **algebraically** rather than approximately. Measured over 31,624 laps, best of five candidates:

| reference | non-negative | spearman | p1 | p99 |
|---|---|---|---|---|
| pooled per-compound (#744a's proposal) | 66.3% | +0.188 | **−32.63** | 4.12 |
| **live single call — what this ships** | **73.9%** | **+0.308** | **−2.33** | 3.67 |
| no reference at all | 65.3% | +0.191 | −32.61 | 4.06 |

Note the p1 column: the pooled reference does not merely fail to correlate, it leaves the catastrophic outliers **intact**, because the noise it would have to average away is the per-stint zero point.

## On a real lap

Lusail 2025 lap 30, five laps into the stint:

```
cumulative_deg_s : -0.498    <- charged directly, this PAYS the car for staying out
deg_cost_s       : +0.015    <- what a nearly-fresh set should cost
```

That sign relationship is pinned by a test, as a relationship rather than a value.

## The bound is measured, not chosen

`[−2.33, +3.67]`, the p1/p99 from `scripts/measure_tyre_reference.py`. **Deliberately not `CLIFF_LOSS = 0.80`** — the measured median at 20-25 laps of tyre life is **1.03 s/lap**, so bounding there would delete the signal instead of the outliers.

## FRESH_GAIN is replaced, not supplemented

`FRESH_GAIN = 0.25  # s/lap advantage of fresh vs degraded tyre` is the same quantity, hardcoded and applied identically at tyre life 3 and 25. The double-count trap is closed **by construction** rather than by a correction term. It survives as the no-signal fallback — which is why **the frozen goldens did not move**.

`deg_cost_s` is `None`, never `0.0`, when no reference exists: zero is a legitimate reading here (a set at its fresh pace), so the sentinel would collide with a real value the way #436 did for the cliff.

## ⚠️ A claim in #744 that turned out to be wrong

#744 says three builders hardcode an empty rival list *"including the backend endpoint, so the backend endpoint runs the legacy scorer in production"*. Traced rather than inherited, it is **two**: `engine.py::_build_default_lap_state` and `strategy_orchestrator.py`, both serving callers that supply only a `RaceState`.

The third — `api/v1/endpoints/strategy.py:882` — builds a lap_state whose **only consumer calls `run_pace_agent_from_state`**, so it never reaches the Monte Carlo. The backend's own MC path is `services/simulation/simulator.py` delegating to `run_lap` with the rivals the state manager emits.

The conclusion is unchanged (both scorers need the term, both have it), but the reason given for it was wrong and would have propagated.

## Mutation results

| mutant | outcome |
|---|---|
| drop the projection kwarg | 1 red |
| drop the legacy kwarg | 2 red |
| gut the projection cost function | 6 red |
| set the value on the green config but not the neutralised one | 1 red |

**The first version of the wiring tests was wrong, and the mutation is what caught it.** The fixture used `gap_s` where `_has_usable_gaps` reads `interval_to_driver_s`, so the test believed it was exercising the projection branch while taking the legacy one — dropping the projection kwarg left all 15 green. That is the same defect class gate G1 found in #755, caught here before review.

## Checks

232 across `tests/mc` + `tests/agents`; `ruff check .` and `ruff format --check .` clean at the pinned version.

## Out of scope

Re-running `f1-eval decision-modes` against the 46.1% decline baseline. That is a ~21-minute sweep and belongs with gate G2, which should also attack monotonicity on real laps — the criterion the reverted design failed.
