### PR TITLE
fix(agents): derive every guard-rail bound the two prompts were restating

### DIFF
--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -29,6 +29,17 @@ from sklearn.preprocessing import LabelEncoder
 # there is no cycle even though src/strategy/inference/no_llm.py imports this package.
 from src.strategy.inference.envelope import OperatingEnvelope
 
+# From the leaf guard-rails module, never restated. These four bounds were prose in the
+# system prompt while the deterministic rails computed against the constants, so the
+# prompt could tell the LLM to refuse what the rails had just allowed (#741, #766).
+# guard_rails imports nothing from this package, so there is no cycle.
+from src.strategy.inference.guard_rails import (
+    _CLIFF_P10_SAFE,
+    _MIN_STINT_LAPS,
+    _NO_PIT_BEFORE_LAP,
+    _NO_PIT_LAST_N_LAPS,
+)
+
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent
 while not (_REPO_ROOT / '.git').exists():
@@ -141,6 +152,13 @@ _NORMAL_STOP_MAX_S: float = 4.5
 
 CLIFF_IMMINENT_LAPS = 3    # laps_to_cliff_p10 below this → PIT_NOW
 CLIFF_SOON_LAPS     = 10   # laps_to_cliff_p10 below this → prefer harder compound
+
+# Above this, an undeployed Safety Car is elevated enough to justify REACTIVE_SC rather
+# than a plain stop. It had no name at all: the value sat as a bare 0.30 in the routing
+# branch and twice more in the system prompt, three copies of a number nobody declared.
+# A constant with no definition cannot drift from its definition, but it can drift from
+# its other copies, which is the same defect wearing a different hat (#766).
+SC_REACTIVE_PROB_THRESHOLD = 0.30
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -615,15 +633,17 @@ Decision rules:
 1. Always call predict_pit_duration_tool first to know the stop cost.
 2. Call score_undercut_tool for each rival within 5 positions ahead.
 3. Call recommend_compound_tool to determine the optimal compound.
-4. If P(undercut_success) >= 0.522 for any rival → recommend UNDERCUT.
-5. If sc_prob context is provided and >= 0.30 → recommend REACTIVE_SC pit.
-6. If tyre_cliff context is provided and laps_to_cliff <= 3 → recommend PIT_NOW.
+4. If score_undercut_tool reports YES for any rival -> recommend UNDERCUT. The tool
+   prints the live threshold it compared against; do not carry your own number. It is
+   loaded from the model's calibration config and moves whenever the model is retuned.
+5. If sc_prob context is provided and >= {SC_REACTIVE_PROB_THRESHOLD} → recommend REACTIVE_SC pit.
+6. If tyre_cliff context is provided and laps_to_cliff <= {CLIFF_IMMINENT_LAPS} → recommend PIT_NOW.
 7. Otherwise → STAY_OUT unless a clear strategic window exists.
 
 ## Strategic guard-rails (HARD constraints — override any decision rule above)
 
 PIT WINDOW — early race:
