### PR TITLE
fix(agents): reject a contaminated lap from the tyre fresh-reference

### DIFF
--- a/documents/audits/MEASURE_fresh_reference_quality_gate.md
+++ b/documents/audits/MEASURE_fresh_reference_quality_gate.md
@@ -1,0 +1,125 @@
+# Fresh-reference quality gate — root cause and measured effect
+
+**Date:** 2026-08-01 · **Instrument:** `scripts/measure_fresh_reference_gate.py`
+**Sample:** 31,624 laps at tyre life > 3, across 1,714 stints with a usable fresh
+reference, seasons 2023-24 (training only).
+
+**Result: `deg_cost_s`'s error bound (0.650 s/lap mean absolute, +0.351 s/lap signed
+bias — `feat/deferral-tyre-liability`, `MEASURE_763_ship_decision.md`) is not evenly
+spread across laps. A handful of stints have a contaminated fresh-reference lap, and
+gating that lap on race pace cuts mean absolute error to 0.434 s/lap and signed bias
+to +0.139, at a cost of 49 of 1,714 stints (2.9%) losing their reference and falling
+back to `None` → `FRESH_GAIN`.**
+
+---
+
+## Where the epic's own bound was measured, and what it didn't decompose
+
+`MEASURE_763_ship_decision.md` published the aggregate bound and, correctly, said the
+bound belongs to `deg_cost_s` as a class — `driver_time_delta` already consumes the
+same input on `main` today. It did not ask WHERE inside that population the error
+concentrates. This note answers that question and ships a fix for the part of it that
+is a data-quality gap rather than a property of the model.
+
+## The mechanism
+
+`deg_cost_s = cumulative_deg_s(now) − cumulative_deg_s(fresh reference)`. The fresh
+reference is a second deterministic TCN pass over the stint's own early laps
+(`TireAgent._fresh_reference`, tyre life ≤ 3). Grouping the raw per-lap residual
+(`pred − target`) by tyre-life band shows almost no drift — mean +0.03 to +0.08 s/lap
+beyond the first few laps, correlation with tyre life +0.04 to +0.11 per compound.
+**The model's own predictions are not what grows.**
+
+What grows is the **fresh-reference residual**, and only for the subset of stints that
+happen to run long: grouped by each stint's own max tyre life, the per-stint
+fresh-reference residual is essentially flat in the MEDIAN (0.01 to 0.04 s/lap across
+every band) but the MEAN at 30+ laps is **−0.691**, dragged there by a tail — one stint
+at **−53.989 s** and another at **−46.454 s**, both from **Mexico City 2023**; five
+more between −4 and −8 s from **Monaco 2024** and **Melbourne 2023**.
+
+Pulling the full lap sequence for the worst case (car 4, Mexico City 2023):
+
+| LapNumber | Stint | TyreLife | LapTime_s | FuelAdjustedDegAbsolute |
+|---|---|---|---|---|
+| 36 | 4 | 3 | **137.757** | 0.000 (the baseline lap) |
+| 37 | 4 | 4 | 84.243 | **−53.459** |
+| 38 | 4 | 5 | 83.841 | **−53.806** |
+
+Green-flag pace at this circuit is ~83 s. Lap 36 is a Safety-Car/red-flag-affected lap
+that FastF1 apparently did not mark inaccurate. N04's target is defined relative to
+*this stint's own baseline lap* — here, that anomalous 137.8 s lap — so every
+subsequent lap reads as ~54 s "faster than fresh," which is not tyre wear, it is the
+zero point being wrong by 54 seconds.
+
+**`track_status_clean` — the column that should catch this — is dead.**
+`_add_session_cols`'s own docstring already says so: it is a constant 0 across every
+row of every featured parquet, because N04's `IsAccurate` gate does not catch every
+neutralised lap. This stint's lap 36 is the counter-example that falsifies the
+docstring's stated reason ("every lap that survives is genuinely green"): it survived,
+and it is not green by any reasonable reading of 137.757 s at a ~83 s circuit.
+
+Two more things worth recording, both checked and both negative:
+
+- The model's prediction on the **current** (non-reference) lap is not similarly
+  contaminated: additionally dropping laps whose own `pct_of_fastest` exceeds the
+  threshold removes only 0.3% of scored rows and moves the bound by <0.01 s/lap.
+- `LapsSincePitStop == 0` (a literal pit-exit out-lap) does not co-occur with these
+  reference laps in the training data — this is a caution-period artefact, not an
+  out-lap artefact, and the existing docstring's second stated cause ("an out-lap or a
+  standing start") is not what this measurement finds driving the tail.
+
+## The fix, and why this signal and not a new one
+
+`lap_time_pct_of_race_fastest` is already one of the TCN's 42 input features,
+computed unconditionally in `_add_session_cols` from `session_meta['fastest_lap_s']`
+— available at exactly the point `track_status_clean` should have been, at zero new
+data cost. Mexico City 2023's lap 36 reads **1.694** on it; the population of 1,822
+training-season fresh-reference laps has median **1.046**, p95 **1.181**, p99
+**1.464** — a long, well-separated tail.
+
+`TireAgent._fresh_reference` now drops any candidate lap above
+`cfg.fresh_reference_max_pct_of_fastest` (default **1.10**) before building the
+reference tensor, via the pure, leaf-level `_reject_contaminated_laps`. If every
+candidate is rejected, it returns `None` — never falls back to a contaminated lap —
+matching the doctrine `_referenced_wear` already applies to a missing half: a wrong
+reference is worse than none.
+
+## Threshold sweep (why 1.10, not looser or tighter)
+
+| threshold | mean abs error | signed bias | stints losing their reference |
+|---|---|---|---|
+| none (baseline) | 0.650 | +0.351 | 0 |
+| **1.10 (shipped)** | **0.434** | **+0.139** | 49 (2.9%) |
+| 1.15 | 0.478 | +0.183 | 20 |
+| 1.20 | 0.502 | +0.208 | 16 |
+| 1.25 | 0.534 | +0.242 | 12 |
+
+1.10 gives the largest error reduction for a coverage cost that stays under 3%.
+Tighter thresholds recover fewer stints' worth of contamination for a shrinking
+marginal gain; looser ones leave more of the tail in.
+
+## What this does NOT claim
+
+**The bound is reduced, not closed.** 0.434 s/lap mean absolute error is still above
+the 0.1 s/lap perturbation `MEASURE_763_ship_decision.md`'s amplification table was
+measured at, and +0.139 s/lap of remaining bias, integrated over a long stint, is
+still a real number. This note does not reopen the #763 ship decision — `deg_cost_s`
+still needs a smaller bound before the deferral liability term can carry it, and nothing
+here changes that verdict. What it does is remove a *known, root-caused, unrelated-to-
+model-capacity* contribution to that bound, which was sitting inside the number
+`MEASURE_763_ship_decision.md` published without being separated out.
+
+**This is a genuine, if partial, improvement to `deg_cost_s` as it exists on `main`
+today** (the term `driver_time_delta` already consumes, at 5 laps of exposure), not
+only to the parked deferral term. The 33% mean-error reduction and 60% bias reduction
+apply to production `deg_cost_s` the moment this ships, independent of #763/#771.
+
+## Reproducing
+
+```bash
+uv run python scripts/measure_fresh_reference_gate.py
+```
+
+Related: `MEASURE_744a_tyre_reference.md` · `MEASURE_763_ship_decision.md`
+(`feat/deferral-tyre-liability`) · `scripts/measure_deg_error_bound.py`
+(same branch, the original bound this note decomposes)

