### PR TITLE
docs(eval): measure what the tyre term did to the decision, and it made it worse

### DIFF
--- a/documents/audits/MEASURE_744b_decision_effect.md
+++ b/documents/audits/MEASURE_744b_decision_effect.md
@@ -1,0 +1,100 @@
+# #744b measured: the tyre term made the decision WORSE, and the reason is not the term
+
+**Date:** 2026-07-31 · **Issue:** #744 · **Instrument:** `f1-eval decision-modes`, six 2025 circuits.
+**Comparison:** harness `99a663d` (before) against `d97a54e` (after). The only production diff
+between them is #760's four files, so this is like-for-like on the same sample and the same metric.
+
+---
+
+## The result
+
+| | without the term | with the term |
+|---|---|---|
+| Stops scored | 53 of 178 (29.8%) | 54 of 178 (30.3%) |
+| **Exact lap** | **43.4%** (23 stops) | **33.3% (18 stops)** |
+| Within 1 lap | 52.8% (28) | 44.4% (24) |
+| Within 2 laps | 62.3% | 51.9% |
+| **Declines (`no_call`)** | **82 (46.1%)** | **79 (44.4%)** |
+| `no_boundary_in_window` | 22 | 24 |
+| Mean signed error | −1.72 | −2.00 |
+
+**Three fewer declines bought at the cost of five exact agreements.** The layer now calls the stop
+earlier, which is the mechanism working exactly as designed — and further from what the teams did.
+
+This is the outcome `project_epic724_scorecard` warned about in writing before the metric could see
+it: *"it is entirely possible the epic traded too reluctant for too eager and the metric cannot tell
+the difference."* It can now, and it did.
+
+## The diagnosis, and it is NOT that the term is too big
+
+Measured over 15,005 real 2025 laps (`scratchpad/wear_magnitude.py`, driving the committed
+instrument with the season overridden), the charge the term applies to STAY_OUT:
+
+| tyre life | positions charged |
+|---|---|
+| (3, 5] | 0.16 |
+| (5, 10] | 0.86 |
+| (10, 15] | 1.79 |
+| (15, 20] | 2.79 |
+| (20, 25] | 3.63 |
+| (25, 100] | **5.43** |
+
+Median across all laps: **2.03 positions**. What it competes with, in the same units:
+
+```
+the flat constant it replaced   0.833
+a full window run past the cliff 2.667
+one whole track position         1.000
+the margin tie-break cap         0.200
+```
+
+**On 73.6% of laps the wear term alone moves STAY_OUT by more than a full track position**, and its
+median is 2.4x the constant it replaced. It is not one input among several any more; it decides.
+
+### Why that happens, and why scaling it down would be the wrong fix
+
+The arithmetic is right. A set 0.61 s/lap off its fresh pace, held five more laps, costs 3.05 s. What
+makes that decisive is the **other** side of the comparison: this scorer deliberately excludes the
+pit-lane traversal, because a stop is mandatory under the two-compound rule and both pit-now and
+pit-later pay it, so it cancels. The pit term is therefore the *physical stop* alone, ~2.8 s ≈ 1.87
+positions.
+
+So a five-lap wear charge and an entire pit stop are the same order of magnitude, and the wear tips
+it. **Charging the true cost of five worn laps against a stop whose dominant cost has been cancelled
+out is not a scale error in the term — it is the window.**
+
+This is the third cause the original plan named and deliberately deferred:
+
+> the 5-lap window prices 100% of a stop's cost against ~5 laps of its benefit (break-even ~92 laps).
+> We re-measure after Sprint 3 and decide with data rather than moving three causes at once.
+
+This document is that data.
+
+## What must NOT be done next
+
+**Do not tune the term until the metric recovers.** That is fitting to the metric, and it is exactly
+the failure this epic retired `mean_signed_error` to avoid. Any change to the scale needs a measured
+reason of its own.
+
+**Do not read "agreement fell" as "the model got worse".** The report says it in its own scope
+section: agreement with the real pit wall is evidence, not correctness. The teams optimise track
+position, traffic and Safety Car odds that this layer does not model. A model that says "box now"
+five laps before a team that was holding position may be arithmetically right and strategically
+wrong for reasons outside its inputs.
+
+**But do not use that as an escape either.** The structural finding stands on its own and does not
+depend on the metric: one term deciding 73.6% of laps means the cliff, the undercut bonus, the
+clean-air gain and the neutralisation hazard have stopped mattering to the argmax. That is a design
+problem whatever the pit wall did.
+
+## Recommendation
+
+Keep the term. Reverting restores `FRESH_GAIN = 0.25`, a hardcoded constant that charges a 3-lap-old
+set and a 25-lap-old set identically, and which this same measurement shows to be 2.4x too small at
+the median and 6.5x too small at 25+ laps. It is not better, it is only quieter.
+
+Open the `WINDOW_LAPS` question with this measurement attached, and treat it as the highest-risk item
+in the layer: it moves every number and requires re-freezing goldens deliberately.
+
+Related: `MEASURE_744a_tyre_reference.md` · `FABLE_G2_tyre_wear_term.md` ·
+`MEASURE_752_metric_and_sample.md` · `documents/eval_reports/decision_modes.md`

