### PR TITLE
Promote the decision-layer epic: measure the decision, connect the tyre channel, and say what it cost

### DIFF
--- a/documents/audits/FABLE_G1_transition_metric.md
+++ b/documents/audits/FABLE_G1_transition_metric.md
@@ -1,0 +1,384 @@
+# FABLE gate G1 — the transition metric (commit `a474ac8`, PR #755, issue #752)
+
+Adversarial gate over the STAY_OUT → PIT transition metric that replaced the retired
+first-pit-lap metric in `src/strategy/eval/decision_modes.py`. Written incrementally:
+each finding is appended the moment it is confirmed with executed evidence. Nothing in
+this file was written from reading alone.
+
+- Gate run: 2026-07-30, on `dev` at `0d52440` (merge of `a474ac8`).
+- Rule: no repository file modified except this report, with the single sanctioned
+  exception of temporary mutants for claim E, restored and verified restored.
+
+## Checklist of claims under attack
+
+- [x] **A** — `_pit_decision_lap` locates a genuine transition, no off-by-one — SOUND on boundaries/oscillation; but see A1/A1b (bucket prose names the wrong mechanism) and A3 (rail release)
+- [x] **B** — replay-span widening — VERIFIED necessary and effective on real data (A2); but its absence is untested, see E1
+- [x] **C** — `no_boundary` inside `eligible` — HOLDS everywhere a denominator lives (executed constructions below)
+- [x] **D** — width-sensitivity claim — CONFIRMED exactly (7 scored at both, 6 same, NOR 42→38, HAM revealed); phrasing "the two that move" conflates a bucket change with a lap change
+- [x] **E** — mutation testing — **M3 (narrowed replay span) leaves ALL 34 tests green while changing the real measurement → HIGH**
+- [x] **F** — the twin — no second first-occurrence scorer found in code; the twin is the COMMITTED REPORT itself (F1, HIGH)
+
+## Findings
+
+(appended below as confirmed)
+
+### F1 — HIGH — the committed eval report still publishes the retired metric; acceptance criterion 4 of #752 is unmet
+
+`documents/eval_reports/decision_modes.json:48` still says `"mean_signed_error": -3.3` over
+90 scored stops, with buckets `{closing_laps: 4, min_stint: 22, no_call_in_window: 78, opening_laps: 4, scored: 90}`
+— **no `no_boundary_in_window` bucket exists in the committed artifact**. The md header says
+`generated 2026-07-30T08:37:07+00:00` on harness `1f0ec9d`; the fix commit `a474ac8` is
+21:06 the same day and touched only `src/strategy/eval/decision_modes.py` and
+`tests/eval/test_decision_modes.py` (verified via `git show a474ac8 --stat`).
+`git log -- documents/eval_reports/decision_modes.md` shows the last touch was `009cbe2`
+(a docs commit), and `git status documents/eval_reports/` is clean — nothing regenerated,
+nothing pending.
+
+Issue #752's acceptance list includes: *"The committed report regenerated, with the decline
+rate and coverage preserved"*. The PR that says `Closes #752` did not do it. The repo's
+committed truth is therefore still the number the commit message itself calls "three readings
+of the window", in the exact artifact a reader of `documents/eval_reports/` would quote. This
+is the same defect class the commit lectures about in its last paragraph ("a doc that outlives
+the code it documents"), applied to the report instead of the docstring.
+
+Failing scenario: anyone running `f1-eval` consumers, the docs site, or a thesis section off
+the committed `decision_modes.json` quotes −3.30 as the system's timing error today.
+
+### A1 — MEDIUM — an evaluation gap inside the window is bucketed as `no_boundary_in_window`, whose documented meaning is then false
+
+`src/strategy/eval/decision_modes.py:500-504` assigns `no_boundary_in_window` whenever
+`_pit_decision_lap` returns None but `_asks_to_stop` is True. That predicate does not
+distinguish "pit on every lap offered" from "STAY_OUT for most of the window, one lap never
+evaluated, then PIT". Executed (transcribing the bucketing at :493-505 exactly):
+
+```
+# 3. pit only at the LAST window lap, lap 31 never evaluated
+actions = {26..30: STAY_OUT, 32: PIT_NOW}      -> no_boundary_in_window
+# 4. STAY_OUT lap 27, gap at 28, PIT 29..32
+actions = {26,27: STAY_OUT, 29..32: PIT_NOW}   -> no_boundary_in_window
+```
+
+Both land in the bucket that `_render_table` (decision_modes.py:573-580) explains as *"The
+stack asked to stop on every lap offered, including the first, so there is no STAY_OUT ->
+PIT transition to locate: it was already committed before the window opened"* and that the
+docstring (:359-361) glosses as *"the call came earlier than we asked"*. In scenario 3 the
+stack demonstrably declined for five consecutive laps and its only pit ask is the LAST lap
+of the window — the call came *later* than almost everything we asked, not earlier. The
+mechanism named by the prose is wrong for every gap case, which is this repo's documented
+bug class (a comment naming the wrong mechanism). The scoring itself stays conservative
+(no lap is invented), so this is an interpretation/reporting defect, not a scoring one —
+but `no_boundary` is the bucket the next analysis will read as "already committed", and gap
+cases silently inflate it with the opposite situation.
+
+Reachability: requires a lap inside [window_low, window_high] with `lap_inputs` returning
+None (missing position / lap_number) while neighbours evaluate — see A2/RE evidence below on
+whether real replay spans contain such holes.
+
+### A1b — MEDIUM — on real data, 4 of 4 inspected `no_boundary` stops do NOT match the bucket's documented mechanism
+
+The gap scenario above turned out to be the minor half. The real-data sweep (2025 Monza,
+w=5, pristine code, actions recorded by wrapping `_decisions_in_window`) shows what the
+bucket actually contains. The four `no_boundary_in_window` stops at w=5:
+
+```
+GAS stop 49, window [44,53], pred(43)=UNDERCUT:
+    44..49: UNDERCUT   50..52: STAY_OUT   53: never evaluated
+STR stop 49, window [44,53], pred(43)=UNDERCUT:  same shape as GAS
+HAM stop 38, window [33,43], pred(32)=PIT_NOW:
+    33..37: PIT_NOW    38..43: STAY_OUT
+PIA stop 45, window [40,50], pred(39)=PIT_NOW:
+    40: PIT_NOW  41..44: UNDERCUT  45: PIT_NOW   46..50: STAY_OUT
+```
+
+None of the four "asked to stop on every lap offered, including the first"
+(`_render_table`, decision_modes.py:574) — every one of them was committed when the window
+opened and then **withdrew mid-window**. HAM flips to STAY_OUT on the exact lap the team
+actually stopped. The docstring gloss "the call came earlier than we asked" (:27-29, :359-361)
+does hold for all four (each was already asking at `window_low` and at its evaluated
+predecessor); the render prose's stronger claim ("every lap offered") is false for 4/4.
+This is the repo's documented defect class — prose naming the wrong mechanism — sitting in
+the artifact every reader of the report will use to interpret the bucket. It also means the
+bucket silently merges "committed and stayed committed" with "committed, then withdrew",
+and the withdrawal lap (which for HAM was the real stop lap — arguably signal) is discarded.
+
+Caveat found while verifying: GAS/STR's STAY_OUT tail at laps 50-52 is NOT model withdrawal —
+`total_laps=53`, so laps 50+ have `remaining <= 3` and the closing rail forces STAY_OUT
+(recorded actions are post-rail, `src/strategy/inference/no_llm.py:293`). HAM's (38-43,
+15 laps remaining) and PIA's (46-49) are genuine model withdrawals.
+
+### A2 — verified sound — replay-span integrity on real data (claim B.i-B.ii)
+
+From the recorded spans at all three widths, every (race, driver) pair at 2025 Monza:
+the widened lap `low` **is** present in `actions` — `evaluated=True` for all pairs, all
+widths. The only holes inside `[low, high]` are trailing-edge: ALO laps 25+ (retired after
+his lap-24 stop; his lap-24 stop is `min_stint`, lap-20 stop scored `no_call` with laps
+15-24 evaluated) and lap 53 for GAS/STR/OCO (lapped cars have no final-lap row). No
+mid-window transient hole was observed, so finding A1's gap scenario is constructible but
+was not reached in this sample.
+
+Scoring range vs replay range (claim B.ii): they are not the same range —
+`low = max(1, min(stop_laps) - DECISION_WINDOW_LAPS - 1)` (:469) vs
+`window_low = max(1, stop_lap - DECISION_WINDOW_LAPS)` (:481). The one case in the entire
+sweep where `chosen == window_low` (HAD, stop 32, w=5, chosen 27) has predecessor lap 26
+evaluated as STAY_OUT — a genuine transition — and the acid test: **at w=10, when the window
+edge moves to 22, HAD's chosen lap stays 27.** The edge report is gone not just by
+construction but demonstrably on data.
+
+Clamp at lap 1 (claim B.iii): hermetic probes — window [1,8] all-PIT from lap 1 returns
+None → `no_boundary_in_window` (lap 1 has no predecessor and is correctly unjudgeable, never
+scored); `{1: STAY_OUT, 2: PIT}` returns 2. No unjudgeable-but-scored path exists.
+
+### A3 — MEDIUM (structural, not observed in sample) — a rail release can still manufacture a "transition" at a constant lap
+
+The recorded action per lap is post-guard-rail (`no_llm.py:293` applies `apply_guard_rails`
+to the MC's best action). The opening rail forces STAY_OUT on every lap `< _NO_PIT_BEFORE_LAP
+= 5` (guard_rails.py:92, no SC). So for a real stop on laps 6-10 (not itself guard-blocked)
+whose MC is pit-eager from the opening laps, the recorded sequence is
+`STAY_OUT(rail) x4, PIT(5), ...` and `_pit_decision_lap` scores **lap 5 — a constant of the
+rails, not a decision of the model**. That is the retired defect's exact shape (a harness/rail
+boundary wearing a timing estimate) relocated from `window_low` to `_NO_PIT_BEFORE_LAP`.
+The transition detector cannot distinguish rail release from model transition because the
+rails are applied before recording. Not observed at Monza (the only early stop, LAW lap 9,
+has a stack that never asks to pit: laps 1-14 all STAY_OUT at every width — executed dump in
+the sweep). The closing rail cannot create a STAY→PIT transition (it only forces STAY late),
+but it does manufacture the fake "withdrawals" noted in A1b.
+
+### D — verified, with the commit's numbers CONFIRMED and one phrasing corrected
+
+Re-derived at three widths (3, 5, 10) on 2025 Monza, pristine code, one process, actions
+recorded. Aggregates:
+
+| | w=3 | w=5 | w=10 |
+|---|---|---|---|
+| scored | 6 | 7 | 8 |
+| no_boundary | 5 | 4 | 3 |
+| no_call | 7 | 7 | 7 |
+| guard-railed | 2 | 2 | 2 |
+| eligible | 20 | 20 | 20 |
+| mean signed error | −0.33 | −1.29 | −2.50 |
+| exact (of scored) | 83.3% | 71.4% | 62.5% |
+
+- **The commit's "6 of the 7 stops scored at both w=5 and w=10 report the same chosen lap"
+  is exactly right**: 7 stops scored at both, 6 identical (TSU 19, ALB 41, COL 33, SAI 30,
+  RUS 27, HAD 27), 1 moved (NOR 46: chosen 42 → 38). The commit's "the two that move" counts
+  NOR plus HAM 38 (`no_boundary` → scored/31 at w=10) — HAM is a bucket change, not a
+  chosen-lap change among stops scored at both; sloppy phrasing, correct facts. Both
+  characterisations ("wider window REVEALS a transition" for HAM, "model oscillates and both
+  are real transitions" for NOR) verified against the recorded actions.
+- w=3 adds a third instance of the reveal mechanism: HAD 32 is `no_boundary` at w=3 and
+  scored 27 at both w=5 and w=10.
+- **Which property holds**: every reported lap is a genuine evaluated STAY→PIT boundary, and
+  the single window-edge coincidence (HAD) survives the edge moving. **Which property does
+  NOT hold**: the aggregate `mean_signed_error` still slides monotonically with width
+  (−0.33 / −1.29 / −2.50) — no longer by edge-pinning, but because a wider window reveals
+  earlier transitions (HAM) and earlier oscillations (NOR: 44 → 42 → 38 at w=3/5/10, each a
+  real transition). For an oscillating stack the metric reports *the first transition after
+  window_low*, which is still a window-dependent choice among real transitions. The commit
+  and module docstring state this limitation explicitly and do not over-claim; but nobody
+  should quote `mean_signed_error` without its width, and the conditional-on-scored rates
+  (exact 83% → 71% → 62%) move with width purely through set composition — cross-width or
+  old-vs-new comparisons of `exact` are apples-to-oranges (old 5/11=45.5% vs new 5/7=71.4%
+  at w=5 counts the SAME five exact stops).
+
+### C — verified sound — the denominator sweep
+
+`eligible` (decision_modes.py:164) = scored + guard_railed + no_call + no_data + no_boundary.
+Executed constructions:
+
+```
+all-no_boundary (20 stops):  eligible=20, scored_share=0.0, coverage=masked, exact=0.0
+3 scored + 9 no_boundary:    eligible=12, scored_share=0.25, coverage=masked
+render:                      "| Stops scored | 3 of 12 (25.0%) |"
+```
+
+A run where every stop is `no_boundary` reports `masked`, never high coverage. Every
+denominator audited: `scored_share` (:188) uses `eligible`; `coverage_verdict` (:241-243)
+uses `eligible` and `scored_share`; the render's "Stops scored X of Y" uses `eligible`; the
+JSON payload's `eligible` comes from the same property and its `buckets` dict carries
+`no_boundary_in_window` explicitly. The only rates NOT over `eligible` are
+`exact`/`within_one`/`within_two`/`mean_*` (:167-184), deliberately conditional on the
+scored subset — correct, but see the LOW note below on how they read.
+
+LOW — the render's Meaning column for `Exact lap` says "chose the lap the team chose"
+without stating the denominator is the scored subset. After #752 that matters more: the new
+bucket removes precisely the committed stops from that denominator, so exact% jumps
+45.5% → 71.4% at w=5 while the COUNT of exact stops (5) is unchanged. A reader comparing the
+regenerated report's exact% against the old committed one will read improvement that is
+bookkeeping.
+
+### E — mutation testing: one mutant survives the entire suite
+
+Method: each mutant applied to `src/strategy/eval/decision_modes.py`, suite run, file
+restored via `git checkout --` and verified with an empty `git diff` after each mutant
+(final verification at the bottom of this report). Hermetic runs:
+`uv run pytest tests/eval/test_decision_modes.py -m "not data" -q`. M3 ran the FULL file
+including the Lusail data test.
+
+| Mutant | Change | Result |
+|---|---|---|
+| M1 | `_pit_decision_lap` returns the first pit lap regardless of predecessor (the mechanical revert) | 3 red: `test_a_stack_already_committed_has_no_decision_lap`, `test_an_unevaluated_predecessor_cannot_witness_a_transition`, `test_asks_to_stop_separates_declining_from_being_already_committed` — caught |
+| M2 | `no_boundary` removed from `eligible` | 1 red: `test_the_new_bucket_counts_toward_eligible_so_the_share_is_not_inflated` — caught |
+| M3 | replay span narrowed back (`- DECISION_WINDOW_LAPS - 1` to `- DECISION_WINDOW_LAPS`) | **0 red — `34 passed in 192.73s`, data test included** |
+| M4 | missing predecessor treated as stay-out (None check dropped) | 1 red: `test_an_unevaluated_predecessor_cannot_witness_a_transition` — caught |
+| M5 | `_asks_to_stop` returns False always | 2 red: `test_a_stack_already_committed...`, `test_asks_to_stop_separates...` — caught |
+
+### E1 — HIGH — the replay-span widening has zero test coverage: a suite-green, non-equivalent mutant
+
+M3 reverts the exact line the commit message calls essential ("Without that the first lap of
+every window would be permanently unjudgeable and the edge report would return through the
+back door"), and **every one of the 34 tests stays green, including the Lusail data-tier
+test** (`34 passed in 192.73s`). The mutant is NOT behaviorally equivalent — executed on
+2025 Monza at w=5 with M3 applied:
+
+```
+pristine: scored=7, no_boundary=4, mean_signed_error=-1.286
+M3:       scored=6, no_boundary=5, mean_signed_error=-0.667
+   HAD actual=32: scored/chosen=27  ->  no_boundary_in_window
+```
+
+HAD's genuine transition at `window_low` (predecessor lap 26 = the widened lap, evaluated
+STAY_OUT) becomes unjudgeable, and the published mean signed error moves by 0.62 laps —
+roughly half its value — with the suite green. This is this work's own instance of the
+defect class it fixes: the mechanism the fix depends on is asserted by a comment, not by a
+test. The hermetic tests cannot see it because the span is computed inside
+`measure_decision_agreement` (:469) and every hermetic test hands `_pit_decision_lap` a
+pre-built dict; the data test asserts only non-emptiness, `eligible == len(verdicts)`,
+`races == 1` and None-offsets for non-scored — all invariant under the narrowing. A hermetic
+test that drives `measure_decision_agreement` with a stubbed `_decisions_in_window`
+(asserting the span it receives starts one lap before the earliest window, or that a
+HAD-shaped action dict scores rather than lands in `no_boundary`) would kill M3.
+
+### E2 — MEDIUM — the two headline tests do not discriminate the defect they advertise, and one docstring's factual claim is false
+
+Both survive M1 (the mechanical revert):
+
+- `test_the_decision_lap_is_the_transition_not_the_earliest_call`
+  (tests/eval/test_decision_modes.py:156): its fixture's earliest pit call (lap 29,
+  predecessor 28 STAY_OUT) IS the transition, so the old helper also returns 29. Executed
+  under M1: green. The name promises a discrimination the fixture cannot perform (a
+  discriminating fixture needs the first pit call to lack an evaluated non-pit predecessor,
+  e.g. `{29: PIT, 30: STAY, 31: PIT}` — old answers 29, new answers 31).
+- `test_the_decision_lap_does_not_move_when_only_the_window_widens` (:193): the docstring
+  claims "Under the old helper the answer was 27, 25 and 22 for these three windows — the
+  left edge each time." **Executed under M1: the old helper returns 30, 30, 30** — the
+  fixture's laps 20-29 are explicit STAY_OUT, and the old helper returned the first pit
+  ACTION in the window, not the first window lap; it pinned to the edge only when the stack
+  pitted on every lap. The test is green under the very code it documents itself as
+  distinguishing. A docstring naming the wrong mechanism is this repo's catalogued defect
+  class, here inside the test advertised as "the property that was missing, and the whole
+  point of #752".
+
+Consequence for #752's acceptance criterion 3 ("A test that fails if the metric's output
+changes when only `DECISION_WINDOW_LAPS` changes"): no test in the file references
+`DECISION_WINDOW_LAPS` at all (it is not in the import list), and the property test passes
+under the old code — the criterion is unmet in letter. The transition semantics ARE pinned,
+but by the three M1-killing tests, not by the two tests named for the property.
+
+### F — the twin search: no second scorer in code; the stale report is the twin
+
+Searched: `_PIT_ACTIONS` across all `*.py` (guard_rails.py owns it, no_llm.py:293 applies
+it, decision_modes.py consumes it — nothing else); `first_pit|earliest.*pit|
+pit.*transition|decision_lap|chosen_lap` across `src/` (decision_modes.py only); `PIT_NOW`
+in the telemetry backend submodule (one comment at `strategy.py:1190`, one type-literal
+tuple at `simulator.py:56` — neither scores anything); stop-lap loops in
+`src/strategy/eval/` (projection.py:311 and stint_lengths.py:215 iterate REAL stop laps
+from the parquet, not model actions). `_first_pit_lap` no longer exists anywhere. No
+arcade/CLI/scripts code derives a "first pit decision" from a sequence of recommendations.
+
+The surviving first-occurrence copy is not code: it is
+`documents/eval_reports/decision_modes.{md,json}` (finding F1) — numbers produced by the
+retired scorer, still committed, never regenerated, in the artifact position a reader
+trusts most.
+
+## Out-of-scope observations (pre-existing, not introduced by a474ac8)
+
+- LOW: `lap_inputs` (decision_modes.py:285-287) uses `or`-defaults for `gap_ahead_s`
+  (`or 2.0`), `air_temp` (`or 25.0`), `track_temp` (`or 35.0`) — a legitimate 0.0 would
+  become the default. The same function reads `tyre_life` the long way and its docstring
+  explains why `or 10` would be wrong; the three floats did not get the same care.
+  Reachability is low (a 0.0 gap/temperature reading is rare-to-impossible), hence LOW.
+- Observed in every measurement run: `Tire tool output did not parse for C3/C4/C5
+  (tyre_life=1..4) - using conservative defaults instead of a 0.0 cliff` fires repeatedly
+  through the no-llm stack on fresh tyres. Outside this gate's scope, but the decision
+  tier's inputs are partially defaulted on exactly the laps right after a stop.
+
+## What I tried to break and could NOT
+
+1. **Off-by-one at the window boundaries of `_pit_decision_lap`.** Probed transitions
+   exactly at `window_low` (scored, predecessor = the widened lap), exactly at `window_high`
+   (scored), one lap before `window_low` (correctly `no_boundary`), one lap after
+   `window_high` (correctly not agreement). `range(low, high + 1)` is inclusive on both ends
+   with no drift.
+2. **The sentinel classes.** `actions.get(lap)` returns None; `None in _PIT_ACTIONS` is
+   False (executed), and the predecessor check is an explicit `is not None`, so a missing
+   lap can never read as either a pit action or a stay-out. No `pandas.Series.get` anywhere
+   in the changed code; `_stop_context` uses positional indexing plus `_is_missing`.
+3. **The lap-1 clamp.** All-PIT from lap 1 in window [1, 8] gives `no_boundary`, never a
+   score (lap 0 cannot exist and the code does not invent it); `{1: STAY, 2: PIT}` scores 2.
+   No unjudgeable-but-scored or judgeable-but-wrong path found.
+4. **Oscillation.** PIT-STAY-PIT re-commits score the re-commit lap; two transitions in one
+   window score the first; verified hermetically and on NOR's real oscillation (44/42/38 at
+   w=3/5/10, each chosen lap verified against the recorded actions to be a genuine evaluated
+   transition).
+5. **The widened lap being requested but not evaluated.** Checked every (race, driver) pair
+   at three widths on 2025 Monza: `low` is present in `actions` in all cases. The only holes
+   are post-retirement (ALO) and the final lap for lapped cars (GAS/STR/OCO, lap 53) —
+   trailing edges, unable to fake a transition.
+6. **Edge-report resurrection through the scoring range.** The single `chosen == window_low`
+   case in the whole sweep (HAD, w=5) survives the window edge moving to 22 at w=10 with the
+   same chosen lap — a model property, not an edge artifact. No mechanical edge pin exists
+   in any of the 21 scored verdicts across three widths.
+7. **Coverage inflation through the new bucket.** Constructed all-no_boundary and mixed
+   runs; `eligible` includes the bucket in every denominator, the render prints it, coverage
+   reports `masked`. The old silent-inflation path is closed.
+8. **The commit's "6 of 7" number.** Re-derived independently at both widths plus a third:
+   exactly 7 stops scored at both w=5 and w=10, exactly 6 with identical chosen laps, and
+   the two movers are exactly HAM 38 (revealed transition) and NOR 46 (real oscillation).
+   The claimed numbers are right.
+9. **Four of five mutants.** M1, M2, M4, M5 all go red on at least one test each; the
+   transition semantics, the None-predecessor rule, the bucket split and the denominator are
+   genuinely pinned.
+
+## Restoration audit
+
+Every mutant was reverted with `git checkout -- src/strategy/eval/decision_modes.py`; after
+the final restore, `git diff src/strategy/eval/decision_modes.py` printed nothing,
+`git status --short src/ tests/` showed only the pre-existing untracked `src/telemetry`
+submodule entry, and the pristine hermetic suite re-ran green (`33 passed, 1 deselected`).
+
+## Verdict
+
+The metric replacement is sound where it was claimed to be sound: the transition detector
+has no boundary defects, the denominator cannot be inflated, the edge report is demonstrably
+gone on real data, and the commit's headline numbers re-derive exactly. What is still
+broken: the committed report still publishes the retired number (F1, HIGH); the one
+mechanism the fix depends on — the widened replay span — is protected by a comment and
+nothing else (E1, HIGH, proven with a suite-green non-equivalent mutant); the new bucket's
+documented meaning is false for 4/4 of its real occupants at Monza w=5 (A1b, MEDIUM); a rail
+release can still put a constant lap where a decision should be (A3, MEDIUM, structural);
+and the two tests named for the new property do not discriminate it, one with a false
+docstring (E2, MEDIUM).
+
+Severity counts: **2 HIGH (F1, E1) · 4 MEDIUM (A1+A1b counted once, A3, E2) · 2 LOW**
+(exact% labeling, `or`-defaults).
+
+## Suggested fixes, ordered by value over risk
+
+1. Regenerate `documents/eval_reports/decision_modes.{md,json}` with the new metric and
+   commit it (closes F1; the decline rate and coverage the issue wanted preserved are
+   bucket-count facts and survive).
+2. Add the M3-killing test: stub `_decisions_in_window`, assert the span starts one lap
+   before the earliest window AND that a transition sitting exactly at `window_low` is
+   scored, not `no_boundary` (closes E1).
+3. Reword the `no_boundary` prose in `_render_table` and the module docstring to what the
+   code actually guarantees: "no evaluated STAY_OUT to pit transition inside the window —
+   in this sample because the stack was already asking at the window's first evaluated lap"
+   — and drop "every lap offered" (closes A1b; optionally split a `withdrew_in_window`
+   observation into the JSON verdicts for the HAM-shaped cases).
+4. Fix the two E2 fixtures (make the first pit call precede its stay-out, and correct the
+   false docstring numbers 27/25/22 to what the old helper actually returned), and add the
+   acceptance-criterion test that sweeps `DECISION_WINDOW_LAPS` itself.
+5. For A3, either record pre-rail MC actions alongside post-rail ones in
+   `_decisions_in_window` and refuse to score a transition whose predecessor STAY_OUT was
+   rail-forced, or document at `_pit_decision_lap` that a chosen lap equal to
+   `_NO_PIT_BEFORE_LAP` may be a rail release (cheapest honest option).

--- a/documents/audits/FABLE_G2_tyre_wear_term.md
+++ b/documents/audits/FABLE_G2_tyre_wear_term.md
@@ -1,0 +1,505 @@
+# FABLE Gate G2 — tyre wear term (PR #760, commit `9fe8887`, branch `dev`)
+
+Adversarial gate over the consumption half of #744: `TireOutput.deg_cost_s` charged in both
+Monte Carlo scorers, replacing `FRESH_GAIN = 0.25`. Written incrementally as findings are
+confirmed; every finding carries file:line, a failing scenario, and executed evidence.
+
+Repo state at audit start: branch `dev` @ `db21e0c` (merge of #760), tree clean except two
+untracked paths (`src/telemetry` dirty submodule pointer, one notebook PNG). All file
+mutations in this audit are backed up with `cp` first and restored from the backup (verified
+by diff), never with `git checkout --`.
+
+## Checklist of claims under attack
+
+- [x] **A. Monotonicity** — training numbers reproduce exactly (A-1); strict band
+      monotonicity FAILS in-sample and the printed report dropped that column (A-2); on
+      2025 the reference IMPROVES: 83.7% / +0.603, monotonic (A-3).
+- [x] **B. FRESH_GAIN not double-counted** — verified in every branch of both scorers,
+      incl. OVERCUT under SC and the no-stop branch (B-1). Docstring/test-name overlap
+      claim about the cliff term is false in one corner (B-2).
+- [x] **C. Lap counts per candidate** — all verified, fallback byte-equivalent to the old
+      formulas (C-1) — but the legacy OVERCUT count is UNGUARDED (H-2).
+- [x] **D. The bound** — p1/p99 re-derived exactly; 2025 clip rates 0.27% / 1.56%,
+      distortion direction is toward STAY_OUT (D-1).
+- [x] **E. Goldens unmoved** — verified fallback-by-construction; the blind spot is real
+      and demonstrated with two executed surviving mutants (E-1, H-1, H-2).
+- [x] **F. Sentinel rule** — holds end to end, incl. no-lap-at-life<=3, partial parses,
+      the NaN edge, and the scorer-side getattr (F-1); latent config split-brain (F-2).
+- [x] **G. The #744 correction** — independently traced and CONFIRMED (G-1); the
+      corrected-away claim still ships inside the new test file's comments (G-2).
+- [x] **H. Mutation testing** — baseline + M1/M2/M3 reproduce (H-0); the fourth reported
+      mutant does NOT — it survives the suite (H-1); new survivor found on the legacy
+      OVERCUT count (H-2); producer-semantics survivor M18 below (H-3).
+
+## Findings
+
+### A-1 [VERIFIED] The training-season numbers reproduce exactly
+
+`uv`-venv run of the unmodified instrument:
+
+```
+$ .venv/Scripts/python.exe scripts/measure_tyre_reference.py --out .../tyre_ref_train.json
+laps scored: 31624  (tyre life > 3, seasons (2023, 2024))
+harness self-check: corr(pred, target) = 0.977
+
+reference         non-neg  spearman  pearson      p1     p99
+pooled              66.3%     0.188   -0.055  -32.63    4.12
+stint_first         71.2%     0.269    0.084   -2.44    3.80
+stint_le3           73.0%     0.295    0.090   -2.34    3.71
+stint_live          73.9%     0.308    0.095   -2.33    3.67
+none                65.3%     0.191   -0.054  -32.61    4.06
+```
+
+73.9% / +0.308 / p1 −2.33 / p99 +3.67 all match the PR and the constants shipped in
+`src/agents/tire_agent.py:246-247` (`deg_cost_floor_s = -2.33`, `deg_cost_ceiling_s = 3.67`).
+Claim D's derivation half is therefore also confirmed. (2025 measurement pending, below.)
+
+### A-2 MEDIUM — the shipped reference FAILS the strict monotonicity criterion the reverted design was killed on, and this PR removed that column from the printed report
+
+- `scripts/measure_tyre_reference.py:190` still computes `monotonic_bands` =
+  `by_band.is_monotonic_increasing`, and for the shipped candidate it is **False** on the
+  training seasons:
+
+```
+stint_live | monotonic_bands: False | median: 0.472
+  bands: {'(3, 5]': 0.069, '(5, 10]': 0.276, '(10, 15]': 0.563, '(15, 20]': 0.807,
+          '(20, 25]': 1.032, '(25, 100]': 0.906}
+```
+
+  The (25, 100] band drops 1.032 → 0.906 — the same shape (`64.8% non-negative,
+  non-monotonic by band`) that `DESIGN_S3_option_b.md` records as the reason the earlier
+  same-stint reference was BUILT and REVERTED.
+- In the same commit, `report()` (`scripts/measure_tyre_reference.py:209-215`) was changed to
+  print `p1`/`p99` **in place of** the `monotone` column (see `git show 9fe8887 --
+  scripts/measure_tyre_reference.py`), so the criterion that would have printed `False` next
+  to the shipped candidate no longer appears in the copy-pasteable summary. The JSON payload
+  still carries it, and `MEASURE_744a_tyre_reference.md` does argue the (25,100] dip is a
+  population change that hits every candidate (verified: `none` is also non-monotonic,
+  1.032→0.906 vs 0.992→0.785). The mitigation is real, but the acceptance criterion #744 set
+  ("monotonic by tyre-life band") is strictly FAILED by what shipped, and the one place that
+  used to say so out loud was edited to say something else in the shipping commit.
+- Failing scenario: the next person re-runs the instrument after a TCN retrain, reads the
+  printed table, sees no monotone column, and concludes the criterion is met.
+- Weight: this is a formal acceptance box on #744 — *"non-negative on the large majority of
+  real laps and **monotonic** by tyre-life band"* — so the in-sample half of that box is
+  strictly unmet as shipped. Mitigating fact from this gate's own measurement: the
+  criterion PASSES on 2025 (A-3), which is the season the layer serves, and the in-sample
+  failure is a single population-change band shared by every candidate. The right close is
+  to say that in the issue, not to stop printing the column.
+
+### A-3 [VERIFIED — the attack FAILED] On 2025, the season the system infers on, the reference gets BETTER, not worse
+
+Ran the PR's own instrument with only `TRAINING_YEARS = (2025,)` overridden (scratchpad
+`measure_2025.py`, imports `scripts/measure_tyre_reference.py` unmodified):
+
+```
+laps scored: 15005  (tyre life > 3, seasons (2025,))
+self-check (informational, threshold bypassed): corr(pred, target) = 0.804
+
+reference         non-neg  spearman  pearson      p1     p99
+stint_live          83.7%     0.603    0.604   -1.11    4.06
+none                77.3%     0.504    0.493   -2.39    3.77
+```
+
+- Non-negative 73.9% → **83.7%**, Spearman +0.308 → **+0.603**, and the band medians are
+  **strictly monotonic on 2025** (`(3,5] 0.049 → (25,100] 1.629`) — the criterion A-2 shows
+  failing in-sample passes out of sample. The degradation-on-2025 attack found the opposite
+  of what it was hunting.
+- One number worth keeping: the shipped `self_check` threshold (0.90) FAILS on 2025 at
+  **corr(pred, target) = 0.804** vs 0.977 in-sample. Same transform, same code path, so this
+  is the TCN's generalisation gap, not harness drift — but anyone re-pointing the instrument
+  at 2025 will hit a `RuntimeError` whose message blames the tensor transform. LOW: the
+  error message names the wrong mechanism for the out-of-sample case.
+
+### G-1 [VERIFIED — the PR's correction is RIGHT] `strategy.py:882`'s empty rival list never reaches the Monte Carlo
+
+Traced in the submodule at `src/telemetry` @ `858418f`, executed greps, not read prose:
+
+- `_build_lap_state_from_row` (defines `"rivals": []` at
+  `backend/api/v1/endpoints/strategy.py:882`) has **exactly one caller**:
+  `strategy.py:695` inside `/pace-range`, and that lap_state feeds
+  `run_pace_agent_from_state(lap_state)` at `strategy.py:698` — the pace agent, never the
+  MC. `grep -rn "_build_lap_state_from_row" backend/` returns only the def and line 695.
+- The backend's MC paths are: (a) `backend/services/simulation/simulator.py:860`
+  `for lap_state in engine.replay()` → `run_lap(race_state, laps_df, lap_state, ...)` at
+  `simulator.py:438` (no-llm) and `simulator.py:896` (rich) — the lap_state is the
+  RaceReplayEngine's, which emits the RSM rivals, so this path is projection-capable; and
+  (b) `/recommend` (`strategy.py:1309`) + `backend/mcp_tools.py:607` →
+  `run_strategy_orchestrator_from_state(..., lap_state=request.lap_state)` →
+  `_run_mc_simulation(rivals=(lap_state or {}).get("rivals"), ...)` at
+  `strategy_orchestrator.py:2464`. `RecommendRequest.lap_state` is required
+  (`strategy.py:107`) and documented as "the raw lap_state dict produced by
+  RaceStateManager", so which scorer runs depends on whether the client's payload carries
+  usable rivals — not on line 882.
+- The two builders that DO hardcode `"rivals": []` are exactly the two the PR names:
+  `src/strategy/inference/engine.py:449` (`_build_default_lap_state`) and
+  `src/agents/strategy_orchestrator.py:2421`, both only on the `lap_state is None` path.
+
+No HIGH here: the correction survives an independent trace.
+
+### G-2 MEDIUM — the corrected-away claim still ships, verbatim, inside the new test file
+
+The commit message and PR body correct #744's "three builders including the backend
+endpoint" claim. The test file that landed **in the same commit** still asserts the wrong
+version in two places:
+
+- `tests/mc/test_tyre_wear_term.py:195-197` (section comment): *"Three shipping builders
+  hardcode `"rivals": []`, which routes to it: `engine.py`, `strategy_orchestrator.py`, and
+  the backend's own `api/v1/endpoints/strategy.py`."*
+- `tests/mc/test_tyre_wear_term.py:313-316` (`test_the_legacy_branch_receives_it`
+  docstring): *"three shipping builders do by hardcoding an empty rival list — including
+  the backend's own endpoint. This is the branch that runs in production behind the API."*
+
+Both restate the mechanism the same commit's own message proves wrong (G-1). This is the
+repo's dominant defect class — one copy corrected, its twin not — inside the artefact that
+outlives the PR body. The propagation risk is not hypothetical: issue #744 carries the same
+claim under the label **"Verified, not inherited"**, which is exactly how a wrong mechanism
+acquires authority. Failing scenario: the next contributor reads the test file (the
+natural first stop), "learns" that `strategy.py:882` routes to the legacy scorer, and
+builds the next fix on that mechanism. Fix is a comment edit only; no behaviour change.
+
+### D-1 [VERIFIED] The bound reproduces; the clip is rare and its bias direction is toward STAY_OUT
+
+- p1/p99 re-derived on training: **−2.33 / +3.67** exactly (A-1 table) — matches
+  `tire_agent.py:246-247`.
+- Clip frequency on 2025 (the served season), measured over the same 15,005 laps:
+  **0.27%** below the floor, **1.56%** above the ceiling, **1.83%** total. The 2025 p99 is
+  **4.06**, above the shipped ceiling, so the upper clip fires ~1.6x more often than the 1%
+  it was calibrated to.
+- Direction of the distortion: a genuinely worn set whose true reading exceeds 3.67 is
+  UNDER-charged, which biases those laps toward STAY_OUT — the same direction as the
+  layer's known 46.1% decline failure mode. At window 5 the maximum understatement at the
+  2025 p99 is 5 × (4.06 − 3.67) ≈ 2.0 s ≈ 1.3 positions on the legacy scale. Affects at
+  most ~1.6% of laps, which are disproportionately the ones where the call matters. LOW,
+  by frequency; worth re-measuring the bound when 2026 data arrives.
+
+### B-1 [VERIFIED] FRESH_GAIN is never double-counted — closed by construction, every branch checked
+
+- The only two places the fresh credit is ever applied are the two exclusive `if/else`
+  helpers: `strategy_orchestrator.py:684-686` (`_tyre_term`) and
+  `position_projection.py:535-537` (`_tyre_cost_s`). `grep -n "FRESH_GAIN\|fresh_gain_s"`
+  over both scorers shows every other occurrence is the constant's definition (`:631`), a
+  comment (`:750`), or the pass-through into `ProjectionConfig` (`:1215`) that only the
+  fallback arm of `_tyre_cost_s` reads.
+- Every candidate branch routes through one helper call: legacy STAY_OUT `:737`,
+  PIT_NOW `:741`, UNDERCUT `:746`, OVERCUT-under-SC `:764`, OVERCUT-green `:770-774`;
+  projection stop-plans `position_projection.py:593`, no-stop `:601`. With a reading,
+  the fresh credit is absent (not offset); with `None`, only the credit exists.
+- OVERCUT under SC (`:764`): `_tyre_term(deg, 0, window)` — with a reading returns 0.0
+  (zero old laps), fallback returns `FRESH_GAIN * window`; identical to PIT_NOW's branch,
+  preserving the documented SC indifference between them. No branch applies both prices.
+- The no-stop projection branch: fallback arm yields `-0.0 * fresh_gain = 0`, reproducing
+  the pre-#744b "a plan that does not stop gains nothing fresh" exactly.
+
+### C-1 [VERIFIED] The lap counts match what each branch models, and the fallback is byte-equivalent to the old formulas
+
+Verified against the pre-change formulas in `git show 9fe8887`:
+
+| branch | old laps | fresh laps | fallback reproduces old code |
+|---|---|---|---|
+| legacy STAY_OUT `:737` | `window` | 0 | `-cliff` (tyre term 0) ✓ |
+| legacy PIT_NOW `:741` / UNDERCUT `:746` | 0 | `window` | `+FRESH_GAIN*window` ✓ |
+| legacy OVERCUT SC `:764` | 0 | `window` | `+FRESH_GAIN*window` ✓ |
+| legacy OVERCUT green `:770` | `window // 2` | `window // 2` | `+FRESH_GAIN*(window//2)` ✓ |
+| projection stop plan `:593` | `laps_before_stop` | `laps_after_stop` | `-laps_after_stop*fresh_gain` ✓ |
+| projection no-stop `:601` | `racing` | 0 | no term ✓ |
+
+Observation, not a finding: legacy OVERCUT green prices 2 old + 2 fresh of a 5-lap window
+(one lap unpriced, the stop lap). That asymmetry predates this PR — the old code's
+`FRESH_GAIN * (window // 2)` had the same shape — so the relative differential against
+STAY_OUT (deg × 3 laps) is mildly conservative, consistently with the previous behaviour.
+
+### E-1 [VERIFIED] The goldens are unmoved because they run the fallback — and the blind spot behind that is real, with two executed survivors to prove it
+
+- `tests/mc/test_strategy_goldens.py:52-60`: the canned `TireOutput` never sets
+  `deg_cost_s`, and the dataclass default (`tire_agent.py:497`) is `None` → the golden
+  exercises exactly the pre-#744b arithmetic (`_tyre_term(None, ...)`), and it passed
+  unchanged in the baseline run. The "unmoved goldens" claim is true and is BY
+  CONSTRUCTION, not evidence about the new path.
+- No golden or frozen fixture pins the measured path numerically anywhere:
+  `grep -rn deg_cost_s tests/` hits only the two new files. The measured path's coverage
+  is: 3 hermetic count tests + 1 sign test (projection), 5 leaf tests on `_tyre_term`,
+  2 wiring inequality tests that read **only `STAY_OUT["E"]`**, and 1 real-lap sign test.
+- What can land unnoticed, demonstrated by execution rather than argued: H-1 (the
+  neutralised-config side of the projection) and H-2 below (the legacy OVERCUT measured
+  count) both mutate shipped behaviour to nonsense and stay green across the full suite.
+
+### E-2 LOW — `test_neither_branch_moves_when_there_is_no_reading` cannot fail for its stated reason
+
+`tests/mc/test_tyre_wear_term.py:341-347` asserts `self._score([], None) ==
+self._score([], None)` (and the rivals twin) — the same call twice. That proves the MC is
+deterministic, which `test_mc_is_deterministic_across_calls` already pins. The docstring
+claims it proves "the fallback keeps every pre-#744b caller on exactly its old numbers";
+nothing in the assertion compares against a pre-#744b value (the goldens do that). A
+future change that altered the fallback's numbers would leave this test green. Rename or
+compare against the frozen golden.
+
+### F-1 [VERIFIED] The sentinel rule holds end to end
+
+Traced every producer edge, all executed via the baseline suite plus code inspection:
+
+- No lap at tyre life <= 3 (replay starts mid-stint): `_get_driver_stint` returns `None`
+  (`tire_agent.py:1053`), `_fresh_reference` returns `None` (`:936-938`), the tool omits
+  the line entirely (`:1169-1171`), the parser writes no `fresh_ref` key
+  (`tire_parsing.py` pattern table), `_referenced_wear` returns `None` (`:408-409`).
+  Pinned by `test_no_reference_line_writes_no_reference_key` and
+  `test_a_missing_half_is_none_and_never_zero` (both green in baseline).
+- Only one tool line parses: both `cum_deg` and `fresh_ref` ride the SAME tool message,
+  and `_referenced_wear` requires both keys — single-key dicts return `None` (executed:
+  same tests).
+- The legitimate 0.0: at tyre life <= 3 the reference prefix IS the prediction prefix
+  (`_get_driver_stint(driver, 3)` capped by `current_lap`), so wear is exactly 0.0 and is
+  charged as zero, distinct from `None` — pinned at the consuming end by
+  `test_a_fresh_set_costs_nothing_and_is_not_the_same_as_no_reading`.
+- A NaN reference cannot leak: `f'{reference:.3f}'` prints `nan`, which
+  `r'Fresh reference:\s*(-?[\d.]+)'` cannot match, so the key is simply absent → `None`.
+- The scorer end: `getattr(tire_out, "deg_cost_s", None)` (`strategy_orchestrator.py:1390`)
+  → stub TireOutputs degrade to the fallback, never to 0.0.
+
+### F-2 LOW — the bounds and the reference tyre life read from two different configs
+
+`_referenced_wear` reads the module singleton (`CFG.deg_cost_floor_s`,
+`tire_agent.py:412`) while `_fresh_reference` reads the instance (`self.cfg.
+fresh_reference_tyre_life`, `:936`). `TireAgent.__init__(cfg=CFG)` defaults to the same
+object (`:854`), and every shipping construction uses the default (`TireAgent()` at
+`:1604`), so today the two agree. A future caller passing a custom `TireAgentConfig`
+would get its reference tyre life honoured and its bounds silently ignored — the split-
+brain config pattern this repo has been bitten by before. One-line fix when touched next.
+
+### B-2 LOW — "the cliff term and the wear term do not overlap" is false for a set already past the cliff, and the test pinning it asserts the opposite of its name
+
+- `position_projection.py:199-205` (ProjectionConfig docstring): *"cliff_loss_s: ... Charged
+  only on laps run PAST the cliff, so it does not overlap deg_cost_s, which is charged on
+  every old-set lap."* The two clauses contradict each other: a lap past the cliff IS an
+  old-set lap, so on those laps BOTH are charged. The decomposition is coherent when the
+  cliff lies in the future (deg = current snapshot, cliff = future worsening), but when the
+  set is ALREADY past the cliff at decision time the TCN's current reading already contains
+  the post-cliff pace, and `CLIFF_LOSS` charges 0.80 s/lap again for the same physical
+  seconds.
+- The test named for the claim pins the additive behaviour, not the absence of overlap:
+  `test_the_cliff_term_and_the_wear_term_do_not_overlap` asserts
+  `past_cliff == 5.0*0.4 + 5.0*0.8` — both terms on the same five laps.
+- Failing scenario: cliff_i ~ 0 (N26 says the cliff is behind us), reading 1.5 s/lap
+  (already cliff-level pace). Legacy STAY_OUT charged 5×1.5 + 5×0.8 = 11.5 s where the
+  physical cost is ~7.5 s. Direction: overcharges STAY_OUT exactly when pitting is already
+  right, so the practical harm is small — the finding is the docstring/test naming a wrong
+  mechanism, this repo's recorded worst kind of comment.
+
+### H-0 [VERIFIED] Baseline and three of the four reported mutants reproduce
+
+- Baseline: `pytest tests/mc tests/agents -q` → **232 passed in 427.00s**, matching the PR.
+- M1 drop the projection kwarg (`strategy_orchestrator.py:1219` removed) → **1 failed**
+  (`test_the_projection_branch_receives_it`), matches "1 red".
+- M2 drop the legacy kwarg (call-site form, `:1457`) → **1 failed**
+  (`test_the_legacy_branch_receives_it`). The PR says 2 red; the difference is consistent
+  with the PR mutating the *signature* rather than the call site (a direct-call test then
+  TypeErrors too). Caught either way — no finding.
+- M3 gut `_tyre_cost_s` (always return the fallback) → **6 failed**, matches "6 red".
+- Each mutant applied on a `cp` backup and restored from it; every restore verified with
+  `diff` against the backup ("Files are identical").
+
+### H-1 HIGH — the PR's fourth mutation claim does NOT reproduce: the green-config-only mutant survives the entire suite
+
+The PR table says *"set the value on the green config but not the neutralised one → 1 red"*.
+Re-run, it is 0 red anywhere.
+
+- Mutant applied at `src/agents/strategy_orchestrator.py:1230-1231` (backed up via `cp`,
+  restored from the backup, restore verified by diff):
+
+```python
+green_config = _config(racing_when_racing, clean_air_s)
+neutralised_config = _replace_m4(_config(racing_when_neutralised, 0.0), deg_cost_s=None)  # MUTANT M4
+```
+
+- Executed evidence:
+
+```
+$ .venv/Scripts/python.exe -m pytest tests/mc/test_tyre_wear_term.py -q
+15 passed in 13.07s
+$ .venv/Scripts/python.exe -m pytest tests/mc -q
+159 passed in 387.49s (0:06:27)
+```
+
+  `tests/agents` never calls the Monte Carlo (verified: no `deg_cost_s` reference outside the
+  two new test files, and the agents tests exercise the producer side only), so the mutant
+  survives the full 232.
+- Why no test can see it: catching this mutant needs a projection-branch scenario with a
+  reading AND an assertion sensitive to the **neutralised** draws. The wiring test's fixture
+  (rivals at −2.0 / +3.5 s, `sc_prob_3lap = 0.10`) charges deg on ~10% of draws under a
+  2.61-lap neutralised window: 0.4 × 2.61 ≈ 1.04 s crosses NO gap in that geometry, so
+  `STAY_OUT["E"]` is identical with and without the neutralised-side reading — the assertion
+  passes for a reason unrelated to what the mutant broke. This is the boundary-assertion
+  defect class the project's own memory warns about.
+- Consequence: the guard for "every Safety Car lap uses the measured wear" is the comment at
+  `strategy_orchestrator.py:1216-1218` and nothing else — precisely the defect class (a
+  mechanism protected by a comment) that gate G1 found in #755 and that this PR says it
+  closed with mutation 4. The shipped CODE is correct (both configs receive the value, read
+  at `:1219`); what is broken is the claimed coverage, and the claim is load-bearing because
+  the commit message cites the four mutants as the evidence the wiring is pinned.
+- Fix direction: score a fully-neutralised scenario (`sc_prob_3lap = 1.0`) with rivals close
+  enough that ~1 s of neutralised-window wear crosses a gap, and assert the reading moves
+  the outcome.
+
+### H-2 HIGH — a survivor the PR did not try: zero the legacy OVERCUT's old-lap count and the whole suite stays green
+
+The mutant claim C warns about ("a wrong count makes the term a constant offset that cancels
+in the argmax and looks connected while doing nothing") exists, on the exact branch the
+in-code comment calls the easiest to get wrong.
+
+- Mutant at `src/agents/strategy_orchestrator.py:772`:
+
+```python
++ _tyre_term(deg_cost_s, 0, window // 2)  # MUTANT M5: old_laps zeroed
+```
+
+  With a reading, OVERCUT-green is now charged NOTHING for the `window // 2` laps it runs on
+  the worn set — its measured-path score is wrong on every green-flag draw. The fallback arm
+  is untouched (`fresh_laps` unchanged → `FRESH_GAIN * (window // 2)`), so every
+  `deg_cost_s=None` caller — including all four goldens — is byte-identical.
+- Executed evidence:
+
+```
+$ .venv/Scripts/python.exe -m pytest tests/mc -q     # with M5 applied
+159 passed in 425.16s (0:07:05)
+```
+
+  (`tests/agents` cannot catch it — no MC call sites there — so this survives the full 232.)
+  Restored from the `cp` backup afterwards; restore verified by diff and `git diff --stat`
+  (empty).
+- Why the suite is blind: `test_the_overcut_green_branch_splits_the_window` tests
+  `_tyre_term(0.4, old_laps=half, fresh_laps=half)` — the FUNCTION with the right arguments,
+  not that `simulate_lap_window` passes those arguments. The wiring tests read only
+  `STAY_OUT["E"]`. Nothing anywhere evaluates OVERCUT (or PIT_NOW/UNDERCUT) with a reading
+  present. The projection scorer's equivalent count IS pinned
+  (`test_an_overcut_pays_for_the_laps_it_waits_and_no_more`) — the legacy twin is not: one
+  copy tested, its twin not.
+- Failing scenario in production: a future edit "simplifies" the OVERCUT branch (or a merge
+  resolves it wrong), OVERCUT stops paying for its old-set laps, its score inflates by
+  `deg x window//2` on worn-tyre laps, and it starts re-winning green-flag argmaxes on
+  exactly the high-wear laps the epic cares about — with 232 tests green.
+- Fix direction: one leaf test on `simulate_lap_window` itself with a reading, asserting the
+  four candidates' relative deltas (e.g. `STAY_OUT - OVERCUT == -deg * (window - window//2)`
+  net of cliff terms), or a frozen golden with `deg_cost_s` set.
+
+### H-3 MEDIUM — a second survivor: neuter the reference semantics and the whole channel silently reads 0.0, with 232 green
+
+The producer's core semantic — the reference is the model on the stint's **early** laps —
+has no test. Mutate it away and the feature becomes a no-op that is WORSE than the fallback.
+
+- Mutant at `src/agents/tire_agent.py:247`:
+
+```python
+fresh_reference_tyre_life: int = 999  # MUTANT M18: reference is the whole stint
+```
+
+  `_get_driver_stint(driver, 999)` returns the same prefix as the main prediction
+  (`TyreLife <= 999` intersected with `LapNumber <= current_lap` and the stint), so the
+  reference tensor IS the prediction tensor and `deg_cost_s` computes **exactly 0.0 on
+  every lap** — not `None`. Both scorers then charge zero for the old set AND grant no
+  fresh credit: the channel actively disables the tyre term instead of degrading to
+  `FRESH_GAIN`.
+- Executed evidence:
+
+```
+$ .venv/Scripts/python.exe -m pytest tests/agents tests/mc -q     # with M18 applied
+232 passed in 396.00s (0:06:36)
+```
+
+  Restored from the `cp` backup; restore verified by diff and `git diff --stat` (empty).
+- Why every test passes, including the one real-lap test: the Lusail assertion is
+  `0.0 <= tire_out.deg_cost_s < 1.0` (`tests/agents/test_tire_cumulative_deg.py:343`) —
+  boundary-INCLUSIVE at exactly the degenerate value, so it cannot distinguish "a
+  nearly-fresh set costs +0.015" from "the reference was neutered and wear is identically
+  zero". Its other assertion, `cumulative_deg_s < deg_cost_s` (−0.498 < 0.0), also passes.
+  This is the assertion-passes-near-a-boundary defect class, at the exact boundary the
+  sentinel rule (claim F) spends so much care distinguishing from `None`.
+- The class this represents is not a config typo: any regression in `_get_driver_stint`'s
+  tyre-life filter, or in how `_fresh_reference` slices the stint, collapses to the same
+  degenerate wear ≈ 0 — and the suite proves it would not notice. `_fresh_reference` has
+  no direct test at all.
+- MEDIUM rather than HIGH only because reaching it requires a change in the producer file
+  rather than the scorers' wiring; the blast radius when it happens is total (the epic's
+  "largest missing term" silently reads zero on every lap of every race).
+- Fix direction: a test on the Lusail fixture asserting `deg_cost_s > 0.0`
+  (strict — a five-lap-old set on a real stint measures +0.015), plus a direct
+  `_fresh_reference` test asserting the reference differs from the current prediction when
+  tyre life > the reference band.
+
+## What I tried to break and could NOT
+
+Stated so silence reads as evidence, per the audit doctrine:
+
+1. **The 2025 degradation attack (claim A).** Ran the PR's own instrument on the held-out
+   season expecting the reverted design's failure shape to reappear. It did not: 83.7%
+   non-negative, Spearman +0.603, strictly monotonic bands — better than in-sample on all
+   three criteria. The reference genuinely works where the system infers.
+2. **The double-count (claim B).** Tried to construct a branch where a measured reading and
+   `FRESH_GAIN` are both applied. There is none: both helpers are exclusive `if/else`, and
+   an exhaustive grep shows no other application site of either price in either scorer.
+3. **Fallback drift (claim C/E).** Tried to find a `deg_cost_s=None` path whose arithmetic
+   differs from pre-#744b. Every branch's fallback reproduces the old formula exactly
+   (C-1 table), and the four frozen goldens pass unmoved (baseline 232 green).
+4. **The bound derivation (claim D).** p1/p99 re-derived to the shipped digits (−2.33 /
+   +3.67) from 31,624 laps.
+5. **The sentinel (claim F).** Tried to make 0.0 appear where `None` was meant: missing
+   halves, absent early laps, single-line parses, and the NaN-format edge all produce
+   `None`; the floor test pins that negative readings survive (so a clamp-to-zero mutant
+   would go red); the scorer-side `getattr` degrades stubs to `None`. The producer→parser→
+   output→scorer chain holds at every seam I could attack.
+6. **The #744 correction (claim G).** Tried to refute it with an independent trace of the
+   submodule; the trace confirmed it instead (G-1).
+7. **Mutants the suite DOES catch (claim H).** M1 (projection kwarg) 1 red; M2 (legacy
+   kwarg) 1 red; M3 (gut `_tyre_cost_s`) 6 red; M6 (sever the `getattr` read at
+   `strategy_orchestrator.py:1390` → `None`) 2 red — so the TireOutput→MC read, both
+   kwargs, and the projection cost function are genuinely pinned.
+8. **The instrument's self-check.** It is a real guard: it fired (correctly, if with a
+   misleading message) the moment the season constant changed the data distribution.
+
+## Numbered fix list, ordered by value and risk
+
+1. **(H-1, HIGH)** Add a neutralised-side wiring test: fully-neutralised scenario, rivals
+   within ~1 s, assert the reading moves the outcome. This is the only guard that can make
+   the "both configs" comment at `strategy_orchestrator.py:1216-1218` enforceable.
+2. **(H-2, HIGH)** Pin the legacy measured path per candidate: one test calling
+   `simulate_lap_window` with a reading and asserting the relative deltas of all four
+   candidates, or a second frozen golden with `deg_cost_s` set.
+3. **(H-3, MEDIUM)** Make the Lusail assertion strict (`> 0.0`) and add a direct
+   `_fresh_reference` test (reference != current prediction when tyre life exceeds the
+   band).
+4. **(G-2, MEDIUM)** Fix the two stale comments in `tests/mc/test_tyre_wear_term.py:195,
+   313-316` to the corrected two-builder mechanism; consider a correcting comment on #744
+   itself, which labels the wrong claim "Verified, not inherited".
+5. **(A-2, MEDIUM)** Either restore the `monotone` column to the printed report or record
+   in #744 that the in-sample band criterion is failed-by-population-change and passed on
+   2025 — the acceptance box should not close silently.
+6. **(E-2/B-2/F-2, LOW)** Rename or strengthen `test_neither_branch_moves_when_there_is_no_
+   reading`; reword the "do not overlap" docstring/test name; unify `_referenced_wear` on
+   `self.cfg` when next touching the file. A-3's note: point the self-check error message
+   at the out-of-sample case too.
+
+## Not run
+
+`f1-eval decision-modes` against the 46.1% decline baseline (~21 min). The PR marks it out
+of scope and assigns it to the epic's measurement step; it is the one acceptance box of
+#744 neither the PR nor this gate has executed. Run it before promoting the epic's claim
+that the term moved the decline rate — nothing in this gate measures that.
+
+## Summary
+
+- **HIGH 2** — H-1 (the reported green-config mutation result does not reproduce; the
+  neutralised side of the projection channel is unguarded), H-2 (legacy OVERCUT's
+  measured-path lap count can be zeroed with 232 green).
+- **MEDIUM 3** — A-2 (in-sample monotonicity criterion failed and its report column
+  removed), G-2 (corrected-away claim ships in the test file), H-3 (reference semantics
+  can be neutered to an all-zero channel with 232 green).
+- **LOW 5** — B-2 (overlap docstring/test name), D-1's clip asymmetry, E-2 (x==x test),
+  F-2 (config split-brain), A-3's misleading self-check message on out-of-sample data.
+- **Verified intact** — A-1/A-3 (the measurement, in- and out-of-sample), B-1 (no double
+  count), C-1 (lap counts + byte-identical fallback), D-1 (bound derivation), E-1 (goldens
+  = fallback by construction), F-1 (sentinel end to end), G-1 (the PR's own correction),
+  H-0 (three of four reported mutants).
+
+The single most important line: **the four-mutant table the commit offers as proof of the
+wiring is one-quarter wrong and three survivors deep** — the code that shipped is, on all
+executed evidence, correct; the safety net around its most SC-critical and most
+wear-critical branches is thinner than the PR says it is.

--- a/documents/audits/FABLE_G3_wave3_exit.md
+++ b/documents/audits/FABLE_G3_wave3_exit.md
@@ -1,0 +1,173 @@
+# FABLE G3 — Adversarial exit gate: Wave 3 (PR #765 + submodule 6e7a20e)
+
+- **Date:** 2026-07-31
+- **Scope:** `dev` @ `8bc9d3d` (parent commit `4520431`), submodule `src/telemetry` @ `6e7a20e`. Closes #741, #742, #746, #750.
+- **Mandate:** twin sweep first (previous-lap producers, restated constants, `pace_delta_s` axis), then attack the specific claims (backend anchor shapes, horizon mutants, prompt-test regex, the 341-SOFT-stint measurement).
+- **Rules:** no repo file modified except this report; mutations via `cp` backup + restore + diff-verified; no LLM calls; evidence executed, not read.
+
+## Checklist
+
+- [x] A. Twin sweep: every producer/deriver/defaulter of a "previous lap time" (parent + submodule) → F-01 + census table
+- [x] B. Twin sweep: restated constants in prose vs computed-against values → F-02, F-07, F-08
+- [x] C. Twin sweep: every construction of `pace_delta_s` / RaceState (parent + submodule) → census table, no fifth surface
+- [x] D. Backend anchor: both frame shapes, real 2025 data, post-pit lap, first lap of stint, worse-than-90.0 check → F-05
+- [x] E. #742 horizon mutants re-run + a fourth attack on the horizon distinction → F-04
+- [x] F. #741 prompt-test regex attack (empty-set / green-while-disagreeing) → F-03, executed
+- [x] G. Re-derive: 341 SOFT stints, median 15, max 50, 33.7% > 18 → F-06, exact
+- [x] Close: what I tried to break and could NOT
+
+## Findings
+
+### F-01 · HIGH · Sweep A — the dict-path orchestrator still has BOTH prev-lap defects #746's class describes, and it crashes on the honest value
+
+`src/agents/strategy_orchestrator.py:1849`:
+
+```python
+prev_lap_time  = lap_state.get("prev_lap_time", 92.0),
+```
+
+Two defects in one line, both catalogued classes:
+
+1. **Two-arg `dict.get`** — the default fires only when the KEY is absent. `RaceStateManager.get_driver_state` emits `prev_lap_time: None` (present key, None value) whenever no surviving predecessor exists. `pace_agent.py:709-724` carries a 15-line comment explaining exactly why the two-arg form is wrong for THIS key and uses `or 90.0` instead. The twin one module over never got the fix.
+2. **A restated default** — 92.0 here vs 90.0 in `pace_agent.py:725` for the same quantity. Two sentinels for one concept; neither derived from the other.
+
+**Executed evidence** (models loaded, no LLM): calling `run_pace_agent(prev_lap_time=None, ...)` — exactly what line 1849 passes when the lap_state carries an explicit None —
+
+```
+TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'
+  File "src/agents/pace_agent.py", line 623, in run
+    delta_vs_prev = lap_time_pred - prev_lap_time
+```
+
+`_predict` first turns the None into NaN (`lap_time_pred = nan`), then `delta_vs_prev = nan - None` raises. So `run_strategy_orchestrator` — the **exported public entry point** (`src/agents/__init__.py:99`, named as THE usage example in the module docstring line 17) — crashes on any lap_state whose `prev_lap_time` is the honest None. Failing scenario: any caller bridging `RaceStateManager.get_lap_state()` output (flattened) into the dict path on the first lap of a stint.
+
+Mitigation of severity: no in-repo live surface calls the dict path today (CLI/arcade/backend all use `_from_state`); it is public API and documented, hence HIGH on the defect-class axis but with a currently-dead blast radius in this repo.
+
+### F-02 · MEDIUM · Sweep B — the SAME two prompts still restate `_MIN_STINT_LAPS`, the guard-rail lap bounds, and `CLIFF_IMMINENT_LAPS` as literals
+
+#741 made exactly ONE number derived (`_STINT_CAPACITY_LAPS['SOFT']`). Rendered-prompt extraction (executed, both prompts) shows the following literals that the code ALSO computes against, none interpolated, none covered by the new test's `<=`-only regex:
+
+| prompt text (both prompts unless noted) | code constant | file:line |
+|---|---|---|
+| "SOFT: current tyre_life must be >= 8 … MEDIUM: >= 12. HARD: >= 15." | `_MIN_STINT_LAPS = {"SOFT": 8, "MEDIUM": 12, "HARD": 15}` | `src/strategy/inference/guard_rails.py:41` |
+| "NEVER … before lap 5" | `_NO_PIT_BEFORE_LAP = 5` | `guard_rails.py:38` |
+| "NEVER … when remaining laps <= 3" | `_NO_PIT_LAST_N_LAPS = 3` | `guard_rails.py:39` |
+| "cliff P10 < 2" exception | `_CLIFF_P10_SAFE = 2` | `guard_rails.py:40` |
+| "laps_to_cliff <= 3 → recommend PIT_NOW" (pit prompt) | `CLIFF_IMMINENT_LAPS = 3` | `src/agents/pit_strategy_agent.py:142` |
+| "MEDIUM: suitable for 12-30 remaining laps" (both prompts) | `_STINT_CAPACITY_LAPS['MEDIUM'] = 30` upper bound + `_MIN_STINT_LAPS['MEDIUM'] = 12` | `pit_strategy_agent.py:91` |
+
+The `_MIN_STINT_LAPS` triple sits **in the same prompt, two sections above the line #741 fixed**, in a constant that was converted to an f-string in this very PR — interpolating them was zero marginal cost and did not happen. Every row is the exact defect class the PR names ("a value restated somewhere it is not derived"); guard-rail drift is enforced-after-the-fact so the outcome class is prompt-vs-rail disagreement, not an unrailed decision.
+
+### F-03 · MEDIUM · Attack F executed — the #741 test stays GREEN while both prompts and the table disagree about MEDIUM
+
+The gate asked for "a phrasing that keeps the test green while the prompts and table disagree". It does not need a phrasing change — it exists today for MEDIUM. **Executed**: with `_STINT_CAPACITY_LAPS['MEDIUM']` mutated 30→32 (cp backup, restore verified byte-identical):
+
+```
+MEDIUM 30->32 mutant, prompt still says '12-30':  pytest exit = 0   (3 passed)
+table says MEDIUM = 32 | prompt says: MEDIUM: suitable for 12-30 remaining laps.
+```
+
+The `_BOUND` regex (`tests/agents/test_prompt_constants_match_tables.py:50`) only parses `<=`-phrased clauses; both prompts state MEDIUM's capacity as the range "12-30" (`pit_strategy_agent.py:661`, `strategy_orchestrator.py:1671`), invisible to it. Failing scenario: exactly #741's, one compound over — at `laps_remaining` 31-32 the selector passes MEDIUM and both prompts call it unsuitable, so the band is decided by prose again, with the guard suite green. The test's docstring claim "every compound it can find" is literally true and materially misleading: it can only find SOFT.
+
+### F-04 · VERIFIED (claim E holds) + one nuance · the three horizon mutants each go red on the named test
+
+Executed, each with `cp` backup and byte-identical restore (`filecmp` after every restore):
+
+| mutant | result |
+|---|---|
+| `rival_time_deltas`: `is_pitting` → `stop_pending is True` | RED on `test_window_horizon_charges_only_the_rival_pitting_this_lap` |
+| `_terminal_gaps`: drop `and not rival.is_pitting` | RED on `test_terminal_horizon_charges_an_owed_stop_exactly_once` |
+| `rank_targets`: add `and not rival.is_pitting` | RED on `test_post_cycle_horizon_charges_every_known_obligation_alike` |
+
+Each mutant pattern was grepped in the pristine file (`count == 1`) before substitution — no pristine-file mutant runs.
+
+**Fourth attack (adapter-level unification):** mutating `strategy_orchestrator._rival_states_from_lap_state` (`:824`) to `is_pitting=... or bool(per_rival_pending.get(driver))` destroys the window/terminal distinction for EVERY live surface (all of them build rivals through this adapter) while the three horizon tests — which construct `RivalState` directly — stay green. Executed over the PR's own scope (`tests/mc` + `tests/agents`, 242 tests): **caught anyway**, by `test_mc_is_a_real_decision.py::test_the_named_target_is_the_car_we_will_be_racing_not_the_first_in_the_list` and `test_projection_golden.py` (2 failed, 240 passed). Nuance worth recording: the horizon FILE does not defend against adapter drift; the projection golden does. If the golden is ever regenerated while such a drift is live, the horizon distinction has no dedicated guard at the adapter seam. LOW.
+
+### F-05 · MEDIUM · Attack D — the anchor fix is faithful to N04 (904/904), but the commit's out-lap claim is refuted by execution, and the function ships with ZERO tests
+
+Executed against the endpoint's own served frames (`_get_race_laps_df(2025, "Lusail")` + `laps_featured_2025.parquet`):
+
+**What holds (verified, executed):**
+- **904/904 exact agreement** between the raw-frame fallback and N04's own `Prev_LapTime` for every Lusail 2025 driver-lap present in both frames. The transform is reproduced, not reinterpreted.
+- In-laps served correctly (NOR lap 25 → 85.97, the last surviving lap, not `lap-1`).
+- SC laps served (27 SC-lap anchors, e.g. VER lap 7 → 87.123).
+- Both frame shapes work: a `LapTime`-only frame (timedelta) and a `LapTime_s` frame both return 85.304 for NOR lap 28; a Stint-less frame degrades to None honestly.
+- **No worse-than-90.0 anchor found**: across all 67 raw-only laps that get an anchor, values span 83.714–88.866 s — never an out-lap, in-lap or SC lap time.
+
+**What breaks:**
+
+1. **The commit message's mechanism claim is false for out-laps.** It says the lookup "must not require THIS lap to have survived the filter, or it returns None on exactly the out-laps and Safety Car laps the raw frame exists to serve; it takes the last surviving lap BEFORE the current one instead." Executed census: **out-laps total = 42, anchored = 0, None = 42.** The Stint scoping makes the out-lap the first lap of its stint, so there is never an earlier lap inside it — the design rationale's first-named beneficiary is structurally unservable. The SC half of the claim is true (27 served). The in-code comment `strategy.py:868-871` ("Anchoring an out-lap on the last good racing lap before it is still the right answer") describes behavior the function cannot produce. Downstream: out-laps AND the first flying lap after every stop (NOR lap 27 → None) fall through to the pace agent's 90.0 — which matches N04's NaN semantics, so the BEHAVIOR is defensible; the NARRATIVE (commit, PR body, comment) is not. A comment naming the wrong mechanism is a catalogued class here.
+2. **The frame-shape comment at `strategy.py:860-861` has the frames backwards**: "A frame without the quality flags excludes nothing on them, which is the raw frame's case". Executed: the raw parquet CARRIES `IsAccurate` and `Deleted` (it is the featured frame that lacks them, harmlessly). Wrong-mechanism comment, LOW on its own, listed here because two of them in one 40-line function is how the next fix gets mis-aimed.
+3. **Zero tests.** Submodule commit `6e7a20e` ships no test file; `grep` finds no test referencing `_prev_lap_time_for_row` in the submodule or the parent. Issue #746's acceptance criteria explicitly demand "a test asserting the lap after a stop is not anchored on the out-lap" and the None-semantics. The most intricate function of the wave — the one whose first draft "would have crashed" per the PR's own verification note — is the only one shipped untested. The PR's "242 across tests/mc + tests/agents" is parent-only and cannot cover a submodule function.
+
+### F-06 · VERIFIED · Attack G — the 341-SOFT-stint measurement reproduces exactly
+
+Re-derived with the same instrument (`measure_stint_lengths()`, defaults):
+
+```
+races: 71 | SOFT n = 341 | median = 15.0 | max = 50.0
+share > 18: 33.7 % | share > 15: 45.7 % | total counted = 1785
+```
+
+Every figure quoted in the commit message, the PR body and the test docstring matches, including the strict `>` reading of "run longer than 18" and the 1785 total the issue cites. No finding.
+
+### F-07 · MEDIUM · Sweep B — `0.522` is a config-loaded threshold restated as a prompt literal, so the prompt can disagree with the tool output in the same conversation
+
+`pit_strategy_agent.py:618` (system prompt): "If P(undercut_success) >= 0.522 for any rival → recommend UNDERCUT." The code does NOT own that number: `:230` loads `self.undercut_threshold = uc_cfg['best_threshold']` from the model's JSON config, `:1201` compares against it, and `:1207` **prints the live threshold into the tool response** (`threshold={agent.cfg.undercut_threshold}`). Retune the model, republish the config, and the LLM receives two different thresholds in one conversation — the tool says one number, the system prompt insists on 0.522. Same defect class as #741 with a sharper failure mode, because here the second copy is not even a repo constant but a data artifact.
+
+### F-08 · MEDIUM · Sweep B — the two prompts disagree TODAY about the same derived figure: ~13 vs ~9 positions, and the 13 derives from the constant the redesign retired
+
+`strategy_orchestrator.py:1664` (rule 2, six lines above the line this PR edited): "Pit cost ~22s vs ~1.5s recovery = **~13 positions lost**." That 13 is `20 s / POS_GAP_S(1.50)` — `POS_GAP_S` being the legacy-scoring constant `measure_mc_tables.py:575` records as "retires_constant". The pit agent's prompt was already corrected to the measured geometry (`pit_strategy_agent.py:636-639`): "worth **~9 positions, not 13**: 13 positions is the Safety Car bunched-field figure (median gap 1.4795s)" — 20 s / 2.226 s ≈ 9. So one prompt explicitly refutes the number the other prompt still teaches, in the same run, to the same orchestrating LLM. One copy fixed, its twin not — the wave's own defect class, inside a file the wave edited.
+
+Related boundary nit (LOW): the pit prompt states REACTIVE_SC at `sc_prob >= 0.30` (twice) while the code routes on `sc_prob_3lap > CFG.sc_prob_threshold` (`:587`, `:1988`) — strict vs inclusive at exactly 0.30, and 0.30 is itself a restated literal for `CFG.sc_prob_threshold` (`:127`).
+
+### Sweep A — census of every previous-lap producer found (parent + submodule)
+
+| producer | what it produces | reproduces the training transform? | reaches a model? |
+|---|---|---|---|
+| `RaceStateManager._precompute_prev_lap_times` (`race_state_manager.py:195-221`) | N04 transform: filter-then-group-shift | YES (read, filter terms verified) | yes — N06 anchor via lap_state |
+| backend `_prev_lap_time_for_row` (`strategy.py:804-877`, this wave) | featured `Prev_LapTime`, else N04 reconstruction | YES — **executed 904/904 match** (F-05) | yes — `/lap-state`, `/simulate` |
+| `pace_agent.py:725` `d.get('prev_lap_time') or 90.0` | 90.0 sentinel only on genuinely-missing | consumer-side default (documented) | yes — N06 |
+| **`strategy_orchestrator.py:1849` `lap_state.get("prev_lap_time", 92.0)`** | **None passthrough + a 92.0 twin default** | **NO — F-01, crashes on None** | yes (dict path, public API) |
+| `tire_agent._add_prev_cols` (`:554-569`) | `shift(1).fillna(current)` over the handed-in frame | its reference is N08/N09 (not N04); on the featured frame shift(1) = previous surviving lap by construction; the `fillna(current)` self-referential fill only touches the window's first row and only survives into `LapTime_Delta`/speed deltas, which N09's manifest excludes as lap-time shortcuts. Pre-existing, out of this wave's blast radius — flagged, not scored | TCN input frame |
+| `race_situation_agent._build_sc_features` (`:991`) `LapNumber == lap_number - 1` | previous-LAP AGGREGATE row for N14's per-lap SC features | N13/N14 aggregate laps by lap number, not by stint survival — this is that pipeline's own transform, not a stint anchor | yes — N14 |
+| CLI `run()` / arcade `_step_once` / simulator `:843,924` bookkeeping `prev_lap_time` | loop variable, **no longer read** by `_build_race_state` (verified in current tree: only the signatures keep it) | n/a — dead input, docstrings say so | no |
+| eval `pace_holdout.py` | reads the parquet's own `Prev_LapTime`; lag features via keyed group shift | yes (parquet is N04's output) | eval only |
+| `scripts/measure_mc_tables.py:849`, `bench_pace_baselines.py:168` | measurement-side lags | eval instruments, not inference | no |
+
+### Sweep C — census of every `pace_delta_s` construction
+
+| surface | feeds | axis |
+|---|---|---|
+| CLI `run_simulation_cli.py:1357` | prompt via RaceState | rival-relative (car ahead, same lap) — FIXED, read |
+| arcade `strategy.py:673` | prompt via RaceState | rival-relative — FIXED, read |
+| backend simulator `:403` | prompt | 0.0 unknown — FIXED |
+| backend mcp_tools `:593` | prompt | 0.0 unknown — FIXED |
+| backend `/recommend` `strategy.py:1342` | prompt | client-supplied; webapp sends 0 (`strategy.ts:356`) |
+| `race_state_builder._targeting_against_rival:46` | prompt | rival-relative (user-selected rival, #431) — the "shared helper recomputes" claim in the new comments is TRUE (verified in source) |
+| N27 producer `race_situation_agent.py:908` | N27 features | rival-relative (two drivers, same lap) — the contract source |
+| eval `decision_modes.py:337` | deterministic replay | constant 0.0 — diverges from what the CLI now feeds, but `race_state.pace_delta_s` is consumed ONLY at `strategy_orchestrator.py:1707` (prompt), so the no-llm scorecard numbers are unaffected. LOW note, no action forced |
+| `debug_agent.py:305`, `prompt_ab/gen_inputs.py:63`, test fixtures | — | 0.0 neutral |
+| `RivalState.pace_delta_s` (`position_projection.py:159`) | MC projection | opposite sign convention (rival minus us) BUT its only producer `_rival_states_from_lap_state:821` never sets it (defaults 0.0), so no cross-axis feed exists today |
+
+**No fifth surface feeding a self-delta (or any wrong-axis value) into the field was found.** The four fixed surfaces are the population.
+
+## What I tried to break and could NOT
+
+- **The three horizon unifications** — each goes red on exactly the test named for its horizon (executed, F-04). The PR's mutation claim is accurate as stated.
+- **A fourth, adapter-level unification** (`_rival_states_from_lap_state` forcing `is_pitting` from `stop_pending`) — bypasses all three horizon tests but is caught by `test_mc_is_a_real_decision` and the projection golden (2 failed / 240 passed, executed).
+- **The SOFT prompt-bound guard** — a reflow that drops the `<=` phrasing is caught by `test_the_soft_bound_is_actually_present_in_both_prompts` (asserted by reading; the guard asserts set membership of the rendered tuple, which the reflow removes).
+- **The 341-stint measurement** — reproduced to the decimal with the shipped instrument, including the strict-inequality reading (F-06).
+- **The backend anchor vs N04** — 904/904 exact agreement on real Lusail 2025 data; no anchor worse than the 90.0 default anywhere in the race (out-laps/first-flying-laps return None, which downstream maps to the same 90.0, never to something worse); in-laps and SC laps anchored correctly; both frame shapes handled; Stint-less and quality-flag-less frames degrade honestly (all executed, F-05).
+- **`Series.get` NaN traps in the new code** — `row.get("LapNumber")` / `row.get("Stint")` both pass through `pd.isna` before use (read; the D battery exercised the NaN-stint path implicitly via frames without the column).
+- **The "shared helper recomputes rival-relative" comment** — verified true against `race_state_builder.py:81-87` (the one mechanism-claim in the new comments that holds).
+
+## Verdict
+
+| severity | count | items |
+|---|---|---|
+| HIGH | 1 | F-01 (dict-path orchestrator: None passthrough crashes + 92.0/90.0 twin default) |
+| MEDIUM | 5 | F-02 (min-stint + rail bounds + cliff literals still restated), F-03 (MEDIUM capacity drifts under a green #741 test, executed), F-05 (out-lap claim refuted 0/42 + zero tests on the wave's riskiest function), F-07 (0.522 vs config-loaded threshold), F-08 (~13 vs ~9 cross-prompt contradiction from a retired constant) |
+| LOW | 3 | adapter-seam nuance (F-04), wrong-frame comment (`strategy.py:860`), eval `decision_modes` 0.0 divergence note + sc `>=`/`>` boundary nit |
+
+**Mutation hygiene:** every mutant was applied from a `cp` backup of the pristine file, the mutant pattern was counted (`== 1`) in the pristine text before substitution, and every restore was verified byte-identical with `filecmp.cmp(..., shallow=False)` — reported `True` in all five runs. `git status` at close shows no tracked file modified in parent or submodule; the only new file is this report. No `git checkout --` was used at any point.

--- a/documents/audits/MEASURE_744a_tyre_reference.md
+++ b/documents/audits/MEASURE_744a_tyre_reference.md
@@ -1,0 +1,124 @@
+# #744a — what a fresh-tyre reference is actually worth
+
+**Date:** 2026-07-30 · **Issue:** #744 · **Instrument:** `scripts/measure_tyre_reference.py`
+**Sample:** 31,624 laps at tyre life > 3, across 2,343 stints, seasons 2023-24 (training only).
+
+**Result: the artefact #744a asked for should not be built.** A pooled per-compound reference is
+worth **+0.02 s/lap** against doing nothing, on a quantity whose zero point scatters between stints
+with a standard deviation of **5.48 s**. The reference that does work is the one this project
+**already built and reverted** — its refutation does not survive a proper sample.
+
+---
+
+## The harness, and why its numbers can be trusted
+
+Predictions come from the training parquet (`laps_tiredeg.parquet`, which already carries all 42
+features) pushed through the same scaler and the same N09 left-ZERO-pad that
+`TireAgent._build_stint_tensor` applies. Two independent checks say that is the right transform:
+
+1. **`corr(pred, target) = 0.977`** over all 42,920 predicted laps. A transform that had drifted from
+   the model would not reproduce the model's own training target. The script asserts this and raises
+   below 0.90, so the guard is permanent rather than a one-off.
+2. **No feature is a frame aggregate.** AST-scanning the ten `_add_*` builders in `tire_agent.py`
+   for `mean/std/min/max/sum/median/rolling/expanding/cumsum/quantile/var` returns **none** — every
+   feature is row-local, backward-looking, or read from `session_meta`. So slicing a stint's
+   precomputed features gives the same rows that recomputing them over the prefix would, which is
+   what lets this run offline instead of reloading 47 FastF1 sessions.
+
+## The measurement
+
+Four candidates, scored on #744's own two criteria plus a rank correlation. Spearman rather than
+Pearson because the quantity has a heavy tail — see below — and a handful of stints would otherwise
+decide the number.
+
+| reference | non-negative | spearman | pearson | median wear |
+|---|---|---|---|---|
+| `pooled` — one median per compound, **the artefact #744a proposed** | 66.3% | +0.188 | −0.055 | 0.519 |
+| `stint_first` — this stint's prediction on its first lap | 71.2% | +0.269 | +0.084 | 0.514 |
+| `stint_le3` — this stint's median prediction at tyre life ≤ 3, **the reverted design** | **73.0%** | **+0.295** | +0.090 | 0.489 |
+| `none` — the raw level, no reference at all | 65.3% | +0.191 | −0.054 | 0.519 |
+
+Median wear by tyre-life band, which is where every candidate looks fine:
+
+| band | pooled | stint_le3 | none |
+|---|---|---|---|
+| (3, 5] | 0.045 | 0.069 | 0.023 |
+| (5, 10] | 0.284 | 0.284 | 0.245 |
+| (10, 15] | 0.591 | 0.569 | 0.554 |
+| (15, 20] | 0.860 | 0.823 | 0.836 |
+| (20, 25] | 1.021 | 1.029 | 0.992 |
+| (25, 100] | 0.810 | 0.941 | 0.785 |
+
+## Reading it
+
+**The pooled reference does nothing.** Compare its row against `none`: 66.3% vs 65.3% non-negative,
+Spearman +0.188 vs **+0.191** — a hair *worse* — and band medians that differ by 0.02-0.03 s. It is a
+per-compound constant, so by construction it cannot change any ranking within a compound; the only
+thing it can move is the zero crossing, and it moves it by two hundredths of a second.
+
+**The reason is measurable.** `FuelAdjustedDegAbsolute` is defined against *each stint's own*
+baseline lap, and those baselines are not similarly biased:
+
+- the **per-stint median target has std 5.48 s**, with a 1st percentile at **−32.87 s**;
+- pooled, `corr(target, tyre_life) = −0.088` — the degradation signal is **absent** across stints;
+- **within** a stint, the median `corr(target, tyre_life)` is **+0.577**, positive on **73.8%** of the
+  2,194 stints long enough to correlate.
+
+So the signal is entirely within-stint, and the between-stint scatter is **13× the 0.411 s/lap swing**
+#744 wants to capture. No single constant per compound can normalise 2,343 different zero points.
+This is a stronger statement than the one `DESIGN_S3_option_b.md` made: that document assumed the
+per-stint baselines were *similarly* biased slow ("an out-lap or a standing start: cold and slow"), so
+that one pooled shift would correct them all. The data says they scatter over tens of seconds.
+
+**The tail is in the data, not in the model.** Predictions reach −65.3 s/lap; the training *target*
+reaches −65.3 s/lap on the same laps. Those are stints whose baseline lap was run under a Safety Car,
+a red flag, or as an out-lap. This is why Pearson is useless here and why any consumer of the per-lap
+value needs a bound.
+
+**The (25, 100] dip is a population change, not a model failure.** Stints that reach 25+ laps are the
+low-degradation ones — hard compounds in low-deg races — so the band draws from a different
+population than the ones below it. Every candidate dips there, including `none`.
+
+## What this means for the reverted design
+
+`DESIGN_S3_option_b.md` reverted the same-stint reference on **110 laps at one race**: 64.8%
+non-negative, correlation +0.291 against the raw level's +0.369. On 31,624 laps it measures **73.0%
+non-negative and Spearman +0.295 against the raw level's +0.191** — better than the raw level on both
+criteria, and better than the numbers it was reverted on.
+
+Two caveats, stated because the conclusion rests on them:
+
+- **The comparison that reverted it was not like-for-like.** +0.291 was compared against +0.369, but
+  +0.369 was itself measured over those same 110 live laps at one circuit. Pooled over the training
+  seasons the raw level correlates **+0.191**, so the reverted design was never actually behind.
+- **This measurement uses the parquet's precomputed features; the reverted implementation recomputed
+  them from raw laps over a 3-lap frame.** The AST scan above says those must agree, since no feature
+  is a frame aggregate — but the reverted code path was never measured at this scale, so #744b should
+  confirm the live values match before consuming them.
+
+## What #744a should be
+
+Do not commit a pooled per-compound table. There is no `data/tire_reference_v1.json` in this PR, and
+no accessor, because a committed constant is a permanent claim and this one measures as noise.
+
+The instrument stays: `scripts/measure_tyre_reference.py` re-runs the comparison whenever the TCN is
+retrained, and its self-check fails loudly if the transform ever drifts from the model.
+
+**#744b consumes `stint_le3`**, which needs no artefact — it is a second forward pass on the stint's
+own early laps. Its open questions are consumption-side, not measurement-side:
+
+1. the per-lap value needs a bound (the tail reaches ±15 s on real laps after referencing);
+2. 27% of laps still price negative, so the sign convention has to be decided rather than assumed;
+3. `FRESH_GAIN = 0.25` is the same quantity hardcoded and must be replaced, not added to;
+4. both scorers, including the legacy one the backend endpoint runs in production.
+
+## Reproducing
+
+```bash
+uv run python scripts/measure_tyre_reference.py --out /tmp/tyre_ref.json
+```
+
+Needs `data/processed/laps_tiredeg.parquet` and `data/models/tire_degradation/`, so it does not run
+on CI. Runtime ~4 min on CPU.
+
+Related: `DESIGN_S3_option_b.md` · `MEASURE_S3_tyre_channel.md` · `src/strategy/eval/hygiene.py`

--- a/documents/audits/MEASURE_744a_tyre_reference.md
+++ b/documents/audits/MEASURE_744a_tyre_reference.md
@@ -79,6 +79,30 @@ value needs a bound.
 low-degradation ones — hard compounds in low-deg races — so the band draws from a different
 population than the ones below it. Every candidate dips there, including `none`.
 
+⚠️ **Say the consequence out loud, because it is a formal acceptance box on #744.** That dip means
+`monotonic_bands` is **False in-sample for what shipped**, so the "monotonic by tyre-life band" half
+of the criterion is strictly unmet on 2023-24. The mitigation above is real, and it is a mitigation,
+not a pass. Gate G2 found that #760 had also replaced the `monotone` column in the printed report
+with `p1`/`p99` in the same commit — not deliberately, but the effect was that the one place stating
+the criterion stopped stating it. The column is back.
+
+## The criterion PASSES on 2025, and the reference is roughly twice as strong there
+
+Measured by gate G2 with the same instrument, overriding only the season (15,005 laps):
+
+| | training 2023-24 | **2025** |
+|---|---|---|
+| non-negative | 73.9% | **83.7%** |
+| Spearman | +0.308 | **+0.603** |
+| monotonic by band | **False** | **True** |
+
+This was an adversarial attack that expected the opposite: 2025 is the test season, excluded from the
+measurement precisely so no constant could be fitted to it, so the honest prior was that an
+out-of-sample check would degrade. It improves. The reference is strongest on the season the layer
+actually serves, and the same direction showed up independently in the decision metric
+(`MEASURE_752_metric_and_sample.md`), where moving the sample to 2025 was worth +12.8 points of exact
+agreement. **No cause is claimed for either.**
+
 ## What this means for the reverted design
 
 `DESIGN_S3_option_b.md` reverted the same-stint reference on **110 laps at one race**: 64.8%

--- a/documents/audits/MEASURE_744b_decision_effect.md
+++ b/documents/audits/MEASURE_744b_decision_effect.md
@@ -1,0 +1,100 @@
+# #744b measured: the tyre term made the decision WORSE, and the reason is not the term
+
+**Date:** 2026-07-31 · **Issue:** #744 · **Instrument:** `f1-eval decision-modes`, six 2025 circuits.
+**Comparison:** harness `99a663d` (before) against `d97a54e` (after). The only production diff
+between them is #760's four files, so this is like-for-like on the same sample and the same metric.
+
+---
+
+## The result
+
+| | without the term | with the term |
+|---|---|---|
+| Stops scored | 53 of 178 (29.8%) | 54 of 178 (30.3%) |
+| **Exact lap** | **43.4%** (23 stops) | **33.3% (18 stops)** |
+| Within 1 lap | 52.8% (28) | 44.4% (24) |
+| Within 2 laps | 62.3% | 51.9% |
+| **Declines (`no_call`)** | **82 (46.1%)** | **79 (44.4%)** |
+| `no_boundary_in_window` | 22 | 24 |
+| Mean signed error | −1.72 | −2.00 |
+
+**Three fewer declines bought at the cost of five exact agreements.** The layer now calls the stop
+earlier, which is the mechanism working exactly as designed — and further from what the teams did.
+
+This is the outcome `project_epic724_scorecard` warned about in writing before the metric could see
+it: *"it is entirely possible the epic traded too reluctant for too eager and the metric cannot tell
+the difference."* It can now, and it did.
+
+## The diagnosis, and it is NOT that the term is too big
+
+Measured over 15,005 real 2025 laps (`scratchpad/wear_magnitude.py`, driving the committed
+instrument with the season overridden), the charge the term applies to STAY_OUT:
+
+| tyre life | positions charged |
+|---|---|
+| (3, 5] | 0.16 |
+| (5, 10] | 0.86 |
+| (10, 15] | 1.79 |
+| (15, 20] | 2.79 |
+| (20, 25] | 3.63 |
+| (25, 100] | **5.43** |
+
+Median across all laps: **2.03 positions**. What it competes with, in the same units:
+
+```
+the flat constant it replaced   0.833
+a full window run past the cliff 2.667
+one whole track position         1.000
+the margin tie-break cap         0.200
+```
+
+**On 73.6% of laps the wear term alone moves STAY_OUT by more than a full track position**, and its
+median is 2.4x the constant it replaced. It is not one input among several any more; it decides.
+
+### Why that happens, and why scaling it down would be the wrong fix
+
+The arithmetic is right. A set 0.61 s/lap off its fresh pace, held five more laps, costs 3.05 s. What
+makes that decisive is the **other** side of the comparison: this scorer deliberately excludes the
+pit-lane traversal, because a stop is mandatory under the two-compound rule and both pit-now and
+pit-later pay it, so it cancels. The pit term is therefore the *physical stop* alone, ~2.8 s ≈ 1.87
+positions.
+
+So a five-lap wear charge and an entire pit stop are the same order of magnitude, and the wear tips
+it. **Charging the true cost of five worn laps against a stop whose dominant cost has been cancelled
+out is not a scale error in the term — it is the window.**
+
+This is the third cause the original plan named and deliberately deferred:
+
+> the 5-lap window prices 100% of a stop's cost against ~5 laps of its benefit (break-even ~92 laps).
+> We re-measure after Sprint 3 and decide with data rather than moving three causes at once.
+
+This document is that data.
+
+## What must NOT be done next
+
+**Do not tune the term until the metric recovers.** That is fitting to the metric, and it is exactly
+the failure this epic retired `mean_signed_error` to avoid. Any change to the scale needs a measured
+reason of its own.
+
+**Do not read "agreement fell" as "the model got worse".** The report says it in its own scope
+section: agreement with the real pit wall is evidence, not correctness. The teams optimise track
+position, traffic and Safety Car odds that this layer does not model. A model that says "box now"
+five laps before a team that was holding position may be arithmetically right and strategically
+wrong for reasons outside its inputs.
+
+**But do not use that as an escape either.** The structural finding stands on its own and does not
+depend on the metric: one term deciding 73.6% of laps means the cliff, the undercut bonus, the
+clean-air gain and the neutralisation hazard have stopped mattering to the argmax. That is a design
+problem whatever the pit wall did.
+
+## Recommendation
+
+Keep the term. Reverting restores `FRESH_GAIN = 0.25`, a hardcoded constant that charges a 3-lap-old
+set and a 25-lap-old set identically, and which this same measurement shows to be 2.4x too small at
+the median and 6.5x too small at 25+ laps. It is not better, it is only quieter.
+
+Open the `WINDOW_LAPS` question with this measurement attached, and treat it as the highest-risk item
+in the layer: it moves every number and requires re-freezing goldens deliberately.
+
+Related: `MEASURE_744a_tyre_reference.md` · `FABLE_G2_tyre_wear_term.md` ·
+`MEASURE_752_metric_and_sample.md` · `documents/eval_reports/decision_modes.md`

--- a/documents/audits/MEASURE_752_metric_and_sample.md
+++ b/documents/audits/MEASURE_752_metric_and_sample.md
@@ -1,0 +1,88 @@
+# What the metric fix bought, and what moving to 2025 bought, separately
+
+**Date:** 2026-07-30 · **Issues:** #752 (the metric), #757 (the gate follow-up)
+**Instrument:** `f1-eval decision-modes`, plus one off-report run holding the code fixed and
+restoring the old race list.
+
+The committed report changed **two things at once**: the metric became a transition detector
+(#752 + #757) and the sample moved from four training-season races to six 2025 ones. Quoting
+"17.8% -> 43.4%" from those two artefacts would attribute one effect to the other. This is the
+third cell that separates them.
+
+---
+
+## The three measurements
+
+| | stops scored | **exact lap** | within 1 | mean signed | declines (`no_call`) |
+|---|---|---|---|---|---|
+| mixed 2023-25, **retired** metric | 90 of 198 (45.5%) | 17.8% | 25.6% | −3.3 | — |
+| mixed 2023-25, **current** metric | 62 of 198 (31.3%) | **30.6%** | 48.4% | −1.82 | 78 (39.4%) |
+| **2025 only, current metric** | 53 of 178 (29.8%) | **43.4%** | 52.8% | −1.72 | 82 (46.1%) |
+
+The two middle rows share a sample; the two bottom rows share a metric. Row 1 to row 2 is the
+metric alone; row 2 to row 3 is the season alone.
+
+## The metric is worth +12.8 points of exact agreement, and it costs 28 stops
+
+Scoring the transition rather than the first pit lap removes 28 of the 90 stops the retired
+scorer graded, and every one of them was graded by reporting the window's own left edge. What
+remains is a set the tier can actually locate a decision in, and on it exact agreement rises
+17.8% -> 30.6%.
+
+**Both the rate and the count improve, which is rare enough to state explicitly.** Exact
+agreements in absolute number go **16 -> 19 -> 23** across the three rows, while the scored set
+shrinks **90 -> 62 -> 53**. The tier grades fewer stops and gets more of them right, in count,
+not just in share. That is the opposite of the pattern the epic's scorecard had to explain
+earlier, where the exact-agreement rate fell while its count rose because the layer had become
+far less reluctant.
+
+## The season is worth another +12.8 points, and this was NOT the expected direction
+
+Holding the metric fixed and moving four races from 2023-24 to 2025 raises exact agreement
+30.6% -> 43.4%.
+
+**2023 and 2024 are TRAINING seasons for every model in the stack, so the naive expectation is
+that agreement would be higher there, not lower.** It is lower by the same margin the metric fix
+bought. Four of the six races changed only their year (Barcelona, Monaco, Silverstone,
+Marina_Bay); Lusail and Monza were already 2025 in both lists, so this is close to a
+year-only comparison.
+
+**No cause is claimed here.** Plausible ones — a more converged strategic meta in the
+regulation's mature year, less variable weather at those four events in 2025, better-calibrated
+degradation on 2025 car behaviour — are guesses, and this project has a scar from publishing a
+cause that was a guess wearing a fact's clothes. What is established is the magnitude and the
+direction.
+
+## What did not move, which is the consistency check
+
+`no_call_in_window` is decided by `_asks_to_stop`, which neither #752 nor #757 touches, and it
+lands at **78/198 = 39.4%** on the mixed sample and **82/178 = 46.1%** on 2025. Those are the
+two decline figures the epic scorecard already carries, reproduced here by a different code path
+after four PRs. A metric change that had silently moved them would have been a defect.
+
+## The number that must not be quoted
+
+`mean_signed_error` reads −1.82 and −1.72 above and **still moves with the window width**: the
+Fable G1 gate measured −0.33 / −1.29 / −2.50 at w=3/5/10 on one race. The mechanism is no longer
+the harness artefact #752 retired (a wider window now admits more distant, and therefore earlier,
+transitions — a real property of how far back you look), but it is still a property of the eval's
+configuration and not of the system. The report's own table now says so in its Meaning column.
+
+## Coverage is `masked`, deliberately
+
+29.8% of eligible stops are scored, against the 60% gate. The headline 43.4% describes the
+subset where a decision is locatable, and the report says so rather than promoting the figure.
+The 46.1% decline rate is the number to attack next, and it is what #744b exists for.
+
+## Reproducing
+
+```bash
+uv run python -m src.strategy.eval.cli decision-modes          # row 3, writes the report
+```
+
+Row 2 was produced by calling `measure_decision_agreement(races=...)` with the old list; it is
+not a committed configuration, deliberately, because a second committed sample is a second thing
+to keep in sync.
+
+Related: `MEASURE_S5_decision_modes_2025.md` · `FABLE_G1_transition_metric.md` ·
+`documents/eval_reports/decision_modes.md`

--- a/documents/eval_reports/decision_modes.json
+++ b/documents/eval_reports/decision_modes.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "99a663d",
+    "harness_sha": "d97a54e",
     "dataset": "data/raw laps, stratified 6-race subset (RAW, not featured)",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-31T07:13:39+00:00",
+    "generated_at": "2026-07-31T09:40:54+00:00",
     "artifacts": {}
   },
   "status": "masked",
@@ -38,22 +38,22 @@
     }
   ],
   "agreement": {
-    "sample_size": 53,
+    "sample_size": 54,
     "eligible": 178,
-    "scored_share": 0.29775280898876405,
+    "scored_share": 0.30337078651685395,
     "races": 6,
-    "exact": 0.4339622641509434,
-    "within_one": 0.5283018867924528,
-    "within_two": 0.6226415094339622,
-    "mean_signed_error": -1.7169811320754718,
-    "mean_absolute_error": 1.8679245283018868
+    "exact": 0.3333333333333333,
+    "within_one": 0.4444444444444444,
+    "within_two": 0.5185185185185185,
+    "mean_signed_error": -2.0,
+    "mean_absolute_error": 2.1481481481481484
   },
   "buckets": {
     "closing_laps": 4,
     "min_stint": 17,
-    "no_boundary_in_window": 22,
-    "no_call_in_window": 82,
-    "scored": 53
+    "no_boundary_in_window": 24,
+    "no_call_in_window": 79,
+    "scored": 54
   },
   "verdicts": [
     {
@@ -70,9 +70,9 @@
       "race": "Barcelona",
       "driver": "VER",
       "actual_lap": 29,
-      "chosen_lap": 27,
-      "offset_laps": -2,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -196,27 +196,27 @@
       "race": "Barcelona",
       "driver": "ALB",
       "actual_lap": 26,
-      "chosen_lap": 23,
-      "offset_laps": -3,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
       "race": "Barcelona",
       "driver": "ALB",
       "actual_lap": 27,
-      "chosen_lap": 23,
-      "offset_laps": -4,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
       "race": "Barcelona",
       "driver": "HUL",
       "actual_lap": 9,
-      "chosen_lap": 8,
-      "offset_laps": -1,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -232,9 +232,9 @@
       "race": "Barcelona",
       "driver": "LAW",
       "actual_lap": 18,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "chosen_lap": 15,
+      "offset_laps": -3,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -252,16 +252,16 @@
       "actual_lap": 20,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
       "race": "Barcelona",
       "driver": "OCO",
       "actual_lap": 43,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 43,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -286,8 +286,8 @@
       "race": "Barcelona",
       "driver": "COL",
       "actual_lap": 14,
-      "chosen_lap": 9,
-      "offset_laps": -5,
+      "chosen_lap": 11,
+      "offset_laps": -3,
       "bucket": "scored"
     },
     {
@@ -331,9 +331,9 @@
       "race": "Barcelona",
       "driver": "BOR",
       "actual_lap": 49,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 49,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -394,9 +394,9 @@
       "race": "Barcelona",
       "driver": "PIA",
       "actual_lap": 22,
-      "chosen_lap": 22,
-      "offset_laps": 0,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -745,9 +745,9 @@
       "race": "Monaco",
       "driver": "PIA",
       "actual_lap": 48,
-      "chosen_lap": 48,
-      "offset_laps": 0,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -1062,7 +1062,7 @@
       "actual_lap": 51,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -1123,8 +1123,8 @@
       "race": "Marina_Bay",
       "driver": "HUL",
       "actual_lap": 25,
-      "chosen_lap": 23,
-      "offset_laps": -2,
+      "chosen_lap": 22,
+      "offset_laps": -3,
       "bucket": "scored"
     },
     {
@@ -1150,8 +1150,8 @@
       "race": "Marina_Bay",
       "driver": "OCO",
       "actual_lap": 30,
-      "chosen_lap": 30,
-      "offset_laps": 0,
+      "chosen_lap": 27,
+      "offset_laps": -3,
       "bucket": "scored"
     },
     {
@@ -1159,8 +1159,8 @@
       "race": "Marina_Bay",
       "driver": "NOR",
       "actual_lap": 26,
-      "chosen_lap": 26,
-      "offset_laps": 0,
+      "chosen_lap": 23,
+      "offset_laps": -3,
       "bucket": "scored"
     },
     {
@@ -1177,9 +1177,9 @@
       "race": "Marina_Bay",
       "driver": "HAM",
       "actual_lap": 24,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "chosen_lap": 19,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1195,9 +1195,9 @@
       "race": "Marina_Bay",
       "driver": "BOR",
       "actual_lap": 13,
-      "chosen_lap": 13,
-      "offset_laps": 0,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -1222,17 +1222,17 @@
       "race": "Marina_Bay",
       "driver": "RUS",
       "actual_lap": 25,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 22,
+      "offset_laps": -3,
+      "bucket": "scored"
     },
     {
       "year": 2025,
       "race": "Marina_Bay",
       "driver": "PIA",
       "actual_lap": 27,
-      "chosen_lap": 25,
-      "offset_laps": -2,
+      "chosen_lap": 24,
+      "offset_laps": -3,
       "bucket": "scored"
     },
     {
@@ -1357,9 +1357,9 @@
       "race": "Lusail",
       "driver": "NOR",
       "actual_lap": 25,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 25,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1447,9 +1447,9 @@
       "race": "Lusail",
       "driver": "PIA",
       "actual_lap": 42,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 42,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1483,9 +1483,9 @@
       "race": "Monza",
       "driver": "VER",
       "actual_lap": 37,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 32,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1528,9 +1528,9 @@
       "race": "Monza",
       "driver": "LEC",
       "actual_lap": 33,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 33,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1546,8 +1546,8 @@
       "race": "Monza",
       "driver": "TSU",
       "actual_lap": 19,
-      "chosen_lap": 19,
-      "offset_laps": 0,
+      "chosen_lap": 18,
+      "offset_laps": -1,
       "bucket": "scored"
     },
     {
@@ -1555,8 +1555,8 @@
       "race": "Monza",
       "driver": "ALB",
       "actual_lap": 41,
-      "chosen_lap": 41,
-      "offset_laps": 0,
+      "chosen_lap": 39,
+      "offset_laps": -2,
       "bucket": "scored"
     },
     {
@@ -1582,17 +1582,17 @@
       "race": "Monza",
       "driver": "NOR",
       "actual_lap": 46,
-      "chosen_lap": 42,
-      "offset_laps": -4,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
       "race": "Monza",
       "driver": "COL",
       "actual_lap": 33,
-      "chosen_lap": 33,
-      "offset_laps": 0,
+      "chosen_lap": 31,
+      "offset_laps": -2,
       "bucket": "scored"
     },
     {
@@ -1600,9 +1600,9 @@
       "race": "Monza",
       "driver": "HAM",
       "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "chosen_lap": 33,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1618,17 +1618,17 @@
       "race": "Monza",
       "driver": "SAI",
       "actual_lap": 30,
-      "chosen_lap": 30,
-      "offset_laps": 0,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
       "race": "Monza",
       "driver": "HAD",
       "actual_lap": 32,
-      "chosen_lap": 27,
-      "offset_laps": -5,
+      "chosen_lap": 29,
+      "offset_laps": -3,
       "bucket": "scored"
     },
     {
@@ -1636,8 +1636,8 @@
       "race": "Monza",
       "driver": "RUS",
       "actual_lap": 27,
-      "chosen_lap": 27,
-      "offset_laps": 0,
+      "chosen_lap": 26,
+      "offset_laps": -1,
       "bucket": "scored"
     },
     {

--- a/documents/eval_reports/decision_modes.json
+++ b/documents/eval_reports/decision_modes.json
@@ -1,31 +1,31 @@
 {
   "header": {
-    "harness_sha": "1f0ec9d",
+    "harness_sha": "99a663d",
     "dataset": "data/raw laps, stratified 6-race subset (RAW, not featured)",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-30T08:37:07+00:00",
+    "generated_at": "2026-07-31T07:13:39+00:00",
     "artifacts": {}
   },
   "status": "masked",
   "window_laps": 5,
   "sampled_races": [
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Monaco"
     },
     {
-      "year": 2024,
+      "year": 2025,
       "race": "Silverstone"
     },
     {
-      "year": 2024,
+      "year": 2025,
       "race": "Marina_Bay"
     },
     {
@@ -38,1391 +38,1211 @@
     }
   ],
   "agreement": {
-    "sample_size": 90,
-    "eligible": 198,
-    "scored_share": 0.45454545454545453,
+    "sample_size": 53,
+    "eligible": 178,
+    "scored_share": 0.29775280898876405,
     "races": 6,
-    "exact": 0.17777777777777778,
-    "within_one": 0.25555555555555554,
-    "within_two": 0.35555555555555557,
-    "mean_signed_error": -3.3,
-    "mean_absolute_error": 3.3
+    "exact": 0.4339622641509434,
+    "within_one": 0.5283018867924528,
+    "within_two": 0.6226415094339622,
+    "mean_signed_error": -1.7169811320754718,
+    "mean_absolute_error": 1.8679245283018868
   },
   "buckets": {
     "closing_laps": 4,
-    "min_stint": 22,
-    "no_call_in_window": 78,
-    "opening_laps": 4,
-    "scored": 90
+    "min_stint": 17,
+    "no_boundary_in_window": 22,
+    "no_call_in_window": 82,
+    "scored": 53
   },
   "verdicts": [
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
       "driver": "VER",
-      "actual_lap": 26,
+      "actual_lap": 13,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "bucket": "no_boundary_in_window"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
       "driver": "VER",
-      "actual_lap": 52,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "GAS",
-      "actual_lap": 19,
-      "chosen_lap": 15,
-      "offset_laps": -4,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "GAS",
-      "actual_lap": 39,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "PER",
-      "actual_lap": 27,
+      "actual_lap": 29,
       "chosen_lap": 27,
-      "offset_laps": 0,
+      "offset_laps": -2,
       "bucket": "scored"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "PER",
-      "actual_lap": 50,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "ALO",
-      "actual_lap": 19,
-      "chosen_lap": 14,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "ALO",
-      "actual_lap": 44,
-      "chosen_lap": 39,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "LEC",
-      "actual_lap": 16,
-      "chosen_lap": 15,
+      "driver": "VER",
+      "actual_lap": 47,
+      "chosen_lap": 46,
       "offset_laps": -1,
       "bucket": "scored"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "LEC",
-      "actual_lap": 41,
+      "driver": "GAS",
+      "actual_lap": 10,
+      "chosen_lap": 6,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "GAS",
+      "actual_lap": 31,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "bucket": "no_boundary_in_window"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "STR",
-      "actual_lap": 14,
-      "chosen_lap": 9,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "STR",
-      "actual_lap": 34,
-      "chosen_lap": 29,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "SAR",
-      "actual_lap": 17,
-      "chosen_lap": 15,
-      "offset_laps": -2,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "SAR",
-      "actual_lap": 36,
-      "chosen_lap": 36,
+      "driver": "ANT",
+      "actual_lap": 21,
+      "chosen_lap": 21,
       "offset_laps": 0,
       "bucket": "scored"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "MAG",
-      "actual_lap": 10,
-      "chosen_lap": 8,
-      "offset_laps": -2,
+      "driver": "ANT",
+      "actual_lap": 49,
+      "chosen_lap": 49,
+      "offset_laps": 0,
       "bucket": "scored"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "MAG",
-      "actual_lap": 24,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "driver": "ALO",
+      "actual_lap": 15,
+      "chosen_lap": 11,
+      "offset_laps": -4,
+      "bucket": "scored"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "MAG",
+      "driver": "ALO",
       "actual_lap": 42,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "DEV",
-      "actual_lap": 9,
-      "chosen_lap": 9,
-      "offset_laps": 0,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "DEV",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "TSU",
-      "actual_lap": 10,
-      "chosen_lap": 8,
-      "offset_laps": -2,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "TSU",
-      "actual_lap": 34,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "ALB",
-      "actual_lap": 16,
-      "chosen_lap": 11,
+      "driver": "LEC",
+      "actual_lap": 17,
+      "chosen_lap": 12,
       "offset_laps": -5,
       "bucket": "scored"
     },
     {
-      "year": 2023,
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "LEC",
+      "actual_lap": 40,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "TSU",
+      "actual_lap": 8,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "TSU",
+      "actual_lap": 24,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "TSU",
+      "actual_lap": 44,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
       "race": "Barcelona",
       "driver": "ALB",
-      "actual_lap": 37,
-      "chosen_lap": 37,
-      "offset_laps": 0,
+      "actual_lap": 6,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "ALB",
+      "actual_lap": 26,
+      "chosen_lap": 23,
+      "offset_laps": -3,
       "bucket": "scored"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "ZHO",
+      "driver": "ALB",
+      "actual_lap": 27,
+      "chosen_lap": 23,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "HUL",
       "actual_lap": 9,
       "chosen_lap": 8,
       "offset_laps": -1,
       "bucket": "scored"
     },
     {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "ZHO",
-      "actual_lap": 36,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
       "driver": "HUL",
-      "actual_lap": 8,
-      "chosen_lap": 5,
-      "offset_laps": -3,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "HUL",
-      "actual_lap": 26,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "HUL",
-      "actual_lap": 43,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "OCO",
-      "actual_lap": 13,
-      "chosen_lap": 8,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "OCO",
-      "actual_lap": 35,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "NOR",
-      "actual_lap": 1,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "opening_laps"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "NOR",
-      "actual_lap": 22,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "NOR",
-      "actual_lap": 50,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "HAM",
-      "actual_lap": 24,
-      "chosen_lap": 22,
-      "offset_laps": -2,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "HAM",
-      "actual_lap": 50,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "SAI",
-      "actual_lap": 15,
-      "chosen_lap": 12,
-      "offset_laps": -3,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "SAI",
-      "actual_lap": 41,
-      "chosen_lap": 41,
-      "offset_laps": 0,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "RUS",
-      "actual_lap": 25,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Barcelona",
-      "driver": "RUS",
       "actual_lap": 45,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "BOT",
-      "actual_lap": 5,
+      "driver": "LAW",
+      "actual_lap": 18,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "min_stint"
+      "bucket": "no_boundary_in_window"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "BOT",
+      "driver": "LAW",
+      "actual_lap": 44,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "OCO",
+      "actual_lap": 20,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "OCO",
+      "actual_lap": 43,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "NOR",
+      "actual_lap": 21,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "NOR",
+      "actual_lap": 48,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "COL",
+      "actual_lap": 14,
+      "chosen_lap": 9,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "COL",
       "actual_lap": 39,
       "chosen_lap": 37,
       "offset_laps": -2,
       "bucket": "scored"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "PIA",
-      "actual_lap": 17,
-      "chosen_lap": 12,
-      "offset_laps": -5,
-      "bucket": "scored"
+      "driver": "HAM",
+      "actual_lap": 16,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
-      "year": 2023,
+      "year": 2025,
       "race": "Barcelona",
-      "driver": "PIA",
-      "actual_lap": 39,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "VER",
-      "actual_lap": 55,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "GAS",
-      "actual_lap": 47,
-      "chosen_lap": 43,
-      "offset_laps": -4,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "GAS",
-      "actual_lap": 54,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "PER",
-      "actual_lap": 1,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "opening_laps"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "PER",
-      "actual_lap": 34,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "PER",
-      "actual_lap": 53,
-      "chosen_lap": 53,
-      "offset_laps": 0,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "PER",
-      "actual_lap": 57,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "PER",
-      "actual_lap": 70,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "ALO",
-      "actual_lap": 54,
-      "chosen_lap": 54,
-      "offset_laps": 0,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "ALO",
-      "actual_lap": 55,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "LEC",
-      "actual_lap": 44,
-      "chosen_lap": 39,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "LEC",
-      "actual_lap": 55,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "STR",
-      "actual_lap": 51,
-      "chosen_lap": 46,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "SAR",
-      "actual_lap": 20,
-      "chosen_lap": 17,
-      "offset_laps": -3,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "SAR",
-      "actual_lap": 23,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "SAR",
-      "actual_lap": 52,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "MAG",
-      "actual_lap": 56,
-      "chosen_lap": 51,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "MAG",
-      "actual_lap": 71,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "DEV",
-      "actual_lap": 53,
-      "chosen_lap": 48,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "TSU",
-      "actual_lap": 53,
-      "chosen_lap": 51,
-      "offset_laps": -2,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "ALB",
-      "actual_lap": 18,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "ALB",
-      "actual_lap": 52,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "ZHO",
-      "actual_lap": 1,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "opening_laps"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "ZHO",
-      "actual_lap": 52,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "HUL",
-      "actual_lap": 1,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "opening_laps"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "HUL",
-      "actual_lap": 54,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "HUL",
-      "actual_lap": 59,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "OCO",
-      "actual_lap": 32,
-      "chosen_lap": 31,
-      "offset_laps": -1,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "OCO",
-      "actual_lap": 54,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "NOR",
-      "actual_lap": 50,
-      "chosen_lap": 47,
-      "offset_laps": -3,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "NOR",
-      "actual_lap": 54,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
       "driver": "HAM",
-      "actual_lap": 31,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "HAM",
-      "actual_lap": 54,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "SAI",
-      "actual_lap": 33,
-      "chosen_lap": 29,
-      "offset_laps": -4,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "SAI",
-      "actual_lap": 55,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "RUS",
-      "actual_lap": 54,
-      "chosen_lap": 49,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "BOT",
-      "actual_lap": 51,
-      "chosen_lap": 46,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2023,
-      "race": "Monaco",
-      "driver": "PIA",
-      "actual_lap": 54,
-      "chosen_lap": 49,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "VER",
-      "actual_lap": 26,
-      "chosen_lap": 21,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "VER",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "PER",
-      "actual_lap": 19,
-      "chosen_lap": 15,
-      "offset_laps": -4,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "PER",
-      "actual_lap": 28,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "PER",
-      "actual_lap": 37,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "PER",
-      "actual_lap": 47,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "ALO",
-      "actual_lap": 27,
-      "chosen_lap": 22,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "ALO",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "LEC",
-      "actual_lap": 19,
-      "chosen_lap": 17,
-      "offset_laps": -2,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "LEC",
-      "actual_lap": 27,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "LEC",
-      "actual_lap": 37,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "STR",
-      "actual_lap": 26,
-      "chosen_lap": 21,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "STR",
-      "actual_lap": 39,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "SAR",
-      "actual_lap": 27,
-      "chosen_lap": 22,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "SAR",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "MAG",
-      "actual_lap": 27,
-      "chosen_lap": 22,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "MAG",
-      "actual_lap": 37,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "TSU",
-      "actual_lap": 27,
-      "chosen_lap": 22,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "TSU",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "ALB",
-      "actual_lap": 27,
-      "chosen_lap": 22,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "ALB",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "ZHO",
-      "actual_lap": 12,
-      "chosen_lap": 8,
-      "offset_laps": -4,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "ZHO",
-      "actual_lap": 19,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "ZHO",
-      "actual_lap": 26,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "ZHO",
-      "actual_lap": 37,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "HUL",
-      "actual_lap": 26,
-      "chosen_lap": 21,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "HUL",
-      "actual_lap": 39,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "RIC",
-      "actual_lap": 26,
-      "chosen_lap": 21,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "RIC",
-      "actual_lap": 37,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "OCO",
-      "actual_lap": 19,
-      "chosen_lap": 14,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "OCO",
-      "actual_lap": 21,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "OCO",
-      "actual_lap": 26,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "OCO",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "NOR",
-      "actual_lap": 27,
-      "chosen_lap": 22,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "NOR",
-      "actual_lap": 39,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "HAM",
-      "actual_lap": 27,
-      "chosen_lap": 22,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "HAM",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "SAI",
-      "actual_lap": 26,
-      "chosen_lap": 21,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "SAI",
-      "actual_lap": 39,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "SAI",
-      "actual_lap": 50,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "closing_laps"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "RUS",
-      "actual_lap": 27,
-      "chosen_lap": 22,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "RUS",
-      "actual_lap": 33,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "BOT",
-      "actual_lap": 26,
-      "chosen_lap": 22,
-      "offset_laps": -4,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "BOT",
-      "actual_lap": 37,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "PIA",
-      "actual_lap": 28,
-      "chosen_lap": 23,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Silverstone",
-      "driver": "PIA",
-      "actual_lap": 38,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "VER",
-      "actual_lap": 29,
-      "chosen_lap": 29,
-      "offset_laps": 0,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "GAS",
-      "actual_lap": 37,
-      "chosen_lap": 32,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "PER",
-      "actual_lap": 28,
-      "chosen_lap": 23,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "ALO",
-      "actual_lap": 25,
-      "chosen_lap": 21,
-      "offset_laps": -4,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "LEC",
-      "actual_lap": 36,
-      "chosen_lap": 31,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "STR",
-      "actual_lap": 26,
-      "chosen_lap": 22,
-      "offset_laps": -4,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "MAG",
-      "actual_lap": 28,
-      "chosen_lap": 26,
-      "offset_laps": -2,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "MAG",
-      "actual_lap": 49,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "MAG",
-      "actual_lap": 57,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "TSU",
-      "actual_lap": 33,
-      "chosen_lap": 28,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "ALB",
-      "actual_lap": 11,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "ALB",
-      "actual_lap": 15,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "ZHO",
-      "actual_lap": 34,
-      "chosen_lap": 29,
-      "offset_laps": -5,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "HUL",
-      "actual_lap": 29,
-      "chosen_lap": 28,
-      "offset_laps": -1,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "RIC",
-      "actual_lap": 10,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "RIC",
       "actual_lap": 46,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "RIC",
-      "actual_lap": 58,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
-    },
-    {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "OCO",
-      "actual_lap": 29,
-      "chosen_lap": 27,
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "BOR",
+      "actual_lap": 19,
+      "chosen_lap": 17,
       "offset_laps": -2,
       "bucket": "scored"
     },
     {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "NOR",
-      "actual_lap": 30,
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "BOR",
+      "actual_lap": 49,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "COL",
-      "actual_lap": 29,
-      "chosen_lap": 24,
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "SAI",
+      "actual_lap": 9,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "SAI",
+      "actual_lap": 34,
+      "chosen_lap": 34,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "HAD",
+      "actual_lap": 19,
+      "chosen_lap": 19,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "HAD",
+      "actual_lap": 48,
+      "chosen_lap": 47,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "RUS",
+      "actual_lap": 20,
+      "chosen_lap": 17,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "RUS",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "PIA",
+      "actual_lap": 22,
+      "chosen_lap": 22,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "PIA",
+      "actual_lap": 49,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "BEA",
+      "actual_lap": 8,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Barcelona",
+      "driver": "BEA",
+      "actual_lap": 35,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "VER",
+      "actual_lap": 28,
+      "chosen_lap": 27,
+      "offset_laps": -1,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "VER",
+      "actual_lap": 77,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "closing_laps"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "GAS",
+      "actual_lap": 8,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "ANT",
+      "actual_lap": 69,
+      "chosen_lap": 64,
       "offset_laps": -5,
       "bucket": "scored"
     },
     {
-      "year": 2024,
-      "race": "Marina_Bay",
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "ANT",
+      "actual_lap": 71,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "ALO",
+      "actual_lap": 16,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "LEC",
+      "actual_lap": 22,
+      "chosen_lap": 22,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "LEC",
+      "actual_lap": 49,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "STR",
+      "actual_lap": 17,
+      "chosen_lap": 14,
+      "offset_laps": -3,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "STR",
+      "actual_lap": 64,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "TSU",
+      "actual_lap": 73,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "ALB",
+      "actual_lap": 32,
+      "chosen_lap": 36,
+      "offset_laps": 4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "ALB",
+      "actual_lap": 40,
+      "chosen_lap": 36,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "HUL",
+      "actual_lap": 12,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "HUL",
+      "actual_lap": 44,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "LAW",
+      "actual_lap": 31,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "LAW",
+      "actual_lap": 40,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "OCO",
+      "actual_lap": 16,
+      "chosen_lap": 12,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "OCO",
+      "actual_lap": 28,
+      "chosen_lap": 24,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "NOR",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "NOR",
+      "actual_lap": 50,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "COL",
+      "actual_lap": 13,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "COL",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
       "driver": "HAM",
+      "actual_lap": 18,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "HAM",
+      "actual_lap": 56,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "BOR",
+      "actual_lap": 26,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "BOR",
+      "actual_lap": 35,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "SAI",
+      "actual_lap": 48,
+      "chosen_lap": 44,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "SAI",
+      "actual_lap": 53,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "HAD",
+      "actual_lap": 14,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "HAD",
+      "actual_lap": 19,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "RUS",
+      "actual_lap": 53,
+      "chosen_lap": 49,
+      "offset_laps": -4,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "RUS",
+      "actual_lap": 62,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "RUS",
+      "actual_lap": 68,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "PIA",
+      "actual_lap": 20,
+      "chosen_lap": 15,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "PIA",
+      "actual_lap": 48,
+      "chosen_lap": 48,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Monaco",
+      "driver": "BEA",
       "actual_lap": 17,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
-      "year": 2024,
-      "race": "Marina_Bay",
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "VER",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "VER",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "GAS",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "GAS",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "ANT",
+      "actual_lap": 9,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "ANT",
+      "actual_lap": 23,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "ALO",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "ALO",
+      "actual_lap": 37,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "LEC",
+      "actual_lap": 10,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "LEC",
+      "actual_lap": 42,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "STR",
+      "actual_lap": 10,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "STR",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "TSU",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "TSU",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "ALB",
+      "actual_lap": 42,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "HUL",
+      "actual_lap": 9,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "HUL",
+      "actual_lap": 42,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "OCO",
+      "actual_lap": 42,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "NOR",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "NOR",
+      "actual_lap": 44,
+      "chosen_lap": 39,
+      "offset_laps": -5,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "HAM",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "HAM",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
       "driver": "SAI",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "SAI",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "HAD",
+      "actual_lap": 10,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "RUS",
+      "actual_lap": 10,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "RUS",
+      "actual_lap": 38,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "PIA",
+      "actual_lap": 11,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "PIA",
+      "actual_lap": 43,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "BEA",
+      "actual_lap": 10,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "min_stint"
+    },
+    {
+      "year": 2025,
+      "race": "Silverstone",
+      "driver": "BEA",
+      "actual_lap": 41,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "VER",
+      "actual_lap": 19,
+      "chosen_lap": 19,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "GAS",
+      "actual_lap": 24,
+      "chosen_lap": 24,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "GAS",
+      "actual_lap": 51,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "ANT",
+      "actual_lap": 25,
+      "chosen_lap": 25,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "ALO",
+      "actual_lap": 27,
+      "chosen_lap": 27,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "LEC",
+      "actual_lap": 21,
+      "chosen_lap": 21,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "STR",
+      "actual_lap": 38,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "TSU",
       "actual_lap": 13,
       "chosen_lap": null,
       "offset_laps": null,
       "bucket": "no_call_in_window"
     },
     {
-      "year": 2024,
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "ALB",
+      "actual_lap": 42,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "HUL",
+      "actual_lap": 25,
+      "chosen_lap": 23,
+      "offset_laps": -2,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "HUL",
+      "actual_lap": 44,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "LAW",
+      "actual_lap": 48,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "OCO",
+      "actual_lap": 30,
+      "chosen_lap": 30,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "NOR",
+      "actual_lap": 26,
+      "chosen_lap": 26,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "COL",
+      "actual_lap": 14,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "HAM",
+      "actual_lap": 24,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "HAM",
+      "actual_lap": 46,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "BOR",
+      "actual_lap": 13,
+      "chosen_lap": 13,
+      "offset_laps": 0,
+      "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "SAI",
+      "actual_lap": 50,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "HAD",
+      "actual_lap": 20,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
+    },
+    {
+      "year": 2025,
       "race": "Marina_Bay",
       "driver": "RUS",
-      "actual_lap": 27,
-      "chosen_lap": 26,
-      "offset_laps": -1,
-      "bucket": "scored"
+      "actual_lap": 25,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
-      "year": 2024,
-      "race": "Marina_Bay",
-      "driver": "BOT",
-      "actual_lap": 33,
-      "chosen_lap": 29,
-      "offset_laps": -4,
-      "bucket": "scored"
-    },
-    {
-      "year": 2024,
+      "year": 2025,
       "race": "Marina_Bay",
       "driver": "PIA",
-      "actual_lap": 38,
-      "chosen_lap": 37,
-      "offset_laps": -1,
+      "actual_lap": 27,
+      "chosen_lap": 25,
+      "offset_laps": -2,
       "bucket": "scored"
+    },
+    {
+      "year": 2025,
+      "race": "Marina_Bay",
+      "driver": "BEA",
+      "actual_lap": 23,
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -1483,9 +1303,9 @@
       "race": "Lusail",
       "driver": "STR",
       "actual_lap": 49,
-      "chosen_lap": 44,
-      "offset_laps": -5,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -1501,9 +1321,9 @@
       "race": "Lusail",
       "driver": "TSU",
       "actual_lap": 32,
-      "chosen_lap": 27,
-      "offset_laps": -5,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -1573,9 +1393,9 @@
       "race": "Lusail",
       "driver": "BOR",
       "actual_lap": 32,
-      "chosen_lap": 27,
-      "offset_laps": -5,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -1672,9 +1492,9 @@
       "race": "Monza",
       "driver": "GAS",
       "actual_lap": 49,
-      "chosen_lap": 44,
-      "offset_laps": -5,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -1717,9 +1537,9 @@
       "race": "Monza",
       "driver": "STR",
       "actual_lap": 49,
-      "chosen_lap": 44,
-      "offset_laps": -5,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -1780,9 +1600,9 @@
       "race": "Monza",
       "driver": "HAM",
       "actual_lap": 38,
-      "chosen_lap": 33,
-      "offset_laps": -5,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -1825,9 +1645,9 @@
       "race": "Monza",
       "driver": "PIA",
       "actual_lap": 45,
-      "chosen_lap": 40,
-      "offset_laps": -5,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,

--- a/documents/eval_reports/decision_modes.md
+++ b/documents/eval_reports/decision_modes.md
@@ -1,17 +1,17 @@
 # decision_modes
 
-- harness `1f0ec9d` · schema v1 · generated 2026-07-30T08:37:07+00:00
+- harness `99a663d` · schema v1 · generated 2026-07-31T07:13:39+00:00
 - era 2022-2025 · dataset data/raw laps, stratified 6-race subset (RAW, not featured) · seed deterministic · llm none
 - artifacts: —
 
 | Metric | Value | Meaning |
 | --- | --- | --- |
-| Stops scored | 90 of 198 (45.5%) | real green-flag stops the tier could grade |
-| Exact lap | 17.8% | chose the lap the team chose |
-| Within 1 lap | 25.6% | same call, one lap either side |
-| Within 2 laps | 35.6% | same strategic window |
-| Mean signed error | -3.30 laps | negative = stops earlier than the team |
-| Mean absolute error | 3.30 laps | magnitude |
+| Stops scored | 53 of 178 (29.8%) | real green-flag stops the tier could grade |
+| Exact lap | 43.4% | chose the lap the team chose |
+| Within 1 lap | 52.8% | same call, one lap either side |
+| Within 2 laps | 62.3% | same strategic window |
+| Mean signed error | -1.72 laps | negative = earlier than the team. **Do not quote as a system property** — still moves with `DECISION_WINDOW_LAPS` (measured -0.33 / -1.29 / -2.50 at w=3/5/10 on one race), because a wider window admits more distant, and therefore earlier, transitions |
+| Mean absolute error | 1.87 laps | magnitude, same width caveat |
 | Coverage verdict | **masked** | `masked` when under 60% of eligible stops were scored |
 
 ### Buckets
@@ -19,10 +19,10 @@
 | Bucket | Stops |
 | --- | --- |
 | `closing_laps` | 4 |
-| `min_stint` | 22 |
-| `no_call_in_window` | 78 |
-| `opening_laps` | 4 |
-| `scored` | 90 |
+| `min_stint` | 17 |
+| `no_boundary_in_window` | 22 |
+| `no_call_in_window` | 82 |
+| `scored` | 53 |
 
 `opening_laps` / `closing_laps` / `min_stint` are stops the guard rails make
 impossible to agree with, so they are excluded from the headline rather than
@@ -32,9 +32,34 @@ number to watch: the stack looked and declined to stop anywhere near the real
 lap. Charging a retirement to the model as a missed call would flatter neither
 side honestly, so the two are never merged.
 
+`no_boundary_in_window` is the third case and it is the one this tier used to
+get wrong (#752). It means only this: the stack asked to stop somewhere in the
+window, but no STAY_OUT -> PIT transition could be located inside it. Read it
+as **no locatable decision**, never as a description of what the stack did.
+Three different shapes land here and they are not the same finding:
+
+- already asking when the window opened, and still asking on every lap;
+- already asking when the window opened, then **withdrawing** later - on the
+  measured 2025 Monza sample this was 4 of 4 occupants, one of them flipping to
+  STAY_OUT on the exact lap the team really stopped;
+- a lap inside the window that was never evaluated, so the only pit ask has no
+  witness for its predecessor.
+
+What they share is that the earliest pit ask has no evaluated non-pit lap before
+it, so any lap reported would be the window's left edge rather than the model's
+choice - which is why `mean_signed_error` used to move with the window width
+instead of with the model. A stop here is counted as looked-at and left unscored.
+The same applies at the opening guard rail: a transition on lap
+5 or earlier is the rail releasing, not the model deciding,
+so it is bucketed here too.
+
 ### Scope
 
-- Sampled races (6 measured): 2023 Barcelona, 2023 Monaco, 2024 Silverstone, 2024 Marina_Bay, 2025 Lusail, 2025 Monza.
+- Sampled races (6 measured): 2025 Barcelona, 2025 Monaco, 2025 Silverstone, 2025 Marina_Bay, 2025 Lusail, 2025 Monza.
+- **All six are 2025, deliberately.** 2023 and 2024 are training seasons for
+  every model in the stack, so a decision tier scored there is partly reading
+  back its own training data. An earlier version of this list took four of its
+  six races from those seasons; the archetypes are unchanged, only the year.
 - A full sweep of the real-stop sample is roughly 11.5 h of wall clock at
   0.51 s per lap through the stack, so this is a stratified subset by circuit
   archetype and **not** full coverage. Read every figure above as conditional

--- a/documents/eval_reports/decision_modes.md
+++ b/documents/eval_reports/decision_modes.md
@@ -1,17 +1,17 @@
 # decision_modes
 
-- harness `99a663d` · schema v1 · generated 2026-07-31T07:13:39+00:00
+- harness `d97a54e` · schema v1 · generated 2026-07-31T09:40:54+00:00
 - era 2022-2025 · dataset data/raw laps, stratified 6-race subset (RAW, not featured) · seed deterministic · llm none
 - artifacts: —
 
 | Metric | Value | Meaning |
 | --- | --- | --- |
-| Stops scored | 53 of 178 (29.8%) | real green-flag stops the tier could grade |
-| Exact lap | 43.4% | chose the lap the team chose |
-| Within 1 lap | 52.8% | same call, one lap either side |
-| Within 2 laps | 62.3% | same strategic window |
-| Mean signed error | -1.72 laps | negative = earlier than the team. **Do not quote as a system property** — still moves with `DECISION_WINDOW_LAPS` (measured -0.33 / -1.29 / -2.50 at w=3/5/10 on one race), because a wider window admits more distant, and therefore earlier, transitions |
-| Mean absolute error | 1.87 laps | magnitude, same width caveat |
+| Stops scored | 54 of 178 (30.3%) | real green-flag stops the tier could grade |
+| Exact lap | 33.3% | chose the lap the team chose |
+| Within 1 lap | 44.4% | same call, one lap either side |
+| Within 2 laps | 51.9% | same strategic window |
+| Mean signed error | -2.00 laps | negative = earlier than the team. **Do not quote as a system property** — still moves with `DECISION_WINDOW_LAPS` (measured -0.33 / -1.29 / -2.50 at w=3/5/10 on one race), because a wider window admits more distant, and therefore earlier, transitions |
+| Mean absolute error | 2.15 laps | magnitude, same width caveat |
 | Coverage verdict | **masked** | `masked` when under 60% of eligible stops were scored |
 
 ### Buckets
@@ -20,9 +20,9 @@
 | --- | --- |
 | `closing_laps` | 4 |
 | `min_stint` | 17 |
-| `no_boundary_in_window` | 22 |
-| `no_call_in_window` | 82 |
-| `scored` | 53 |
+| `no_boundary_in_window` | 24 |
+| `no_call_in_window` | 79 |
+| `scored` | 54 |
 
 `opening_laps` / `closing_laps` / `min_stint` are stops the guard rails make
 impossible to agree with, so they are excluded from the headline rather than

--- a/scripts/measure_tyre_reference.py
+++ b/scripts/measure_tyre_reference.py
@@ -206,13 +206,22 @@ def report(results: dict, n_laps: int, correlation: float) -> str:
         f"laps scored: {n_laps}  (tyre life > {FRESH_MAX_TYRE_LIFE}, seasons {TRAINING_YEARS})",
         f"harness self-check: corr(pred, target) = {correlation:.3f}",
         "",
-        f"{'reference':<16}{'non-neg':>9}{'spearman':>10}{'pearson':>9}{'p1':>8}{'p99':>8}",
+        f"{'reference':<16}{'non-neg':>9}{'spearman':>10}{'monotone':>10}{'p1':>8}{'p99':>8}",
     ]
     for name, scores in results.items():
         lines.append(
             f"{name:<16}{scores['non_negative_pct']:>8.1f}%{scores['spearman']:>10.3f}"
-            f"{scores['pearson']:>9.3f}{scores['p1']:>8.2f}{scores['p99']:>8.2f}"
+            f"{str(scores['monotonic_bands']):>10}{scores['p1']:>8.2f}{scores['p99']:>8.2f}"
         )
+    lines += [
+        "",
+        "`monotone` is one of #744's two acceptance criteria and it reads False on the",
+        "training seasons for EVERY candidate, including having no reference at all: the",
+        "(25, 100] band dips because stints that reach 25 laps are the low-degradation ones,",
+        "so that band draws from a different population. It reads True on 2025. The column is",
+        "printed rather than argued away, because an earlier version of this script dropped it",
+        "in the same commit that shipped a candidate it reads False for.",
+    ]
     return "\n".join(lines)
 
 

--- a/scripts/measure_tyre_reference.py
+++ b/scripts/measure_tyre_reference.py
@@ -13,6 +13,10 @@ laps, monotonic by tyre-life band) plus a rank correlation with tyre life:
 * ``pooled``      — one median per compound, the artefact #744a proposed
 * ``stint_first`` — the model's prediction on this stint's first lap
 * ``stint_le3``   — the median of this stint's predictions at tyre life <= 3
+* ``stint_live``  — the prediction at the LAST lap with tyre life <= 3, which is the
+  only one the live path can produce: ``_get_driver_stint(driver, 3)`` returns the
+  whole prefix and ``_build_stint_tensor`` predicts from it once. It is what #744b
+  ships, so it is measured rather than assumed equivalent to ``stint_le3``.
 
 Training seasons only (2023-24). ``src/strategy/eval/hygiene.py`` documents why a
 constant fitted on the 2025 test season would repeat a leak this project already paid
@@ -163,6 +167,7 @@ def add_candidate_references(predictions: pd.DataFrame) -> pd.DataFrame:
     scored["ref_pooled"] = scored["compound"].map(fresh.groupby("compound")["pred"].median())
     scored["ref_stint_first"] = scored["stint"].map(scored.groupby("stint")["pred"].first())
     scored["ref_stint_le3"] = scored["stint"].map(fresh.groupby("stint")["pred"].median())
+    scored["ref_stint_live"] = scored["stint"].map(fresh.groupby("stint")["pred"].last())
     return scored
 
 
@@ -184,6 +189,14 @@ def score_candidate(scored: pd.DataFrame, reference: str | None) -> dict:
         "median": round(float(wear.median()), 3),
         "monotonic_bands": bool(by_band.is_monotonic_increasing),
         "band_medians": {str(k): round(float(v), 3) for k, v in by_band.items()},
+        # The bound a consumer needs, measured rather than chosen. The raw quantity
+        # reaches +-15 s/lap on real laps because a handful of stints have a Safety Car
+        # or an out-lap as their N04 baseline, and a scorer fed one of those prices a
+        # single lap like ten positions. Do NOT bound this at CLIFF_LOSS = 0.80: the
+        # measured median at 20-25 laps of tyre life is already above it, so that would
+        # delete the signal instead of the outliers.
+        "p1": round(float(wear.quantile(0.01)), 3),
+        "p99": round(float(wear.quantile(0.99)), 3),
     }
 
 
@@ -193,12 +206,12 @@ def report(results: dict, n_laps: int, correlation: float) -> str:
         f"laps scored: {n_laps}  (tyre life > {FRESH_MAX_TYRE_LIFE}, seasons {TRAINING_YEARS})",
         f"harness self-check: corr(pred, target) = {correlation:.3f}",
         "",
-        f"{'reference':<16}{'non-neg':>9}{'spearman':>10}{'pearson':>9}{'monotone':>10}",
+        f"{'reference':<16}{'non-neg':>9}{'spearman':>10}{'pearson':>9}{'p1':>8}{'p99':>8}",
     ]
     for name, scores in results.items():
         lines.append(
             f"{name:<16}{scores['non_negative_pct']:>8.1f}%{scores['spearman']:>10.3f}"
-            f"{scores['pearson']:>9.3f}{str(scores['monotonic_bands']):>10}"
+            f"{scores['pearson']:>9.3f}{scores['p1']:>8.2f}{scores['p99']:>8.2f}"
         )
     return "\n".join(lines)
 