--- a/scripts/measure_fresh_reference_gate.py
+++ b/scripts/measure_fresh_reference_gate.py
@@ -1,0 +1,160 @@
+"""Measure what gating the fresh-reference lap on race pace buys `deg_cost_s`.
+
+`deg_cost_s = pred(now) - pred(fresh reference)`, both from the TCN. Its TRUE
+counterpart is the same difference taken on N04's own target column, and the
+error is the difference of the two differences -- the same bound
+`scripts/measure_deg_error_bound.py` (branch `feat/deferral-tyre-liability`,
+issue #763) measured at 0.650 s/lap mean absolute, +0.351 s/lap signed bias.
+
+That investigation traced the growth to a small number of STINTS whose
+fresh-reference lap (`TyreLife <= FRESH_MAX_TYRE_LIFE`) was itself a
+Safety-Car- or red-flag-affected lap: `track_status_clean` is supposed to flag
+this but is a constant 0 across the whole featured parquet (see
+`_add_session_cols`'s docstring), because N04's `IsAccurate` gate does not
+catch every neutralised lap. Measured counter-example: Mexico City 2023 car 4,
+lap 36 reads 137.757 s on a circuit whose green-flag pace is ~83 s, and every
+later lap in that nominal stint then priced tens of seconds "faster than
+fresh" -- not tyre wear, an artefact of a contaminated zero point.
+
+`TireAgent._fresh_reference` now rejects a candidate lap slower than
+`fresh_reference_max_pct_of_fastest` times the race's fastest lap via
+`_reject_contaminated_laps`, imported here rather than reimplemented so this
+measures what actually ships.
+
+Training seasons only (2023-24), matching `measure_tyre_reference.py` and
+`src/strategy/eval/hygiene.py`'s reasoning against fitting on the test season.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.measure_tyre_reference import (  # noqa: E402
+    FRESH_MAX_TYRE_LIFE,
+    predict_training_stints,
+)
+from src.agents.tire_agent import CFG, _reject_contaminated_laps  # noqa: E402
+
+LAPS_PATH = Path("data/processed/laps_tiredeg.parquet")
+TRAINING_YEARS = (2023, 2024)
+STINT_KEYS = ["Year", "GP_Name", "DriverNumber", "Stint"]
+
+
+def attach_pct_of_fastest(frame: pd.DataFrame) -> pd.DataFrame:
+    """Join `lap_time_pct_of_race_fastest`'s two inputs from the raw parquet.
+
+    `predict_training_stints()` returns only `stint`/`tyre_life`/`pred`/`target`,
+    so the lap time and the race's fastest lap have to be pulled back in.
+    `TyreLife` is not unique within a (stint) group for a handful of red-flag
+    affected stints -- the same nominal `Stint` number restarts `TyreLife` after
+    the restart -- so duplicates are collapsed to the WORST (slowest) candidate:
+    missing a contaminated lap is exactly the failure mode being measured.
+    """
+    laps = pd.read_parquet(LAPS_PATH)
+    laps = laps[laps["Year"].isin(TRAINING_YEARS)].copy()
+    laps["stint_id"] = laps[STINT_KEYS].astype(str).agg("|".join, axis=1)
+    laps["fastest_lap_s"] = laps.groupby(["Year", "GP_Name"])["LapTime_s"].transform("min")
+
+    lap_time = laps.groupby(["stint_id", "TyreLife"])["LapTime_s"].max()
+    fastest = laps.groupby(["stint_id", "TyreLife"])["fastest_lap_s"].first()
+
+    key = frame.set_index(["stint", "tyre_life"]).index
+    frame = frame.copy()
+    frame["lap_time_s"] = key.map(lap_time)
+    frame["fastest_lap_s"] = key.map(fastest)
+    return frame
+
+
+def score(scored: pd.DataFrame, label: str) -> dict:
+    """The bound: mean/median absolute error, signed bias, and error by band."""
+    absolute = scored["error"].abs()
+    bands = pd.cut(scored["tyre_life"], [3, 10, 20, 30, 100])
+    by_band = scored.groupby(bands, observed=True)["error"].mean()
+
+    result = {
+        "label": label,
+        "n": len(scored),
+        "mean_abs_error": round(float(absolute.mean()), 3),
+        "median_abs_error": round(float(absolute.median()), 3),
+        "signed_bias": round(float(scored["error"].mean()), 3),
+        "by_band_mean_error": {str(k): round(float(v), 3) for k, v in by_band.items()},
+    }
+    print(
+        f"\n=== {label} (n={result['n']}) ===\n"
+        f"  mean abs error   {result['mean_abs_error']:7.3f} s/lap\n"
+        f"  median abs error {result['median_abs_error']:7.3f} s/lap\n"
+        f"  bias (signed)    {result['signed_bias']:+7.3f} s/lap"
+    )
+    for band, value in result["by_band_mean_error"].items():
+        print(f"    {band:<12} {value:+.3f}")
+    return result
+
+
+def build_reference(fresh: pd.DataFrame, gated: bool) -> tuple[pd.Series, pd.Series]:
+    """The fresh-reference prediction and target, gated or not, per stint."""
+    if gated:
+        clean = _reject_contaminated_laps(
+            fresh.rename(columns={"lap_time_s": "LapTime_s"}),
+            fastest_lap_s=fresh["fastest_lap_s"],
+            max_pct=CFG.fresh_reference_max_pct_of_fastest,
+        )
+    else:
+        clean = fresh
+    return clean.groupby("stint")["pred"].last(), clean.groupby("stint")["target"].last()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, help="write the measured scores to this JSON path")
+    args = parser.parse_args()
+
+    frame = predict_training_stints().sort_values(["stint", "tyre_life"])
+    frame = attach_pct_of_fastest(frame)
+    fresh = frame[frame["tyre_life"] <= FRESH_MAX_TYRE_LIFE].dropna(
+        subset=["lap_time_s", "fastest_lap_s"]
+    )
+
+    def scored_bound(gated: bool) -> pd.DataFrame:
+        ref_pred, ref_true = build_reference(fresh, gated)
+        n_stints_before = fresh["stint"].nunique()
+        n_stints_after = ref_pred.notna().sum()
+
+        scored = frame[frame["tyre_life"] > FRESH_MAX_TYRE_LIFE].copy()
+        scored["ref_pred"] = scored["stint"].map(ref_pred)
+        scored["ref_true"] = scored["stint"].map(ref_true)
+        scored = scored.dropna(subset=["ref_pred", "ref_true"])
+        scored["error"] = (scored["pred"] - scored["ref_pred"]) - (
+            scored["target"] - scored["ref_true"]
+        )
+        print(
+            f"  stints with a reference: {n_stints_after} of {n_stints_before} "
+            f"({n_stints_before - n_stints_after} lost to the gate)"
+            if gated
+            else f"  stints with a reference: {n_stints_after} of {n_stints_before}"
+        )
+        return scored
+
+    before = score(scored_bound(gated=False), "BASELINE -- no quality gate (current main)")
+    after = score(scored_bound(gated=True), "GATED -- fresh_reference_max_pct_of_fastest")
+
+    if args.out:
+        payload = {
+            "generated_by": "scripts/measure_fresh_reference_gate.py",
+            "years": list(TRAINING_YEARS),
+            "gate_threshold": CFG.fresh_reference_max_pct_of_fastest,
+            "before": before,
+            "after": after,
+        }
+        args.out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -225,6 +225,27 @@ class TireAgentConfig:
             standing start, so the level is biased slow and cannot be charged as a
             cost directly. Asking the same model on the same stint's early laps
             cancels that baseline algebraically instead of approximately.
+        fresh_reference_max_pct_of_fastest: Reject a fresh-reference candidate lap
+            whose ``lap_time_pct_of_race_fastest`` exceeds this ratio. ``track_status_
+            clean`` (see ``_add_session_cols``) is supposed to be the signal for a
+            Safety-Car- or red-flag-affected lap, but it is dead on the shipping
+            path — a constant 0 across every featured parquet, because N04's
+            ``IsAccurate`` gate does not catch every neutralised lap (measured
+            counter-example: Mexico City 2023 car 4, lap 36, 137.8 s on a circuit
+            whose green-flag pace is ~83 s, ``track_status_clean == 0`` regardless).
+            When such a lap lands as the fresh reference, the model correctly
+            predicts it as an outlier and every later lap in the stint reads as
+            tens of seconds "faster than fresh" — not tyre wear, an artefact of a
+            contaminated zero point. ``lap_time_pct_of_race_fastest`` is already a
+            TCN input feature, computed unconditionally and cheaply from
+            ``session_meta['fastest_lap_s']``, so it is available at the same point
+            ``track_status_clean`` should have been. Threshold measured over 31,624
+            training-season laps: gating at 1.10 cuts the deg_cost_s error bound's
+            mean absolute error from 0.650 to 0.434 s/lap and its signed bias from
+            +0.351 to +0.139, at the cost of 49 of 1714 stints (2.9%) losing their
+            reference entirely and falling back to ``None`` (``scripts/
+            measure_deg_error_bound.py``, ``documents/audits/MEASURE_fresh_reference_
+            quality_gate.md``).
         deg_cost_floor_s / deg_cost_ceiling_s: Bounds on the referenced wear, in
             seconds per lap. MEASURED, not chosen: they are the 1st and 99th
             percentiles over 31,624 training-season laps
@@ -245,6 +266,7 @@ class TireAgentConfig:
     cliff_pit_soon_laps: int = 3
     cliff_monitor_laps: int  = 7
     fresh_reference_tyre_life: int = 3
+    fresh_reference_max_pct_of_fastest: float = 1.10
     deg_cost_floor_s: float   = -2.33
     deg_cost_ceiling_s: float = 3.67
 
@@ -396,6 +418,20 @@ CLIFF_THRESHOLD: dict[str, int] = {
 # session_meta.total_laps is present on every shipping path, so this only guards
 # hand-built states.
 MAX_RACE_LAPS: int = 78
+
+
+def _reject_contaminated_laps(
+    laps: pd.DataFrame, fastest_lap_s: float, max_pct: float,
+) -> pd.DataFrame:
+    """Drop candidate fresh-reference laps slower than ``max_pct`` times the
+    race's fastest lap -- a Safety-Car or red-flag-affected lap that
+    ``track_status_clean`` should flag but does not (see
+    ``TireAgentConfig.fresh_reference_max_pct_of_fastest``).
+
+    Pure and leaf-level so the threshold is testable without model weights --
+    the same split ``tire_parsing.py`` made, and for the same reason.
+    """
+    return laps[laps['LapTime_s'] <= max_pct * fastest_lap_s]
 
 
 def _referenced_wear(parsed: dict) -> Optional[float]:
@@ -932,9 +968,29 @@ class TireAgent:
         life — a replay that starts mid-stint. Zero is a legitimate reading of the
         wear it feeds, so collapsing "unknown" into it would be the same sentinel
         collision that #436 fixed for the cliff.
+
+        Also drops any candidate lap slower than ``cfg.fresh_reference_max_pct_of_
+        fastest`` times the race's fastest lap — a Safety-Car or red-flag-affected
+        lap that ``track_status_clean`` should have flagged but does not (see the
+        config docstring). Returns ``None`` rather than falling back to a
+        contaminated lap when every candidate is rejected, for the same reason: a
+        wrong reference is worse than none.
         """
         early_laps = self._get_driver_stint(driver, self.cfg.fresh_reference_tyre_life)
         if early_laps is None or not len(early_laps):