-  NEVER recommend PIT_NOW, UNDERCUT, or OVERCUT before lap 5 of the race.
+  NEVER recommend PIT_NOW, UNDERCUT, or OVERCUT before lap {_NO_PIT_BEFORE_LAP} of the race.
   Exception: Safety Car IS currently deployed (prompt shows "SC STATUS: SAFETY
   CAR DEPLOYED RIGHT NOW"), or radio confirms damage/puncture/mechanical failure.
   Rationale: no tyre degrades enough in 1-4 laps to justify a stop; the pit lane time cost
@@ -631,8 +651,8 @@ PIT WINDOW — early race:
   in your reasoning.
 
 PIT WINDOW — end of race:
-  NEVER recommend PIT_NOW, UNDERCUT, or OVERCUT when remaining laps <= 3.
-  Exception: tyre failure is imminent (laps_to_cliff P10 < 2) or Safety Car deployed.
+  NEVER recommend PIT_NOW, UNDERCUT, or OVERCUT when remaining laps <= {_NO_PIT_LAST_N_LAPS}.
+  Exception: tyre failure is imminent (laps_to_cliff P10 < {_CLIFF_P10_SAFE}) or Safety Car deployed.
   Rationale: a pit stop costs ~22-25s; with ≤3 laps, fresh tyres recover at most ~1.5s
   total. Net loss ≈ 20s. Under green-flag racing, where consecutive cars sit a
   measured median 2.226s apart, that is worth ~9 positions, not 13: 13 positions
@@ -640,8 +660,8 @@ PIT WINDOW — end of race:
   the exception handled above, not this rule.
 
 MINIMUM STINT LENGTH before a pit makes sense:
-  SOFT: current tyre_life must be >= 8 laps before recommending a stop.
-  MEDIUM: >= 12 laps.  HARD: >= 15 laps.
+  SOFT: current tyre_life must be >= {_MIN_STINT_LAPS['SOFT']} laps before recommending a stop.
+  MEDIUM: >= {_MIN_STINT_LAPS['MEDIUM']} laps.  HARD: >= {_MIN_STINT_LAPS['HARD']} laps.
   If the driver has NOT completed the minimum stint, recommend STAY_OUT (the current
   set still has useful life; pitting now wastes a tyre allocation).
 
@@ -660,7 +680,7 @@ MINIMUM STINT LENGTH before a pit makes sense:
 
 COMPOUND vs REMAINING LAPS:
   SOFT: recommend only if remaining laps <= {_STINT_CAPACITY_LAPS['SOFT']} (it won't last longer).
-  MEDIUM: suitable for 12-30 remaining laps.
+  MEDIUM: suitable for {_MIN_STINT_LAPS['MEDIUM']}-{_STINT_CAPACITY_LAPS['MEDIUM']} remaining laps.
   HARD: suitable for 20+ remaining laps.
   Picking SOFT with 25 laps to go forces an extra pit stop — factor that cost in.
 
@@ -668,7 +688,7 @@ REACTIVE_SC usage:
   REACTIVE_SC is for the rare in-between case where sc_prob is elevated but the
   Safety Car is NOT yet deployed.  When the prompt states "SC STATUS: SAFETY CAR
   DEPLOYED RIGHT NOW", prefer PIT_NOW directly.  Use REACTIVE_SC only when
-  sc_prob >= 0.30 AND the prompt shows the legacy "SC probability" line.  A high
+  sc_prob >= {SC_REACTIVE_PROB_THRESHOLD} AND the prompt shows the legacy "SC probability" line.  A high
   sc_prob without confirmation is still a contingency — mention it in reasoning
   and set ACTION to STAY_OUT unless the SC is actually out.
 
@@ -1597,7 +1617,7 @@ class PitStrategyAgent:
         # the surrendered position unrecoverable). The regulatory facts an SC does
         # force live in N27; see tests/mc/test_sc_regulatory_rails.py.
         sc_reactive = sc_currently_active or (action == 'REACTIVE_SC') or (
-            sc_prob >= 0.30 and action in ('PIT_NOW', 'UNDERCUT')
+            sc_prob >= SC_REACTIVE_PROB_THRESHOLD and action in ('PIT_NOW', 'UNDERCUT')
         )
 
         return PitStrategyOutput(

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -81,6 +81,17 @@ from src.agents.pit_strategy_agent import (
     run_pit_strategy_agent_from_state,
     _STINT_CAPACITY_LAPS,
 )
+
+# From the leaf guard-rails module, so this prompt states the same bounds the rails
+# enforce rather than a prose copy of them. Every one of these was a literal here and a
+# constant there, which is how the SOFT capacity ended up telling the LLM to refuse what
+# the selector had just allowed (#741, #766).
+from src.strategy.inference.guard_rails import (
+    _CLIFF_P10_SAFE,
+    _MIN_STINT_LAPS,
+    _NO_PIT_BEFORE_LAP,
+    _NO_PIT_LAST_N_LAPS,
+)
 from src.agents.radio_agent        import (
     run_radio_agent,
     run_radio_agent_from_state,
@@ -1661,10 +1672,12 @@ def _build_orchestrator_prompt(
         f"(if present) one regulation signal. If evidence across agents disagrees, say so\n"
         f"and explain which signal you trusted and why.\n\n"
         f"STRATEGIC GUARD-RAILS (HARD — override any sub-agent or MC signal that conflicts):\n"
-        f"  1. NO pit action (PIT_NOW / UNDERCUT / OVERCUT) before lap 5 unless SC deployed\n"
+        f"  1. NO pit action (PIT_NOW / UNDERCUT / OVERCUT) before lap {_NO_PIT_BEFORE_LAP} "
+        f"unless SC deployed\n"
         f"     or damage/puncture confirmed by radio. Fresh tyres cannot degrade in 1-4 laps;\n"
         f"     pit lane costs ~22-25s which is unrecoverable this early. Force STAY_OUT.\n"
-        f"  2. NO pit action when remaining laps <= 3 unless tyre failure imminent\n"
+        f"  2. NO pit action when remaining laps <= {_NO_PIT_LAST_N_LAPS} unless tyre failure "
+        f"imminent\n"
         # ~9, not ~13. The 13 was 20 s / POS_GAP_S(1.50), and POS_GAP_S is the legacy
         # scoring constant `measure_mc_tables.py` records as retired. The MEASURED
         # median gap between consecutive cars under green flag is 2.227 s (n=69,487),
@@ -1673,19 +1686,22 @@ def _build_orchestrator_prompt(
         # excludes. The pit agent's prompt already said exactly that, so the two
         # prompts were teaching one orchestrating LLM contradictory numbers in the
         # same run (#766).
-        f"     (cliff P10 < 2 laps). Pit cost ~22s vs ~1.5s recovery = ~9 positions lost\n"
+        f"     (cliff P10 < {_CLIFF_P10_SAFE} laps). Pit cost ~22s vs ~1.5s recovery = "
+        f"~9 positions lost\n"
         f"     under green flag (measured median gap 2.227s). The ~13 figure is the\n"
         f"     Safety Car bunched field (1.4795s), which is the exception above.\n"
         f"  3. REACTIVE_SC only when SC IS deployed (confirmed). High sc_prob is a\n"
         f"     contingency trigger, not a primary action — use STAY_OUT with SC contingency.\n"
-        f"  4. Minimum stint before pit: SOFT >= 8 laps, MEDIUM >= 12, HARD >= 15.\n"
+        f"  4. Minimum stint before pit: SOFT >= {_MIN_STINT_LAPS['SOFT']} laps, "
+        f"MEDIUM >= {_MIN_STINT_LAPS['MEDIUM']}, HARD >= {_MIN_STINT_LAPS['HARD']}.\n"
         f"     If tyre_life is below minimum, override to STAY_OUT (current set has life left).\n"
         # SOFT bound derived from _STINT_CAPACITY_LAPS (imported above), not restated:
         # this line and the pit agent's own system prompt used to disagree with the
         # deterministic selector's table (18 vs 15), so laps_remaining=16-18 had the
         # selector pass SOFT while both prompts told the LLM to refuse it (#741).
         f"  5. Compound must fit remaining laps: SOFT only if <= {_STINT_CAPACITY_LAPS['SOFT']} laps remain,\n"
-        f"     MEDIUM for 12-30, HARD for 20+. Wrong compound forces an extra stop.\n"
+        f"     MEDIUM for {_MIN_STINT_LAPS['MEDIUM']}-{_STINT_CAPACITY_LAPS['MEDIUM']}, "
+        f"HARD for 20+. Wrong compound forces an extra stop.\n"
         f"  6. Opening laps 1-3: threat levels from N27 are inflated by start chaos.\n"
         f"     Discount them one tier (HIGH→MEDIUM, MEDIUM→LOW) for decision-making.\n"
         f"  If a sub-agent recommends an action that violates these rules, override to\n"

--- a/tests/agents/test_prompt_constants_match_tables.py
+++ b/tests/agents/test_prompt_constants_match_tables.py
@@ -81,6 +81,16 @@ def _orchestrator_prompt() -> str:
     return _build_orchestrator_prompt(race_state, {}, "STAY_OUT")
 
 
+def _prompts() -> dict[str, str]:
+    """Both rendered prompts, so every check below covers the pair rather than one."""
+    from src.agents.pit_strategy_agent import _PIT_STRATEGY_SYSTEM_PROMPT
+
+    return {
+        "pit agent prompt": _PIT_STRATEGY_SYSTEM_PROMPT,
+        "orchestrator prompt": _orchestrator_prompt(),
+    }
+
+
 def test_no_prompt_states_a_capacity_the_table_disagrees_with():
     """The relation, not the value. Both prompts, every compound they mention."""
     from src.agents.pit_strategy_agent import _PIT_STRATEGY_SYSTEM_PROMPT, _STINT_CAPACITY_LAPS
@@ -141,3 +151,75 @@ def test_the_selector_and_the_prompt_agree_across_the_band_that_used_to_split_th
         selector_allows = _STINT_CAPACITY_LAPS["SOFT"] >= laps_remaining
         prompt_allows = laps_remaining <= prompt_bound
         assert selector_allows == prompt_allows, laps_remaining
+
+
+# The four guard-rail bounds, each of which was prose in both prompts while the
+# deterministic rails computed against the constant. Gate G3 listed them; #741 had
+# derived exactly one number and left these.
+_MIN_STINT = re.compile(r"\b(SOFT|MEDIUM|HARD)\b[^.\n]*?>=\s*(\d+)\s*lap")
+_BEFORE_LAP = re.compile(r"before lap (\d+)")
+# Anchored on "when", because a looser pattern also matches the COMPOUND capacity line
+# ("recommend only if remaining laps <= 18") and then asserts the guard-rail bound
+# equals a stint capacity. Caught by this very test on its first run.
+_LAST_LAPS = re.compile(r"when remaining laps <=\s*(\d+)")
+_CLIFF_P10 = re.compile(r"cliff P10 <\s*(\d+)|laps_to_cliff P10 <\s*(\d+)")
+
+
+def test_no_prompt_states_a_minimum_stint_the_rails_disagree_with():
+    """`_MIN_STINT_LAPS` sat two sections above the one number #741 derived.
+
+    Same defect, same file, left in place because the fix was applied to the instance
+    in front of me rather than to the class. That is the pattern three gates have now
+    found, so this pins the whole table instead of one compound of it.
+    """
+    from src.strategy.inference.guard_rails import _MIN_STINT_LAPS
+
+    for name, prompt in _prompts().items():
+        stated = {m.group(1): int(m.group(2)) for m in _MIN_STINT.finditer(prompt)}
+        assert stated, f"{name} states no minimum stint the pattern can see"
+        for compound, value in stated.items():
+            assert value == _MIN_STINT_LAPS[compound], (
+                f"{name} says {compound} >= {value}, the rails enforce {_MIN_STINT_LAPS[compound]}"
+            )
+
+
+def test_no_prompt_states_a_pit_window_bound_the_rails_disagree_with():
+    """The two hard bounds an LLM is told to treat as inviolable.
+
+    If prose and rail disagree here the model is told to refuse an action the rails
+    would have allowed, or to allow one they will override, and either way the
+    disagreement is invisible until someone reads both files.
+    """
+    from src.strategy.inference.guard_rails import (
+        _CLIFF_P10_SAFE,
+        _NO_PIT_BEFORE_LAP,
+        _NO_PIT_LAST_N_LAPS,
+    )
+
+    for name, prompt in _prompts().items():
+        early = [int(m.group(1)) for m in _BEFORE_LAP.finditer(prompt)]
+        late = [int(m.group(1)) for m in _LAST_LAPS.finditer(prompt)]
+        cliff = [int(m.group(1) or m.group(2)) for m in _CLIFF_P10.finditer(prompt)]
+
+        assert early, f"{name}: the early-window bound is no longer visible"
+        assert late, f"{name}: the end-of-race bound is no longer visible"
+        assert cliff, f"{name}: the cliff exception is no longer visible"
+
+        assert set(early) == {_NO_PIT_BEFORE_LAP}, name
+        assert set(late) == {_NO_PIT_LAST_N_LAPS}, name
+        assert set(cliff) == {_CLIFF_P10_SAFE}, name
+
+
+def test_the_undercut_threshold_is_not_restated_at_all():
+    """This one cannot be interpolated, so it must not appear.
+
+    The threshold is loaded per-instance from the model's calibration config and the
+    tool PRINTS the live value into its own response. A module-level prompt cannot see
+    it, so restating it means the LLM can receive two different thresholds in one
+    conversation the moment the model is retuned. The prompt now points at what the
+    tool reports instead.
+    """
+    from src.agents.pit_strategy_agent import _PIT_STRATEGY_SYSTEM_PROMPT
+
+    assert "0.522" not in _PIT_STRATEGY_SYSTEM_PROMPT
+    assert "score_undercut_tool reports" in _PIT_STRATEGY_SYSTEM_PROMPT


### PR DESCRIPTION
Refs #766 — the last item gate G3 left open.

**#741 derived exactly one number and left five more literals in the same two prompts.** That is the pattern three gates have now found in this work: the guard gets applied to the instance in front of me, not to the class.

## Derived from `guard_rails`, in both prompts

| was a literal | now reads |
|---|---|
| "before lap **5**" | `_NO_PIT_BEFORE_LAP` |
| "when remaining laps <= **3**" | `_NO_PIT_LAST_N_LAPS` |
| "cliff P10 < **2**" | `_CLIFF_P10_SAFE` |
| "SOFT >= **8**, MEDIUM >= **12**, HARD >= **15**" | `_MIN_STINT_LAPS` |
| "laps_to_cliff <= **3**" | `CLIFF_IMMINENT_LAPS` |
| "MEDIUM: **12-30** remaining laps" | `_MIN_STINT_LAPS` + `_STINT_CAPACITY_LAPS` |

`guard_rails` imports nothing from the agents package, so there is no cycle.

## The Safety Car threshold had no constant at all

A bare `0.30` sat in the routing branch and **twice more** in the prompt — three copies of a number nobody had declared. Now `SC_REACTIVE_PROB_THRESHOLD`, read by all three. A constant with no definition cannot drift from its definition, but it can drift from its other copies.

## The undercut threshold gets a different fix, because it is a different problem

It is **loaded per-instance from the model's calibration config**, and the tool already **prints the live value into its own response**. A module-level prompt cannot interpolate it, so restating it means the LLM receives two different thresholds in one conversation the moment the model is retuned.

The prompt now points at what the tool reports, and a test asserts the number is **absent** rather than merely correct.

## The mutation work, because my first attempt tested the wrong thing

Changing a guard-rail constant leaves every test green — **correctly**, because the prompts now move with it. That is the whole point, and for a moment it looked like the tests were worthless.

What has to go red is **reverting an interpolation back to a literal**, and all four of those mutants do:

| mutant | result |
|---|---|
| prompt hardcoded to lap 7 | 1 red |
| prompt hardcoded to 4 remaining laps | 1 red |
| prompt hardcoded to SOFT min stint 9 | 1 red |
| prompt hardcoded to cliff P10 1 | 1 red |

## The test caught a defect in itself on its first run

Its pattern for the end-of-race bound also matched the **compound capacity** line, so it asserted that a guard-rail bound equals a stint capacity — `{3, 18} == {3}`. Anchored on the phrasing that distinguishes them. Worth stating: an over-broad regex in a coverage test is the same failure as an under-broad one, just louder.

## Checks

**248** across `tests/agents` + `tests/mc`; `ruff check .` and `ruff format --check .` clean at the pinned version.