@@ -220,6 +233,7 @@ def main() -> None:
         "pooled": score_candidate(usable, "ref_pooled"),
         "stint_first": score_candidate(usable, "ref_stint_first"),
         "stint_le3": score_candidate(usable, "ref_stint_le3"),
+        "stint_live": score_candidate(usable, "ref_stint_live"),
         "none": score_candidate(usable, None),
     }
 

--- a/scripts/measure_tyre_reference.py
+++ b/scripts/measure_tyre_reference.py
@@ -1,0 +1,243 @@
+"""Measure what a fresh-tyre reference for the TCN's own predictions is worth.
+
+The tyre channel needs *seconds per lap that staying out costs versus a fresh set*.
+The TCN supplies ``cumulative_deg_s`` — N04's ``FuelAdjustedDegAbsolute``, measured
+against **this stint's own baseline lap**. Turning that level into a cost needs a
+reference for zero, and #744 proposed a pooled per-compound one measured on the
+model's own scale.
+
+This script measures whether that reference is worth building, by scoring three
+candidates against the two criteria #744 set (non-negative on the large majority of
+laps, monotonic by tyre-life band) plus a rank correlation with tyre life:
+
+* ``pooled``      — one median per compound, the artefact #744a proposed
+* ``stint_first`` — the model's prediction on this stint's first lap
+* ``stint_le3``   — the median of this stint's predictions at tyre life <= 3
+
+Training seasons only (2023-24). ``src/strategy/eval/hygiene.py`` documents why a
+constant fitted on the 2025 test season would repeat a leak this project already paid
+for once.
+
+--- WHERE TO CHANGE IF THE MODEL CHANGES ---
+The transform below (bundle scaler, then N09's left-ZERO-pad) mirrors
+``TireAgent._build_stint_tensor``. If that changes, this changes with it, or the
+reference lands on a different scale than the value it is subtracted from — the exact
+defect CLAUDE.md records for 2026-07-27. ``--self-check`` is the guard: it correlates
+predictions against the training target and fails below the threshold.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+from scipy.stats import spearmanr
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.agents.tire_agent import TireDegTCN  # noqa: E402
+
+MODEL_DIR = Path("data/models/tire_degradation")
+LAPS_PATH = Path("data/processed/laps_tiredeg.parquet")
+TRAINING_YEARS = (2023, 2024)
+STINT_KEYS = ["Year", "GP_Name", "DriverNumber", "Stint"]
+TARGET = "FuelAdjustedDegAbsolute"
+
+# The band that stands in for "fresh". N04's baseline is the stint's lowest-tyre-life
+# lap, which is an out-lap or a standing start, so anything tighter than this leaves
+# the reference resting on a single cold lap.
+FRESH_MAX_TYRE_LIFE = 3
+
+# Below this, the transform above no longer reproduces the model and every number the
+# script prints is measuring the harness rather than the reference.
+SELF_CHECK_MIN_CORR = 0.90
+
+TYRE_LIFE_BANDS = [3, 5, 10, 15, 20, 25, 100]
+
+
+def load_bundles() -> dict[str, dict]:
+    """Load one bundle per compound, sharing the file when the routing does.
+
+    Five of the six compounds route to the same global model, so loading per compound
+    key without the cache would instantiate it five times.
+    """
+    routing = json.loads((MODEL_DIR / "routing_config.json").read_text(encoding="utf-8"))
+    by_file: dict[str, dict] = {}
+    by_compound: dict[str, dict] = {}
+    for compound, entry in routing.items():
+        filename = entry["bundle"]
+        if filename not in by_file:
+            bundle = torch.load(MODEL_DIR / filename, map_location="cpu", weights_only=False)
+            model = TireDegTCN(bundle["n_features"], **bundle["model_hparams"])
+            model.load_state_dict(bundle["state_dict"])
+            model.eval()
+            bundle["model"] = model
+            by_file[filename] = bundle
+        by_compound[compound] = by_file[filename]
+    return by_compound
+
+
+def stint_sequences(stint: pd.DataFrame, bundle: dict) -> np.ndarray:
+    """One scaled (window, n_features) sequence per lap, each from that lap's prefix.
+
+    Every feature in the manifest is row-local or backward-looking — verified by
+    AST-scanning the ten ``_add_*`` builders in ``tire_agent`` for frame aggregates —
+    so slicing the stint's precomputed features gives the same rows that recomputing
+    them over the prefix would. That equivalence is what lets this run from the
+    training parquet instead of reloading every FastF1 session.
+    """
+    window = bundle["window"]
+    raw = stint[bundle["feature_names"]].astype(float).fillna(0)
+    scaled = bundle["scaler"].transform(raw)
+
+    sequences = []
+    for length in range(1, len(scaled) + 1):
+        prefix = scaled[:length]
+        if len(prefix) >= window:
+            sequences.append(prefix[-window:])
+            continue
+        # N09's `_pad_or_truncate`, verbatim: zeros, never a tiled first lap (#443).
+        padding = np.zeros((window - len(prefix), prefix.shape[1]), dtype=prefix.dtype)
+        sequences.append(np.concatenate([padding, prefix], axis=0))
+    return np.stack(sequences)
+
+
+def predict_training_stints() -> pd.DataFrame:
+    """Run every training-season stint through its compound's TCN, lap by lap."""
+    laps = pd.read_parquet(LAPS_PATH)
+    training = laps[laps["Year"].isin(TRAINING_YEARS)]
+    bundles = load_bundles()
+
+    rows = []
+    for keys, stint in training.groupby(STINT_KEYS, sort=False):
+        absolute_id = stint["AbsoluteCompoundID"].iloc[0]
+        if pd.isna(absolute_id):
+            continue
+        compound = f"C{int(absolute_id)}"
+        if compound not in bundles:
+            continue
+
+        bundle = bundles[compound]
+        ordered = stint.sort_values("TyreLife")
+        sequences = stint_sequences(ordered, bundle)
+        with torch.no_grad():
+            batch = torch.tensor(sequences, dtype=torch.float32)
+            predictions = bundle["model"](batch).numpy().reshape(-1)
+
+        stint_id = "|".join(str(k) for k in keys)
+        for tyre_life, prediction, target in zip(
+            ordered["TyreLife"].to_numpy(), predictions, ordered[TARGET].to_numpy()
+        ):
+            rows.append((stint_id, compound, float(tyre_life), float(prediction), float(target)))
+
+    return pd.DataFrame(rows, columns=["stint", "compound", "tyre_life", "pred", "target"])
+
+
+def self_check(predictions: pd.DataFrame) -> float:
+    """Correlation against the training target — the guard on the whole harness.
+
+    A transform that no longer reproduces the model still returns numbers, and every
+    reference measured from them would look plausible. This is the one check that
+    fails loudly instead.
+    """
+    correlation = predictions["pred"].corr(predictions["target"])
+    if correlation < SELF_CHECK_MIN_CORR:
+        raise RuntimeError(
+            f"predictions correlate {correlation:.3f} with the training target, below "
+            f"{SELF_CHECK_MIN_CORR}: the tensor transform no longer reproduces the model, "
+            "so every reference below would be measured on the wrong scale"
+        )
+    return correlation
+
+
+def add_candidate_references(predictions: pd.DataFrame) -> pd.DataFrame:
+    """Attach the three candidate references as columns, one per proposal."""
+    scored = predictions.sort_values(["stint", "tyre_life"]).copy()
+    fresh = scored[scored["tyre_life"] <= FRESH_MAX_TYRE_LIFE]
+
+    scored["ref_pooled"] = scored["compound"].map(fresh.groupby("compound")["pred"].median())
+    scored["ref_stint_first"] = scored["stint"].map(scored.groupby("stint")["pred"].first())
+    scored["ref_stint_le3"] = scored["stint"].map(fresh.groupby("stint")["pred"].median())
+    return scored
+
+
+def score_candidate(scored: pd.DataFrame, reference: str | None) -> dict:
+    """The two acceptance criteria plus a rank correlation, for one reference.
+
+    Spearman rather than Pearson because the quantity has a heavy tail — the training
+    target itself reaches -65 s/lap — and a handful of stints whose baseline lap was a
+    Safety Car or an out-lap would otherwise decide the number.
+    """
+    wear = scored["pred"] if reference is None else scored["pred"] - scored[reference]
+    bands = pd.cut(scored["tyre_life"], TYRE_LIFE_BANDS)
+    by_band = wear.groupby(bands, observed=True).median()
+
+    return {
+        "non_negative_pct": round(100 * float((wear >= 0).mean()), 1),
+        "spearman": round(float(spearmanr(wear, scored["tyre_life"]).statistic), 3),
+        "pearson": round(float(wear.corr(scored["tyre_life"])), 3),
+        "median": round(float(wear.median()), 3),
+        "monotonic_bands": bool(by_band.is_monotonic_increasing),
+        "band_medians": {str(k): round(float(v), 3) for k, v in by_band.items()},
+    }
+
+
+def report(results: dict, n_laps: int, correlation: float) -> str:
+    """A copy-pasteable summary, ordered so the baseline reads last."""
+    lines = [
+        f"laps scored: {n_laps}  (tyre life > {FRESH_MAX_TYRE_LIFE}, seasons {TRAINING_YEARS})",
+        f"harness self-check: corr(pred, target) = {correlation:.3f}",
+        "",
+        f"{'reference':<16}{'non-neg':>9}{'spearman':>10}{'pearson':>9}{'monotone':>10}",
+    ]
+    for name, scores in results.items():
+        lines.append(
+            f"{name:<16}{scores['non_negative_pct']:>8.1f}%{scores['spearman']:>10.3f}"
+            f"{scores['pearson']:>9.3f}{str(scores['monotonic_bands']):>10}"
+        )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, help="write the measured scores to this JSON path")
+    args = parser.parse_args()
+
+    predictions = predict_training_stints()
+    correlation = self_check(predictions)
+
+    scored = add_candidate_references(predictions)
+    past_fresh = scored["tyre_life"] > FRESH_MAX_TYRE_LIFE
+    has_stint_reference = scored["ref_stint_le3"].notna()
+    usable = scored[past_fresh & has_stint_reference]
+
+    results = {
+        "pooled": score_candidate(usable, "ref_pooled"),
+        "stint_first": score_candidate(usable, "ref_stint_first"),
+        "stint_le3": score_candidate(usable, "ref_stint_le3"),
+        "none": score_candidate(usable, None),
+    }
+
+    summary = report(results, len(usable), correlation)
+    print(summary)
+
+    if args.out:
+        payload = {
+            "generated_by": "scripts/measure_tyre_reference.py",
+            "years": list(TRAINING_YEARS),
+            "laps_scored": len(usable),
+            "self_check_corr": round(correlation, 4),
+            "fresh_max_tyre_life": FRESH_MAX_TYRE_LIFE,
+            "candidates": results,
+        }
+        args.out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -1306,7 +1306,14 @@ def _build_race_state(
     driver_code: str,
     prev_lap_time: float,
 ) -> RaceState:
