### PR TITLE
fix(agents): scoped anti-slop cleanup -- dead code, restated defaults, doc drift

### DIFF
--- a/docs/pages/agents-api.md
+++ b/docs/pages/agents-api.md
@@ -22,7 +22,7 @@ Every agent has two entry points:
 `lap_state`, which is why the stint fuel baseline is carried there rather than derived from a
 frame. The adapters are not uniform, so check the signature before assuming.
 
-Every agent except N29 also exposes a `get_*_react_agent()` factory returning a compiled LangGraph `CompiledGraph`, for callers that want to drive the graph directly. The radio agent has none: its pipeline is a fixed sequence of model calls rather than a ReAct loop, so there is no graph to compile.
+Only the RAG agent (N30) exposes a module-level `get_rag_react_agent()` factory returning a compiled LangGraph `CompiledGraph`, for callers that want to drive the graph directly — it is genuinely invoked (the chat backend calls it). N25-N28 (pace, tire, race situation, pit strategy) used to have an equivalent free function each; all four were confirmed dead (zero callers anywhere in the repo) and removed in the 2026-08-01 cleanup pass. Each of those agents still has its own `get_react_agent()` *instance method*, called internally from its own `_run_core` — only the redundant module-level wrapper was removed. The radio agent (N29) never had one: its pipeline is a fixed sequence of model calls rather than a ReAct loop, so there is no graph to compile.
 
 ## Output dataclasses
 

--- a/documents/audits/AUDIT_cleanup_session_2026-08-01.md
+++ b/documents/audits/AUDIT_cleanup_session_2026-08-01.md
@@ -72,6 +72,25 @@ site's own comment says "Fall back to the same conservative stub the wet/interme
 already uses" — the intent to share was explicit, the code never did. **Fixed** (Part 4): extracted
 `_conservative_tire_stub(...)` helper.
 
+### N4. `pace_agent.py`'s entire LangGraph ReAct scaffold is unreachable — flagged, not removed
+
+Beyond the dead `get_pace_react_agent()` free function (M1, fixed below), the whole
+subsystem it wrapped is unreachable too: the `get_react_agent()` instance method,
+`self._react_agent`, `PACE_TOOLS`, `predict_pace_tool`, `get_session_median_tool`, and
+`_PACE_SYSTEM_PROMPT` (`pace_agent.py:752-988`, confirmed via a repo-wide grep for
+`.get_react_agent(` — zero callers anywhere, unlike `tire_agent`/`race_situation_agent`/
+`pit_strategy_agent`, whose identical-shaped scaffolds ARE called internally from
+`_run_core`). `PaceAgent.run()`/`run_from_state()` call the XGBoost model directly and
+never touch any of it.
+
+**Not removed.** The section header directly above it reads `# LangGraph tools and ReAct
+agent (preserved 100% — no functional changes)` — a signal that a past change
+deliberately chose to keep this block untouched, most likely for eventual parity with
+the other three agents' ReAct capability. Deleting ~235 lines on the strength of "zero
+callers" alone would override that stated intent without knowing the reason behind it.
+Flagging for Víctor: either delete it (if the parity plan is abandoned) or wire it into
+`run()`/`run_from_state()` (if still planned) — this session does neither.
+
 ### N3. Weather-default divergence spans pace/tire/race_situation agents (3 different value sets) — folded into the architecture report
 
 `pace_agent.py` (`run_pace_agent_from_state`) defaults air/track temp to **25.0/35.0** reading the
@@ -105,16 +124,27 @@ over the shared `build_race_state` helper"), so it does not count as a fourth im
 | `track_temp` | `.get("track_temp", 40.0)` | `.get("track_temp", 35.0)` | `.get("track_temp", 35.0)` |
 | `position is None` | raises `ValueError` (#628) | raises `ValueError` (#465) | raises `ValueError` (#465) |
 | `gap_ahead_s` unknown fallback | `GAP_UNKNOWN_FALLBACK_S` (imported, single-sourced) | `GAP_UNKNOWN_FALLBACK_S` (imported, single-sourced) | `GAP_UNKNOWN_FALLBACK_S` (imported, single-sourced) |
-| `radio_msgs`/`rcm_events` | **not populated** (RaceState field left at its Pydantic default) | populated inline from `RadioPipelineRunner` | accepted as parameters, `None` → `[]` |
+| `radio_msgs`/`rcm_events` | left empty by `_build_race_state` itself, populated **370 lines later in the main loop** (`run_simulation_cli.py:1739-1762`, `.extend()`/`.append()` on the already-built `race_state` object) | populated **inline inside** `_build_race_state` from `RadioPipelineRunner` | accepted as **parameters** of `build_race_state`, `None` → `[]` |
 
 `compound` and `track_temp` are the two fields where CLI disagrees with BOTH other copies
 (`"UNKNOWN"` vs `"MEDIUM"`, `40.0` vs `35.0`), confirming the informal audit's claim with exact
 line numbers. `total_laps`'s CLI copy is actually the "more correct" one (fails loudly instead of
 guessing), which itself is a divergence in *error-handling philosophy*, not just in literal values.
-`radio_msgs`/`rcm_events` is a **new**, previously-unreported divergence this session found: the CLI
-path silently produces a `RaceState` with no radio/RCM context at all, while Arcade and the backend
-populate it — meaning the CLI's orchestrator input is missing information that the other two
-surfaces carry, not just different numbers for the same fields.
+
+**Correction (caught by this session's own adversarial gate, see the GATE report):** an earlier
+draft of this document claimed the CLI's `RaceState` ends up "radio-blind" — that claim was
+**refuted**. The CLI is not missing radio/RCM context: `run_simulation_cli.py`'s main loop mutates
+`race_state.radio_msgs`/`race_state.rcm_events` in place immediately after `_build_race_state`
+returns (lines 1739-1762 — real corpus radios/RCMs via `.extend()`, the SC-tracker's synthetic
+re-assertion, and simulated radios via `.append()`), and the arcade docstring's own words ("same as
+the CLI") already said as much. The real divergence is **structural, not functional**: Arcade and
+the backend build `radio_msgs`/`rcm_events` as part of the single `_build_race_state`/`build_race_state`
+call, while the CLI splits that responsibility — the builder returns an empty-list `RaceState` and a
+separate, later block in the caller fills it in. Whether that split is intentional (the CLI's
+main loop already owns the `sc_tracker`/`RadioPipelineRunner` instances for other reasons) or an
+artifact of the CLI predating the other two surfaces is exactly the kind of question the next
+dedicated session should resolve — but it is a "where does this responsibility live" question, not
+a missing-data one.
 
 ### The prior unification attempt, and its documented blocker
 
@@ -147,14 +177,15 @@ currently **not importable** without that shim.
    boundary (e.g. a new `src/shared_race_state.py` that the backend then imports, inverting today's
    direction), or (c) accept 3 copies and enforce parity with a test that diffs their literal
    defaults (cheapest, weakest).
-2. **`radio_msgs`/`rcm_events` in the CLI path** is a functional gap, not just a style one — worth
-   flagging to Víctor as its own question: is the CLI's `RaceState` deliberately radio-blind, or is
-   this an oversight from before Radio/RCM wiring existed?
-2. **`compound`/`track_temp`/`tyre_life`/`total_laps` fallback values** need one canonical answer
+2. **`radio_msgs`/`rcm_events` responsibility placement** — not a data gap (see the correction
+   above), but worth deciding: should the CLI's `_build_race_state` build these fields inline like
+   Arcade/backend do, or should Arcade/backend instead adopt the CLI's split (build empty, populate
+   from the caller)? Either answer removes one more structural difference between the three copies.
+3. **`compound`/`track_temp`/`tyre_life`/`total_laps` fallback values** need one canonical answer
    each — this session found the weather-default divergence extends further (`pace_agent.py`'s
    25.0/35.0 is a *fourth* value set for the same physical quantities, Part 2 §N3), so the "pick one
    number" scope is bigger than just the three `_build_race_state` copies.
-3. Whichever direction is chosen, it touches the untouchable CLI PMV (`run_simulation_cli.py`) and
+4. Whichever direction is chosen, it touches the untouchable CLI PMV (`run_simulation_cli.py`) and
    the `src/telemetry` submodule — per the project's issue-first rule for important/risky changes,
    file the issue before writing code, as `project_cleanup_audit_session_plan` already specifies.
 
@@ -162,4 +193,38 @@ currently **not importable** without that shim.
 
 ## Part 4 — Fixes applied in this session
 
