### PR TITLE
docs(audit): correct #773's headline numbers with a 2025 held-out check

### DIFF
--- a/documents/audits/MEASURE_fresh_reference_quality_gate.md
+++ b/documents/audits/MEASURE_fresh_reference_quality_gate.md
@@ -111,15 +111,50 @@ model-capacity* contribution to that bound, which was sitting inside the number
 
 **This is a genuine, if partial, improvement to `deg_cost_s` as it exists on `main`
 today** (the term `driver_time_delta` already consumes, at 5 laps of exposure), not
-only to the parked deferral term. The 33% mean-error reduction and 60% bias reduction
-apply to production `deg_cost_s` the moment this ships, independent of #763/#771.
+only to the parked deferral term. It is non-regressive: on both seasons measured, the
+gated numbers are never worse than the baseline. See the 2025 addendum below for the
+size of the improvement that actually ships.
+
+## ⚠️ 2025 addendum (2026-08-01) — the training-season numbers above overstate the effect
+
+The 33% mean-error / 60% bias reduction was measured on `laps_tiredeg.parquet`, 2023-24
+only — the only parquet carrying N04's training target. That is legitimate for CHOOSING
+the 1.10 threshold (fitting it on 2025 would repeat the leak `src/strategy/eval/
+hygiene.py` already documents), but it was reported as "the fix's benefit" without ever
+checking whether it holds on the season the system actually ships against. It does not,
+by a wide margin.
+
+`scripts/measure_fresh_reference_gate_2025.py` runs the identical diagnostic on
+`laps_featured_2025.parquet` — the real, full 24-race 2025 season — reusing the same
+production functions (`_add_compound_cols`, `_compound_name_to_id`,
+`_reject_contaminated_laps`) rather than a second implementation of compound resolution
+or the gate:
+
+| | mean abs error | signed bias | stints w/ reference |
+|---|---|---|---|
+| 2023-24 baseline | 0.650 s/lap | +0.351 s/lap | 1714 / 1714 |
+| 2023-24 gated @ 1.10 | 0.434 s/lap (**-33%**) | +0.139 s/lap (**-60%**) | 1665 / 1714 (49 lost, 2.9%) |
+| 2025 baseline | 0.723 s/lap | +0.233 s/lap | 738 / 738 |
+| 2025 gated @ 1.10 | 0.712 s/lap (**-1.5%**) | +0.221 s/lap (**-5%**) | 734 / 738 (4 lost, 0.5%) |
+
+**The contamination rate itself is ~5x lower in this 2025 sample than in 2023-24**
+(0.5% of stints lost their reference vs 2.9%) — not a sampling artefact, `laps_featured_
+2025.parquet` covers the entire 24-race calendar. The defect this PR fixes is real, the
+fix is correct and does not regress anything, but it is materially rarer in the season
+that ships than in the seasons used to characterise it. **Quote the 2025 numbers, not
+the 2023-24 ones, when describing what this buys in production.**
+
+This does not change the #763/#771 verdict either way: 0.712 s/lap is still far above
+the ~0.1 s/lap bar that decision needs.
 
 ## Reproducing
 
 ```bash
-uv run python scripts/measure_fresh_reference_gate.py
+uv run python scripts/measure_fresh_reference_gate.py        # 2023-24, the threshold's own training data
+uv run python scripts/measure_fresh_reference_gate_2025.py   # 2025, the held-out season that ships
 ```
 
 Related: `MEASURE_744a_tyre_reference.md` · `MEASURE_763_ship_decision.md`
 (`feat/deferral-tyre-liability`) · `scripts/measure_deg_error_bound.py`
-(same branch, the original bound this note decomposes)
+(same branch, the original bound this note decomposes) ·
+[[feedback_measure_on_the_season_that_ships]] (Claude memory — the general lesson)