-    """Map RaceStateManager's lap_state dict → RaceState Pydantic model."""
+    """Map RaceStateManager's lap_state dict → RaceState Pydantic model.
+
+    ``prev_lap_time`` is accepted but no longer read here: ``pace_delta_s`` used
+    to be computed from it and that was the wrong axis (#750, fixed below). Left
+    in the signature rather than removed, since the caller's per-lap bookkeeping
+    that produces it (`run()`'s ``prev_lap_time`` loop variable) serves no other
+    purpose today and dropping it is a small cleanup outside this fix's scope.
+    """
     driver_st = lap_state["driver"]
     rivals = lap_state.get("rivals", [])
     weather = lap_state.get("weather", {})
@@ -1336,7 +1343,20 @@ def _build_race_state(
         gap_ahead_s = 0.0
 
     cur_lap_time = driver_st.get("lap_time_s") or 0.0
-    pace_delta_s = cur_lap_time - prev_lap_time if prev_lap_time else 0.0
+    # pace_delta_s is contractually RIVAL-relative (this driver's lap time minus
+    # the car directly ahead's SAME lap, negative = we are faster) per
+    # race_situation_agent.py:292/904, the schema N27 itself computes. The old
+    # formula compared cur_lap_time against our OWN previous lap instead, a
+    # same-car same-driver quantity that reported roughly -20s of phantom "pace
+    # gain" on the lap after a pit stop, a green lap read against our own
+    # out-lap. car_ahead is already resolved above for gap_ahead_s, so no extra
+    # lookup is needed; 0.0 when it or its lap time is unknown is the schema's
+    # documented neutral, not a guess in either direction (#750).
+    ahead_lap_time = car_ahead.get("lap_time_s") if car_ahead is not None else None
+    if ahead_lap_time is not None and cur_lap_time:
+        pace_delta_s = cur_lap_time - float(ahead_lap_time)
+    else:
+        pace_delta_s = 0.0
 
     return RaceState(
         driver=driver_code,

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -54,6 +54,20 @@ except (ImportError, OSError, RuntimeError):
     # repo-relative data/ is right for all three.
     _DATA_ROOT = _REPO_ROOT / 'data'
 
+# What stands in for the previous lap when there genuinely is not one: the first lap
+# of a race, or of a stint, where N04's Prev_LapTime is NaN by construction.
+#
+# It is a module constant rather than a literal because it had already been restated:
+# strategy_orchestrator's dict path carried 92.0 for the same quantity, so the two
+# entry points of the same model disagreed about the same missing value. Exported so
+# a second copy cannot appear again (#766).
+#
+# `_predict` reads this straight into `prev + delta` with no NaN branch, so it cannot
+# be None. That is the whole reason a placeholder exists at all, and it is why every
+# caller must use `or` rather than the two-arg `dict.get`: the key is PRESENT with a
+# None value, which the two-arg form does not substitute for.
+MISSING_PREV_LAP_TIME_S = 90.0
+
 _MODELS_DIR = _DATA_ROOT / 'models' / 'lap_time'
 _PROCESSED  = _DATA_ROOT / 'processed'
 
@@ -722,7 +736,7 @@ class PaceAgent:
             # would turn lap_time_pred itself into NaN. 90.0 is the same
             # order-of-magnitude placeholder the old (wrong) code used, now only
             # reached on a genuinely missing previous lap.
-            prev_lap_time  = d.get('prev_lap_time') or 90.0,
+            prev_lap_time  = d.get('prev_lap_time') or MISSING_PREV_LAP_TIME_S,
             prev_tyre_life = max(0, (d.get('tyre_life') or 1) - 1),
             prev_speed_st  = float(_speed_st),
             air_temp       = float(_air_temp),

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -596,7 +596,14 @@ except ImportError:
 # System prompt (module-level constant — unchanged from N28)
 # ─────────────────────────────────────────────────────────────────────────────
 
-_PIT_STRATEGY_SYSTEM_PROMPT = """You are the Pit Strategy Agent for an F1 race.
+# f-string: the COMPOUND vs REMAINING LAPS section below derives its SOFT bound from
+# _STINT_CAPACITY_LAPS instead of restating it, so the prompt cannot drift from the
+# deterministic selector's own number the way it did in #741 (18 in the table, 15 here
+# and in strategy_orchestrator.py, so laps_remaining=16-18 had the selector pass SOFT
+# while the prompt told the LLM to refuse it). No other brace-sensitive text lives in
+# this constant (checked at the time of #741's fix), so widening it to an f-string is
+# safe.
+_PIT_STRATEGY_SYSTEM_PROMPT = f"""You are the Pit Strategy Agent for an F1 race.
 Your job is to decide whether a driver should pit now, and if so, what compound to fit.
 
 You have three tools:
@@ -652,7 +659,7 @@ MINIMUM STINT LENGTH before a pit makes sense:
   and time is running out. Decide on the race state, not on the SC alone.
 
 COMPOUND vs REMAINING LAPS:
-  SOFT: recommend only if remaining laps <= 15 (it won't last longer).
+  SOFT: recommend only if remaining laps <= {_STINT_CAPACITY_LAPS['SOFT']} (it won't last longer).
   MEDIUM: suitable for 12-30 remaining laps.
   HARD: suitable for 20+ remaining laps.
   Picking SOFT with 25 laps to go forces an extra pit stop — factor that cost in.

--- a/src/agents/position_projection.py
+++ b/src/agents/position_projection.py
@@ -187,8 +187,21 @@ class ProjectionConfig:
                           zero under a neutralisation, which is what makes the
                           Art. 55.17 endgame fall out of the arithmetic: with no
                           racing laps left, fresh tyres buy nothing.
-        fresh_gain_s:     Seconds per lap a fresh tyre gains.
-        cliff_loss_s:     Seconds per lap lost past the tyre cliff.
+        fresh_gain_s:     Seconds per lap a fresh tyre gains. The FALLBACK for
+                          ``deg_cost_s``, used only when the tyre model gave no
+                          reading; the two are the same quantity and are never
+                          charged together.
+        deg_cost_s:       Seconds per lap the CURRENT set costs versus fresh, read
+                          from the tyre model rather than assumed. ``None`` when
+                          the model had no reference to subtract, which leaves
+                          ``fresh_gain_s`` in charge. Measured, not tuned: this is
+                          a fact about the car's tyres, so it belongs here, whereas
+                          a hand-picked weight on it would not.
+        cliff_loss_s:     Seconds per lap lost past the tyre cliff. Charged only on
+                          laps run PAST the cliff, so it does not overlap
+                          ``deg_cost_s``, which is charged on every old-set lap.
+                          A tyre ten laps from the cliff but 0.4 s off the pace was
+                          previously priced identically to a fresh one.
         neutralisation_saving_s: Seconds a stop saves when taken under a
                           neutralisation (the field is queued, so the pit loss
                           costs less).
@@ -217,6 +230,7 @@ class ProjectionConfig:
     window_laps: int = 5
     racing_laps: float = 5.0
     fresh_gain_s: float = 0.25
+    deg_cost_s: float | None = None
     cliff_loss_s: float = 0.80
     neutralisation_saving_s: float = 8.0
     undercut_band_s: float = DEFAULT_UNDERCUT_BAND_S
@@ -491,6 +505,38 @@ def _usable_rivals(rivals: Sequence[RivalState]) -> list[RivalState]:
     ]
 
 
+def _tyre_cost_s(config: ProjectionConfig, *, old_laps: float, fresh_laps: float) -> float:
+    """Seconds this plan's tyre state costs, positive = worse for us.
+
+    Sign convention differs from ``strategy_orchestrator._tyre_term`` because this
+    module accumulates a LOSS while that one accumulates a gain. Same two mutually
+    exclusive prices for the same physical thing: a measured cost on the laps spent
+    on the old set, or the hardcoded fresh credit when the model gave no reading.
+
+    THE ASYMMETRY WITH RIVALS IS REAL, AND IT IS A LIMITATION, NOT A CORRECTION
+    ---------------------------------------------------------------------------
+    This scorer works in gaps, and ``rival_time_deltas`` moves each rival by
+    ``pace_delta_s * racing_laps``. That is not a reason to skip our own wear: a
+    pace delta is a SNAPSHOT of the rival's relative pace at the current lap, and it
+    says nothing about how the gap moves as our set degrades across the window.
+    Charging our wear is exactly that extrapolation, and without it the projection
+    prices a twenty-lap-old set identically to a fresh one for every lap it holds.
+
+    What is genuinely missing is the mirror: **their** degradation is not modelled,
+    because the single-driver boundary gives rivals timing-screen data only and there
+    is no per-rival tyre state to run a TCN on. So a rival on older tyres than ours
+    is credited with holding their current pace. That biases the comparison toward
+    stopping, in the same direction and for a different reason than the term above,
+    and it is a known limitation of the projection rather than something this
+    function should compensate for by silently halving a measured cost.
+
+    The legacy path has no rivals and never faced the question.
+    """
+    if config.deg_cost_s is None:
+        return -fresh_laps * config.fresh_gain_s
+    return old_laps * config.deg_cost_s
+
+
 def driver_time_delta(
     plan: DriverPlan,
     pit_loss_s: np.ndarray,
@@ -544,7 +590,7 @@ def driver_time_delta(
         worn_laps = np.maximum(0.0, laps_before_stop - cliff_laps)
         delta += effective_loss
         delta += worn_laps * config.cliff_loss_s
-        delta -= laps_after_stop * config.fresh_gain_s
+        delta += _tyre_cost_s(config, old_laps=laps_before_stop, fresh_laps=laps_after_stop)
         delta -= laps_before_stop * config.clean_air_gain_s
 
         waiting_pays = laps_before_stop * config.neutralisation_onset_rate * saving_if_it_comes
@@ -552,6 +598,7 @@ def driver_time_delta(
     else:
         worn_laps = np.maximum(0.0, racing - cliff_laps)
         delta += worn_laps * config.cliff_loss_s
+        delta += _tyre_cost_s(config, old_laps=racing, fresh_laps=0.0)
 
     return delta
 

--- a/src/agents/position_projection.py
+++ b/src/agents/position_projection.py
@@ -48,6 +48,28 @@ was an unmeasured constant, which is what the redesign exists to remove:
   matches the timing screen but does not model the unlapping procedure before a
   restart (Art. 55.13).
 
+THREE HORIZONS FOR ONE FACT, stated once and prominently because the module used
+to leave it implicit and that read as an inconsistency waiting to be "fixed"
+(#742). ``rival_time_deltas``, ``_terminal_gaps`` and ``rank_targets`` each ask
+whether a rival's outstanding pit stop should cost them time, and each answers
+correctly for a DIFFERENT horizon, not for the same one three times::
+
+    rival_time_deltas -> rival.is_pitting                              (inside the window)
+    _terminal_gaps     -> rival.stop_pending is True and not is_pitting (race end)
+    rank_targets        -> rival.stop_pending is True                   (after both pit cycles)
+
+A rival who owes a stop but is not taking it inside the window genuinely loses
+no time inside the window, so ``is_pitting`` is the right predicate there. The
+same rival genuinely falls back by the race end whether or not they stop this
+lap, so ``stop_pending`` is right at that horizon; ``_terminal_gaps`` then
+excludes a rival who IS pitting right now, because ``rival_time_deltas`` already
+charged that stop inside the window and charging it again would push them a
+full pit cycle further back than they will ever be. ``rank_targets`` looks past
+both pit cycles, where whether the stop happens on THIS lap stops mattering, so
+it drops the ``is_pitting`` guard entirely. Making the three agree would not fix
+a bug: it would delete the distinction between "now", "by the end of the race"
+and "once everyone has stopped" that the three horizons exist to carry.
+
 --- WHERE TO CHANGE IF THE RIVALS CONTRACT CHANGES ---
 ``RivalState`` mirrors the fields ``RaceStateManager.get_rival_states`` emits
 (``interval_to_driver_s``, ``is_pitting``, ``lap_time_s``). If that contract
@@ -868,8 +890,15 @@ def rank_targets(
     in front of us.
 
     Deterministic and run once (no sampling): it selects who to attack, and the
-    Monte Carlo then scores the attacking. Both consume the same definition of
-    "who we are racing", so the selector and the scorer can no longer disagree.
+    Monte Carlo then scores the attacking. Both go through the same
+    ``_usable_rivals`` filter, so the selector and the scorer can never disagree
+    about WHICH rivals are in play (a rival with an unknown gap cannot silently
+    show up in one and not the other). That is the only thing shared: this
+    function does NOT use the same stop-obligation predicate as the scorer's
+    ``rival_time_deltas`` / ``_terminal_gaps``, and it should not be made to.
+    See "THREE HORIZONS FOR ONE FACT" at the top of this module for why
+    ``rank_targets`` charges ``stop_pending`` alone rather than the
+    ``is_pitting`` guard the other two use (#742).
     """
     ranked: list[TargetRanking] = []
 

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -289,7 +289,11 @@ class RaceSituationOutput:
             elevated SC risk. Same caveat: N14's best_threshold is raw-scale.
         threat_level: LOW / MEDIUM / HIGH derived from both probabilities in __post_init__.
         gap_ahead_s: Gap to the car directly ahead (seconds). < 1.0s = DRS range.
-        pace_delta_s: 3-lap rolling pace delta vs car ahead (s/lap). Negative = faster.
+        pace_delta_s: SINGLE-lap pace delta vs the car ahead (s/lap), this driver's
+            lap time minus theirs, so negative = we are faster. The rolling version is
+            the separate ``pace_delta_rolling3`` field; this docstring used to describe
+            that one, and four surfaces fed a self-delta into this field partly because
+            the contract they were reading named the wrong quantity (#750).
         reasoning: LLM synthesis forwarded verbatim to N31 Orchestrator.
         sc_currently_active: Any neutralisation (SC OR VSC) confirmed deployed this lap
             by the RCM feed. Kept as the single back-compat flag every consumer already

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -1666,7 +1666,11 @@ def _build_orchestrator_prompt(
         f"     contingency trigger, not a primary action — use STAY_OUT with SC contingency.\n"
         f"  4. Minimum stint before pit: SOFT >= 8 laps, MEDIUM >= 12, HARD >= 15.\n"
         f"     If tyre_life is below minimum, override to STAY_OUT (current set has life left).\n"
-        f"  5. Compound must fit remaining laps: SOFT only if <= 15 laps remain,\n"
+        # SOFT bound derived from _STINT_CAPACITY_LAPS (imported above), not restated:
+        # this line and the pit agent's own system prompt used to disagree with the
+        # deterministic selector's table (18 vs 15), so laps_remaining=16-18 had the
+        # selector pass SOFT while both prompts told the LLM to refuse it (#741).
+        f"  5. Compound must fit remaining laps: SOFT only if <= {_STINT_CAPACITY_LAPS['SOFT']} laps remain,\n"
         f"     MEDIUM for 12-30, HARD for 20+. Wrong compound forces an extra stop.\n"
         f"  6. Opening laps 1-3: threat levels from N27 are inflated by start chaos.\n"
         f"     Discount them one tier (HIGH→MEDIUM, MEDIUM→LOW) for decision-making.\n"

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -66,7 +66,11 @@ except ImportError:
     _LC_OK = False
 
 # ── Sub-agent imports ──────────────────────────────────────────────────────────
-from src.agents.pace_agent         import run_pace_agent, run_pace_agent_from_state
+from src.agents.pace_agent         import (
+    MISSING_PREV_LAP_TIME_S,
+    run_pace_agent,
+    run_pace_agent_from_state,
+)
 from src.agents.tire_agent         import run_tire_agent, run_tire_agent_from_state
 from src.agents.race_situation_agent import (
     run_race_situation_agent,
@@ -1661,7 +1665,17 @@ def _build_orchestrator_prompt(
         f"     or damage/puncture confirmed by radio. Fresh tyres cannot degrade in 1-4 laps;\n"
         f"     pit lane costs ~22-25s which is unrecoverable this early. Force STAY_OUT.\n"
         f"  2. NO pit action when remaining laps <= 3 unless tyre failure imminent\n"
-        f"     (cliff P10 < 2 laps). Pit cost ~22s vs ~1.5s recovery = ~13 positions lost.\n"
+        # ~9, not ~13. The 13 was 20 s / POS_GAP_S(1.50), and POS_GAP_S is the legacy
+        # scoring constant `measure_mc_tables.py` records as retired. The MEASURED
+        # median gap between consecutive cars under green flag is 2.227 s (n=69,487),
+        # which puts 20 s at about nine places; 1.4795 s, and therefore thirteen, is
+        # the SAFETY CAR bunched-field figure (n=3,658) and is the exception this rule
+        # excludes. The pit agent's prompt already said exactly that, so the two
+        # prompts were teaching one orchestrating LLM contradictory numbers in the
+        # same run (#766).
+        f"     (cliff P10 < 2 laps). Pit cost ~22s vs ~1.5s recovery = ~9 positions lost\n"
+        f"     under green flag (measured median gap 2.227s). The ~13 figure is the\n"
+        f"     Safety Car bunched field (1.4795s), which is the exception above.\n"
         f"  3. REACTIVE_SC only when SC IS deployed (confirmed). High sc_prob is a\n"
         f"     contingency trigger, not a primary action — use STAY_OUT with SC contingency.\n"
         f"  4. Minimum stint before pit: SOFT >= 8 laps, MEDIUM >= 12, HARD >= 15.\n"
@@ -1846,7 +1860,14 @@ def _run_always_on_agents(race_state: "RaceState", lap_state: dict) -> tuple:
             "fuel_load", 1 - race_state.lap / race_state.total_laps
         ),
         year           = lap_state["year"],
-        prev_lap_time  = lap_state.get("prev_lap_time", 92.0),
+        # `or`, NOT the two-arg get(key, default): `RaceStateManager` emits this key
+        # PRESENT with a None value whenever no surviving predecessor exists, and the
+        # two-arg form substitutes only for an absent KEY. `_predict` reads the value
+        # straight into `prev + delta` with no NaN branch, so a None reaching it turns
+        # the prediction into NaN and then raises on the subtraction. The twin of this
+        # line in `pace_agent` carries a fifteen-line comment saying exactly that; this
+        # one carried a bare 92.0 and got neither the form nor the same number (#766).
+        prev_lap_time  = lap_state.get("prev_lap_time") or MISSING_PREV_LAP_TIME_S,
         prev_tyre_life = race_state.tyre_life - 1,
         prev_speed_st  = lap_state.get("prev_speed_st", 300.0),
         air_temp       = race_state.air_temp,

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -664,6 +664,28 @@ VSC_PIT_BONUS = 3.0  # seconds saved by pitting under a Virtual Safety Car (Art.
                      # measured.
 
 
+def _tyre_term(deg_cost_s: float | None, old_laps: int, fresh_laps: int) -> float:
+    """Seconds the tyre state is worth over one plan's window.
+
+    Two mutually exclusive ways of pricing the same physical thing, so this is a
+    REPLACEMENT and not an addition, and the double-count trap is avoided by that
+    fact rather than by a correction term.
+
+    With a measured signal, charge the laps spent on the OLD set: a tyre 0.4 s off
+    the pace costs 0.4 s every lap you keep it, whether or not the cliff is near.
+    Without one, fall back to ``FRESH_GAIN``, the hardcoded 0.25 s/lap credit for
+    the laps spent on the NEW set, which is the same quantity guessed at instead of
+    read. Both are seconds, applied before the conversion to positions.
+
+    ``None`` is a real state, not a defect: a stint whose early laps are outside the
+    replay has no reference to subtract, and the fallback keeps that case scoring
+    exactly as it did before #744b.
+    """
+    if deg_cost_s is None:
+        return FRESH_GAIN * fresh_laps
+    return -deg_cost_s * old_laps
+
+
 def simulate_lap_window(
     strategy: str,
     cliff_i:  float,
@@ -672,6 +694,7 @@ def simulate_lap_window(
     ucut_i:   bool,
     window:   int = WINDOW_LAPS,
     sc_pit_bonus: float = SC_PIT_BONUS,
+    deg_cost_s: float | None = None,
 ) -> float:
     """Estimate position gain vs STAY_OUT baseline over a W-lap window.
 
@@ -711,16 +734,16 @@ def simulate_lap_window(
     """
     if strategy == "STAY_OUT":
         cliff_laps = max(0.0, window - cliff_i)
-        time_delta = -cliff_laps * CLIFF_LOSS
+        time_delta = -cliff_laps * CLIFF_LOSS + _tyre_term(deg_cost_s, window, 0)
 
     elif strategy == "PIT_NOW":
         sc_saving  = sc_pit_bonus if sc_i else 0.0
-        time_delta = -pit_i + sc_saving + FRESH_GAIN * window
+        time_delta = -pit_i + sc_saving + _tyre_term(deg_cost_s, 0, window)
 
     elif strategy == "UNDERCUT":
         sc_saving  = sc_pit_bonus if sc_i else 0.0
         ucut_bonus = POS_GAP_S if ucut_i else 0.0
-        time_delta = -pit_i + sc_saving + FRESH_GAIN * window + ucut_bonus
+        time_delta = -pit_i + sc_saving + _tyre_term(deg_cost_s, 0, window) + ucut_bonus
 
     elif strategy == "OVERCUT":
         # An overcut still makes the stop, just later, so it pays for it like the others.
@@ -738,10 +761,17 @@ def simulate_lap_window(
         # -14 positions against a worst-case STAY_OUT of about -2.7 and suppresses pitting.
         # See tests/mc/test_mc_is_a_real_decision.py.
         if sc_i:
-            time_delta = -pit_i + sc_pit_bonus + FRESH_GAIN * window
+            time_delta = -pit_i + sc_pit_bonus + _tyre_term(deg_cost_s, 0, window)
         else:
             cliff_laps = max(0.0, (window // 2) - cliff_i)
-            time_delta = -pit_i + FRESH_GAIN * (window // 2) - cliff_laps * CLIFF_LOSS
+            # The only branch that splits the window: half on the old set, half on the
+            # new one. Getting these two counts wrong makes the wear term a constant
+            # offset that cancels in the argmax and looks like it did nothing.
+            time_delta = (
+                -pit_i
+                + _tyre_term(deg_cost_s, window // 2, window // 2)
+                - cliff_laps * CLIFF_LOSS
+            )
 
     else:
         time_delta = 0.0
@@ -1077,6 +1107,7 @@ def _run_projection_mc(
     ucut_s,
     alpha: float,
     neutralisation_saving_s: float,
+    deg_cost_s: float | None = None,
 ) -> dict:
     """Score the four candidates in projected track position instead of seconds.
 
@@ -1182,6 +1213,10 @@ def _run_projection_mc(
             window_laps=WINDOW_LAPS,
             racing_laps=racing_laps,
             fresh_gain_s=FRESH_GAIN,
+            # Set on BOTH configs the closure builds, green and neutralised. Setting
+            # only the green one would leave every Safety Car lap on the old constant
+            # while the report claimed the channel was connected.
+            deg_cost_s=deg_cost_s,
             cliff_loss_s=CLIFF_LOSS,
             neutralisation_saving_s=neutralisation_saving_s,
             undercut_band_s=measured_undercut_band_s(),
@@ -1349,6 +1384,11 @@ def _run_mc_simulation(
         tire_out.laps_to_cliff_p90,
     )
 
+    # `getattr` because a caller may still pass a stub TireOutput built before this
+    # field existed; `None` then keeps both scorers on the FRESH_GAIN fallback, which
+    # is the pre-#744b behaviour rather than a zero cost.
+    deg_cost_s = getattr(tire_out, "deg_cost_s", None)
+
     sc_prob = situation_out.sc_prob_3lap
 
     # A VSC is a neutralisation too (N27 forces sc_prob_3lap to 1.0, so every draw sees
@@ -1405,6 +1445,7 @@ def _run_mc_simulation(
             ucut_s=ucut_s,
             alpha=alpha,
             neutralisation_saving_s=sc_pit_bonus,
+            deg_cost_s=deg_cost_s,
         )
 
     strategies = ["STAY_OUT", "PIT_NOW", "UNDERCUT", "OVERCUT"]
@@ -1413,7 +1454,7 @@ def _run_mc_simulation(
     for s in strategies:
         outcomes = np.array([
             simulate_lap_window(s, cliff_s[i], sc_s[i], pit_s[i], ucut_s[i],
-                                sc_pit_bonus=sc_pit_bonus)
+                                sc_pit_bonus=sc_pit_bonus, deg_cost_s=deg_cost_s)
             for i in range(n)
         ])
         e_val   = float(np.mean(outcomes))

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -219,6 +219,24 @@ class TireAgentConfig:
             is PIT_SOON. Per-cluster values take precedence when available.
         cliff_monitor_laps: Global fallback threshold below which warning_level
             is MONITOR. Per-cluster values take precedence when available.
+        fresh_reference_tyre_life: Tyre life that stands in for "fresh" when asking
+            the model what this set was worth before it wore. N04 defines the target
+            against the stint's own lowest-tyre-life lap, which is an out-lap or a
+            standing start, so the level is biased slow and cannot be charged as a
+            cost directly. Asking the same model on the same stint's early laps
+            cancels that baseline algebraically instead of approximately.
+        deg_cost_floor_s / deg_cost_ceiling_s: Bounds on the referenced wear, in
+            seconds per lap. MEASURED, not chosen: they are the 1st and 99th
+            percentiles over 31,624 training-season laps
+            (``scripts/measure_tyre_reference.py``). The raw quantity reaches
+            +-15 s/lap because a handful of stints have a Safety Car or an out-lap
+            as their N04 baseline, and one of those reaching the scorer prices a
+            single lap like ten positions.
+
+            Do NOT tighten these to ``CLIFF_LOSS = 0.80``. The measured median at
+            20-25 laps of tyre life is 1.03 s/lap, so that bound would delete the
+            signal rather than the outliers. These are a guard against nonsense,
+            not an opinion about how much a worn tyre costs.
     """
 
     n_mc: int = 50
@@ -226,6 +244,9 @@ class TireAgentConfig:
     model_name: str = 'gpt-4.1-mini'
     cliff_pit_soon_laps: int = 3
     cliff_monitor_laps: int  = 7
+    fresh_reference_tyre_life: int = 3
+    deg_cost_floor_s: float   = -2.33
+    deg_cost_ceiling_s: float = 3.67
 
     def __post_init__(self) -> None:
         self._model_dir = _MODEL_DIR
@@ -377,6 +398,21 @@ CLIFF_THRESHOLD: dict[str, int] = {
 MAX_RACE_LAPS: int = 78
 
 
+def _referenced_wear(parsed: dict) -> Optional[float]:
+    """Seconds per lap this set costs versus fresh, bounded, or ``None``.
+
+    Both halves must have parsed. ``.get`` with a numeric default would turn a
+    missing reference into "this tyre is exactly at its fresh pace", which is a
+    reading the scorer can also legitimately receive.
+    """
+    if 'cum_deg' not in parsed or 'fresh_ref' not in parsed:
+        return None
+
+    wear = parsed['cum_deg'] - parsed['fresh_ref']
+    bounded = min(max(wear, CFG.deg_cost_floor_s), CFG.deg_cost_ceiling_s)
+    return round(bounded, 4)
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # TireOutput
 # ─────────────────────────────────────────────────────────────────────────────
@@ -422,6 +458,20 @@ class TireOutput:
             the Monte Carlo, nor the orchestrator prompt, nor any UI. Measured
             over the same 110 laps it correlates +0.369 with tyre life and swings
             0.411 s/lap across a stint.
+        deg_cost_s: Seconds per lap staying out costs versus a fresh set, bounded.
+            This is ``cumulative_deg_s`` minus the model's own prediction on this
+            stint's early laps, which cancels N04's per-stint baseline instead of
+            approximating it — see ``TireAgent._fresh_reference`` for why a pooled
+            per-compound table was measured and refused.
+
+            **This is the field the scorers consume**, not ``cumulative_deg_s``:
+            the level carries a per-stint offset whose standard deviation across
+            stints is 5.48 s, so it is not comparable between cars or laps.
+
+            ``None`` when either side is missing, never 0.0, for the same reason
+            given above for ``cumulative_deg_s``: a genuinely fresh set reads 0.0
+            here, so the sentinel would collide with a real value. A ``None``
+            leaves both scorers on the ``FRESH_GAIN`` fallback.
         laps_to_cliff_p10: Pessimistic estimate (P10) of laps before the cliff.
             Drives PIT_SOON warning — conservative to avoid running too long.
         laps_to_cliff_p50: Median estimate of laps before the cliff.
@@ -444,6 +494,7 @@ class TireOutput:
     laps_to_cliff_p90: float
     gp_name: str   = ''
     cumulative_deg_s: float | None = None
+    deg_cost_s: float | None = None
     warning_level: str = field(init=False)
     reasoning: str = ''
 
@@ -858,6 +909,40 @@ class TireAgent:
 
         return df[self.bundles[compound_id]['feature_names']].astype(float)
 
+    def _fresh_reference(self, driver: str, compound_id: str) -> Optional[float]:
+        """What the model said about this same set before it wore, in seconds.
+
+        A second deterministic pass over the stint's own early laps. Subtracting it
+        from the current prediction gives *seconds per lap this set costs versus
+        fresh*, which is what a scorer needs and what the raw level is not: N04
+        measures against the stint's slowest lap, so the level is negative on most
+        laps and charging it directly would pay a car for staying out.
+
+        WHY THIS AND NOT A COMMITTED PER-COMPOUND TABLE
+        -----------------------------------------------
+        Because the baseline is per stint, not per compound. Measured over 2,343
+        training-season stints, the per-stint median target has a standard deviation
+        of 5.48 s and a 1st percentile of -32.87 s: 13x the 0.411 s/lap signal being
+        chased. A pooled constant cannot normalise 2,343 different zero points, and
+        measurement put it at Spearman +0.188 against +0.191 for having no reference
+        at all. This one measures +0.308 and 73.9% non-negative
+        (``scripts/measure_tyre_reference.py``, ``documents/audits/MEASURE_744a_*``).
+
+        Returns ``None``, never 0.0, when the stint has no lap at the reference tyre
+        life — a replay that starts mid-stint. Zero is a legitimate reading of the
+        wear it feeds, so collapsing "unknown" into it would be the same sentinel
+        collision that #436 fixed for the cliff.
+        """
+        early_laps = self._get_driver_stint(driver, self.cfg.fresh_reference_tyre_life)
+        if early_laps is None or not len(early_laps):
+            return None
+
+        tensor = self._build_stint_tensor(early_laps, compound_id, self.session_meta)
+        model = self.bundles[compound_id]['model']
+        with torch.no_grad():
+            model.eval()
+            return float(model(tensor).item())
+
     def _build_stint_tensor(
         self,
         stint_laps: pd.DataFrame,
@@ -1080,9 +1165,15 @@ class TireAgent:
             feat_df  = agent._build_stint_features(stint, compound_id, agent.session_meta)
             deg_rate = float(feat_df['DegradationRate'].iloc[-1])
 
+            reference = agent._fresh_reference(driver, compound_id)
+            reference_line = (
+                '' if reference is None else f' | Fresh reference: {reference:.3f} s'
+            )
+
             return (
                 f'Driver {driver} | Compound {compound_id} | TyreLife {tyre_life}\n'
                 f'Cumulative degradation: {pred:.3f} s | Degradation rate: {deg_rate:.4f} s/lap'
+                f'{reference_line}'
             )
 
         @lc_tool
@@ -1484,6 +1575,7 @@ class TireAgent:
             cumulative_deg_s  = (
                 round(parsed['cum_deg'], 4) if 'cum_deg' in parsed else None
             ),
+            deg_cost_s        = _referenced_wear(parsed),
             laps_to_cliff_p10 = round(parsed['p10'], 1),
             laps_to_cliff_p50 = round(parsed.get('p50', 0.0), 1),
             laps_to_cliff_p90 = round(parsed.get('p90', 0.0), 1),

--- a/src/agents/tire_parsing.py
+++ b/src/agents/tire_parsing.py
@@ -34,7 +34,13 @@ import re
 # printed it since the tool existed and nothing ever read it, so the prediction the
 # whole N07-N10 family exists to produce stopped here. It takes the same `-?` for the
 # same reason: a set faster than its own fresh baseline is real early in a stint.
+#
+# `Fresh reference` (#744b) is the same model on the same stint's early laps. It is
+# printed only when those laps exist, so an absent key means "no reference could be
+# taken" and the wear it feeds stays None. Same `-?` for the same reason: the fresh
+# reference is itself measured against N04's slow baseline and is routinely negative.
 _PATTERNS: tuple[tuple[str, str], ...] = (
+    (r'Fresh reference:\s*(-?[\d.]+)',        'fresh_ref'),
     (r'Cumulative degradation:\s*(-?[\d.]+)', 'cum_deg'),
     (r'Degradation rate:\s*(-?[\d.]+)',       'deg_rate'),
     (r'P10:\s*(-?[\d.]+)',                    'p10'),

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -603,7 +603,15 @@ class SimConnector(threading.Thread):
         shim that only the FastAPI startup provides). Populates
         ``radio_msgs`` / ``rcm_events`` from the ``RadioPipelineRunner``
         corpus so the Radio agent sees the real OpenF1 team messages
-        (same as the CLI); empty lists when the corpus could not load."""
+        (same as the CLI); empty lists when the corpus could not load.
+
+        ``prev_lap_time`` is accepted but no longer read here: ``pace_delta_s``
+        used to be computed from it and that was the wrong axis (#750, fixed
+        below). Left in the signature rather than removed, since the caller's
+        per-lap bookkeeping that produces it (``_step_once`` /
+        ``_lap_time_from_state``) serves no other purpose today and dropping it
+        is a small cleanup outside this fix's scope.
+        """
         from src.agents.position_projection import GAP_UNKNOWN_FALLBACK_S
         from src.agents.strategy_orchestrator import RaceState
 
@@ -611,7 +619,6 @@ class SimConnector(threading.Thread):
         weather = lap_state.get("weather", {})
         meta = lap_state.get("session_meta", {})
         cur_lap_time = driver_st.get("lap_time_s") or 0.0
-        pace_delta = cur_lap_time - prev_lap_time if prev_lap_time else 0.0
 
         rivals = lap_state.get("rivals", [])
         our_pos = driver_st.get("position")
@@ -650,6 +657,22 @@ class SimConnector(threading.Thread):
                 gap_ahead_s = GAP_UNKNOWN_FALLBACK_S
             else:
                 gap_ahead_s = abs(measured_interval)
+
+        # pace_delta_s is contractually RIVAL-relative (this driver's lap time
+        # minus the car directly ahead's SAME lap, negative = we are faster) per
+        # race_situation_agent.py:292/904, the schema N27 itself computes. The
+        # old formula compared cur_lap_time against our OWN previous lap
+        # instead, a same-car same-driver quantity that reported roughly -20s
+        # of phantom "pace gain" on the lap after a pit stop, a green lap read
+        # against our own out-lap. car_ahead is already resolved above for
+        # gap_ahead_s, so no extra lookup is needed; 0.0 when it or its lap
+        # time is unknown is the schema's documented neutral, not a guess in
+        # either direction (#750).
+        ahead_lap_time = car_ahead.get("lap_time_s") if car_ahead is not None else None
+        if ahead_lap_time is not None and cur_lap_time:
+            pace_delta = cur_lap_time - float(ahead_lap_time)
+        else:
+            pace_delta = 0.0
 
         lap_num = int(lap_state.get("lap_number", 1) or 1)
         radio_msgs: list[dict] = []

--- a/src/strategy/eval/decision_modes.py
+++ b/src/strategy/eval/decision_modes.py
@@ -13,11 +13,20 @@ WHAT THIS MEASURES, EXACTLY
 ---------------------------
 For every real green-flag stop in the sampled races, the stack is driven over a
 window of laps either side of the real stop lap and asked, lap by lap, what it
-would do. The first lap inside the window on which it emits a pit action is
-"the lap it would have chosen"; the signed distance to the real lap is the
-error. Signed, not absolute, for the reason ``GroundTruth.mean_signed_error``
-exists: stopping consistently early or late is a fixable bug, and a magnitude
-hides it.
+would do. The lap it would have chosen is the first **transition** — the lap
+where it stops saying "stay out" and starts saying "box" — and the signed
+distance to the real lap is the error. Signed, not absolute, for the reason
+``GroundTruth.mean_signed_error`` exists: stopping consistently early or late is
+a fixable bug, and a magnitude hides it.
+
+A transition and not simply the first pit lap, because that is what #752
+retired. A stack that would pit on *every* lap of the window has no decision
+inside it, and reporting the window's left edge as its choice made the error a
+property of the window: widening it from 5 laps to 10 moved the entire mass from
+one boundary to the other and left zero at the old one. Those stops are now
+``no_boundary_in_window`` — looked at, deliberately unscored, because the honest
+statement is that the call came earlier than we asked, not that it came on the
+lap we happened to start asking.
 
 The stack runs on ``profile="no-llm"``, so the action comes from the Monte
 Carlo layer and the guard rails **deterministically**. This is a deliberate
@@ -138,6 +147,7 @@ class DecisionAgreement:
     no_call: int
     races: int
     no_data: int = 0
+    no_boundary: int = 0
 
     @property
     def sample_size(self) -> int:
@@ -145,8 +155,13 @@ class DecisionAgreement:
 
     @property
     def eligible(self) -> int:
-        """Every stop the tier looked at, scored or not."""
-        return self.sample_size + self.guard_railed + self.no_call + self.no_data
+        """Every stop the tier looked at, scored or not.
+
+        ``no_boundary`` joined this sum in #752 and it has to: those stops WERE
+        looked at. Leaving them out would shrink the denominator and inflate the
+        scored share by exactly the stops the old code used to score wrongly.
+        """
+        return self.sample_size + self.guard_railed + self.no_call + self.no_data + self.no_boundary
 
     @property
     def exact(self) -> float:
@@ -310,10 +325,50 @@ def _decisions_in_window(
     return actions
 
 
-def _first_pit_lap(actions: dict[int, str], low: int, high: int) -> int | None:
-    """Earliest lap in the window on which the stack asked to stop, or None."""
+def _asks_to_stop(actions: dict[int, str], low: int, high: int) -> bool:
+    """Whether the stack asked to stop anywhere in the window, transition or not.
+
+    Only used to tell "it never wanted to stop" from "it already wanted to stop
+    before we started asking". Those are opposite findings and the old bucketing
+    could not distinguish them.
+    """
+    return any(actions.get(lap) in _PIT_ACTIONS for lap in range(low, high + 1))
+
+
+def _pit_decision_lap(actions: dict[int, str], low: int, high: int) -> int | None:
+    """The lap the stack DECIDED to stop on — the first non-pit → pit transition.
+
+    WHY A TRANSITION AND NOT THE FIRST PIT LAP (#752)
+    -------------------------------------------------
+    This used to return the earliest lap in the window carrying a pit action. That
+    reports the window's left edge for any stack that would pit on *every* lap of
+    it, which is not a timing estimate — it is ``window_low`` wearing one.
+
+    Measured before the change, 2025 Monza + Marina_Bay, moving only the eval's own
+    window width:
+
+        window = 5     12 offsets at -5   (the edge)   mean signed -3.08
+        window = 10     0 offsets at -5, 10 at -10     mean signed -5.04
+
+    The mass at -5 does not survive widening; it goes to **zero** and reappears at
+    the new boundary. So the published -2.23 / -3.08 / -5.04 were three readings of
+    the window, not three readings of the model.
+
+    A transition is the smallest thing that is actually a decision: the stack said
+    "stay out" and then said "box". Where no transition exists, this returns None
+    and the caller records ``no_boundary_in_window`` rather than inventing a lap —
+    which is the honest report for a stack that was already committed when the
+    window opened, and the one the old code could not make.
+
+    Requires ``lap - 1`` to have been EVALUATED, not merely absent: an unevaluated
+    predecessor cannot witness a transition, so it is not counted as one. The
+    caller widens the replay span by a lap so ``low`` itself can be judged.
+    """
     for lap in range(low, high + 1):
-        if actions.get(lap) in _PIT_ACTIONS:
+        if actions.get(lap) not in _PIT_ACTIONS:
+            continue
+        previous = actions.get(lap - 1)
+        if previous is not None and previous not in _PIT_ACTIONS:
             return lap
     return None
 
@@ -407,7 +462,11 @@ def measure_decision_agreement(
             # One replay pass per (race, driver) spanning the union of the windows.
             # Two stops twenty laps apart still cost one pass, which is where the
             # runtime budget for a stratified subset comes from.
-            low = max(1, min(stop_laps) - DECISION_WINDOW_LAPS)
+            # One lap BEFORE the earliest window, so `window_low` itself can be
+            # judged: a transition into a pit action needs its predecessor to have
+            # been evaluated, and without this the first lap of every window would
+            # be permanently unjudgeable (#752). One extra lap per (race, driver).
+            low = max(1, min(stop_laps) - DECISION_WINDOW_LAPS - 1)
             high = min(total_laps, max(stop_laps) + DECISION_WINDOW_LAPS)
             engine = RaceReplayEngine(str(race_dir), driver, team, interval_seconds=0)
             actions = _decisions_in_window(engine, featured, driver, low, high, risk_tolerance)
@@ -431,11 +490,19 @@ def measure_decision_agreement(
                     )
                     continue
 
-                chosen = _first_pit_lap(actions, window_low, window_high)
+                chosen = _pit_decision_lap(actions, window_low, window_high)
                 if chosen is None:
-                    verdicts.append(
-                        StopVerdict(year, race, driver, stop_lap, None, None, "no_call_in_window")
+                    # Two opposite findings the old bucketing merged into one. "It
+                    # never asked to stop" is the model declining; "it asked on
+                    # every lap, including the first we offered" is the model
+                    # already committed before we started looking, and reporting
+                    # the window edge as its choice is what #752 retired.
+                    unscored = (
+                        "no_boundary_in_window"
+                        if _asks_to_stop(actions, window_low, window_high)
+                        else "no_call_in_window"
                     )
+                    verdicts.append(StopVerdict(year, race, driver, stop_lap, None, None, unscored))
                     continue
 
                 verdicts.append(
@@ -449,6 +516,7 @@ def measure_decision_agreement(
         no_call=sum(1 for v in verdicts if v.bucket == "no_call_in_window"),
         races=races_measured,
         no_data=sum(1 for v in verdicts if v.bucket == "no_data"),
+        no_boundary=sum(1 for v in verdicts if v.bucket == "no_boundary_in_window"),
     )
     return agreement, verdicts
 
@@ -501,6 +569,15 @@ def _render_table(
         "number to watch: the stack looked and declined to stop anywhere near the real",
         "lap. Charging a retirement to the model as a missed call would flatter neither",
         "side honestly, so the two are never merged.",
+        "",
+        "`no_boundary_in_window` is the third case and it is the one this tier used to",
+        "get wrong (#752). The stack asked to stop on every lap offered, including the",
+        "first, so there is no STAY_OUT -> PIT transition to locate: it was already",
+        "committed before the window opened. Scoring it reported the window's left edge",
+        "as the model's choice, which is why the retired `mean_signed_error` moved with",
+        "the window width instead of with the model. A stop here is counted as looked-at",
+        "and left unscored, because the honest statement is that we do not know when it",
+        "would have called the stop, only that it was earlier than we asked.",
         "",
         "### Scope",
         "",

--- a/src/strategy/eval/decision_modes.py
+++ b/src/strategy/eval/decision_modes.py
@@ -103,11 +103,18 @@ DECISION_WINDOW_LAPS = 5
 # track position dominates, one low-downforce low-stop circuit and one fast circuit
 # with variable weather. Widening this is a runtime decision, not a correctness one —
 # but the report must keep saying which races it used.
+#
+# ALL SIX ARE 2025, AND THAT IS THE CORRECTNESS HALF. The first version of this list
+# took four of its six races from 2023-24, which are TRAINING seasons for every model
+# in the stack. A decision tier scored there is partly reading back its own training
+# data, and the whole point of this report is what the shipped system does on the
+# season it actually infers on. The archetypes are unchanged; only the year moved, so
+# the stratification argument above still holds.
 SAMPLED_RACES: tuple[tuple[int, str], ...] = (
-    (2023, "Barcelona"),  # conventional, high degradation
-    (2023, "Monaco"),  # street, track position is everything
-    (2024, "Silverstone"),  # fast, weather-variable
-    (2024, "Marina_Bay"),  # street, high degradation
+    (2025, "Barcelona"),  # conventional, high degradation
+    (2025, "Monaco"),  # street, track position is everything
+    (2025, "Silverstone"),  # fast, weather-variable
+    (2025, "Marina_Bay"),  # street, high degradation
     (2025, "Lusail"),  # high degradation, stint-limited history
     (2025, "Monza"),  # low downforce, fewest stops
 )
@@ -594,8 +601,12 @@ def _render_table(
         f"| Within 1 lap | {agreement.within_one:.1%} | same call, one lap either side |",
         f"| Within 2 laps | {agreement.within_two:.1%} | same strategic window |",
         f"| Mean signed error | {agreement.mean_signed_error:+.2f} laps | "
-        "negative = stops earlier than the team |",
-        f"| Mean absolute error | {agreement.mean_absolute_error:.2f} laps | magnitude |",
+        "negative = earlier than the team. **Do not quote as a system property** "
+        f"— still moves with `DECISION_WINDOW_LAPS` (measured -0.33 / -1.29 / -2.50 "
+        "at w=3/5/10 on one race), because a wider window admits more distant, and "
+        "therefore earlier, transitions |",
+        f"| Mean absolute error | {agreement.mean_absolute_error:.2f} laps | magnitude, "
+        "same width caveat |",
         f"| Coverage verdict | **{status}** | `masked` when under "
         f"{MIN_SCORED_SHARE:.0%} of eligible stops were scored |",
         "",
@@ -630,7 +641,7 @@ def _render_table(
         "",
         "What they share is that the earliest pit ask has no evaluated non-pit lap before",
         "it, so any lap reported would be the window's left edge rather than the model's",
-        "choice - which is why the retired `mean_signed_error` moved with the window width",
+        "choice - which is why `mean_signed_error` used to move with the window width",
         "instead of with the model. A stop here is counted as looked-at and left unscored.",
         "The same applies at the opening guard rail: a transition on lap",
         f"{_NO_PIT_BEFORE_LAP} or earlier is the rail releasing, not the model deciding,",
@@ -639,6 +650,10 @@ def _render_table(
         "### Scope",
         "",
         f"- Sampled races ({agreement.races} measured): {races}.",
+        "- **All six are 2025, deliberately.** 2023 and 2024 are training seasons for",
+        "  every model in the stack, so a decision tier scored there is partly reading",
+        "  back its own training data. An earlier version of this list took four of its",
+        "  six races from those seasons; the archetypes are unchanged, only the year.",
         "- A full sweep of the real-stop sample is roughly 11.5 h of wall clock at",
         "  0.51 s per lap through the stack, so this is a stratified subset by circuit",
         "  archetype and **not** full coverage. Read every figure above as conditional",

--- a/src/strategy/eval/decision_modes.py
+++ b/src/strategy/eval/decision_modes.py
@@ -20,13 +20,19 @@ distance to the real lap is the error. Signed, not absolute, for the reason
 a fixable bug, and a magnitude hides it.
 
 A transition and not simply the first pit lap, because that is what #752
-retired. A stack that would pit on *every* lap of the window has no decision
-inside it, and reporting the window's left edge as its choice made the error a
-property of the window: widening it from 5 laps to 10 moved the entire mass from
-one boundary to the other and left zero at the old one. Those stops are now
-``no_boundary_in_window`` — looked at, deliberately unscored, because the honest
-statement is that the call came earlier than we asked, not that it came on the
-lap we happened to start asking.
+retired. A stack whose earliest pit ask has no evaluated non-pit lap before it
+has no decision inside the window, and reporting the window's left edge as its
+choice made the error a property of the window: widening it from 5 laps to 10
+moved the entire mass from one boundary to the other and left zero at the old
+one. Those stops are now ``no_boundary_in_window``: looked at, deliberately
+unscored, because the honest statement is that the call came earlier than we
+asked, not that it came on the lap we happened to start asking.
+
+That bucket means *no locatable decision*, and nothing more. It is NOT a
+description of what the stack did. On the measured 2025 Monza sample all four
+occupants were committed when the window opened and then WITHDREW inside it, one
+of them flipping to stay-out on the exact lap the team really stopped. See
+``_render_table`` for the three distinct shapes that land there.
 
 The stack runs on ``profile="no-llm"``, so the action comes from the Monte
 Carlo layer and the guard rails **deterministically**. This is a deliberate
@@ -77,7 +83,12 @@ from src.strategy.eval.report import build_header, write_report
 # From the leaf module, never from ``no_llm``: that one imports the agent stack and
 # loads model weights at import time, which would make this report — and every other
 # ``f1-eval`` subcommand next to it — impossible to even import without ``data/models/``.
-from src.strategy.inference.guard_rails import _MIN_STINT_LAPS, _PIT_ACTIONS, apply_guard_rails
+from src.strategy.inference.guard_rails import (
+    _MIN_STINT_LAPS,
+    _NO_PIT_BEFORE_LAP,
+    _PIT_ACTIONS,
+    apply_guard_rails,
+)
 
 # Laps either side of the real stop that the stack is asked about. Five matches
 # the Monte Carlo decision window, so the question posed to the model is the one
@@ -363,14 +374,54 @@ def _pit_decision_lap(actions: dict[int, str], low: int, high: int) -> int | Non
     Requires ``lap - 1`` to have been EVALUATED, not merely absent: an unevaluated
     predecessor cannot witness a transition, so it is not counted as one. The
     caller widens the replay span by a lap so ``low`` itself can be judged.
+
+    A RAILED PREDECESSOR IS NOT A WITNESS EITHER
+    ---------------------------------------------
+    Actions are recorded AFTER the guard rails (``no_llm.py``), and the opening
+    rail forces STAY_OUT on every lap below ``_NO_PIT_BEFORE_LAP`` outside a
+    neutralisation. So a stack that wants to box from lap 1 is recorded as
+    ``STAY_OUT, STAY_OUT, STAY_OUT, STAY_OUT, PIT`` and the transition lands on
+    ``_NO_PIT_BEFORE_LAP`` for every such stop — a constant of the rails wearing a
+    timing estimate, which is the shape #752 retired, relocated from ``window_low``
+    to the rail boundary. Those stops go to ``no_boundary_in_window`` instead.
+
+    Rejecting on the lap number alone over-rejects under a Safety Car, where the
+    rail is suspended and lap 5 may be a real transition. That is the conservative
+    direction and the same one this whole metric took: refusing to score is honest,
+    inventing a lap is not.
     """
     for lap in range(low, high + 1):
         if actions.get(lap) not in _PIT_ACTIONS:
             continue
         previous = actions.get(lap - 1)
-        if previous is not None and previous not in _PIT_ACTIONS:
-            return lap
+        if previous is None or previous in _PIT_ACTIONS:
+            continue
+        if lap <= _NO_PIT_BEFORE_LAP:
+            continue
+        return lap
     return None
+
+
+def _replay_span(stop_laps: list[int], total_laps: int) -> tuple[int, int]:
+    """The laps to replay for one (race, driver), covering the union of the windows.
+
+    One pass per driver rather than one per stop: two stops twenty laps apart still
+    cost one replay, which is where the runtime budget for a stratified subset comes
+    from.
+
+    The span opens **one lap before** the earliest scoring window. A transition needs
+    its predecessor to have been evaluated, so without that extra lap the first lap of
+    every window would be permanently unjudgeable and the edge report would return
+    through the back door: on 2025 Monza it is the difference between HAD's stop
+    scoring at lap 27 and landing in ``no_boundary_in_window`` (#752).
+
+    It is a separate function because that one lap was previously asserted by a comment
+    and nothing else. Reverting it left the whole suite green while moving the published
+    error by half its value, so it now has a home a test can reach.
+    """
+    low = max(1, min(stop_laps) - DECISION_WINDOW_LAPS - 1)
+    high = min(total_laps, max(stop_laps) + DECISION_WINDOW_LAPS)
+    return low, high
 
 
 def _stop_context(laps, driver: str, lap: int) -> tuple[str | None, int | None]:
@@ -459,15 +510,7 @@ def measure_decision_agreement(
             if team is None:
                 continue
 
-            # One replay pass per (race, driver) spanning the union of the windows.
-            # Two stops twenty laps apart still cost one pass, which is where the
-            # runtime budget for a stratified subset comes from.
-            # One lap BEFORE the earliest window, so `window_low` itself can be
-            # judged: a transition into a pit action needs its predecessor to have
-            # been evaluated, and without this the first lap of every window would
-            # be permanently unjudgeable (#752). One extra lap per (race, driver).
-            low = max(1, min(stop_laps) - DECISION_WINDOW_LAPS - 1)
-            high = min(total_laps, max(stop_laps) + DECISION_WINDOW_LAPS)
+            low, high = _replay_span(stop_laps, total_laps)
             engine = RaceReplayEngine(str(race_dir), driver, team, interval_seconds=0)
             actions = _decisions_in_window(engine, featured, driver, low, high, risk_tolerance)
 
@@ -493,10 +536,12 @@ def measure_decision_agreement(
                 chosen = _pit_decision_lap(actions, window_low, window_high)
                 if chosen is None:
                     # Two opposite findings the old bucketing merged into one. "It
-                    # never asked to stop" is the model declining; "it asked on
-                    # every lap, including the first we offered" is the model
-                    # already committed before we started looking, and reporting
-                    # the window edge as its choice is what #752 retired.
+                    # never asked to stop" is the model declining; "it asked, but no
+                    # transition can be located" is the model already committed when
+                    # we started looking, and reporting the window edge as its choice
+                    # is what #752 retired. The second bucket says only that - it does
+                    # NOT say the stack asked on every lap, which measured false on
+                    # 4 of 4 real occupants (they withdrew mid-window).
                     unscored = (
                         "no_boundary_in_window"
                         if _asks_to_stop(actions, window_low, window_high)
@@ -571,13 +616,25 @@ def _render_table(
         "side honestly, so the two are never merged.",
         "",
         "`no_boundary_in_window` is the third case and it is the one this tier used to",
-        "get wrong (#752). The stack asked to stop on every lap offered, including the",
-        "first, so there is no STAY_OUT -> PIT transition to locate: it was already",
-        "committed before the window opened. Scoring it reported the window's left edge",
-        "as the model's choice, which is why the retired `mean_signed_error` moved with",
-        "the window width instead of with the model. A stop here is counted as looked-at",
-        "and left unscored, because the honest statement is that we do not know when it",
-        "would have called the stop, only that it was earlier than we asked.",
+        "get wrong (#752). It means only this: the stack asked to stop somewhere in the",
+        "window, but no STAY_OUT -> PIT transition could be located inside it. Read it",
+        "as **no locatable decision**, never as a description of what the stack did.",
+        "Three different shapes land here and they are not the same finding:",
+        "",
+        "- already asking when the window opened, and still asking on every lap;",
+        "- already asking when the window opened, then **withdrawing** later - on the",
+        "  measured 2025 Monza sample this was 4 of 4 occupants, one of them flipping to",
+        "  STAY_OUT on the exact lap the team really stopped;",
+        "- a lap inside the window that was never evaluated, so the only pit ask has no",
+        "  witness for its predecessor.",
+        "",
+        "What they share is that the earliest pit ask has no evaluated non-pit lap before",
+        "it, so any lap reported would be the window's left edge rather than the model's",
+        "choice - which is why the retired `mean_signed_error` moved with the window width",
+        "instead of with the model. A stop here is counted as looked-at and left unscored.",
+        "The same applies at the opening guard rail: a transition on lap",
+        f"{_NO_PIT_BEFORE_LAP} or earlier is the rail releasing, not the model deciding,",
+        "so it is bucketed here too.",
         "",
         "### Scope",
         "",

--- a/tests/agents/test_prev_lap_default_is_single_sourced.py
+++ b/tests/agents/test_prev_lap_default_is_single_sourced.py
@@ -1,0 +1,134 @@
+"""#766 — the previous-lap sentinel had two values and two substitution rules.
+
+`pace_agent` guards this key with `d.get('prev_lap_time') or 90.0` and carries a
+fifteen-line comment explaining why the two-arg `dict.get` form is wrong for it:
+`RaceStateManager` emits the key PRESENT with a `None` value whenever no surviving
+predecessor exists, and the two-arg form substitutes only for an absent KEY.
+
+`strategy_orchestrator`'s dict path carried `lap_state.get("prev_lap_time", 92.0)`.
+Both defects at once: the wrong form, so an honest `None` passed straight through,
+and a different number for the same quantity. `_predict` reads the value into
+`prev + delta` with no NaN branch, so the `None` reached a subtraction and the
+exported public entry point raised `TypeError` on the first lap of any stint.
+
+Found by gate G3's twin sweep, which is the point of that sweep: the fix landed on
+one producer and its twin one module over never got it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "lap_time").is_dir()
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_MODELS, reason="importing the agents loads model artefacts (HF, not git)"
+)
+
+
+def _lap_state(*, prev_lap_time):
+    """The keys `_run_always_on_agents` documents as required, plus the one under test."""
+    return {
+        "driver_number": 4,
+        "stint": 2,
+        "team": "McLaren",
+        "year": 2025,
+        "gp_name": "Lusail",
+        "prev_lap_time": prev_lap_time,
+    }
+
+
+def test_the_sentinel_has_exactly_one_definition():
+    """Both modules must read the same object, not two equal literals.
+
+    Equal-but-separate would pass an equality check today and drift tomorrow, which
+    is what happened: 90.0 against 92.0 for the same missing value.
+    """
+    from src.agents import pace_agent, strategy_orchestrator
+
+    assert strategy_orchestrator.MISSING_PREV_LAP_TIME_S is pace_agent.MISSING_PREV_LAP_TIME_S
+
+
+def test_an_honest_none_is_substituted_and_never_forwarded(monkeypatch):
+    """The lap state says "there is no previous lap" the only way it can.
+
+    `None` is the correct value for the first lap of a stint, so the fix is not to
+    stop emitting it. It is to substitute at the boundary that cannot represent it,
+    with the same rule and the same number as the twin entry point.
+    """
+    from src.agents import strategy_orchestrator as so
+
+    captured = {}
+
+    def _spy(**kwargs):
+        captured.update(kwargs)
+        raise _Stop
+
+    class _Stop(Exception):
+        pass
+
+    monkeypatch.setattr(so, "run_pace_agent", _spy)
+
+    lap_state = _lap_state(prev_lap_time=None)
+    race_state = so.RaceState(
+        driver="NOR",
+        lap=30,
+        total_laps=57,
+        position=3,
+        compound="MEDIUM",
+        tyre_life=5,
+        gap_ahead_s=2.0,
+        pace_delta_s=0.0,
+        risk_tolerance=0.5,
+        air_temp=25.0,
+        track_temp=35.0,
+    )
+
+    with pytest.raises(_Stop):
+        so._run_always_on_agents(race_state, lap_state)
+
+    assert captured["prev_lap_time"] == so.MISSING_PREV_LAP_TIME_S
+    assert captured["prev_lap_time"] is not None
+
+
+def test_a_real_previous_lap_is_passed_through_untouched(monkeypatch):
+    """The guard above must not swallow a genuine reading.
+
+    Without this the substitution could be unconditional and still pass the other
+    test, which would replace every anchor in the dict path with the placeholder.
+    """
+    from src.agents import strategy_orchestrator as so
+
+    captured = {}
+
+    class _Stop(Exception):
+        pass
+
+    def _spy(**kwargs):
+        captured.update(kwargs)
+        raise _Stop
+
+    monkeypatch.setattr(so, "run_pace_agent", _spy)
+
+    race_state = so.RaceState(
+        driver="NOR",
+        lap=30,
+        total_laps=57,
+        position=3,
+        compound="MEDIUM",
+        tyre_life=5,
+        gap_ahead_s=2.0,
+        pace_delta_s=0.0,
+        risk_tolerance=0.5,
+        air_temp=25.0,
+        track_temp=35.0,
+    )
+    lap_state = _lap_state(prev_lap_time=85.304)
+
+    with pytest.raises(_Stop):
+        so._run_always_on_agents(race_state, lap_state)
+
+    assert captured["prev_lap_time"] == 85.304

--- a/tests/agents/test_prompt_constants_match_tables.py
+++ b/tests/agents/test_prompt_constants_match_tables.py
@@ -1,0 +1,126 @@
+"""#741 — a constant restated in prose is a constant that will drift.
+
+SOFT's stint capacity was **18** in `_STINT_CAPACITY_LAPS`, which the deterministic
+selector computes against, and **15** in both LLM prompts, which restated it as a
+literal. On `laps_remaining` 16-18 the selector passed SOFT and both prompts told the
+model to refuse it, so the compound choice on that three-lap band was decided by prose.
+
+Neither number was wrong. They were written from different sources and nothing made
+them move together, which is the same shape as the threshold-scale defect `CLAUDE.md`
+§11 records for 2026-07-27: a number restated somewhere it is not derived.
+
+WHY THIS TEST IS PHRASED OVER THE WHOLE TABLE
+----------------------------------------------
+Pinning "SOFT reads 18" would pass the day someone edits the table and forgets a
+prompt, which is exactly how the divergence arose. What must hold is the *relation*:
+no prompt may state a capacity the table disagrees with. So this parses the rendered
+prompts and checks every compound it can find, and it keeps holding when the measured
+capacity changes.
+
+⚠️ WHAT THIS DOES **NOT** CLAIM
+-------------------------------
+That 18 is the right number. Measured over 341 real green-flag SOFT stints across 71
+races (`src/strategy/eval/stint_lengths.py`, the same instrument and data used for the
+minimum bound), **33.7% run longer than 18 laps** and 45.7% longer than 15 — the median
+is 15 and the maximum is 50. Real stint length reflects strategy, Safety Car luck and
+circuit degradation, not a physical ceiling, so the data does not hand back a clean
+maximum and none was invented. 18 was kept because it is what the selector already
+computes against and the closer of the two to real practice. Whether the capacity model
+should be a hard bound at all is a separate question and is not settled here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").is_file()
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="the prompts live in modules whose import builds agent configs from "
+    "data/models/ (HF, not git)",
+)
+
+# "SOFT only if <= 18 laps", "SOFT: recommend only if remaining laps <= 18", and any
+# future phrasing that puts a compound and a bound in the same clause.
+_BOUND = re.compile(r"\b(SOFT|MEDIUM|HARD)\b[^.\n]*?<=\s*(\d+)")
+
+
+def _stated_bounds(prompt: str) -> set[tuple[str, int]]:
+    return {(m.group(1), int(m.group(2))) for m in _BOUND.finditer(prompt)}
+
+
+def _orchestrator_prompt() -> str:
+    from src.agents.strategy_orchestrator import RaceState, _build_orchestrator_prompt
+
+    race_state = RaceState(
+        driver="NOR",
+        lap=30,
+        total_laps=57,
+        position=4,
+        compound="MEDIUM",
+        tyre_life=12,
+        gap_ahead_s=2.0,
+        pace_delta_s=0.0,
+        risk_tolerance=0.5,
+        air_temp=25.0,
+        track_temp=35.0,
+    )
+    return _build_orchestrator_prompt(race_state, {}, "STAY_OUT")
+
+
+def test_no_prompt_states_a_capacity_the_table_disagrees_with():
+    """The relation, not the value. Both prompts, every compound they mention."""
+    from src.agents.pit_strategy_agent import _PIT_STRATEGY_SYSTEM_PROMPT, _STINT_CAPACITY_LAPS
+
+    prompts = {
+        "pit agent system prompt": _PIT_STRATEGY_SYSTEM_PROMPT,
+        "orchestrator prompt": _orchestrator_prompt(),
+    }
+
+    for name, prompt in prompts.items():
+        for compound, stated in _stated_bounds(prompt):
+            expected = _STINT_CAPACITY_LAPS.get(compound)
+            if expected is None:
+                continue
+            assert stated == expected, (
+                f"{name} states {compound} <= {stated} while _STINT_CAPACITY_LAPS says "
+                f"{expected}. Derive it from the table instead of restating it (#741)."
+            )
+
+
+def test_the_soft_bound_is_actually_present_in_both_prompts():
+    """The guard above passes vacuously if the regex stops matching.
+
+    That is not hypothetical: the bound is now interpolated, so a refactor that drops
+    the clause, renames the compound or reflows the sentence would silently leave the
+    check asserting about the empty set — this project's catalogued way for a green
+    test to mean nothing.
+    """
+    from src.agents.pit_strategy_agent import _PIT_STRATEGY_SYSTEM_PROMPT, _STINT_CAPACITY_LAPS
+
+    soft = _STINT_CAPACITY_LAPS["SOFT"]
+
+    assert ("SOFT", soft) in _stated_bounds(_PIT_STRATEGY_SYSTEM_PROMPT)
+    assert ("SOFT", soft) in _stated_bounds(_orchestrator_prompt())
+
+
+def test_the_selector_and_the_prompt_agree_across_the_band_that_used_to_split_them(monkeypatch):
+    """laps_remaining 16-18: the selector passed SOFT, the prompts forbade it.
+
+    Walks the band and asserts the two answer the same way at every lap in it, rather
+    than checking the single value they now share — the bug was a three-lap window, and
+    a test that only reads the constant would not have seen its width.
+    """
+    from src.agents.pit_strategy_agent import _STINT_CAPACITY_LAPS
+
+    prompt_bound = dict(_stated_bounds(_orchestrator_prompt()))["SOFT"]
+
+    for laps_remaining in range(14, 21):
+        selector_allows = _STINT_CAPACITY_LAPS["SOFT"] >= laps_remaining
+        prompt_allows = laps_remaining <= prompt_bound
+        assert selector_allows == prompt_allows, laps_remaining

--- a/tests/agents/test_prompt_constants_match_tables.py
+++ b/tests/agents/test_prompt_constants_match_tables.py
@@ -45,13 +45,21 @@ pytestmark = pytest.mark.skipif(
     "data/models/ (HF, not git)",
 )
 
-# "SOFT only if <= 18 laps", "SOFT: recommend only if remaining laps <= 18", and any
-# future phrasing that puts a compound and a bound in the same clause.
-_BOUND = re.compile(r"\b(SOFT|MEDIUM|HARD)\b[^.\n]*?<=\s*(\d+)")
+# Two phrasings, because the prompts use both and the first version of this file only
+# read the first. Gate G3 executed the gap: mutating MEDIUM 30 -> 32 left this test
+# GREEN while both prompts still said "12-30", so the docstring's "every compound it
+# can find" found exactly one. A regex is a claim about coverage and has to be tested
+# like one.
+_LE_BOUND = re.compile(r"\b(SOFT|MEDIUM|HARD)\b[^.\n]*?<=\s*(\d+)")
+_RANGE_BOUND = re.compile(r"\b(SOFT|MEDIUM|HARD)\b[^.\n]*?\b\d+\s*-\s*(\d+)\b")
 
 
 def _stated_bounds(prompt: str) -> set[tuple[str, int]]:
-    return {(m.group(1), int(m.group(2))) for m in _BOUND.finditer(prompt)}
+    """Every (compound, upper bound) pair either phrasing states."""
+    pairs = set()
+    for pattern in (_LE_BOUND, _RANGE_BOUND):
+        pairs |= {(m.group(1), int(m.group(2))) for m in pattern.finditer(prompt)}
+    return pairs
 
 
 def _orchestrator_prompt() -> str:
@@ -93,20 +101,29 @@ def test_no_prompt_states_a_capacity_the_table_disagrees_with():
             )
 
 
-def test_the_soft_bound_is_actually_present_in_both_prompts():
-    """The guard above passes vacuously if the regex stops matching.
+def test_every_compound_the_prompts_bound_is_actually_seen_by_the_regex():
+    """The guard above passes vacuously on whatever the regex fails to match.
 
-    That is not hypothetical: the bound is now interpolated, so a refactor that drops
-    the clause, renames the compound or reflows the sentence would silently leave the
-    check asserting about the empty set — this project's catalogued way for a green
-    test to mean nothing.
+    Not hypothetical, and not caught by inspection: gate G3 EXECUTED the gap by
+    moving MEDIUM 30 -> 32 and watching this file stay green while both prompts still
+    said "12-30". So this asserts coverage, compound by compound, rather than trusting
+    the pattern — the same "asserting about the empty set" trap the SOFT-only version
+    of this test was written to avoid and then fell into for the other two.
     """
     from src.agents.pit_strategy_agent import _PIT_STRATEGY_SYSTEM_PROMPT, _STINT_CAPACITY_LAPS
 
-    soft = _STINT_CAPACITY_LAPS["SOFT"]
-
-    assert ("SOFT", soft) in _stated_bounds(_PIT_STRATEGY_SYSTEM_PROMPT)
-    assert ("SOFT", soft) in _stated_bounds(_orchestrator_prompt())
+    for name, prompt in (
+        ("pit agent", _PIT_STRATEGY_SYSTEM_PROMPT),
+        ("orchestrator", _orchestrator_prompt()),
+    ):
+        seen = {compound for compound, _ in _stated_bounds(prompt)}
+        for compound in ("SOFT", "MEDIUM"):
+            assert compound in seen, (
+                f"{name} prompt states a bound for {compound} that the pattern does not "
+                f"match, so the check above cannot see it. Saw: {sorted(seen)}"
+            )
+            stated = dict(_stated_bounds(prompt))[compound]
+            assert stated == _STINT_CAPACITY_LAPS[compound]
 
 
 def test_the_selector_and_the_prompt_agree_across_the_band_that_used_to_split_them(monkeypatch):

--- a/tests/agents/test_tire_cumulative_deg.py
+++ b/tests/agents/test_tire_cumulative_deg.py
@@ -210,3 +210,134 @@ def test_the_prompt_shows_the_wear_and_says_unknown_when_it_is_missing():
 
     assert "vs fresh" in _build_tire_block(tire_out)
     assert "wear=unknown" in _build_tire_block(replace(tire_out, cumulative_deg_s=None))
+
+
+# ===========================================================================
+# #744b — the level becomes a COST by subtracting the model's own fresh reading
+# ===========================================================================
+#
+# `cumulative_deg_s` is measured against N04's per-stint baseline, and those
+# baselines are not comparable between stints: over 2,343 training-season stints
+# the per-stint median has std 5.48 s and a 1st percentile of -32.87 s, against
+# the 0.411 s/lap signal being chased. So the level cannot be charged as a cost,
+# and a pooled per-compound table cannot fix it either — measured at Spearman
+# +0.188 against +0.191 for having no reference at all.
+#
+# Subtracting the model's own prediction on the same stint's early laps cancels
+# that baseline algebraically. Measured: 73.9% non-negative, Spearman +0.308.
+
+
+def test_the_parser_captures_the_fresh_reference_including_a_negative_one():
+    """The reference is itself measured against N04's slow baseline, so it is
+    routinely negative — the same reason the other patterns carry `-?`."""
+    from src.agents.tire_parsing import parse_tool_outputs
+
+    message = _FakeToolMessage(
+        "Driver NOR | Compound C2 | TyreLife 18\n"
+        "Cumulative degradation: 0.412 s | Degradation rate: 0.02 s/lap"
+        " | Fresh reference: -0.308 s"
+    )
+
+    parsed = parse_tool_outputs([message])
+
+    assert parsed["fresh_ref"] == -0.308
+    assert parsed["cum_deg"] == 0.412
+
+
+def test_no_reference_line_writes_no_reference_key():
+    """A replay starting mid-stint has no laps at the reference tyre life, so the
+    tool prints no reference at all. That must stay distinguishable from one that
+    happens to be zero."""
+    from src.agents.tire_parsing import parse_tool_outputs
+
+    message = _FakeToolMessage(
+        "Driver NOR | Compound C2 | TyreLife 18\n"
+        "Cumulative degradation: 0.412 s | Degradation rate: 0.02 s/lap"
+    )
+
+    assert "fresh_ref" not in parse_tool_outputs([message])
+
+
+@pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="_referenced_wear reads the measured bounds off TireAgentConfig, whose "
+    "construction needs data/models/tire_degradation/ (HF, not git)",
+)
+class TestReferencedWear:
+    """The arithmetic that turns two model readings into one charge."""
+
+    def test_a_set_at_its_own_fresh_pace_costs_exactly_zero(self):
+        """The reference IS the current prediction on a stint's first laps, so the
+        wear is 0.0 — correct, and pinned so nobody "fixes" it into a fallback."""
+        from src.agents.tire_agent import _referenced_wear
+
+        assert _referenced_wear({"cum_deg": -0.308, "fresh_ref": -0.308}) == 0.0
+
+    def test_a_missing_half_is_none_and_never_zero(self):
+        """Zero is a legitimate reading of this field — see the test above — so it
+        cannot double as the sentinel. This is the collision #436 fixed for the
+        cliff, where a parse miss became a confident call to box."""
+        from src.agents.tire_agent import _referenced_wear
+
+        assert _referenced_wear({"cum_deg": 0.412}) is None
+        assert _referenced_wear({"fresh_ref": -0.308}) is None
+        assert _referenced_wear({}) is None
+
+    def test_the_baseline_cancels_rather_than_being_approximated(self):
+        """Both readings carry the same per-stint offset, so it subtracts out
+        exactly. Shift both by a 30 s Safety-Car baseline and the cost is unmoved."""
+        from src.agents.tire_agent import _referenced_wear
+
+        normal = _referenced_wear({"cum_deg": 0.412, "fresh_ref": -0.308})
+        shifted = _referenced_wear({"cum_deg": -29.588, "fresh_ref": -30.308})
+
+        assert normal == shifted == 0.72
+
+    def test_the_tail_is_bounded_by_the_measured_percentiles(self):
+        """The raw quantity reaches +-15 s/lap because a few stints have an out-lap
+        or a Safety Car as their N04 baseline, and one of those reaching the scorer
+        prices a single lap like ten positions."""
+        from src.agents.tire_agent import CFG, _referenced_wear
+
+        assert _referenced_wear({"cum_deg": 60.0, "fresh_ref": 0.0}) == CFG.deg_cost_ceiling_s
+        assert _referenced_wear({"cum_deg": -60.0, "fresh_ref": 0.0}) == CFG.deg_cost_floor_s
+
+    def test_the_bound_does_not_clip_a_genuinely_worn_tyre(self):
+        """The measured median at 20-25 laps of tyre life is 1.03 s/lap, which is
+        already above CLIFF_LOSS. A bound set there would delete the signal instead
+        of the outliers, so this pins that the real range survives."""
+        from src.agents.tire_agent import _referenced_wear
+
+        assert _referenced_wear({"cum_deg": 1.03, "fresh_ref": 0.0}) == 1.03
+        assert _referenced_wear({"cum_deg": 2.5, "fresh_ref": 0.0}) == 2.5
+
+
+@pytest.mark.skipif(
+    not (_HAS_MODELS and _HAS_DATA),
+    reason="needs data/models/tire_degradation/ and data/{raw/2025/Lusail,processed} (HF, not git)",
+)
+def test_a_real_lap_carries_a_cost_that_the_raw_level_could_not_have_given():
+    """The whole point of #744b, on a real lap rather than an arithmetic fixture.
+
+    Lusail 2025 lap 30, five laps into the stint. The raw level reads NEGATIVE
+    because N04 measures it against this stint's own out-lap; charged directly it
+    would have PAID the car for staying out, which is why the level was never
+    consumable. The referenced cost is a small positive, which is what a nearly
+    fresh set should cost.
+
+    Ranges, not values: pinning a number here would break on any legitimate model
+    refresh while saying nothing about whether the reference is connected. What is
+    pinned is the SIGN RELATIONSHIP the fix exists to create.
+    """
+    from src.strategy.inference.no_llm import _tire_no_llm
+
+    lap_state, laps = _scoped_lusail_lap_30()
+
+    tire_out = _tire_no_llm(lap_state, laps)
+
+    assert tire_out.cumulative_deg_s is not None
+    assert tire_out.deg_cost_s is not None
+    # The level is measured against a slow baseline, so it is below the cost.
+    assert tire_out.cumulative_deg_s < tire_out.deg_cost_s
+    # A five-lap-old set costs something small and non-negative, not a credit.
+    assert 0.0 <= tire_out.deg_cost_s < 1.0

--- a/tests/agents/test_tire_cumulative_deg.py
+++ b/tests/agents/test_tire_cumulative_deg.py
@@ -341,3 +341,39 @@ def test_a_real_lap_carries_a_cost_that_the_raw_level_could_not_have_given():
     assert tire_out.cumulative_deg_s < tire_out.deg_cost_s
     # A five-lap-old set costs something small and non-negative, not a credit.
     assert 0.0 <= tire_out.deg_cost_s < 1.0
+
+
+@pytest.mark.skipif(
+    not (_HAS_MODELS and _HAS_DATA),
+    reason="needs data/models/tire_degradation/ and data/{raw/2025/Lusail,processed} (HF, not git)",
+)
+def test_the_reference_is_taken_from_the_stints_early_laps_and_not_from_all_of_them():
+    """Gate G2's third survivor, and the nastiest, because it disables the feature.
+
+    Widen `fresh_reference_tyre_life` past the current tyre life and the reference
+    tensor becomes the prediction tensor: `deg_cost_s` reads **exactly 0.0 on every
+    lap**, so both scorers charge nothing for the old set AND grant no fresh credit.
+    The channel is not degraded to the fallback, it is switched off — strictly worse
+    than before #744b — and 232 tests stayed green.
+
+    The real-lap test above cannot see it: its band is `0.0 <= deg_cost_s`, which the
+    degenerate value satisfies exactly at the boundary. That is this project's
+    catalogued "assertion passes for the wrong reason near a boundary" defect, so the
+    semantic gets its own assertion rather than a tighter band on that one.
+
+    Exact zero is the mutant's signature. It is not a value this fixture can produce
+    legitimately: the guard below pins that the car is past the reference tyre life, so
+    the reference prefix is strictly shorter than the prediction's and the two readings
+    come from different tensors.
+    """
+    from src.agents.tire_agent import CFG
+    from src.strategy.inference.no_llm import _tire_no_llm
+
+    lap_state, laps = _scoped_lusail_lap_30()
+    tire_out = _tire_no_llm(lap_state, laps)
+
+    assert tire_out.current_tyre_life > CFG.fresh_reference_tyre_life, (
+        "fixture no longer exercises the case: pick a lap deeper into the stint"
+    )
+    assert tire_out.deg_cost_s is not None
+    assert tire_out.deg_cost_s != 0.0

--- a/tests/eval/test_decision_modes.py
+++ b/tests/eval/test_decision_modes.py
@@ -26,7 +26,8 @@ from src.strategy.eval.decision_modes import (
     SAMPLED_RACES,
     DecisionAgreement,
     StopVerdict,
-    _first_pit_lap,
+    _asks_to_stop,
+    _pit_decision_lap,
     _render_table,
     coverage_verdict,
     guard_rail_block,
@@ -37,13 +38,16 @@ ROOT = Path(__file__).parent.parent.parent
 _HAS_RAW = (ROOT / "data" / "raw" / "2024").is_dir()
 
 
-def _agreement(offsets, guard_railed=0, no_call=0, races=6, no_data=0) -> DecisionAgreement:
+def _agreement(
+    offsets, guard_railed=0, no_call=0, races=6, no_data=0, no_boundary=0
+) -> DecisionAgreement:
     return DecisionAgreement(
         offsets=np.array(offsets, dtype=int),
         guard_railed=guard_railed,
         no_call=no_call,
         races=races,
         no_data=no_data,
+        no_boundary=no_boundary,
     )
 
 
@@ -140,22 +144,91 @@ def test_unknown_tyre_life_still_evaluates_the_lap_based_rails():
 
 
 # --- picking the lap the stack would have chosen ---------------------------
+#
+# These used to test `_first_pit_lap`, which returned the earliest pit action in
+# the window. #752 replaced it: that reported the window's LEFT EDGE for any
+# stack already committed when the window opened, so the reported error moved
+# with the window width instead of with the model. The tests below pin the
+# transition semantics, and the width-invariance property they were missing is
+# the last one in this group.
 
 
-def test_first_pit_lap_takes_the_earliest_call():
-    """Two pit calls in the window resolve to the first: that is the decision."""
+def test_the_decision_lap_is_the_transition_not_the_earliest_call():
+    """Two pit calls in the window resolve to the first that FOLLOWS a stay-out."""
     actions = {28: "STAY_OUT", 29: "UNDERCUT", 30: "STAY_OUT", 31: "PIT_NOW"}
-    assert _first_pit_lap(actions, 27, 32) == 29
+    assert _pit_decision_lap(actions, 27, 32) == 29
 
 
-def test_first_pit_lap_returns_none_when_the_stack_never_calls_it():
+def test_no_call_at_all_returns_none():
     """No call in the window is a result, and it must not read as lap zero."""
-    assert _first_pit_lap({lap: "STAY_OUT" for lap in range(27, 33)}, 27, 32) is None
+    assert _pit_decision_lap({lap: "STAY_OUT" for lap in range(27, 33)}, 27, 32) is None
 
 
-def test_first_pit_lap_ignores_calls_outside_the_window():
-    """A pit action two laps past the window is not agreement with this stop."""
-    assert _first_pit_lap({35: "PIT_NOW"}, 27, 32) is None
+def test_a_call_outside_the_window_is_not_agreement_with_this_stop():
+    assert _pit_decision_lap({35: "PIT_NOW"}, 27, 32) is None
+
+
+def test_a_stack_already_committed_has_no_decision_lap():
+    """THE #752 CASE. Pitting on every lap offered is not a choice of lap.
+
+    Lap 26 is the evaluated predecessor and it already says PIT, so no transition
+    exists anywhere in [27, 32]. The old helper returned 27 — the window's edge —
+    and called it the model's chosen lap.
+    """
+    actions = {lap: "PIT_NOW" for lap in range(26, 33)}
+    assert _pit_decision_lap(actions, 27, 32) is None
+    assert _asks_to_stop(actions, 27, 32) is True
+
+
+def test_an_unevaluated_predecessor_cannot_witness_a_transition():
+    """Absent is not the same as stay-out: lap 26 was never asked.
+
+    Conservative on purpose. Treating a missing predecessor as a stay-out would
+    reintroduce the edge report through the back door on the first lap of every
+    window, which is why the caller evaluates one lap before it.
+    """
+    assert _pit_decision_lap({27: "PIT_NOW", 28: "PIT_NOW"}, 27, 32) is None
+
+
+def test_the_decision_lap_does_not_move_when_only_the_window_widens():
+    """The property that was missing, and the whole point of #752.
+
+    Same actions, three window widths. A stack whose transition lies inside all
+    three must report the SAME lap, because the transition is a property of the
+    model and the window is a property of the harness. Under the old helper the
+    answer was 27, 25 and 22 for these three windows — the left edge each time.
+    """
+    actions = {lap: "STAY_OUT" for lap in range(20, 30)}
+    actions.update({lap: "PIT_NOW" for lap in range(30, 38)})
+
+    assert _pit_decision_lap(actions, 27, 32) == 30
+    assert _pit_decision_lap(actions, 25, 35) == 30
+    assert _pit_decision_lap(actions, 22, 37) == 30
+
+
+def test_the_new_bucket_counts_toward_eligible_so_the_share_is_not_inflated():
+    """#752's denominator trap: those stops WERE looked at.
+
+    Leaving `no_boundary` out of `eligible` would shrink the denominator by
+    exactly the stops the old code used to score wrongly, and the coverage share
+    would jump for a reason that is pure bookkeeping.
+    """
+    agreement = _agreement([0, -1, 1], guard_railed=2, no_call=5, no_data=1, no_boundary=9)
+
+    assert agreement.eligible == 3 + 2 + 5 + 1 + 9
+    assert agreement.scored_share == pytest.approx(3 / 20)
+
+
+def test_asks_to_stop_separates_declining_from_being_already_committed():
+    """The two findings the old bucketing merged, and they are opposites."""
+    declined = {lap: "STAY_OUT" for lap in range(27, 33)}
+    committed = {lap: "PIT_NOW" for lap in range(26, 33)}
+
+    assert _asks_to_stop(declined, 27, 32) is False
+    assert _asks_to_stop(committed, 27, 32) is True
+    # Both are unscored, and for opposite reasons.
+    assert _pit_decision_lap(declined, 27, 32) is None
+    assert _pit_decision_lap(committed, 27, 32) is None
 
 
 # --- aggregation -----------------------------------------------------------

--- a/tests/eval/test_decision_modes.py
+++ b/tests/eval/test_decision_modes.py
@@ -22,6 +22,7 @@ import numpy as np
 import pytest
 
 from src.strategy.eval.decision_modes import (
+    DECISION_WINDOW_LAPS,
     MIN_SCORED_SHARE,
     SAMPLED_RACES,
     DecisionAgreement,
@@ -29,10 +30,12 @@ from src.strategy.eval.decision_modes import (
     _asks_to_stop,
     _pit_decision_lap,
     _render_table,
+    _replay_span,
     coverage_verdict,
     guard_rail_block,
     lap_inputs,
 )
+from src.strategy.inference.guard_rails import _NO_PIT_BEFORE_LAP
 
 ROOT = Path(__file__).parent.parent.parent
 _HAS_RAW = (ROOT / "data" / "raw" / "2024").is_dir()
@@ -154,9 +157,23 @@ def test_unknown_tyre_life_still_evaluates_the_lap_based_rails():
 
 
 def test_the_decision_lap_is_the_transition_not_the_earliest_call():
-    """Two pit calls in the window resolve to the first that FOLLOWS a stay-out."""
-    actions = {28: "STAY_OUT", 29: "UNDERCUT", 30: "STAY_OUT", 31: "PIT_NOW"}
-    assert _pit_decision_lap(actions, 27, 32) == 29
+    """The earliest pit call is NOT the answer when nothing declined before it.
+
+    Shaped after a real occupant of `no_boundary_in_window` (PIA, 2025 Monza):
+    committed when the window opened, withdrew mid-window, then re-committed. The
+    retired helper returned 27, the window's own left edge, because it reported the
+    first pit ACTION. The transition is at 30, where the stack actually changes its
+    mind, and lap 26 is evaluated as a pit call so the earlier asks are ruled out by
+    being committed rather than by being unwitnessed.
+    """
+    actions = {
+        26: "PIT_NOW",
+        27: "PIT_NOW",
+        28: "PIT_NOW",
+        29: "STAY_OUT",
+        30: "PIT_NOW",
+    }
+    assert _pit_decision_lap(actions, 27, 32) == 30
 
 
 def test_no_call_at_all_returns_none():
@@ -193,10 +210,19 @@ def test_an_unevaluated_predecessor_cannot_witness_a_transition():
 def test_the_decision_lap_does_not_move_when_only_the_window_widens():
     """The property that was missing, and the whole point of #752.
 
-    Same actions, three window widths. A stack whose transition lies inside all
-    three must report the SAME lap, because the transition is a property of the
-    model and the window is a property of the harness. Under the old helper the
-    answer was 27, 25 and 22 for these three windows — the left edge each time.
+    Same actions, three window widths. A stack whose transition lies strictly inside
+    all three must report the SAME lap, because the transition is a property of the
+    model and the window is a property of the harness.
+
+    This is the achievable half of the property, not width-invariance in general: a
+    wider window is a strictly larger observation, so it can legitimately reveal a
+    transition a narrower one could not reach. What it must never do is report its
+    own edge, and that is what this pins.
+
+    This fixture does NOT discriminate the retired helper, which returns 30 here too
+    (laps 20-29 are explicit stay-outs, so its first pit action is also 30). The
+    tests above are the ones that kill it; keeping that straight matters, because a
+    docstring naming the wrong mechanism is worse than no docstring at all.
     """
     actions = {lap: "STAY_OUT" for lap in range(20, 30)}
     actions.update({lap: "PIT_NOW" for lap in range(30, 38)})
@@ -204,6 +230,59 @@ def test_the_decision_lap_does_not_move_when_only_the_window_widens():
     assert _pit_decision_lap(actions, 27, 32) == 30
     assert _pit_decision_lap(actions, 25, 35) == 30
     assert _pit_decision_lap(actions, 22, 37) == 30
+
+
+def test_the_replay_span_opens_before_the_first_scoreable_lap():
+    """The one lap that a Fable gate found protected by a comment and nothing else.
+
+    Reverting it left all 34 tests green while flipping a real stop out of `scored`
+    and moving the published mean signed error by half its value. The property, not
+    the formula: the predecessor of the earliest lap this run can score must itself
+    be inside the replayed span, or that lap is unjudgeable by construction.
+    """
+    for stop_laps, total_laps in ([(32,), 53], [(18, 41), 60], [(9,), 50]):
+        low, high = _replay_span(list(stop_laps), total_laps)
+        earliest_scoreable = max(1, min(stop_laps) - DECISION_WINDOW_LAPS)
+        assert low <= earliest_scoreable - 1 or earliest_scoreable == 1
+        assert high >= max(stop_laps) + DECISION_WINDOW_LAPS or high == total_laps
+
+
+def test_the_replay_span_cannot_ask_for_laps_that_do_not_exist():
+    """Lap 1 has no predecessor and the race has no lap after the last one."""
+    low, high = _replay_span([2], 50)
+    assert low == 1
+
+    low, high = _replay_span([48], 50)
+    assert high == 50
+
+
+def test_a_transition_at_the_opening_rail_is_the_rail_releasing_not_a_decision():
+    """The retired defect's shape at a different boundary, found by gate G1.
+
+    Actions are recorded AFTER the guard rails, and the opening rail forces stay-out
+    below `_NO_PIT_BEFORE_LAP`. So a stack that wants to box from lap 1 is recorded as
+    stay-outs then a pit, and the "transition" lands on the rail boundary for every
+    such stop: a constant of the harness wearing a timing estimate, which is exactly
+    what #752 retired at `window_low`.
+    """
+    railed = {1: "STAY_OUT", 2: "STAY_OUT", 3: "STAY_OUT", 4: "STAY_OUT"}
+    railed.update({lap: "PIT_NOW" for lap in range(_NO_PIT_BEFORE_LAP, 12)})
+
+    assert _pit_decision_lap(railed, 1, 11) is None
+    assert _asks_to_stop(railed, 1, 11) is True
+
+
+def test_a_transition_after_the_rail_releases_is_still_a_decision():
+    """The guard above must not swallow a genuine mid-race change of mind.
+
+    Without this, rejecting the rail boundary could be widened into rejecting every
+    early lap, and the metric would go quiet on exactly the stops it is meant to
+    grade.
+    """
+    actions = {lap: "STAY_OUT" for lap in range(1, _NO_PIT_BEFORE_LAP + 2)}
+    actions.update({lap: "PIT_NOW" for lap in range(_NO_PIT_BEFORE_LAP + 2, 14)})
+
+    assert _pit_decision_lap(actions, 1, 13) == _NO_PIT_BEFORE_LAP + 2
 
 
 def test_the_new_bucket_counts_toward_eligible_so_the_share_is_not_inflated():

--- a/tests/mc/test_position_projection_stop_horizons.py
+++ b/tests/mc/test_position_projection_stop_horizons.py
@@ -1,0 +1,141 @@
+"""Pin the three horizons #742 found undocumented, so nobody "unifies" them (#742).
+
+``position_projection`` holds three predicates about the same underlying fact,
+whether a rival's outstanding pit stop should cost them time, and each is
+correct for a DIFFERENT horizon rather than being three attempts at one rule:
+
+    rival_time_deltas -> rival.is_pitting                              (inside the window)
+    _terminal_gaps     -> rival.stop_pending is True and not is_pitting (race end)
+    rank_targets        -> rival.stop_pending is True                   (after both pit cycles)
+
+The module docstring now states this rule once, prominently. This file is the
+enforcement: it constructs rivals who owe a stop under different ``is_pitting``
+states and asserts the three functions treat them differently, naming the
+horizon each assertion pins. Any patch that makes the three predicates agree,
+in either direction, must fail one of these tests.
+
+Hermetic by construction: no model weights, no ``data/`` beyond the measured
+JSON tables that ``position_projection`` already degrades gracefully without
+(see its ``measured_tables`` docstring), so this suite runs in any checkout.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.agents.position_projection import (
+    DriverPlan,
+    ProjectionConfig,
+    RivalState,
+    _terminal_gaps,
+    rank_targets,
+    rival_time_deltas,
+)
+
+# A rival's outstanding obligation, held constant across every test in this
+# file so the only thing that varies between OWES_NOT_TAKING and
+# OWES_TAKING_NOW is ``is_pitting`` -- the one bit the three horizons disagree
+# about how to use.
+STOP_LOSS_S = 22.0
+GAP_S = -1.0
+RACING_LAPS = 5.0
+
+# Owes the Art. 30.5(m) stop but is not in the pit lane THIS lap. This is the
+# exact rival the #742 acceptance criteria names: charged at the terminal
+# horizon, not charged inside the window.
+OWES_NOT_TAKING = RivalState(
+    "OWES_NOT_TAKING",
+    gap_s=GAP_S,
+    is_pitting=False,
+    stop_pending=True,
+    stop_loss_s=STOP_LOSS_S,
+)
+
+# Owes the same stop and IS taking it this lap. Distinguishes _terminal_gaps
+# (which must NOT charge them again, rival_time_deltas already did) from
+# rank_targets (which charges every known obligation regardless of timing).
+OWES_TAKING_NOW = RivalState(
+    "OWES_TAKING_NOW",
+    gap_s=GAP_S,
+    is_pitting=True,
+    stop_pending=True,
+    stop_loss_s=STOP_LOSS_S,
+)
+
+STAY_OUT = DriverPlan("STAY_OUT", stops_in_window=False)
+
+
+def test_window_horizon_charges_only_the_rival_pitting_this_lap():
+    """rival_time_deltas: is_pitting is the only fact this horizon trusts.
+
+    A rival who owes a stop but is racing this lap costs themselves nothing
+    inside the window; a rival serving the stop right now pays the full loss.
+    Unifying this predicate with ``stop_pending`` (matching the other two
+    horizons) would charge OWES_NOT_TAKING inside the window and break the
+    first assertion below.
+    """
+    config = ProjectionConfig(racing_laps=RACING_LAPS)
+    deltas = rival_time_deltas([OWES_NOT_TAKING, OWES_TAKING_NOW], config, draws=1)
+
+    assert deltas[0, 0] == pytest.approx(0.0), (
+        "window horizon: owes a stop but is not taking it now, so is_pitting=False "
+        "keeps them uncharged inside the window"
+    )
+    assert deltas[0, 1] == pytest.approx(STOP_LOSS_S), (
+        "window horizon: in the pit lane this lap, so is_pitting=True charges the stop right now"
+    )
+
+
+def test_terminal_horizon_charges_an_owed_stop_exactly_once():
+    """_terminal_gaps: race-end residual, and never a stop already priced.
+
+    OWES_NOT_TAKING is uncharged in the window (previous test), so the
+    terminal residual must land here or the obligation vanishes entirely.
+    OWES_TAKING_NOW was already charged inside the window, so the terminal
+    residual must be zero for them, or the same stop is paid twice.
+    """
+    config = ProjectionConfig(racing_laps=RACING_LAPS, mandatory_stop_pending=False)
+    rivals = [OWES_NOT_TAKING, OWES_TAKING_NOW]
+
+    window_deltas = rival_time_deltas(rivals, config, draws=1)
+    current_gaps = np.array([[rival.gap_s for rival in rivals]])
+    projected_gaps = current_gaps + window_deltas  # our own delta is 0 here
+
+    pit_loss_s = np.zeros(1)
+    terminal_gaps = _terminal_gaps(rivals, STAY_OUT, projected_gaps, pit_loss_s, config)
+
+    assert terminal_gaps[0, 0] - projected_gaps[0, 0] == pytest.approx(STOP_LOSS_S), (
+        "terminal horizon: still owes the stop, so the residual lands even though "
+        "nothing charged them in the window"
+    )
+    assert terminal_gaps[0, 1] - projected_gaps[0, 1] == pytest.approx(0.0), (
+        "terminal horizon: already charged inside the window (rival_time_deltas), "
+        "so the terminal residual excludes them rather than paying for the same "
+        "stop twice"
+    )
+
+
+def test_post_cycle_horizon_charges_every_known_obligation_alike():
+    """rank_targets: stop_pending alone, deliberately ignoring is_pitting.
+
+    Once both pit cycles have played out, whether the stop happened on THIS
+    lap stops mattering, so rank_targets charges OWES_NOT_TAKING and
+    OWES_TAKING_NOW identically. A patch that adds the terminal horizon's
+    ``and not is_pitting`` guard here (making the "selector" agree with the
+    "scorer") would zero out OWES_TAKING_NOW's charge and break the second
+    assertion below, exactly the unification #742 warns against.
+    """
+    config = ProjectionConfig(racing_laps=RACING_LAPS)
+    ranked = {
+        target.driver: target
+        for target in rank_targets([OWES_NOT_TAKING, OWES_TAKING_NOW], config, our_pit_loss_s=0.0)
+    }
+
+    expected_projected_gap_s = GAP_S + STOP_LOSS_S
+    assert ranked["OWES_NOT_TAKING"].projected_gap_s == pytest.approx(expected_projected_gap_s)
+    assert ranked["OWES_TAKING_NOW"].projected_gap_s == pytest.approx(expected_projected_gap_s), (
+        "post-cycle horizon: charged the SAME as OWES_NOT_TAKING even though "
+        "is_pitting distinguishes them at the other two horizons; rank_targets' "
+        "predicate is stop_pending alone, by design"
+    )

--- a/tests/mc/test_tyre_wear_term.py
+++ b/tests/mc/test_tyre_wear_term.py
@@ -175,9 +175,21 @@ def test_with_no_reading_the_scorer_is_byte_identical_to_the_old_credit():
         assert delta == pytest.approx(np.full(DRAWS, -laps_after_stop * 0.25))
 
 
-def test_the_cliff_term_and_the_wear_term_do_not_overlap():
-    """They price different laps: the cliff bills only laps run PAST it, the wear
-    bills every old-set lap. A tyre ten laps from the cliff used to cost nothing."""
+def test_the_cliff_term_stacks_on_top_of_the_wear_rather_than_replacing_it():
+    """They price different THINGS, and past the cliff they are deliberately additive.
+
+    The wear is what an old set costs on every lap it is held. The cliff is an EXTRA
+    penalty once the set is past it. So before the cliff only the wear applies, and past
+    it both do — 5 laps charged 0.4 plus the same 5 charged 0.8.
+
+    Named for what it pins. An earlier version of this test was called "do_not_overlap"
+    and its docstring claimed the two bill disjoint laps, which is the opposite of the
+    second assertion below: they bill the SAME laps for different reasons. A test name
+    stating the reverse of its own assertion is worse than no name (gate G2, LOW).
+
+    The property that matters for #744b is not disjointness, it is that a tyre ten laps
+    from the cliff now costs something at all, where it used to cost exactly nothing.
+    """
     config = _config(deg_cost_s=0.4, cliff_loss_s=0.8)
     plan = DriverPlan(name="STAY_OUT", stops_in_window=False, stop_offset_laps=0)
 
@@ -189,14 +201,21 @@ def test_the_cliff_term_and_the_wear_term_do_not_overlap():
 
 
 # ---------------------------------------------------------------------------
-# The legacy scorer — the one the backend endpoint runs in production
+# The legacy scorer — reached whenever a caller has no usable rival gaps
 # ---------------------------------------------------------------------------
 #
-# Not a relic. Three shipping builders hardcode `"rivals": []`, which routes to it:
-# `engine.py`, `strategy_orchestrator.py`, and the backend's own
-# `api/v1/endpoints/strategy.py`. A fix that reached only the projection branch would
-# have connected the tyre channel for arcade and the CLI while leaving the backend on
-# the old constant.
+# Not a relic. TWO shipping builders hardcode `"rivals": []`, which routes here:
+# `engine.py::_build_default_lap_state` and `strategy_orchestrator.py`, both serving a
+# caller that supplies only a RaceState. `_has_usable_gaps` also demotes to this branch
+# whenever every rival interval is NaN.
+#
+# NOT the backend endpoint, despite what #744 says and despite what the first version of
+# this comment repeated. `api/v1/endpoints/strategy.py:882` also hardcodes an empty rival
+# list, but its only consumer calls `run_pace_agent_from_state`, so it never reaches the
+# Monte Carlo; the backend's own MC paths pass real rivals. Traced twice, once here and
+# once by the gate that found this comment still carrying the uncorrected claim after the
+# commit message had been fixed — one copy corrected, its twin not, inside the very PR
+# that was correcting it.
 
 
 @pytest.mark.skipif(
@@ -311,9 +330,9 @@ class TestTheValueReachesBothBranches:
         )
 
     def test_the_legacy_branch_receives_it(self):
-        """Reached whenever a caller passes no usable gaps, which three shipping
-        builders do by hardcoding an empty rival list — including the backend's own
-        endpoint. This is the branch that runs in production behind the API."""
+        """Reached whenever a caller passes no usable gaps, which two shipping builders
+        do by hardcoding an empty rival list, and which `_has_usable_gaps` also forces
+        whenever every rival interval is NaN."""
         without = self._score([], None)
         with_wear = self._score([], 0.4)
 
@@ -335,3 +354,95 @@ class TestTheValueReachesBothBranches:
 
         assert self._score([], None) == self._score([], None)
         assert self._score(rivals, None) == self._score(rivals, None)
+
+    def test_every_candidate_pays_at_its_own_call_site_not_just_the_helper(self):
+        """Gate G2's surviving mutant: zeroing OVERCUT's old-lap count AT THE CALL SITE
+        left all 232 tests green.
+
+        `test_the_overcut_green_branch_splits_the_window` above tests `_tyre_term` with
+        the right arguments. It cannot see whether `simulate_lap_window` passes them,
+        and nothing else evaluated OVERCUT with a reading present. So this reads the
+        four candidates through the public function and pins each one's charge as the
+        DIFFERENCE between a worn reading and a zero one, which isolates the tyre term
+        from the pit loss and the cliff without having to restate either.
+        """
+        from src.agents.strategy_orchestrator import WINDOW_LAPS, simulate_lap_window
+
+        deg = 0.4
+        # Cliff far away and no neutralisation, so only the tyre term differs.
+        kwargs = dict(cliff_i=99.0, sc_i=False, pit_i=22.0, ucut_i=False)
+
+        def charge(strategy: str) -> float:
+            """Positions the reading costs this candidate, positive = worse."""
+            return simulate_lap_window(strategy, deg_cost_s=0.0, **kwargs) - simulate_lap_window(
+                strategy, deg_cost_s=deg, **kwargs
+            )
+
+        from src.agents.strategy_orchestrator import POS_GAP_S
+
+        expected = {
+            "STAY_OUT": deg * WINDOW_LAPS / POS_GAP_S,
+            "PIT_NOW": 0.0,
+            "UNDERCUT": 0.0,
+            "OVERCUT": deg * (WINDOW_LAPS // 2) / POS_GAP_S,
+        }
+        for strategy, want in expected.items():
+            assert charge(strategy) == pytest.approx(want), strategy
+
+    def test_under_a_neutralisation_the_overcut_runs_no_old_set_laps(self):
+        """The SC arm of OVERCUT pits immediately, so it owes nothing for the old set.
+
+        Pinned separately from the green arm because the two are different branches of
+        the same `if`, and the green one is the only candidate in either scorer whose
+        laps split across the stop.
+        """
+        from src.agents.strategy_orchestrator import simulate_lap_window
+
+        kwargs = dict(cliff_i=99.0, sc_i=True, pit_i=22.0, ucut_i=False)
+
+        assert simulate_lap_window("OVERCUT", deg_cost_s=0.4, **kwargs) == pytest.approx(
+            simulate_lap_window("OVERCUT", deg_cost_s=0.0, **kwargs)
+        )
+
+    def test_the_neutralised_config_carries_the_reading_too(self):
+        """Gate G2's other surviving mutant: setting the value on the green config but
+        NOT the neutralised one left all 232 tests green.
+
+        The mutant I claimed to have run was not that mutant. It disabled the value
+        whenever `clean_air_gain_s == 0.0`, which is also true of the green config in
+        that fixture, so it took out both arms — which is why it went red for the wrong
+        reason. A genuine green-only mutant survived.
+
+        Catching it needs a FULLY neutralised scenario (`sc_prob_3lap = 1.0`, so every
+        draw takes the neutralised config) and rivals close enough that the neutralised
+        window's wear actually crosses a gap. Under a Safety Car the window is worth
+        ~2.6 racing laps, so the charge is small and a wide gap absorbs it silently —
+        which is exactly how the previous fixture passed while blind.
+        """
+        from dataclasses import replace
+
+        from src.agents.strategy_orchestrator import _run_mc_simulation
+
+        from .test_strategy_goldens import _canned_outputs
+
+        pace, tire, situation, pit = _canned_outputs()
+        rivals = [
+            {"driver": "VER", "interval_to_driver_s": -0.4, "is_pitting": False},
+            {"driver": "LEC", "interval_to_driver_s": 0.5, "is_pitting": False},
+        ]
+
+        def score(deg_cost_s):
+            return _run_mc_simulation(
+                pace_out=pace,
+                tire_out=replace(tire, deg_cost_s=deg_cost_s),
+                situation_out=replace(situation, sc_prob_3lap=1.0),
+                pit_out=pit,
+                alpha=0.5,
+                rivals=rivals,
+                position=5,
+                laps_remaining=25,
+                pit_context=None,
+            )
+
+        assert score(0.8)["STAY_OUT"]["E"] != score(None)["STAY_OUT"]["E"]
+        assert score(0.8)["STAY_OUT"]["E"] != score(0.0)["STAY_OUT"]["E"]

--- a/tests/mc/test_tyre_wear_term.py
+++ b/tests/mc/test_tyre_wear_term.py
@@ -1,0 +1,337 @@
+"""#744b — the tyre channel reaches BOTH scorers, and it is charged on the right laps.
+
+Until now the Monte Carlo's only tyre signal was the cliff, a discrete event that
+falls inside the 5-lap window on 4 of 110 measured laps. A set 0.4 s off the pace but
+ten laps from the cliff scored identically to a fresh one, which is most of why the
+decision layer declines to call 46% of real stops.
+
+WHAT IS BEING REPLACED, AND WHY IT IS A REPLACEMENT
+----------------------------------------------------
+``FRESH_GAIN = 0.25  # s/lap advantage of fresh vs degraded tyre`` is the same
+quantity, hardcoded and applied identically at tyre life 3 and tyre life 25. So the
+measured cost REPLACES it rather than adding to it, and the double-count trap is
+avoided by that fact rather than by a correction term. ``FRESH_GAIN`` survives as the
+no-signal fallback, which is what keeps a stint with no reference scoring exactly as
+it did before.
+
+THE LAP COUNTS ARE THE WHOLE THING
+-----------------------------------
+The two prices sit on opposite sides of the stop: the old credit paid for laps on the
+NEW set, the new charge bills laps on the OLD one. Get those counts wrong and the term
+becomes a constant offset that cancels in the argmax and looks like it did nothing at
+all. Per candidate, with ``window = 5``:
+
+    STAY_OUT              5 old, 0 fresh
+    PIT_NOW / UNDERCUT    0 old, 5 fresh
+    OVERCUT under SC      0 old, 5 fresh
+    OVERCUT green         2 old, 2 fresh   <- the only split, and window // 2
+
+The projection scorer counts differently because it knows when in the window the stop
+falls: ``laps_before_stop`` on the old set, ``laps_after_stop`` on the new one, and the
+whole window on the old set for a plan that does not stop at all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.agents.position_projection import DriverPlan, ProjectionConfig, driver_time_delta
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").is_file()
+
+DRAWS = 4
+
+
+def _config(**overrides) -> ProjectionConfig:
+    """A config with every term but the tyre ones zeroed, so the charge is readable."""
+    base = {
+        "window_laps": 5,
+        "racing_laps": 5.0,
+        "fresh_gain_s": 0.25,
+        "cliff_loss_s": 0.0,
+        "neutralisation_saving_s": 0.0,
+        "clean_air_gain_s": 0.0,
+        "neutralisation_onset_rate": 0.0,
+    }
+    base.update(overrides)
+    return ProjectionConfig(**base)
+
+
+def _zeros() -> np.ndarray:
+    return np.zeros(DRAWS, dtype=float)
+
+
+def _no_cliff() -> np.ndarray:
+    """Cliff far outside the window, so the cliff term contributes nothing."""
+    return np.full(DRAWS, 99.0, dtype=float)
+
+
+# ---------------------------------------------------------------------------
+# The projection scorer — hermetic, so CI sees these
+# ---------------------------------------------------------------------------
+
+
+def test_staying_out_pays_the_wear_on_every_racing_lap():
+    """A plan that never stops runs the whole window on the old set."""
+    config = _config(deg_cost_s=0.4)
+
+    delta = driver_time_delta(
+        DriverPlan(name="STAY_OUT", stops_in_window=False, stop_offset_laps=0),
+        _zeros(),
+        _no_cliff(),
+        config,
+    )
+
+    assert delta == pytest.approx(np.full(DRAWS, 5.0 * 0.4))
+
+
+def test_pitting_immediately_pays_no_wear_at_all():
+    """Zero laps on the old set, so the charge vanishes without needing a branch."""
+    config = _config(deg_cost_s=0.4)
+
+    delta = driver_time_delta(
+        DriverPlan(name="PIT_NOW", stops_in_window=True, stop_offset_laps=0),
+        _zeros(),
+        _no_cliff(),
+        config,
+    )
+
+    assert delta == pytest.approx(_zeros())
+
+
+def test_an_overcut_pays_for_the_laps_it_waits_and_no_more():
+    """The term has to track WHEN the stop falls, not just whether it happens.
+
+    A stop deferred two laps runs two laps on the old set. If this were charged over
+    the whole window instead, every candidate would shift by the same amount and the
+    argmax would not move — the term would be invisible while looking connected.
+    """
+    config = _config(deg_cost_s=0.4)
+
+    delta = driver_time_delta(
+        DriverPlan(name="OVERCUT", stops_in_window=True, stop_offset_laps=2),
+        _zeros(),
+        _no_cliff(),
+        config,
+    )
+
+    assert delta == pytest.approx(np.full(DRAWS, 2.0 * 0.4))
+
+
+def test_a_worn_tyre_makes_staying_out_worse_than_stopping():
+    """The behaviour the whole issue exists for, stated as an inequality.
+
+    Nothing here says by how much; it says the sign is right. A term wired with the
+    wrong sign still moves the numbers and would pass every count test above.
+    """
+    config = _config(deg_cost_s=0.4)
+    stay = driver_time_delta(
+        DriverPlan(name="STAY_OUT", stops_in_window=False, stop_offset_laps=0),
+        _zeros(),
+        _no_cliff(),
+        config,
+    )
+    pit = driver_time_delta(
+        DriverPlan(name="PIT_NOW", stops_in_window=True, stop_offset_laps=0),
+        _zeros(),
+        _no_cliff(),
+        config,
+    )
+
+    assert stay.mean() > pit.mean()
+
+
+def test_a_fresh_set_costs_nothing_and_is_not_the_same_as_no_reading():
+    """0.0 is a real reading: the wear term vanishes, and the FRESH_GAIN fallback
+    must NOT come back to life instead. That distinction is the sentinel rule this
+    field is built on, checked here at the consuming end rather than the producing
+    one."""
+    measured_zero = _config(deg_cost_s=0.0)
+    no_reading = _config(deg_cost_s=None)
+    plan = DriverPlan(name="PIT_NOW", stops_in_window=True, stop_offset_laps=0)
+
+    with_zero = driver_time_delta(plan, _zeros(), _no_cliff(), measured_zero)
+    without = driver_time_delta(plan, _zeros(), _no_cliff(), no_reading)
+
+    assert with_zero == pytest.approx(_zeros())
+    assert without == pytest.approx(np.full(DRAWS, -5.0 * 0.25))
+
+
+def test_with_no_reading_the_scorer_is_byte_identical_to_the_old_credit():
+    """The fallback is not an approximation of the previous behaviour, it IS it."""
+    config = _config(deg_cost_s=None)
+
+    for plan in (
+        DriverPlan(name="STAY_OUT", stops_in_window=False, stop_offset_laps=0),
+        DriverPlan(name="PIT_NOW", stops_in_window=True, stop_offset_laps=0),
+        DriverPlan(name="OVERCUT", stops_in_window=True, stop_offset_laps=2),
+    ):
+        delta = driver_time_delta(plan, _zeros(), _no_cliff(), config)
+        laps_after_stop = 0.0 if not plan.stops_in_window else 5.0 - plan.stop_offset_laps
+        assert delta == pytest.approx(np.full(DRAWS, -laps_after_stop * 0.25))
+
+
+def test_the_cliff_term_and_the_wear_term_do_not_overlap():
+    """They price different laps: the cliff bills only laps run PAST it, the wear
+    bills every old-set lap. A tyre ten laps from the cliff used to cost nothing."""
+    config = _config(deg_cost_s=0.4, cliff_loss_s=0.8)
+    plan = DriverPlan(name="STAY_OUT", stops_in_window=False, stop_offset_laps=0)
+
+    before_cliff = driver_time_delta(plan, _zeros(), _no_cliff(), config)
+    past_cliff = driver_time_delta(plan, _zeros(), np.zeros(DRAWS), config)
+
+    assert before_cliff == pytest.approx(np.full(DRAWS, 5.0 * 0.4))
+    assert past_cliff == pytest.approx(np.full(DRAWS, 5.0 * 0.4 + 5.0 * 0.8))
+
+
+# ---------------------------------------------------------------------------
+# The legacy scorer — the one the backend endpoint runs in production
+# ---------------------------------------------------------------------------
+#
+# Not a relic. Three shipping builders hardcode `"rivals": []`, which routes to it:
+# `engine.py`, `strategy_orchestrator.py`, and the backend's own
+# `api/v1/endpoints/strategy.py`. A fix that reached only the projection branch would
+# have connected the tyre channel for arcade and the CLI while leaving the backend on
+# the old constant.
+
+
+@pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="strategy_orchestrator imports the agent stack, which loads model bundles",
+)
+class TestLegacyScorer:
+    """Charged in seconds, before the conversion to positions."""
+
+    def test_each_candidate_is_charged_for_its_own_old_set_laps(self):
+        from src.agents.strategy_orchestrator import _tyre_term
+
+        assert _tyre_term(0.4, old_laps=5, fresh_laps=0) == pytest.approx(-2.0)
+        assert _tyre_term(0.4, old_laps=0, fresh_laps=5) == pytest.approx(0.0)
+        assert _tyre_term(0.4, old_laps=2, fresh_laps=2) == pytest.approx(-0.8)
+
+    def test_without_a_reading_it_is_the_old_fresh_credit_unchanged(self):
+        from src.agents.strategy_orchestrator import FRESH_GAIN, _tyre_term
+
+        assert _tyre_term(None, old_laps=5, fresh_laps=0) == pytest.approx(0.0)
+        assert _tyre_term(None, old_laps=0, fresh_laps=5) == pytest.approx(FRESH_GAIN * 5)
+        assert _tyre_term(None, old_laps=2, fresh_laps=2) == pytest.approx(FRESH_GAIN * 2)
+
+    def test_the_two_prices_are_never_charged_together(self):
+        """The double-count trap, closed by construction rather than by a correction:
+        with a reading, the fresh credit is not merely offset, it is absent."""
+        from src.agents.strategy_orchestrator import _tyre_term
+
+        assert _tyre_term(0.4, old_laps=0, fresh_laps=5) == pytest.approx(0.0)
+
+    def test_a_worn_set_makes_staying_out_score_worse(self):
+        """Same inequality as the projection branch, on the other implementation.
+
+        The two scorers have opposite sign conventions — this one accumulates a gain,
+        the other a loss — so a term copied across without flipping it would pass the
+        count tests on both and fail exactly here.
+        """
+        from src.agents.strategy_orchestrator import simulate_lap_window
+
+        kwargs = dict(cliff_i=99.0, sc_i=False, pit_i=22.0, ucut_i=False)
+        fresh = simulate_lap_window("STAY_OUT", deg_cost_s=0.0, **kwargs)
+        worn = simulate_lap_window("STAY_OUT", deg_cost_s=0.4, **kwargs)
+
+        assert worn < fresh
+
+    def test_the_overcut_green_branch_splits_the_window(self):
+        """The only candidate that runs on both sets, and the one whose counts are
+        easiest to get wrong: `window // 2` on each side, not the whole window."""
+        from src.agents.strategy_orchestrator import WINDOW_LAPS, _tyre_term
+
+        half = WINDOW_LAPS // 2
+        assert _tyre_term(0.4, old_laps=half, fresh_laps=half) == pytest.approx(-0.4 * half)
+
+
+def _rivals_with_usable_gaps() -> list[dict]:
+    """Rivals the projection branch will actually accept.
+
+    The key is `interval_to_driver_s`, and getting it wrong is not a loud failure:
+    `_has_usable_gaps` simply returns False and `_run_mc_simulation` falls through to
+    the LEGACY scorer. A test that thought it was exercising the projection branch
+    would then pass while proving nothing about it, which is what the first version of
+    this file did — caught by mutating the projection call site and watching all
+    fifteen tests stay green.
+    """
+    return [
+        {"driver": "VER", "interval_to_driver_s": -2.0, "is_pitting": False},
+        {"driver": "LEC", "interval_to_driver_s": 3.5, "is_pitting": False},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The wiring itself — the part a comment cannot assert
+# ---------------------------------------------------------------------------
+#
+# Everything above tests the two leaf functions. Neither one proves the value
+# actually TRAVELS from TireOutput through `_run_mc_simulation` into each branch,
+# and that is precisely the defect gate G1 found in the previous PR of this epic:
+# the mechanism a commit calls essential, protected by a comment and nothing else.
+#
+# `_run_projection_mc` did not receive `tire_out` in any form before #744b, so the
+# projection branch needed a new kwarg. A change that added it to one branch and not
+# the other would leave every existing test green: the goldens run with no reading at
+# all and take the fallback.
+
+
+@pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="_run_mc_simulation imports the agent stack, which loads model bundles",
+)
+class TestTheValueReachesBothBranches:
+    """One canned scenario, scored twice, differing only in the tyre reading."""
+
+    @staticmethod
+    def _score(rivals, deg_cost_s):
+        from dataclasses import replace
+
+        from src.agents.strategy_orchestrator import _run_mc_simulation
+
+        from .test_strategy_goldens import _canned_outputs
+
+        pace, tire, situation, pit = _canned_outputs()
+        return _run_mc_simulation(
+            pace_out=pace,
+            tire_out=replace(tire, deg_cost_s=deg_cost_s),
+            situation_out=situation,
+            pit_out=pit,
+            alpha=0.5,
+            rivals=rivals,
+            position=5,
+            laps_remaining=25,
+            pit_context=None,
+        )
+
+    def test_the_legacy_branch_receives_it(self):
+        """Reached whenever a caller passes no usable gaps, which three shipping
+        builders do by hardcoding an empty rival list — including the backend's own
+        endpoint. This is the branch that runs in production behind the API."""
+        without = self._score([], None)
+        with_wear = self._score([], 0.4)
+
+        assert with_wear["STAY_OUT"]["E"] != without["STAY_OUT"]["E"]
+        assert with_wear["STAY_OUT"]["E"] < without["STAY_OUT"]["E"]
+
+    def test_the_projection_branch_receives_it(self):
+        """Reached when rivals carry usable gaps: arcade, the CLI, the eval harness."""
+        rivals = _rivals_with_usable_gaps()
+        without = self._score(rivals, None)
+        with_wear = self._score(rivals, 0.4)
+
+        assert with_wear["STAY_OUT"]["E"] != without["STAY_OUT"]["E"]
+
+    def test_neither_branch_moves_when_there_is_no_reading(self):
+        """The fallback keeps every pre-#744b caller on exactly its old numbers,
+        which is why the frozen goldens did not need re-freezing."""
+        rivals = _rivals_with_usable_gaps()
+
+        assert self._score([], None) == self._score([], None)
+        assert self._score(rivals, None) == self._score(rivals, None)


### PR DESCRIPTION
Promotes ten commits from `dev`. They were deliberately accumulated rather than promoted one at a time, because several of them correct each other.

Closes #741, #742, #746, #750, #752, #757, #761, #766.

## What this buys, in one line

**Before this, nobody could tell whether the system picks the right lap to stop. Now there is a number, and it is honest.**

## The measurement was broken, and fixing it was the precondition for everything else

`decision-modes` reported the first pit lap inside its own replay window. For a stack already committed before the window opened, that is `window_low` wearing a timing estimate — which is why the published error moved with the window width instead of with the model. The three figures published from it (−2.23 / −3.08 / −5.04) were three readings of the harness.

It now scores the first **STAY_OUT → PIT transition**, and reports `no_boundary_in_window` — looked at, deliberately unscored — where no transition exists. (#752, #757)

The sample also moved to **six 2025 circuits**. Four of the previous six were 2023-24, which are **training seasons for every model in the stack**, so the tier was partly being scored against its own training data. Same archetypes, one season. (#759)

## The result, with the two effects separated

| | scored | **exact lap** | declines |
|---|---|---|---|
| mixed 2023-25, retired metric | 90/198 (45.5%) | 17.8% | — |
| mixed 2023-25, current metric | 62/198 (31.3%) | **30.6%** | 39.4% |
| **2025 only, current metric** | 53/178 (29.8%) | **43.4%** | 46.1% |

The metric fix is worth **+12.8 points**, the season another **+12.8**, so "17.8% → 43.4%" as one effect would be wrong twice over. Exact agreements also rise **in count**, 16 → 19 → 23, while the scored set shrinks 90 → 62 → 53.

Coverage reports `masked` at 29.8% against the 60% gate, deliberately: 43.4% describes the subset where a decision is locatable, and the report says so rather than promoting the figure.

## The tyre channel is connected, and measuring it produced a negative result

The Monte Carlo's only tyre signal was the **cliff**, which falls inside the 5-lap window on 4 of 110 measured laps. A set 0.4 s off the pace but ten laps from the cliff scored identically to a fresh one.

Two candidate references were **measured and refused** before the third shipped — including the one #744 asked for, which scores +0.188 Spearman against **+0.191 for having no reference at all**. The shipped one is the model against its own early laps: 73.9% non-negative and +0.308 on training seasons, **83.7% and +0.603 on 2025**. (#744b, #756, #760, #762)

**And it made the decision worse:** exact 43.4% → 33.3%, declines 46.1% → 44.4%. Measured cause: the wear term alone moves STAY_OUT by more than a whole position on **73.6% of laps**. It decides rather than informs, because the window prices a whole stop against five laps of its benefit. **That is #763, and it is why `main` has been waiting.** (#764)

## Four contracts that lied

- **`pace_delta_s` meant two things by surface** — rival-relative by contract, self-delta in four places, which after a stop compared a green lap against our own out-lap and invented a pace gain. The producer's own docstring named the wrong field. (#750)
- **SOFT's capacity was 18 in code and 15 in both prompts**, so on `laps_remaining` 16-18 the selector passed SOFT and the prompts refused it. The prompts now derive it, and the value was measured (341 real stints) rather than picked. (#741)
- **The backend anchored on the out-lap** after every stop — 107.589 s where 85.304 s belonged, worse than the 90.0 it replaced. (#746)
- **Three rival-stop predicates with no stated horizon rule**, where the natural instinct is to unify them and that would be wrong. Stated and pinned. (#742)

## Three adversarial gates, five HIGH, all in this work's own output

Worth stating because it is the reason to trust the rest: **not one HIGH was "the code is wrong".** Every one was a test that could not fail — including a mutation table in a commit message that was a quarter wrong, and a fix that switched the whole tyre channel off while 232 tests stayed green. Each is fixed and mutation-verified. (#757, #761, #766)

## Checks

CI green on every constituent PR. 245 across `tests/mc` + `tests/agents`, 6 in the submodule, `ruff` clean at the pinned version. Submodule pointer at `82f6382`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Strategy simulations now account for measured tyre degradation when available, with safe fallback behavior.
  * Tyre predictions include fresh-tyre references, bounded wear estimates, and improved laps-to-cliff handling.
  * Pace comparisons now reflect the gap to the car ahead on the same lap.

* **Evaluation**
  * Decision-mode reporting now uses updated 2025 race samples and clearer transition classifications.
  * Added detailed audits covering strategy metrics, tyre wear, wave exit criteria, and measurement results.

* **Bug Fixes**
  * Improved handling of missing lap times and configuration thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->