+            return None
+
+        # `_get_driver_stint` returns the raw slice of `self.laps_df` as-is, so
+        # `LapTime_s` does not exist yet on the FastF1 `run()` path (raw `LapTime`
+        # Timedelta) -- it is only created by `_add_timing_cols`, the first step
+        # inside `_build_stint_tensor`. Reuse it here rather than assume a column
+        # that `_build_stint_features` itself only guarantees after this point.
+        early_laps = _reject_contaminated_laps(
+            _add_timing_cols(early_laps),
+            self.session_meta['fastest_lap_s'],
+            self.cfg.fresh_reference_max_pct_of_fastest,
+        )
+        if not len(early_laps):
             return None
 
         tensor = self._build_stint_tensor(early_laps, compound_id, self.session_meta)

--- a/tests/agents/test_tire_cumulative_deg.py
+++ b/tests/agents/test_tire_cumulative_deg.py
@@ -377,3 +377,109 @@ def test_the_reference_is_taken_from_the_stints_early_laps_and_not_from_all_of_t
     )
     assert tire_out.deg_cost_s is not None
     assert tire_out.deg_cost_s != 0.0
+
+
+# ===========================================================================
+# fresh-reference quality gate -- track_status_clean is dead on the shipping
+# path (a constant 0: N04's IsAccurate gate does not catch every neutralised
+# lap), so a Safety-Car- or red-flag-affected lap can land as the fresh
+# reference. Measured counter-example: Mexico City 2023 car 4, lap 36 reads
+# 137.8 s on a circuit whose green-flag pace is ~83 s, and every later lap in
+# that stint then priced tens of seconds "faster than fresh". Gating on
+# `lap_time_pct_of_race_fastest` -- already a TCN input feature, so no new
+# data is needed -- cuts the deg_cost_s error bound's mean absolute error from
+# 0.650 to 0.434 s/lap and its signed bias from +0.351 to +0.139 s/lap
+# (documents/audits/MEASURE_fresh_reference_quality_gate.md).
+
+
+class TestRejectContaminatedLaps:
+    """The gate as a pure function -- no model weights needed to test the threshold."""
+
+    def test_a_lap_at_the_races_fastest_pace_survives(self):
+        from src.agents.tire_agent import _reject_contaminated_laps
+
+        laps = pd.DataFrame({"LapTime_s": [85.0]})
+        kept = _reject_contaminated_laps(laps, fastest_lap_s=85.0, max_pct=1.10)
+
+        assert len(kept) == 1
+
+    def test_a_lap_exactly_at_the_threshold_survives(self):
+        """The gate is <=, not <, so the boundary itself is not rejected."""
+        from src.agents.tire_agent import _reject_contaminated_laps
+
+        laps = pd.DataFrame({"LapTime_s": [93.5]})  # 85.0 * 1.10
+
+        kept = _reject_contaminated_laps(laps, fastest_lap_s=85.0, max_pct=1.10)
+
+        assert len(kept) == 1
+
+    def test_a_safety_car_affected_lap_is_rejected(self):
+        """The measured counter-example, in ratio form: 137.757 / 81.372 = 1.693."""
+        from src.agents.tire_agent import _reject_contaminated_laps
+
+        laps = pd.DataFrame({"LapTime_s": [137.757]})
+
+        kept = _reject_contaminated_laps(laps, fastest_lap_s=81.372, max_pct=1.10)
+
+        assert len(kept) == 0
+
+    def test_only_the_contaminated_rows_are_dropped_from_a_mixed_stint(self):
+        laps = pd.DataFrame({"LapTime_s": [86.0, 150.0, 88.5], "TyreLife": [1.0, 2.0, 3.0]})
+        from src.agents.tire_agent import _reject_contaminated_laps
+
+        kept = _reject_contaminated_laps(laps, fastest_lap_s=85.0, max_pct=1.10)
+
+        assert kept["TyreLife"].tolist() == [1.0, 3.0]
+
+
+@pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="TireAgent() loads the compound bundles from data/models/tire_degradation/ (HF, not git)",
+)
+def test_a_stint_whose_only_candidate_lap_is_a_safety_car_lap_has_no_reference():
+    """The agent-level wiring: every candidate rejected must return None, never
+    fall back to the contaminated lap. A wrong reference is worse than none --
+    the same doctrine ``_referenced_wear`` already applies to a missing half."""
+    from src.agents.tire_agent import TireAgent
+
+    agent = TireAgent()
+    agent.laps_df = pd.DataFrame(
+        {
+            "Driver": ["NOR"],
+            "Compound": ["MEDIUM"],
+            "TyreLife": [2.0],
+            "LapNumber": [36.0],
+            "LapTime_s": [137.757],  # the measured Mexico City 2023 counter-example
+        }
+    )
+    agent.session_meta = {"fastest_lap_s": 81.372}
+
+    assert agent._fresh_reference("NOR", "C3") is None
+
+
+@pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="TireAgent() loads the compound bundles from data/models/tire_degradation/ (HF, not git)",
+)
+def test_the_gate_also_works_on_the_raw_fastf1_laptime_column():
+    """`_get_driver_stint` returns `self.laps_df` as-is, and the raw FastF1 `run()`
+    path carries `LapTime` (a Timedelta), not the featured parquet's `LapTime_s` --
+    `_add_timing_cols` is what creates it, and only inside `_build_stint_tensor`.
+    A gate that assumes `LapTime_s` already exists breaks every raw-FastF1 caller,
+    which is exactly the regression this test pins (caught by
+    tests/engine/test_engine_no_llm.py before this test existed)."""
+    from src.agents.tire_agent import TireAgent
+
+    agent = TireAgent()
+    agent.laps_df = pd.DataFrame(
+        {
+            "Driver": ["NOR"],
+            "Compound": ["MEDIUM"],
+            "TyreLife": [2.0],
+            "LapNumber": [36.0],
+            "LapTime": [pd.Timedelta(seconds=137.757)],
+        }
+    )
+    agent.session_meta = {"fastest_lap_s": 81.372}
+
+    assert agent._fresh_reference("NOR", "C3") is None