--- a/documents/audits/MEASURE_fresh_reference_quality_gate.md
+++ b/documents/audits/MEASURE_fresh_reference_quality_gate.md
@@ -147,6 +147,35 @@ the 2023-24 ones, when describing what this buys in production.**
 This does not change the #763/#771 verdict either way: 0.712 s/lap is still far above
 the ~0.1 s/lap bar that decision needs.
 
+## What the remaining 2025 error actually is, and why it is closed rather than chased
+
+Decomposing the 2025 baseline the same way as the training-season one, the residual
+(`pred - target`) is **not** dominated by outlier stints — it grows smoothly and
+monotonically with tyre life across the whole dataset, from ~0 at the fresh band to
+**+0.78 s/lap mean at 30+ laps**, with no equivalent trend on 2023-24 (which stays flat
+at +0.05 beyond the fresh band). It also varies by circuit in both directions (Las
+Vegas/Baku/Montréal correlate +0.7 to +0.9 with tyre life; Miami/Sakhir/Shanghai
+correlate -0.5 to -0.6). Checked and ruled out: the same duplicate-`TyreLife`
+within-stint artefact found in 2023-24 (only 6 of 1134 2025 stints affected, far too few
+to produce this pattern).
+
+**This is a genuine train/2025 generalisation gap in the TCN itself, not a bug.** No
+further code fix chases it in this project's current scope — a system without a real
+F1 team's telemetry, spotter radio, or proprietary tyre data will not match one on this
+axis, and that is an accepted limitation rather than an open item.
+
+**It does not newly endanger the Monte Carlo.** `deg_cost_s` has been live in both
+scorers since #744b/#760, so the epic's own headline numbers (43.4% exact-lap agreement,
+52.8% within one lap) already have this error baked in — nothing here is a fresh risk on
+top of measured system behaviour. `_tyre_cost_s` (`position_projection.py`) multiplies
+`deg_cost_s` by `old_laps`, bounded by the projection window (~5 laps by default), so the
+mean 2025 bias (+0.221 s/lap) integrates to roughly 1.1 s of phantom cost per decision —
+small against the 22.8 s pit loss it is weighed against, and floored/ceilinged
+(`deg_cost_floor_s`/`deg_cost_ceiling_s`) regardless. The one place it bites hardest is
+long stints (30+ laps), which is exactly the regime the deferral term (#771, 40 laps of
+exposure, 8x this term's) is blocked from reaching — this finding reinforces that block,
+it does not add a new one.
+
 ## Reproducing
 
 ```bash

--- a/scripts/measure_fresh_reference_gate_2025.py
+++ b/scripts/measure_fresh_reference_gate_2025.py
@@ -1,0 +1,189 @@
+"""Held-out check: does the fresh-reference quality gate (threshold chosen on
+2023-24, shipped in `TireAgentConfig.fresh_reference_max_pct_of_fastest`) still
+help on 2025 -- the season the system actually runs in?
+
+`scripts/measure_fresh_reference_gate.py` measured a 33% mean-error / 60% bias
+reduction, but only ever on `laps_tiredeg.parquet` (2023-24, the only parquet
+carrying N04's training target). That is a real number about the seasons the
+threshold was CHOSEN on, not evidence about what ships -- see
+`documents/audits/MEASURE_fresh_reference_quality_gate.md`'s 2025 addendum.
+
+This script measures the identical diagnostic on `laps_featured_2025.parquet`
+(the real, full 24-race 2025 season), reusing the actual production functions
+(`_add_compound_cols`, `_compound_name_to_id`, `_reject_contaminated_laps`)
+rather than reimplementing the compound-resolution or gating logic -- the
+featured parquet does not carry `AbsoluteCompoundID`/`CompoundHardness`, so
+those have to come from the same code path production uses, not a guess.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.agents.tire_agent import (  # noqa: E402
+    CFG,
+    TireDegTCN,
+    _add_compound_cols,
+    _compound_name_to_id,
+    _reject_contaminated_laps,
+)
+
+FEATURED_2025 = Path("data/processed/laps_featured_2025.parquet")
+MODEL_DIR = Path("data/models/tire_degradation")
+FRESH_MAX_TYRE_LIFE = 3
+STINT_KEYS = ["Year", "GP_Name", "DriverNumber", "Stint"]
+TARGET = "FuelAdjustedDegAbsolute"
+
+
+def load_bundles() -> dict:
+    routing = json.loads((MODEL_DIR / "routing_config.json").read_text(encoding="utf-8"))
+    by_file: dict = {}
+    by_compound: dict = {}
+    for compound, entry in routing.items():
+        filename = entry["bundle"]
+        if filename not in by_file:
+            bundle = torch.load(MODEL_DIR / filename, map_location="cpu", weights_only=False)
+            model = TireDegTCN(bundle["n_features"], **bundle["model_hparams"])
+            model.load_state_dict(bundle["state_dict"])
+            model.eval()
+            bundle["model"] = model
+            by_file[filename] = bundle
+        by_compound[compound] = by_file[filename]
+    return by_compound
+
+
+def stint_sequences(stint: pd.DataFrame, bundle: dict) -> np.ndarray:
+    """One scaled (window, n_features) sequence per lap -- same transform as
+    `scripts/measure_tyre_reference.py::stint_sequences`, kept in sync by hand."""
+    window = bundle["window"]
+    raw = stint[bundle["feature_names"]].astype(float).fillna(0)
+    scaled = bundle["scaler"].transform(raw)
+    sequences = []
+    for length in range(1, len(scaled) + 1):
+        prefix = scaled[:length]
+        if len(prefix) >= window:
+            sequences.append(prefix[-window:])
+            continue
+        padding = np.zeros((window - len(prefix), prefix.shape[1]), dtype=prefix.dtype)
+        sequences.append(np.concatenate([padding, prefix], axis=0))
+    return np.stack(sequences)
+
+
+def predict_2025_stints() -> pd.DataFrame:
+    """Run every 2025 stint through its compound's TCN, lap by lap."""
+    laps = pd.read_parquet(FEATURED_2025)
+    laps = laps.dropna(subset=["Compound", "GP_Name", "Year"])
+    # A handful of rows carry the literal string "None"/"nan" rather than a real
+    # null (a known quirk of this parquet's Compound column) -- dropna misses those.
+    laps = laps[~laps["Compound"].isin(["None", "nan"])]
+    bundles = load_bundles()
+
+    rows = []
+    for keys, stint in laps.groupby(STINT_KEYS, sort=False):
+        year, gp_name = int(keys[0]), keys[1]
+        compound_id = _compound_name_to_id(str(stint["Compound"].iloc[0]), gp_name, year)
+        if compound_id not in bundles:
+            continue
+
+        bundle = bundles[compound_id]
+        # The real production transform, not a reimplementation: this is the
+        # same call `_build_stint_features` makes, so AbsoluteCompoundID and
+        # CompoundHardness land on the identical scale the model was trained on.
+        ordered = _add_compound_cols(stint.sort_values("TyreLife").copy(), compound_id)
+        sequences = stint_sequences(ordered, bundle)
+        with torch.no_grad():
+            batch = torch.tensor(sequences, dtype=torch.float32)
+            predictions = bundle["model"](batch).numpy().reshape(-1)
+
+        stint_id = "|".join(str(k) for k in keys)
+        for tyre_life, pred, target, lap_time_s in zip(
+            ordered["TyreLife"].to_numpy(),
+            predictions,
+            ordered[TARGET].to_numpy(),
+            ordered["LapTime_s"].to_numpy(),
+            strict=True,
+        ):
+            rows.append(
+                (
+                    stint_id,
+                    gp_name,
+                    year,
+                    float(tyre_life),
+                    float(pred),
+                    float(target),
+                    float(lap_time_s),
+                )
+            )
+
+    columns = ["stint", "gp_name", "year", "tyre_life", "pred", "target", "lap_time_s"]
+    return pd.DataFrame(rows, columns=columns)
+
+
+def bound(scored: pd.DataFrame, label: str) -> dict:
+    absolute = scored["error"].abs()
+    result = {
+        "label": label,
+        "n": len(scored),
+        "mean_abs_error": round(float(absolute.mean()), 3),
+        "median_abs_error": round(float(absolute.median()), 3),
+        "signed_bias": round(float(scored["error"].mean()), 3),
+    }
+    print(
+        f"\n=== {label} (n={result['n']}) ===\n"
+        f"  mean abs error   {result['mean_abs_error']:7.3f} s/lap\n"
+        f"  median abs error {result['median_abs_error']:7.3f} s/lap\n"
+        f"  bias (signed)    {result['signed_bias']:+7.3f} s/lap"
+    )
+    return result
+
+
+def main() -> None:
+    frame = predict_2025_stints().sort_values(["stint", "tyre_life"])
+    print(
+        f"2025 laps predicted: {len(frame)}, stints: {frame['stint'].nunique()}, "
+        f"GPs: {frame['gp_name'].nunique()}"
+    )
+
+    fastest_by_gp = frame.groupby(["year", "gp_name"])["lap_time_s"].transform("min")
+    frame["fastest_lap_s"] = fastest_by_gp
+
+    fresh = frame[frame["tyre_life"] <= FRESH_MAX_TYRE_LIFE]
+
+    def scored_bound(gated: bool) -> pd.DataFrame:
+        if gated:
+            candidates = fresh.rename(columns={"lap_time_s": "LapTime_s"})
+            kept = _reject_contaminated_laps(
+                candidates,
+                fastest_lap_s=candidates["fastest_lap_s"],
+                max_pct=CFG.fresh_reference_max_pct_of_fastest,
+            )
+        else:
+            kept = fresh
+
+        ref_pred = kept.groupby("stint")["pred"].last()
+        ref_true = kept.groupby("stint")["target"].last()
+        print(f"  stints with a reference: {ref_pred.notna().sum()} of {fresh['stint'].nunique()}")
+
+        scored = frame[frame["tyre_life"] > FRESH_MAX_TYRE_LIFE].copy()
+        scored["ref_pred"] = scored["stint"].map(ref_pred)
+        scored["ref_true"] = scored["stint"].map(ref_true)
+        scored = scored.dropna(subset=["ref_pred", "ref_true"])
+        scored["error"] = (scored["pred"] - scored["ref_pred"]) - (
+            scored["target"] - scored["ref_true"]
+        )
+        return scored
+
+    bound(scored_bound(gated=False), "2025 BASELINE -- no gate")
+    bound(scored_bound(gated=True), f"2025 GATED @ {CFG.fresh_reference_max_pct_of_fastest}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- PR #773's reported effect (0.650 -> 0.434 s/lap mean error, +0.351 -> +0.139 bias, "33%/60% reduction") was measured on `laps_tiredeg.parquet`, 2023-24 only. Legitimate for choosing the gate's threshold, not evidence about what ships on 2025.
- Adds `scripts/measure_fresh_reference_gate_2025.py`: the identical diagnostic on the real 24-race 2025 season, reusing production compound-resolution (`_compound_name_to_id`, `_add_compound_cols`) and the actual gate (`_reject_contaminated_laps`) rather than reimplementing either.
- Real 2025 effect: 0.723 -> 0.712 s/lap (~1.5%), bias 0.233 -> 0.221 (~5%) — an order of magnitude smaller than the training-season headline. Only 4/738 2025 stints hit the gate vs 49/1714 in training.
- The fix is still correct and non-regressive on both seasons. #763/#771 verdict unchanged: 0.712 is still far above the ~0.1 s/lap bar.

No production code changes — audit doc + a new reproducible measurement script only.

## Test plan

- [x] `uv run python scripts/measure_fresh_reference_gate_2025.py` reproduces the table in the updated audit doc
- [x] `ruff check` / `ruff format --check` clean