-(Appended incrementally as each fix lands — see commit history on `fix/cleanup-anti-slop-scoped`.)
+| # | Finding | Fix | Files |
+|---|---|---|---|
+| 1 | M1: 3 dead constants (`_CLUSTER_PARQUET`, `_LAPS_FEATURED`, `_FEATURE_MANIFEST`) | Deleted — zero references anywhere in the repo, `_load_encoding_maps` builds the same paths inline | `src/agents/pace_agent.py` |
+| 2 | M1: 4 dead `get_*_react_agent()` free functions (~90 lines) | Deleted, plus their stale mentions in each file's own "Public API" module docstring | `pace_agent.py`, `tire_agent.py`, `race_situation_agent.py`, `pit_strategy_agent.py` |
+| 3 | M2: `total_laps` fallback literal `57` restated 6× across 3 files | Extracted `DEFAULT_TOTAL_LAPS` into a new leaf module `src/agents/_shared_defaults.py` (mirrors the existing `guard_rails.py` leaf-import pattern already used in `pit_strategy_agent.py`), imported everywhere | `pit_strategy_agent.py` (×3), `race_situation_agent.py` (×2), `tire_agent.py` (×1) |
+| 4 | N1: `race_situation_agent.py` disagreed with itself on `TrackTemp` fallback (35.0 vs 38.0) | Aligned `_compute_weather_features`'s fallback to 38.0, matching the file's own `run()`/`run_from_state()` | `src/agents/race_situation_agent.py` |
+| 5 | N2: `tire_agent.py::_run_core` restated the same "conservative stub" `TireOutput` twice | Extracted `_conservative_stub()` static helper, both call sites now pass only the differing `reason` string | `src/agents/tire_agent.py` |
+| 6 | M3: CLAUDE.md documented `f1-streamlit`/Streamlit (retired for `f1-webapp`/React SPA in #551) in 4 places, and described `src/shared/` as the live extraction home instead of the archived one | Updated §1 overview, §2 tech stack table, §3 project tree (added `data_extraction/`, marked `shared/` archived, corrected `telemetry/`'s description), §9 tooling note, §10 skills table | `CLAUDE.md` |
+
+### Findings detected but deliberately NOT fixed (flagged for follow-up, not silently dropped)
+
+| # | Finding | Why not fixed here |
+|---|---|---|
+| N4 | `pace_agent.py`'s entire LangGraph ReAct scaffold (~235 lines: `get_react_agent`, `_react_agent`, `PACE_TOOLS`, both tools, the system prompt) is unreachable — confirmed via repo-wide grep, zero callers | Its own section header says "preserved 100% — no functional changes", signalling deliberate intent (likely future parity with the other 3 agents). Deleting on "zero callers" alone would override that without knowing the reason. Flagged for Víctor to decide. |
+| N3 | Weather-default divergence across `pace_agent.py` (25.0/35.0) vs `tire_agent.py`/`race_situation_agent.py` (28.0/38.0) | Same disease as the architecture question (Part 3) — multiple independent "assemble race context with a plausible default" implementations. Picking one canonical value is a product decision, not a mechanical dedup; folded into the architecture report instead. |
+| A2/Part 3 | `_build_race_state` triplicated across CLI/Arcade/telemetry-backend | Explicit user instruction: detect and report only, fix in the dedicated follow-up session. |
+
+### Verification
+
+- `ruff check` on every touched Python file: clean (only `F821` is enforced inside `src/agents/**` per `pyproject.toml`'s deliberate per-file-ignores; nothing else applies there).
+- `ruff format --check` reports these files as "needs formatting" — **expected and not a regression**: `[tool.ruff.format]` explicitly excludes `src/agents/**` (deliberate hand-aligned `=` style), so this never runs in CI either.
+- AST parse + `importlib.import_module` on all 5 touched agent modules: clean.
+- `pytest tests/agents/ tests/audit/`: 129 passed.
+- `pytest tests/mc/ tests/simulation/ tests/eval/`: 286 passed.
+- Real `f1-sim Budapest NOR McLaren --no-real-radios --no-llm` run: all 70 laps OK, positions P5 → P1,
+  actions STAY_OUT·59 / PIT_NOW·5 / UNDERCUT·6, no errors.
+- Independent adversarial gate (Fable, separate agent, full details in
+  `documents/audits/AUDIT_cleanup_session_2026-08-01_GATE.md`): reproduced the test runs and the
+  real `f1-sim` run itself, re-verified every "zero callers" claim, confirmed all dedup sites
+  behaviourally identical, and found 1 HIGH (the radio_msgs/rcm_events claim corrected above), 3
+  MEDIUM (this branch's non-bisectable commit order, this section's then-unfilled placeholders, a
+  stale `docs/pages/agents-api.md` line), 3 LOW (a "2022-2025" vs "2023-2025" dataset-year slip in
+  the new constant's comment, a line-number-hardcoded comment, a stale "unchanged" docstring claim
+  in `pace_agent.py`). All 7 fixed post-gate; see the branch's commit history for the reordering and
+  follow-up commits.

--- a/documents/audits/AUDIT_cleanup_session_2026-08-01.md
+++ b/documents/audits/AUDIT_cleanup_session_2026-08-01.md
@@ -1,0 +1,165 @@
+# Dedicated clean-code / anti-slop cleanup session — 2026-08-01
+
+**Instrument:** foreground session (Fable), not a background agent. Method: `~/.claude/CLEAN_CODE.md`
+as the standard, `ponytail` doctrine as the "simplest thing that works" filter, then senior-dev
+judgment ("would a senior engineer keep this?"). This session both finds AND fixes the general
+AI-slop findings in scope; the single-contract/architecture question is detected and reported here,
+fixed in a separate dedicated session (per `project_cleanup_audit_session_plan`).
+
+**Scope, recomputed mechanically** (not the informal 2026-08-01 audit's broader scope):
+`git log --name-only aa1d274~1..HEAD` (aa1d274 = PR #730's merge commit), matching `gh pr list
+--state merged --limit 30`, i.e. the last 30 merged PRs, #730-#775, all landed 2026-07-29 to
+2026-08-01. Non-notebook, non-legacy files touched in that window:
+
+```
+scripts/measure_fresh_reference_gate.py, scripts/measure_fresh_reference_gate_2025.py,
+scripts/measure_tyre_reference.py, scripts/run_simulation_cli.py,
+src/agents/pace_agent.py, src/agents/pit_strategy_agent.py, src/agents/position_projection.py,
+src/agents/race_situation_agent.py, src/agents/strategy_orchestrator.py, src/agents/tire_agent.py,
+src/agents/tire_parsing.py, src/arcade/strategy.py, src/simulation/race_state_manager.py,
+src/strategy/eval/decision_modes.py, plus CLAUDE.md (checked on explicit instruction),
+documents/audits/*, documents/eval_reports/*, tests/**, pyproject.toml, uv.lock,
+.release-please-manifest.json, CHANGELOG.md
+```
+
+**Important scoping consequence:** this window is almost entirely the epic-724 decision-layer
+sprint + the tyre fresh-reference gate — a slice that already went through heavy adversarial
+scrutiny (FABLE_G1-G3, FABLE_S1-S5, MEASURE_*, AUDIT_A1-A5; see `project_epic724_scorecard`). Most
+of the informal 2026-08-01 audit's headline findings (A1 RCM-classifier bench-script fork, A3
+`theme.py`'s `_ACTION_STYLE` mirror, M4 bootstrap-preamble duplication across ~15 scripts, B1-B4
+legacy fossils) live in files **outside** this window (`bench_nlp_pipeline_cpu.py`, `theme.py`,
+`gap_calculation.py`, `tire_predictor.py`, `fastf1_extractor.py`) and are therefore **not touched in
+this session** — not because they stopped being valid, but because the user's explicit instruction
+was to scope this session to files touched in the last ~30 merged PRs, recomputed mechanically, not
+a fixed list. They remain open for a future sweep once a new 30-PR window covers them, or a
+deliberately widened scope.
+
+---
+
+## Part 1 — Verification of the 2026-08-01 informal audit against the recomputed scope
+
+| ID | Finding | In this scope? | Status |
+|---|---|---|---|
+| A1 | RCM classifier 3rd copy in `bench_nlp_pipeline_cpu.py` | No (`scripts/bench_nlp_pipeline_cpu.py` not touched in #730-#775) | Deferred, still valid per informal audit |
+| A2 | `_build_race_state` CLI vs Arcade divergence | **Yes** (`run_simulation_cli.py`, `arcade/strategy.py`) | **Confirmed, expanded — see Part 3 (architecture report)** |
+| A3 | `theme.py` `_ACTION_STYLE` mirror | No (`src/arcade/dashboard/theme.py` not touched) | Deferred, still valid per informal audit |
+| M1 | Dead code: pace_agent constants, 4× `get_*_react_agent`, `simulate_real_time_predictions` | Partially — pace_agent.py constants and all 4 `get_*_react_agent` fns are in scope; `tire_predictor.py` is not | **Fixed here (see Part 4)** for the in-scope pieces |
+| M2 | Restated constants: `total_laps=57`, weather defaults, tire stub duplication, compound RGB | **Yes**, all example files are in scope except `theme.py`'s RGB tuples | **Fixed here** for `total_laps` and the tire stub; weather defaults folded into the architecture report (see below) |
+| M3 | CLAUDE.md doc drift (`f1-streamlit`, `src/shared/`) | Yes, user named CLAUDE.md explicitly | **Fixed here** |
+| M4 | Bootstrap preamble duplication across ~15 scripts | No (only 3 of the ~15 scripts are in this window, and none is the divergence example) | Deferred |
+| B1-B4 | Legacy fossils, false docstrings | No (`src/vision/`, `strategy/inference/tire_predictor.py`, `fastf1_extractor.py` not touched) | Deferred |
+| B5 | Minor twins (`_bar_style`, `measure_*_gate*.py` near-identical harness, `_load_ner_model`) | `measure_fresh_reference_gate.py` vs `_2025.py` is in scope | Re-verified: still a deliberately-frozen reproducibility-script pair per the original audit's own judgment call — not touched |
+
+---
+
+## Part 2 — New findings from this session's deeper sweep (not in the informal audit)
+
+### N1. `race_situation_agent.py` disagrees with itself on the TrackTemp fallback
+
+`_compute_weather_features` (line 676) reads `session_meta.get('TrackTemp', 35.0)` — but the
+**same file's own** `run()` (line 1314) and `run_from_state()` (line 1401) build that very
+`session_meta['TrackTemp']` key with a fallback of **38.0** when the source weather is missing. If
+`_compute_weather_features` is ever called on a hand-built `session_meta` that omits `TrackTemp`
+(e.g. a test fixture), it silently produces a temperature 3°C different from what the rest of the
+file considers its own default — a same-file twin-that-never-got-the-fix, not a cross-file one.
+**Fixed** (Part 4): align to 38.0, the value the file's own constructors use.
+
+### N2. `tire_agent.py::_run_core` restates its own "conservative stub" twice, byte-for-byte except the message
+
+Lines 1566-1578 and 1609-1621 both construct an identical `TireOutput` (same `deg_rate=0.03`,
+`laps_to_cliff_p10/50/90=20.0/30.0/40.0`) with only the `reasoning` string differing. The second
+site's own comment says "Fall back to the same conservative stub the wet/intermediate branch above
+already uses" — the intent to share was explicit, the code never did. **Fixed** (Part 4): extracted
+`_conservative_tire_stub(...)` helper.
+
+### N3. Weather-default divergence spans pace/tire/race_situation agents (3 different value sets) — folded into the architecture report
+
+`pace_agent.py` (`run_pace_agent_from_state`) defaults air/track temp to **25.0/35.0** reading the
+raw `weather` sub-dict directly; `tire_agent.py` and `race_situation_agent.py` default to
+**28.0/38.0** reading their own already-transformed `session_meta['AirTemp'/'TrackTemp']`. This is
+the same disease as `_build_race_state`'s weather divergence (Part 3) — multiple independent
+"assemble race/session context with a plausible-looking default" implementations that were never
+reconciled — so it is reported as architecture evidence, not fixed here. Picking a single canonical
+value requires a product decision this session should not make unilaterally.
+
+---
+
+## Part 3 — Architecture question: is there duplicated "backend"/state-assembly logic that should be single-sourced?
+
+**Detected and reported only, per explicit instruction — not fixed in this session.**
+
+### The three confirmed independent implementations
+
+All three build a `src.agents.strategy_orchestrator.RaceState` from the same conceptual
+`lap_state` dict shape (`RaceStateManager.get_lap_state()`'s contract, CLAUDE.md §6). This is
+confirmed, not just "hinted at via a comment" — a fourth suspect, `simulator.py::_local_build_race_state`,
+turned out to be a genuine **thin wrapper** over the backend copy (its own docstring: "Thin wrapper
+over the shared `build_race_state` helper"), so it does not count as a fourth implementation.
+
+| Field | CLI `run_simulation_cli.py:1304-1373` | Arcade `src/arcade/strategy.py:599-715` | Backend `src/telemetry/backend/utils/race_state_builder.py:53-120` |
+|---|---|---|---|
+| `total_laps` | `lap_state["session_meta"]["total_laps"]` — **direct index, raises if absent** | `meta.get("total_laps", 57)` | `meta.get("total_laps", 57)` |
+| `compound` | `.get("compound", "UNKNOWN")` | `.get("compound", "MEDIUM")` | `.get("compound", "MEDIUM")` |
+| `tyre_life` | `.get("tyre_life", 0)` | `.get("tyre_life", 1)` | `.get("tyre_life", 1)` |
+| `air_temp` | `.get("air_temp", 25.0)` | `.get("air_temp", 25.0)` | `.get("air_temp", 25.0)` |
+| `track_temp` | `.get("track_temp", 40.0)` | `.get("track_temp", 35.0)` | `.get("track_temp", 35.0)` |
+| `position is None` | raises `ValueError` (#628) | raises `ValueError` (#465) | raises `ValueError` (#465) |
+| `gap_ahead_s` unknown fallback | `GAP_UNKNOWN_FALLBACK_S` (imported, single-sourced) | `GAP_UNKNOWN_FALLBACK_S` (imported, single-sourced) | `GAP_UNKNOWN_FALLBACK_S` (imported, single-sourced) |
+| `radio_msgs`/`rcm_events` | **not populated** (RaceState field left at its Pydantic default) | populated inline from `RadioPipelineRunner` | accepted as parameters, `None` → `[]` |
+
+`compound` and `track_temp` are the two fields where CLI disagrees with BOTH other copies
+(`"UNKNOWN"` vs `"MEDIUM"`, `40.0` vs `35.0`), confirming the informal audit's claim with exact
+line numbers. `total_laps`'s CLI copy is actually the "more correct" one (fails loudly instead of
+guessing), which itself is a divergence in *error-handling philosophy*, not just in literal values.
+`radio_msgs`/`rcm_events` is a **new**, previously-unreported divergence this session found: the CLI
+path silently produces a `RaceState` with no radio/RCM context at all, while Arcade and the backend
+populate it — meaning the CLI's orchestrator input is missing information that the other two
+surfaces carry, not just different numbers for the same fields.
+
+### The prior unification attempt, and its documented blocker
+
+The maintainers have **already reasoned about this exact question once**. `arcade/strategy.py:599-606`'s
+own docstring:
+
+> "Duplicate of `_local_build_race_state` from simulator.py, small enough to inline so the arcade
+> stays independent of `backend.utils.race_state_builder` (which requires a sys.path shim that only
+> the FastAPI startup provides)."
+
+And `arcade/strategy.py:641-644`:
+
+> "The telemetry backend still has its own copies and is a submodule, so this is a two-way
+> unification, not the three-way one an earlier draft of this comment claimed."
+
+So a **two-way** unification already happened for exactly one field (`GAP_UNKNOWN_FALLBACK_S`,
+imported from `src.agents.position_projection` in all three copies — genuinely single-sourced, not
+duplicated). A **three-way** unification of the whole function was considered and explicitly
+rejected, for a concrete, named reason: `src/telemetry` is a **git submodule** with its own FastAPI
+startup path that establishes a `sys.path` shim CLI/Arcade do not have, so importing
+`backend.utils.race_state_builder` from `src/arcade` or `scripts/` is not just a style choice, it is
+currently **not importable** without that shim.
+
+### What the next dedicated session needs to resolve
+
+1. **The import-boundary blocker is real and needs a design decision**, not a mechanical merge:
+   either (a) give CLI/Arcade a way to import the backend module (requires resolving the sys.path
+   shim, and accepting a dependency from `src/` onto the `src/telemetry` submodule — a layering
+   change), or (b) move the shared logic to a location both sides can import without the submodule
+   boundary (e.g. a new `src/shared_race_state.py` that the backend then imports, inverting today's
+   direction), or (c) accept 3 copies and enforce parity with a test that diffs their literal
+   defaults (cheapest, weakest).
+2. **`radio_msgs`/`rcm_events` in the CLI path** is a functional gap, not just a style one — worth
+   flagging to Víctor as its own question: is the CLI's `RaceState` deliberately radio-blind, or is
+   this an oversight from before Radio/RCM wiring existed?
+2. **`compound`/`track_temp`/`tyre_life`/`total_laps` fallback values** need one canonical answer
+   each — this session found the weather-default divergence extends further (`pace_agent.py`'s
+   25.0/35.0 is a *fourth* value set for the same physical quantities, Part 2 §N3), so the "pick one
+   number" scope is bigger than just the three `_build_race_state` copies.
+3. Whichever direction is chosen, it touches the untouchable CLI PMV (`run_simulation_cli.py`) and
+   the `src/telemetry` submodule — per the project's issue-first rule for important/risky changes,
+   file the issue before writing code, as `project_cleanup_audit_session_plan` already specifies.
+
+---
+
+## Part 4 — Fixes applied in this session
+
+(Appended incrementally as each fix lands — see commit history on `fix/cleanup-anti-slop-scoped`.)

--- a/documents/audits/AUDIT_cleanup_session_2026-08-01_GATE.md
+++ b/documents/audits/AUDIT_cleanup_session_2026-08-01_GATE.md
@@ -1,0 +1,276 @@
+# ADVERSARIAL GATE — cleanup session 2026-08-01 (branch `fix/cleanup-anti-slop-scoped`)
+
+**Instrument:** adversarial gate agent (Fable), read-only except this file. Success condition:
+find what is STILL broken or overclaimed in the cleanup diff (4 commits on top of `dev`) and the
+gitignored CLAUDE.md edit. Findings are appended incrementally as they are confirmed.
+
+**Commits under review:**
+
+```
+99f17eb fix(agents): add the leaf module backing DEFAULT_TOTAL_LAPS
+08864fb fix(agents): dedupe restated defaults across tire/race_situation/pit_...
+1fec855 fix(agents): remove pace_agent's dead ReAct scaffold entry point + ar...
+ea280e9 docs(audit): open the dedicated cleanup-session report
+```
+
+## Checklist (claims a-k)
+
+- [x] a) 4 `get_*_react_agent` free functions had ZERO callers — VERIFIED
+- [x] b) pace_agent's 3 deleted constants dead — VERIFIED
+- [x] c) `DEFAULT_TOTAL_LAPS=57` identical at all 6 sites; leaf verified by execution — VERIFIED
+- [x] d) TrackTemp 35.0→38.0 — VERIFIED (executed: empty session_meta → 38.0); caveat j-2
+- [x] e) `_conservative_stub()` identical values — VERIFIED
+- [x] f) deeper pace scaffold unreachable; keeping it was right — VERIFIED
+- [x] g) Part 3 table VERIFIED row-by-row; **radio-blind-CLI claim REFUTED (HIGH)**
+- [x] h) CLAUDE.md edits — VERIFIED, no overclaim
+- [x] i) ruff clean; tests/agents+audit 129 passed; smoke 5 passed/1 pre-existing data skip; mc/simulation/eval below
+- [x] j) new slop: j-1 bisect break (MED), j-4 uncommitted report + dangling placeholders (MED), j-7 stale docs page (MED), j-2/j-3/j-6 (LOW)
+- [x] k) no residual in-scope literals; no surviving removed symbols — VERIFIED
+
+## Findings
+
+### a) Dead free functions — VERIFIED
+
+Repo-wide ripgrep (src/, scripts/, tests/, notebooks/, documents/, docs/, and the `src/telemetry`
+submodule — 27,391 .py files on disk, so the submodule content WAS searched) for
+`get_pace_react_agent|get_tire_react_agent|get_race_situation_react_agent|get_pit_strategy_react_agent`:
+the ONLY hits are the two audit markdown files describing the deletion. `src/agents/__init__.py`
+read in full: `_EXPORTS` (lines 25-51) and the `TYPE_CHECKING` block (79-101) list only the
+`run_*`/`run_*_from_state` names plus dataclasses — no react-agent entry ever existed there.
+Methodology note: my first grep pass was silently broken (the RTK hook rewrote `rg` to a `grep`
+that rejects `--no-ignore`, and my `2>/dev/null` hid the error) — re-executed with a working
+ripgrep before trusting the zero.
+
+### b) pace_agent's 3 deleted constants — VERIFIED
+
+`_load_encoding_maps` (pace_agent.py:183-221) builds `feature_manifest_laptime.json`,
+`circuit_clustering/circuit_clusters_k4_2025.parquet` and `laps_featured_2025.parquet` inline from
+its `processed_dir` argument — byte-identical relative paths to the three deleted constants.
+Repo-wide grep for `_CLUSTER_PARQUET|_LAPS_FEATURED|_FEATURE_MANIFEST`: only the two audit docs.
+`_PROCESSED` (the module global the constants used) is NOT newly orphaned — still the default for
+`processed_dir` at line 148.
+
+### d) TrackTemp 35.0 → 38.0 — VERIFIED with caveats
+
+The changed line is genuinely inside `_compute_weather_features` (race_situation_agent.py:675-693;
+the git hunk header naming `_compute_rcm_features` is just git's nearest-context artifact). The
+same file's `run()` builds `'TrackTemp': ... else 38.0` at line 1317 (+ `track_temp_start` 38.0 at
+1319) and `run_from_state()` uses `wx.get('track_temp', 38.0)` at line 1403 — the claim holds
+against current code. `_compute_weather_features` has exactly one caller (line 1009, fed by
+run/run_from_state-built session_meta where the key always exists), so production behaviour is
+unchanged; only hand-built session_meta changes. No test asserts the old 35.0 fallback: the eight
+`35.0` hits in tests/ all SET `track_temp=35.0` explicitly on constructed states (pass-through, not
+fallback), and `test_race_situation_hardening.py:164` sets `"TrackTemp": 38.0` explicitly.
+**Caveat (LOW, see j-2):** the new comment hardcodes "lines ~1314/~1401" — actual lines today are
+1317/1403, and any edit above them rots the reference.
+
+### e) `_conservative_stub()` — VERIFIED
+
+Old inline constructors (diff, both sites): `deg_rate=0.03`, `laps_to_cliff_p10/50/90 =
+20.0/30.0/40.0`, `compound`/`current_tyre_life`/`gp_name` from locals, `reasoning` per-site. New
+helper reproduces exactly these fields; both call sites pass the same locals and only the `reason`
+string differs (site 2 still appends the parse-`reasoning` suffix, as before). No value drift.
+
+### f) pace_agent's deeper ReAct scaffold — VERIFIED (and keeping it was the right call)
+
+`.get_react_agent(` grep: 3 hits, all *self*-calls inside tire/race_situation/pit_strategy
+`_run_core` — none for pace. `PACE_TOOLS`: only pace_agent.py itself (798, 985, 988), the frozen
+notebook N25, and the audit docs. So the ~235-line scaffold is unreachable from outside, as
+claimed. Judgment: leaving it was correct — not because of the "preserved 100%" header alone, but
+because the other three siblings' identical-shaped scaffolds ARE live, so deleting pace's would
+make the four agents structurally asymmetric while the parity question is still open. Deleting is
+a one-commit follow-up once Víctor decides; resurrecting after deletion is also trivial via git.
+Either way it's a decision, not a cleanup, and the audit correctly routed it to the owner.
+
+### k) Residual literals — VERIFIED (with one honest-scope note)
+
+Repo-wide grep for `total_laps` near `57`: the only remaining *fallback* literals are
+`src/arcade/strategy.py:703` and `src/telemetry/backend/utils/race_state_builder.py:108` — exactly
+the two out-of-scope `_build_race_state` copies Part 3 defers to the architecture session, and the
+audit's Part 3 table already lists both. Everything else is tests/notebooks/docs passing 57 as an
+explicit VALUE, not a fallback. No in-scope site was missed. No removed symbol survives anywhere
+in code.
+
+### i) Test suites + lint — VERIFIED (executed by this gate, not read from the report)
+
+- `uv run ruff check` on all 5 touched files: "All checks passed!"
+- `uv run pytest tests/agents/ tests/audit/ -q`: **129 passed** in 165s (matches 08864fb's claim
+  exactly).
+- `uv run pytest tests/mc/ tests/simulation/ tests/eval/ -q`: **286 passed**, 627 warnings, 14:49.
+  This is the number the audit report's dangling "see below" never recorded (j-4) — recorded here.
+- `uv run pytest tests/infra/test_smoke.py -q`: 5 passed, 1 skipped ("Qatar 2025 parquets not
+  available in this environment" — pre-existing data-availability skip, unrelated to this diff).
+
+### g) Architecture report (Part 3) — table VERIFIED, but one headline claim REFUTED
+
+**Table: verified row by row against current code.** CLI (`run_simulation_cli.py:1304-1373`):
+`total_laps` direct index (raises), compound `"UNKNOWN"`, tyre_life `0`, air 25.0, track **40.0**,
+position-None → ValueError (#628), gap fallback imported `_GAP_UNKNOWN_FALLBACK_S`. Arcade
+(`strategy.py:599-715`): `.get("total_laps", 57)`, `"MEDIUM"`, `1`, 25.0, 35.0, ValueError (#465),
+imported fallback, radios from `RadioPipelineRunner`. Backend (`race_state_builder.py:53-120`):
+identical to Arcade's literals, radios as parameters `None → []`. Both quoted arcade comments exist
+verbatim (`strategy.py:600-603` sys.path-shim blocker; `strategy.py:642-644` "two-way unification,
+not the three-way one an earlier draft of this comment claimed"). `simulator.py:378-406`
+`_local_build_race_state` is a genuine thin wrapper delegating to `build_race_state`. Line ranges
+in the audit are exact.
+
+**REFUTED (HIGH, report-accuracy): "the CLI's orchestrator input is missing radio/RCM context".**
+The audit's self-described *new, previously-unreported divergence* — "the CLI path silently
+produces a `RaceState` with no radio/RCM context at all … the CLI's orchestrator input is missing
+information that the other two surfaces carry" — is false. `_build_race_state` indeed leaves the
+fields at their Pydantic default, but the CLI main loop then populates the SAME object before
+inference: `run_simulation_cli.py:1744-1762` extends `race_state.radio_msgs` with `real_radios`,
+`race_state.rcm_events` with `real_rcms`, appends the SC-tracker synthetic event, and appends
+simulated radio/rcm — 370 lines below the builder. The arcade's own docstring even says it
+populates radios "(same as the CLI)" (`strategy.py:604-606`), which the audit quoted around but
+did not reconcile. The divergence that EXISTS is only *where* population happens (inside the
+builder vs in the caller); the audit's follow-up question for Víctor ("is the CLI's RaceState
+deliberately radio-blind, or an oversight?") rests on a false premise and, uncorrected, would send
+the dedicated architecture session hunting a gap that does not exist — or "fixing" it into
+double-injection. This is the project's own documented failure shape: a claim written into the
+planning artifact without verifying against the consumer (cf. "a false claim inside an ISSUE is
+SCOPE").
+
+### h) CLAUDE.md edits — VERIFIED
+
+Live file (gitignored, read directly): `f1-webapp = "scripts.run_webapp:main"` IS in
+`pyproject.toml` `[project.scripts]` (line 124, alongside f1-strat/f1-sim/f1-arcade/f1-eval).
+`src/shared/README.md` opens "**Status: archived.**" and points at `src/data_extraction/` as
+canonical. `scripts/run_webapp.py`'s docstring says "post-race web app (FastAPI backend + React
+SPA)" served via docker compose. In CLAUDE.md: `grep -i streamlit` → **zero matches** (all 4
+stale references gone), line 55 adds `data_extraction/` as canonical, line 56 marks `shared/`
+ARCHIVED, line 99 documents `f1-webapp`, §9/§10 updated. No overclaim found in the CLAUDE.md edit.
+
+### j-0) No newly-orphaned code — VERIFIED
+
+`_get_default_pace_agent`/`_get_default_pit_agent`/`_get_default_situation_agent`/
+`_get_default_tire_agent` all retain live callers (each file's `run_*`/`run_*_from_state` free
+functions). `_PROCESSED` still used. Nothing the deletions touched became dead. The one sibling
+that must NOT be deleted, `get_rag_react_agent`, is untouched and still invoked
+(`rag_agent.py:134/195`) — the cleanup did not over-delete into the live twin.
+
+### c) `DEFAULT_TOTAL_LAPS` — VERIFIED
+
+All 6 call sites confirmed in the diff (pit_strategy ×3: 1037/1271/1452; race_situation ×2:
+1008/1360; tire ×1: 1478); every one is the same `meta.get('total_laps', <57>)` shape, value and
+`.get`-fallback semantics unchanged (race_situation's `int(...)` wrap kept). Leaf-module claim
+verified by execution, not reading: `importlib.import_module('src.agents._shared_defaults')` in a
+fresh interpreter returns 57 and loads NO heavy modules (torch/xgboost/lightgbm/transformers/
+langgraph/pandas all absent from `sys.modules`) — no import cycle, and the lazy `src/agents/
+__init__` stays lazy through it.
+
+### j-1) MEDIUM — non-bisectable commit order: 08864fb imports a module that does not exist until 99f17eb
+
+`git ls-tree 08864fb -- src/agents/_shared_defaults.py` → empty, while at that same commit
+pit_strategy/race_situation/tire all contain `from src.agents._shared_defaults import
+DEFAULT_TOTAL_LAPS` (git grep at 08864fb, 3 import sites). Checking out 08864fb gives
+`ModuleNotFoundError` on three agent modules; `git bisect` across this branch will land on a
+broken tree. The companion commit even says "Companion to the previous commit" — the order is
+simply inverted. Fix before pushing: reorder (add the leaf module first) via rebase, or squash
+99f17eb into 08864fb. CI on the PR head won't catch this; only bisect/checkout will.
+
+### j-2) LOW — the new TrackTemp comment hardcodes line numbers
+
+`race_situation_agent.py:678` says "(lines ~1314/~1401)"; actual lines today are 1317/1403 and
+any edit above them rots the pointer. The project's own style rule bans internal line references
+in comments. Name the functions (`run` / `run_from_state`), not the lines.
+
+### j-3) LOW — the new module's docstring perpetuates the "2022-2025 dataset" falsehood
+
+`_shared_defaults.py` says "57 is the median/mode race length across the 2022-2025 dataset".
+Executed check: `data/processed/laps_featured.parquet` holds years **[2023, 2024, 2025]**, 71
+races, median **57.0**, mode **57.0** — the NUMBER is right, the dataset naming is wrong, and
+CLAUDE.md §1 explicitly warns against exactly this conflation ("'2022–2025' names the
+ground-effect regulation ERA, not the data range … there is no 2022 season anywhere in `data/`").
+The error was inherited from the old inline comments (race_situation's deleted comment said
+"2022-2025 dataset (71 races)") — the consolidation was the one moment to correct it and instead
+promoted it into the single-sourced docstring. One-word fix: "2023-2025".
+
+### j-4) MEDIUM — the audit report's Part 4 + Verification section is UNCOMMITTED, and ends with two dangling "see below" placeholders
+
+`git status`: `documents/audits/AUDIT_cleanup_session_2026-08-01.md` is modified in the working
+tree (+44 lines vs HEAD) — the committed version (ea280e9) ends at "(Appended incrementally as
+each fix lands…)" and contains NEITHER the N4 finding, NOR the Part 4 fix/deferred tables, NOR
+the Verification section. Pushing the branch as-is ships a report missing its own results. Worse,
+even the working-tree version's Verification section still reads "`pytest tests/mc/
+tests/simulation/ tests/eval/`: **see below**" and "Real `f1-sim …` run: **see below**" — and the
+file ends there. The 70/70-laps real-run claim exists only in commit 08864fb's message, recorded
+nowhere with evidence. Fix: fill both placeholders with actual results and commit the report
+update as a fifth commit before pushing.
+
+### j-7) MEDIUM — the docs site still teaches the deleted API (the twin that never got the fix, docs edition)
+
+`docs/pages/agents-api.md:25`: "Every agent except N29 also exposes a `get_*_react_agent()`
+factory returning a compiled LangGraph `CompiledGraph`, for callers that want to drive the graph
+directly." After this diff that sentence is false for FOUR of the six agents — only N30's
+`get_rag_react_agent` survives. A reader following the docs site gets an `AttributeError`. The
+exact-name greps (mine included, first pass) miss it because the page names the *pattern*
+(`get_*_react_agent()`), not the identifiers — the literal instance of "grep is not an audit".
+This is the project's own codified lesson (CLAUDE.md §11, 2026-07-16): "cuando un fix cambia un
+contrato, la página que lo describe es parte del fix, no un follow-up". The audit's scope defense
+(agents-api.md wasn't touched in the 30-PR window) does not apply: the CLEANUP itself changed the
+contract the page describes, so the page became part of THIS fix. Update the sentence (only N30
+exposes a factory; the other four keep an internal `get_react_agent()` method — pace's unwired)
+in this same PR.
+
+### j-6) LOW — pace_agent's docstring header now makes a false claim this diff itself created
+
+`pace_agent.py:7` still titles its API list "Public API (**unchanged — backward compatible**)"
+— but this diff REMOVED a public function (`get_pace_react_agent`) from that very list. The
+parenthetical was written for an earlier refactor's promise; after this deletion it asserts the
+opposite of what the commit did. The sibling files are consistent (their docstrings just list the
+API without the "unchanged" claim). One-line fix: drop the parenthetical.
+
+### j-5) Commit-message honesty — VERIFIED otherwise
+
+1fec855's diff is exactly what it says (39 deletions, pace_agent only; explicitly discloses NOT
+removing the deeper scaffold). 08864fb's "four fixes bundled" matches its diff; its "129 passed"
+claim reproduced exactly by this gate. ea280e9's message matches its content (though that content
+carries the Part-3 radio-blind claim refuted in g). `_shared_defaults.py` is a justified
+extraction, not premature abstraction: 6 real call sites across 3 files, mirrors the existing
+`guard_rails.py` leaf pattern, and the leaf property was verified by execution (see c).
+
+### Real-run reproduction — VERIFIED
+
+`uv run f1-sim Budapest NOR McLaren --no-real-radios --no-llm`, executed by this gate on the
+post-diff tree: exit 0, "**All 70 lap(s) OK**", P5 → P1, actions STAY_OUT·59 / PIT_NOW·5 /
+UNDERCUT·6, wallclock 44.0s. Commit 08864fb's 70/70 claim is independently reproduced — it just
+needs to be RECORDED in the report's dangling placeholder (j-4).
+
+---
+
+## Severity ranking
+
+| # | Severity | Finding | Where | Fix effort |
+|---|---|---|---|---|
+| 1 | **HIGH** (report accuracy, not code) | Part 3's "CLI orchestrator input has no radio/RCM context" claim is FALSE — the CLI main loop populates `race_state.radio_msgs`/`rcm_events` at `run_simulation_cli.py:1744-1762`. Uncorrected, it aims the dedicated architecture session at a nonexistent gap (or a double-injection "fix"). | `AUDIT_cleanup_session_2026-08-01.md` Part 3 | Rewrite the paragraph: the divergence is WHERE population happens, not WHETHER. |
+| 2 | **MEDIUM** | Non-bisectable history: 08864fb imports `_shared_defaults`, created only in 99f17eb. Checkout/bisect at 08864fb = ModuleNotFoundError in 3 agent modules. | branch history | `git rebase -i` reorder or squash the two commits before pushing. |
+| 3 | **MEDIUM** | The audit report's Part 4 + Verification (+ N4) are UNCOMMITTED (+44 lines in working tree), and both "see below" placeholders are still dangling — the mc/sim/eval result and the real-run result are recorded nowhere. | working tree + report | Fill placeholders (286 passed measured by this gate) and commit as a 5th commit. |
+| 4 | **MEDIUM** | `docs/pages/agents-api.md:25` still says every agent except N29 exposes `get_*_react_agent()` — false for 4 of 6 after this diff. The project's own §11 lesson: the page describing a changed contract is part of the fix. | docs site | One-sentence rewrite in this PR. |
+| 5 | LOW | New docstring in `_shared_defaults.py` perpetuates "2022-2025 dataset" — data is 2023-2025 (verified: 71 races, years [2023,2024,2025]); CLAUDE.md §1 explicitly warns against this exact conflation. The 57 itself is correct (median 57.0, mode 57.0). | `_shared_defaults.py:14` | s/2022-2025/2023-2025/. |
+| 6 | LOW | New comment hardcodes "(lines ~1314/~1401)" (actual: 1317/1403) — banned internal line refs, rots on next edit. | `race_situation_agent.py:678` | Name the functions instead. |
+| 7 | LOW | `pace_agent.py:7` still claims "Public API (unchanged — backward compatible)" in the very diff that removed a public function from that list. | `pace_agent.py:7` | Drop the parenthetical. |
+
+No HIGH/MEDIUM **code-behaviour** defect was found: every code change in the diff is behaviourally
+identical to what it replaced (verified by diff, by execution, and by 420 passing tests).
+
+## What I tried to break and could NOT
+
+- **Hidden callers of the 4 deleted functions**: exact-name grep over the full tree including the
+  27k-file telemetry submodule, notebooks (.ipynb JSON), documents/, docs/, plus the lazy-loading
+  `__init__.py`'s `_EXPORTS` dict and `TYPE_CHECKING` block, plus a PATTERN-level grep
+  (`react_agent`) that caught what exact names couldn't (j-7 was found this way — in docs, not
+  code). No code caller exists. Also verified the one live twin (`get_rag_react_agent`) was not
+  over-deleted.
+- **Value drift in the dedup**: all 6 `DEFAULT_TOTAL_LAPS` sites diff-compared (same `.get`
+  semantics, same 57); `_conservative_stub` field-by-field identical at both sites; TrackTemp
+  fallback executed with an empty dict → 38.0/28.0/delta 0.0 exactly as claimed.
+- **Import-time regression**: fresh-interpreter import of `_shared_defaults` loads zero heavy
+  modules — the lazy-package property survives; no cycle.
+- **Test suite regressions**: 129 (agents+audit) + 286 (mc+simulation+eval) + 5 (smoke) all pass
+  post-diff on this machine; ruff clean on all 5 touched files.
+- **The architecture table**: re-derived every row from current code at the cited line ranges —
+  all values, both ValueError issue numbers, both quoted arcade comments, and the thin-wrapper
+  claim check out. The only thing that broke was the radio-blind interpretation (finding 1).
+- **A newly-dead orphan**: every helper the deleted code called (`_get_default_*`, `_PROCESSED`)
+  still has live callers.

--- a/src/agents/_shared_defaults.py
+++ b/src/agents/_shared_defaults.py
@@ -1,0 +1,19 @@
+"""Fallback constants shared by the agent modules when session_meta arrives incomplete.
+
+A leaf module — no other agent internals, no heavy imports — so pulling in this one
+constant never drags in model weights (same reasoning as ``tire_parsing.py``).
+"""
+
+from __future__ import annotations
+
+# RaceStateManager.get_session_meta() always supplies total_laps (CLAUDE.md section 6,
+# "lap_state is the single contract"; race_state_manager.py's own get_session_meta sets
+# it unconditionally). This constant only guards a hand-built session_meta -- a test
+# fixture, or a partially populated state -- from resolving a missing key to a
+# different number at every call site. 57 is the median/mode race length across the
+# 2023-2025 dataset (71 races) -- NOT "2022-2025": there is no 2022 season anywhere in
+# data/ (CLAUDE.md section 1). Previously restated as a bare literal in
+# pit_strategy_agent.py (x3), race_situation_agent.py (x2) and tire_agent.py (x1);
+# consolidated here so a future change updates every caller at once instead of drifting
+# one site at a time.
+DEFAULT_TOTAL_LAPS: int = 57

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -8,7 +8,6 @@ Public API (unchanged — backward compatible)
 --------------------------------------------
 run_pace_agent(**kwargs)               → PaceOutput
 run_pace_agent_from_state(lap_state)   → PaceOutput
-get_pace_react_agent()                 → LangGraph ReAct agent (lazy, LLM required)
 
 Internal structure
 ------------------
@@ -83,11 +82,6 @@ _NOISE_PCT: float  = 0.02   # 2 % Gaussian noise on continuous features
 # lives in tire_agent._add_fuel_cols; deliberately duplicated rather than shared, since
 # unifying constants across agent modules is a wider refactor than this fix (#446).
 FUEL_GAIN_PER_LAP_S: float = 0.055
-
-# ── Artifact paths ────────────────────────────────────────────────────────────
-_CLUSTER_PARQUET  = _PROCESSED / 'circuit_clustering' / 'circuit_clusters_k4_2025.parquet'
-_LAPS_FEATURED    = _PROCESSED / 'laps_featured_2025.parquet'
-_FEATURE_MANIFEST = _PROCESSED / 'feature_manifest_laptime.json'
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -990,38 +984,5 @@ Never invent numbers — use only the values returned by the tools."""
 
     PACE_TOOLS = [predict_pace_tool, get_session_median_tool]
 
-    def get_pace_react_agent(
-        provider: str = 'lmstudio',
-        model_name: str = 'gpt-4.1-mini',
-        base_url: str = 'http://localhost:1234/v1',
-        api_key: str = 'lmstudio',
-    ):
-        """Return the LangGraph ReAct agent for the Pace Agent (lazy singleton).
-
-        Delegates to the shared PaceAgent instance so model weights and the
-        LangGraph graph are only created once per process.
-
-        Args:
-            provider: 'lmstudio' or 'openai'.
-            model_name: Model identifier for ChatOpenAI.
-            base_url: Base URL for LM Studio (ignored when provider='openai').
-            api_key: API key; use 'lmstudio' for local server.
-
-        Returns:
-            LangGraph CompiledGraph — invoke with {"messages": [("user", query)]}.
-        """
-        return _get_default_pace_agent().get_react_agent(
-            provider=provider,
-            model_name=model_name,
-            base_url=base_url,
-            api_key=api_key,
-        )
-
 else:
     PACE_TOOLS = []
-
-    def get_pace_react_agent(**kwargs):
-        raise ImportError(
-            "LangGraph / LangChain not installed. "
-            "Install with: pip install langgraph langchain-openai"
-        )

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -4,8 +4,8 @@ Extracted from N25_pace_agent.ipynb. Wraps the N06 XGBoost delta-lap-time
 model into a clean OOP agent interface that returns lap time predictions,
 delta signals, and bootstrap confidence intervals.
 
-Public API (unchanged — backward compatible)
---------------------------------------------
+Public API
+----------
 run_pace_agent(**kwargs)               → PaceOutput
 run_pace_agent_from_state(lap_state)   → PaceOutput
 

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -8,7 +8,6 @@ Public API
 ----------
 run_pit_strategy_agent(lap_state)                     → PitStrategyOutput  (FastF1 session)
 run_pit_strategy_agent_from_state(lap_state, laps_df) → PitStrategyOutput  (RSM adapter)
-get_pit_strategy_react_agent(**kwargs)                 → CompiledGraph
 """
 
 from __future__ import annotations
@@ -39,6 +38,8 @@ from src.strategy.inference.guard_rails import (
     _NO_PIT_BEFORE_LAP,
     _NO_PIT_LAST_N_LAPS,
 )
+
+from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS
 
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent
@@ -1036,7 +1037,7 @@ class PitStrategyAgent:
 
         gp_name    = self.session_meta.get('gp_name', '')
         year       = self.session_meta.get('year', 2025)
-        total_laps = self.session_meta.get('total_laps', 57)
+        total_laps = self.session_meta.get('total_laps', DEFAULT_TOTAL_LAPS)
         team_x_raw = self.session_meta.get('team_lookup', {}).get(driver_x, 'Unknown')
         team_x     = _TEAM_ALIASES.get(team_x_raw, team_x_raw)
 
@@ -1270,7 +1271,7 @@ class PitStrategyAgent:
                     f'Pick a driver from that list.'
                 )
 
-            total_laps       = agent.session_meta.get('total_laps', 57)
+            total_laps       = agent.session_meta.get('total_laps', DEFAULT_TOTAL_LAPS)
             laps_remaining   = total_laps - lap_number
             current_compound = current_compound.upper()
 
@@ -1451,9 +1452,9 @@ class PitStrategyAgent:
         lap_number = lap_state['lap_number']
         driver     = meta['driver']
         gp_name    = meta.get('gp_name', '')
-        # 57 = median/mode race length across the 2022-2025 dataset; the same fallback the
-        # other strategy surfaces use, so a missing key resolves to one value everywhere.
-        total_laps = meta.get('total_laps', 57)
+        # DEFAULT_TOTAL_LAPS: see src/agents/_shared_defaults.py for why this fallback
+        # exists and why it is single-sourced across the strategy agents.
+        total_laps = meta.get('total_laps', DEFAULT_TOTAL_LAPS)
         year       = meta.get('year', 2025)
         team       = meta.get('team', 'Unknown')
         compound   = d.get('compound', 'MEDIUM')
@@ -1697,31 +1698,3 @@ def run_pit_strategy_agent_from_state(
         PitStrategyOutput with all fields populated.
     """
     return _get_default_pit_agent().run_from_state(lap_state, laps_df)
-
-
-def get_pit_strategy_react_agent(
-    provider: str = 'lmstudio',
-    model_name: str = 'gpt-4.1-mini',
-    base_url: str = 'http://localhost:1234/v1',
-    api_key: str = 'lm-studio',
-):
-    """Return the LangGraph ReAct agent backed by the singleton PitStrategyAgent.
-
-    Avoids connecting to the LLM at import time — created only when N31 or tests
-    actually invoke the agent.
-
-    Args:
-        provider: 'lmstudio' or 'openai'.
-        model_name: Model identifier for ChatOpenAI.
-        base_url: Base URL for LM Studio (ignored when provider='openai').
-        api_key: API key; 'lm-studio' for local server.
-
-    Returns:
-        LangGraph CompiledGraph.
-    """
-    return _get_default_pit_agent().get_react_agent(
-        provider=provider,
-        model_name=model_name,
-        base_url=base_url,
-        api_key=api_key,
-    )

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -7,7 +7,6 @@ Public API
 ----------
 run_race_situation_agent(lap_state)                       → RaceSituationOutput  (FastF1 session)
 run_race_situation_agent_from_state(lap_state, laps_df)   → RaceSituationOutput  (RSM adapter)
-get_race_situation_react_agent(**kwargs)                   → CompiledGraph
 
 Module-level singletons
 -----------------------
@@ -28,6 +27,8 @@ from typing import Optional
 import joblib
 import numpy as np
 import pandas as pd
+
+from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS
 
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent
@@ -673,7 +674,11 @@ def _compute_rcm_features(
 
 def _compute_weather_features(session_meta: dict) -> dict:
     """Extract weather scalars from session_meta for the SC feature vector."""
-    track_temp       = float(session_meta.get('TrackTemp', 35.0))
+    # 38.0, not 35.0: matches the fallback run()/run_from_state() already use (grep this
+    # file for 'TrackTemp' to find both) when they build this same session_meta key, so a
+    # hand-built session_meta missing the key resolves to the same temperature this file
+    # uses everywhere else instead of silently disagreeing with itself.
+    track_temp       = float(session_meta.get('TrackTemp', 38.0))
     air_temp         = float(session_meta.get('AirTemp', 28.0))
     humidity         = float(session_meta.get('Humidity', 50.0))
     track_temp_start = float(session_meta.get('track_temp_start', track_temp))
@@ -1003,11 +1008,9 @@ class RaceSituationAgent:
         feat.update(_compute_rcm_features(all_laps, lap_number, session_meta, cur_code, prev_code))
         feat.update(_compute_weather_features(session_meta))
 
-        # RaceStateManager and the FastF1 session always supply total_laps, so this
-        # fallback only fires for hand-built states (tests, debug). 57 is the median and
-        # mode race length across the 2022-2025 dataset (71 races), so it is the least
-        # surprising stand-in and is kept identical across every strategy surface.
-        total_laps = int(session_meta.get('total_laps', 57))
+        # DEFAULT_TOTAL_LAPS: see src/agents/_shared_defaults.py for why this fallback
+        # exists and why it is single-sourced across the strategy agents.
+        total_laps = int(session_meta.get('total_laps', DEFAULT_TOTAL_LAPS))
         is_lap1    = int(lap_number == 1)
         lap_pct    = float(lap_number) / max(total_laps, 1)
 
@@ -1357,9 +1360,8 @@ class RaceSituationAgent:
         lap_number = lap_state['lap_number']
         driver     = meta['driver']
         gp_name    = meta.get('gp_name', '')
-        # 57 = median/mode race length across the dataset; matches _build_features above
-        # and the other strategy surfaces so the fallback is one value, not several.
-        total_laps = meta.get('total_laps', 57)
+        # DEFAULT_TOTAL_LAPS: see src/agents/_shared_defaults.py.
+        total_laps = meta.get('total_laps', DEFAULT_TOTAL_LAPS)
         year       = meta.get('year', 2025)
 
         # #465 (F6): a defaulted position (previously `.get('position', 20)`) is a
@@ -1655,31 +1657,3 @@ def run_race_situation_agent_from_state(
         RaceSituationOutput with all fields populated.
     """
     return _get_default_situation_agent().run_from_state(lap_state, laps_df)
-
-
-def get_race_situation_react_agent(
-    provider: str = 'lmstudio',
-    model_name: str = 'gpt-4.1-mini',
-    base_url: str = 'http://localhost:1234/v1',
-    api_key: str = 'lm-studio',
-):
-    """Return the LangGraph ReAct agent backed by the singleton RaceSituationAgent.
-
-    Avoids connecting to the LLM at import time — created only when N31 or tests
-    actually invoke the agent.
-
-    Args:
-        provider: 'lmstudio' or 'openai'.
-        model_name: Model identifier for ChatOpenAI.
-        base_url: Base URL for LM Studio (ignored when provider='openai').
-        api_key: API key; use 'lm-studio' for local server.
-
-    Returns:
-        LangGraph CompiledGraph — invoke with {"messages": [HumanMessage(...)]}.
-    """
-    return _get_default_situation_agent().get_react_agent(
-        provider=provider,
-        model_name=model_name,
-        base_url=base_url,
-        api_key=api_key,
-    )

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -8,7 +8,6 @@ Public API
 ----------
 run_tire_agent(stint_state)                   → TireOutput  (FastF1 session in stint_state)
 run_tire_agent_from_state(lap_state, laps_df) → TireOutput  (RSM adapter, no FastF1 session)
-get_tire_react_agent(**kwargs)                → CompiledGraph
 
 Module-level singletons
 -----------------------
@@ -33,6 +32,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS
 from src.agents.tire_parsing import parse_tool_outputs
 
 # ── Repo root (module-relative) ───────────────────────────────────────────────
@@ -1478,7 +1478,7 @@ class TireAgent:
         compound    = d.get('compound', 'MEDIUM')
         tyre_life   = d.get('tyre_life', 1)
         gp_name     = meta.get('gp_name', '')
-        total_laps  = meta.get('total_laps', 57)
+        total_laps  = meta.get('total_laps', DEFAULT_TOTAL_LAPS)
         year        = meta.get('year', 2025)
         team        = meta.get('team', 'Unknown')
 
@@ -1538,6 +1538,26 @@ class TireAgent:
 
         return self._run_core(driver, compound_id, tyre_life, gp_name)
 
+    @staticmethod
+    def _conservative_stub(
+        compound_id: str, tyre_life: int, gp_name: str, reason: str,
+    ) -> TireOutput:
+        """TireOutput with the fixed conservative defaults used whenever a real TCN
+        reading is unavailable (no bundle for this compound, or a tool-output parse
+        miss). ``reason`` is folded into ``reasoning`` so the degradation is visible
+        instead of masquerading as a genuine reading.
+        """
+        return TireOutput(
+            compound          = compound_id,
+            current_tyre_life = tyre_life,
+            gp_name           = gp_name,
+            deg_rate          = 0.03,
+            laps_to_cliff_p10 = 20.0,
+            laps_to_cliff_p50 = 30.0,
+            laps_to_cliff_p90 = 40.0,
+            reasoning         = reason,
+        )
+
     def _run_core(
         self,
         driver: str,
@@ -1563,15 +1583,9 @@ class TireAgent:
         # TCN bundles only exist for dry compounds (C1–C6). For wet/intermediate
         # compounds return a stub with conservative defaults — no TCN inference.
         if compound_id not in self.bundles:
-            return TireOutput(
-                compound          = compound_id,
-                current_tyre_life = tyre_life,
-                gp_name           = gp_name,
-                deg_rate          = 0.03,
-                laps_to_cliff_p10 = 20.0,
-                laps_to_cliff_p50 = 30.0,
-                laps_to_cliff_p90 = 40.0,
-                reasoning         = (
+            return self._conservative_stub(
+                compound_id, tyre_life, gp_name,
+                reason=(
                     f"[{compound_id} — TCN model not available for wet/intermediate compounds; "
                     f"conservative defaults used]"
                 ),
@@ -1606,15 +1620,9 @@ class TireAgent:
                 'Tire tool output did not parse for %s (tyre_life=%s) — using conservative '
                 'defaults instead of a 0.0 cliff', compound_id, tyre_life,
             )
-            return TireOutput(
-                compound          = compound_id,
-                current_tyre_life = tyre_life,
-                gp_name           = gp_name,
-                deg_rate          = 0.03,
-                laps_to_cliff_p10 = 20.0,
-                laps_to_cliff_p50 = 30.0,
-                laps_to_cliff_p90 = 40.0,
-                reasoning         = (
+            return self._conservative_stub(
+                compound_id, tyre_life, gp_name,
+                reason=(
                     f"[{compound_id} — tire tool output could not be parsed; conservative "
                     f"defaults used] {reasoning}"
                 ),
@@ -1698,31 +1706,3 @@ def run_tire_agent_from_state(lap_state: dict, laps_df: pd.DataFrame) -> TireOut
         TireOutput with all fields populated.
     """
     return _get_default_tire_agent().run_from_state(lap_state, laps_df)
-
-
-def get_tire_react_agent(
-    provider: str = 'lmstudio',
-    model_name: str = 'gpt-4.1-mini',
-    base_url: str = 'http://localhost:1234/v1',
-    api_key: str = 'lm-studio',
-):
-    """Return the LangGraph ReAct agent backed by the singleton TireAgent instance.
-
-    Avoids connecting to the LLM at import time — created only when N31 or tests
-    actually invoke the agent.
-
-    Args:
-        provider: 'lmstudio' or 'openai'.
-        model_name: Model identifier for ChatOpenAI.
-        base_url: Base URL for LM Studio (ignored when provider='openai').
-        api_key: API key; use 'lm-studio' for local server.
-
-    Returns:
-        LangGraph CompiledGraph — invoke with {"messages": [{"role": "user", "content": ...}]}.
-    """
-    return _get_default_tire_agent().get_react_agent(
-        provider=provider,
-        model_name=model_name,
-        base_url=base_url,
-        api_key=api_key,
-    )


### PR DESCRIPTION
## Summary

Dedicated clean-code / anti-AI-slop cleanup session, scoped mechanically to files touched
across the last ~30 merged PRs (#730-#775, recomputed via `git log --name-only`, not a fixed
list). Full findings + fix log in `documents/audits/AUDIT_cleanup_session_2026-08-01.md`, plus
an independent adversarial gate report in `AUDIT_cleanup_session_2026-08-01_GATE.md`.

- Removes ~150 lines of verified dead code: 4 unreachable `get_*_react_agent()` free functions
  (zero callers anywhere in the repo -- each sibling's underlying `get_react_agent()` instance
  method stays live) and 3 dead artifact-path constants in `pace_agent.py`.
- Single-sources the `total_laps=57` fallback (previously a literal restated six times across
  three agent files) into a new leaf module, `src/agents/_shared_defaults.py`.
- Fixes an intra-file inconsistency in `race_situation_agent.py`: `TrackTemp` fallback was 35.0
  in one function, 38.0 in the two that actually build that key.
- Dedupes `tire_agent.py`'s twice-repeated "conservative stub" `TireOutput` construction into a
  helper.
- Corrects a stale doc page (`docs/pages/agents-api.md`) that the code changes above invalidated.

## Architecture question -- detected and reported, not fixed here

Confirmed a third independent `RaceState` builder (`src/telemetry/backend/utils/race_state_builder.py`,
in addition to the CLI's and Arcade's `_build_race_state`), with a documented prior 2-way
unification attempt and an explicit, real blocker (a `sys.path` shim only FastAPI startup
provides). Full comparison table and evidence in the audit doc's Part 3. Per explicit scoping
instruction, unifying these is left to a separate dedicated session.

## Verification

- `ruff check` on every touched Python file: clean.
- `pytest tests/agents/ tests/audit/`: 129 passed.
- `pytest tests/mc/ tests/simulation/ tests/eval/`: 286 passed.
- Real `f1-sim Budapest NOR McLaren --no-real-radios --no-llm` run: 70/70 laps OK, P5 → P1, no errors.
- Independent adversarial gate (separate Fable agent): re-verified every "zero callers"/dedup claim,
  found and this branch fixed 1 HIGH (a refuted claim in the architecture report), 3 MEDIUM
  (non-bisectable commit order, unfilled report placeholders, the stale docs page), 3 LOW.

## Out of scope (deliberately deferred, not silently dropped)

- `_build_race_state` triplication itself (architecture question above).
- Items from the earlier informal audit whose files fall outside the recomputed 30-PR window
  (RCM classifier bench-script fork, `theme.py`'s `_ACTION_STYLE` mirror, the ~15-script
  bootstrap-preamble duplication, legacy fossils) -- still valid, just outside this session's
  mechanically-computed scope.
- `pace_agent.py`'s deeper unreachable LangGraph scaffold (`get_react_agent` method, tools,
  system prompt) -- its own comment says "preserved 100%", a deliberate-intent signal flagged
  for a product decision rather than deleted unilaterally.