--- a/tests/agents/test_tire_cumulative_deg.py
+++ b/tests/agents/test_tire_cumulative_deg.py
@@ -392,8 +392,15 @@ def test_the_reference_is_taken_from_the_stints_early_laps_and_not_from_all_of_t
 # (documents/audits/MEASURE_fresh_reference_quality_gate.md).
 
 
+@pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="_reject_contaminated_laps is logically pure, but it lives in tire_agent, "
+    "whose import builds TireAgentConfig() and reads data/models/tire_degradation/ "
+    "(HF, not git) -- the same constraint TestReferencedWear is already under.",
+)
 class TestRejectContaminatedLaps:
-    """The gate as a pure function -- no model weights needed to test the threshold."""
+    """The gate's threshold logic -- no model weights needed to EVALUATE it, but the
+    import that defines it needs them regardless (see the skip reason)."""
 
     def test_a_lap_at_the_races_fastest_pace_survives(self):
         from src.agents.tire_agent import _reject_contaminated_laps


### PR DESCRIPTION
## Summary

- `TireAgent._fresh_reference` (the wear-scorer's zero point for `deg_cost_s`) can pick a Safety-Car- or red-flag-affected lap as the "fresh" baseline: `track_status_clean` is supposed to guard against this but is dead on the shipping path (a constant 0 across every featured parquet — N04's `IsAccurate` gate does not catch every neutralised lap).
- Measured counter-example: Mexico City 2023 car 4, lap 36 reads 137.757s on a circuit whose green-flag pace is ~83s. Every later lap in that stint then priced tens of seconds "faster than fresh" — an artefact of a contaminated zero point, not tyre wear.
- Adds `fresh_reference_max_pct_of_fastest` (1.10, measured) and a pure `_reject_contaminated_laps` helper: a candidate reference lap slower than that ratio of the race's fastest lap is dropped before the reference tensor is built. If every candidate is rejected, returns `None` rather than a wrong reference — the same doctrine `_referenced_wear` already applies to a missing half.
- The gate uses `lap_time_pct_of_race_fastest`, already one of the TCN's 42 input features — no new data needed.

