### PR TITLE
fix(agents): single-source the previous-lap sentinel and stop the prompts contradicting

### DIFF
--- a/documents/audits/FABLE_G3_wave3_exit.md
+++ b/documents/audits/FABLE_G3_wave3_exit.md
@@ -1,0 +1,173 @@
+# FABLE G3 — Adversarial exit gate: Wave 3 (PR #765 + submodule 6e7a20e)
+
+- **Date:** 2026-07-31
+- **Scope:** `dev` @ `8bc9d3d` (parent commit `4520431`), submodule `src/telemetry` @ `6e7a20e`. Closes #741, #742, #746, #750.
+- **Mandate:** twin sweep first (previous-lap producers, restated constants, `pace_delta_s` axis), then attack the specific claims (backend anchor shapes, horizon mutants, prompt-test regex, the 341-SOFT-stint measurement).
+- **Rules:** no repo file modified except this report; mutations via `cp` backup + restore + diff-verified; no LLM calls; evidence executed, not read.
+
+## Checklist
+
+- [x] A. Twin sweep: every producer/deriver/defaulter of a "previous lap time" (parent + submodule) → F-01 + census table
+- [x] B. Twin sweep: restated constants in prose vs computed-against values → F-02, F-07, F-08
+- [x] C. Twin sweep: every construction of `pace_delta_s` / RaceState (parent + submodule) → census table, no fifth surface
+- [x] D. Backend anchor: both frame shapes, real 2025 data, post-pit lap, first lap of stint, worse-than-90.0 check → F-05
+- [x] E. #742 horizon mutants re-run + a fourth attack on the horizon distinction → F-04
+- [x] F. #741 prompt-test regex attack (empty-set / green-while-disagreeing) → F-03, executed
+- [x] G. Re-derive: 341 SOFT stints, median 15, max 50, 33.7% > 18 → F-06, exact
+- [x] Close: what I tried to break and could NOT
+
+## Findings
+
+### F-01 · HIGH · Sweep A — the dict-path orchestrator still has BOTH prev-lap defects #746's class describes, and it crashes on the honest value
+
+`src/agents/strategy_orchestrator.py:1849`:
+
+```python
+prev_lap_time  = lap_state.get("prev_lap_time", 92.0),
+```
+
+Two defects in one line, both catalogued classes:
+
+1. **Two-arg `dict.get`** — the default fires only when the KEY is absent. `RaceStateManager.get_driver_state` emits `prev_lap_time: None` (present key, None value) whenever no surviving predecessor exists. `pace_agent.py:709-724` carries a 15-line comment explaining exactly why the two-arg form is wrong for THIS key and uses `or 90.0` instead. The twin one module over never got the fix.
+2. **A restated default** — 92.0 here vs 90.0 in `pace_agent.py:725` for the same quantity. Two sentinels for one concept; neither derived from the other.
+
+**Executed evidence** (models loaded, no LLM): calling `run_pace_agent(prev_lap_time=None, ...)` — exactly what line 1849 passes when the lap_state carries an explicit None —
+
+```
+TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'
+  File "src/agents/pace_agent.py", line 623, in run
+    delta_vs_prev = lap_time_pred - prev_lap_time
+```
+
+`_predict` first turns the None into NaN (`lap_time_pred = nan`), then `delta_vs_prev = nan - None` raises. So `run_strategy_orchestrator` — the **exported public entry point** (`src/agents/__init__.py:99`, named as THE usage example in the module docstring line 17) — crashes on any lap_state whose `prev_lap_time` is the honest None. Failing scenario: any caller bridging `RaceStateManager.get_lap_state()` output (flattened) into the dict path on the first lap of a stint.
+
+Mitigation of severity: no in-repo live surface calls the dict path today (CLI/arcade/backend all use `_from_state`); it is public API and documented, hence HIGH on the defect-class axis but with a currently-dead blast radius in this repo.
+
+### F-02 · MEDIUM · Sweep B — the SAME two prompts still restate `_MIN_STINT_LAPS`, the guard-rail lap bounds, and `CLIFF_IMMINENT_LAPS` as literals
+
+#741 made exactly ONE number derived (`_STINT_CAPACITY_LAPS['SOFT']`). Rendered-prompt extraction (executed, both prompts) shows the following literals that the code ALSO computes against, none interpolated, none covered by the new test's `<=`-only regex:
+
+| prompt text (both prompts unless noted) | code constant | file:line |
+|---|---|---|
+| "SOFT: current tyre_life must be >= 8 … MEDIUM: >= 12. HARD: >= 15." | `_MIN_STINT_LAPS = {"SOFT": 8, "MEDIUM": 12, "HARD": 15}` | `src/strategy/inference/guard_rails.py:41` |
+| "NEVER … before lap 5" | `_NO_PIT_BEFORE_LAP = 5` | `guard_rails.py:38` |
+| "NEVER … when remaining laps <= 3" | `_NO_PIT_LAST_N_LAPS = 3` | `guard_rails.py:39` |
+| "cliff P10 < 2" exception | `_CLIFF_P10_SAFE = 2` | `guard_rails.py:40` |
+| "laps_to_cliff <= 3 → recommend PIT_NOW" (pit prompt) | `CLIFF_IMMINENT_LAPS = 3` | `src/agents/pit_strategy_agent.py:142` |
+| "MEDIUM: suitable for 12-30 remaining laps" (both prompts) | `_STINT_CAPACITY_LAPS['MEDIUM'] = 30` upper bound + `_MIN_STINT_LAPS['MEDIUM'] = 12` | `pit_strategy_agent.py:91` |
+
+The `_MIN_STINT_LAPS` triple sits **in the same prompt, two sections above the line #741 fixed**, in a constant that was converted to an f-string in this very PR — interpolating them was zero marginal cost and did not happen. Every row is the exact defect class the PR names ("a value restated somewhere it is not derived"); guard-rail drift is enforced-after-the-fact so the outcome class is prompt-vs-rail disagreement, not an unrailed decision.
+
+### F-03 · MEDIUM · Attack F executed — the #741 test stays GREEN while both prompts and the table disagree about MEDIUM
+
+The gate asked for "a phrasing that keeps the test green while the prompts and table disagree". It does not need a phrasing change — it exists today for MEDIUM. **Executed**: with `_STINT_CAPACITY_LAPS['MEDIUM']` mutated 30→32 (cp backup, restore verified byte-identical):
+
+```
+MEDIUM 30->32 mutant, prompt still says '12-30':  pytest exit = 0   (3 passed)
+table says MEDIUM = 32 | prompt says: MEDIUM: suitable for 12-30 remaining laps.
+```
+
+The `_BOUND` regex (`tests/agents/test_prompt_constants_match_tables.py:50`) only parses `<=`-phrased clauses; both prompts state MEDIUM's capacity as the range "12-30" (`pit_strategy_agent.py:661`, `strategy_orchestrator.py:1671`), invisible to it. Failing scenario: exactly #741's, one compound over — at `laps_remaining` 31-32 the selector passes MEDIUM and both prompts call it unsuitable, so the band is decided by prose again, with the guard suite green. The test's docstring claim "every compound it can find" is literally true and materially misleading: it can only find SOFT.
+
+### F-04 · VERIFIED (claim E holds) + one nuance · the three horizon mutants each go red on the named test
+
+Executed, each with `cp` backup and byte-identical restore (`filecmp` after every restore):
+
+| mutant | result |
+|---|---|
+| `rival_time_deltas`: `is_pitting` → `stop_pending is True` | RED on `test_window_horizon_charges_only_the_rival_pitting_this_lap` |
+| `_terminal_gaps`: drop `and not rival.is_pitting` | RED on `test_terminal_horizon_charges_an_owed_stop_exactly_once` |
+| `rank_targets`: add `and not rival.is_pitting` | RED on `test_post_cycle_horizon_charges_every_known_obligation_alike` |
+
+Each mutant pattern was grepped in the pristine file (`count == 1`) before substitution — no pristine-file mutant runs.
+
+**Fourth attack (adapter-level unification):** mutating `strategy_orchestrator._rival_states_from_lap_state` (`:824`) to `is_pitting=... or bool(per_rival_pending.get(driver))` destroys the window/terminal distinction for EVERY live surface (all of them build rivals through this adapter) while the three horizon tests — which construct `RivalState` directly — stay green. Executed over the PR's own scope (`tests/mc` + `tests/agents`, 242 tests): **caught anyway**, by `test_mc_is_a_real_decision.py::test_the_named_target_is_the_car_we_will_be_racing_not_the_first_in_the_list` and `test_projection_golden.py` (2 failed, 240 passed). Nuance worth recording: the horizon FILE does not defend against adapter drift; the projection golden does. If the golden is ever regenerated while such a drift is live, the horizon distinction has no dedicated guard at the adapter seam. LOW.
+
+### F-05 · MEDIUM · Attack D — the anchor fix is faithful to N04 (904/904), but the commit's out-lap claim is refuted by execution, and the function ships with ZERO tests
+
+Executed against the endpoint's own served frames (`_get_race_laps_df(2025, "Lusail")` + `laps_featured_2025.parquet`):
+
+**What holds (verified, executed):**
+- **904/904 exact agreement** between the raw-frame fallback and N04's own `Prev_LapTime` for every Lusail 2025 driver-lap present in both frames. The transform is reproduced, not reinterpreted.
+- In-laps served correctly (NOR lap 25 → 85.97, the last surviving lap, not `lap-1`).
+- SC laps served (27 SC-lap anchors, e.g. VER lap 7 → 87.123).
+- Both frame shapes work: a `LapTime`-only frame (timedelta) and a `LapTime_s` frame both return 85.304 for NOR lap 28; a Stint-less frame degrades to None honestly.
+- **No worse-than-90.0 anchor found**: across all 67 raw-only laps that get an anchor, values span 83.714–88.866 s — never an out-lap, in-lap or SC lap time.
+
+**What breaks:**
+
+1. **The commit message's mechanism claim is false for out-laps.** It says the lookup "must not require THIS lap to have survived the filter, or it returns None on exactly the out-laps and Safety Car laps the raw frame exists to serve; it takes the last surviving lap BEFORE the current one instead." Executed census: **out-laps total = 42, anchored = 0, None = 42.** The Stint scoping makes the out-lap the first lap of its stint, so there is never an earlier lap inside it — the design rationale's first-named beneficiary is structurally unservable. The SC half of the claim is true (27 served). The in-code comment `strategy.py:868-871` ("Anchoring an out-lap on the last good racing lap before it is still the right answer") describes behavior the function cannot produce. Downstream: out-laps AND the first flying lap after every stop (NOR lap 27 → None) fall through to the pace agent's 90.0 — which matches N04's NaN semantics, so the BEHAVIOR is defensible; the NARRATIVE (commit, PR body, comment) is not. A comment naming the wrong mechanism is a catalogued class here.
+2. **The frame-shape comment at `strategy.py:860-861` has the frames backwards**: "A frame without the quality flags excludes nothing on them, which is the raw frame's case". Executed: the raw parquet CARRIES `IsAccurate` and `Deleted` (it is the featured frame that lacks them, harmlessly). Wrong-mechanism comment, LOW on its own, listed here because two of them in one 40-line function is how the next fix gets mis-aimed.
+3. **Zero tests.** Submodule commit `6e7a20e` ships no test file; `grep` finds no test referencing `_prev_lap_time_for_row` in the submodule or the parent. Issue #746's acceptance criteria explicitly demand "a test asserting the lap after a stop is not anchored on the out-lap" and the None-semantics. The most intricate function of the wave — the one whose first draft "would have crashed" per the PR's own verification note — is the only one shipped untested. The PR's "242 across tests/mc + tests/agents" is parent-only and cannot cover a submodule function.
+
+### F-06 · VERIFIED · Attack G — the 341-SOFT-stint measurement reproduces exactly
+
+Re-derived with the same instrument (`measure_stint_lengths()`, defaults):
+
+```
+races: 71 | SOFT n = 341 | median = 15.0 | max = 50.0
+share > 18: 33.7 % | share > 15: 45.7 % | total counted = 1785
+```
+
+Every figure quoted in the commit message, the PR body and the test docstring matches, including the strict `>` reading of "run longer than 18" and the 1785 total the issue cites. No finding.
+
+### F-07 · MEDIUM · Sweep B — `0.522` is a config-loaded threshold restated as a prompt literal, so the prompt can disagree with the tool output in the same conversation
+
+`pit_strategy_agent.py:618` (system prompt): "If P(undercut_success) >= 0.522 for any rival → recommend UNDERCUT." The code does NOT own that number: `:230` loads `self.undercut_threshold = uc_cfg['best_threshold']` from the model's JSON config, `:1201` compares against it, and `:1207` **prints the live threshold into the tool response** (`threshold={agent.cfg.undercut_threshold}`). Retune the model, republish the config, and the LLM receives two different thresholds in one conversation — the tool says one number, the system prompt insists on 0.522. Same defect class as #741 with a sharper failure mode, because here the second copy is not even a repo constant but a data artifact.
+
+### F-08 · MEDIUM · Sweep B — the two prompts disagree TODAY about the same derived figure: ~13 vs ~9 positions, and the 13 derives from the constant the redesign retired
+
+`strategy_orchestrator.py:1664` (rule 2, six lines above the line this PR edited): "Pit cost ~22s vs ~1.5s recovery = **~13 positions lost**." That 13 is `20 s / POS_GAP_S(1.50)` — `POS_GAP_S` being the legacy-scoring constant `measure_mc_tables.py:575` records as "retires_constant". The pit agent's prompt was already corrected to the measured geometry (`pit_strategy_agent.py:636-639`): "worth **~9 positions, not 13**: 13 positions is the Safety Car bunched-field figure (median gap 1.4795s)" — 20 s / 2.226 s ≈ 9. So one prompt explicitly refutes the number the other prompt still teaches, in the same run, to the same orchestrating LLM. One copy fixed, its twin not — the wave's own defect class, inside a file the wave edited.
+
+Related boundary nit (LOW): the pit prompt states REACTIVE_SC at `sc_prob >= 0.30` (twice) while the code routes on `sc_prob_3lap > CFG.sc_prob_threshold` (`:587`, `:1988`) — strict vs inclusive at exactly 0.30, and 0.30 is itself a restated literal for `CFG.sc_prob_threshold` (`:127`).
+
+### Sweep A — census of every previous-lap producer found (parent + submodule)
+
+| producer | what it produces | reproduces the training transform? | reaches a model? |
+|---|---|---|---|
+| `RaceStateManager._precompute_prev_lap_times` (`race_state_manager.py:195-221`) | N04 transform: filter-then-group-shift | YES (read, filter terms verified) | yes — N06 anchor via lap_state |
+| backend `_prev_lap_time_for_row` (`strategy.py:804-877`, this wave) | featured `Prev_LapTime`, else N04 reconstruction | YES — **executed 904/904 match** (F-05) | yes — `/lap-state`, `/simulate` |
+| `pace_agent.py:725` `d.get('prev_lap_time') or 90.0` | 90.0 sentinel only on genuinely-missing | consumer-side default (documented) | yes — N06 |
+| **`strategy_orchestrator.py:1849` `lap_state.get("prev_lap_time", 92.0)`** | **None passthrough + a 92.0 twin default** | **NO — F-01, crashes on None** | yes (dict path, public API) |
+| `tire_agent._add_prev_cols` (`:554-569`) | `shift(1).fillna(current)` over the handed-in frame | its reference is N08/N09 (not N04); on the featured frame shift(1) = previous surviving lap by construction; the `fillna(current)` self-referential fill only touches the window's first row and only survives into `LapTime_Delta`/speed deltas, which N09's manifest excludes as lap-time shortcuts. Pre-existing, out of this wave's blast radius — flagged, not scored | TCN input frame |
+| `race_situation_agent._build_sc_features` (`:991`) `LapNumber == lap_number - 1` | previous-LAP AGGREGATE row for N14's per-lap SC features | N13/N14 aggregate laps by lap number, not by stint survival — this is that pipeline's own transform, not a stint anchor | yes — N14 |
+| CLI `run()` / arcade `_step_once` / simulator `:843,924` bookkeeping `prev_lap_time` | loop variable, **no longer read** by `_build_race_state` (verified in current tree: only the signatures keep it) | n/a — dead input, docstrings say so | no |
+| eval `pace_holdout.py` | reads the parquet's own `Prev_LapTime`; lag features via keyed group shift | yes (parquet is N04's output) | eval only |
+| `scripts/measure_mc_tables.py:849`, `bench_pace_baselines.py:168` | measurement-side lags | eval instruments, not inference | no |
+
+### Sweep C — census of every `pace_delta_s` construction
+
+| surface | feeds | axis |
+|---|---|---|
+| CLI `run_simulation_cli.py:1357` | prompt via RaceState | rival-relative (car ahead, same lap) — FIXED, read |
+| arcade `strategy.py:673` | prompt via RaceState | rival-relative — FIXED, read |
+| backend simulator `:403` | prompt | 0.0 unknown — FIXED |
+| backend mcp_tools `:593` | prompt | 0.0 unknown — FIXED |
+| backend `/recommend` `strategy.py:1342` | prompt | client-supplied; webapp sends 0 (`strategy.ts:356`) |
+| `race_state_builder._targeting_against_rival:46` | prompt | rival-relative (user-selected rival, #431) — the "shared helper recomputes" claim in the new comments is TRUE (verified in source) |
+| N27 producer `race_situation_agent.py:908` | N27 features | rival-relative (two drivers, same lap) — the contract source |
+| eval `decision_modes.py:337` | deterministic replay | constant 0.0 — diverges from what the CLI now feeds, but `race_state.pace_delta_s` is consumed ONLY at `strategy_orchestrator.py:1707` (prompt), so the no-llm scorecard numbers are unaffected. LOW note, no action forced |
+| `debug_agent.py:305`, `prompt_ab/gen_inputs.py:63`, test fixtures | — | 0.0 neutral |
+| `RivalState.pace_delta_s` (`position_projection.py:159`) | MC projection | opposite sign convention (rival minus us) BUT its only producer `_rival_states_from_lap_state:821` never sets it (defaults 0.0), so no cross-axis feed exists today |
+
+**No fifth surface feeding a self-delta (or any wrong-axis value) into the field was found.** The four fixed surfaces are the population.
+
+## What I tried to break and could NOT
+
+- **The three horizon unifications** — each goes red on exactly the test named for its horizon (executed, F-04). The PR's mutation claim is accurate as stated.
+- **A fourth, adapter-level unification** (`_rival_states_from_lap_state` forcing `is_pitting` from `stop_pending`) — bypasses all three horizon tests but is caught by `test_mc_is_a_real_decision` and the projection golden (2 failed / 240 passed, executed).
+- **The SOFT prompt-bound guard** — a reflow that drops the `<=` phrasing is caught by `test_the_soft_bound_is_actually_present_in_both_prompts` (asserted by reading; the guard asserts set membership of the rendered tuple, which the reflow removes).
+- **The 341-stint measurement** — reproduced to the decimal with the shipped instrument, including the strict-inequality reading (F-06).
+- **The backend anchor vs N04** — 904/904 exact agreement on real Lusail 2025 data; no anchor worse than the 90.0 default anywhere in the race (out-laps/first-flying-laps return None, which downstream maps to the same 90.0, never to something worse); in-laps and SC laps anchored correctly; both frame shapes handled; Stint-less and quality-flag-less frames degrade honestly (all executed, F-05).
+- **`Series.get` NaN traps in the new code** — `row.get("LapNumber")` / `row.get("Stint")` both pass through `pd.isna` before use (read; the D battery exercised the NaN-stint path implicitly via frames without the column).
+- **The "shared helper recomputes rival-relative" comment** — verified true against `race_state_builder.py:81-87` (the one mechanism-claim in the new comments that holds).
+
+## Verdict
+
+| severity | count | items |
+|---|---|---|
+| HIGH | 1 | F-01 (dict-path orchestrator: None passthrough crashes + 92.0/90.0 twin default) |
+| MEDIUM | 5 | F-02 (min-stint + rail bounds + cliff literals still restated), F-03 (MEDIUM capacity drifts under a green #741 test, executed), F-05 (out-lap claim refuted 0/42 + zero tests on the wave's riskiest function), F-07 (0.522 vs config-loaded threshold), F-08 (~13 vs ~9 cross-prompt contradiction from a retired constant) |
+| LOW | 3 | adapter-seam nuance (F-04), wrong-frame comment (`strategy.py:860`), eval `decision_modes` 0.0 divergence note + sc `>=`/`>` boundary nit |
+
+**Mutation hygiene:** every mutant was applied from a `cp` backup of the pristine file, the mutant pattern was counted (`== 1`) in the pristine text before substitution, and every restore was verified byte-identical with `filecmp.cmp(..., shallow=False)` — reported `True` in all five runs. `git status` at close shows no tracked file modified in parent or submodule; the only new file is this report. No `git checkout --` was used at any point.

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -54,6 +54,20 @@ except (ImportError, OSError, RuntimeError):
     # repo-relative data/ is right for all three.
     _DATA_ROOT = _REPO_ROOT / 'data'
 
+# What stands in for the previous lap when there genuinely is not one: the first lap
+# of a race, or of a stint, where N04's Prev_LapTime is NaN by construction.
+#
+# It is a module constant rather than a literal because it had already been restated:
+# strategy_orchestrator's dict path carried 92.0 for the same quantity, so the two
+# entry points of the same model disagreed about the same missing value. Exported so
+# a second copy cannot appear again (#766).
+#
+# `_predict` reads this straight into `prev + delta` with no NaN branch, so it cannot
+# be None. That is the whole reason a placeholder exists at all, and it is why every
+# caller must use `or` rather than the two-arg `dict.get`: the key is PRESENT with a
+# None value, which the two-arg form does not substitute for.
+MISSING_PREV_LAP_TIME_S = 90.0
+
 _MODELS_DIR = _DATA_ROOT / 'models' / 'lap_time'
 _PROCESSED  = _DATA_ROOT / 'processed'
 
@@ -722,7 +736,7 @@ class PaceAgent:
             # would turn lap_time_pred itself into NaN. 90.0 is the same
             # order-of-magnitude placeholder the old (wrong) code used, now only
             # reached on a genuinely missing previous lap.
-            prev_lap_time  = d.get('prev_lap_time') or 90.0,
+            prev_lap_time  = d.get('prev_lap_time') or MISSING_PREV_LAP_TIME_S,
             prev_tyre_life = max(0, (d.get('tyre_life') or 1) - 1),
             prev_speed_st  = float(_speed_st),
             air_temp       = float(_air_temp),

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -66,7 +66,11 @@ except ImportError:
     _LC_OK = False
 
 # ── Sub-agent imports ──────────────────────────────────────────────────────────
-from src.agents.pace_agent         import run_pace_agent, run_pace_agent_from_state
+from src.agents.pace_agent         import (
+    MISSING_PREV_LAP_TIME_S,
+    run_pace_agent,
+    run_pace_agent_from_state,
+)
 from src.agents.tire_agent         import run_tire_agent, run_tire_agent_from_state
 from src.agents.race_situation_agent import (
     run_race_situation_agent,
@@ -1661,7 +1665,17 @@ def _build_orchestrator_prompt(
         f"     or damage/puncture confirmed by radio. Fresh tyres cannot degrade in 1-4 laps;\n"
         f"     pit lane costs ~22-25s which is unrecoverable this early. Force STAY_OUT.\n"
         f"  2. NO pit action when remaining laps <= 3 unless tyre failure imminent\n"
-        f"     (cliff P10 < 2 laps). Pit cost ~22s vs ~1.5s recovery = ~13 positions lost.\n"
+        # ~9, not ~13. The 13 was 20 s / POS_GAP_S(1.50), and POS_GAP_S is the legacy
+        # scoring constant `measure_mc_tables.py` records as retired. The MEASURED
+        # median gap between consecutive cars under green flag is 2.227 s (n=69,487),
+        # which puts 20 s at about nine places; 1.4795 s, and therefore thirteen, is
+        # the SAFETY CAR bunched-field figure (n=3,658) and is the exception this rule
+        # excludes. The pit agent's prompt already said exactly that, so the two
+        # prompts were teaching one orchestrating LLM contradictory numbers in the
+        # same run (#766).
+        f"     (cliff P10 < 2 laps). Pit cost ~22s vs ~1.5s recovery = ~9 positions lost\n"
+        f"     under green flag (measured median gap 2.227s). The ~13 figure is the\n"
+        f"     Safety Car bunched field (1.4795s), which is the exception above.\n"
         f"  3. REACTIVE_SC only when SC IS deployed (confirmed). High sc_prob is a\n"
         f"     contingency trigger, not a primary action — use STAY_OUT with SC contingency.\n"
         f"  4. Minimum stint before pit: SOFT >= 8 laps, MEDIUM >= 12, HARD >= 15.\n"
@@ -1846,7 +1860,14 @@ def _run_always_on_agents(race_state: "RaceState", lap_state: dict) -> tuple:
             "fuel_load", 1 - race_state.lap / race_state.total_laps
         ),
         year           = lap_state["year"],
-        prev_lap_time  = lap_state.get("prev_lap_time", 92.0),
+        # `or`, NOT the two-arg get(key, default): `RaceStateManager` emits this key
+        # PRESENT with a None value whenever no surviving predecessor exists, and the
+        # two-arg form substitutes only for an absent KEY. `_predict` reads the value
+        # straight into `prev + delta` with no NaN branch, so a None reaching it turns
+        # the prediction into NaN and then raises on the subtraction. The twin of this
+        # line in `pace_agent` carries a fifteen-line comment saying exactly that; this
+        # one carried a bare 92.0 and got neither the form nor the same number (#766).
+        prev_lap_time  = lap_state.get("prev_lap_time") or MISSING_PREV_LAP_TIME_S,
         prev_tyre_life = race_state.tyre_life - 1,
         prev_speed_st  = lap_state.get("prev_speed_st", 300.0),
         air_temp       = race_state.air_temp,

--- a/tests/agents/test_prev_lap_default_is_single_sourced.py
+++ b/tests/agents/test_prev_lap_default_is_single_sourced.py
@@ -1,0 +1,134 @@
+"""#766 — the previous-lap sentinel had two values and two substitution rules.
+
+`pace_agent` guards this key with `d.get('prev_lap_time') or 90.0` and carries a
+fifteen-line comment explaining why the two-arg `dict.get` form is wrong for it:
+`RaceStateManager` emits the key PRESENT with a `None` value whenever no surviving
+predecessor exists, and the two-arg form substitutes only for an absent KEY.
+
+`strategy_orchestrator`'s dict path carried `lap_state.get("prev_lap_time", 92.0)`.
+Both defects at once: the wrong form, so an honest `None` passed straight through,
+and a different number for the same quantity. `_predict` reads the value into
+`prev + delta` with no NaN branch, so the `None` reached a subtraction and the
+exported public entry point raised `TypeError` on the first lap of any stint.
+
+Found by gate G3's twin sweep, which is the point of that sweep: the fix landed on
+one producer and its twin one module over never got it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "lap_time").is_dir()
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_MODELS, reason="importing the agents loads model artefacts (HF, not git)"
+)
+
+
+def _lap_state(*, prev_lap_time):
+    """The keys `_run_always_on_agents` documents as required, plus the one under test."""
+    return {
+        "driver_number": 4,
+        "stint": 2,
+        "team": "McLaren",
+        "year": 2025,
+        "gp_name": "Lusail",
+        "prev_lap_time": prev_lap_time,
+    }
+
+
+def test_the_sentinel_has_exactly_one_definition():
+    """Both modules must read the same object, not two equal literals.
+
+    Equal-but-separate would pass an equality check today and drift tomorrow, which
+    is what happened: 90.0 against 92.0 for the same missing value.
+    """
+    from src.agents import pace_agent, strategy_orchestrator
+
+    assert strategy_orchestrator.MISSING_PREV_LAP_TIME_S is pace_agent.MISSING_PREV_LAP_TIME_S
+
+
+def test_an_honest_none_is_substituted_and_never_forwarded(monkeypatch):
+    """The lap state says "there is no previous lap" the only way it can.
+
+    `None` is the correct value for the first lap of a stint, so the fix is not to
+    stop emitting it. It is to substitute at the boundary that cannot represent it,
+    with the same rule and the same number as the twin entry point.
+    """
+    from src.agents import strategy_orchestrator as so
+
+    captured = {}
+
+    def _spy(**kwargs):
+        captured.update(kwargs)
+        raise _Stop
+
+    class _Stop(Exception):
+        pass
+
+    monkeypatch.setattr(so, "run_pace_agent", _spy)
+
+    lap_state = _lap_state(prev_lap_time=None)
+    race_state = so.RaceState(
+        driver="NOR",
+        lap=30,
+        total_laps=57,
+        position=3,
+        compound="MEDIUM",
+        tyre_life=5,
+        gap_ahead_s=2.0,
+        pace_delta_s=0.0,
+        risk_tolerance=0.5,
+        air_temp=25.0,
+        track_temp=35.0,
+    )
+
+    with pytest.raises(_Stop):
+        so._run_always_on_agents(race_state, lap_state)
+
+    assert captured["prev_lap_time"] == so.MISSING_PREV_LAP_TIME_S
+    assert captured["prev_lap_time"] is not None
+
+
+def test_a_real_previous_lap_is_passed_through_untouched(monkeypatch):
+    """The guard above must not swallow a genuine reading.
+
+    Without this the substitution could be unconditional and still pass the other
+    test, which would replace every anchor in the dict path with the placeholder.
+    """
+    from src.agents import strategy_orchestrator as so
+
+    captured = {}
+
+    class _Stop(Exception):
+        pass
+
+    def _spy(**kwargs):
+        captured.update(kwargs)
+        raise _Stop
+
+    monkeypatch.setattr(so, "run_pace_agent", _spy)
+
+    race_state = so.RaceState(
+        driver="NOR",
+        lap=30,
+        total_laps=57,
+        position=3,
+        compound="MEDIUM",
+        tyre_life=5,
+        gap_ahead_s=2.0,
+        pace_delta_s=0.0,
+        risk_tolerance=0.5,
+        air_temp=25.0,
+        track_temp=35.0,
+    )
+    lap_state = _lap_state(prev_lap_time=85.304)
+
+    with pytest.raises(_Stop):
+        so._run_always_on_agents(race_state, lap_state)
+
+    assert captured["prev_lap_time"] == 85.304

--- a/tests/agents/test_prompt_constants_match_tables.py
+++ b/tests/agents/test_prompt_constants_match_tables.py
@@ -45,13 +45,21 @@ pytestmark = pytest.mark.skipif(
     "data/models/ (HF, not git)",
 )
 
-# "SOFT only if <= 18 laps", "SOFT: recommend only if remaining laps <= 18", and any
-# future phrasing that puts a compound and a bound in the same clause.
-_BOUND = re.compile(r"\b(SOFT|MEDIUM|HARD)\b[^.\n]*?<=\s*(\d+)")
+# Two phrasings, because the prompts use both and the first version of this file only
+# read the first. Gate G3 executed the gap: mutating MEDIUM 30 -> 32 left this test
+# GREEN while both prompts still said "12-30", so the docstring's "every compound it
+# can find" found exactly one. A regex is a claim about coverage and has to be tested
+# like one.
+_LE_BOUND = re.compile(r"\b(SOFT|MEDIUM|HARD)\b[^.\n]*?<=\s*(\d+)")
+_RANGE_BOUND = re.compile(r"\b(SOFT|MEDIUM|HARD)\b[^.\n]*?\b\d+\s*-\s*(\d+)\b")
 
 
 def _stated_bounds(prompt: str) -> set[tuple[str, int]]:
-    return {(m.group(1), int(m.group(2))) for m in _BOUND.finditer(prompt)}
+    """Every (compound, upper bound) pair either phrasing states."""
+    pairs = set()
+    for pattern in (_LE_BOUND, _RANGE_BOUND):
+        pairs |= {(m.group(1), int(m.group(2))) for m in pattern.finditer(prompt)}
+    return pairs
 
 
 def _orchestrator_prompt() -> str:
@@ -93,20 +101,29 @@ def test_no_prompt_states_a_capacity_the_table_disagrees_with():
             )
 
 
-def test_the_soft_bound_is_actually_present_in_both_prompts():
-    """The guard above passes vacuously if the regex stops matching.
+def test_every_compound_the_prompts_bound_is_actually_seen_by_the_regex():
+    """The guard above passes vacuously on whatever the regex fails to match.
 
-    That is not hypothetical: the bound is now interpolated, so a refactor that drops
-    the clause, renames the compound or reflows the sentence would silently leave the
-    check asserting about the empty set — this project's catalogued way for a green
-    test to mean nothing.
+    Not hypothetical, and not caught by inspection: gate G3 EXECUTED the gap by
+    moving MEDIUM 30 -> 32 and watching this file stay green while both prompts still
+    said "12-30". So this asserts coverage, compound by compound, rather than trusting
+    the pattern — the same "asserting about the empty set" trap the SOFT-only version
+    of this test was written to avoid and then fell into for the other two.
     """
     from src.agents.pit_strategy_agent import _PIT_STRATEGY_SYSTEM_PROMPT, _STINT_CAPACITY_LAPS
 
-    soft = _STINT_CAPACITY_LAPS["SOFT"]
-
-    assert ("SOFT", soft) in _stated_bounds(_PIT_STRATEGY_SYSTEM_PROMPT)
-    assert ("SOFT", soft) in _stated_bounds(_orchestrator_prompt())
+    for name, prompt in (
+        ("pit agent", _PIT_STRATEGY_SYSTEM_PROMPT),
+        ("orchestrator", _orchestrator_prompt()),
+    ):
+        seen = {compound for compound, _ in _stated_bounds(prompt)}
+        for compound in ("SOFT", "MEDIUM"):
+            assert compound in seen, (
+                f"{name} prompt states a bound for {compound} that the pattern does not "
+                f"match, so the check above cannot see it. Saw: {sorted(seen)}"
+            )
+            stated = dict(_stated_bounds(prompt))[compound]
+            assert stated == _STINT_CAPACITY_LAPS[compound]
 
 
 def test_the_selector_and_the_prompt_agree_across_the_band_that_used_to_split_them(monkeypatch):


### PR DESCRIPTION
Closes #766

Gate G3 was the **exit gate** over wave 3, and its mandate was a **twin sweep** rather than a diff review. It found the twin. **1 HIGH, 5 MEDIUM, 3 LOW**; report committed.

## F-01 (HIGH) — the un-fixed twin, with both defects in one line

`strategy_orchestrator.py` carried `lap_state.get("prev_lap_time", 92.0)`:

1. **The two-arg `dict.get`** substitutes only for an absent *key*, and `RaceStateManager` emits this one **present with a `None` value** whenever no surviving predecessor exists. `pace_agent` spends **fifteen lines** explaining exactly that and uses `or`. The twin one module over never got it.
2. **92.0 against 90.0** for the same quantity — a restated constant, the very defect class wave 3 was about.

Executed: `run_pace_agent(prev_lap_time=None)` → `TypeError` at `pace_agent.py:623`. So `run_strategy_orchestrator` — the **exported public entry point, named as THE usage example in the module docstring** — crashed on the first lap of any stint.

The number now has **one definition**, `MISSING_PREV_LAP_TIME_S`, which both entry points import, and the dict path uses the same form as its twin. Three tests; one fails on the exact original line.

## F-08 — the two prompts contradicted each other, six lines above what wave 3 edited

The orchestrator taught *"~13 positions lost"* — that is `20 / POS_GAP_S(1.50)`, and `POS_GAP_S` is the constant `measure_mc_tables.py` records as **retired**. The pit agent's prompt already said *"~9 positions, **not 13**: 13 is the Safety Car bunched-field figure"*.

**One orchestrating LLM, one run, two numbers, one explicitly refuting the other.** Corrected to the measured green-flag geometry: median gap **2.227 s** over 69,487 samples.

## F-03 — and this one is mine

The prompt test I added in wave 3 claims to check *"every compound it can find"* and finds **only SOFT**, because its regex reads `<=` clauses while MEDIUM is stated as a range. The gate **executed** the gap: moving MEDIUM 30 → 32 left the file green while both prompts still said "12-30".

I wrote a guard against asserting-about-the-empty-set for SOFT and left the same hole open for the other two. Both phrasings are matched now, and **the coverage itself is asserted compound by compound** so the pattern cannot silently stop seeing one.

## F-05 — the anchor is faithful; the narrative around it was not

**What the gate verified holds:** 904/904 exact agreement with N04's own `Prev_LapTime` on real Lusail 2025, in-laps and SC laps served, both frame shapes work, and **no worse-than-90.0 anchor exists**.

**What was wrong:**
- The rationale claimed the lookup serves **out-laps**. Executed census: **42 out-laps, 0 anchored** — stint scoping makes an out-lap the first lap of its stint, so no earlier lap exists inside it. Behaviour right (N04 has NaN there too), rationale naming a beneficiary the function cannot have. What it *does* serve is **27 Safety Car laps**.
- The frame-shape comment had the frames **backwards**.
- **Zero tests**, despite #746 asking for them. The most intricate function of the wave was its only untested one.

Six tests added in the submodule, mutation-verified: dropping the survival filter re-anchors lap 27 on the out-lap's 107.589 and the right test goes red.

## F-06 — verified, no finding

The 341 SOFT stints / median 15 / max 50 / 33.7% over 18 measurement **reproduces to the decimal**, including the strict `>` reading.

## Still open, filed rather than smuggled in

The guard-rail bounds, `CLIFF_IMMINENT_LAPS` and the config-loaded undercut threshold remain restated literals in the same two prompts. The last is the sharpest — the code **prints the live threshold into the tool response**, so a retune makes the LLM receive two different numbers in one conversation.

## Checks

**245** across `tests/mc` + `tests/agents`, plus **6** in the submodule; `ruff check .` and `ruff format --check .` clean. Submodule pointer bumped to `82f6382`.
