### PR TITLE
fix(agents): retire pace_agent's dead LangGraph ReAct scaffold

### DIFF
--- a/docs/pages/agents-api.md
+++ b/docs/pages/agents-api.md
@@ -22,7 +22,9 @@ Every agent has two entry points:
 `lap_state`, which is why the stint fuel baseline is carried there rather than derived from a
 frame. The adapters are not uniform, so check the signature before assuming.
 
-Only the RAG agent (N30) exposes a module-level `get_rag_react_agent()` factory returning a compiled LangGraph `CompiledGraph`, for callers that want to drive the graph directly — it is genuinely invoked (the chat backend calls it). N25-N28 (pace, tire, race situation, pit strategy) used to have an equivalent free function each; all four were confirmed dead (zero callers anywhere in the repo) and removed in the 2026-08-01 cleanup pass. Each of those agents still has its own `get_react_agent()` *instance method*, called internally from its own `_run_core` — only the redundant module-level wrapper was removed. The radio agent (N29) never had one: its pipeline is a fixed sequence of model calls rather than a ReAct loop, so there is no graph to compile.
+Only the RAG agent (N30) exposes a module-level `get_rag_react_agent()` factory returning a compiled LangGraph `CompiledGraph`, for callers that want to drive the graph directly — it is genuinely invoked (the chat backend calls it). N25-N28 (pace, tire, race situation, pit strategy) used to have an equivalent free function each; all four were confirmed dead (zero callers anywhere in the repo) and removed in the 2026-08-01 cleanup pass. Tire, race situation and pit strategy still have their own `get_react_agent()` *instance method*, called internally from each agent's own `_run_core` — only the redundant module-level wrapper was removed for those three. The radio agent (N29) never had one: its pipeline is a fixed sequence of model calls rather than a ReAct loop, so there is no graph to compile.
+
+**N25 (pace) is deliberately deterministic — no ReAct loop at all.** Unlike its three siblings above, pace's `run()`/`run_from_state()` call the N06 XGBoost model directly; there is no LLM step to invoke and no category field (`warning_level`/`action`/`threat_level`) for an LLM to decide. `pace_agent.py` used to carry a complete but never-wired LangGraph ReAct scaffold (tools, system prompt, `get_react_agent()`) from the moment the module was first extracted — confirmed by archaeology to have been a deliberate per-agent choice made in the same commit that wired tire/pit/race_situation, not a wiring gap. It was formally retired (deleted, not left dead) in #781; see #778 for the full decision record.
 
 ## Output dataclasses
 
@@ -35,7 +37,7 @@ Only the RAG agent (N30) exposes a module-level `get_rag_react_agent()` factory 
 | `delta_vs_median` | float | Delta vs session median |
 | `ci_p10` | float | 10th percentile bootstrap CI |
 | `ci_p90` | float | 90th percentile bootstrap CI |
-| `reasoning` | str | LLM-generated reasoning text |
+| `reasoning` | str | Deterministic summary string (no LLM call — see the note above) |
 
 ### TireOutput (N26)
 
