### PR TITLE
fix(agents): derive restated constants and state the horizon rule the module never had

### DIFF
--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -1306,7 +1306,14 @@ def _build_race_state(
     driver_code: str,
     prev_lap_time: float,
 ) -> RaceState:
-    """Map RaceStateManager's lap_state dict → RaceState Pydantic model."""
+    """Map RaceStateManager's lap_state dict → RaceState Pydantic model.
+
+    ``prev_lap_time`` is accepted but no longer read here: ``pace_delta_s`` used
+    to be computed from it and that was the wrong axis (#750, fixed below). Left
+    in the signature rather than removed, since the caller's per-lap bookkeeping
+    that produces it (`run()`'s ``prev_lap_time`` loop variable) serves no other
+    purpose today and dropping it is a small cleanup outside this fix's scope.
+    """
     driver_st = lap_state["driver"]
     rivals = lap_state.get("rivals", [])
     weather = lap_state.get("weather", {})
@@ -1336,7 +1343,20 @@ def _build_race_state(
         gap_ahead_s = 0.0
 
     cur_lap_time = driver_st.get("lap_time_s") or 0.0
-    pace_delta_s = cur_lap_time - prev_lap_time if prev_lap_time else 0.0
+    # pace_delta_s is contractually RIVAL-relative (this driver's lap time minus
+    # the car directly ahead's SAME lap, negative = we are faster) per
+    # race_situation_agent.py:292/904, the schema N27 itself computes. The old
+    # formula compared cur_lap_time against our OWN previous lap instead, a
+    # same-car same-driver quantity that reported roughly -20s of phantom "pace
+    # gain" on the lap after a pit stop, a green lap read against our own
+    # out-lap. car_ahead is already resolved above for gap_ahead_s, so no extra
+    # lookup is needed; 0.0 when it or its lap time is unknown is the schema's
+    # documented neutral, not a guess in either direction (#750).
+    ahead_lap_time = car_ahead.get("lap_time_s") if car_ahead is not None else None
+    if ahead_lap_time is not None and cur_lap_time:
+        pace_delta_s = cur_lap_time - float(ahead_lap_time)
+    else:
+        pace_delta_s = 0.0
 
     return RaceState(
         driver=driver_code,

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -596,7 +596,14 @@ except ImportError:
 # System prompt (module-level constant — unchanged from N28)
 # ─────────────────────────────────────────────────────────────────────────────
 
-_PIT_STRATEGY_SYSTEM_PROMPT = """You are the Pit Strategy Agent for an F1 race.
+# f-string: the COMPOUND vs REMAINING LAPS section below derives its SOFT bound from
+# _STINT_CAPACITY_LAPS instead of restating it, so the prompt cannot drift from the
+# deterministic selector's own number the way it did in #741 (18 in the table, 15 here
+# and in strategy_orchestrator.py, so laps_remaining=16-18 had the selector pass SOFT
+# while the prompt told the LLM to refuse it). No other brace-sensitive text lives in
+# this constant (checked at the time of #741's fix), so widening it to an f-string is
+# safe.
+_PIT_STRATEGY_SYSTEM_PROMPT = f"""You are the Pit Strategy Agent for an F1 race.
 Your job is to decide whether a driver should pit now, and if so, what compound to fit.
 
 You have three tools:
@@ -652,7 +659,7 @@ MINIMUM STINT LENGTH before a pit makes sense:
   and time is running out. Decide on the race state, not on the SC alone.
 
 COMPOUND vs REMAINING LAPS:
-  SOFT: recommend only if remaining laps <= 15 (it won't last longer).
+  SOFT: recommend only if remaining laps <= {_STINT_CAPACITY_LAPS['SOFT']} (it won't last longer).
   MEDIUM: suitable for 12-30 remaining laps.
   HARD: suitable for 20+ remaining laps.
   Picking SOFT with 25 laps to go forces an extra pit stop — factor that cost in.

--- a/src/agents/position_projection.py
+++ b/src/agents/position_projection.py
@@ -48,6 +48,28 @@ was an unmeasured constant, which is what the redesign exists to remove:
   matches the timing screen but does not model the unlapping procedure before a
   restart (Art. 55.13).
 
+THREE HORIZONS FOR ONE FACT, stated once and prominently because the module used
+to leave it implicit and that read as an inconsistency waiting to be "fixed"
+(#742). ``rival_time_deltas``, ``_terminal_gaps`` and ``rank_targets`` each ask
+whether a rival's outstanding pit stop should cost them time, and each answers
+correctly for a DIFFERENT horizon, not for the same one three times::
+
+    rival_time_deltas -> rival.is_pitting                              (inside the window)
+    _terminal_gaps     -> rival.stop_pending is True and not is_pitting (race end)
+    rank_targets        -> rival.stop_pending is True                   (after both pit cycles)
+
+A rival who owes a stop but is not taking it inside the window genuinely loses
+no time inside the window, so ``is_pitting`` is the right predicate there. The
+same rival genuinely falls back by the race end whether or not they stop this
+lap, so ``stop_pending`` is right at that horizon; ``_terminal_gaps`` then
+excludes a rival who IS pitting right now, because ``rival_time_deltas`` already
+charged that stop inside the window and charging it again would push them a
+full pit cycle further back than they will ever be. ``rank_targets`` looks past
+both pit cycles, where whether the stop happens on THIS lap stops mattering, so
+it drops the ``is_pitting`` guard entirely. Making the three agree would not fix
+a bug: it would delete the distinction between "now", "by the end of the race"
+and "once everyone has stopped" that the three horizons exist to carry.
+
 --- WHERE TO CHANGE IF THE RIVALS CONTRACT CHANGES ---
 ``RivalState`` mirrors the fields ``RaceStateManager.get_rival_states`` emits
 (``interval_to_driver_s``, ``is_pitting``, ``lap_time_s``). If that contract
@@ -868,8 +890,15 @@ def rank_targets(
     in front of us.
 
     Deterministic and run once (no sampling): it selects who to attack, and the
-    Monte Carlo then scores the attacking. Both consume the same definition of
-    "who we are racing", so the selector and the scorer can no longer disagree.
+    Monte Carlo then scores the attacking. Both go through the same
+    ``_usable_rivals`` filter, so the selector and the scorer can never disagree
+    about WHICH rivals are in play (a rival with an unknown gap cannot silently
+    show up in one and not the other). That is the only thing shared: this
+    function does NOT use the same stop-obligation predicate as the scorer's
+    ``rival_time_deltas`` / ``_terminal_gaps``, and it should not be made to.
+    See "THREE HORIZONS FOR ONE FACT" at the top of this module for why
+    ``rank_targets`` charges ``stop_pending`` alone rather than the
+    ``is_pitting`` guard the other two use (#742).
     """
     ranked: list[TargetRanking] = []
 

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -289,7 +289,11 @@ class RaceSituationOutput:
             elevated SC risk. Same caveat: N14's best_threshold is raw-scale.
         threat_level: LOW / MEDIUM / HIGH derived from both probabilities in __post_init__.
         gap_ahead_s: Gap to the car directly ahead (seconds). < 1.0s = DRS range.
-        pace_delta_s: 3-lap rolling pace delta vs car ahead (s/lap). Negative = faster.
+        pace_delta_s: SINGLE-lap pace delta vs the car ahead (s/lap), this driver's
+            lap time minus theirs, so negative = we are faster. The rolling version is
+            the separate ``pace_delta_rolling3`` field; this docstring used to describe
+            that one, and four surfaces fed a self-delta into this field partly because
+            the contract they were reading named the wrong quantity (#750).
         reasoning: LLM synthesis forwarded verbatim to N31 Orchestrator.
         sc_currently_active: Any neutralisation (SC OR VSC) confirmed deployed this lap
             by the RCM feed. Kept as the single back-compat flag every consumer already

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -1666,7 +1666,11 @@ def _build_orchestrator_prompt(
         f"     contingency trigger, not a primary action — use STAY_OUT with SC contingency.\n"
         f"  4. Minimum stint before pit: SOFT >= 8 laps, MEDIUM >= 12, HARD >= 15.\n"
         f"     If tyre_life is below minimum, override to STAY_OUT (current set has life left).\n"
-        f"  5. Compound must fit remaining laps: SOFT only if <= 15 laps remain,\n"
+        # SOFT bound derived from _STINT_CAPACITY_LAPS (imported above), not restated:
+        # this line and the pit agent's own system prompt used to disagree with the
+        # deterministic selector's table (18 vs 15), so laps_remaining=16-18 had the
+        # selector pass SOFT while both prompts told the LLM to refuse it (#741).
+        f"  5. Compound must fit remaining laps: SOFT only if <= {_STINT_CAPACITY_LAPS['SOFT']} laps remain,\n"
         f"     MEDIUM for 12-30, HARD for 20+. Wrong compound forces an extra stop.\n"
         f"  6. Opening laps 1-3: threat levels from N27 are inflated by start chaos.\n"
         f"     Discount them one tier (HIGH→MEDIUM, MEDIUM→LOW) for decision-making.\n"

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -603,7 +603,15 @@ class SimConnector(threading.Thread):
         shim that only the FastAPI startup provides). Populates
         ``radio_msgs`` / ``rcm_events`` from the ``RadioPipelineRunner``
         corpus so the Radio agent sees the real OpenF1 team messages
-        (same as the CLI); empty lists when the corpus could not load."""
+        (same as the CLI); empty lists when the corpus could not load.
+
+        ``prev_lap_time`` is accepted but no longer read here: ``pace_delta_s``
+        used to be computed from it and that was the wrong axis (#750, fixed
+        below). Left in the signature rather than removed, since the caller's
+        per-lap bookkeeping that produces it (``_step_once`` /
+        ``_lap_time_from_state``) serves no other purpose today and dropping it
+        is a small cleanup outside this fix's scope.
+        """
         from src.agents.position_projection import GAP_UNKNOWN_FALLBACK_S
         from src.agents.strategy_orchestrator import RaceState
 
@@ -611,7 +619,6 @@ class SimConnector(threading.Thread):
         weather = lap_state.get("weather", {})
         meta = lap_state.get("session_meta", {})
         cur_lap_time = driver_st.get("lap_time_s") or 0.0
-        pace_delta = cur_lap_time - prev_lap_time if prev_lap_time else 0.0
 
         rivals = lap_state.get("rivals", [])
         our_pos = driver_st.get("position")
@@ -650,6 +657,22 @@ class SimConnector(threading.Thread):
                 gap_ahead_s = GAP_UNKNOWN_FALLBACK_S
             else:
                 gap_ahead_s = abs(measured_interval)
+
+        # pace_delta_s is contractually RIVAL-relative (this driver's lap time
+        # minus the car directly ahead's SAME lap, negative = we are faster) per
+        # race_situation_agent.py:292/904, the schema N27 itself computes. The
+        # old formula compared cur_lap_time against our OWN previous lap
+        # instead, a same-car same-driver quantity that reported roughly -20s
+        # of phantom "pace gain" on the lap after a pit stop, a green lap read
+        # against our own out-lap. car_ahead is already resolved above for
+        # gap_ahead_s, so no extra lookup is needed; 0.0 when it or its lap
+        # time is unknown is the schema's documented neutral, not a guess in
+        # either direction (#750).
+        ahead_lap_time = car_ahead.get("lap_time_s") if car_ahead is not None else None
+        if ahead_lap_time is not None and cur_lap_time:
+            pace_delta = cur_lap_time - float(ahead_lap_time)
+        else:
+            pace_delta = 0.0
 
         lap_num = int(lap_state.get("lap_number", 1) or 1)
         radio_msgs: list[dict] = []

--- a/tests/agents/test_prompt_constants_match_tables.py
+++ b/tests/agents/test_prompt_constants_match_tables.py
@@ -1,0 +1,126 @@
+"""#741 — a constant restated in prose is a constant that will drift.
+
+SOFT's stint capacity was **18** in `_STINT_CAPACITY_LAPS`, which the deterministic
+selector computes against, and **15** in both LLM prompts, which restated it as a
+literal. On `laps_remaining` 16-18 the selector passed SOFT and both prompts told the
+model to refuse it, so the compound choice on that three-lap band was decided by prose.
+
+Neither number was wrong. They were written from different sources and nothing made
+them move together, which is the same shape as the threshold-scale defect `CLAUDE.md`
+§11 records for 2026-07-27: a number restated somewhere it is not derived.
+
+WHY THIS TEST IS PHRASED OVER THE WHOLE TABLE
+----------------------------------------------
+Pinning "SOFT reads 18" would pass the day someone edits the table and forgets a
+prompt, which is exactly how the divergence arose. What must hold is the *relation*:
+no prompt may state a capacity the table disagrees with. So this parses the rendered
+prompts and checks every compound it can find, and it keeps holding when the measured
+capacity changes.
+
+⚠️ WHAT THIS DOES **NOT** CLAIM
+-------------------------------
+That 18 is the right number. Measured over 341 real green-flag SOFT stints across 71
+races (`src/strategy/eval/stint_lengths.py`, the same instrument and data used for the
+minimum bound), **33.7% run longer than 18 laps** and 45.7% longer than 15 — the median
+is 15 and the maximum is 50. Real stint length reflects strategy, Safety Car luck and
+circuit degradation, not a physical ceiling, so the data does not hand back a clean
+maximum and none was invented. 18 was kept because it is what the selector already
+computes against and the closer of the two to real practice. Whether the capacity model
+should be a hard bound at all is a separate question and is not settled here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").is_file()
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="the prompts live in modules whose import builds agent configs from "
+    "data/models/ (HF, not git)",
+)
+
+# "SOFT only if <= 18 laps", "SOFT: recommend only if remaining laps <= 18", and any
+# future phrasing that puts a compound and a bound in the same clause.
+_BOUND = re.compile(r"\b(SOFT|MEDIUM|HARD)\b[^.\n]*?<=\s*(\d+)")
+
+
+def _stated_bounds(prompt: str) -> set[tuple[str, int]]:
+    return {(m.group(1), int(m.group(2))) for m in _BOUND.finditer(prompt)}
+
+
+def _orchestrator_prompt() -> str:
+    from src.agents.strategy_orchestrator import RaceState, _build_orchestrator_prompt
+
+    race_state = RaceState(
+        driver="NOR",
+        lap=30,
+        total_laps=57,
+        position=4,
+        compound="MEDIUM",
+        tyre_life=12,
+        gap_ahead_s=2.0,
+        pace_delta_s=0.0,
+        risk_tolerance=0.5,
+        air_temp=25.0,
+        track_temp=35.0,
+    )
+    return _build_orchestrator_prompt(race_state, {}, "STAY_OUT")
+
+
+def test_no_prompt_states_a_capacity_the_table_disagrees_with():
+    """The relation, not the value. Both prompts, every compound they mention."""
+    from src.agents.pit_strategy_agent import _PIT_STRATEGY_SYSTEM_PROMPT, _STINT_CAPACITY_LAPS
+
+    prompts = {
+        "pit agent system prompt": _PIT_STRATEGY_SYSTEM_PROMPT,
+        "orchestrator prompt": _orchestrator_prompt(),
+    }
+
+    for name, prompt in prompts.items():
+        for compound, stated in _stated_bounds(prompt):
+            expected = _STINT_CAPACITY_LAPS.get(compound)
+            if expected is None:
+                continue
+            assert stated == expected, (
+                f"{name} states {compound} <= {stated} while _STINT_CAPACITY_LAPS says "
+                f"{expected}. Derive it from the table instead of restating it (#741)."
+            )
+
+
+def test_the_soft_bound_is_actually_present_in_both_prompts():
+    """The guard above passes vacuously if the regex stops matching.
+
+    That is not hypothetical: the bound is now interpolated, so a refactor that drops
+    the clause, renames the compound or reflows the sentence would silently leave the
+    check asserting about the empty set — this project's catalogued way for a green
+    test to mean nothing.
+    """
+    from src.agents.pit_strategy_agent import _PIT_STRATEGY_SYSTEM_PROMPT, _STINT_CAPACITY_LAPS
+
+    soft = _STINT_CAPACITY_LAPS["SOFT"]
+
+    assert ("SOFT", soft) in _stated_bounds(_PIT_STRATEGY_SYSTEM_PROMPT)
+    assert ("SOFT", soft) in _stated_bounds(_orchestrator_prompt())
+
+
+def test_the_selector_and_the_prompt_agree_across_the_band_that_used_to_split_them(monkeypatch):
+    """laps_remaining 16-18: the selector passed SOFT, the prompts forbade it.
+
+    Walks the band and asserts the two answer the same way at every lap in it, rather
+    than checking the single value they now share — the bug was a three-lap window, and
+    a test that only reads the constant would not have seen its width.
+    """
+    from src.agents.pit_strategy_agent import _STINT_CAPACITY_LAPS
+
+    prompt_bound = dict(_stated_bounds(_orchestrator_prompt()))["SOFT"]
+
+    for laps_remaining in range(14, 21):
+        selector_allows = _STINT_CAPACITY_LAPS["SOFT"] >= laps_remaining
+        prompt_allows = laps_remaining <= prompt_bound
+        assert selector_allows == prompt_allows, laps_remaining

--- a/tests/mc/test_position_projection_stop_horizons.py
+++ b/tests/mc/test_position_projection_stop_horizons.py
@@ -1,0 +1,141 @@
+"""Pin the three horizons #742 found undocumented, so nobody "unifies" them (#742).
+
+``position_projection`` holds three predicates about the same underlying fact,
+whether a rival's outstanding pit stop should cost them time, and each is
+correct for a DIFFERENT horizon rather than being three attempts at one rule:
+
+    rival_time_deltas -> rival.is_pitting                              (inside the window)
+    _terminal_gaps     -> rival.stop_pending is True and not is_pitting (race end)
+    rank_targets        -> rival.stop_pending is True                   (after both pit cycles)
+
+The module docstring now states this rule once, prominently. This file is the
+enforcement: it constructs rivals who owe a stop under different ``is_pitting``
+states and asserts the three functions treat them differently, naming the
+horizon each assertion pins. Any patch that makes the three predicates agree,
+in either direction, must fail one of these tests.
+
+Hermetic by construction: no model weights, no ``data/`` beyond the measured
+JSON tables that ``position_projection`` already degrades gracefully without
+(see its ``measured_tables`` docstring), so this suite runs in any checkout.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.agents.position_projection import (
+    DriverPlan,
+    ProjectionConfig,
+    RivalState,
+    _terminal_gaps,
+    rank_targets,
+    rival_time_deltas,
+)
+
+# A rival's outstanding obligation, held constant across every test in this
+# file so the only thing that varies between OWES_NOT_TAKING and
+# OWES_TAKING_NOW is ``is_pitting`` -- the one bit the three horizons disagree
+# about how to use.
+STOP_LOSS_S = 22.0
+GAP_S = -1.0
+RACING_LAPS = 5.0
+
+# Owes the Art. 30.5(m) stop but is not in the pit lane THIS lap. This is the
+# exact rival the #742 acceptance criteria names: charged at the terminal
+# horizon, not charged inside the window.
+OWES_NOT_TAKING = RivalState(
+    "OWES_NOT_TAKING",
+    gap_s=GAP_S,
+    is_pitting=False,
+    stop_pending=True,
+    stop_loss_s=STOP_LOSS_S,
+)
+
+# Owes the same stop and IS taking it this lap. Distinguishes _terminal_gaps
+# (which must NOT charge them again, rival_time_deltas already did) from
+# rank_targets (which charges every known obligation regardless of timing).
+OWES_TAKING_NOW = RivalState(
+    "OWES_TAKING_NOW",
+    gap_s=GAP_S,
+    is_pitting=True,
+    stop_pending=True,
+    stop_loss_s=STOP_LOSS_S,
+)
+
+STAY_OUT = DriverPlan("STAY_OUT", stops_in_window=False)
+
+
+def test_window_horizon_charges_only_the_rival_pitting_this_lap():
+    """rival_time_deltas: is_pitting is the only fact this horizon trusts.
+
+    A rival who owes a stop but is racing this lap costs themselves nothing
+    inside the window; a rival serving the stop right now pays the full loss.
+    Unifying this predicate with ``stop_pending`` (matching the other two
+    horizons) would charge OWES_NOT_TAKING inside the window and break the
+    first assertion below.
+    """
+    config = ProjectionConfig(racing_laps=RACING_LAPS)
+    deltas = rival_time_deltas([OWES_NOT_TAKING, OWES_TAKING_NOW], config, draws=1)
+
+    assert deltas[0, 0] == pytest.approx(0.0), (
+        "window horizon: owes a stop but is not taking it now, so is_pitting=False "
+        "keeps them uncharged inside the window"
+    )
+    assert deltas[0, 1] == pytest.approx(STOP_LOSS_S), (
+        "window horizon: in the pit lane this lap, so is_pitting=True charges the stop right now"
+    )
+
+
+def test_terminal_horizon_charges_an_owed_stop_exactly_once():
+    """_terminal_gaps: race-end residual, and never a stop already priced.
+
+    OWES_NOT_TAKING is uncharged in the window (previous test), so the
+    terminal residual must land here or the obligation vanishes entirely.
+    OWES_TAKING_NOW was already charged inside the window, so the terminal
+    residual must be zero for them, or the same stop is paid twice.
+    """
+    config = ProjectionConfig(racing_laps=RACING_LAPS, mandatory_stop_pending=False)
+    rivals = [OWES_NOT_TAKING, OWES_TAKING_NOW]
+
+    window_deltas = rival_time_deltas(rivals, config, draws=1)
+    current_gaps = np.array([[rival.gap_s for rival in rivals]])
+    projected_gaps = current_gaps + window_deltas  # our own delta is 0 here
+
+    pit_loss_s = np.zeros(1)
+    terminal_gaps = _terminal_gaps(rivals, STAY_OUT, projected_gaps, pit_loss_s, config)
+
+    assert terminal_gaps[0, 0] - projected_gaps[0, 0] == pytest.approx(STOP_LOSS_S), (
+        "terminal horizon: still owes the stop, so the residual lands even though "
+        "nothing charged them in the window"
+    )
+    assert terminal_gaps[0, 1] - projected_gaps[0, 1] == pytest.approx(0.0), (
+        "terminal horizon: already charged inside the window (rival_time_deltas), "
+        "so the terminal residual excludes them rather than paying for the same "
+        "stop twice"
+    )
+
+
+def test_post_cycle_horizon_charges_every_known_obligation_alike():
+    """rank_targets: stop_pending alone, deliberately ignoring is_pitting.
+
+    Once both pit cycles have played out, whether the stop happened on THIS
+    lap stops mattering, so rank_targets charges OWES_NOT_TAKING and
+    OWES_TAKING_NOW identically. A patch that adds the terminal horizon's
+    ``and not is_pitting`` guard here (making the "selector" agree with the
+    "scorer") would zero out OWES_TAKING_NOW's charge and break the second
+    assertion below, exactly the unification #742 warns against.
+    """
+    config = ProjectionConfig(racing_laps=RACING_LAPS)
+    ranked = {
+        target.driver: target
+        for target in rank_targets([OWES_NOT_TAKING, OWES_TAKING_NOW], config, our_pit_loss_s=0.0)
+    }
+
+    expected_projected_gap_s = GAP_S + STOP_LOSS_S
+    assert ranked["OWES_NOT_TAKING"].projected_gap_s == pytest.approx(expected_projected_gap_s)
+    assert ranked["OWES_TAKING_NOW"].projected_gap_s == pytest.approx(expected_projected_gap_s), (
+        "post-cycle horizon: charged the SAME as OWES_NOT_TAKING even though "
+        "is_pitting distinguishes them at the other two horizons; rank_targets' "
+        "predicate is stop_pending alone, by design"
+    )


### PR DESCRIPTION
Closes #741, #742, #750, #746

Wave 3 of the decision-layer epic. Three issues, **one defect class**: a value or a rule restated somewhere it is not derived. Built by three parallel workers on disjoint files; verified centrally, and the verification found real problems in two of the three.

## #741 — SOFT's capacity was 18 in code and 15 in both prompts

On `laps_remaining` **16-18** the deterministic selector passed SOFT and both prompts told the LLM to refuse it, so the compound choice on that band was decided by prose. The prompts now **interpolate `_STINT_CAPACITY_LAPS`**.

**The number was measured before it was chosen**, with the same instrument and data `stint_lengths.py` already uses for the minimum bound: **341 real green-flag SOFT stints across 71 races**, median 15, max 50 — and **33.7% run longer than 18**. So the data does not hand back a clean maximum (real stint length is a strategic choice, not a physical ceiling) and **no third number was invented**. 18 stands because it is what the selector already computes against and the closer of the two to real practice.

⚠️ That measurement raises its own question — a bound a third of real stints violate may be the wrong model entirely — but that is not settled here.

**The test is phrased over the whole table, not over SOFT.** Pinning "SOFT reads 18" would pass the day someone edits the table and forgets a prompt, which is exactly how this arose. It parses both rendered prompts and asserts no prompt states a capacity the table disagrees with, plus a guard that the clause is still *there* so a reflow cannot leave it asserting about the empty set.

## #742 — three predicates, three horizons, and ⛔ they must NOT be unified

| function | predicate | horizon |
|---|---|---|
| `rival_time_deltas` | `is_pitting` | inside the window |
| `_terminal_gaps` | `stop_pending and not is_pitting` | race end |
| `rank_targets` | `stop_pending` | after both pit cycles |

**Each is correct for its own horizon.** Nothing in the module said so, and `rank_targets`' docstring was broad enough to be read as covering the stop predicate — so the natural instinct is to "fix" the inconsistency, which would delete the distinction.

The rule is now stated once in the module docstring, that sentence is narrowed, and three tests pin the **distinction**. Verified by mutation: each of the three tempting unifications goes red, **and each goes red on the test named for its horizon**.

## #750 — `pace_delta_s` meant two different things

Contractually rival-relative (this driver minus the car ahead), but the CLI and the arcade fed a **self-delta** from our own consecutive laps. After a stop that compared a green lap against our own out-lap and **invented a pace gain**. Both now use the car ahead, already resolved a few lines above for `gap_ahead_s`, falling back to 0.0 where unknown.

**The producer's own docstring was part of why:** it described `pace_delta_s` as a *3-lap rolling* delta — which is the separate `pace_delta_rolling3` field — while the code computes a single-lap one. Four surfaces fed the wrong quantity into a field whose contract named a different one. Corrected.

## #746 — the backend's anchor (submodule, pointer bumped to `6e7a20e`)

Its fallback used `lap_number - 1` with no `Stint` scoping and no quality filter, so it anchored on the **out-lap** after every stop: Lusail 2025 NOR lap 27 anchored on 107.589 s instead of 85.304 s, ~22 s wrong — worse than the 90.0 default it replaced. Now reproduces N04's transform (previous **surviving** lap within the stint).

### What central verification caught in the workers' output

- **The submodule fix would have crashed.** It filtered on `LapTime` and returned `LapTime_s` — but the featured frame carries only `LapTime_s` and the raw frame only `LapTime`, so it raised `KeyError` on whichever it was handed. Fixed, and the lookup no longer requires *this* lap to have survived the filter, which would have returned `None` on exactly the out-laps and Safety Car laps the raw frame exists to serve.
- **One of my own mutation runs was invalid** — the pattern I substituted did not exist, so the "surviving mutant" was the pristine file. Caught by grepping for the real line before drawing a conclusion. Re-run properly, it goes red.

## Checks

**242** across `tests/mc` + `tests/agents`; `ruff check .` and `ruff format --check .` clean at the pinned version. Four unification mutants and one prompt-drift mutant each verified red, restores diffed against `cp` backups.
