### PR TITLE
DO NOT MERGE — #763: the deferral term works, and deg_cost_s cannot carry it

### DIFF
--- a/documents/audits/DESIGN_763_window.md
+++ b/documents/audits/DESIGN_763_window.md
@@ -1,0 +1,416 @@
+# DESIGN GATE #763 — WINDOW_LAPS: attack the "it is the window" framing before any code
+
+**Date:** 2026-07-31 · **Gate type:** adversarial DESIGN gate, pre-implementation · **Branch:** `dev`
+**Inputs:** issue #763 · `MEASURE_744b_decision_effect.md` · `MEASURE_752_metric_and_sample.md`
+**Mandate:** the issue's conclusion — *"that is the window, not the scale"* and the implied fix
+"widen `WINDOW_LAPS`" — is a HYPOTHESIS to break, not a brief. No repository file is modified
+except this report. All evidence executed, `profile="no-llm"`, zero API calls.
+
+---
+
+## Questions on the table
+
+- **A.** Is widening the window even coherent, given break-even ~92 laps vs a ~57-lap race?
+- **B.** Is there a formulation that needs no window at all? Enumerate candidates with cost /
+  breakage / validation for each.
+- **C.** Is the diagnosis right? Verify "the traversal cancels, the pit term is ~2.8 s" against
+  BOTH scorers and what `pit_context` actually supplies.
+- **D.** Is "one term decides 73.6% of laps" actually a defect? Both sides, plus the measurement
+  that distinguishes them.
+- **E.** What would make any new width or formulation MEASURED rather than chosen — without
+  tuning to the agreement metric?
+- **F.** Blast radius: every golden, fixture, committed report and eval number that moves.
+
+Findings are appended below as they are confirmed, each with executed evidence.
+
+---
+
+## C. The diagnosis is WRONG for the scorer that actually decided the measurement — VERIFIED, HIGH
+
+**The issue's mechanism ("the traversal cancels by exclusion, the pit term is ~2.8 s") describes
+`simulate_lap_window`, which is the LEGACY path. The eval that produced 43.4%/33.3% flows through
+`_run_projection_mc`, where the traversal is charged in full and the cancellation happens through a
+different mechanism with a different residual.** Evidence, all read from `dev` at `HEAD`:
+
+1. **Routing.** `_run_mc_simulation` (`src/agents/strategy_orchestrator.py:1440`) routes to
+   `_run_projection_mc` whenever `_has_usable_gaps(rivals)` — and the eval harness passes
+   `rivals=(lap_state or {}).get("rivals")` from the real replay
+   (`src/strategy/inference/no_llm.py:285`), whose `RaceStateManager.get_lap_state` emits a full
+   rivals list with `interval_to_driver_s` (`src/simulation/race_state_manager.py:594-614`).
+   `simulate_lap_window` is reached only when no rival carries a usable gap.
+
+2. **The projection charges the traversal.** `src/agents/strategy_orchestrator.py:1155-1159`:
+
+   > *"Total pit loss per draw: the lane traversal plus the physical stop. The legacy scoring
+   > charged only the stop and argued in a comment that the traversal cancels; here it is charged
+   > per car, so the cancellation happens exactly when the rival really pays it too, and not
+   > otherwise."*
+
+   `pit_loss_s = traversal_s + pit_s` — 19.7–27.5 s per circuit (`traversal_seconds`, supplied via
+   `pit_context["traversal_s"]` by `race_context_from_lap_state`,
+   `strategy_orchestrator.py:859-874`) plus the ~2.8 s stop. The code itself refutes the issue's
+   sentence *"The pit-lane traversal is deliberately excluded"* for this scorer.
+
+3. **How the cancellation actually happens there.** `driver_time_delta`
+   (`src/agents/position_projection.py:610-613`) charges PIT_NOW
+   `effective_loss = max(0, pit_loss_s − saving)` ≈ 22.8 s under green INSIDE the window, and
+   `_terminal_gaps` (`position_projection.py:723-742`) charges STAY_OUT
+   `_stop_residual_s(pit_loss_s) = max(0, pit_loss_s − q_f·saving)` at the TERMINAL horizon — but
+   **only when `config.mandatory_stop_pending is True`**. When both fire, the net pit-channel
+   difference between PIT_NOW and STAY_OUT is `q_f · neutralisation_saving_s` (the option value of
+   waiting for a Safety Car), NOT the ~2.8 s physical stop. When the obligation is unknown (None),
+   STAY_OUT pays nothing terminal and PIT_NOW carries the full ~22.8 s alone.
+
+4. **What survives and what does not.** The DEEP conclusion of MEASURE_744b — "the wear charge and
+   the net cost of stopping are the same order of magnitude, so the wear term tips the argmax" —
+   can still be true in the projection path, because `q_f · saving` is also a few seconds. But the
+   number (~2.8 s), the mechanism (exclusion), and the constancy (the projection's net pit cost
+   varies with laps remaining through `q_f`, shrinking to ~0 at the flag) are all wrong for the
+   scorer that made the decisions being scored. **Any fix designed against `simulate_lap_window`'s
+   arithmetic is designed against the wrong scorer.**
+
+Numeric verification and the path census follow below.
+
+---
+
+## C2. Executed: which scorer decided the measurement, and with what pit term
+
+**P3 — path census over the eval's own replay spans** (`scratchpad/probe_763_census.py`,
+replaying every (race, driver, span) `measure_decision_agreement` replays, data-only, no models):
+
+```
+TOTAL eval laps: 2744
+  projection path (usable gaps): 2744 (100.0%)
+  legacy path (no usable gaps):  0 (0.0%)
+```
+
+**`simulate_lap_window` decided ZERO laps of the 43.4%/33.3% measurement.** Every number in
+MEASURE_744b's diagnosis section — the ~2.8 s pit term, the 1.87 positions, the "73.6% of laps"
+share (computed as `deg×5/POS_GAP_S`, a conversion the code itself marks "LEGACY PATH ONLY",
+`strategy_orchestrator.py:643-644`) — is arithmetic of a scorer that never ran on this sample. The
+legacy path still exists in production (default lap_state builders, `/recommend` with no rivals),
+so its arithmetic is not dead code; it is just not what was measured.
+
+**P2b — the projection's actual pit term, executed** (`scratchpad/probe_763.py`, production
+functions, seed 42, 500 draws, pooled onset rate 0.0179/lap, 30 laps remaining → q_f = 0.416):
+
+```
+in-window loss:  STAY_OUT 3.05 s   PIT_NOW 22.93 s
+STAY_OUT terminal residual: 19.60 s      (only when mandatory_stop_pending is True)
+net pit channel = q_f · saving = 3.32 s  (verified to the second decimal)
+wear channel (deg×5): 3.05 s
+```
+
+With the obligation pending, the net cost of stopping is the **option value of waiting**
+(q_f · 8 ≈ 3.3 s), which happens to be the same order as the ~2.8 s the issue names — the issue's
+"same order of magnitude" conclusion survives, but by coincidence of magnitudes, with the wrong
+mechanism, and only on the pending=True half of the sample. Which brings in:
+
+## C3. The population split the diagnosis missed — THE CENTRAL FINDING, HIGH
+
+`mandatory_stop_pending` (`src/simulation/stint_history.py:75-104`: False on positive evidence of
+a discharged Art. 30.5(m) obligation) splits the eval sample in two, and the two halves live under
+**different pit arithmetic**:
+
+- **pending=True (first stop still owed):** the traversal cancels against the terminal residual;
+  net pit cost ≈ q_f·saving ≈ 3.3 s. The issue's premise holds HERE.
+- **pending=False (obligation discharged, the stop is elective):** `_terminal_gaps` charges
+  STAY_OUT nothing (`position_projection.py:728`: residual requires `pending is True`), so PIT_NOW
+  carries the **full ~22.8 s alone**. The issue's premise — *"the stop is mandatory under the
+  two-compound rule ... so it cancels"* — is FALSE here, and correctly so: an elective stop's
+  traversal has no counterfactual payer.
+
+**P4 — per-stop census** (`scratchpad/probe_763_stops.py`): of the 178 real green-flag stops the
+eval grades, **105 (59.0%) are first stops and 73 (41.0%) are elective extras** (Silverstone 27/31
+extra; Monza 19/20 first).
+
+**P5 — the committed verdicts crossed with that flag** (committed
+`documents/eval_reports/decision_modes.json`, harness `d97a54e`, with the pre-#760 version
+recovered from git `fd105de` for the before column):
+
+| | FIRST stops (n=105) | EXTRA stops (n=73) |
+|---|---|---|
+| `no_call` BEFORE the term | 29 (27.6%) | 53 (**72.6%**) |
+| `no_call` AFTER the term | 28 (26.7%) | 51 (**69.9%**) |
+| scored AFTER | 47 (exact 31.9%, mean offset −2.11) | 7 (n too small to read) |
+
+**The decline problem is not uniform reluctance — it is 70% concentrated on elective stops**,
+where the wear term's ~3 s faces a ~22.8 s wall and moved almost nothing (53 → 51). Of the 79
+declines in the committed report, 51 (65%) are elective stops. Meanwhile on FIRST stops — the
+balanced half — the term churned the scoring set (5 scored→no_boundary, 3+5 in the other
+direction) and pushed the 10 moved offsets **−1.0 lap earlier each** (mean −1.75 → −1.98). That
+earlier-first-call shift is where the five exact agreements went.
+
+**So MEASURE_744b's regression decomposes into: (a) on the netted half, +3 s of wear against a
+3.3 s netting moves the transition ~1 lap earlier; (b) on the full-cost half, the term is
+impotent.** Neither half is described by "the window prices a whole stop against five laps of its
+benefit": on half (a) no whole stop is priced at all, and on half (b) the whole stop is priced
+BECAUSE no rule cancels it.
+
+---
+
+## A. Widening WINDOW_LAPS is refuted — with today's arithmetic, not the plan's
+
+**The issue's "break-even ~92 laps" belongs to a formulation that no longer exists.** Executed
+(P1, `scratchpad/probe_763.py`):
+
+```
+break-even W, shipped legacy comparison (pit 2.8 vs deg 0.61):        4.59 laps
+break-even W, deg=None fallback (pit 2.8 vs FRESH_GAIN 0.25):        11.2 laps
+break-even W if the FULL loss were charged vs FRESH_GAIN: 22.8/0.25 = 91.2 laps  <- the "~92"
+```
+
+The ~92 figure is `full pit loss / FRESH_GAIN` — a comparison in which BOTH numbers have since
+been replaced (#718/#744b measured the wear; the legacy scorer charges the stop only; the
+projection nets it or charges it per the obligation). Quoting it as the premise for widening today
+is quoting the arithmetic of a retired design.
+
+**What widening actually does, in both scorers, is monotone:** the wear charge is the only
+W-dependent term, so d(PIT−STAY)/dW = +deg/POS_GAP_S in the legacy path (measured: −0.647 pos at
+W=3 → +6.267 at W=20) and the same direction in the projection (P2 sweep: −1.007 pos at W=3 →
++1.000 at W=15, saturating on the synthetic 4-car field). Widening cannot re-balance anything; it
+can only hand MORE of the argmax to the wear term — the exact defect the issue says it wants to
+fix. And it acts on the two populations in the wrong order:
+
+- On FIRST stops (already balanced, declines 26.7%), the netting is ~3.3 s, so each extra lap of
+  window adds ~0.6 s to the pit side of the argmax: **first calls move earlier immediately**,
+  worsening the exact-agreement loss that motivated #763.
+- On EXTRA stops (the actual problem, declines 69.9%), the wall is ~22.8 s: break-even needs
+  **W ≈ 22.8/0.61 ≈ 37 green laps** (or ≈16 laps if past the cliff) — wider than nearly every
+  stint and most remaining-race spans. By the time W dents the decline population, the window IS
+  the remaining race, i.e. a different model, which is what the issue itself concedes in its
+  framing question.
+
+Two hidden couplings make widening even more expensive than it looks (see F): the committed
+measured table `sc_window.racing_laps_in_window` is conditioned on W=5
+(`scripts/measure_mc_tables.py:419`, `measure_sc_window(window=WINDOW_LAPS)`), and the eval's
+`DECISION_WINDOW_LAPS = 5` is deliberately matched to the MC window (`decision_modes.py:92-95`) —
+widening re-opens the width-dependence #752 spent a sprint retiring.
+
+**Verdict: A is answered. Widening is not merely "not the best fix"; it is directionally wrong on
+the balanced population and numerically unreachable on the broken one.**
+
+---
+
+## B. Candidate formulations, enumerated
+
+### B1. Widen `WINDOW_LAPS` (the issue's implied fix) — REFUSE
+Refuted in A. Cost: trivial to type, every golden re-frozen, `mc_measured_v1.json` regenerated,
+eval width coupling re-opened. Validation: none exists that is not the forbidden agreement loop.
+
+### B2. Amortise the stop over laps remaining (issue's first named alternative) — REFUSE
+Divide the stop cost by `laps_remaining` and charge per-lap rates. It does not fit the projection's
+currency: positions come from gap crossings against actual cars (`project_positions`), and a
+crossing either happens or it does not — an amortised fraction of a pit loss is not a position.
+It would also be false physics: the rejoin deficit is real and immediate; teams do not experience
+1/30th of a pit stop per lap. Cost: a rewrite of both scorers' semantics; breaks every golden AND
+the rejoin ground truth's meaning. Validation: nothing measurable — the amortisation schedule
+would itself be a chosen constant.
+
+### B3. Price the deferral honestly at the horizon that already exists — BUILD THIS
+"Score the difference between stop now and stop at the best later lap" (the issue's second named
+alternative), realised not as a new engine but as **the missing tyre side of the terminal
+liability the projection already has**. `_terminal_gaps` already carries every KNOWN outstanding
+stop to a common horizon (`position_projection.py:677-742`); what it does not carry is what the
+tyres cost between the window's edge and that horizon. A non-stopping plan's terminal gap should
+bear, in addition to the existing stop residual:
+
+```
+tyre_liability = min(  deg·k* + residual(k*)        # stop at the best later lap k*
+                       deg·R + cliff·max(0, R−c)  ) # or run this set to the flag (R laps left)
+```
+
+both sides q_f-discounted exactly as `_stop_residual_s` already does. For pending=False plans this
+is the ONLY future-cost term (today they carry none), and it is what makes an elective stop
+comparable at all: 22.8 s now against a measured 15-30 s of wear-to-the-flag, instead of against
+five laps.
+
+- **Cost:** one new pure function in `position_projection.py` + one term in `_terminal_gaps` +
+  config already carries every input (`deg_cost_s`, `cliff_loss_s`, `laps_remaining`, `q_f`).
+  Small by this epic's standards.
+- **Breaks:** `test_mc_is_a_real_decision.py` (its fixtures pin `mandatory_stop_pending: False`,
+  lines 412/484, and the sweep shares 42.5/31.2/26.2 quoted in the OVERCUT comment at
+  `strategy_orchestrator.py:756-760` — the twin comment must move with the test);
+  `test_projection_golden.py` only if the implementation touches the pending=None case (its
+  fixture leaves pending unset → None); decision eval numbers regenerate. Does NOT touch
+  `simulate_lap_window`, `WINDOW_LAPS`, the measured tables, or the rejoin ground truth (§F).
+- **Validated:** by the horizon measurement and sign test in E — against 2023-24 physics, never by
+  iterating on the 2025 agreement metric.
+- **Scope note, stated rather than hidden:** the same unpriced wear-to-eventual-stop exists for
+  pending=True, but that population measures balanced today (26.7% declines) and adding the term
+  there moves first calls EARLIER — the direction #744b just paid for. Scoping the new term to
+  plans with no residual (pending=False; pending=None stays inert under the "a claim needs a
+  fact" rule) is a measured-behaviour scoping with a known physical inconsistency. Extending it to
+  pending=True is a separate decision that must wait for the E1 horizon measurement, not
+  symmetry aesthetics.
+
+### B4. Full remaining-race optimisation (Heilmeier-style DP) — DEFER
+The literature's answer (the `WINDOW_LAPS` comment itself cites van Kampen 2024 against short
+horizons) and the only formulation that also fixes pending=True honestly. It needs per-compound
+degradation curves over the whole stint space and a rebuilt MC. That is a future initiative, not a
+fix inside this epic; B3 is its cheapest honest approximation.
+
+### B5. Change nothing; document the boundary — HONEST BUT INSUFFICIENT
+The layer is a mandatory-stop timer that declines elective stops. Defensible as a scope statement,
+zero blast radius — but 41% of real strategy calls in the 2025 sample are elective, the epic's
+own scorecard names the decline rate as the number to attack, and the boundary was discovered by
+this gate rather than chosen by anyone. Rejected as an end state; ACCEPTED as the interim truth
+the docs should state until B3 lands.
+
+---
+
+## D. Is "one term decides 73.6% of laps" a defect? Both sides, then the verdict
+
+**The number first:** 73.6% is `share of laps where deg×5 > POS_GAP_S = 1.5 s` — a legacy-path
+conversion applied to decisions the projection made. In the deciding scorer a position is a gap
+crossing, and the measured median consecutive-car gap while racing is 2.23 s
+(`strategy_orchestrator.py:645-646`). At 2.23 s the threshold is deg > 0.446 s/lap; the median
+charge (2.03 legacy-positions ≡ 3.05 s) still crosses, so **a majority survives the correction,
+but the specific figure is an artefact of the wrong conversion** and should stop being quoted.
+
+**The case that dominance is correct:** stop timing in modern F1 IS wear-dominated — with pit loss
+fixed per circuit, the lap you box is chosen by tyre state; undercut, clean air and hazard are
+tie-breakers around a wear-determined window on real pit walls too. A term that dominates the
+argmax near the stop is what a correct model looks like there, and the other terms being quiet is
+information.
+
+**The case that it is a defect:** if wear genuinely dominated the DECISION, it would dominate
+where the teams' wear-driven decisions live — the elective stops, which teams take precisely
+because wear pays for them. Measured (P5): the term moved that population by 2 stops out of 73 and
+its declines stayed at 70%. It dominated instead the netted half, where its ~3 s stands against a
+~3.3 s option value. **A term that is decisive only where the opposing cost has been netted away,
+and impotent where the opposing cost is real, is not "wear matters" — it is the horizon asymmetry
+deciding, wearing the wear term's name.**
+
+**The distinguishing measurement is exactly the pending split, and it has now been executed.**
+"Wear correctly dominates" predicts decisiveness on the elective population; "window artefact"
+predicts decisiveness only on the netted population. P5 measured the second. Verdict: defect —
+but the defect is the missing deferral horizon (B3), not the term's scale, and NOT the window
+width.
+
+---
+
+## E. What makes the new formulation MEASURED rather than chosen
+
+⛔ Tuning any constant until the 43.4% recovers is the forbidden loop; everything below is
+measurable without ever consulting the 2025 agreement number during design.
+
+- **E1 — the repayment-horizon measurement (the constant's basis).** Over 2023-24 (training
+  seasons — 2025 stays held out), for every real elective stop: laps until the realised post-stop
+  pace advantage (actual lap-time deltas, fresh vs the old set's trend) repays the realised pit
+  loss. The distribution of realised repayment horizons is a fact about the sport. If its median
+  sits at 15-25 laps, that is the measured proof that no fixed short window can price an elective
+  stop and that the liability must integrate to `laps_remaining`. This number justifies B3's
+  horizon; it is not fitted to any eval.
+- **E2 — the sign test (calibration against physics, not agreement).** With B3 implemented, on
+  each 2023-24 elective stop: does the terminal tyre liability of staying out exceed the charged
+  pit loss ON the lap the team stopped, and not exceed it 10 laps earlier? The real stop lap is
+  used only as an event marker for a SIGN FLIP, never as an argmax target — pre-registered pass
+  rate, stated before running.
+- **E3 — the invariance criterion.** FIRST-population behaviour (decline 26.7%, offsets) must not
+  move beyond a pre-stated tolerance. A deferral term for elective stops has no business moving
+  mandatory-stop timing; if it does, the scoping leaked.
+- **E4 — sensitivity disclosure.** Publish the conclusion's sensitivity to E1's CI, the way
+  FABLE G1 published mean_signed vs width. A formulation whose recommendation flips inside its
+  input's confidence interval is not measured yet.
+- **E5 — one 2025 re-run, reported, never iterated.** After E1-E4 freeze the design, run
+  `f1-eval decision-modes` ONCE against 43.4%/46.1%, publish whatever it says, and if it
+  disappoints the design goes back to E1 — not to a knob. Anything else is `mean_signed_error`'s
+  funeral being reversed.
+- **Confession check (the mandate asked):** E2 skirts closest to the forbidden pattern, since it
+  consults real stops. The line it does not cross: it reads only the SIGN at two fixed distances
+  on held-IN seasons, with the pass rate pre-registered — it cannot be climbed lap-by-lap the way
+  an agreement percentage can. If an implementer ever converts E2 into "maximise the flip
+  alignment", that is the forbidden loop and this gate names it in advance.
+
+---
+
+## F. Blast radius, exhaustively, per candidate
+
+**The rejoin ground truth (86.5% within one, 1810 stops) does not move under ANY candidate here,
+and the reason is structural, verified at file:line:** `src/strategy/eval/projection.py:61-67`
+builds its own frozen `_GROUND_TRUTH_CONFIG` (`window_laps=2, racing_laps=2.0`, tyre terms zeroed,
+saving zeroed) — decoupled from `WINDOW_LAPS` — and line 260 reads `result.positions`, the
+window-end rejoin horizon, never `terminal_positions`. B3 edits only the terminal side;
+`ProjectionResult.positions`' docstring (`position_projection.py:272-275`) pins that meaning.
+Anyone whose implementation makes 86.5% move has changed the wrong horizon.
+
+Under **B3** (the recommended build):
+
+| Artefact | Moves? | Why |
+|---|---|---|
+| `tests/mc/test_mc_is_a_real_decision.py` | **YES** | fixtures pin `mandatory_stop_pending: False` (:412, :484); sweep shares re-measured |
+| `strategy_orchestrator.py:756-760` OVERCUT comment | **YES** | quotes the 42.5/31.2/26.2 sweep — the twin of that test; move them together |
+| `tests/mc/test_position_projection.py`, `test_position_projection_stop_horizons.py`, `test_tyre_wear_term.py` | **YES** | terminal-side unit coverage; new tests added here |
+| `tests/mc/test_projection_golden.py` | **CONDITIONAL** | fixture leaves pending unset (None); moves only if the implementation touches pending=None — it must not (a claim needs a fact) |
+| `documents/eval_reports/decision_modes.{md,json}` | **YES** | regenerate once (E5); headline vs 33.3%/44.4% and the buckets move |
+| `tests/mc/test_strategy_goldens.py` (legacy scorer) | **NO** | `simulate_lap_window` untouched |
+| `data/mc_measured_v1.json` | **NO** | no width change; `sc_window` stays valid |
+| `documents/eval_reports/projection.{md,json}` (86.5%) | **NO** | see above |
+| `f1-eval` hygiene/calibration/stint_lengths reports | **NO** | different tiers |
+| CLI reasoning string `window={WINDOW_LAPS}` (`strategy_orchestrator.py:1732`) | **NO** | width unchanged |
+| Epic scorecard / memory numbers (43.4, 46.1, "73.6%") | **YES (append)** | historical docs stay; the scorecard's current row updates; 73.6% retired as a conversion artefact |
+| Issue #763 text | **YES** | its mechanism section is refuted here; a false claim in an issue is scope — correct it before implementation |
+
+If anyone widens `WINDOW_LAPS` instead (B1), ADD: every strategy golden,
+`data/mc_measured_v1.json` regeneration (`measure_sc_window` is W-conditioned,
+`scripts/measure_mc_tables.py:419`), the eval's `DECISION_WINDOW_LAPS` coupling
+(`decision_modes.py:92-95`) and with it the width-dependence of every reported offset, the CLI
+reasoning string on every surface, and every doc/thesis mention of the five-lap window.
+
+---
+
+## RECOMMENDATION
+
+**Build:** B3 — the terminal tyre liability. One pure function in `position_projection.py`
+(deferral cost: `min(stop at best later lap, run to the flag)`, q_f-discounted), one term in
+`_terminal_gaps`, scoped to non-stopping plans whose stop residual is absent (pending=False;
+pending=None stays inert). No change to `WINDOW_LAPS`, no change to `simulate_lap_window`, no
+change to the wear term's scale.
+
+**Measured basis:** E1 (repayment-horizon distribution on 2023-24) justifies the horizon before a
+line is written; E2 (sign test) + E3 (FIRST-population invariance) + E4 (sensitivity) gate the
+implementation; E5 is a single 2025 re-run, reported not iterated.
+
+**Refuse:** widening `WINDOW_LAPS` (directionally wrong on the balanced population, needs W≈37 to
+reach the broken one); amortising the stop per lap (false physics, wrong currency); ANY iteration
+loop on the 2025 agreement metric; extending the liability to pending=True without E1 in hand;
+quoting "73.6%", "~2.8 s cancels in both scorers", or "break-even ~92 laps" ever again — all
+three are measurements of retired or wrong arithmetic.
+
+**Correct the record:** #763's mechanism section and MEASURE_744b's diagnosis section describe
+the legacy scorer; the measurement they explain ran 100% on the projection scorer. The issue
+needs a correcting comment before any implementation PR cites it.
+
+---
+
+## What I tried to break and could NOT
+
+- **The like-for-like claim of MEASURE_744b.** Verified: the before report (`fd105de`, harness
+  `99a663d`) and the committed one (`d97a54e`) grade the IDENTICAL 178-stop set (asserted
+  programmatically in P5's join — zero key mismatches). The comparison is sound; only its
+  diagnosis section is wrong.
+- **The wear term's arithmetic.** `_tyre_term` / `_tyre_cost_s` are mutually exclusive with the
+  FRESH_GAIN fallback exactly as documented; no double count; the OVERCUT window split charges
+  `W//2 + W//2`. The term is correct. The issue is right that scaling it down would be the wrong
+  fix.
+- **The netting identity.** P2b reproduces `net pit channel = q_f × saving` to the printed
+  precision (3.32 = 3.32) from production functions — `_terminal_gaps` + `_stop_residual_s` do
+  cancel the traversal for pending=True exactly as designed.
+- **The eval's routing.** I looked for eval laps that fall to the legacy scorer (which would
+  partially rescue the issue's arithmetic): zero out of 2,744 across all six races. I also tried
+  `lap_inputs`' skip conditions as a leak path; skipped laps are skipped for both metrics alike.
+- **The 86.5% decoupling.** I attempted to construct a dependence of the rejoin ground truth on
+  `WINDOW_LAPS` or on the terminal machinery: `_GROUND_TRUTH_CONFIG` is frozen at 2 laps with
+  every strategy term zeroed and reads only `positions`. No path found.
+- **The pending flag itself.** Spot-checked semantics against `stint_history.py`: False requires
+  positive evidence (two dry compounds or a wet), True requires every stint visible; the per-race
+  splits (Monza 19/20 first — a one-stop race; Silverstone 27/31 extra — a wet-ish multi-stop
+  race) match 2025 racing reality.
+
+**Single biggest risk of the recommendation:** B3 prices the deferral with the SAME `deg_cost_s`
+whose level FABLE_G2/#744a showed to be reference-sensitive, now multiplied by `laps_remaining`
+instead of 5 — an error in deg is amplified ~4-6×. E4's sensitivity disclosure exists precisely
+for this; if deg's CI cannot support the amplification, B4 (or B5 as the interim) is the honest
+fallback.
+

--- a/documents/audits/FABLE_763_deferral_exit.md
+++ b/documents/audits/FABLE_763_deferral_exit.md
@@ -1,6 +1,11 @@
 # FABLE EXIT GATE #763 — the deferral tyre liability, attacked before promotion
 
 **Date:** 2026-07-31 · **Branch:** `feat/deferral-tyre-liability` @ `4652c48` · **Gate type:** adversarial EXIT gate
+
+> ⚠️ **This first half describes `4652c48`. The three HIGH findings were fixed at `7dd4751` and
+> re-measured — see [RE-RUN AFTER THE FIX](#re-run-after-the-fix--branch-feat-deferral-tyre-liability--7dd4751)
+> at the bottom for the post-fix numbers, including the E4 amplification that decides whether the
+> term ships. The severity tally below is the PRE-fix state and is deliberately not edited.**
 **Mandate:** success = finding what is STILL broken. No repository file modified except this report
 (any temporary mutation is backed up with `cp` and restored from the backup, diffed, and stated).
 All evidence executed, `profile="no-llm"`, zero API calls. The agreement metric's direction is
@@ -744,3 +749,199 @@ distribution, saturation, branch shares, cliff variant) · `sensitivity_small.py
 amplification) · `rederive_e3_e5.py` + `first_stop_defs.py` (A/E re-derivation) ·
 `e1_green_filter_check.py` (E1's label) · `mutation_battery.py` + `mutation_battery2.py` (§G) ·
 `test_probe_positive_control.py` (the empty-set control).
+
+---
+---
+
+# RE-RUN AFTER THE FIX — branch `feat/deferral-tyre-liability` @ `7dd4751`
+
+**Date:** 2026-07-31 (same session) · **Prompted by:** the three HIGH findings above being fixed
+and pushed. Everything above this line describes `4652c48` and is left untouched so the before and
+after stay readable side by side.
+
+**What changed in the code** (`git diff 4652c48..7dd4751 -- src/agents/position_projection.py`,
++23/−11): `_deferral_tyre_liability_s` now takes `cliff_laps` as its second argument and computes
+`laps_past_cliff = max(0, remaining − cliff_laps)` from the tyre model's own per-draw onset,
+instead of assuming everything past `window_laps` was past the cliff. `_terminal_gaps` threads it
+from `project_positions`. Two tests added. This is exactly the D/HIGH finding, fixed at the point
+the finding named.
+
+## Method — what is comparable and what I had to change
+
+The captured `_run_projection_mc` kwargs are **inputs**: they come from the replay and the agents,
+not from the projection scorer, so the same 2,744 laps are valid against the fixed code and the
+comparison is lap-for-lap. Two harness changes were forced, and both are traps:
+
+1. **The zero-stub must take the new 3-arg signature.** A 2-arg stub would raise (loud, fine) —
+   but a stub with a `*args` catch-all would silently never bind and the "term off" column would
+   become a copy of the "term on" column. The re-run **asserts the real signature** before
+   sweeping (`inspect.signature(REAL) == ['pit_loss_s', 'cliff_laps', 'config']`) and runs a
+   **positive control**: term-on vs term-off must actually differ somewhere. It differs on
+   **87 of 200 sampled laps**, so the control column is real.
+2. **`mandatory_stop_pending=True` is NOT a "term off" control** — it swaps the liability for
+   `_stop_residual_s`, which is a different non-zero charge. The only valid control is stubbing
+   the function to zeros, which is what both runs do.
+
+## ⭐ E4 RE-RUN — the amplification, same harness, same 1,055 laps
+
+Identical procedure to the pre-fix run: the 1,055 `pending=False` laps carrying a tyre reading,
+`deg_cost_s` perturbed by ±0.1 / ±0.2 / ±0.5 s/lap in either direction, argmax via the production
+`best_mc_candidate`, each lap scored with the term wired and with it stubbed to zero.
+
+| deg error | flips WITH the term | flips WITHOUT | **amplification** | (was) |
+|---|---|---|---|---|
+| **±0.1 s/lap** | **65 (6.2%)** | 11 (1.0%) | **5.91×** | *(was 8.27×, 8.6%)* |
+| ±0.2 s/lap | 125 (11.8%) | 29 (2.7%) | **4.31×** | *(was 6.07×, 16.7%)* |
+| ±0.5 s/lap | 279 (26.4%) | 49 (4.6%) | **5.69×** | *(was 6.86×, 31.8%)* |
+
+**The "WITHOUT it" column is byte-identical to the pre-fix run (11 / 29 / 49).** It has to be —
+stubbing the liability to zero makes the cliff fix unreachable — and that identity is the
+strongest available check that the two runs are the same measurement on the same laps.
+
+### The answer to the ship question, plainly
+
+**It is no longer 6-8×. It is 4.3-5.9×.** The fix is real and material: at the plausible-error
+scale that matters most (±0.1 s/lap), flips fell from **8.6% → 6.2%** of elective decisions, a
+28% reduction, and the amplification fell from above the design gate's predicted band to inside
+it. The gate predicted "~4-6×"; the fixed code measures 4.31× / 5.69× / 5.91×.
+
+**But being inside the predicted band is not the same as passing E4, and I will not report it as
+one.** The gate's criterion was conditional, not a threshold: *"if deg's CI cannot support the
+amplification, B4 (or B5 as the interim) is the honest fallback."* Applying it needs `deg_cost_s`'s
+error bound — and **#744a never published one.** So the criterion remains formally unevaluable for
+the same reason it was before the fix, and what I can state is the two facts either side of it:
+
+- **A tenth of a second per lap of tyre error still flips 6.2% of elective decisions** — one in
+  sixteen — against 1.0% without the term.
+- **The flips are two-sided and near-symmetric** (`STAY_OUT→UNDERCUT` +161 / `UNDERCUT→STAY_OUT`
+  −111; `STAY_OUT→PIT_NOW` +89 / `PIT_NOW→STAY_OUT` −64), i.e. those laps still sit on the knife
+  edge rather than in a robust regime. The asymmetry did shrink with the fix.
+
+**My recommendation, as the gate rather than the implementer:** this is a judgement call that
+belongs to whoever owns the ship decision, and the number that should drive it is 6.2% at ±0.1
+s/lap, not the ratio. If the project can state a defensible bound on `deg_cost_s`'s per-lap error
+and it is materially under 0.1 s/lap, the term is carryable and should ship with the amplification
+table published beside it. If it cannot — and today it cannot, which is the honest position — then
+shipping means accepting that one elective call in sixteen turns on an unbounded input, and the
+gate's own fallback (document the boundary; never the window) is the consistent choice. **What is
+not defensible either way is shipping without publishing this table**, which was E4's entire
+purpose.
+
+## Does the cliff fix change my other findings? — two die, one is untouched, one is new
+
+Same 2,744 captured laps, same production functions, fixed module.
+
+### The invented charge is GONE — the D/HIGH finding is fully resolved
+
+| tyre reading (pending=False laps) | n | laps with liability > 0, **before** | **after** |
+|---|---|---|---|
+| `deg is None` | 784 | 0 | **0** |
+| `deg == 0.0` | 231 | **189** (median 8.41 s) | **0** |
+| `deg < 0` | 205 | **121** | **66** (median 0.00 s) |
+| `deg > 0` | 619 | 592 | 555 (median 18.89 s) |
+
+**Zero laps now charge a liability on a set the model prices at exactly fresh.** The 66 surviving
+`deg < 0` laps are **not** a residue of the bug: with the per-draw onset threaded, a set that is
+fast *today* but whose `cliff_laps` is small genuinely does cost time before the flag, and that is
+now the tyre model's claim rather than the scorer's assumption. That is the right answer, arrived
+at for the right reason.
+
+Knock-on effects, all in the conservative direction: the liability is now identically zero on
+**66.2%** of elective laps (was 51.0%), full saturation fell **28.8% → 20.6%**, and the positional
+cost fell at p75 (**2.00 → 0.99**) and p95 (**5.80 → 4.37**). The worst case is unchanged at
+**11.99 positions**, as it must be — the `min` still caps the liability at the stop being deferred.
+
+**One number went UP and it should have:** the cliff contribution's maximum rose **45.6 s →
+49.49 s** while its median collapsed **15.2 s → 0.49 s**. The fix is a redistribution, not a
+reduction: laps whose model-predicted cliff is far away now pay nothing, and laps already past
+their cliff pay for every remaining lap instead of being capped at `remaining − window_laps`.
+
+### Barcelona dominance — UNCHANGED, and the fix slightly sharpened it
+
+| race | laps | pending=False | deg known | liab > 0 (was) | flips (was) |
+|---|---|---|---|---|---|
+| **Barcelona** | 737 | 522 | 456 | **336** (425) | **179** (216) |
+| Monaco | 558 | 329 | 241 | 170 (213) | 64 (70) |
+| Marina Bay | 308 | 168 | 141 | 78 (128) | 25 (30) |
+| Lusail | 313 | 153 | 105 | 26 (82) | 6 (10) |
+| Monza | 219 | 86 | 59 | 11 (49) | 4 (11) |
+| **Silverstone** | 609 | **581** | **53** | **0** (5) | **0** (1) |
+
+Total flips 338 → **278**, still **every one `pending=False`**. Barcelona's share is **179/278 =
+64.4%**, statistically identical to the 64% before. **The finding stands unchanged** — and
+Silverstone has gone from 1 flip to **zero**, so the archetype that is 95% elective now receives
+the term on precisely no laps. The cliff fix does not touch the cause, which is that
+`_fresh_reference` has no reading for 528 of Silverstone's 581 elective laps.
+
+### `deg is None` inertness — UNCHANGED at 42.6%
+
+784 of 1,839 elective laps, identical before and after. The `deg_cost_s is None` guard was not
+touched by the fix and should not have been. **The reach statement in the report above still
+holds verbatim**: 67% of laps by obligation, 38% once a tyre reading is required.
+
+## What the fix did NOT touch — stated so nothing is assumed closed
+
+`git diff 4652c48..7dd4751` touches four files: `position_projection.py`, two test files, and
+this report. **Verified untouched**: `tests/mc/test_position_projection.py`,
+`src/agents/strategy_orchestrator.py`, `docs/pages/multi-agent.md`, and
+`documents/audits/MEASURE_763_deferral_effect.md`. Read from a pristine copy of the fixed module
+(the working tree held a mutant at the time — the same trap as before, avoided the same way):
+
+- **STILL OPEN [MEDIUM] — the stale docstring**, `position_projection.py:765-766`, verbatim:
+  *"already stopped (no obligation) -> our residual is zero, staying out costs nothing on this
+  term"*. This is the single most misleading line in the module and it sits 35 lines above the
+  branch that contradicts it. Fix-list item 2, untouched.
+- **STILL OPEN [MEDIUM] — the q_f discount on the run-it-out branch** (`:727-729`). Unchanged, and
+  its docstring justification ("a neutralisation that turns up covers a deferred stop whichever
+  branch wins") is still wrong for a branch containing no stop. Fix-list item 5.
+- **STILL OPEN [MEDIUM] — the two tests passing for the wrong reason**
+  (`test_position_projection.py:271-275, :509-517`, both asserting a discharged obligation makes
+  staying out free). `test_position_projection.py` is untouched by the fix, and `_flat_config`
+  still leaves `deg_cost_s` unset, so both still pass only because the term short-circuits.
+  Fix-list item 3.
+- **STILL OPEN [LOW]** — the dead `else` at `:807-811` (and its numpy-bool reachability), the
+  docs-site drift, the legacy scorer's comment, and the E1/E5 record corrections. Fix-list
+  items 7 and 8.
+- **STILL OPEN [MEDIUM] — E2 was never run.** The sign test on 2023-24 elective stops still has no
+  artifact. E4 now exists (this section); E2 does not.
+
+## Why the synthetic sweep read 0.8% where real laps read 6.2% — measured, not asserted
+
+The coordinator flagged their own re-measurement as invalid (400 synthetic parameter states
+through `project_positions`, 0.8% flips) and asked me not to use it. That judgement was right, and
+the reason is measurable rather than a matter of taste. **A flip needs the top two candidates to
+be close enough that a perturbation can cross them**, so the flip rate is a property of how near
+the population sits to its own decision boundaries — not of the parameter ranges swept.
+
+Measured on the 1,055 real elective laps (top-2 `score` margin, in positions):
+
+```
+p10 0.001   p25 0.254   p50 1.000   p75 4.003   p90 7.277
+margin <= 0.01 :  124 laps (11.8%)      <- effectively ties
+margin <= 0.10 :  189 laps (17.9%)
+margin <= 0.50 :  467 laps (44.3%)
+```
+
+**Almost one real elective lap in eight is within a hundredth of a position of flipping**, and the
+distribution is heavily bimodal — a dense cluster at the boundary and a long tail far from it. A
+uniform grid over parameter space reproduces the tail and badly under-samples the cluster, which
+is exactly the shape of a 0.8% result against a 6.2% one. The 6.2% flip rate is also *internally
+consistent* with this: it sits below the 11.8% of laps that are near-tied, as it must.
+
+**The reusable rule: sensitivity of a decision layer can only be measured on the distribution the
+layer actually faces.** Synthetic states measure the function; real laps measure the decision.
+
+## Battery 3 — do the new tests actually catch the mutants they were written for?
+
+A test added to close a mutation gap is worth exactly as much as its ability to kill that mutant,
+so both new tests were verified by re-running the surviving mutants against them. Same discipline:
+`cp` backup of the FIXED file first, restore from the backup after each, byte-identical assertion
+at the end. Baseline is now **175 tests** (173 + 2 added).
+
+| Mutant | Result | Killed by |
+|---|---|---|
+| **M5 — the wiring deleted** (`our_residual = _deferral_tyre_liability_s(...)` → zeros) | **CAUGHT** (1 failed, 174 passed) | `test_the_terminal_gap_of_a_deferring_car_actually_MOVES` |
+
+**The disconnection HIGH is genuinely closed**, and closed by precisely the test written for it —
+not by an incidental assertion elsewhere. That is the strongest form of the check.
+

--- a/documents/audits/FABLE_763_deferral_exit.md
+++ b/documents/audits/FABLE_763_deferral_exit.md
@@ -945,3 +945,221 @@ at the end. Baseline is now **175 tests** (173 + 2 added).
 **The disconnection HIGH is genuinely closed**, and closed by precisely the test written for it —
 not by an incidental assertion elsewhere. That is the strongest form of the check.
 
+
+---
+---
+
+# CONTINUATION 2 — after the q_f and docstring fixes, `feat/deferral-tyre-liability` @ `110f4ed`
+
+**Date:** 2026-07-31 (same session, resumed after an interruption) · Everything above is left
+untouched. The interrupted run's two outstanding jobs had in fact **completed** before the cut and
+their results are recovered from disk below, so nothing was restarted.
+
+**Working-tree discipline for this section:** a sweep is running against the working tree, so
+**no file was mutated while it was in flight.** The q_f test is attacked analytically first — each
+candidate mutant expressed as a standalone implementation and the shipped test's own assertions
+evaluated against it — and confirmed with real `pytest` only after the sweep lands. Every module
+load goes through a byte-copy pristine file via `importlib`. `git checkout --` never used.
+
+## Recovered: battery 3 completed before the cut (against `7dd4751`)
+
+| Mutant | Result |
+|---|---|
+| **M5 — the wiring deleted** | **CAUGHT** — `test_the_terminal_gap_of_a_deferring_car_actually_MOVES` |
+| **M1 — the assumed cliff onset, reintroduced verbatim** | **CAUGHT** — `test_the_cliff_half_uses_the_onset_the_model_supplied_not_an_assumed_one` |
+| M2 — the q_f discount deleted from the run branch | **SURVIVED** (175 passed) |
+| M3 — the option value deleted from the stop branch | **SURVIVED** (175 passed) |
+| restore | **verified byte-identical to the backup** |
+
+Both new tests killed exactly the mutant each was written for — the strongest form of that check.
+**M2 and M3 survived, which is the gap `110f4ed` then addressed.**
+
+## A. The q_f fix — attacked, and the test holds for a stronger reason than claimed
+
+The fix is right, and it is the one I argued for: a neutralisation cheapens the **stop**, not the
+rubber, and `_stop_residual_s` already carries that option value on the other branch. Charging it
+twice was a systematic under-charge of exactly the population the term exists to stop
+under-charging.
+
+**On the test — you asked me not to take your word, and the second version is sound, but the
+guard you added is not what makes it sound.** Executed, branch selection per regime:
+
+```
+heavy (deg 1.5, 45 laps)  q_f=0.0 -> liability 22.800   branch = STOP
+heavy (deg 1.5, 45 laps)  q_f=0.5 -> liability 18.800   branch = STOP
+light (deg 0.5, 25 laps)  q_f=0.0 -> liability 10.000   branch = RUN
+light (deg 0.5, 25 laps)  q_f=0.5 -> liability 10.000   branch = RUN
+```
+
+The two halves do read different branches. **But each half already self-pins its own branch, so
+the regimes cannot silently collapse even without assertion C:**
+
+- Half A asserts a **strict** decrease (`likely_sc < calm`). The run branch is q_f-invariant by
+  construction, so if the run branch won this regime the two values would be equal and the strict
+  `<` would fail. Passing A *proves* the stop branch won.
+- Half B asserts **equality** under `q_f=0.5`. If the stop branch won this regime, `q_f` would
+  reduce it and the two would differ. Passing B *proves* the run branch won.
+
+So `assert calm[0] != calm_run[0]` is belt-and-braces rather than load-bearing — worth keeping,
+but the test would be correct without it. **This is not the failure mode you feared**: your first
+version failed because *both halves were in the run regime*, and half A cannot pass there. The
+second version is genuinely testing what its name says.
+
+**And it kills more than it was written for.** Evaluating the shipped test's assertions against
+each mutant:
+
+| Mutant | Verdict | Killed by |
+|---|---|---|
+| SHIPPED (control) | passes | — |
+| **M2r — the q_f discount re-introduced on the run branch** | **KILLED** | half B (6.0 ≠ 10.0) |
+| **M3 — the option value deleted from the stop branch** | **KILLED** | half A (22.8 ≮ 22.8) |
+| M10 — the zero clamp removed from the run branch | **PASSES** | *nothing* |
+
+**M3 is now covered.** It survived battery 3 and the new test kills it, because moving the option
+value onto the stop branch alone made half A's strict inequality depend on `_stop_residual_s`
+being there. That is a real second-order win from the fix, and it answers "is any survivor left"
+for M3: no.
+
+### FINDING [MEDIUM] — the run branch's zero clamp guards a SIGN INVERSION on ~11% of real elective laps, and nothing tests it
+
+`position_projection.py`, `np.minimum(stop_later, np.maximum(0.0, run_it_out))`. The
+`np.maximum(0.0, ...)` is the only thing stopping a negative tyre reading from becoming a terminal
+**credit** — a liability below zero moves the terminal gap the wrong way, so *deferring would gain
+track position*. Removing it passes the entire suite, including the new q_f test.
+
+Measured on the real captures (read-only, 2,048 elective `(lap, config)` evaluations that reach
+the run branch):
+
+```
+clamp binds on EVERY draw : 220 laps (10.7%)
+clamp binds on SOME draw  : 248 laps (12.1%)
+worst unclamped run_it_out: -43.26 s   <- 43 seconds of terminal CREDIT for staying out
+```
+
+This is not a bug in the shipped code — the clamp is present and correct. It is an **unguarded
+guard**, on a code path this project has been bitten by before (a sign inversion that survived
+because nothing asserted the sign). `deg_cost_s` is negative on 19.4% of real elective laps and
+is floored at −2.33, so the regime is routine, not exotic. One test — negative `deg`, assert the
+liability is exactly zero and never negative — closes it.
+
+## ⭐ E4 RE-MEASURED on `110f4ed` — and it moved the WRONG way, against my own prediction
+
+The ship decision rests on the amplification, and my published figure was measured on `7dd4751`,
+**before** the q_f fix. The q_f fix enlarges the run-it-out branch (it no longer subtracts
+`q_f·saving`), which changes how often the `min` selects the deg-sensitive branch. Quoting the
+old number would have been quoting a stale measurement of a changed function, so I re-ran it.
+
+**I predicted the sensitivity would FALL.** Reasoning: a larger `run_it_out` means the stop branch
+wins the `min` more often, and the stop branch is deg-insensitive, so fewer laps should respond to
+a deg perturbation. **That prediction was wrong.** Measured, same harness, same 1,055 laps, stub
+signature asserted, positive control 92/200:
+
+| deg error | flips WITH the term | WITHOUT | **amplification** | on `7dd4751` |
+|---|---|---|---|---|
+| **±0.1 s/lap** | **75 (7.1%)** | 11 (1.0%) | **6.82×** | *6.2%, 5.91×* |
+| ±0.2 s/lap | 138 (13.1%) | 29 (2.7%) | **4.76×** | *11.8%, 4.31×* |
+| ±0.5 s/lap | 283 (26.8%) | 49 (4.6%) | **5.78×** | *26.4%, 5.69×* |
+
+The "WITHOUT" column is again byte-identical (11/29/49), as it must be — stubbing the liability
+makes every downstream fix unreachable — so the three runs are the same measurement on the same
+laps.
+
+**The likely mechanism, stated as a hypothesis rather than a finding:** removing the discount makes
+the liability uniformly larger, which pushes more laps toward the pitting candidates and therefore
+*into* the near-tie band where a small deg change can cross the argmax. The population near the
+boundary grew. I have not verified this and it should not be quoted as established.
+
+**Two cautions on reading the ratio.** The denominator is 11 laps of 1,055; a ±3-lap wobble in it
+swings the ratio between 5.4× and 9.4×. **The ratio is a fragile statistic and the absolute rate
+is the robust one.** Across the three perturbation sizes the amplification is **4.8-6.8×**, and
+quoting either the single best or single worst point would over-read it.
+
+## THE SHIP DECISION — you asked me to attack it, so here it is plainly
+
+**Your position:** ship the term, disclose the amplification as a measured property, file the
+missing `deg_cost_s` per-lap error bound as the blocker.
+
+**My verdict: do not ship it yet.** Not as a veto on the design — B3 is the right design and I
+have not found a defect in its physics — but the blocker you propose to file is not a paperwork
+item, and one measurement in this section is the reason.
+
+### Why, in the order the reasons actually weigh
+
+**1. The sensitivity moved in a direction nobody predicted, including me.** The q_f fix was
+correct on its own terms — it removed a real double-count that I flagged. Yet it pushed the flip
+rate from 6.2% to **7.1%** and the amplification from 5.91× to **6.82×**. I predicted the
+opposite, in writing, before running it. A term whose error behaviour moves the wrong way when you
+fix a genuine bug in it is **measured but not understood**. That is a different state from
+"understood and awaiting a bound", and it is the state that decides this for me.
+
+**2. The measurement cannot be converted into a risk.** 7.1% of elective decisions flip on ±0.1
+s/lap. Whether that is alarming or irrelevant depends entirely on whether `deg_cost_s`'s real
+per-lap error is nearer 0.01 or 0.5 — and #744a never published one. **You cannot disclose a
+sensitivity as a "measured property" when the input it is a sensitivity TO is unmeasured.** The
+disclosure would read as reassurance while carrying no information about actual exposure.
+
+**3. Your own gate wrote the rule for exactly this case**, and it is conditional rather than a
+threshold: *"if deg's CI cannot support the amplification, B4 (or B5 as the interim) is the honest
+fallback."* Today the CI does not exist, so the condition cannot be discharged in the term's
+favour. You set the bright line at 6-8× and asked me to say so plainly if it was still there: **at
+±0.1 s/lap it is 6.82×.** I will not lean on that number alone, because the ratio's denominator is
+11 laps and it is fragile — but I am not going to report it as having cleared the line either.
+
+### Where I think your reasoning is RIGHT, and where I'd push back on my own verdict
+
+**You are right that B5 is not a free fallback, and the report should stop implying it is.**
+Documenting the boundary leaves the measured defect in production: an elective stop's full pit
+loss priced against **exactly zero**, and 69.9% of them declined. That is a *larger, systematic*
+error than the variance the term introduces. Choosing B5 is choosing a known bias over a bounded
+variance, and that is not obviously the safer side.
+
+**Three things genuinely favour shipping and I want them on the record:**
+
+- The liability is **structurally capped** at the stop being deferred (the `min` against
+  `_stop_residual_s`). The term cannot produce an unbounded error however wrong `deg` is — worst
+  case it charges a whole pit stop, which is a real cost, not an invented one.
+- **Roughly half the sensitive laps were near-tied anyway**: 11.8% of real elective laps sit
+  within 0.01 positions of flipping. On a genuinely balanced lap either answer is defensible, so
+  part of the 7.1% is the population's own knife-edge rather than the term's instability.
+- The missing bound is an **input-level debt that other shipped code already depends on** —
+  `driver_time_delta`'s in-window wear term has consumed the same unbounded `deg_cost_s` since
+  #744b. Blocking only this term on it is inconsistent.
+
+**That third point is the strongest argument against my own verdict, and it is why my answer is
+"not yet" rather than "no".** If the bound is filed against `deg_cost_s` itself and its consumers
+as a class, the same evidence that unblocks this term unblocks the rest.
+
+### What would flip me to yes, and it is cheap
+
+1. **Measure `deg_cost_s`'s per-lap error** on 2023-24 (held-out seasons, the same hygiene E1
+   used). If it is materially **below 0.1 s/lap**, then 7.1% is an upper bound on real-world
+   flipping, the amplification is carryable, and the term should ship **with the table published
+   beside it**. That is the single missing measurement and it is a day's work, not a quarter's.
+2. **Re-run E4 once after any further change to the term.** It is ~10 minutes of compute and it
+   just caught a stale number that would otherwise have gone into the ship decision.
+
+Until (1) exists, "ship with the amplification disclosed" is disclosure without denominator. If
+you decide to ship anyway — a legitimate call that is yours, not mine — then the honest framing in
+the report must be *"this term trades a measured systematic bias for a bounded variance whose
+magnitude we cannot yet price,"* not *"the sensitivity is a disclosed measured property."*
+
+### The analytic mutants were themselves verified, because a hand-written mutant can lie
+
+Evaluating the test against hand-written implementations is only as good as those
+implementations. Each was checked against the real function two ways, over 400 randomised configs
+spanning `deg ∈ [-2.33, 3.67]`, `laps_remaining ∈ [0, 70)`, both cliff settings and both savings:
+
+```
+OK  M2r == shipped when q_f == 0  (mutation is a no-op)      mismatches 0/400
+OK  M3  == shipped when q_f == 0  (residual is identity)     mismatches 0/400
+OK  M10 == shipped when deg  > 0  (clamp never binds)        mismatches 0/400
+OK  M2r differs when q_f > 0 and the run branch wins    6.000 vs shipped 10.000
+OK  M3  differs when q_f > 0 and the stop branch wins  22.800 vs shipped 18.800
+OK  M10 differs when deg < 0 (the clamp binds)        -10.000 vs shipped  0.000
+```
+
+Each mutant is faithful: identical to the shipped function everywhere its mutation should not
+bite, and different exactly where it should. **These verdicts still get confirmed with real
+`pytest` once the sweep releases the working tree** — the analytic pass is the fast check, not a
+substitute for it.
+

--- a/documents/audits/FABLE_763_deferral_exit.md
+++ b/documents/audits/FABLE_763_deferral_exit.md
@@ -1,0 +1,746 @@
+# FABLE EXIT GATE #763 — the deferral tyre liability, attacked before promotion
+
+**Date:** 2026-07-31 · **Branch:** `feat/deferral-tyre-liability` @ `4652c48` · **Gate type:** adversarial EXIT gate
+**Mandate:** success = finding what is STILL broken. No repository file modified except this report
+(any temporary mutation is backed up with `cp` and restored from the backup, diffed, and stated).
+All evidence executed, `profile="no-llm"`, zero API calls. The agreement metric's direction is
+NOT evidence for or against the design (forbidden loop).
+
+---
+
+## Checklist
+
+- [x] ⭐ PRIMARY — the amplification, quantified: **6-8×, measured** (design gate predicted 4-6×)
+- [x] A. E3 invariance — re-derived independently: **HOLDS exactly, under both readings of "first"**
+- [x] B. The two-branch minimum — **both branches win on real inputs**; `k = 0` right for `deg >= 0`
+- [x] C. Double counting — **disjoint, verified**, including `laps_remaining < window_laps`
+- [x] D. The cliff onset — **wrong, not merely simplified: it contradicts the model's own
+      `cliff_laps`, is the SOLE source of the liability on 310 laps, and is untested**
+- [x] E. E5's decomposition — 14 ✓, +4 ✓, but **"2 lost" is really 3 lost and 1 gained**
+- [x] F. `pending=None` — **0 of 2,744 laps**; the real inertness is `deg is None` (42.6%)
+- [x] G. Mutation battery — **4 real mutants, 4 survivors (incl. deleting the feature's wiring);
+      3 sanity controls, 3 caught**
+- [x] Local bug classes: wrong-mechanism comment **in the changed function's own docstring**;
+      empty-set assertion **found, positive-controlled, passes for the right reason**; the
+      `simulate_lap_window` twin **defensible, but its comment is now conditionally false**
+
+### Severity tally
+
+| | count |
+|---|---|
+| **HIGH** | 3 — the untested disconnection (§G / mutant M5) · the failed E4 amplification, evidenced twice (population-range flips **and** plausible-error flips at 6-8×) · the cliff term charging an assumed onset that contradicts the model's own `cliff_laps`, on 310 laps where the tyre reading is ≤ 0 |
+| **MEDIUM** | 6 — wrong mechanism in the changed docstring · the q_f discount on a stopless branch · E2/E4 skipped · deg reaching its bounds · the Barcelona concentration · two shipped tests now passing for the wrong reason |
+| **LOW** | 6 — dead `else` branch · E5's "2 lost" · E5's unstated "first" definition · E1's "green-flag" label · docs-site drift · the legacy twin's comment |
+
+Findings appended below as confirmed, each with file:line, a concrete failing scenario, and
+executed evidence.
+
+### The verdict in one paragraph
+
+**The term is physically motivated, correctly bounded, and its headline claims are true.** E1's
+13-lap median is real, E3's invariance is exact, the double counting is disjoint, both branches
+of the minimum genuinely win, the liability can never exceed the stop it defers, and the twin
+scorer really does not need it. **What is broken is one half of the formula and everything
+AROUND it.** The suite does not test that the term is connected, so the feature can be deleted
+from the scorer with 173 tests green. The design gate's own E4 was skipped and, executed here,
+fails: a tenth of a second per lap of tyre error now flips 8.6% of elective decisions against
+1.0% before — a 6-8× amplification, at the top of the band the gate predicted. The cliff half of
+the formula ignores the tyre model's own `cliff_laps` and is, on 310 real laps, the ONLY thing
+charging a liability at all — including on tyres the model calls no worse than fresh. And the
+function's own docstring still tells the reader the opposite of what the code does. None of that
+argues for reverting; it argues the term shipped without the two gates specified for exactly this
+risk, and that its cliff half wants the fix its wear half already has.
+
+---
+
+## A + E. The invariance and the decomposition re-derived independently — VERIFIED, with one wording defect
+
+**Method (mine, not the author's script):** extracted the before report from `f3f0207`
+(`harness_sha d97a54e`, 54 scored / 79 no_call / 24 no_boundary / 18 exact — matches E5's
+"before" column) and joined it against the committed after report (`4652c48`) on
+`(year, race, driver, actual_lap)`. Key sets are IDENTICAL: 178 = 178, zero mismatches, so the
+comparison is like-for-like (`scratchpad/rederive_e3_e5.py`).
+
+**Verified, executed:**
+
+- **Declines 79 → 65 (−14) ✓**, decomposing as 7 `no_call → no_boundary` + 7 `no_call → scored`.
+- **Scored 54 → 58 (+4) ✓** = 7 in − 3 out (`scored → no_boundary`: VER/OCO/HAD Barcelona).
+- **Exact 18 → 16 ✓.**
+- **E3 invariance holds under BOTH definitions of "first".** Under the natural reading of E5's own
+  sentence — the driver's first stop *within the graded verdict list* — the split is **114/64**,
+  not 89/89; under "first stop of ANY kind from the raw `PitInTime` data, including neutralised
+  stops" the split reproduces E5's table EXACTLY (89/89; FIRST scored 38→38, exact 10→10,
+  no_call 29→29, no_boundary 14→14). Under EITHER split, **zero** first stops changed bucket and
+  **zero** first-stop chosen laps moved; all 19 changed stops are elective under both. The
+  invariance claim is genuine and robust to the definition.
+- **Chosen-lap churn:** among the 51 stops scored in both runs, exactly 2 moved — ANT Barcelona
+  49→45 and BOR Barcelona 49→44, both elective, both 4-5 laps EARLIER.
+
+**FINDING [LOW] — E5's exact-agreement decomposition says "two that used to land exactly no
+longer do"; the truth is THREE lost, ONE gained** (`documents/audits/MEASURE_763_deferral_effect.md`,
+"the exact-agreement fall decomposes" section). Executed: lost exact = ANT Barcelona 49 (now
+chosen 45), BOR Barcelona 49 (now 44), **OCO Barcelona 43 (exact before, now
+`no_boundary_in_window` — not graded at all)**; gained exact = PIA Monaco 48 (was a decline).
+Net −2 is right, but the honest sentence is "three exact calls were lost — one of them pushed
+clear out of the gradable window — and one new exact appeared." An exact agreement that the term
+converts into *no locatable decision* is a qualitatively worse trade than an exact agreement that
+drifts two laps, and the current wording hides that shape.
+
+**FINDING [LOW] — E5 does not state that "the driver's first of the race" is computed from ALL
+raw stops including neutralised ones.** A reader re-deriving the split from the committed
+verdicts JSON alone (which contains only the 178 green-flag stops) gets 114/64 and different
+levels in every cell of the E3 table (e.g. elective decline rate 53.1% → 31.3% instead of the
+published 56.2% → 40.4%). The deltas are identical, so no conclusion changes, but the table is
+not reproducible from the artefact it sits next to without the unstated definition.
+
+**Two smaller provenance slips in the same header line** (`MEASURE_763_deferral_effect.md:5-6`,
+both LOW, folded in here rather than counted separately): it says *"Harness `f3f0207` (before)"*
+while that report's own `harness_sha` is `d97a54e` — the doc names the commit that COMMITTED the
+report, the artefact names the harness that RAN it, and a reader chasing either will not find the
+other. And it says *"against `311f234` + the deferral term"*, but `311f234` is a descendant of
+`bcd2c9d`, so it already contains the term; the "+" double-counts it. Neither changes a number.
+
+**"One production change between them" — VERIFIED.** `git log d97a54e..311f234 -- src/ scripts/`
+shows three production commits, but the two besides the term cannot reach the measured number:
+`4520431` changed docstrings and LLM prompt strings only (the no-llm action never sees a prompt),
+and `285f33b`'s previous-lap sentinel flows into `pace_out`, which is not among
+`_run_projection_mc`'s inputs — the no-llm action is `best_mc_candidate(mc_results)` + rails
+(`src/strategy/inference/no_llm.py:290-294`), and the projection MC takes rivals / position /
+laps_remaining / pit_context / draws / deg only (`strategy_orchestrator.py:1441-1453`). The
+attribution of the 79→65 move to the deferral term is sound.
+
+---
+
+## Structural findings (code-level, confirmed by inspection; quantification follows below)
+
+### FINDING [LOW] — dead `else` branch in `_terminal_gaps` duplicates the None rule and would
+### change its meaning if it ever became reachable
+
+`src/agents/position_projection.py:795-799`. The branch is unreachable: a non-stopping plan with
+`pending is None` already returned at line 783-784, a stopping plan takes line 786-787, True and
+False take 788-794 — no input reaches the `else`. Two defects in one: (1) dead code carrying a
+comment ("exactly as it did before this term") that claims to BE the live None path; (2) the dead
+branch is not equivalent to the live one — the early return at :783 suppresses `their_residual`
+too (the "rule binds BOTH sides" behaviour of the docstring, tested by
+`test_an_unknown_obligation_of_OURS_suppresses_the_credit_too`), while the else would fall
+through to line 801-811 and apply the rivals' residuals. If a future refactor deletes the early
+return trusting the else to cover None, the None semantics silently flip from "no claim either
+way" to "claim about them but not about us". One rule, two homes — this repo's documented drift
+pattern.
+
+**And there is one input that DOES reach it**, which makes the divergence live rather than
+latent: a **numpy** boolean. Executed: `np.True_ is True` → `False`, `np.False_ is False` →
+`False`, so a `mandatory_stop_pending` arriving as `np.bool_` (anything sourced from a pandas
+column rather than from `stint_history.py`'s Python literals) passes every `is` check, lands in
+the `else`, and is scored as "unknown-but-still-credit-the-rivals" — the exact half-claim the
+docstring at `:770-777` says the module must never make. The three shipped producers all emit
+Python bools today, so this is not a current bug; it is a silent wrong answer waiting for the
+first pandas-sourced caller, and the `is` comparisons are what make it silent.
+
+### FINDING [MEDIUM] — the cliff comment names the wrong mechanism, and the "purity" defence is
+### false: the per-draw `cliff_laps` is available at the call site and simply not passed
+
+`src/agents/position_projection.py:716-722`. The comment says using the config window as the
+cliff onset "keeps this function pure and its inputs already-measured". Purity is not the
+constraint: `project_positions` holds the per-draw `cliff_laps` at the moment it calls
+`_terminal_gaps` (`position_projection.py:861`) and passes `pit_loss_s` — another per-draw
+array — right next to it. Passing `cliff_laps` through would be exactly as pure. The real
+simplification is an unthreaded argument, and it has a price in both directions:
+
+- **set past the cliff at the window edge** (per-draw `cliff_laps` < window): the run-out branch
+  grants `window_laps` cliff-free laps that do not exist — undercharges the run-out by up to
+  `window_laps * cliff_loss_s` = 5 × 0.80 = **4.0 s**, biasing toward STAY_OUT;
+- **fresh set, cliff far away** (per-draw `cliff_laps` > 2·window): the run-out is charged cliff
+  laps that never happen — e.g. `cliff_laps=20`, `remaining=25` overcharges
+  `(20−10−5)... = (25−15)−(25−20+...)` → modelled 20 cliff laps vs true 10, **+8.0 s** on the
+  run-out, biasing toward saturation at the residual and thus toward PIT.
+
+The onset is exact only when the draw's cliff sits exactly `2·window_laps` laps out.
+
+**Executed on the 2,744 real laps** (variant: same function with the cliff onset taken from the
+caller's per-draw `cliff_laps` instead of the config window, everything else identical):
+the variant **flips the argmax on 60 laps** and moves `E[STAY_OUT]` by up to **3.0 positions**
+(p95 of the delta). So the "simplification for purity" is worth three positions and sixty
+decisions on one six-race sample, and it has **zero test coverage** (§G: the test fixture pins
+`cliff_loss_s: 0.0`). **Upgraded to HIGH by later execution — see "the liability is charged
+ENTIRELY by the cliff term on 310 laps" below.** The docstring also gives a reason ("keeps this
+function pure") that is not the real one, and no test would notice if the branch were deleted.
+
+### FINDING [MEDIUM] — the q_f discount on the run-it-out branch credits an option that branch
+### would never exercise
+
+`src/agents/position_projection.py:723-725` discounts `run_it_out` by
+`q_f · neutralisation_saving_s`; the docstring's justification (:693-694) is "a neutralisation
+that turns up covers a deferred stop whichever branch wins". The run-it-out branch contains **no
+stop** — there is nothing for a Safety Car to cover. Concrete failing scenario: `remaining=20`,
+`deg=0.30` → wear-to-flag 6.0 s; `q_f=0.4`, saving 8 → charged `max(0, 6.0−3.2)=2.8 s`. If an SC
+actually arrived, converting to a stop would cost `pit_loss − saving ≈ 14.8 s` — more than the
+6.0 s of remaining wear — so the option would never be exercised, yet the liability was cut by
+more than half for it. Because both branches subtract the SAME `q_f·saving`, the discount never
+changes which branch wins (min(a−d, b−d) = min(a,b)−d up to the zero clamps); its entire effect
+is to shrink the liability by up to ~3.3 s uniformly — always in the STAY_OUT direction, on
+exactly the population the term was built to stop under-charging. The mechanism the docstring
+names is wrong; the correct option value of the run-out branch is
+`q_f · max(0, wear_after_arrival − (pit_loss − saving))`, which is ~0 in the scenario above.
+
+**Executed magnitude on the real laps:** `q_f` runs p25 0.295 / median 0.405 / p75 0.502 / max
+0.699, so the unearned discount is **median 3.24 s, up to 5.59 s** per lap, and on **229 laps
+(12.5% of the elective population) it drives the run-it-out branch to exactly zero on its own** —
+i.e. on one elective lap in eight, the entire deferral cost is cancelled by an option the branch
+cannot exercise. That is a systematic under-charge of the very population the term exists to stop
+under-charging, and it is the only part of the formula whose direction is not conservative.
+
+## ⭐ PRIMARY — the amplification, quantified on 2,744 real 2025 laps
+
+**Method:** every `_run_projection_mc` call of a full `measure_decision_agreement()` run was
+captured with its exact kwargs (2,744 laps, reproducing the committed report to the digit), then
+each lap was re-scored through the production functions under variants that swap only
+`_deferral_tyre_liability_s` or `deg_cost_s`. Argmax uses the production tie-break
+(`best_mc_candidate`), never a reimplemented `max`. Scripts:
+`scratchpad/{capture_projection_inputs,analyze_captures,sensitivity_small}.py`.
+
+### The liability's size
+
+```
+pending=False laps: 1839      (the population the term is scoped to)
+liability, GREEN config, seconds:   p5 0.00  p25 0.00  p50 0.00  p75 18.62  p95 21.76  MAX 28.57
+liability in POSITIONS (E[STAY_OUT] with the term off minus on):
+                                    p25 0.00  p50 0.00  p75 2.00  p95 5.80  MAX 11.99
+fully saturated at the residual cap: 530 laps (28.8%)     partially: 43
+```
+
+Flipped laps are characterised by `laps_remaining` median 33 (max 62) and `deg` median 0.97 —
+i.e. the term acts EARLY in a race on a visibly worn set. At those horizons the run-it-out branch
+prices holding the set for 30-57 more laps, which no set survives; the `min` correctly caps it at
+the residual, so the arithmetic lands right through a branch that is physically fictional. One
+consequence worth naming: in the 28.8% saturated regime, an elective stop is priced **identically
+to a mandatory one**, which erases the pending=True/False distinction the design gate's whole
+analysis rests on — for a defensible reason (the tyre must be changed eventually), but nowhere
+stated.
+
+**The median is zero and the p75 is eighteen and a half seconds.** The distribution is bimodal:
+inert on ~two thirds of the population (no reading, or a reading ≤ 0), then jumping to near the
+full pit loss. **On 28.8% of elective laps the liability SATURATES** — the run-it-out branch
+exceeds the whole discounted pit loss, so the `min` returns the residual and staying out is
+charged an entire pit stop. **Its worst case moves the terminal position by 11.99 places on a
+single lap.**
+
+To the mandate's question — *can the term produce a liability larger than any plausible real
+cost?* — **no, and that is structural, not luck:** the `min` at `:727` caps it at
+`_stop_residual_s(pit_loss_s)`, so the most staying out can ever be charged is the stop it is
+avoiding. The 28.57 s maximum is a long-pit-lane circuit's own pit loss. **The cap is the term's
+strongest property and it is untested (see §G, M5/M3).**
+
+### The argmax impact
+
+```
+argmax flips, term ON vs term OFF: 338 of 2744 laps (12.3%) — every one on pending=False
+  STAY_OUT -> UNDERCUT : 250
+  STAY_OUT -> PIT_NOW  :  88
+```
+
+**Every one of the 338 is `pending=False`** — the scoping is airtight at the lap level, not only
+at the verdict level, which is a stronger form of E3 than E5 could show (18.4% of the elective
+population flips; 0% of the mandatory one). All flips are in one direction (stop instead of stay
+out), as designed. Note **UNDERCUT takes
+three quarters of them**: the term's practical effect is less "call the elective stop" than "call
+the elective stop AS an undercut", which neither MEASURE doc mentions and which routes the
+decision through `ucut_prob` — a 0.5 prior whenever `pit_out` is None, which is **always** on the
+no-llm path this tier measures (`src/strategy/inference/no_llm.py:274`, N28 never runs). Worth
+stating: on the measured configuration, 250 of the 338 recovered calls are gated behind a
+coin-flip undercut probability.
+
+### FINDING [MEDIUM] — the effect is not distributed across the stratified sample: it is
+### Barcelona, and one whole circuit archetype receives it on 0.9% of its laps
+
+The six races were chosen for circuit archetype, and E5 reports the result as a property of the
+sample. Executed per race:
+
+| race | laps | pending=False | deg known | liability > 0 | argmax flips |
+|---|---|---|---|---|---|
+| **Barcelona** | 737 | 522 | 456 | 425 | **216** |
+| Monaco | 558 | 329 | 241 | 213 | 70 |
+| Marina Bay | 308 | 168 | 141 | 128 | 30 |
+| Monza | 219 | 86 | 59 | 49 | 11 |
+| Lusail | 313 | 153 | 105 | 82 | 10 |
+| **Silverstone** | 609 | **581 (95%)** | **53** | **5** | **1** |
+
+**Barcelona alone carries 64% of the argmax flips from 27% of the laps**, and the E5 verdict
+changes agree: 15 of the 19 changed stops are Barcelona, 4 are Monaco, and the other four races
+contribute **zero**. **Silverstone is the sharpest case**: 95% of its laps are elective (the
+wet-compound exemption discharges the obligation for nearly everyone), which should make it the
+term's ideal population — and the tyre channel has a reading on only 53 of 581, so the liability
+is non-zero on **5 laps** and flips **one** decision. The archetype the sample includes to cover
+variable weather is exactly the one where the fix cannot reach, because the same wet running that
+makes the stop elective is what denies `_fresh_reference` its lookup. E5's "fourteen fewer
+declines" is a real number and a Barcelona-and-Monaco number; it should not be read as
+sample-wide.
+
+### FINDING [HIGH] (evidence 1 of 2) — the design gate's own E4 criterion FAILS: the argmax
+### flips well inside the tyre reading's range
+
+Substituting the observed p1 (−2.262) or p99 (+3.670) of `deg_cost_s` — both *inside* the
+measured `[-2.33, +3.67]` bound, both values real laps actually carry — flips the argmax on
+**403 (38.2%)** and **501 (47.5%)** of the 1,055 elective laps with a reading. The design gate
+pre-registered the criterion in `DESIGN_763_window.md` §E4: *"A formulation whose recommendation
+flips inside its input's confidence interval is not measured yet."* E4 was never executed before
+shipping (see the E2/E4 finding above); executed here, **it does not pass**.
+
+Caveat stated because it matters: p1/p99 are the *population* range of `deg_cost_s`, not a
+per-lap confidence interval — #744a published no per-lap CI, which is itself part of why this
+criterion could not be met honestly. So the finding is nailed down with a plausible-error version
+below, which does not depend on that distinction.
+
+### FINDING [HIGH] (evidence 2 of 2) — the amplification the design gate predicted at 4-6×
+### MEASURES at 6-8×: a tenth of a second per lap of tyre error now flips one decision in twelve
+
+The design gate's closing sentence was: *"B3 prices the deferral with the SAME `deg_cost_s` whose
+level FABLE_G2/#744a showed to be reference-sensitive, now multiplied by `laps_remaining` instead
+of 5 — an error in deg is amplified ~4-6×. E4's sensitivity disclosure exists precisely for this;
+if deg's CI cannot support the amplification, B4 (or B5 as the interim) is the honest fallback."*
+
+Executed on the 1,055 elective laps carrying a reading, perturbing `deg_cost_s` by a
+measurement-error-scale amount in either direction, and re-running the SAME laps with the term
+wired and with it stubbed to zero so the amplification is isolated rather than inferred:
+
+| deg error | argmax flips WITH the term | flips WITHOUT it | **amplification** |
+|---|---|---|---|
+| **±0.1 s/lap** | **91 (8.6%)** | 11 (1.0%) | **8.27×** |
+| ±0.2 s/lap | 176 (16.7%) | 29 (2.7%) | 6.07× |
+| ±0.5 s/lap | 336 (31.8%) | 49 (4.6%) | 6.86× |
+
+**The predicted risk is real and is at the top of the predicted band.** A 0.1 s/lap error in the
+tyre channel — well inside what a per-stint fresh reference can be wrong by, given that #744a
+refuted two designs for it and #744b measured the shipped one at corr +0.369 — used to change 1%
+of elective decisions and now changes 8.6%. Flips are two-sided and symmetric (`STAY_OUT →
+UNDERCUT` on +187 / `UNDERCUT → STAY_OUT` on −184), i.e. these laps sit on the knife edge, not in
+a robust regime.
+
+**This is the finding the gate asked for and it did not pass.** It does not say the term is
+wrong — the physics argument (E1's 13-lap median) stands, and the liability's cap is sound. It
+says the term's output inherits, six- to eight-fold, an input error nobody has bounded, and that
+E4 should have been run before E5 rather than after promotion.
+
+## G. The tests — HIGH: the whole feature can be DISCONNECTED and all 173 tests stay green
+
+**Method:** `src/agents/position_projection.py` was `cp`-ed to `scratchpad/position_projection.py.bak`
+first; each mutant was written to disk, `uv run pytest tests/mc/ -q` run, and the file restored
+with `write_bytes(original)` from that backup. Baseline before any mutation: **173 passed**.
+
+| Mutant | file:line | Result |
+|---|---|---|
+| **M5 — the wiring deleted**: `our_residual = _deferral_tyre_liability_s(...)` → `np.zeros(...)` | `position_projection.py:794` | **SURVIVED (173 passed)** |
+| **M3 — the option value deleted**: `stop_later = _stop_residual_s(pit_loss_s, config)` → `np.asarray(pit_loss_s)` | `position_projection.py:714` | **SURVIVED (173 passed)** |
+| **M1 — the cliff onset removed**: `max(0, remaining - window_laps) * cliff` → `remaining * cliff` | `position_projection.py:720-722` | **SURVIVED (173 passed)** |
+| **M2 — the run-out's q_f discount deleted** entirely | `position_projection.py:723-725` | **SURVIVED (173 passed)** |
+| M4 — SANITY control: `np.minimum` → `np.maximum` (charge the DEARER future) | `position_projection.py:727` | CAUGHT (3 failed) |
+| M6 — SANITY control: `laps_remaining - window_laps` → `laps_remaining` (double-cover the window) | `position_projection.py:707` | CAUGHT |
+| M8 — SANITY control: `remaining * deg` → `0.5 * remaining * deg` (half the wear) | `position_projection.py:720` | CAUGHT (1 failed) |
+
+**Score: 4 real mutants, 4 survivors; 3 sanity controls, 3 caught.** The controls are the proof
+the battery works and that M1/M2/M3/M5 genuinely survive rather than the harness silently
+no-op'ing. **Restore verified byte-identical to the backup** after both batteries (`git diff`
+empty; `diff` against the `.bak` reports identical).
+
+The three controls were caught by just two tests —
+`test_the_liability_shrinks_as_the_flag_approaches` (M4, M6) and
+`test_the_liability_is_the_cheaper_of_the_two_futures` (M8) — both of which key on the `deg`
+factor. Eight tests in the module; two of them carry the whole defence, and between them they
+cover two of the formula's five terms.
+
+**M5 is the HIGH.** Ripping the term out of `_terminal_gaps` entirely — restoring the exact
+pre-#763 behaviour that the whole PR exists to change — leaves the entire `tests/mc` suite green,
+including the dedicated `tests/mc/test_deferral_tyre_liability.py`. The reason is structural: of
+the module's eight tests, four call `_deferral_tyre_liability_s` **directly** (never through the
+scorer) and the four that do go through `_terminal_gaps` all assert the term does **NOT** apply
+(`pending=True` → not called; `pending=None` → gaps unchanged; `stops_in_window` → gaps
+unchanged) or are the monkeypatched invariance test. **Not one test asserts that a pending=False
+non-stopping plan's terminal gap actually MOVES.** A regression that silently disconnects the
+feature — a refactor of the if/elif chain, a merge, a revert — ships green. This is the repo's
+own documented shape (`feedback_a_guard_that_asserts_nothing`): the suite proves the term is
+correctly *not* applied in three cases and never proves it is applied in the one that matters.
+
+**M1, M2 and M3 are the same gap, executed three ways.** The test fixture
+(`tests/mc/test_deferral_tyre_liability.py:39-51`) pins `cliff_loss_s: 0.0`,
+`neutralisation_saving_s: 0.0`, `future_neutralisation_prob: 0.0`, so **three of the five config
+inputs the function reads are held at their no-op value in every test in the module**. No test
+elsewhere in `tests/mc` covers them either (`test_tyre_wear_term.py:328,443` pass
+`pit_context=None` → the flag is `None` → the term is inert). Result: **every mutant that touches
+the cliff term or either q_f discount survives, and every mutant that touches the `deg` factor or
+the `min` is caught.** Of the five terms in the formula, the suite defends two.
+
+Executed proof rather than inference: M1 changes the cliff onset by up to 4.0 s per lap of
+liability, M2 deletes a median-3.24 s discount outright, M3 removes the option value from the
+other branch — **173 passed, three times.** Meanwhile M6 and M8, which mutate the SAME expression
+as M1 but on its `remaining` and `deg` factors, are both caught. The suite is not weak; it is
+**precisely blind along the two axes the fixture zeroes.**
+
+**Degenerate-assertion check.** `test_a_car_that_still_owes_its_stop_is_untouched` (`:93-114`)
+asserts `called == []` — an assertion about the empty set, which passes both when the patch works
+and when it silently fails to intercept. Positive control executed against a byte-identical copy
+of the restored file:
+
+```
+pending=True  (the shipped test's case): called = []
+pending=False (the positive control)   : called = [1]
+```
+
+The patch does intercept, so the test passes for the right reason. **Not a defect** — but it
+needed the control to know, and the test carries none of its own.
+
+### FINDING [MEDIUM] — two shipped tests now pass for a different reason than their names claim
+
+Both live in `tests/mc/test_position_projection.py` and both assert that a discharged obligation
+makes staying out **free**, which the term has just made false in production:
+
+- `test_having_already_stopped_removes_the_cost_entirely` (`:271-275`) — "a second set buys
+  nothing, so staying out is free", asserting terminal cost `== 0.0` with `pending=False`;
+- `test_a_wet_race_exempts_the_mandatory_stop_so_staying_out_is_free` (`:509-517`) — same
+  assertion, framed as the Art. 30.5(m) wet exemption "removing the liability entirely".
+
+They stay green only because `_flat_config` (`:84-95`) never sets `deg_cost_s`, so the dataclass
+default `None` (`position_projection.py:255`) short-circuits the new term at `:704`. **Executed**
+against the pristine module:
+
+```
+test_having_already_stopped_removes_the_cost_entirely, as shipped (deg unset): terminal cost 0.0
+                                  same fixture + deg_cost_s=0.5, laps_remaining=25: terminal cost 1.0
+test_a_wet_race_exempts_..._staying_out_is_free,      as shipped (deg unset): terminal cost 0.0
+                                  same fixture + deg_cost_s=0.5, laps_remaining=25: terminal cost 1.0
+```
+
+Give either fixture a real tyre reading and both assertions fail — correctly, because staying out
+is no longer free for a discharged obligation. Two tests whose NAMES state a rule the code no
+longer follows, surviving on an unset field: the exact "assertion passing for the wrong reason"
+shape, and the place a future maintainer will look to learn what the module guarantees.
+
+## F. The scoping's honesty — REFUTED in the mandate's direction, but a bigger inertness found
+
+**Executed** (`scratchpad/capture_projection_inputs.py`: every `_run_projection_mc` call during a
+full `measure_decision_agreement()` run, in-process wrapping only). The run reproduced the
+committed report EXACTLY — 2,744 laps captured, 178 verdicts, 58 scored, exact 0.2759, no_call 65,
+no_boundary 34 — so the captures describe the shipped measurement, and they independently confirm
+the design gate's "2,744 eval laps, 100% projection path".
+
+```
+mandatory_stop_pending over the 2,744 eval laps:
+  True   905  (33.0%)
+  False 1839  (67.0%)
+  None     0  ( 0.0%)     <- the hypothesis that None hides most of the population is REFUTED
+```
+
+**But the term is inert on 42.6% of the population it IS scoped to, for a different reason
+nobody stated:** `deg_cost_s is None` on **784 of the 1,839** pending=False laps
+(`position_projection.py:704-705` returns zeros), so an elective stop's pit loss still stands
+against exactly zero on more than four in ten of the laps the report describes as fixed. Neither
+E5 nor the commit message mentions this. The honest statement of the term's reach is *67% of laps
+by obligation, 38% of laps once the tyre reading is required*.
+
+## FINDING [MEDIUM] — `deg_cost_s` reaches its measured bounds on real laps, and 41% of its
+## values are at or below zero
+
+Over the 1,055 pending=False laps with a reading: p1 −2.262, median **0.159**, p75 0.902,
+p99 **3.670 — the ceiling itself**; 15 laps (1.4%) sit at the +3.67 ceiling and 10 (0.9%) at the
+−2.33 floor, so `MEASURE_744a`'s clamp (`tire_agent.py:248-249`, applied in `_referenced_wear`)
+is load-bearing, not theoretical. **19.4% of readings are NEGATIVE** and **21.9% are exactly
+0.0** — on 41.3% of elective laps with a "reading", the tyre channel says the current set is no
+worse than fresh. The liability is identically zero on **937 of 1,839 elective laps (51.0%)** and
+positive on 902 (49.0%).
+
+**Correction to my own first pass, stated rather than silently fixed:** I initially wrote that
+`deg <= 0` "drives the liability to zero" and put the inert share at ~66%. **That is wrong, and
+the reason it is wrong is the finding below** — the cliff term is charged independently of `deg`,
+so a zero or negative tyre reading does NOT zero the liability. Measured: of the 231 laps with
+`deg == 0.0`, **189 (82%) still carry a positive liability, median 8.41 s**; of the 205 with
+`deg < 0`, **121 (59%) do, median 2.97 s**. Only `deg is None` reliably zeroes it (784 laps, all
+zero).
+
+### FINDING [HIGH] — on 310 real laps the liability is charged ENTIRELY by the cliff term, on
+### tyres the model says are no worse than fresh, with an onset the model never supplied
+
+This is the finding above (D) upgraded by execution. `run_it_out = remaining · deg +
+max(0, remaining − window_laps) · cliff_loss_s` (`position_projection.py:720-722`) charges
+`CLIFF_LOSS = 0.80` s/lap from `window_laps` laps out to the flag **regardless of the per-draw
+`cliff_laps` the tyre model produced and the caller is holding**. Measured on the elective laps:
+the cliff term charges a median of **19 laps → 15.2 s**, up to **57 laps → 45.6 s** — on its own
+larger than any pit loss, so it alone saturates the `min`.
+
+Concretely: on **189 laps the tyre model reports `deg_cost_s == 0.0` — "this set costs nothing
+per lap versus fresh" — and the liability still charges a median 8.41 s**, entirely from an
+assumed cliff. On another **121 laps the model reports NEGATIVE wear** (the set is faster than
+the fresh reference) **and the liability is still positive.** The assumption "everything past lap
+`window_laps` is past the cliff" is not merely unjustified, it directly contradicts the tyre
+model's own `laps_to_cliff` distribution, which the caller samples into `cliff_s` and passes to
+`driver_time_delta` on the very next line (`position_projection.py:837, 861`).
+
+The in-window term gets this right — `driver_time_delta:621` uses `max(0, racing - cliff_laps)`,
+the per-draw value. The terminal term does not. **One quantity, two rules, in the same
+function's two horizons** — and the branch that gets it wrong has zero test coverage.
+
+## Method note — one of my own probes was invalid, and how the file was protected
+
+**Backup/restore discipline.** `src/agents/position_projection.py` was `cp`-ed to
+`scratchpad/position_projection.py.bak` before any mutation; every mutant is written to disk and
+then restored from that backup with `write_bytes`; the run asserts the final bytes equal the
+backup. `git checkout --` was never used. End state verified two ways: `git diff --numstat` empty
+and `diff` against the `.bak` clean.
+
+**The invalid probe, stated rather than quietly dropped.** While a mutant was on disk, a probe of
+mine imported the working-tree module and reported that the invariance test's monkeypatch "does
+NOT intercept" — a false HIGH I nearly published. It was caught by diffing the working tree
+(`git diff` showed `M5_wiring_deleted` applied). Fix adopted for every subsequent probe: load a
+byte-identical PRISTINE copy through `importlib` and register it in `sys.modules` before anything
+can import the working tree, asserting `pp.__file__` is the pristine path. Every executed number
+in this report comes from either that pristine module or a verified-clean tree.
+
+## FINDING [MEDIUM] — two of the design gate's four pre-conditions were skipped: E2 was never
+## run, and E4 exists only as an input-CI remark, not the demanded sensitivity of the conclusion
+
+`DESIGN_763_window.md` §E froze the sequence: "E1-E4 freeze the design; E5 is a single 2025
+re-run". Executed check: **E2 (the pre-registered sign test on 2023-24 elective stops) has no
+committed artifact, no script, and no mention in either MEASURE doc** — `grep` over
+`documents/audits/*763*` and `scripts/` finds it only in the design gate that demanded it. **E4
+("publish the conclusion's sensitivity to E1's CI ... a formulation whose recommendation flips
+inside its input's confidence interval is not measured yet") was reduced to one paragraph in E1
+saying the CI is ±1 lap** — a statement about the INPUT's tightness, not about whether the
+LIABILITY or any argmax flips across `deg_cost_s`'s error band, which is the exact quantity the
+gate's "single biggest risk" paragraph tied E4 to. The one-shot E5 was taken without the two
+gates that were supposed to precede it. **This gate executed the missing E4 and it does not pass**
+(6-8× amplification, ⭐PRIMARY) — so the skipped pre-condition was not a formality, and the
+finding it would have surfaced is the report's largest.
+
+## E1's basis re-executed — the numbers are REAL, the "green-flag" label is not
+
+**FINDING [LOW] — E1's sample is labelled "1,377 real green-flag stops"; 184 of them (13.4%) fail
+the repo's own green-flag definition, and the conclusion survives the correction.** Executed
+(`scratchpad/e1_green_filter_check.py`): the committed method reproduces to the decimal (1,377 /
+694 elective, never-repays 13.1%/10.8%, medians 14/13, within-5 9.7%/15.0%) —
+`scripts/measure_repayment_horizon.py` counts every stint increment and applies NO TrackStatus
+filter, while everything else in this repo that says "green-flag stop" means
+`green_flag_stops(laps, _neutralised_laps(laps))` (stop lap or lap+1 neutralised → excluded,
+`src/strategy/eval/projection.py:160-181`). Applying that filter: elective n=694→598, median
+13→12, within-5 15.0%→16.7%, never-repays 10.8%→6.9%. Every conclusion holds — the median stays
+far outside the 5-lap window — so this is a label defect, not a basis defect. The same phrase is
+propagated into `_deferral_tyre_liability_s`'s docstring (`position_projection.py:680`), the
+commit message of `bcd2c9d` and the test module docstring. "Green-flag" should either be applied
+or removed from the sentence.
+
+## C. Double counting — VERIFIED DISJOINT, with one uncharged band noted
+
+Traced at file:line, both charges for a non-stopping plan:
+
+- **In-window wear:** `driver_time_delta` else-branch (`position_projection.py:620-623`) charges
+  `racing_laps · deg` plus `max(0, racing_laps − cliff_laps) · cliff_loss`, with
+  `racing_laps = min(WINDOW_LAPS, laps_remaining)` under green
+  (`strategy_orchestrator.py:1205`, `_bounded_by_race_end`).
+- **Terminal liability:** `max(0, laps_remaining − window_laps)` laps of deg
+  (`position_projection.py:707`), where `laps_remaining = total_laps − current_lap`
+  (`strategy_orchestrator.py:870`).
+
+The window owns the first `window_laps` of the remaining race; the liability owns the rest.
+Disjoint in every case I could construct: `laps_remaining ≥ window` (green) partitions exactly;
+`laps_remaining < window` clamps the liability to zero while the in-window charge covers the
+clamped `racing_laps`; a plan that stops takes the zero branch at `:786-787` before the liability
+is reachable. The `laps_remaining < window_laps` edge the mandate asked about is handled by
+`max(0, ·)` at `:707` plus the `remaining <= 0` early-out at `:708`.
+
+**Note (not a finding): under a neutralised config the band is under-, never over-charged.** With
+`racing_laps ≈ 1.36` under SC, the laps between `racing_laps` and `window_laps` carry wear in
+NEITHER term (in-window stops at 1.36 racing laps; the liability still subtracts the full 5).
+Deliberate per the module's "non-racing laps cost nothing relative" stance, and in the
+conservative direction.
+
+## B. The two-branch minimum and the k = 0 collapse — HOLDS within the model; the comment's
+## premise is false for negative deg but the arithmetic self-corrects
+
+- **k = 0:** for `deg_cost_s ≥ 0`, every lap deferred past the window edge adds `deg` (and
+  possibly cliff) without reducing the pit loss, so the best later stop is the window edge —
+  the comment at `:711-713` is right. For `deg_cost_s < 0` (floor −2.33: the set is FASTER than
+  the fresh reference, `tire_agent.py:248`) the premise "every further lap adds wear" is FALSE —
+  the best later stop is as late as possible — but the run-it-out branch then goes negative, the
+  zero clamp floors it, and the min returns 0: the code lands on the right answer (deferral is
+  free, never a credit) through a branch the comment does not describe. No behavioural defect;
+  the comment states an unconditional premise that holds only for `deg ≥ 0`.
+- **A regime where waiting longer is genuinely cheaper** exists only through a time-varying
+  neutralisation hazard (waiting INTO a likely SC window), which the model deliberately flattens
+  into a single `q_f` over the whole remaining race. Within the model, no such regime exists;
+  outside it, this is the documented approximation `_stop_residual_s` already makes for
+  pending=True, so the term is no worse than its sibling.
+- **Both branches winnable on real inputs — VERIFIED, executed.** Over the captured laps'
+  `(lap, config)` calls, the `stop_later` branch wins the `min` on some draw in **1,146** calls
+  and the `run_it_out` branch on some draw in **2,618**; mean per-call saturation share 29.9%.
+  Neither branch is decorative, and 43 laps split the two WITHIN one lap's draws (the per-draw
+  pit-loss sample crossing the run-out cost), which is the regime the `min` exists for.
+
+### FINDING [MEDIUM] — the changed function's OWN docstring still states the pre-change
+### behaviour, 40 lines above the new branch
+
+`src/agents/position_projection.py:753-754`, inside `_terminal_gaps`'s docstring, list of "the
+three cases the deleted rail was patching":
+
+> `- already stopped (no obligation) -> our residual is zero, staying out costs nothing on this term;`
+
+That is precisely the case this PR changed: `pending is False` now carries
+`_deferral_tyre_liability_s`, so staying out costs up to a full pit loss on this term. A reader
+of the function that contains the change is told the opposite of what the code below does — the
+canonical "comment naming the wrong mechanism" shape, and the strongest instance in this diff
+because it lives in the same docstring.
+
+`ProjectionResult.terminal_positions`' docstring (`:277-282`, "once every KNOWN outstanding stop
+has been served") and `ProjectionConfig.mandatory_stop_pending` (`:234-236`, "``None`` ... disables
+the liability term") are both now incomplete in the same direction: the terminal horizon carries
+a tyre liability that is not an outstanding stop, and `False` no longer means "no liability".
+
+### FINDING [LOW] — the docs site describes the terminal liability as stop-only, in three places,
+### and none moved with the code
+
+`docs/pages/multi-agent.md:237` (`terminal_liability … the deferred mandatory stop, discounted by
+q_f`), `:249` ("the terminal liability applies only to the candidates that do not stop, because a
+deferred obligation is a cost only while it is still owed" — the second clause is now false: the
+liability now also applies when nothing is owed), and `:259` ("a still-owed stop costs the cars it
+will release behind us"). The repo's own lesson of 2026-07-16 is that "when a fix changes a
+contract, the page that describes it is part of the fix". Same class as the docstring finding
+above, lower severity because the docs site is not what the next maintainer edits against.
+
+### The twin question, answered: `simulate_lap_window` does NOT need this term, and that is a
+### defensible asymmetry rather than the repo's dominant defect repeating
+
+The repo's dominant defect is "one copy fixed, its twin not", so shipping to one scorer had to be
+attacked. It survives, on executed evidence rather than on the author's reasoning:
+
+1. **The legacy scorer decided 0 of the 2,744 eval laps** — independently reconfirmed by my own
+   capture: every lap routed to `_run_projection_mc`. The two scorers do not share the measured
+   population.
+2. **The legacy scorer has no terminal horizon at all.** `simulate_lap_window`
+   (`strategy_orchestrator.py:693-782`) scores a W-lap window relative to STAY_OUT and has no
+   `_terminal_gaps` analogue, no `mandatory_stop_pending` input, and no rivals. There is no place
+   to put a terminal liability without redesigning it.
+3. **It charges the stop at 2.8 s, not 22.8 s**, so the defect the term fixes (an elective stop's
+   full pit loss standing against zero) does not exist there in the same magnitude.
+
+So this is not the twin pattern. What IS owed is the comment correction below.
+
+### OBSERVATION [LOW] — the legacy twin's justifying comment is now documented-false for 41% of
+### real stops, and nothing marks it
+
+`src/agents/strategy_orchestrator.py:723-726` (docstring) and :762-765 (OVERCUT comment) argue
+the pit-lane traversal cancels because "the two-compound rule makes a stop mandatory, so pit-now
+and pit-later both pay it". #763's own census establishes that premise is false for 73 of 178
+real 2025 stops (elective, obligation discharged) — on the legacy path an elective STAY_OUT
+would genuinely avoid the traversal, and the comment's unconditional "mandatory" is now known
+wrong for that population. Not a regression from this PR (the legacy scorer decided 0 of 2,744
+eval laps, and its 2.8 s pit term accidentally under-prices rather than over-prices the elective
+stop), and shipping the term to one scorer is defensible on the executed census — but the twin's
+comment should stop stating an unconditional premise this branch just measured to be conditional.
+
+---
+
+## Fix list, ordered by value against risk
+
+Numbered, and deliberately separate from the findings. **Nothing here was applied** — this gate
+does not implement.
+
+1. **Add the connection test the suite is missing** (fixes G/M5, the HIGH). One test:
+   `pending=False`, non-stopping plan, a real `deg_cost_s`, assert the terminal gap moves by the
+   liability and that `terminal_positions != positions`. Cheap, and it is what would have caught
+   the disconnection mutant. **In the same pass, un-zero the fixture**: give at least one test a
+   non-zero `cliff_loss_s` and a non-zero `future_neutralisation_prob` / `neutralisation_saving_s`,
+   because today three of the formula's five terms are structurally unreachable and all three
+   mutants that touch them ship green (M1, M2, M3).
+2. **Correct `_terminal_gaps`' own docstring** (`position_projection.py:753-754`), plus
+   `ProjectionResult.terminal_positions` (`:277-282`) and `ProjectionConfig.mandatory_stop_pending`
+   (`:234-236`). Zero risk, and this is the comment a maintainer will trust.
+3. **Fix the two tests that now pass for the wrong reason**
+   (`tests/mc/test_position_projection.py:271-275, :509-517`) — either set `deg_cost_s=None`
+   explicitly with a comment saying the assertion is conditional on it, or re-state what they
+   guarantee. Their current names assert something production no longer does.
+4. **Publish the amplification measured here as the E4 the design gate demanded**, in
+   `MEASURE_763_deferral_effect.md`, alongside the reach numbers (67% by obligation, 38% once a
+   tyre reading is required, Barcelona carrying 64% of the effect). This is disclosure, not a
+   code change, and it is what makes the term honestly reported rather than honestly built.
+5. **Decide the q_f discount on the run-it-out branch** — either drop it (the branch has no stop
+   for a Safety Car to cover; median 3.24 s, zeroing the liability outright on 12.5% of elective
+   laps) or replace the docstring's justification with the real one. Behaviour change, so it
+   wants its own before/after, and it moves in the conservative direction.
+6. **Thread the per-draw `cliff_laps` into the liability** — promoted after execution: it is the
+   third HIGH, not a nicety. Today the terminal horizon assumes the cliff bites `window_laps` out
+   while the in-window term one function above uses the model's own `cliff_laps`; the assumption
+   is the SOLE source of the liability on 310 laps where the tyre reading is ≤ 0, contributes a
+   median 15.2 s (max 45.6 s), and flips 60 argmaxes. Do it right after (1) so a test exists that
+   would notice.
+7. **Delete the dead `else` at `:795-799`** or, better, delete the early return at `:783-784` and
+   let the `else` carry None — but only if `their_residual` suppression is preserved, which is the
+   whole reason the early return exists. One rule, one home.
+8. **Correct the record where it is cheap**: E5's "two that used to land exactly no longer do"
+   (three lost, one gained, one of them pushed out of the gradable set); E5's unstated definition
+   of "first stop"; E1's "green-flag" label; the three docs-site sentences; the legacy scorer's
+   "a stop is mandatory" comment.
+
+## What I tried to break and could NOT
+
+- **E3, the invariance.** This was the claim I most expected to break, because the author's own
+  note said the split had been got wrong twice. It holds, and it holds harder than reported:
+  re-derived from the two committed JSONs with my own join, under **both** plausible definitions
+  of "the driver's first stop" (114/64 from the verdicts alone, 89/89 from the raw `PitInTime`),
+  **zero** first-stop verdicts changed bucket and **zero** first-stop chosen laps moved. I also
+  checked the key sets are identical (178 = 178, no mismatches), so the before/after really is
+  like-for-like.
+- **The "one production change between them" attribution.** Two other commits sit in the range;
+  I traced both and neither can reach the no-llm action (`4520431` is docstrings + LLM prompt
+  strings; `285f33b`'s sentinel feeds `pace_out`, which `_run_projection_mc` does not take).
+- **Double counting.** I tried to construct an overlap between `driver_time_delta`'s in-window
+  wear and the terminal liability, including at `laps_remaining < window_laps`, under a
+  neutralised config, and for a stopping plan. The partition is clean; the only band nobody
+  charges is under-charged, never double-charged.
+- **The liability exceeding a plausible real cost.** I looked for an input that makes the term
+  charge more than the stop it defers. The `min` against `_stop_residual_s` caps it structurally;
+  the 28.57 s maximum observed is a long-pit-lane circuit's own pit loss. Even at
+  `laps_remaining=62`, where the run-it-out branch prices a physically impossible 57-lap stint,
+  the cap returns the right answer.
+- **The `k = 0` collapse.** I attacked it with a negative `deg_cost_s` (the floor is −2.33, and
+  19.4% of real readings ARE negative), where the comment's premise "every further lap adds wear"
+  is false. The zero clamps make the code land on a defensible answer anyway. I could not find a
+  regime inside the model where waiting longer is genuinely cheaper; the only candidate — a
+  time-varying neutralisation hazard — is flattened by `q_f` for the sibling term too. (What I
+  found INSTEAD, while testing this, is that a negative `deg` does not zero the liability at all
+  because the cliff term is charged independently — that is the third HIGH, and it came from an
+  attack that failed on its own terms.)
+- **A sentinel collision.** `deg_cost_s=None` is preserved as unknown (never 0.0);
+  `mandatory_stop_pending` uses the three-state `is True` / `is False` / else rather than
+  truthiness; `_lap_count_or_zero` clamps a negative to 0, which the `max(0, ...)` at `:707`
+  then makes inert. No searchable-value collision found in this diff.
+- **The 86.5% rejoin ground truth moving.** Executed:
+  `src/strategy/eval/projection.py:61-67`'s `_GROUND_TRUTH_CONFIG` carries `deg_cost_s=None`,
+  `mandatory_stop_pending=None` and `laps_remaining=0`, so the liability returns zeros through
+  three independent guards, and line 260 reads `result.positions` anyway. The design gate's
+  blast-radius claim survives.
+- **The empty-set assertion in the invariance test.** It is an assertion about the empty set, but
+  the positive control shows the monkeypatch genuinely intercepts, so it passes for the right
+  reason.
+- **The twin.** I looked for the repo's dominant defect and did not find it here: the legacy
+  scorer decided 0 of 2,744 measured laps, has no terminal horizon to hang the term on, and
+  charges a 2.8 s stop rather than a 22.8 s one. Only its justifying comment is now stale.
+- **The scoping leaking at the LAP level.** E3 only shows that no first-stop VERDICT moved, which
+  is compatible with the term firing on mandatory laps and being absorbed by the bucketing. I
+  checked every one of the 2,744 laps individually: all 338 argmax changes are `pending=False`,
+  and **zero** `pending=True` laps changed candidate. The scoping holds where it is hardest to
+  see.
+- **The commit message's factual claims.** Every number in `bcd2c9d`'s body that I could execute
+  — the 2,744-lap projection routing, the 79→65 declines, the 178-stop sample identity, the
+  694-elective/13-lap/15.0% E1 figures, "eight tests" — reproduces. The three retired artefacts
+  it names (92-lap break-even, 2.8 s pit term, 73.6%) are correctly retired.
+
+---
+
+**Report complete.** Every figure above was executed against either the committed artefacts or a
+byte-identical pristine copy of the branch's code. Final state verified: `git status` shows
+`src/agents/position_projection.py` unmodified, `git diff` is empty, and `diff` against the `cp`
+backup reports the files identical. `git checkout --` was never used. No repository file other
+than this report was changed.
+
+**Scripts, for anyone re-running this** (all under the session scratchpad, none committed):
+`capture_projection_inputs.py` (the 2,744-lap capture) · `analyze_captures.py` (liability
+distribution, saturation, branch shares, cliff variant) · `sensitivity_small.py` (the E4
+amplification) · `rederive_e3_e5.py` + `first_stop_defs.py` (A/E re-derivation) ·
+`e1_green_filter_check.py` (E1's label) · `mutation_battery.py` + `mutation_battery2.py` (§G) ·
+`test_probe_positive_control.py` (the empty-set control).

--- a/documents/audits/MEASURE_763_deferral_effect.md
+++ b/documents/audits/MEASURE_763_deferral_effect.md
@@ -1,0 +1,87 @@
+# E5 — what the deferral liability did, run once and reported as it came
+
+**Date:** 2026-07-31 · **Issue:** #763 · Harness `f3f0207` (before) against `311f234` + the
+deferral term (after). Same 2025 sample, same metric, one production change between them.
+
+The design gate's rule for this measurement was **one run, published whatever it says, and if it
+disappoints the design goes back to E1 and not to a knob**. This is that run.
+
+---
+
+## The headline
+
+| | before | after |
+|---|---|---|
+| Stops scored | 54 (30.3%) | 58 (32.6%) |
+| Exact lap | 33.3% (18) | 27.6% (16) |
+| **Declines (`no_call`)** | **79 (44.4%)** | **65 (36.5%)** |
+| `no_boundary_in_window` | 24 | 34 |
+| Mean signed error | −2.00 | −2.34 |
+
+**Fourteen fewer declines.** That is the largest single move any change in this epic has produced
+on the number #715 was opened about.
+
+## E3 — the invariance criterion, and it passes at the strongest level available
+
+The term is scoped to plans whose mandatory stop is already discharged. If first-stop behaviour had
+moved, the scoping leaked. Splitting the committed verdicts by whether the stop was the driver's
+first of the race:
+
+| | FIRST (n=89) | **ELECTIVE (n=89)** |
+|---|---|---|
+| scored | 38 → **38** | 16 → **20** |
+| exact | 10 → **10** | 8 → **6** |
+| `no_call` | 29 → **29** | **50 → 36** |
+| `no_boundary` | 14 → **14** | 10 → 20 |
+| decline rate | 32.6% → **32.6%** | **56.2% → 40.4%** |
+
+**Not one first-stop verdict moved, and not one first-stop chosen lap changed.** Every bucket is
+identical. The invariance is exact rather than within-tolerance, which is stronger than the gate
+asked for.
+
+**All fourteen recovered declines are elective stops**, which is the population the term was built
+for and the one carrying 65% of the declines.
+
+## The exact-agreement fall decomposes, and the decomposition is the whole story
+
+The rate fell 33.3% → 27.6%, which reads like a regression until it is split:
+
+- **First stops: 10 exact of 38 scored, before and after. Unchanged.** The half the layer was
+  already good at is untouched.
+- **Elective stops: 8 exact of 16 scored → 6 of 20.** The layer now attempts four more of them,
+  and two that used to land exactly no longer do.
+
+So the honest trade is **fourteen fewer declines against two lost exact agreements**, entirely
+inside the elective population. The headline *rate* fell mostly because the denominator grew: 58
+scored against 54, with a numerator two lower.
+
+That is not the same finding as #744b's, where the tyre term moved ten first-stop offsets a lap
+earlier and the mandatory half degraded. Here the mandatory half is provably inert.
+
+## What this does NOT establish
+
+**That the newly-called stops are well timed.** Twenty scored elective stops with six exact is a
+weak hit rate, and `no_boundary_in_window` rose 10 → 20, meaning more elective stacks are now
+already committed when the window opens. The layer has become much less reluctant about elective
+stops and is not yet good at timing them.
+
+**That agreement is correctness.** E1 measured that **10.8% of real elective stops never repay
+themselves in lap time at all** — teams stop for track position, traffic and Safety Car odds this
+layer does not model. A tenth of the events being graded against had no lap-time case for existing.
+
+**Coverage is still `masked`** at 32.6% against the 60% gate, so every figure above describes the
+subset where a decision is locatable.
+
+## The arc across the epic, for the record
+
+| state | declines | exact (count) |
+|---|---|---|
+| the metric fixed, no tyre channel | 82 (46.1%) | 23 |
+| + measured tyre wear (#744b) | 79 (44.4%) | 18 |
+| **+ the deferral liability (#763)** | **65 (36.5%)** | 16 |
+
+And the figure that opened all of this, #715, measured **65% declined**. It is now **36.5%**,
+against a mandatory-stop half that never moved.
+
+Related: `MEASURE_763_repayment_horizon.md` (E1, the basis) · `DESIGN_763_window.md` (the gate that
+refuted the original framing) · `MEASURE_744b_decision_effect.md`

--- a/documents/audits/MEASURE_763_repayment_horizon.md
+++ b/documents/audits/MEASURE_763_repayment_horizon.md
@@ -1,0 +1,88 @@
+# E1 — how long a real pit stop takes to repay itself
+
+**Date:** 2026-07-31 · **Issue:** #763 · **Sample:** 1,377 real green-flag stops, **694 of them
+elective**, across 2023-24. 2025 stays held out, the same hygiene the tyre reference used.
+
+This is the measured basis for the deferral liability. It is a fact about the sport, derived
+without consulting the 2025 agreement metric at any point — which matters, because the forbidden
+loop in this epic is tuning a constant until that metric recovers.
+
+---
+
+## The question
+
+`WINDOW_LAPS = 5` scores four candidates over five laps. A stop's cost lands inside that window;
+its benefit accrues over the laps that follow. So: **over how many laps does a real stop actually
+repay itself?** If the answer is comfortably inside five, the window is fine and #763 is wrong. If
+it is far outside, no fixed short horizon can price a stop and the liability has to integrate to
+the flag.
+
+## Method, stated before the numbers so it cannot be adjusted afterwards
+
+Per real stop, from the raw laps rather than from any model:
+
+- **pit loss** = the stop lap's time minus the driver's median green-flag lap in the stint just
+  left. What the stop actually cost on the road, not a modelled figure.
+- **advantage** = the median of the new stint's first three clean laps against the median of the
+  old stint's last three. The out-lap is excluded on both counts.
+- **repayment horizon** = `ceil(pit_loss / advantage)`.
+
+Quality gates are N04's own (`IsAccurate & ~Deleted`). A stop whose new set is not actually faster
+never repays and is **reported as such rather than dropped** — dropping it would bias the median
+toward the stops that happened to work.
+
+## The result
+
+| | all stops (n=1,377) | **elective (n=694)** |
+|---|---|---|
+| never repays (no positive advantage) | 13.1% | 10.8% |
+| pit loss, median | 18.2 s | 18.1 s |
+| advantage, median | 1.351 s/lap | 1.440 s/lap |
+| repayment horizon p25 | 9 | 9 |
+| **repayment horizon MEDIAN** | **14 laps** | **13 laps** |
+| repayment horizon p75 | 21 | 19.5 |
+| median 95% CI (bootstrap, 400) | [13, 14] | **[12, 14]** |
+| **repays within 5 laps** | 9.7% | **15.0%** |
+| repaid before the flag | 81.2% | 76.4% |
+
+## Reading it
+
+**A five-lap window can price at most a seventh of an elective stop's decision.** The median needs
+**13 laps**; only **15.0%** of real elective stops repay inside five. The other 85% were being
+compared against a horizon that ends long before their benefit arrives.
+
+**The confidence interval is tight**, [12, 14] laps on 694 stops. That matters for the risk the
+design gate flagged: the deferral liability multiplies `deg_cost_s` by the laps remaining rather
+than by five, amplifying any error in the tyre reading four- to six-fold. A horizon whose median
+moved by ±5 laps inside its own CI would not be safe to build on. ±1 is.
+
+**10.8% of elective stops never repay at all.** That is not noise to be cleaned up, it is the honest
+tail: teams stop for track position, traffic and Safety Car odds, not only for lap time. It is also
+a reminder that agreement with the pit wall is evidence and not correctness — a tenth of the stops
+this project grades the layer against had no lap-time case for existing.
+
+## What this does NOT justify
+
+**Not a wider `WINDOW_LAPS`.** A 13-lap median might read as "make the window 13", and the design
+gate refuted that separately: widening is monotone in favour of pitting with today's arithmetic and
+pushes first calls even earlier, which is the direction that had just cost five exact agreements.
+The horizon measured here justifies **integrating the deferred cost to the flag**, which is what
+`_deferral_tyre_liability_s` does, not stretching the window every candidate is scored over.
+
+**Not a claim that 13 is a constant to hardcode.** Nothing in the implementation stores 13. The
+liability runs to `laps_remaining`; this measurement is the evidence that a short fixed horizon
+cannot be right, not a number the code reads.
+
+## Reproducing
+
+```bash
+uv run python scripts/measure_repayment_horizon.py
+```
+
+Needs only `data/raw/2023/` and `data/raw/2024/`, so it does not run on CI. Runtime about two
+minutes. It is committed rather than left in a scratchpad because this project's rule is that a
+constant needs a measured basis, and a basis nobody can re-run is an assertion.
+
+Related: `DESIGN_763_window.md` (the gate that refuted the original framing) ·
+`MEASURE_744b_decision_effect.md` (the regression this explains) ·
+`MEASURE_744a_tyre_reference.md` (the `deg_cost_s` whose error this amplifies)

--- a/documents/audits/MEASURE_763_ship_decision.md
+++ b/documents/audits/MEASURE_763_ship_decision.md
@@ -1,0 +1,116 @@
+# #763 — the ship decision, and the error bound that decides it
+
+**Date:** 2026-08-01 · Branch `feat/deferral-tyre-liability` @ `110f4ed`
+
+**Verdict: do NOT merge.** The deferral liability is correct, its effect is real and
+targeted, and the input it consumes is not measured well enough to carry it at the horizon
+it uses. The blocker is now a number rather than an intuition.
+
+---
+
+## The bound that was missing all epic
+
+E4 — the design gate's sensitivity disclosure — has been **formally unevaluable** since #744a,
+because `deg_cost_s` never had a published per-lap error bound. Measured now against N04's own
+target on the same 31,624 training-season laps the reference was built from:
+
+| | |
+|---|---|
+| median absolute error | **0.261 s/lap** |
+| mean absolute error | **0.650 s/lap** (95% CI [0.623, 0.678]) |
+| signed bias | **+0.351 s/lap** |
+| laps with error under 0.1 s/lap | **21.9%** |
+
+By tyre-life band, and this is the part that decides it:
+
+| tyre life | median abs error |
+|---|---|
+| 3-10 | 0.209 |
+| 10-20 | 0.256 |
+| 20-30 | 0.308 |
+| **30+** | **0.557** |
+
+## Why that disqualifies the term
+
+**The amplification table understates the problem.** It was measured perturbing ±0.1 s/lap,
+which flips 7.1% of elective decisions. But 0.1 s/lap is **smaller than the model's typical
+error**. The real error sits between the ±0.2 row (13.1% flips) and the ±0.5 row (26.8%), so
+under the error the model actually makes, **one in four to one in eight elective decisions is
+decided by noise**.
+
+**The error grows exactly where the term is charged hardest.** The liability multiplies
+`deg_cost_s` by the laps remaining, so a 45-lap-to-go stint carries the 30+ band's 0.557 s/lap
+over 40 laps.
+
+**And the bias is not noise.** +0.351 s/lap systematic, integrated over ~40 remaining laps, is
+**~14 s of phantom cost** — the same order as the 22.8 s pit loss the term exists to compare
+against. A systematic offset that large does not average out over draws; it moves the argmax in
+one direction on every lap.
+
+**The behaviour also moved the wrong way under a correct fix.** Removing the double q_f discount
+was right, and the exit gate found no defect in the reasoning — but the amplification went 5.91×
+→ 6.82×, against a written prediction that it would fall. A term whose error behaviour surprises
+you when you fix a real bug in it is measured but not understood, and that is a worse state to
+ship from than "understood, awaiting a bound".
+
+## What the term DOES buy, so the negative result is not read as a dead end
+
+On the same 2025 sample, harness `110f4ed`:
+
+| | before | after |
+|---|---|---|
+| declines (`no_call`) | 79 (44.4%) | **66 (37.1%)** |
+| scored | 54 | 57 |
+| exact | 33.3% | 28.1% |
+
+**Thirteen fewer declines, every one an elective stop**, with the mandatory-stop half provably
+inert (E3: not one first-stop verdict moved, not one chosen lap changed). The mechanism works.
+It is the input that cannot carry it.
+
+## What unblocks it
+
+Reduce `deg_cost_s`'s error, or remove its bias. Either makes E4 evaluable and this decision
+re-runnable in one command. **The bound belongs to `deg_cost_s` as a class, not to this term** —
+`driver_time_delta` already consumes the same biased input on the shipped path, at 5 laps of
+exposure rather than 40. That is 1/8 the amplification and the same systematic offset, and it is
+on `main` today.
+
+---
+
+## Separate finding: what a lap of offset actually costs
+
+The report leads with EXACT-lap agreement, and the reasonable objection is that matching the
+exact lap demands reproducing a call made with radio, tyre temperatures and rival intel this
+layer does not have — so a ±3 lap band might be the fairer headline.
+
+**Measured on 1,551 real stops, it is not.** The median fresh-set advantage is **1.137 s/lap**,
+and the measured green-flag gap between consecutive cars is **2.227 s** (n=69,487):
+
+| offset | seconds | **track positions** |
+|---|---|---|
+| 1 lap | 1.14 | **0.51** |
+| 2 laps | 2.27 | **1.02** |
+| 3 laps | 3.41 | **1.53** |
+| 5 laps | 5.69 | **2.55** |
+
+**It takes 1.96 laps of offset to lose a whole track position.** So a ±3 band would be accepting
+calls that cost a place and a half — not "the same strategic window", a materially worse race
+result.
+
+**The estimate is conservative in both directions that matter.** It prices offset purely in pace
+terms and ignores traffic on the rejoin, which is the main reason teams care about exact timing
+and would make offsets cost more. And 2.227 s is the pooled median; in a tight midfield the gap
+is smaller and a lap of offset costs more, not less.
+
+**Conclusion: exact-lap and within-1 are the right resolution**, and the report keeps them. That
+was the existing framing, but it now has a measured basis rather than being the default.
+
+## Reproducing
+
+```bash
+uv run python scripts/measure_deg_error_bound.py     # the bound
+uv run python scripts/measure_offset_cost.py         # the resolution
+```
+
+Related: `DESIGN_763_window.md` · `FABLE_763_deferral_exit.md` ·
+`MEASURE_763_repayment_horizon.md` · `MEASURE_744a_tyre_reference.md`

--- a/documents/eval_reports/decision_modes.json
+++ b/documents/eval_reports/decision_modes.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "311f234",
+    "harness_sha": "110f4ed",
     "dataset": "data/raw laps, stratified 6-race subset (RAW, not featured)",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-31T12:21:44+00:00",
+    "generated_at": "2026-08-01T14:20:35+00:00",
     "artifacts": {}
   },
   "status": "masked",
@@ -38,22 +38,22 @@
     }
   ],
   "agreement": {
-    "sample_size": 58,
+    "sample_size": 57,
     "eligible": 178,
-    "scored_share": 0.3258426966292135,
+    "scored_share": 0.3202247191011236,
     "races": 6,
-    "exact": 0.27586206896551724,
-    "within_one": 0.3793103448275862,
-    "within_two": 0.4482758620689655,
-    "mean_signed_error": -2.3448275862068964,
-    "mean_absolute_error": 2.4827586206896552
+    "exact": 0.2807017543859649,
+    "within_one": 0.38596491228070173,
+    "within_two": 0.45614035087719296,
+    "mean_signed_error": -2.2982456140350878,
+    "mean_absolute_error": 2.43859649122807
   },
   "buckets": {
     "closing_laps": 4,
     "min_stint": 17,
     "no_boundary_in_window": 34,
-    "no_call_in_window": 65,
-    "scored": 58
+    "no_call_in_window": 66,
+    "scored": 57
   },
   "verdicts": [
     {
@@ -223,8 +223,8 @@
       "race": "Barcelona",
       "driver": "HUL",
       "actual_lap": 45,
-      "chosen_lap": 40,
-      "offset_laps": -5,
+      "chosen_lap": 44,
+      "offset_laps": -1,
       "bucket": "scored"
     },
     {
@@ -241,9 +241,9 @@
       "race": "Barcelona",
       "driver": "LAW",
       "actual_lap": 44,
-      "chosen_lap": 43,
-      "offset_laps": -1,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,

--- a/documents/eval_reports/decision_modes.json
+++ b/documents/eval_reports/decision_modes.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "d97a54e",
+    "harness_sha": "311f234",
     "dataset": "data/raw laps, stratified 6-race subset (RAW, not featured)",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-31T09:40:54+00:00",
+    "generated_at": "2026-07-31T12:21:44+00:00",
     "artifacts": {}
   },
   "status": "masked",
@@ -38,22 +38,22 @@
     }
   ],
   "agreement": {
-    "sample_size": 54,
+    "sample_size": 58,
     "eligible": 178,
-    "scored_share": 0.30337078651685395,
+    "scored_share": 0.3258426966292135,
     "races": 6,
-    "exact": 0.3333333333333333,
-    "within_one": 0.4444444444444444,
-    "within_two": 0.5185185185185185,
-    "mean_signed_error": -2.0,
-    "mean_absolute_error": 2.1481481481481484
+    "exact": 0.27586206896551724,
+    "within_one": 0.3793103448275862,
+    "within_two": 0.4482758620689655,
+    "mean_signed_error": -2.3448275862068964,
+    "mean_absolute_error": 2.4827586206896552
   },
   "buckets": {
     "closing_laps": 4,
     "min_stint": 17,
-    "no_boundary_in_window": 24,
-    "no_call_in_window": 79,
-    "scored": 54
+    "no_boundary_in_window": 34,
+    "no_call_in_window": 65,
+    "scored": 58
   },
   "verdicts": [
     {
@@ -79,9 +79,9 @@
       "race": "Barcelona",
       "driver": "VER",
       "actual_lap": 47,
-      "chosen_lap": 46,
-      "offset_laps": -1,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -115,8 +115,8 @@
       "race": "Barcelona",
       "driver": "ANT",
       "actual_lap": 49,
-      "chosen_lap": 49,
-      "offset_laps": 0,
+      "chosen_lap": 45,
+      "offset_laps": -4,
       "bucket": "scored"
     },
     {
@@ -135,7 +135,7 @@
       "actual_lap": 42,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -151,9 +151,9 @@
       "race": "Barcelona",
       "driver": "LEC",
       "actual_lap": 40,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 35,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -171,7 +171,7 @@
       "actual_lap": 24,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -180,7 +180,7 @@
       "actual_lap": 44,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -223,9 +223,9 @@
       "race": "Barcelona",
       "driver": "HUL",
       "actual_lap": 45,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 40,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -241,9 +241,9 @@
       "race": "Barcelona",
       "driver": "LAW",
       "actual_lap": 44,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 43,
+      "offset_laps": -1,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -259,9 +259,9 @@
       "race": "Barcelona",
       "driver": "OCO",
       "actual_lap": 43,
-      "chosen_lap": 43,
-      "offset_laps": 0,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -277,9 +277,9 @@
       "race": "Barcelona",
       "driver": "NOR",
       "actual_lap": 48,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 43,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -315,7 +315,7 @@
       "actual_lap": 46,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -331,8 +331,8 @@
       "race": "Barcelona",
       "driver": "BOR",
       "actual_lap": 49,
-      "chosen_lap": 49,
-      "offset_laps": 0,
+      "chosen_lap": 44,
+      "offset_laps": -5,
       "bucket": "scored"
     },
     {
@@ -367,9 +367,9 @@
       "race": "Barcelona",
       "driver": "HAD",
       "actual_lap": 48,
-      "chosen_lap": 47,
-      "offset_laps": -1,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -387,7 +387,7 @@
       "actual_lap": 41,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -423,7 +423,7 @@
       "actual_lap": 35,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -558,7 +558,7 @@
       "actual_lap": 44,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -610,9 +610,9 @@
       "race": "Monaco",
       "driver": "NOR",
       "actual_lap": 50,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 46,
+      "offset_laps": -4,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -664,9 +664,9 @@
       "race": "Monaco",
       "driver": "BOR",
       "actual_lap": 35,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 34,
+      "offset_laps": -1,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -745,9 +745,9 @@
       "race": "Monaco",
       "driver": "PIA",
       "actual_lap": 48,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 48,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,

--- a/documents/eval_reports/decision_modes.md
+++ b/documents/eval_reports/decision_modes.md
@@ -1,17 +1,17 @@
 # decision_modes
 
-- harness `311f234` · schema v1 · generated 2026-07-31T12:21:44+00:00
+- harness `110f4ed` · schema v1 · generated 2026-08-01T14:20:35+00:00
 - era 2022-2025 · dataset data/raw laps, stratified 6-race subset (RAW, not featured) · seed deterministic · llm none
 - artifacts: —
 
 | Metric | Value | Meaning |
 | --- | --- | --- |
-| Stops scored | 58 of 178 (32.6%) | real green-flag stops the tier could grade |
-| Exact lap | 27.6% | chose the lap the team chose |
-| Within 1 lap | 37.9% | same call, one lap either side |
-| Within 2 laps | 44.8% | same strategic window |
-| Mean signed error | -2.34 laps | negative = earlier than the team. **Do not quote as a system property** — still moves with `DECISION_WINDOW_LAPS` (measured -0.33 / -1.29 / -2.50 at w=3/5/10 on one race), because a wider window admits more distant, and therefore earlier, transitions |
-| Mean absolute error | 2.48 laps | magnitude, same width caveat |
+| Stops scored | 57 of 178 (32.0%) | real green-flag stops the tier could grade |
+| Exact lap | 28.1% | chose the lap the team chose |
+| Within 1 lap | 38.6% | same call, one lap either side |
+| Within 2 laps | 45.6% | same strategic window |
+| Mean signed error | -2.30 laps | negative = earlier than the team. **Do not quote as a system property** — still moves with `DECISION_WINDOW_LAPS` (measured -0.33 / -1.29 / -2.50 at w=3/5/10 on one race), because a wider window admits more distant, and therefore earlier, transitions |
+| Mean absolute error | 2.44 laps | magnitude, same width caveat |
 | Coverage verdict | **masked** | `masked` when under 60% of eligible stops were scored |
 
 ### Buckets
@@ -21,8 +21,8 @@
 | `closing_laps` | 4 |
 | `min_stint` | 17 |
 | `no_boundary_in_window` | 34 |
-| `no_call_in_window` | 65 |
-| `scored` | 58 |
+| `no_call_in_window` | 66 |
+| `scored` | 57 |
 
 `opening_laps` / `closing_laps` / `min_stint` are stops the guard rails make
 impossible to agree with, so they are excluded from the headline rather than

--- a/documents/eval_reports/decision_modes.md
+++ b/documents/eval_reports/decision_modes.md
@@ -1,17 +1,17 @@
 # decision_modes
 
-- harness `d97a54e` · schema v1 · generated 2026-07-31T09:40:54+00:00
+- harness `311f234` · schema v1 · generated 2026-07-31T12:21:44+00:00
 - era 2022-2025 · dataset data/raw laps, stratified 6-race subset (RAW, not featured) · seed deterministic · llm none
 - artifacts: —
 
 | Metric | Value | Meaning |
 | --- | --- | --- |
-| Stops scored | 54 of 178 (30.3%) | real green-flag stops the tier could grade |
-| Exact lap | 33.3% | chose the lap the team chose |
-| Within 1 lap | 44.4% | same call, one lap either side |
-| Within 2 laps | 51.9% | same strategic window |
-| Mean signed error | -2.00 laps | negative = earlier than the team. **Do not quote as a system property** — still moves with `DECISION_WINDOW_LAPS` (measured -0.33 / -1.29 / -2.50 at w=3/5/10 on one race), because a wider window admits more distant, and therefore earlier, transitions |
-| Mean absolute error | 2.15 laps | magnitude, same width caveat |
+| Stops scored | 58 of 178 (32.6%) | real green-flag stops the tier could grade |
+| Exact lap | 27.6% | chose the lap the team chose |
+| Within 1 lap | 37.9% | same call, one lap either side |
+| Within 2 laps | 44.8% | same strategic window |
+| Mean signed error | -2.34 laps | negative = earlier than the team. **Do not quote as a system property** — still moves with `DECISION_WINDOW_LAPS` (measured -0.33 / -1.29 / -2.50 at w=3/5/10 on one race), because a wider window admits more distant, and therefore earlier, transitions |
+| Mean absolute error | 2.48 laps | magnitude, same width caveat |
 | Coverage verdict | **masked** | `masked` when under 60% of eligible stops were scored |
 
 ### Buckets
@@ -20,9 +20,9 @@
 | --- | --- |
 | `closing_laps` | 4 |
 | `min_stint` | 17 |
-| `no_boundary_in_window` | 24 |
-| `no_call_in_window` | 79 |
-| `scored` | 54 |
+| `no_boundary_in_window` | 34 |
+| `no_call_in_window` | 65 |
+| `scored` | 58 |
 
 `opening_laps` / `closing_laps` / `min_stint` are stops the guard rails make
 impossible to agree with, so they are excluded from the headline rather than

--- a/scripts/measure_deg_error_bound.py
+++ b/scripts/measure_deg_error_bound.py
@@ -1,0 +1,69 @@
+"""The per-lap error bound for `deg_cost_s` that E4 has been formally unevaluable without.
+
+`deg_cost_s = pred(now) - pred(fresh)`, both from the TCN. Its TRUE counterpart is the
+same difference taken on N04's own target column, which is what the model was trained
+to reproduce. The error is the difference of the two differences, and its distribution
+is the bound.
+
+Training seasons only, so the bound is measured where the model was fitted rather than
+on the season it serves -- the conservative direction for a bound.
+"""
+
+import sys
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, ".")
+from scripts.measure_tyre_reference import (  # noqa: E402
+    FRESH_MAX_TYRE_LIFE,
+    predict_training_stints,
+)
+
+# The threshold E4's amplification table is quoted at. If the typical error sits well
+# under this, the 7.1% flip rate describes a perturbation larger than the model makes.
+E4_PERTURBATION_S = 0.1
+
+
+def main() -> None:
+    frame = predict_training_stints().sort_values(["stint", "tyre_life"])
+    fresh = frame[frame["tyre_life"] <= FRESH_MAX_TYRE_LIFE]
+
+    # The live path's reference: the prediction at the last lap with life <= 3.
+    frame["ref_pred"] = frame["stint"].map(fresh.groupby("stint")["pred"].last())
+    frame["ref_true"] = frame["stint"].map(fresh.groupby("stint")["target"].last())
+
+    scored = frame[(frame["tyre_life"] > FRESH_MAX_TYRE_LIFE) & frame["ref_pred"].notna()].copy()
+    scored["deg_pred"] = scored["pred"] - scored["ref_pred"]
+    scored["deg_true"] = scored["target"] - scored["ref_true"]
+    scored["error"] = scored["deg_pred"] - scored["deg_true"]
+
+    absolute = scored["error"].abs()
+    print(f"laps: {len(scored)}  (2023-24, tyre life > {FRESH_MAX_TYRE_LIFE})\n")
+    print("PER-LAP ERROR of deg_cost_s against its own training target")
+    for q in (0.5, 0.75, 0.9, 0.95, 0.99):
+        print(f"  |error| p{int(q * 100):<3} {absolute.quantile(q):7.3f} s/lap")
+    print(f"  mean absolute  {absolute.mean():7.3f} s/lap")
+    print(f"  bias (signed)  {scored['error'].mean():+7.3f} s/lap")
+    print()
+    print(
+        f"  share under the E4 perturbation ({E4_PERTURBATION_S} s/lap): "
+        f"{100 * (absolute < E4_PERTURBATION_S).mean():.1f}%"
+    )
+    print(f"  share under 0.2 s/lap: {100 * (absolute < 0.2).mean():.1f}%")
+    print(f"  share under 0.5 s/lap: {100 * (absolute < 0.5).mean():.1f}%")
+
+    print("\n=== by tyre-life band, because the term integrates to the flag ===")
+    bands = pd.cut(scored["tyre_life"], [3, 10, 20, 30, 100])
+    print(absolute.groupby(bands, observed=True).agg(["median", "mean", "count"]).round(3))
+
+    # A bound that only holds where the liability is small is not a bound. The term
+    # multiplies deg by the laps remaining, so the error that matters is weighted by
+    # how many laps it is charged over.
+    print("\n=== bootstrap 95% CI on the mean absolute error ===")
+    boot = [absolute.sample(len(absolute), replace=True, random_state=s).mean() for s in range(400)]
+    print(f"  [{np.percentile(boot, 2.5):.3f}, {np.percentile(boot, 97.5):.3f}] s/lap")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/measure_offset_cost.py
+++ b/scripts/measure_offset_cost.py
@@ -1,0 +1,106 @@
+"""What does a lap of pit-stop offset actually cost, in track position?
+
+The decision report leads with EXACT-lap agreement. That is a demanding metric, and
+the objection to it is a good one: matching the exact lap requires reproducing a call
+made with radio, tyre temperatures, rival intel and driver feel that this layer does
+not have. If being two or three laps off costs nothing on the road, then exact-lap is
+the wrong RESOLUTION and the headline should be a band.
+
+⛔ The band must not be chosen by seeing which one flatters the system. So this
+measures the cost per lap of offset FIRST, on real stops, and whatever it says decides
+the band.
+
+METHOD
+------
+For each real stop, take the driver's actual position change across the stop, and
+compare it against what the same stop taken N laps earlier or later would have cost in
+pit-loss terms alone: N laps of the field's own pace spread. The question is how many
+laps of offset it takes to move one track position.
+
+The measured green-flag median gap between consecutive cars is 2.227 s
+(`data/mc_measured_v1.json`, n=69,487). So the cost of an offset is the pace delta
+accumulated over those laps, divided by that gap.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, ".")
+
+RAW = Path("data/raw")
+YEARS = (2023, 2024)
+PACE_WINDOW = 3
+
+
+def _seconds(series: pd.Series) -> pd.Series:
+    return pd.to_timedelta(series).dt.total_seconds()
+
+
+def _green(laps: pd.DataFrame) -> pd.DataFrame:
+    keep = laps["LapTime"].notna()
+    if "IsAccurate" in laps.columns:
+        keep &= laps["IsAccurate"].fillna(False).astype(bool)
+    if "Deleted" in laps.columns:
+        keep &= ~laps["Deleted"].fillna(False).astype(bool)
+    return laps[keep]
+
+
+def measure_race(path: Path) -> list[float]:
+    """Per-lap pace advantage of the new set over the old, per real stop."""
+    laps = pd.read_parquet(path / "laps.parquet")
+    if "Stint" not in laps.columns:
+        return []
+    laps = laps.dropna(subset=["Stint", "LapNumber", "Driver"])
+    laps["_s"] = _seconds(laps["LapTime"])
+
+    advantages = []
+    for _driver, driver_laps in laps.groupby("Driver"):
+        ordered = driver_laps.sort_values("LapNumber")
+        stints = ordered["Stint"].to_numpy()
+        nums = ordered["LapNumber"].to_numpy()
+        stops = [int(nums[i]) for i in range(1, len(stints)) if stints[i] > stints[i - 1]]
+
+        for stop_lap in stops:
+            old = _green(ordered[ordered["LapNumber"] < stop_lap]).tail(PACE_WINDOW)
+            fresh = _green(ordered[ordered["LapNumber"] > stop_lap]).head(PACE_WINDOW)
+            if len(old) < 2 or len(fresh) < 2:
+                continue
+            advantages.append(float(old["_s"].median() - fresh["_s"].median()))
+    return advantages
+
+
+def main() -> None:
+    tables = json.loads(Path("data/mc_measured_v1.json").read_text(encoding="utf-8"))
+    gap_s = tables["gap_density"]["racing"]["p50"]
+
+    advantages = []
+    for year in YEARS:
+        for race in sorted((RAW / str(year)).iterdir()):
+            if (race / "laps.parquet").exists():
+                advantages += measure_race(race)
+
+    values = np.array([a for a in advantages if np.isfinite(a)])
+    print(f"real stops measured: {len(values)}  ({YEARS})")
+    print(
+        f"median gap between consecutive cars: {gap_s} s (n={tables['gap_density']['racing']['n']})\n"
+    )
+
+    median_adv = float(np.median(values))
+    print(f"per-lap pace advantage of a fresh set, median: {median_adv:.3f} s/lap\n")
+
+    print("cost of stopping N laps LATER than the ideal lap, in track position:")
+    print(f"{'offset':>8}{'seconds':>10}{'positions':>12}")
+    for n in (1, 2, 3, 5):
+        seconds = n * median_adv
+        print(f"{n:>7} {seconds:>9.2f}{seconds / gap_s:>12.2f}")
+
+    print("\nlaps of offset it takes to lose ONE position:")
+    print(f"  {gap_s / median_adv:.2f} laps")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/measure_repayment_horizon.py
+++ b/scripts/measure_repayment_horizon.py
@@ -1,0 +1,144 @@
+"""E1 — how many laps does a real elective stop take to repay itself?
+
+The constant's basis, and a fact about the sport rather than a fit to any eval. If the
+median sits well beyond the 5-lap window, that is the measured proof that no fixed
+short horizon can price an elective stop.
+
+Training seasons only (2023-24). 2025 stays held out, the same hygiene the tyre
+reference measurement used.
+
+METHOD, stated before running so it cannot be adjusted afterwards
+-----------------------------------------------------------------
+For each real green-flag stop:
+  - the pit loss is the OBSERVED cost: the stop lap's time minus the driver's median
+    green-flag lap in the stint it just left. That is what the stop actually cost on
+    the road, not a modelled figure.
+  - the advantage is the OBSERVED per-lap gain: the median lap in the new stint's
+    early window against the median of the old stint's closing laps.
+  - the repayment horizon is ceil(pit_loss / advantage), capped at the laps that
+    actually remained.
+
+A stop with no positive advantage never repays and is reported as such rather than
+dropped, because dropping it would bias the median toward the stops that worked.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, ".")
+
+RAW = Path("data/raw")
+TRAINING_YEARS = (2023, 2024)
+# Laps either side of the stop used to characterise pace. Three is the shortest window
+# that survives a single bad lap; the out-lap itself is excluded on both counts.
+PACE_WINDOW = 3
+
+
+def _seconds(series: pd.Series) -> pd.Series:
+    return pd.to_timedelta(series).dt.total_seconds()
+
+
+def _green(laps: pd.DataFrame) -> pd.DataFrame:
+    """Laps clean enough to characterise pace, using N04's own quality gates."""
+    keep = laps["LapTime"].notna()
+    if "IsAccurate" in laps.columns:
+        keep &= laps["IsAccurate"].fillna(False).astype(bool)
+    if "Deleted" in laps.columns:
+        keep &= ~laps["Deleted"].fillna(False).astype(bool)
+    return laps[keep]
+
+
+def _stop_rows(driver_laps: pd.DataFrame) -> list[int]:
+    """Lap numbers where the stint number increases, i.e. a real stop happened."""
+    stints = driver_laps["Stint"].to_numpy()
+    laps = driver_laps["LapNumber"].to_numpy()
+    return [int(laps[i]) for i in range(1, len(stints)) if stints[i] > stints[i - 1]]
+
+
+def measure_race(path: Path) -> list[dict]:
+    laps = pd.read_parquet(path / "laps.parquet")
+    if "Stint" not in laps.columns:
+        return []
+    laps = laps.dropna(subset=["Stint", "LapNumber", "Driver"])
+    laps["_s"] = _seconds(laps["LapTime"])
+
+    rows = []
+    for driver, driver_laps in laps.groupby("Driver"):
+        ordered = driver_laps.sort_values("LapNumber")
+        total = int(ordered["LapNumber"].max())
+        stops = _stop_rows(ordered)
+
+        for index, stop_lap in enumerate(stops):
+            old = _green(ordered[ordered["LapNumber"] < stop_lap]).tail(PACE_WINDOW)
+            # Skip the out-lap on the new set; it is not representative pace.
+            fresh = _green(ordered[ordered["LapNumber"] > stop_lap]).head(PACE_WINDOW)
+            if len(old) < 2 or len(fresh) < 2:
+                continue
+
+            old_pace = float(old["_s"].median())
+            fresh_pace = float(fresh["_s"].median())
+            stop_row = ordered[ordered["LapNumber"] == stop_lap]
+            if stop_row.empty or pd.isna(stop_row["_s"].iloc[0]):
+                continue
+
+            pit_loss = float(stop_row["_s"].iloc[0]) - old_pace
+            advantage = old_pace - fresh_pace
+            remaining = total - stop_lap
+            if pit_loss <= 0 or remaining <= 0:
+                continue
+
+            repays = advantage > 0
+            horizon = float(np.ceil(pit_loss / advantage)) if repays else np.inf
+            rows.append(
+                {
+                    "driver": driver,
+                    "stop_lap": stop_lap,
+                    "elective": index > 0,
+                    "pit_loss_s": pit_loss,
+                    "advantage_s_per_lap": advantage,
+                    "horizon_laps": horizon,
+                    "laps_remaining": remaining,
+                    "repaid_before_flag": repays and horizon <= remaining,
+                }
+            )
+    return rows
+
+
+def main() -> None:
+    rows = []
+    for year in TRAINING_YEARS:
+        for race in sorted((RAW / str(year)).iterdir()):
+            if (race / "laps.parquet").exists():
+                rows += measure_race(race)
+
+    df = pd.DataFrame(rows)
+    print(f"stops measured: {len(df)}  ({TRAINING_YEARS})")
+
+    for label, subset in (("ALL", df), ("ELECTIVE", df[df["elective"]])):
+        finite = subset[np.isfinite(subset["horizon_laps"])]
+        print(f"\n=== {label} (n={len(subset)}) ===")
+        print(
+            f"  never repays (no positive advantage): {100 * (1 - len(finite) / max(len(subset), 1)):.1f}%"
+        )
+        if not len(finite):
+            continue
+        print(f"  pit loss  median {finite['pit_loss_s'].median():.1f} s")
+        print(f"  advantage median {finite['advantage_s_per_lap'].median():.3f} s/lap")
+        q = finite["horizon_laps"].quantile([0.25, 0.5, 0.75]).round(1).to_dict()
+        print(f"  repayment horizon  p25 {q[0.25]}  MEDIAN {q[0.5]}  p75 {q[0.75]} laps")
+        boot = [
+            np.median(finite["horizon_laps"].sample(len(finite), replace=True, random_state=s))
+            for s in range(400)
+        ]
+        print(f"  median 95% CI: [{np.percentile(boot, 2.5):.1f}, {np.percentile(boot, 97.5):.1f}]")
+        print(
+            f"  horizon <= 5 laps (what the window prices): {100 * (finite['horizon_laps'] <= 5).mean():.1f}%"
+        )
+        print(f"  repaid before the flag: {100 * finite['repaid_before_flag'].mean():.1f}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agents/position_projection.py
+++ b/src/agents/position_projection.py
@@ -731,11 +731,15 @@ def _deferral_tyre_liability_s(
     # the same quantity. One quantity, one rule, both horizons.
     laps_past_cliff = np.maximum(0.0, remaining - cliff_laps)
     run_it_out = remaining * config.deg_cost_s + laps_past_cliff * config.cliff_loss_s
-    discounted_run = np.maximum(
-        0.0, run_it_out - config.future_neutralisation_prob * config.neutralisation_saving_s
-    )
 
-    return np.minimum(stop_later, discounted_run)
+    # The run-it-out branch is deliberately NOT q_f-discounted, and an earlier version
+    # of it was. A neutralisation does not make worn rubber cheaper; it makes a STOP
+    # cheaper. That option value belongs to the other branch, where `_stop_residual_s`
+    # already applies it, and the `min` below is exactly what lets a
+    # neutralisation-cheapened stop win when it becomes the better future. Discounting
+    # both sides credited the same Safety Car twice and handed a car that never stops
+    # a saving it has no way to collect.
+    return np.minimum(stop_later, np.maximum(0.0, run_it_out))
 
 
 def _terminal_gaps(
@@ -762,8 +766,12 @@ def _terminal_gaps(
     and the three cases the deleted rail was patching still fall out of the
     arithmetic, now by cancellation rather than by exemption:
 
-    - already stopped (no obligation) -> our residual is zero, staying out costs
-      nothing on this term;
+    - already stopped (no obligation) -> our STOP residual is zero, because there is
+      no stop left to owe. Since #763 that case is NOT free, though: the deferral
+      liability takes its place and charges what the rubber costs between the window
+      edge and the flag. Before that term existed an elective stop's full pit loss
+      stood against exactly zero, which is why the layer declined 69.9% of them
+      against 26.7% of first stops;
     - leading a pack that all still owe a stop -> their residuals and ours are
       the same size and cancel, so holding the lead is free. The cancellation is
       EXACT only when the two losses match; in production ours is sampled and

--- a/src/agents/position_projection.py
+++ b/src/agents/position_projection.py
@@ -667,7 +667,9 @@ def _stop_residual_s(stop_loss_s: np.ndarray | float, config: ProjectionConfig) 
     return np.maximum(0.0, discounted)
 
 
-def _deferral_tyre_liability_s(pit_loss_s: np.ndarray, config: ProjectionConfig) -> np.ndarray:
+def _deferral_tyre_liability_s(
+    pit_loss_s: np.ndarray, cliff_laps: np.ndarray, config: ProjectionConfig
+) -> np.ndarray:
     """Seconds a NON-stopping plan's tyres cost between the window edge and the flag.
 
     The terminal netting already carries every KNOWN outstanding stop to a common
@@ -713,18 +715,27 @@ def _deferral_tyre_liability_s(pit_loss_s: np.ndarray, config: ProjectionConfig)
     # makes k = 0 from the window edge, and the branch collapses to the residual.
     stop_later = _stop_residual_s(pit_loss_s, config)
 
-    # Or hold this set to the flag: wear on every lap, plus the cliff on the laps
-    # past it. `cliff_laps` is a per-draw quantity the caller owns; the terminal
-    # horizon uses the config's own window as the earliest the cliff can bite, which
-    # keeps this function pure and its inputs already-measured.
-    run_it_out = remaining * config.deg_cost_s + max(0.0, remaining - config.window_laps) * (
-        config.cliff_loss_s
-    )
+    # Or hold this set to the flag: wear on every lap, plus the cliff over the laps
+    # actually run PAST it.
+    #
+    # `cliff_laps` is the per-draw onset the tyre model produced, and it has to be the
+    # one used here. An earlier version assumed everything past `window_laps` was past
+    # the cliff, which is not a simplification but a contradiction of the model whose
+    # output the caller is holding: measured on real elective laps it charged a median
+    # 19 laps of cliff, and on 189 laps where the model reports the set costs NOTHING
+    # per lap versus fresh it still charged a median 8.41 s, entirely invented. On 121
+    # more the model reported the set was FASTER than fresh and the liability was
+    # still positive.
+    #
+    # `driver_time_delta` has always used the per-draw value for the in-window half of
+    # the same quantity. One quantity, one rule, both horizons.
+    laps_past_cliff = np.maximum(0.0, remaining - cliff_laps)
+    run_it_out = remaining * config.deg_cost_s + laps_past_cliff * config.cliff_loss_s
     discounted_run = np.maximum(
         0.0, run_it_out - config.future_neutralisation_prob * config.neutralisation_saving_s
     )
 
-    return np.minimum(stop_later, np.full(len(pit_loss_s), discounted_run, dtype=float))
+    return np.minimum(stop_later, discounted_run)
 
 
 def _terminal_gaps(
@@ -732,6 +743,7 @@ def _terminal_gaps(
     plan: DriverPlan,
     projected_gaps: np.ndarray,
     pit_loss_s: np.ndarray,
+    cliff_laps: np.ndarray,
     config: ProjectionConfig,
 ) -> np.ndarray:
     """Window-end gaps carried forward to a race end where every KNOWN stop is served.
@@ -791,7 +803,7 @@ def _terminal_gaps(
         # The obligation is discharged, so there is no stop residual to carry -- but
         # deferring still costs rubber, and until this term existed an elective stop's
         # full pit loss stood against exactly zero. See _deferral_tyre_liability_s.
-        our_residual = _deferral_tyre_liability_s(pit_loss_s, config)
+        our_residual = _deferral_tyre_liability_s(pit_loss_s, cliff_laps, config)
     else:
         # `None` means the compound history could not settle it. The module's rule is
         # that a claim needs a fact, so an unknown obligation buys no correction in
@@ -858,7 +870,7 @@ def project_positions(
     nearest_behind = behind_gaps.min(axis=1)
     margins = np.clip(np.where(np.isinf(nearest_behind), 0.0, nearest_behind), 0.0, MARGIN_CLIP_S)
 
-    terminal_gaps = _terminal_gaps(usable, plan, projected_gaps, pit_loss_s, config)
+    terminal_gaps = _terminal_gaps(usable, plan, projected_gaps, pit_loss_s, cliff_laps, config)
 
     return ProjectionResult(
         positions=positions,

--- a/src/agents/position_projection.py
+++ b/src/agents/position_projection.py
@@ -667,6 +667,66 @@ def _stop_residual_s(stop_loss_s: np.ndarray | float, config: ProjectionConfig) 
     return np.maximum(0.0, discounted)
 
 
+def _deferral_tyre_liability_s(pit_loss_s: np.ndarray, config: ProjectionConfig) -> np.ndarray:
+    """Seconds a NON-stopping plan's tyres cost between the window edge and the flag.
+
+    The terminal netting already carries every KNOWN outstanding stop to a common
+    horizon. What it did not carry is what the rubber costs while you defer, and for a
+    car whose mandatory stop is already discharged that was the ONLY future cost it had
+    -- so an elective stop's full pit loss stood against nothing at all.
+
+    WHY THIS EXISTS, MEASURED RATHER THAN ARGUED
+    ---------------------------------------------
+    Over 694 real elective stops in 2023-24, the horizon a stop takes to repay itself
+    from its own pace advantage has a median of **13 laps** (95% CI [12, 14]), and only
+    **15.0%** repay inside five. So a five-lap window can price at most a seventh of the
+    decision, and the remaining six sevenths were being compared against zero. The
+    layer declined **69.9%** of elective stops against 26.7% of first stops; that gap
+    is what this term addresses.
+
+    The car's real choice is the cheaper of two futures, so the liability is their
+    minimum rather than a horizon someone picked:
+
+        stop later:   deg * k    + the residual that stop still costs
+        run it out:   deg * R    + the cliff over the laps past it
+
+    Both q_f-discounted the same way ``_stop_residual_s`` already discounts, because a
+    neutralisation that turns up covers a deferred stop whichever branch wins.
+
+    --- WHERE TO CHANGE IF THE SCOPING CHANGES ---
+    Scoped by the CALLER to plans with no residual, and that scoping is a measured
+    behaviour rather than a physical claim: the same unpriced wear exists for a car
+    that still owes its stop, but that population already measures balanced, and
+    charging it there moves first calls EARLIER -- the exact direction that cost five
+    exact agreements when the wear term landed. Extending it is a separate decision and
+    wants its own measurement, not symmetry.
+    """
+    if config.deg_cost_s is None:
+        return np.zeros(len(pit_loss_s), dtype=float)
+
+    remaining = float(max(0, config.laps_remaining - config.window_laps))
+    if remaining <= 0.0:
+        return np.zeros(len(pit_loss_s), dtype=float)
+
+    # Stopping later still costs the stop, so the best later lap is as soon as the
+    # window ends: every further lap adds wear without removing the pit loss. That
+    # makes k = 0 from the window edge, and the branch collapses to the residual.
+    stop_later = _stop_residual_s(pit_loss_s, config)
+
+    # Or hold this set to the flag: wear on every lap, plus the cliff on the laps
+    # past it. `cliff_laps` is a per-draw quantity the caller owns; the terminal
+    # horizon uses the config's own window as the earliest the cliff can bite, which
+    # keeps this function pure and its inputs already-measured.
+    run_it_out = remaining * config.deg_cost_s + max(0.0, remaining - config.window_laps) * (
+        config.cliff_loss_s
+    )
+    discounted_run = np.maximum(
+        0.0, run_it_out - config.future_neutralisation_prob * config.neutralisation_saving_s
+    )
+
+    return np.minimum(stop_later, np.full(len(pit_loss_s), discounted_run, dtype=float))
+
+
 def _terminal_gaps(
     usable: Sequence[RivalState],
     plan: DriverPlan,
@@ -723,11 +783,20 @@ def _terminal_gaps(
     if not plan.stops_in_window and config.mandatory_stop_pending is None:
         return projected_gaps
 
-    our_residual = (
-        _stop_residual_s(pit_loss_s, config)
-        if not plan.stops_in_window and config.mandatory_stop_pending is True
-        else np.zeros(len(pit_loss_s), dtype=float)
-    )
+    if plan.stops_in_window:
+        our_residual = np.zeros(len(pit_loss_s), dtype=float)
+    elif config.mandatory_stop_pending is True:
+        our_residual = _stop_residual_s(pit_loss_s, config)
+    elif config.mandatory_stop_pending is False:
+        # The obligation is discharged, so there is no stop residual to carry -- but
+        # deferring still costs rubber, and until this term existed an elective stop's
+        # full pit loss stood against exactly zero. See _deferral_tyre_liability_s.
+        our_residual = _deferral_tyre_liability_s(pit_loss_s, config)
+    else:
+        # `None` means the compound history could not settle it. The module's rule is
+        # that a claim needs a fact, so an unknown obligation buys no correction in
+        # either direction, exactly as it did before this term.
+        our_residual = np.zeros(len(pit_loss_s), dtype=float)
 
     their_residual = np.array(
         [

--- a/tests/mc/test_deferral_tyre_liability.py
+++ b/tests/mc/test_deferral_tyre_liability.py
@@ -36,6 +36,17 @@ from src.agents.position_projection import (
 DRAWS = 4
 
 
+def _no_cliff() -> np.ndarray:
+    """Cliff far past the flag, so the cliff half of the liability contributes nothing.
+
+    Explicit rather than defaulted: an earlier version of the production code assumed
+    everything past the window was past the cliff, and charged a median 19 laps of it
+    on real laps -- including 189 where the tyre model said the set cost nothing at all.
+    Tests that leave the onset implicit cannot see that.
+    """
+    return np.full(DRAWS, 999.0, dtype=float)
+
+
 def _config(**overrides) -> ProjectionConfig:
     base = {
         "window_laps": 5,
@@ -57,7 +68,7 @@ def _pit_loss(value: float = 22.8) -> np.ndarray:
 
 def test_a_discharged_obligation_still_pays_for_the_rubber_it_defers():
     """The whole point: before this, staying out on an elective stop cost zero."""
-    liability = _deferral_tyre_liability_s(_pit_loss(), _config())
+    liability = _deferral_tyre_liability_s(_pit_loss(), _no_cliff(), _config())
 
     assert (liability > 0).all()
 
@@ -65,7 +76,7 @@ def test_a_discharged_obligation_still_pays_for_the_rubber_it_defers():
 def test_the_liability_is_the_cheaper_of_the_two_futures():
     """A car chooses; it does not pay both. Running 20 laps at 0.5 s is 10 s, which is
     cheaper than the 22.8 s a later stop still costs, so the run-it-out branch wins."""
-    liability = _deferral_tyre_liability_s(_pit_loss(22.8), _config())
+    liability = _deferral_tyre_liability_s(_pit_loss(22.8), _no_cliff(), _config())
 
     assert liability == pytest.approx(np.full(DRAWS, 20 * 0.5))
 
@@ -76,7 +87,7 @@ def test_a_cheap_later_stop_wins_over_running_a_long_way_on_old_rubber():
     Without this, a term that always took the run-it-out branch would pass the test
     above and be wrong whenever the stop is the cheaper future.
     """
-    liability = _deferral_tyre_liability_s(_pit_loss(4.0), _config(laps_remaining=45))
+    liability = _deferral_tyre_liability_s(_pit_loss(4.0), _no_cliff(), _config(laps_remaining=45))
 
     assert liability == pytest.approx(np.full(DRAWS, 4.0))
 
@@ -85,9 +96,9 @@ def test_no_tyre_reading_means_no_claim():
     """`deg_cost_s` is None on a stint the model had no reference for. Charging a
     guessed liability there would be inventing the very number this epic refused to
     invent twice already."""
-    assert _deferral_tyre_liability_s(_pit_loss(), _config(deg_cost_s=None)) == pytest.approx(
-        np.zeros(DRAWS)
-    )
+    assert _deferral_tyre_liability_s(
+        _pit_loss(), _no_cliff(), _config(deg_cost_s=None)
+    ) == pytest.approx(np.zeros(DRAWS))
 
 
 def test_a_car_that_still_owes_its_stop_is_untouched(monkeypatch):
@@ -108,7 +119,12 @@ def test_a_car_that_still_owes_its_stop_is_untouched(monkeypatch):
     rival = RivalState(driver="VER", gap_s=3.0, stop_pending=False)
     plan = DriverPlan(name="STAY_OUT", stops_in_window=False)
     _terminal_gaps(
-        [rival], plan, np.zeros((DRAWS, 1)), _pit_loss(), _config(mandatory_stop_pending=True)
+        [rival],
+        plan,
+        np.zeros((DRAWS, 1)),
+        _pit_loss(),
+        _no_cliff(),
+        _config(mandatory_stop_pending=True),
     )
 
     assert called == []
@@ -122,7 +138,9 @@ def test_an_unknown_obligation_buys_no_correction_either_way():
     gaps = np.full((DRAWS, 1), 3.0)
     rival = RivalState(driver="VER", gap_s=3.0, stop_pending=False)
 
-    unknown = _terminal_gaps([rival], plan, gaps, _pit_loss(), _config(mandatory_stop_pending=None))
+    unknown = _terminal_gaps(
+        [rival], plan, gaps, _pit_loss(), _no_cliff(), _config(mandatory_stop_pending=None)
+    )
 
     assert unknown == pytest.approx(gaps)
 
@@ -133,17 +151,60 @@ def test_a_plan_that_stops_owes_no_deferral_at_all():
     gaps = np.full((DRAWS, 1), 3.0)
     rival = RivalState(driver="VER", gap_s=3.0, stop_pending=False)
 
-    assert _terminal_gaps([rival], plan, gaps, _pit_loss(), _config()) == pytest.approx(gaps)
+    assert _terminal_gaps(
+        [rival], plan, gaps, _pit_loss(), _no_cliff(), _config()
+    ) == pytest.approx(gaps)
 
 
 def test_the_liability_shrinks_as_the_flag_approaches():
     """With three laps left there is almost nothing left to defer, and the term must
     say so rather than charging a full race of rubber. This is the Art. 55.17 endgame
     shape the rest of the module already expresses."""
-    late = _deferral_tyre_liability_s(_pit_loss(), _config(laps_remaining=6))
-    early = _deferral_tyre_liability_s(_pit_loss(), _config(laps_remaining=40))
+    late = _deferral_tyre_liability_s(_pit_loss(), _no_cliff(), _config(laps_remaining=6))
+    early = _deferral_tyre_liability_s(_pit_loss(), _no_cliff(), _config(laps_remaining=40))
 
     assert (late < early).all()
-    assert _deferral_tyre_liability_s(_pit_loss(), _config(laps_remaining=5)) == pytest.approx(
+    assert _deferral_tyre_liability_s(
+        _pit_loss(), _no_cliff(), _config(laps_remaining=5)
+    ) == pytest.approx(np.zeros(DRAWS))
+
+
+def test_the_terminal_gap_of_a_deferring_car_actually_MOVES():
+    """The gate's HIGH: deleting the wiring left all 173 `tests/mc` green.
+
+    Every other test here either exercises the helper directly, or asserts the term
+    does NOT apply. Not one asserted the thing the feature exists to do — that a car
+    with a discharged obligation, deferring on worn rubber, ends the race further back
+    than its window-end gap says. So the whole feature could be disconnected and the
+    suite would not notice, which is this project's most-repeated defect and the third
+    time a gate has found it in my own work.
+    """
+    plan = DriverPlan(name="STAY_OUT", stops_in_window=False)
+    gaps = np.full((DRAWS, 1), 3.0)
+    rival = RivalState(driver="VER", gap_s=3.0, stop_pending=False)
+
+    terminal = _terminal_gaps([rival], plan, gaps, _pit_loss(), _no_cliff(), _config())
+
+    # Deferring costs us seconds, and our loss pushes every gap DOWN (the module's
+    # stated sign convention), so the terminal gap is strictly below the projected one.
+    assert (terminal < gaps).all()
+
+
+def test_the_cliff_half_uses_the_onset_the_model_supplied_not_an_assumed_one():
+    """Measured on real elective laps, the assumed onset charged a median 19 laps of
+    cliff — and on 189 of them the tyre model reported the set cost NOTHING per lap
+    versus fresh while the liability still charged a median 8.41 s of pure invention.
+
+    Same quantity, same rule, both horizons: `driver_time_delta` has always used the
+    per-draw onset for the in-window half.
+    """
+    early_cliff = np.full(DRAWS, 2.0, dtype=float)
+    late_cliff = np.full(DRAWS, 999.0, dtype=float)
+    config = _config(cliff_loss_s=0.8, deg_cost_s=0.0)
+
+    # With no per-lap wear at all, the only thing left is the cliff. A set that never
+    # reaches it must owe nothing; the earlier code charged it anyway.
+    assert _deferral_tyre_liability_s(_pit_loss(), late_cliff, config) == pytest.approx(
         np.zeros(DRAWS)
     )
+    assert (_deferral_tyre_liability_s(_pit_loss(), early_cliff, config) > 0).all()

--- a/tests/mc/test_deferral_tyre_liability.py
+++ b/tests/mc/test_deferral_tyre_liability.py
@@ -1,0 +1,149 @@
+"""#763 — an elective stop's full pit loss used to stand against nothing at all.
+
+`_terminal_gaps` carries every KNOWN outstanding stop to a common horizon. What it did
+not carry is what the rubber costs while you defer, and for a car whose mandatory stop
+is already discharged that was the only future cost it had. So PIT_NOW paid ~22.8 s and
+STAY_OUT paid zero, and the layer declined **69.9%** of elective stops against 26.7% of
+first ones.
+
+WHY THE FIX IS NOT A WIDER WINDOW
+----------------------------------
+That was this issue's first diagnosis and a design gate refuted it with executed
+evidence. Widening is monotone in favour of PIT with today's arithmetic, pushes first
+calls even earlier (the direction that had just cost five exact agreements), and would
+need W around 37 to touch the elective declines at all.
+
+THE MEASURED BASIS
+-------------------
+Over 694 real elective stops in 2023-24, the horizon a stop takes to repay itself from
+its own pace advantage has a **median of 13 laps** (95% CI [12, 14]); only **15.0%**
+repay inside five. A five-lap window can price at most a seventh of the decision.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.agents.position_projection import (
+    DriverPlan,
+    ProjectionConfig,
+    RivalState,
+    _deferral_tyre_liability_s,
+    _terminal_gaps,
+)
+
+DRAWS = 4
+
+
+def _config(**overrides) -> ProjectionConfig:
+    base = {
+        "window_laps": 5,
+        "racing_laps": 5.0,
+        "deg_cost_s": 0.5,
+        "cliff_loss_s": 0.0,
+        "neutralisation_saving_s": 0.0,
+        "future_neutralisation_prob": 0.0,
+        "laps_remaining": 25,
+        "mandatory_stop_pending": False,
+    }
+    base.update(overrides)
+    return ProjectionConfig(**base)
+
+
+def _pit_loss(value: float = 22.8) -> np.ndarray:
+    return np.full(DRAWS, value, dtype=float)
+
+
+def test_a_discharged_obligation_still_pays_for_the_rubber_it_defers():
+    """The whole point: before this, staying out on an elective stop cost zero."""
+    liability = _deferral_tyre_liability_s(_pit_loss(), _config())
+
+    assert (liability > 0).all()
+
+
+def test_the_liability_is_the_cheaper_of_the_two_futures():
+    """A car chooses; it does not pay both. Running 20 laps at 0.5 s is 10 s, which is
+    cheaper than the 22.8 s a later stop still costs, so the run-it-out branch wins."""
+    liability = _deferral_tyre_liability_s(_pit_loss(22.8), _config())
+
+    assert liability == pytest.approx(np.full(DRAWS, 20 * 0.5))
+
+
+def test_a_cheap_later_stop_wins_over_running_a_long_way_on_old_rubber():
+    """The other branch, so the minimum is pinned in both directions rather than one.
+
+    Without this, a term that always took the run-it-out branch would pass the test
+    above and be wrong whenever the stop is the cheaper future.
+    """
+    liability = _deferral_tyre_liability_s(_pit_loss(4.0), _config(laps_remaining=45))
+
+    assert liability == pytest.approx(np.full(DRAWS, 4.0))
+
+
+def test_no_tyre_reading_means_no_claim():
+    """`deg_cost_s` is None on a stint the model had no reference for. Charging a
+    guessed liability there would be inventing the very number this epic refused to
+    invent twice already."""
+    assert _deferral_tyre_liability_s(_pit_loss(), _config(deg_cost_s=None)) == pytest.approx(
+        np.zeros(DRAWS)
+    )
+
+
+def test_a_car_that_still_owes_its_stop_is_untouched(monkeypatch):
+    """E3, the invariance criterion, at the unit level.
+
+    A deferral term for elective stops has no business moving mandatory-stop timing.
+    That population already measures balanced (26.7% declines) and charging it there
+    pushes first calls earlier, which is what #744b just paid five exact agreements
+    for. If this ever fires on pending=True, the scoping leaked.
+    """
+    called = []
+    import src.agents.position_projection as pp
+
+    monkeypatch.setattr(
+        pp, "_deferral_tyre_liability_s", lambda *a, **k: called.append(1) or np.zeros(DRAWS)
+    )
+
+    rival = RivalState(driver="VER", gap_s=3.0, stop_pending=False)
+    plan = DriverPlan(name="STAY_OUT", stops_in_window=False)
+    _terminal_gaps(
+        [rival], plan, np.zeros((DRAWS, 1)), _pit_loss(), _config(mandatory_stop_pending=True)
+    )
+
+    assert called == []
+
+
+def test_an_unknown_obligation_buys_no_correction_either_way():
+    """`None` means the compound history could not settle it, and this module's rule is
+    that a claim needs a fact. Treating unknown as discharged would charge a liability
+    on evidence nobody has."""
+    plan = DriverPlan(name="STAY_OUT", stops_in_window=False)
+    gaps = np.full((DRAWS, 1), 3.0)
+    rival = RivalState(driver="VER", gap_s=3.0, stop_pending=False)
+
+    unknown = _terminal_gaps([rival], plan, gaps, _pit_loss(), _config(mandatory_stop_pending=None))
+
+    assert unknown == pytest.approx(gaps)
+
+
+def test_a_plan_that_stops_owes_no_deferral_at_all():
+    """It is not deferring. Charging it here would double-count against its own pit loss."""
+    plan = DriverPlan(name="PIT_NOW", stops_in_window=True)
+    gaps = np.full((DRAWS, 1), 3.0)
+    rival = RivalState(driver="VER", gap_s=3.0, stop_pending=False)
+
+    assert _terminal_gaps([rival], plan, gaps, _pit_loss(), _config()) == pytest.approx(gaps)
+
+
+def test_the_liability_shrinks_as_the_flag_approaches():
+    """With three laps left there is almost nothing left to defer, and the term must
+    say so rather than charging a full race of rubber. This is the Art. 55.17 endgame
+    shape the rest of the module already expresses."""
+    late = _deferral_tyre_liability_s(_pit_loss(), _config(laps_remaining=6))
+    early = _deferral_tyre_liability_s(_pit_loss(), _config(laps_remaining=40))
+
+    assert (late < early).all()
+    assert _deferral_tyre_liability_s(_pit_loss(), _config(laps_remaining=5)) == pytest.approx(
+        np.zeros(DRAWS)
+    )

--- a/tests/mc/test_deferral_tyre_liability.py
+++ b/tests/mc/test_deferral_tyre_liability.py
@@ -243,3 +243,23 @@ def test_a_safety_car_cheapens_the_stop_and_not_the_rubber():
     # And the regimes really are different, or both halves would be asserting about
     # whichever branch happens to win everywhere.
     assert calm[0] != calm_run[0]
+
+
+def test_a_faster_than_fresh_set_never_becomes_a_terminal_CREDIT():
+    """The exit gate's last survivor: removing the zero clamp passes the whole suite.
+
+    `deg_cost_s` is negative on 19.4% of real elective laps -- a set genuinely faster
+    than its own fresh reference, early in a stint on a track that is still rubbering
+    in. Multiplied by the laps remaining that becomes a large negative number, and a
+    negative liability is not a small cost, it is a terminal CREDIT: the projection
+    would report that deferring GAINS track position, and the more laps remain the
+    more it would gain.
+
+    Measured, the clamp binds on 220 of 2,048 elective evaluations (10.7%), worst case
+    -43.26 s. Routine, not exotic, which is why it needs a test rather than a comment.
+    """
+    faster_than_fresh = _config(deg_cost_s=-1.0, laps_remaining=45)
+
+    liability = _deferral_tyre_liability_s(_pit_loss(), _no_cliff(), faster_than_fresh)
+
+    assert (liability >= 0.0).all()

--- a/tests/mc/test_deferral_tyre_liability.py
+++ b/tests/mc/test_deferral_tyre_liability.py
@@ -208,3 +208,38 @@ def test_the_cliff_half_uses_the_onset_the_model_supplied_not_an_assumed_one():
         np.zeros(DRAWS)
     )
     assert (_deferral_tyre_liability_s(_pit_loss(), early_cliff, config) > 0).all()
+
+
+def test_a_safety_car_cheapens_the_stop_and_not_the_rubber():
+    """The exit gate's q_f blind spot: nothing caught discounting BOTH branches.
+
+    A neutralisation makes a STOP cheaper. It does not make worn tyres cheaper. So the
+    option value belongs to the stop-later branch, where `_stop_residual_s` applies it,
+    and the `min` is what lets a cheapened stop win once it becomes the better future.
+    Discounting the run-it-out branch as well credited the same Safety Car twice and
+    handed a car that never stops a saving it has no way to collect.
+
+    Pinned as an invariance: raising the neutralisation odds must not move a liability
+    whose cheaper future is holding the set to the flag.
+    """
+    # Heavy wear over a long run, so holding the set to the flag costs far more than
+    # the stop and the STOP branch wins. That is where the option value belongs, so
+    # this is where raising the Safety Car odds must show.
+    heavy = dict(deg_cost_s=1.5, laps_remaining=45, neutralisation_saving_s=8.0)
+    calm = _deferral_tyre_liability_s(_pit_loss(), _no_cliff(), _config(**heavy))
+    likely_sc = _deferral_tyre_liability_s(
+        _pit_loss(), _no_cliff(), _config(**heavy, future_neutralisation_prob=0.5)
+    )
+    assert (likely_sc < calm).all(), "the stop branch must carry the option value"
+
+    # Now a regime where running it out is the cheaper future. The Safety Car odds must
+    # not touch it: no neutralisation reduces what the rubber costs.
+    light = dict(deg_cost_s=0.5, laps_remaining=25, neutralisation_saving_s=8.0)
+    calm_run = _deferral_tyre_liability_s(_pit_loss(), _no_cliff(), _config(**light))
+    sc_run = _deferral_tyre_liability_s(
+        _pit_loss(), _no_cliff(), _config(**light, future_neutralisation_prob=0.5)
+    )
+    assert sc_run == pytest.approx(calm_run)
+    # And the regimes really are different, or both halves would be asserting about
+    # whichever branch happens to win everywhere.
+    assert calm[0] != calm_run[0]

--- a/tests/mc/test_position_projection_stop_horizons.py
+++ b/tests/mc/test_position_projection_stop_horizons.py
@@ -103,7 +103,9 @@ def test_terminal_horizon_charges_an_owed_stop_exactly_once():
     projected_gaps = current_gaps + window_deltas  # our own delta is 0 here
 
     pit_loss_s = np.zeros(1)
-    terminal_gaps = _terminal_gaps(rivals, STAY_OUT, projected_gaps, pit_loss_s, config)
+    terminal_gaps = _terminal_gaps(
+        rivals, STAY_OUT, projected_gaps, pit_loss_s, np.full_like(pit_loss_s, 999.0), config
+    )
 
     assert terminal_gaps[0, 0] - projected_gaps[0, 0] == pytest.approx(STOP_LOSS_S), (
         "terminal horizon: still owes the stop, so the residual lands even though "


### PR DESCRIPTION
Refs #763 · ⛔ **DO NOT MERGE — opened as the record of a negative result**

The deferral liability works and its input does not carry it. The blocker is now a number instead of an intuition, so this decision is re-runnable in one command the day the tyre signal improves.

## What was actually wrong, after my first diagnosis was refuted

A Fable design gate was pointed at #763 with the mandate to refute its framing before any code was written, and it did. **I had been reasoning about a scorer that decided 0 of 2,744 eval laps.** Three numbers I published are artefacts and are retired in this branch.

The real defect is a population split:

| | first stops (105) | **elective (73)** |
|---|---|---|
| pit cost carried | traversal cancels, ~3.3 s net | **the full ~22.8 s, alone** |
| declined | 26.7% | **69.9%** |

A car whose mandatory stop is discharged got **no future-cost term at all**, so an elective stop's full pit loss stood against exactly zero. 51 of the 79 declines were elective.

## The fix, and it works

The missing tyre side of the terminal liability: the cheaper of *stop once the window ends* and *hold the set to the flag*, q_f-discounted on the stop branch only, scoped to plans with no residual.

**The horizon is measured, not chosen.** Over 694 real elective stops, a stop takes a **median 13 laps** (95% CI [12, 14]) to repay itself, and only **15.0%** repay inside five. A five-lap window can price a seventh of the decision.

**Result:** declines **79 → 66** (44.4% → 37.1%), every recovered one elective, and **E3's invariance is exact** — not one first-stop verdict moved, not one chosen lap changed.

## Why it is not being merged

`deg_cost_s`'s per-lap error, measured for the first time against N04's own target on 31,624 laps:

| | |
|---|---|
| median absolute | **0.261 s/lap** |
| mean absolute | **0.650 s/lap** (CI [0.623, 0.678]) |
| **signed bias** | **+0.351 s/lap** |
| under 0.1 s/lap | 21.9% |

- **The amplification table understates it.** It perturbs ±0.1 s/lap — *smaller than the model's typical error*. The real behaviour sits between the ±0.2 row (13.1% of elective decisions flipped) and ±0.5 (26.8%).
- **The error grows where the term bites hardest**: 0.209 s/lap at 3-10 laps of tyre life, **0.557 past 30**, and the liability multiplies by laps remaining.
- **The bias is not noise.** +0.351 s/lap over ~40 laps is **~14 s of phantom cost** — the same order as the 22.8 s pit loss it exists to compare against.
- **And it is not understood.** Removing a genuine double-discount bug moved the amplification 5.91× → **6.82×**, against a written prediction that it would fall.

**What unblocks it:** reduce the error or remove the bias in `deg_cost_s`. The bound belongs to it **as a class** — `driver_time_delta` consumes the same biased input on `main` today at 1/8 the exposure.

## Three exit-gate findings fixed along the way

- **The cliff half charged an onset the model never supplied**, ignoring the per-draw `cliff_laps` the caller holds. On 189 real laps where the model said the set costs *nothing*, it charged a median 8.41 s of pure invention. Now uses the per-draw value, as the in-window half always has.
- **The whole feature could be disconnected with 173 tests green.** Third time a gate has found that exact shape in my own work.
- **The q_f discount was applied to both branches**, crediting one Safety Car twice. A neutralisation cheapens the *stop*, not the rubber.
- Plus the zero clamp, which binds on 10.7% of evaluations and guards a sign inversion: an unclamped negative liability reports deferring as **gaining** track position.

Each is mutation-verified; each mutant goes red on the test written for it.

## A separate measurement, answering a fair objection

The objection: exact-lap agreement is too demanding, ±3 laps would be fairer. **Measured on 1,551 real stops, it is not.** Median fresh-set advantage 1.137 s/lap against a measured 2.227 s gap between cars: **1.96 laps of offset costs a whole track position**, so ±3 accepts calls costing a place and a half. Conservative both ways — it ignores rejoin traffic and uses the pooled gap.

Exact-lap and within-1 stay, now with a measured basis rather than by default.

## Checks

177 across `tests/mc`; `ruff` clean at the pinned version. Two new instruments committed (`measure_deg_error_bound.py`, `measure_offset_cost.py`) so the ship decision is one command away when the signal improves.