@@ -158,10 +160,11 @@ Every LangChain tool the LLM can call takes free-text arguments (`driver`, `lap_
 
 | Agent | Tools guarded | Refuses when |
 |---|---|---|
-| N25 Pace | `predict_pace_tool` | `driver_number`/`gp_name`/`year` do not resolve to a driver on track for that GP/year, or `lap_number` is outside `[1, total_laps]` |
 | N26 Tire | `predict_tire_deg_tool`, `estimate_laps_to_cliff_tool` | `driver` is not on track at the currently loaded lap, or the loaded `current_lap` is outside `[1, total_laps]` |
 | N27 Situation | `predict_overtake_tool`, `predict_sc_tool` | `lap_number` is out of range, or (for `predict_overtake_tool`) either driver is unknown for that lap |
 | N28 Pit | `predict_pit_duration_tool`, `score_undercut_tool` | the named driver (`driver`/`driver_y`) is not present in the live roster for the current lap |
+
+N25 Pace originally had an equivalent guard on its own `predict_pace_tool` (#476), but that tool was deleted along with the rest of pace's unreachable LangGraph scaffold in #781 — pace has no LLM-facing tool left to guard, so the class of bug #476 fixed cannot occur for it anymore.
 
 The refusal is a plain string return (e.g. `"error: 'HAM' is not on track at lap 12; valid: [...]"` or `"... REFUSED — {driver} is not on track ..."`), not an exception, the LLM sees a normal-looking tool result it can react to, rather than a traceback. `predict_pit_duration_tool` additionally cross-checks the LLM-supplied `under_sc` flag against the RCM-confirmed `sc_currently_active` ground truth when a real orchestrator run has set it, and trusts the confirmed value over the guess (logging a warning) rather than the other way round.
 

--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -102,7 +102,7 @@ Wraps the N06 XGBoost delta-lap-time model. Returns predicted lap time, delta si
 
 - **Model**: XGBoost trained on 2023–2025 lap data
 - **Output**: `PaceOutput` (lap_time_pred, delta_vs_prev, delta_vs_median, ci_p10, ci_p90)
-- **No LLM step**: unlike its three always-on siblings below, pace calls the XGBoost model directly — `reasoning` is a deterministic f-string, not LLM output. Pace is the one always-on agent with no qualitative judgment to make (no `warning_level`/`action`/`threat_level` category alongside its numbers), so a `pace_agent.py` once carried a complete but never-wired LangGraph ReAct scaffold; it was formally retired in #781 after the #778/#779/#780 archaeology and decision. See [agents-api.md](#/agents-api) for the full record.
+- **No LLM step**: unlike its tire/pit/race-situation siblings below, pace calls the XGBoost model directly — `reasoning` is a deterministic f-string, not LLM output. Pace is the one always-on agent with no qualitative judgment to make (no `warning_level`/`action`/`threat_level` category alongside its numbers), so a `pace_agent.py` once carried a complete but never-wired LangGraph ReAct scaffold; it was formally retired in #781 after the #778/#779/#780 archaeology and decision. See [agents-api.md](#/agents-api) for the full record.
 
 ### N26: Tire Agent (`tire_agent.py`)
 
@@ -329,7 +329,7 @@ One consequence worth knowing before debugging a call: **the effect does not sho
 | Sub-agents N26–N29 | gpt-4.1-mini | OpenAI or LM Studio |
 | Orchestrator N31 | gpt-5.4-mini | OpenAI or LM Studio |
 
-N25 (pace) is not in this table — it never calls an LLM, see the "No LLM step" note under [N25: Pace Agent](#n25-pace-agent-pace_agentpy) above.
+N25 (pace) is not in this table — it never calls an LLM, see the "No LLM step" note under [N25: Pace Agent](#/multi-agent#n25-pace-agent-paceagentpy) above.
 
 Set `F1_LLM_PROVIDER=openai` env var to use the real OpenAI API. Default is LM Studio at `http://localhost:1234/v1`.
 

--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -102,6 +102,7 @@ Wraps the N06 XGBoost delta-lap-time model. Returns predicted lap time, delta si
 
 - **Model**: XGBoost trained on 2023–2025 lap data
 - **Output**: `PaceOutput` (lap_time_pred, delta_vs_prev, delta_vs_median, ci_p10, ci_p90)
+- **No LLM step**: unlike its three always-on siblings below, pace calls the XGBoost model directly — `reasoning` is a deterministic f-string, not LLM output. Pace is the one always-on agent with no qualitative judgment to make (no `warning_level`/`action`/`threat_level` category alongside its numbers), so a `pace_agent.py` once carried a complete but never-wired LangGraph ReAct scaffold; it was formally retired in #781 after the #778/#779/#780 archaeology and decision. See [agents-api.md](#/agents-api) for the full record.
 
 ### N26: Tire Agent (`tire_agent.py`)
 
@@ -325,8 +326,10 @@ One consequence worth knowing before debugging a call: **the effect does not sho
 
 | Layer | Model | Provider |
 |---|---|---|
-| Sub-agents N25–N29 | gpt-4.1-mini | OpenAI or LM Studio |
+| Sub-agents N26–N29 | gpt-4.1-mini | OpenAI or LM Studio |
 | Orchestrator N31 | gpt-5.4-mini | OpenAI or LM Studio |
+
+N25 (pace) is not in this table — it never calls an LLM, see the "No LLM step" note under [N25: Pace Agent](#n25-pace-agent-pace_agentpy) above.
 
 Set `F1_LLM_PROVIDER=openai` env var to use the real OpenAI API. Default is LM Studio at `http://localhost:1234/v1`.
 

--- a/documents/audits/AUDIT_pace_agent_react_archaeology_779.md
+++ b/documents/audits/AUDIT_pace_agent_react_archaeology_779.md
@@ -1,0 +1,218 @@
+# pace_agent ReAct archaeology (#779)
+
+Part of epic #778. Answers: why does `src/agents/pace_agent.py` carry a complete
+LangGraph ReAct scaffold that nothing calls, while the structurally identical
+scaffolds in `tire_agent.py` / `pit_strategy_agent.py` / `race_situation_agent.py`
+are genuinely wired into `run()`/`run_from_state()`?
+
+Method: read `notebooks/agents/N25_pace_agent.ipynb` and
+`notebooks/agents/N31_strategy_orchestrator.ipynb` in full (source-only dump,
+outputs stripped, via a throwaway script — no notebook file was edited), plus
+`git log -p --follow` / `git log -S` on `src/agents/pace_agent.py` and the
+GitHub history of issue #476. This report is the full finding; nothing here was
+buffered, the investigation is complete.
+
+## Summary verdict
+
+**The scaffold was born unreachable, then deliberately left unreachable at a
+later decision point, and never had a stated future-use commitment — only a
+"do not delete without knowing why" caution note added during last week's
+cleanup.** No PR description, commit message, issue, or notebook markdown was
+found promising to wire it. The one place a rationale IS on record
+(`N25_pace_agent.ipynb`, Step 5 markdown) argues pace's own case for an inner
+ReAct loop is weak by design, not that it was deferred.
+
+## Timeline
+
+### 1. 2026-03-31 — `88dfe40` — first extraction commit
+
+`pace_agent.py` is created from the notebook. The ReAct scaffold
+(`get_pace_react_agent`, `PACE_TOOLS`, `predict_pace_tool`,
+`get_session_median_tool`, `_PACE_SYSTEM_PROMPT`) exists from line 1 of the
+module's life, **alongside** `run_pace_agent()`, which already builds its
+`reasoning` field as a deterministic f-string — never a call into the ReAct
+agent. The two paths were born side by side and never unified.
+
+### 2. 2026-04-05 — `3f55c9f` — "agents: LangGraph fix + gpt-4.1-mini defaults..."
+
+**This is the pivotal commit.** It rewrites all four per-lap agents
+(`pace_agent.py`, `tire_agent.py`, `pit_strategy_agent.py`,
+`race_situation_agent.py`) in the *same commit*, converting each from
+free-function modules to an OOP `XAgent` class with a lazy `get_react_agent()`
+method. At the end of this exact commit:
+
+- `tire_agent.py`'s `run()`/`run_from_state()` call `self._run_core()`, which
+  calls `self.get_react_agent()` and `.invoke()`s it — confirmed by grepping
+  the commit's own tree state (`git show 3f55c9f:src/agents/tire_agent.py`).
+  Same for `pit_strategy_agent.py` and `race_situation_agent.py`.
+- `pace_agent.py`'s `run()`/`run_from_state()` build the feature row, call
+  `self._predict()`/`self._bootstrap_ci()`/`self._session_median()` directly,
+  and assemble the f-string `reasoning` — `self.get_react_agent()` is defined
+  but has **zero call sites** anywhere in the same commit's tree.
+
+So this was not incremental drift — in one sitting, three agents were wired to
+their ReAct scaffold and pace deliberately was not, even though its scaffold
+was written to the same level of completeness (tools, prompt, lazy singleton)
+as the other three. The same commit also renamed the section header above the
+scaffold from `# LangGraph ReAct agent` to
+`# LangGraph tools and ReAct agent (preserved 100% — no functional changes)` —
+in context this reads as "I touched everything else in this file in this
+refactor pass, this block's *behavior* is exactly what it was before", not as
+a forward-looking commitment to wire it later. It is refactor-commit hygiene,
+not a design promise.
+
+### 3. 2026-07-18 — `5f84218` — "fix(agents): validate LLM tool inputs..." (closes part of #476)
+
+A prior Fable-audit hardening pass added `PaceAgent._validate_pace_inputs()`
+and wired it into `predict_pace_tool`, explicitly treating pace's tool as
+LLM-facing: *"reuse the `_live_drivers` guard across the pit, tire, situation
+and pace agents so an off-track driver or out-of-range lap is refused instead
+of computed on"* (commit message). Issue #476 itself frames `predict_pace_tool`
+as the *"extreme"* case among the four agents' tools — 19 raw parameters, no
+`laps_df` closure — and says the "rich" (LLM) profile *"hands the same
+arguments to the LLM and never checks them back."*
+
+**This is significant: a previous audit session hardened pace's tool as if it
+were reachable by an LLM, without ever discovering that it wasn't.** The false
+belief "pace is wired like its siblings" did not start with Víctor in the
+2026-08-01 cleanup session — it was already latent in the codebase's own audit
+history three weeks earlier, and that audit pass reinforced it instead of
+catching it (its own fix touched all four agents' input-validation uniformly,
+which is exactly the kind of pattern-matched fix that would not surface a
+one-of-four wiring gap).
+
+### 4. 2026-08-01 — `1fec855` / `d5b6084` — this epic's origin
+
+The cleanup session removes the dead **wrapper** function `get_pace_react_agent()`
+(module-level, zero callers, distinct from the instance method
+`PaceAgent.get_react_agent()`), confirms the deeper scaffold is also dead, and
+explicitly declines to delete it because of the "preserved 100%" header —
+opening this epic instead.
+
+## What the notebooks actually say
+
+### N25_pace_agent.ipynb — Step 5 markdown (cell 31), the one on-record rationale
+
+> "This step wraps the inference functions from Steps 1–3 into a proper
+> LangGraph ReAct agent — the interface that N31 (Strategy Orchestrator) will
+> use to delegate pace queries."
+>
+> "**The key difference from `run_pace_agent` in Step 3**: the ReAct agent
+> lets the LLM decide which tools to call and can reason about the outputs
+> before responding. **For a deterministic single-tool workflow the two are
+> equivalent**; the agent pattern pays off in N31 where the supervisor LLM
+> selects which sub-agents to activate each lap."
+
+Two things follow from this, in the notebook author's own words, at design
+time:
+
+1. The *stated* intended consumer of pace's ReAct wrapping was N31's
+   *supervisor* calling pace's tools directly (a single flat ReAct with every
+   sub-agent's tools available to one outer LLM) — **not** an inner ReAct loop
+   private to `PaceAgent` the way tire/pit/situation ended up implementing.
+2. The notebook itself already flags that pace is a weak case for the pattern:
+   *"for a deterministic single-tool workflow the two are equivalent"* — i.e.
+   wrapping pace in ReAct was expected to buy nothing over calling it directly,
+   specifically because pace has no decision for an LLM to make.
+
+### N31_strategy_orchestrator.ipynb — the "LLM-as-router" design note (cell 7) that supersedes (1)
+
+N31's own Step 1 markdown contains an explicit, reasoned rejection of exactly
+the architecture N25 anticipated:
+
+> "**Why deterministic routing is the right choice here:** ... 4. *Latency* —
+> an LLM-as-router (e.g. ReAct-style planner deciding which agents to call)
+> adds one extra round-trip before any real computation starts. For a
+> real-time system making per-lap decisions every ~90 seconds, this matters."
+>
+> "**What could be made more complex (and why it's deferred):** ... *LLM-as-router*:
+> let the LLM itself decide which agents to invoke ... Rejected for latency
+> and non-determinism — a strategy call must be auditable and fast, not
+> dependent on an LLM reasoning about whether to call another LLM."
+
+N31's real `_decide_agents_to_call` is a plain deterministic `if`/`else`
+function. N31's own demo/production code (`_run_always_on_agents`) calls
+`run_pace_agent(...)` as an ordinary function with keyword arguments — never
+through a tool-call interface — and does the exact same thing for
+tire/situation (`run_tire_agent(lap_state)`, `run_race_situation_agent(lap_state)`),
+even though those two *do* internally spin up their own ReAct loop once called.
+
+**This is the resolving fact.** N31 was never going to be the "one supervisor
+ReAct with everyone's tools" that N25's Step 5 markdown anticipated — that
+architecture was explicitly designed away in N31 for auditability/latency
+reasons, for the routing decision specifically. What N31 actually calls is a
+plain function per agent; whether that function's *internal* implementation
+uses an LLM ReAct loop is a decision private to each agent module, made
+per-agent in commit `3f55c9f`. Pace's Step 5 rationale ("equivalent for a
+deterministic workflow") was never revisited against that outcome — it just
+turned out to still apply, because N31 changed the routing layer, not the
+individual agents' honesty about whether they have a qualitative judgment to
+make.
+
+## Corroborating architecture evidence (from the current codebase, not the notebooks)
+
+- `src/strategy/inference/no_llm.py` (`_NullReActRunner`, `run_no_llm_lap`)
+  calls `run_pace_agent_from_state(lap_state)` directly with **no** injection
+  seam — because there is no LLM step to null out. For tire and situation, the
+  same module has to inject a `_NullReActRunner` at the `_react_agent` cache
+  seam specifically because those two *do* run a live ReAct loop in normal
+  ("rich") mode. This file's own docstring states the asymmetry as a design
+  fact: *"N25/N26/N27/N29 produce REAL model numbers... pace via its public
+  XGBoost entry, tire/situation by injecting a deterministic tool-runner."*
+- `src/telemetry/backend/mcp_tools.py`'s chat-facing MCP tools
+  (`predict_pace`, `predict_tire`, `predict_situation`, `predict_pit`) are
+  *uniform* — each just calls that agent's `run_*_agent_from_state(...)` and
+  lets the agent's own implementation decide whether an inner LLM runs. The
+  outer chat LLM already can (and does) call pace today; the only missing
+  piece is whether `PaceAgent.run_from_state()` itself nests a second LLM call
+  the way tire/situation/pit do.
+- `TireOutput.warning_level` (the categorical judgment tire's siblings each
+  carry) is computed in `__post_init__` from a numeric threshold on
+  `laps_to_cliff_p10` — **not** by the LLM. The ReAct loop's real contribution
+  for tire is (a) which of 1–2 tools to call and in what order, and (b) a
+  natural-language `reasoning` sentence built from the tool outputs — not a
+  categorical decision the deterministic code couldn't make itself. Relevant
+  context for #780: the siblings' "qualitative judgment" is itself
+  post-hoc-deterministic; the LLM's value-add across all three is narrower
+  than "produces the category field" might suggest.
+
+## What was NOT found
+
+- No PR description, issue, or commit message stating an intended future date
+  or trigger for wiring pace's ReAct path.
+  the closest candidate, #476, hardens the tool as if reachable but never
+  states an intent to make it reachable.
+- No notebook cell, in either N25 or N31, that actually exercises
+  `pace_react_agent.invoke(...)` successfully — N25's own Step 5 demo cell
+  (cell 35) is wrapped in a `try/except` that falls back to the direct
+  `run_pace_agent()` call, "when the LLM is unavailable"; nothing in the
+  dumped notebook confirms it was ever run with a live LLM connected — but
+  we assume that never was tried given that we're focusing on Local LM Studio
+  for provider testing and OpenAI (paid) for chat testing.
+- No sign that a "future chat-style pace query, distinct from the per-lap
+  orchestrator loop" (the RAG-agent-shaped precedent named in the epic) was
+  ever planned for pace specifically — the actual chat surface
+  (`backend/mcp_tools.py::predict_pace`) already exists and bypasses the
+  scaffold entirely, calling the deterministic path like its three siblings'
+  MCP wrappers call theirs (the difference is only inside each agent's own
+  `run_from_state`).
+
+## Bearing on #780
+
+This archaeology does not resolve #780 — that is a product decision, not a
+historical fact, and it is Víctor's to make. What it does establish, for the
+decision conversation:
+
+1. The scaffold's existence is not itself evidence of a deferred plan — it was
+   written from a template shared with three other agents in one commit, and
+   whether to wire it was a call made per-agent in that same commit, not left
+   open.
+2. The one contemporaneous design rationale on record for pace specifically
+   (N25 Step 5) argues against wiring it, on the grounds that pace has no tool
+   arbitration or qualitative judgment for an LLM to add — a rationale that
+   was never contradicted by any later document.
+3. A previous audit pass (#476, 2026-07-18) hardened pace's tool inputs as if
+   it were live, which shows the "pace is wired" belief has already once
+   produced real (if harmless) engineering effort in the codebase based on a
+   false premise — a second data point, beyond Víctor's own belief, that this
+   gap is easy to miss by pattern-matching against the other three agents.

--- a/documents/dev_docs/diagrams/README.md
+++ b/documents/dev_docs/diagrams/README.md
@@ -15,13 +15,13 @@ All of these were last edited on 2026-05-13, before two releases landed: v2.0.0 
 | `webapp_structure` | **new**: the React app's feature folders and how they reach the backend |
 | `frontend_pages_streamlit_legacy` | **renamed and marked retired**: it is the Streamlit page tree, kept as a record of a surface that no longer exists |
 | `arcade_3window_architecture` | current |
-| `multi_agent_architecture` | current |
+| `multi_agent_architecture` | updated 2026-08-02: N25's box no longer says "LangGraph ReAct" — pace's scaffold was formally retired in #781, N25 is now shown as a direct XGBoost call, same as the sub-agents header line |
 | `multi_agent_flow` | current, but predates the projection redesign |
 | `strategy_pipeline_flow` | predates the shared inference engine |
 | `subprocess_launch_sequence` | current |
 | `tcp_broadcast_dataflow` | current |
 | `data_pipeline` | current on the surfaces; note the FastF1 cache is one directory now, not two |
-| `agents/` | one per sub-agent (N25 to N30) plus the `StrategyRecommendation` schema |
+| `agents/` | one per sub-agent (N25 to N30) plus the `StrategyRecommendation` schema; `N25_pace_agent` updated 2026-08-02 to drop the ReAct-tool boxes it never actually used (#781) |
 
 Verified: every file parses as XML, and no label outside the file marked legacy names a retired surface.
 

--- a/documents/dev_docs/diagrams/agents/N25_pace_agent.drawio
+++ b/documents/dev_docs/diagrams/agents/N25_pace_agent.drawio
@@ -14,29 +14,29 @@
           <mxGeometry x="295" y="70" width="310" height="60" as="geometry" />
         </mxCell>
 
-        <!-- AGENT -->
-        <mxCell id="agent" value="&lt;b&gt;LangGraph ReAct Agent&lt;/b&gt;&lt;br/&gt;Local/Cloud LLM&lt;br/&gt;Iterative tool calls until convergence" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+        <!-- AGENT (no LLM — direct call) -->
+        <mxCell id="agent" value="&lt;b&gt;PaceAgent.run() — direct call&lt;/b&gt;&lt;br/&gt;No LLM, no ReAct loop&lt;br/&gt;Deterministic: same input always yields the same output" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;" vertex="1" parent="1">
           <mxGeometry x="295" y="195" width="310" height="70" as="geometry" />
         </mxCell>
 
-        <!-- TOOL 1 -->
-        <mxCell id="tool1" value="&lt;b&gt;predict_pace_tool&lt;/b&gt;&lt;br/&gt;&lt;i&gt;Model: XGBoost N06&lt;/i&gt;&lt;br/&gt;N=200 bootstrap CI&lt;br/&gt;→ lap_time_pred, ci_p10, ci_p90" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=11;" vertex="1" parent="1">
+        <!-- STEP 1 -->
+        <mxCell id="tool1" value="&lt;b&gt;_predict() + _bootstrap_ci()&lt;/b&gt;&lt;br/&gt;&lt;i&gt;Model: XGBoost N06&lt;/i&gt;&lt;br/&gt;N=200 bootstrap CI&lt;br/&gt;→ lap_time_pred, ci_p10, ci_p90" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=11;" vertex="1" parent="1">
           <mxGeometry x="100" y="345" width="240" height="80" as="geometry" />
         </mxCell>
 
-        <!-- TOOL 2 -->
-        <mxCell id="tool2" value="&lt;b&gt;get_session_median_tool&lt;/b&gt;&lt;br/&gt;&lt;i&gt;Race statistics&lt;/i&gt;&lt;br/&gt;Median lap time for GP/year/compound&lt;br/&gt;→ delta_vs_median" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=11;" vertex="1" parent="1">
+        <!-- STEP 2 -->
+        <mxCell id="tool2" value="&lt;b&gt;_session_median()&lt;/b&gt;&lt;br/&gt;&lt;i&gt;Race statistics&lt;/i&gt;&lt;br/&gt;Median lap time for GP/year/compound&lt;br/&gt;→ delta_vs_median" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=11;" vertex="1" parent="1">
           <mxGeometry x="560" y="345" width="240" height="80" as="geometry" />
         </mxCell>
 
         <!-- OUTPUT -->
-        <mxCell id="output" value="&lt;b&gt;PaceOutput&lt;/b&gt;&lt;br/&gt;lap_time_pred · delta_vs_prev · delta_vs_median&lt;br/&gt;ci_p10 · ci_p90 · reasoning" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;" vertex="1" parent="1">
+        <mxCell id="output" value="&lt;b&gt;PaceOutput&lt;/b&gt;&lt;br/&gt;lap_time_pred · delta_vs_prev · delta_vs_median&lt;br/&gt;ci_p10 · ci_p90 · reasoning (f-string, not LLM)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;" vertex="1" parent="1">
           <mxGeometry x="295" y="500" width="310" height="60" as="geometry" />
         </mxCell>
 
         <!-- NOTE -->
-        <mxCell id="note" value="→ N31 Strategy Orchestrator (consumed via prompt and Monte Carlo dispersion)" style="text;html=1;strokeColor=none;fillColor=none;align=center;fontStyle=2;fontSize=11;" vertex="1" parent="1">
-          <mxGeometry x="230" y="578" width="440" height="20" as="geometry" />
+        <mxCell id="note" value="→ N31 Strategy Orchestrator (consumed via prompt and Monte Carlo dispersion) — deliberately deterministic, see #778/#780/#781" style="text;html=1;strokeColor=none;fillColor=none;align=center;fontStyle=2;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="180" y="578" width="540" height="20" as="geometry" />
         </mxCell>
 
         <!-- EDGES -->

--- a/documents/dev_docs/diagrams/multi_agent_architecture.drawio
+++ b/documents/dev_docs/diagrams/multi_agent_architecture.drawio
@@ -216,23 +216,26 @@
         <mxCell id="leg_react" value="Sub-agent (LangGraph ReAct)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=9;" vertex="1" parent="1">
           <mxGeometry x="1346" y="424" width="252" height="26" as="geometry" />
         </mxCell>
-        <mxCell id="leg_n29" value="N29: NLP-first synthesizer + Pydantic v2" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=9;" vertex="1" parent="1">
+        <mxCell id="leg_n25" value="N25: Direct deterministic call (no LLM)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=9;" vertex="1" parent="1">
           <mxGeometry x="1346" y="456" width="252" height="26" as="geometry" />
         </mxCell>
-        <mxCell id="leg_n31l1" value="N31 Layer 1: MoE routing" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e8d5f5;strokeColor=#9673a6;fontSize=9;" vertex="1" parent="1">
+        <mxCell id="leg_n29" value="N29: NLP-first synthesizer + Pydantic v2" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=9;" vertex="1" parent="1">
           <mxGeometry x="1346" y="488" width="252" height="26" as="geometry" />
         </mxCell>
-        <mxCell id="leg_n31l3" value="N31 Layer 3: LLM synthesis" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#c8b0e0;strokeColor=#9673a6;fontSize=9;" vertex="1" parent="1">
+        <mxCell id="leg_n31l1" value="N31 Layer 1: MoE routing" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e8d5f5;strokeColor=#9673a6;fontSize=9;" vertex="1" parent="1">
           <mxGeometry x="1346" y="520" width="252" height="26" as="geometry" />
         </mxCell>
+        <mxCell id="leg_n31l3" value="N31 Layer 3: LLM synthesis" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#c8b0e0;strokeColor=#9673a6;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="1346" y="552" width="252" height="26" as="geometry" />
+        </mxCell>
         <mxCell id="leg_dep_lbl" value="── ─ ─ → cross-agent dependency (N26/N27 → N28)" style="text;html=1;strokeColor=none;fillColor=none;align=left;fontSize=9;fontColor=#FF6600;" vertex="1" parent="1">
-          <mxGeometry x="1346" y="554" width="252" height="18" as="geometry" />
+          <mxGeometry x="1346" y="586" width="252" height="18" as="geometry" />
         </mxCell>
         <mxCell id="leg_hard_lbl" value="────────→ hard constraint (N30 → N31 L3)" style="text;html=1;strokeColor=none;fillColor=none;align=left;fontSize=9;fontColor=#9673a6;" vertex="1" parent="1">
-          <mxGeometry x="1346" y="574" width="252" height="18" as="geometry" />
+          <mxGeometry x="1346" y="606" width="252" height="18" as="geometry" />
         </mxCell>
         <mxCell id="leg_fia_lbl" value="── ─ ─ → FIA PDFs → Qdrant (offline index build)" style="text;html=1;strokeColor=none;fillColor=none;align=left;fontSize=9;fontColor=#6c8ebf;" vertex="1" parent="1">
-          <mxGeometry x="1346" y="594" width="252" height="18" as="geometry" />
+          <mxGeometry x="1346" y="626" width="252" height="18" as="geometry" />
         </mxCell>
 
       </root>

--- a/documents/dev_docs/diagrams/multi_agent_architecture.drawio
+++ b/documents/dev_docs/diagrams/multi_agent_architecture.drawio
@@ -100,11 +100,11 @@
         <mxCell id="e_fia_rag" value="build index" style="edgeStyle=orthogonalEdgeStyle;dashed=1;strokeColor=#6c8ebf;fontColor=#6c8ebf;fontSize=9;" edge="1" source="fia_pdf" target="m_qdrant" parent="1"><mxGeometry relative="1" as="geometry"/></mxCell>
 
         <!-- ═══════════════════════════ SUB-AGENTS ═══════════════════════════ -->
-        <mxCell id="lbl_agents" value="SUB-AGENTS (LangGraph ReAct — except N29 which is NLP-first)" style="text;html=1;strokeColor=none;fillColor=none;align=left;fontStyle=1;fontSize=10;fontColor=#666666;" vertex="1" parent="1">
-          <mxGeometry x="60" y="444" width="500" height="18" as="geometry" />
+        <mxCell id="lbl_agents" value="SUB-AGENTS (LangGraph ReAct — except N25, direct XGBoost call, and N29, NLP-first)" style="text;html=1;strokeColor=none;fillColor=none;align=left;fontStyle=1;fontSize=10;fontColor=#666666;" vertex="1" parent="1">
+          <mxGeometry x="60" y="444" width="560" height="18" as="geometry" />
         </mxCell>
 
-        <mxCell id="n25" value="&lt;b&gt;N25 — Pace Agent&lt;/b&gt;&#xa;LangGraph ReAct&#xa;───────────&#xa;@tool predict_pace&#xa;@tool get_median&#xa;───────────&#xa;Output: PaceOutput&#xa;lap_time_pred&#xa;ci_p10 / ci_p90&#xa;reasoning" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
+        <mxCell id="n25" value="&lt;b&gt;N25 — Pace Agent&lt;/b&gt;&#xa;Direct XGBoost call (no LLM)&#xa;───────────&#xa;No tools, no ReAct loop —&#xa;deterministic regression,&#xa;no judgment for an LLM to&#xa;add (#778/#780/#781)&#xa;───────────&#xa;Output: PaceOutput&#xa;lap_time_pred&#xa;ci_p10 / ci_p90&#xa;reasoning (f-string)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=10;" vertex="1" parent="1">
           <mxGeometry x="60" y="464" width="160" height="176" as="geometry" />
         </mxCell>
 

--- a/documents/research/AGENT_ORCHESTRATION_FLOW.md
+++ b/documents/research/AGENT_ORCHESTRATION_FLOW.md
@@ -38,7 +38,7 @@ so and the v2 graph preserves it.
 
 | Agent | Module | Pattern (shipped) | LLM in per-lap path | Cadence |
 |---|---|---|---|---|
-| N25 Pace | `src/agents/pace_agent.py` | ReAct agent exists (`create_agent`, :648) but the per-lap path calls `PaceAgent.run()` directly; reasoning is a template string | none (ReAct idle) | every lap |
+| N25 Pace | `src/agents/pace_agent.py` | Direct call — `PaceAgent.run()`, reasoning is a template string. (Written 2026-07-07 against a ReAct scaffold that existed but was idle; formally retired and deleted in #781 after the #778/#779/#780 archaeology confirmed it was never wired and had no stated future use — do not plan v2 work around resurrecting it.) | none | every lap |
 | N26 Tire | `src/agents/tire_agent.py` | ReAct (`create_agent`, :997; invoke :1162), 2 tools | ~3 turns | every lap |
 | N27 Situation | `src/agents/race_situation_agent.py` | ReAct (:985; invoke :1145), 2 tools | ~3 turns | every lap |
 | N28 Pit | `src/agents/pit_strategy_agent.py` | ReAct (:837; invoke :996), 3 tools; output parsed from tool messages + final-message prose | up to 4 turns | conditional |

--- a/documents/research/RIVAL_AGENT_DESIGN.md
+++ b/documents/research/RIVAL_AGENT_DESIGN.md
@@ -105,11 +105,18 @@ integration design:
   `POS_GAP_S = 1.50` seconds per position and a single N16 success probability for OUR
   undercut. The rival's possible counter-move (pitting first, covering our stop) does not
   exist in the simulation. That is the concrete hole the agent fills.
-- The sub-agents are LangGraph ReAct agents (built via `create_agent` with tools wrapping
-  each ML model); the orchestrator itself is a plain Python pipeline that calls their
-  public entry points. "A new LangGraph node" therefore means: a new agent module in the
-  same ReAct style as N25-N29, invoked by an additive orchestration entry point, plus a
-  formalization of the whole graph for the multi-agent portion of the TFM (section 7).
+- Tire (N26), race situation (N27), pit strategy (N28) and RAG (N30) are LangGraph ReAct
+  agents (built via `create_agent` with tools wrapping each ML model); pace (N25) is
+  deliberately NOT — it has no qualitative judgment for an LLM to add, and its once-built
+  ReAct scaffold was formally retired in #781 (documents/audits/AUDIT_pace_agent_react_archaeology_779.md)
+  after archaeology showed it was never wired. Radio (N29) is a different shape again: a
+  deterministic NLP pipeline (RoBERTa/SetFit/BERT NER) followed by ONE
+  `with_structured_output()` synthesis call, not a ReAct tool loop. The orchestrator itself
+  is a plain Python pipeline that calls the sub-agents' public entry points. "A new
+  LangGraph node" for the Rival Agent should follow the ReAct pattern of N26-N28/N30 if it
+  needs qualitative judgment over its own tools — decide this on the Rival Agent's own
+  merits rather than assuming "same as N25-N29", which is no longer a uniform group — plus
+  a formalization of the whole graph for the multi-agent portion of the TFM (section 7).
 
 **The data already on disk.** Verified against `data/raw/2025/Budapest/` (and the P5
 audit, which verified this repo-wide):
@@ -622,11 +629,16 @@ nothing the MC cannot draw from directly**.
 `reasoning` is deliberately template-generated (from feature attributions), not
 LLM-generated, in v1: the agent then works identically in the no-LLM path (the project
 maintains a hard no-LLM mode in the CLI and programmatic guardrails; an agent whose
-output depends on an LLM would break that parity). Whether the Rival Agent gets an
-optional LLM synthesis layer like N25-N29 (nicer prose, tool-calling ReAct shape for
-architectural symmetry) is open question Q3; the default answer is: ReAct-wrapped like
-its siblings for the multi-agent narrative, but with the deterministic path as the
-guaranteed spine, mirroring how the existing agents degrade.
+output depends on an LLM would break that parity). This is precisely the shape N25 (pace)
+was formalized into by #781 (documents/audits/AUDIT_pace_agent_react_archaeology_779.md):
+a deterministic template-reasoning agent with no LLM step at all, once it was established
+the agent has no qualitative judgment for an LLM to add. Whether the Rival Agent instead
+gets an optional LLM synthesis layer like N26-N28/N30 (nicer prose, tool-calling ReAct
+shape for architectural symmetry) is open question Q3 — decide it the same way pace's was
+decided, on whether the Rival Agent's own output carries a qualitative judgment beyond its
+quantile triples and probabilities, not by defaulting to "ReAct because the siblings are."
+The deterministic path is the guaranteed spine either way, mirroring how the existing
+agents degrade.
 
 ---
 
@@ -967,11 +979,13 @@ per-circuit window as proposed?) and the overcut bounds (stay out >= 2 laps, pit
 L+6): fix them from the M1 sensitivity study, or pre-commit now for pre-registration
 cleanliness?
 
-**Q3: Does the Rival Agent get an LLM layer?** Recommended: ReAct wrapper for
-architectural symmetry with N25-N29, but the deterministic ML spine is the guaranteed
-path and the no-LLM mode ships first. Alternative: purely deterministic agent (cheaper,
-simpler, less symmetric). This also affects LLM cost per lap (about 6 rivals must NOT
-mean 6 extra LLM calls; the design assumes at most one).
+**Q3: Does the Rival Agent get an LLM layer?** Decide it on the Rival Agent's own merits
+(does its output carry a qualitative judgment beyond quantile triples and probabilities,
+per #781's precedent for pace), not by defaulting to architectural symmetry with a group
+that is no longer uniform (N26-N28/N30 are ReAct; N25 deliberately is not; N29 is NLP-first
++ one structured-output call). Either way the deterministic ML spine is the guaranteed
+path and the no-LLM mode ships first. This also affects LLM cost per lap (about 6 rivals
+must NOT mean 6 extra LLM calls; the design assumes at most one).
 
 **Q4: Schema discipline confirmation.** Keep `StrategyRecommendation` frozen at 14
 fields and integrate rival intent via prompt, contingencies, and `undercut_target`

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -129,8 +129,12 @@ class PaceAgent:
 
     All model artifacts (XGBoost weights, encoding maps, reference laps) are
     loaded once in __init__ and stored as instance attributes — no module-level
-    globals are used. The LangGraph ReAct agent is created lazily on first call
-    to get_react_agent() to avoid connecting to the LLM at import time.
+    globals are used.
+
+    Deliberately deterministic, unlike its tire/pit/race_situation siblings:
+    pace has no qualitative judgment to make (no warning_level/action/threat_level
+    category alongside its numbers), so there is no LLM step to wire — see #778/#780
+    for the archaeology and decision record.
 
     Instantiate via the module-level _get_default_pace_agent() factory to avoid
     redundant disk I/O; do not instantiate PaceAgent directly in hot paths.
@@ -153,7 +157,6 @@ class PaceAgent:
         self.team_id: dict            = {}
         self.compound_id, self.circuit_cluster, self.team_id = self._load_encoding_maps(processed_dir)
         self.laps_ref: pd.DataFrame   = self._load_reference_laps(processed_dir)
-        self._react_agent             = None   # lazy LangGraph agent
 
     # ── Loaders ───────────────────────────────────────────────────────────────
 
@@ -223,20 +226,18 @@ class PaceAgent:
     def _load_reference_laps(self, processed_dir: Path) -> pd.DataFrame:
         """Load the reference laps parquet used for session median computation.
 
-        Five columns are loaded to keep the in-memory footprint small. The median
-        baseline is used by N31 to contextualise absolute predictions. DriverNumber
-        is also kept so predict_pace_tool can refuse an LLM-invented car number for
-        a real GP/year instead of predicting from data that does not exist (#476).
+        Four columns are loaded to keep the in-memory footprint small. The median
+        baseline is used by N31 to contextualise absolute predictions.
 
         Args:
             processed_dir: Root of the processed data directory.
 
         Returns:
-            DataFrame with columns GP_Name, Year, Compound, LapTime_s, DriverNumber.
+            DataFrame with columns GP_Name, Year, Compound, LapTime_s.
         """
         return pd.read_parquet(
             processed_dir / 'laps_featured_2025.parquet',
-            columns=['GP_Name', 'Year', 'Compound', 'LapTime_s', 'DriverNumber'],
+            columns=['GP_Name', 'Year', 'Compound', 'LapTime_s'],
         )
 
     # ── Encoding helpers ──────────────────────────────────────────────────────
@@ -493,56 +494,6 @@ class PaceAgent:
         subset = self.laps_ref.loc[mask, 'LapTime_s'].dropna()
         return float(subset.median()) if len(subset) > 0 else None
 
-    def _validate_pace_inputs(
-        self, driver_number: int, lap_number: int, total_laps: int,
-        gp_name: str, year: int,
-    ) -> Optional[str]:
-        """Refuse an LLM-supplied pace query when the lap or driver cannot be real.
-
-        predict_pace_tool takes 19 raw scalar params straight from the LLM with no
-        closure over a live-drivers roster or a lap_state at all (#476) — unlike
-        score_undercut_tool in pit_strategy_agent.py, which checks its free-text
-        driver_y against self._live_drivers before scoring. This is the pace-side
-        equivalent: an out-of-range lap or an invented car number would otherwise
-        produce a confident-looking lap-time prediction from data that does not
-        exist.
-
-        laps_ref only carries the 2025 season (see _load_reference_laps), so a
-        legitimate 2023/2024 call, or a GP name outside the 2025 calendar, yields
-        an empty ``known`` set here. That means "the roster is unknown", not "no
-        cars are racing", so the driver check is skipped rather than rejecting
-        every call outside 2025 — the same unknown-disables-the-guard rule
-        score_undercut_tool follows for its own live_drivers=None case.
-
-        Args:
-            driver_number: Car number as supplied by the LLM caller.
-            lap_number: Lap number as supplied by the LLM caller.
-            total_laps: Total scheduled race laps, also LLM-supplied.
-            gp_name: GP name matching the laps_ref GP_Name column.
-            year: Race year integer.
-
-        Returns:
-            An error string when the query should be refused, None when it is
-            safe to run inference.
-        """
-        if not (1 <= lap_number <= total_laps):
-            return (
-                f'Pace prediction REFUSED — lap {lap_number} is out of range for a '
-                f'{total_laps}-lap race (valid range: 1-{total_laps}).'
-            )
-
-        known = self.laps_ref.loc[
-            (self.laps_ref['GP_Name'] == gp_name) & (self.laps_ref['Year'] == year),
-            'DriverNumber',
-        ].dropna().astype(int)
-        known_set = set(known)
-        if known_set and driver_number not in known_set:
-            return (
-                f'Pace prediction REFUSED — car number {driver_number} is not on '
-                f'track at {gp_name} {year}. Known car numbers: {sorted(known_set)}.'
-            )
-        return None
-
     # ── Main inference entrypoint ─────────────────────────────────────────────
 
     def run(
@@ -749,57 +700,6 @@ class PaceAgent:
             stint_baseline_tyre_life = d.get('stint_baseline_tyre_life'),
         )
 
-    # ── LangGraph ReAct agent ─────────────────────────────────────────────────
-
-    def get_react_agent(
-        self,
-        provider: str = None,
-        model_name: str = 'gpt-4.1-mini',
-        base_url: str = 'http://localhost:1234/v1',
-        api_key: str = 'lmstudio',
-    ):
-        """Return the LangGraph ReAct agent, creating it lazily on the first call.
-
-        Avoids connecting to the LLM at import time — the agent is only
-        created when actually needed (N31 orchestrator or tests).
-
-        Args:
-            provider: 'lmstudio' (default) or 'openai'.
-            model_name: Model identifier for the ChatOpenAI client.
-            base_url: Base URL for LM Studio (ignored when provider='openai').
-            api_key: API key; use 'lmstudio' for the local server.
-
-        Returns:
-            LangGraph CompiledGraph — invoke with {"messages": [("user", query)]}.
-        """
-        if self._react_agent is not None:
-            return self._react_agent
-
-        if not _LANGGRAPH_AVAILABLE:
-            raise ImportError(
-                "LangGraph / LangChain not installed. "
-                "Install with: pip install langgraph langchain-openai"
-            )
-
-        from langchain_openai import ChatOpenAI
-        from langchain.agents import create_agent
-
-        import os
-        if provider is None:
-            provider = os.environ.get('F1_LLM_PROVIDER', 'lmstudio')
-
-        if provider == 'lmstudio':
-            llm = ChatOpenAI(model=model_name, base_url=base_url, api_key=api_key, temperature=0, timeout=120, max_retries=1)
-        else:
-            llm = ChatOpenAI(model=model_name, temperature=0, timeout=120, max_retries=1)
-
-        self._react_agent = create_agent(
-            model=llm,
-            tools=PACE_TOOLS,
-            system_prompt=_PACE_SYSTEM_PROMPT,
-        )
-        return self._react_agent
-
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Module-level lazy singleton
@@ -840,8 +740,6 @@ def run_pace_agent(
     Thin entry point that delegates to the shared PaceAgent singleton. All
     inference logic lives in PaceAgent.run() — see its docstring for full
     parameter documentation.
-
-    This function is the primary call target for the LangGraph predict_pace_tool.
     """
     return _get_default_pace_agent().run(
         driver_number=driver_number, lap_number=lap_number, stint=stint,
@@ -869,120 +767,3 @@ def run_pace_agent_from_state(lap_state: dict) -> PaceOutput:
         PaceOutput with all fields populated.
     """
     return _get_default_pace_agent().run_from_state(lap_state)
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# LangGraph tools and ReAct agent (preserved 100% — no functional changes)
-# ─────────────────────────────────────────────────────────────────────────────
-
-try:
-    from langchain_core.tools import tool as lc_tool
-    from langchain_openai import ChatOpenAI  # noqa: F401
-    from langchain.agents import create_agent  # noqa: F401
-    _LANGGRAPH_AVAILABLE = True
-except ImportError:
-    _LANGGRAPH_AVAILABLE = False
-
-
-if _LANGGRAPH_AVAILABLE:
-
-    @lc_tool
-    def predict_pace_tool(
-        driver_number: int, lap_number: int, stint: int, tyre_life: int,
-        compound: str, position: int, team: str, laps_since_pit: int,
-        fuel_load: float, year: int, prev_lap_time: float, prev_tyre_life: int,
-        prev_speed_st: float, air_temp: float, track_temp: float,
-        humidity: float, rainfall: float, total_laps: int, gp_name: str,
-    ) -> dict:
-        """Predict the absolute lap time (seconds) for the current lap using the N06 XGBoost model.
-
-        Call this whenever a lap time prediction is needed for pace or strategy analysis.
-
-        Args:
-            driver_number: Car number used to look up TeamID encoding.
-            lap_number: Current race lap number (1-indexed).
-            stint: Stint number (1-indexed).
-            tyre_life: Laps on the current tyre set.
-            compound: Pirelli compound string ('SOFT', 'MEDIUM', 'HARD', etc.).
-            position: Current race position (1-based).
-            team: Team name matching TEAM_ID encoding map (e.g. 'McLaren').
-            laps_since_pit: Laps elapsed since the last pit stop.
-            fuel_load: Fuel fraction in [0, 1].
-            year: Race year integer (2023/2024/2025).
-            prev_lap_time: Previous lap time in seconds.
-            prev_tyre_life: TyreLife on the previous lap.
-            prev_speed_st: Speed trap reading in km/h from the previous lap.
-            air_temp: Air temperature in degrees C.
-            track_temp: Track surface temperature in degrees C.
-            humidity: Relative humidity in %.
-            rainfall: True if rain was recorded during this lap.
-            total_laps: Total scheduled race laps.
-            gp_name: GP name matching CIRCUIT_CLUSTER keys (e.g. 'Sakhir').
-
-        Returns:
-            Dict with keys: lap_time_pred, delta_vs_prev, delta_vs_median,
-            ci_p10, ci_p90 (all floats in seconds). Returns {'error': str}
-            instead, without running inference, when the driver is not on
-            track for the given GP/year or the lap is outside [1, total_laps]
-            (#476) — the LLM supplies every one of these 19 params as free
-            text with no server-side roster or range check otherwise.
-        """
-        agent = _get_default_pace_agent()
-        validation_error = agent._validate_pace_inputs(
-            driver_number, lap_number, total_laps, gp_name, year,
-        )
-        if validation_error is not None:
-            return {'error': validation_error}
-
-        out = run_pace_agent(
-            driver_number=driver_number, lap_number=lap_number, stint=stint,
-            tyre_life=tyre_life, compound=compound, position=position, team=team,
-            laps_since_pit=laps_since_pit, fuel_load=fuel_load, year=year,
-            prev_lap_time=prev_lap_time, prev_tyre_life=prev_tyre_life,
-            prev_speed_st=prev_speed_st, air_temp=air_temp, track_temp=track_temp,
-            humidity=humidity, rainfall=rainfall, total_laps=total_laps,
-            gp_name=gp_name,
-        )
-        return {
-            'lap_time_pred':   out.lap_time_pred,
-            'delta_vs_prev':   out.delta_vs_prev,
-            'delta_vs_median': out.delta_vs_median,
-            'ci_p10':          out.ci_p10,
-            'ci_p90':          out.ci_p90,
-        }
-
-    @lc_tool
-    def get_session_median_tool(gp_name: str, year: int, compound: str) -> dict:
-        """Return the historical median lap time (seconds) for a GP / year / compound.
-
-        Use this as a reference baseline to contextualise a predicted lap time from
-        predict_pace_tool. The median is computed from the N06 training parquet,
-        filtered to IsAccurate laps in non-SC, non-VSC conditions.
-
-        Args:
-            gp_name: GP name matching the parquet GP_Name column (e.g. 'Sakhir').
-            year: Race year integer (2023/2024/2025).
-            compound: Pirelli compound string ('SOFT', 'MEDIUM', 'HARD').
-
-        Returns:
-            Dict with key: median_lap_time (float, seconds). NaN when no data.
-        """
-        median = _get_default_pace_agent()._session_median(gp_name, year, compound)
-        return {'median_lap_time': median if median is not None else float('nan')}
-
-    _PACE_SYSTEM_PROMPT = """You are the Pace Agent in an F1 race strategy system.
-
-Your responsibility: answer the question "how fast is this car going this lap?"
-
-Tools available:
-- `predict_pace_tool` — predicts absolute lap time using the N06 XGBoost model
-- `get_session_median_tool` — returns the historical median for this GP/compound as a baseline
-
-Always call `predict_pace_tool` first, then `get_session_median_tool` to contextualise the result.
-Respond with a concise JSON summary: lap_time_pred, delta_vs_prev, delta_vs_median, ci_p10, ci_p90.
-Never invent numbers — use only the values returned by the tools."""
-
-    PACE_TOOLS = [predict_pace_tool, get_session_median_tool]
-
-else:
-    PACE_TOOLS = []

--- a/tests/audit/test_pace_orchestrator_hardening.py
+++ b/tests/audit/test_pace_orchestrator_hardening.py
@@ -1,6 +1,6 @@
 """Hardening tests for the pace agent, RaceStateManager, and strategy orchestrator —
-#435 (pace self-fulfilling prev_lap_time), #476 (unvalidated predict_pace_tool LLM
-input), and #433 (unvalidated expected_stint_end LLM free text).
+#435 (pace self-fulfilling prev_lap_time) and #433 (unvalidated expected_stint_end
+LLM free text).
 
 Doctrine: no-LLM assertions only.
 
@@ -8,12 +8,18 @@ Doctrine: no-LLM assertions only.
   parquet, merged with ``Prev_LapTime`` from the real featured parquet (the same
   join ``src/f1_strat_manager/laps_augment.py`` performs in the opposite direction),
   and reads the real dataclass method — no mocks, no LLM.
-- The #476 section calls ``PaceAgent.run()`` (the real N06 XGBoost model) through
-  ``predict_pace_tool.invoke()`` directly — deterministic inference, never a
-  LangGraph ReAct loop or a live LLM client.
 - The #433 section calls the pure ``_clamp_expected_stint_end`` helper directly
   (never a live orchestrator), but skips when ``data/`` is absent: importing
   ``strategy_orchestrator`` instantiates the tire agent, which loads model files.
+
+#476 (unvalidated ``predict_pace_tool`` LLM input) used to have its own section
+here, testing ``PaceAgent._validate_pace_inputs`` through ``predict_pace_tool.invoke()``.
+Both the tool and the validator were deleted by #781: pace_agent's LangGraph ReAct
+scaffold was formally retired (#778/#780) because it was never wired to anything —
+``run()``/``run_from_state()`` always called the XGBoost model directly. With no LLM
+caller left for pace, the class of bug #476 fixed (an LLM inventing a driver number
+or an out-of-range lap) cannot occur for this agent anymore, so the guard and its
+tests were removed together rather than left testing dead code.
 """
 
 from __future__ import annotations
@@ -30,15 +36,6 @@ RAW_LUSAIL = ROOT / "data" / "raw" / "2025" / "Lusail" / "laps.parquet"
 FEATURED_2025 = ROOT / "data" / "processed" / "laps_featured_2025.parquet"
 
 _HAS_RSM_DATA = RAW_LUSAIL.exists() and FEATURED_2025.exists()
-
-_HAS_PACE_MODEL = (
-    (ROOT / "data" / "models" / "lap_time" / "xgb_laptime_delta_final.json").exists()
-    and (ROOT / "data" / "processed" / "feature_manifest_laptime.json").exists()
-    and (
-        ROOT / "data" / "processed" / "circuit_clustering" / "circuit_clusters_k4_2025.parquet"
-    ).exists()
-    and FEATURED_2025.exists()
-)
 
 
 # =============================================================================
@@ -115,116 +112,6 @@ def test_prev_lap_time_matches_the_real_prev_laptime_and_differs_from_current(
 
     assert driver["prev_lap_time"] == pytest.approx(float(row["Prev_LapTime"]), abs=1e-6)
     assert driver["prev_lap_time"] != driver["lap_time_s"]
-
-
-# =============================================================================
-# #476 — predict_pace_tool must refuse an off-roster driver number or an
-# out-of-range lap instead of predicting from data that cannot exist.
-# =============================================================================
-
-
-@pytest.fixture(scope="module")
-def pace_agent_and_valid_driver():
-    """The real, singleton PaceAgent plus a genuinely-on-track Lusail 2025 car
-    number, discovered from the agent's own loaded reference data rather than
-    guessed — so the "still works for a real driver" control case cannot
-    accidentally be wrong about who was racing.
-    """
-    if not _HAS_PACE_MODEL:
-        pytest.skip(
-            "needs data/models/lap_time/, data/processed/feature_manifest_laptime.json, "
-            "data/processed/circuit_clustering/circuit_clusters_k4_2025.parquet and "
-            "data/processed/laps_featured_2025.parquet (data/ comes from HF, not git)"
-        )
-
-    from src.agents.pace_agent import _get_default_pace_agent
-
-    agent = _get_default_pace_agent()
-    ref = agent.laps_ref
-    lusail_2025 = ref[(ref["GP_Name"] == "Lusail") & (ref["Year"] == 2025)]
-    valid_numbers = lusail_2025["DriverNumber"].dropna().astype(int)
-    if valid_numbers.empty:
-        pytest.skip("no DriverNumber found for Lusail 2025 in laps_ref")
-    return agent, int(valid_numbers.iloc[0])
-
-
-def _pace_tool_kwargs(**overrides) -> dict:
-    """Base kwargs for predict_pace_tool.invoke() — all 19 params, overridable.
-
-    Values are plausible but not required to be exact: everything except
-    driver_number/lap_number/gp_name/year/total_laps degrades gracefully
-    (unknown team/compound fall back to encoding defaults), so the guard under
-    test is isolated from the rest of the feature row.
-    """
-    kwargs = dict(
-        driver_number=1,
-        lap_number=10,
-        stint=1,
-        tyre_life=5,
-        compound="MEDIUM",
-        position=5,
-        team="Red Bull Racing",
-        laps_since_pit=5,
-        fuel_load=0.8,
-        year=2025,
-        prev_lap_time=85.0,
-        prev_tyre_life=4,
-        prev_speed_st=320.0,
-        air_temp=28.0,
-        track_temp=38.0,
-        humidity=50.0,
-        rainfall=False,
-        total_laps=57,
-        gp_name="Lusail",
-    )
-    kwargs.update(overrides)
-    return kwargs
-
-
-def test_predict_pace_tool_refuses_a_driver_not_on_track(pace_agent_and_valid_driver):
-    """#476: an invented car number for a real GP/year must error, not predict."""
-    from src.agents.pace_agent import predict_pace_tool
-
-    _agent, _valid_number = pace_agent_and_valid_driver
-    off_roster_number = -999  # no real car has ever carried this number
-
-    result = predict_pace_tool.invoke(_pace_tool_kwargs(driver_number=off_roster_number))
-
-    assert "error" in result, f"expected a refusal, got: {result}"
-    assert "REFUSED" in result["error"]
-    assert str(off_roster_number) in result["error"]
-
-
-def test_predict_pace_tool_refuses_an_out_of_range_lap(pace_agent_and_valid_driver):
-    """#476: a lap far beyond total_laps must error, not predict."""
-    from src.agents.pace_agent import predict_pace_tool
-
-    _agent, valid_number = pace_agent_and_valid_driver
-
-    result = predict_pace_tool.invoke(
-        _pace_tool_kwargs(driver_number=valid_number, lap_number=9999, total_laps=57)
-    )
-
-    assert "error" in result, f"expected a refusal, got: {result}"
-    assert "REFUSED" in result["error"]
-
-
-def test_predict_pace_tool_still_computes_for_a_real_driver_in_range(
-    pace_agent_and_valid_driver,
-):
-    """The guard must not buy safety by refusing everyone — a real, in-range
-    driver number must still run inference and return a prediction.
-    """
-    from src.agents.pace_agent import predict_pace_tool
-
-    _agent, valid_number = pace_agent_and_valid_driver
-
-    result = predict_pace_tool.invoke(
-        _pace_tool_kwargs(driver_number=valid_number, lap_number=10, total_laps=57)
-    )
-
-    assert "error" not in result, f"a live, in-range driver was refused: {result}"
-    assert "lap_time_pred" in result
 
 
 # =============================================================================


### PR DESCRIPTION
## What

Formally retires `pace_agent.py`'s LangGraph ReAct scaffold (`get_react_agent()`, `PACE_TOOLS`, `predict_pace_tool`, `get_session_median_tool`, `_PACE_SYSTEM_PROMPT`, `_validate_pace_inputs()`) — confirmed dead by exhaustive grep before this change, unlike the structurally identical scaffolds tire/pit/race_situation genuinely use every lap.

Closes #778, #779, #780, #781.

## Why

Archaeology (`documents/audits/AUDIT_pace_agent_react_archaeology_779.md`) traced the scaffold to a deliberate choice made in the same commit (2026-04-05) that wired its three siblings for real — not incremental drift. The one on-record design rationale, from N25's own extraction notebook, already argued against wiring it: pace has no qualitative judgment for an LLM to add, unlike tire/pit/race_situation which each also emit a category (`warning_level`/`action`/`threat_level`) alongside their numbers. Decision made explicitly by Víctor after reviewing the evidence (#780), not unilaterally.

## What changed

- `src/agents/pace_agent.py`: deletes the scaffold + its only-caller `_validate_pace_inputs` guard + the now-orphaned `DriverNumber` column load. `run()`/`run_from_state()`/`PaceOutput`/`run_pace_agent()`/`run_pace_agent_from_state()` are byte-for-byte unchanged.
- `tests/audit/test_pace_orchestrator_hardening.py`: removes the 3 now-dead #476 tests for the deleted `predict_pace_tool`; #435/#433 sections untouched.
- `docs/pages/agents-api.md`, `docs/pages/multi-agent.md`: fix the stale "LLM-generated reasoning text" / "gpt-4.1-mini" claims for `PaceOutput`.
- `documents/dev_docs/diagrams/multi_agent_architecture.drawio`, `documents/dev_docs/diagrams/agents/N25_pace_agent.drawio`: redrawn to show pace as a direct XGBoost call, not a ReAct agent.
- `documents/research/RIVAL_AGENT_DESIGN.md`, `documents/research/AGENT_ORCHESTRATION_FLOW.md`: corrected forward-looking design guidance that assumed pace was still ReAct-shaped or still had a live scaffold to reference.

## Verification

- 35 targeted tests green (`tests/audit/`, `tests/agents/test_agents.py`, `tests/audit/test_engine_scope_defaults.py`).
- Full suite: 551 passed, 2 failed — both pre-existing and unrelated (a data-schema gap in `laps_featured_2025.parquet` hit by `src/strategy/eval/reproduce.py`, filed as #782; neither failing test imports `src.agents.pace_agent`).
- Real `f1-sim` run, `--no-llm` profile, 8 laps: clean, pace output/reasoning correct.
- Real `f1-sim` run, `rich`/OpenAI profile, 2 laps: clean, pace deterministic output coexists correctly alongside tire/situation/radio's real LLM reasoning.
- Arcade shares the exact same `run_lap()` engine call exercised above (`src/arcade/strategy_pipeline.py`'s own docstring: "One code path, three surfaces") — no separate arcade-specific pace logic exists to verify independently.
- Adversarial gate (Fable, `general-purpose` agent) run against this diff before push: confirmed the code/tests/API changes (A-E, G) with executed evidence; found 4 doc/diagram-only defects, all fixed in the second commit.

## Out of scope

- #782 (pre-existing eval test failure, filed not fixed).