--- a/documents/eval_reports/decision_modes.json
+++ b/documents/eval_reports/decision_modes.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "99a663d",
+    "harness_sha": "d97a54e",
     "dataset": "data/raw laps, stratified 6-race subset (RAW, not featured)",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-31T07:13:39+00:00",
+    "generated_at": "2026-07-31T09:40:54+00:00",
     "artifacts": {}
   },
   "status": "masked",
@@ -38,22 +38,22 @@
     }
   ],
   "agreement": {
-    "sample_size": 53,
+    "sample_size": 54,
     "eligible": 178,
-    "scored_share": 0.29775280898876405,
+    "scored_share": 0.30337078651685395,
     "races": 6,
-    "exact": 0.4339622641509434,
-    "within_one": 0.5283018867924528,
-    "within_two": 0.6226415094339622,
-    "mean_signed_error": -1.7169811320754718,
-    "mean_absolute_error": 1.8679245283018868
+    "exact": 0.3333333333333333,
+    "within_one": 0.4444444444444444,
+    "within_two": 0.5185185185185185,
+    "mean_signed_error": -2.0,
+    "mean_absolute_error": 2.1481481481481484
   },
   "buckets": {
     "closing_laps": 4,
     "min_stint": 17,
-    "no_boundary_in_window": 22,
-    "no_call_in_window": 82,
-    "scored": 53
+    "no_boundary_in_window": 24,
+    "no_call_in_window": 79,
+    "scored": 54
   },
   "verdicts": [
     {
@@ -70,9 +70,9 @@
       "race": "Barcelona",
       "driver": "VER",
       "actual_lap": 29,
-      "chosen_lap": 27,
-      "offset_laps": -2,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -196,27 +196,27 @@
       "race": "Barcelona",
       "driver": "ALB",
       "actual_lap": 26,
-      "chosen_lap": 23,
-      "offset_laps": -3,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
       "race": "Barcelona",
       "driver": "ALB",
       "actual_lap": 27,
-      "chosen_lap": 23,
-      "offset_laps": -4,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
       "race": "Barcelona",
       "driver": "HUL",
       "actual_lap": 9,
-      "chosen_lap": 8,
-      "offset_laps": -1,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -232,9 +232,9 @@
       "race": "Barcelona",
       "driver": "LAW",
       "actual_lap": 18,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "chosen_lap": 15,
+      "offset_laps": -3,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -252,16 +252,16 @@
       "actual_lap": 20,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
       "race": "Barcelona",
       "driver": "OCO",
       "actual_lap": 43,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 43,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -286,8 +286,8 @@
       "race": "Barcelona",
       "driver": "COL",
       "actual_lap": 14,
-      "chosen_lap": 9,
-      "offset_laps": -5,
+      "chosen_lap": 11,
+      "offset_laps": -3,
       "bucket": "scored"
     },
     {
@@ -331,9 +331,9 @@
       "race": "Barcelona",
       "driver": "BOR",
       "actual_lap": 49,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 49,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -394,9 +394,9 @@
       "race": "Barcelona",
       "driver": "PIA",
       "actual_lap": 22,
-      "chosen_lap": 22,
-      "offset_laps": 0,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -745,9 +745,9 @@
       "race": "Monaco",
       "driver": "PIA",
       "actual_lap": 48,
-      "chosen_lap": 48,
-      "offset_laps": 0,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -1062,7 +1062,7 @@
       "actual_lap": 51,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -1123,8 +1123,8 @@
       "race": "Marina_Bay",
       "driver": "HUL",
       "actual_lap": 25,
-      "chosen_lap": 23,
-      "offset_laps": -2,
+      "chosen_lap": 22,
+      "offset_laps": -3,
       "bucket": "scored"
     },
     {
@@ -1150,8 +1150,8 @@
       "race": "Marina_Bay",
       "driver": "OCO",
       "actual_lap": 30,
-      "chosen_lap": 30,
-      "offset_laps": 0,
+      "chosen_lap": 27,
+      "offset_laps": -3,
       "bucket": "scored"
     },
     {
@@ -1159,8 +1159,8 @@
       "race": "Marina_Bay",
       "driver": "NOR",
       "actual_lap": 26,
-      "chosen_lap": 26,
-      "offset_laps": 0,
+      "chosen_lap": 23,
+      "offset_laps": -3,
       "bucket": "scored"
     },
     {
@@ -1177,9 +1177,9 @@
       "race": "Marina_Bay",
       "driver": "HAM",
       "actual_lap": 24,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "chosen_lap": 19,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1195,9 +1195,9 @@
       "race": "Marina_Bay",
       "driver": "BOR",
       "actual_lap": 13,
-      "chosen_lap": 13,
-      "offset_laps": 0,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -1222,17 +1222,17 @@
       "race": "Marina_Bay",
       "driver": "RUS",
       "actual_lap": 25,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 22,
+      "offset_laps": -3,
+      "bucket": "scored"
     },
     {
       "year": 2025,
       "race": "Marina_Bay",
       "driver": "PIA",
       "actual_lap": 27,
-      "chosen_lap": 25,
-      "offset_laps": -2,
+      "chosen_lap": 24,
+      "offset_laps": -3,
       "bucket": "scored"
     },
     {
@@ -1357,9 +1357,9 @@
       "race": "Lusail",
       "driver": "NOR",
       "actual_lap": 25,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 25,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1447,9 +1447,9 @@
       "race": "Lusail",
       "driver": "PIA",
       "actual_lap": 42,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 42,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1483,9 +1483,9 @@
       "race": "Monza",
       "driver": "VER",
       "actual_lap": 37,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 32,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1528,9 +1528,9 @@
       "race": "Monza",
       "driver": "LEC",
       "actual_lap": 33,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 33,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1546,8 +1546,8 @@
       "race": "Monza",
       "driver": "TSU",
       "actual_lap": 19,
-      "chosen_lap": 19,
-      "offset_laps": 0,
+      "chosen_lap": 18,
+      "offset_laps": -1,
       "bucket": "scored"
     },
     {
@@ -1555,8 +1555,8 @@
       "race": "Monza",
       "driver": "ALB",
       "actual_lap": 41,
-      "chosen_lap": 41,
-      "offset_laps": 0,
+      "chosen_lap": 39,
+      "offset_laps": -2,
       "bucket": "scored"
     },
     {
@@ -1582,17 +1582,17 @@
       "race": "Monza",
       "driver": "NOR",
       "actual_lap": 46,
-      "chosen_lap": 42,
-      "offset_laps": -4,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
       "race": "Monza",
       "driver": "COL",
       "actual_lap": 33,
-      "chosen_lap": 33,
-      "offset_laps": 0,
+      "chosen_lap": 31,
+      "offset_laps": -2,
       "bucket": "scored"
     },
     {
@@ -1600,9 +1600,9 @@
       "race": "Monza",
       "driver": "HAM",
       "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "chosen_lap": 33,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1618,17 +1618,17 @@
       "race": "Monza",
       "driver": "SAI",
       "actual_lap": 30,
-      "chosen_lap": 30,
-      "offset_laps": 0,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
       "race": "Monza",
       "driver": "HAD",
       "actual_lap": 32,
-      "chosen_lap": 27,
-      "offset_laps": -5,
+      "chosen_lap": 29,
+      "offset_laps": -3,
       "bucket": "scored"
     },
     {
@@ -1636,8 +1636,8 @@
       "race": "Monza",
       "driver": "RUS",
       "actual_lap": 27,
-      "chosen_lap": 27,
-      "offset_laps": 0,
+      "chosen_lap": 26,
+      "offset_laps": -1,
       "bucket": "scored"
     },
     {

--- a/documents/eval_reports/decision_modes.md
+++ b/documents/eval_reports/decision_modes.md
@@ -1,17 +1,17 @@
 # decision_modes
 
-- harness `99a663d` · schema v1 · generated 2026-07-31T07:13:39+00:00
+- harness `d97a54e` · schema v1 · generated 2026-07-31T09:40:54+00:00
 - era 2022-2025 · dataset data/raw laps, stratified 6-race subset (RAW, not featured) · seed deterministic · llm none
 - artifacts: —
 
 | Metric | Value | Meaning |
 | --- | --- | --- |
-| Stops scored | 53 of 178 (29.8%) | real green-flag stops the tier could grade |
-| Exact lap | 43.4% | chose the lap the team chose |
-| Within 1 lap | 52.8% | same call, one lap either side |
-| Within 2 laps | 62.3% | same strategic window |
-| Mean signed error | -1.72 laps | negative = earlier than the team. **Do not quote as a system property** — still moves with `DECISION_WINDOW_LAPS` (measured -0.33 / -1.29 / -2.50 at w=3/5/10 on one race), because a wider window admits more distant, and therefore earlier, transitions |
-| Mean absolute error | 1.87 laps | magnitude, same width caveat |
+| Stops scored | 54 of 178 (30.3%) | real green-flag stops the tier could grade |
+| Exact lap | 33.3% | chose the lap the team chose |
+| Within 1 lap | 44.4% | same call, one lap either side |
+| Within 2 laps | 51.9% | same strategic window |
+| Mean signed error | -2.00 laps | negative = earlier than the team. **Do not quote as a system property** — still moves with `DECISION_WINDOW_LAPS` (measured -0.33 / -1.29 / -2.50 at w=3/5/10 on one race), because a wider window admits more distant, and therefore earlier, transitions |
+| Mean absolute error | 2.15 laps | magnitude, same width caveat |
 | Coverage verdict | **masked** | `masked` when under 60% of eligible stops were scored |
 
 ### Buckets
@@ -20,9 +20,9 @@
 | --- | --- |
 | `closing_laps` | 4 |
 | `min_stint` | 17 |
-| `no_boundary_in_window` | 22 |
-| `no_call_in_window` | 82 |
-| `scored` | 53 |
+| `no_boundary_in_window` | 24 |
+| `no_call_in_window` | 79 |
+| `scored` | 54 |
 
 `opening_laps` / `closing_laps` / `min_stint` are stops the guard rails make
 impossible to agree with, so they are excluded from the headline rather than


### PR DESCRIPTION
Refs #744, and files #763 with the numbers attached.

The last unanswered question of the epic: **did connecting the tyre channel improve the decision?** It did not.

Like-for-like — same 2025 sample, same metric, and the only production diff between the two harnesses is #760's four files.

| | without the term | with the term |
|---|---|---|
| **Exact lap** | **43.4%** (23 stops) | **33.3% (18)** |
| Within 1 lap | 52.8% (28) | 44.4% (24) |
| Within 2 laps | 62.3% | 51.9% |
| **Declines** | **82 (46.1%)** | **79 (44.4%)** |
| Mean signed error | −1.72 | −2.00 |

**Three fewer declines bought at the cost of five exact agreements.** The layer calls the stop earlier — the mechanism working exactly as designed, and further from what the teams did.

`project_epic724_scorecard` predicted this in writing before the metric could see it: *"it is entirely possible the epic traded too reluctant for too eager and the metric cannot tell the difference."* It can now.

## The diagnosis is not "the term is too big"

Measured over 15,005 real 2025 laps, the charge the term applies to STAY_OUT:

| tyre life | positions |
|---|---|
| (5, 10] | 0.86 |
| (15, 20] | 2.79 |
| (25, 100] | **5.43** |

Median **2.03 positions**, against **0.833** for the constant it replaced, **2.667** for a full window past the cliff, **1.000** for a whole track position. **On 73.6% of laps the wear term alone moves STAY_OUT by more than one position.**

The arithmetic is right. What makes it decisive is the *other* side: `simulate_lap_window` deliberately excludes the pit-lane traversal, because the stop is mandatory under the two-compound rule and both pit-now and pit-later pay it, so it cancels. The pit term is the **physical stop alone**, ~2.8 s ≈ 1.87 positions.

So five laps of true wear and an entire pit stop are the same order of magnitude, and the wear tips it. **That is the window, not the scale** — and it is the third cause the original plan named and deferred *on the explicit condition that it be reopened with a measurement rather than an argument*. → #763.

## Two things that must not happen next

**Do not tune the term until the metric recovers.** That is fitting to the metric, which is precisely why `mean_signed_error` was retired.

**Do not read "agreement fell" as "the model got worse"** — the report's own scope section says agreement with the pit wall is evidence, not correctness; teams optimise track position and traffic this layer does not model. **But that is not an escape either:** one term deciding 73.6% of laps means the cliff, the undercut bonus, the clean-air gain and the neutralisation hazard have stopped mattering to the argmax. That is a design problem whatever the pit wall did.

## Recommendation: keep the term

Reverting restores `FRESH_GAIN = 0.25`, a constant that charges a 3-lap-old set and a 25-lap-old set identically, and which this same measurement shows to be **2.4× too small at the median and 6.5× too small at 25+ laps**. It is not better, it is only quieter.

## Contents

Docs and the regenerated report only — no production change.