## Measured effect

Over 31,624 training-season laps (`scripts/measure_fresh_reference_gate.py`), reproduces the deg_cost_s error bound from `documents/audits/MEASURE_763_ship_decision.md` (branch `feat/deferral-tyre-liability`, issue #763) and shows most of it concentrates in a small subset of stints:

| | mean abs error | signed bias | stints w/ reference |
|---|---|---|---|
| baseline (current `main`) | 0.650 s/lap | +0.351 s/lap | 1714 / 1714 |
| gated @ 1.10 | 0.434 s/lap | +0.139 s/lap | 1665 / 1714 (49 lost) |

Full root-cause writeup, threshold sweep, and what this does NOT claim: `documents/audits/MEASURE_fresh_reference_quality_gate.md`.

## Scope note

This is an improvement to `deg_cost_s` as it ships on `main` today (consumed by `driver_time_delta`), independent of the parked `feat/deferral-tyre-liability` branch (#771, still blocked on #763 for unrelated reasons — the residual bound after this fix is still above that decision's bar).

## Test plan

- [x] `tests/agents/test_tire_cumulative_deg.py` — 6 new tests: the gate as a pure function (boundary, rejection, mixed stint), agent-level wiring (all-contaminated -> None), and the raw-FastF1 `LapTime` Timedelta path (regression guard, see below)
- [x] Full tire-agent-touching suite green: `test_tire_cumulative_deg.py`, `test_agents.py`, `test_agent_llm_timeout.py`, `test_tire_agent_hardening.py`, `test_engine_no_llm.py`, `test_mc_state_helpers.py`, `test_strategy_goldens.py`, `test_tyre_wear_term.py` (118 passed)
- [x] `ruff check` / `ruff format --check` clean on all changed files
- [x] `scripts/measure_fresh_reference_gate.py` reproduces the numbers above using the actual shipped `_reject_contaminated_laps`, not a reimplementation

Caught during review: the gate initially assumed `LapTime_s` already exists on the candidate laps, which broke the raw FastF1 `run()` path (`LapTime` as a `Timedelta`, normalised only inside `_build_stint_tensor`). Fixed by reusing `_add_timing_cols` instead of the column name, with a dedicated regression test.