### PR TITLE
refactor(agents): single-source the RaceState builder and close the present-None crash it exposed

### DIFF
--- a/documents/audits/DESIGN_race_state_single_contract.md
+++ b/documents/audits/DESIGN_race_state_single_contract.md
@@ -1,0 +1,434 @@
+# DESIGN GATE — Single canonical `RaceState` builder (options a/b/c)
+
+**Date:** 2026-08-02
+**Role:** adversarial design gate, read-only. No implementation code. Success = finding what is
+still broken in the proposal, not approving it.
+**Scope:** the three (or four) independent builders of `src.agents.strategy_orchestrator.RaceState`
+from the `lap_state` contract, and the decision between options (a) shim-down import,
+(b) shared module in `src/`, (c) parity test over accepted copies.
+
+## Verification checklist (updated as each item is confirmed/refuted)
+
+- [x] V1. CLI `_build_race_state` — CONFIRMED, all defaults as briefed (F1)
+- [x] V2. Arcade `_build_race_state` — CONFIRMED, plus extra divergences the brief missed (F1)
+- [x] V3. Backend `build_race_state` — CONFIRMED (F1)
+- [x] V4. `GAP_UNKNOWN_FALLBACK_S` shared import — CONFIRMED in all three (F1)
+- [x] V5. CLI post-construction radio/rcm mutation + `--radio-every` — CONFIRMED (F3)
+- [x] V6. `_local_build_race_state` is a thin wrapper — CONFIRMED (F3)
+- [x] V7. `_compute_gap_ahead` is a genuine 4th copy — CONFIRMED (F7)
+- [x] V8. `compound` plain str; "UNKNOWN" traced through all consumers, never crashes (F5)
+- [x] V9. `total_laps` present from every internal producer; the ONE reachable hole is client JSON at /recommend (F6)
+- [x] V10. Shim direction — CONFIRMED: backend reaches UP (bare-metal shim + Docker `../../src` mount); reverse NOT wired; zero parent-side `backend` imports (F8)
+- [x] V11. "Independence" is a REAL, load-bearing install contract, not historical caution (F8)
+- [x] V12. CLI imports RaceState natively at `scripts/run_simulation_cli.py:158` — CONFIRMED
+- [x] V13. `_targeting_against_rival` is a pure function; composes as an optional param (F2)
+- [x] V14. TyreLife: measured on the real parquets — 0 NEVER occurs, 1 does (F10)
+
+## Findings
+
+### F1. The three builders and their literal divergences — VERIFIED (V1, V2, V3 ✔)
+
+All three re-read 2026-08-02. The brief's table is accurate, and it is INCOMPLETE — there are
+more divergences than the four it lists.
+
+| Field | CLI `scripts/run_simulation_cli.py:1361-1373` | Arcade `src/arcade/strategy.py:699-715` | Backend `src/telemetry/backend/utils/race_state_builder.py:105-120` |
+|---|---|---|---|
+| `driver` | `driver_code` param (line 1362) | `driver_st.get("driver", "UNK")` (700) | `drv.get("driver", "UNK")` (106) |
+| `lap` | `driver_st["lap_number"]` — from DRIVER dict, direct index (1363) | `int(lap_state.get("lap_number", 1) or 1)` — from TOP-LEVEL dict, default 1 (677, 701) | `lap_state.get("lap_number", 1)` — top-level, default 1, no int cast (107) |
+| `total_laps` | `lap_state["session_meta"]["total_laps"]` direct index → KeyError if absent (1364) | `meta.get("total_laps", 57)` (703) | `meta.get("total_laps", 57)` (108) |
+| `compound` | default `"UNKNOWN"` (1366) | default `"MEDIUM"` (705) | default `"MEDIUM"` (110) |
+| `tyre_life` | default `0` (1367) | default `1` (706) | default `1` (111) |
+| `air_temp` | `25.0` (1370) | `25.0` (709) | `25.0` (114) |
+| `track_temp` | `40.0` (1371) | `35.0` (710) | `35.0` (115) |
+| `position is None` | raise ValueError "#628" (1332-1337) | raise ValueError "#465" (632-636) | raise ValueError, no issue number in msg, #465 in comment (98-103) |
+| `gap_ahead_s` | no-car-ahead → 0.0; unknown interval → `GAP_UNKNOWN_FALLBACK_S` (1338-1343) | same shape (652-659) | value comes in as PARAMETER `gap_ahead_s: float = GAP_UNKNOWN_FALLBACK_S` (56) — the positional-car-ahead computation lives in the CALLER (`simulator.py::_compute_gap_ahead`) |
+| `pace_delta_s` | computed inline vs car ahead, #750 (1355-1359) | computed inline vs car ahead, #750 (671-675) | PARAMETER, default 0.0 (57); rival-targeted recompute if `rival` set (81-87) |
+| `radio_msgs`/`rcm_events` | NOT passed to constructor — schema defaults, main loop mutates after (see F3) | built INSIDE from `self._radio_runner`/`self._sc_tracker` (678-697) | optional params, `None → []` (59-60, 117-118) |
+| `risk_tolerance` | NOT passed (schema default) | `float(self._request.risk_tolerance)` (714) | param, default 0.5 (58, 119) |
+| SC re-injection (`should_inject`) | in the CLI main loop, not the builder | INSIDE the builder (695-697) | in the CALLER (`simulator.py::_rcm_events_for_lap` at ~357) |
+
+**Divergences the brief missed:** (i) the `lap` field has THREE different sources/behaviors —
+CLI reads `driver_st["lap_number"]` (fail-loud, from the driver dict), Arcade/backend read
+top-level `lap_state["lap_number"]` with default 1. A missing top-level `lap_number` would
+silently build "lap 1" state in Arcade/backend and crash the CLI. (ii) `driver` default
+"UNK" exists only in Arcade/backend. (iii) `risk_tolerance` plumbing differs in all three.
+(iv) The SC-tracker injection sits at a different layer in each surface (builder vs caller vs
+main loop). Any canonical builder has to decide (i)-(iv) too, not just the four fields flagged.
+
+**GAP_UNKNOWN_FALLBACK_S (V4 ✔):** all three import it from `src.agents.position_projection` —
+CLI at `scripts/run_simulation_cli.py:1299-1301`, Arcade at `src/arcade/strategy.py:615`,
+backend at `src/telemetry/backend/utils/race_state_builder.py:3`. So the backend ALREADY
+imports up into the parent repo's `src/agents` from this exact module — the (b) mechanism is
+proven at the exact file that would consume it.
+
+### F2. `_targeting_against_rival` (#431) — VERIFIED (V13 partially, see F8)
+
+`src/telemetry/backend/utils/race_state_builder.py:7-50`. Pure function of
+`(lap_state, rival, fallback_gap_s, fallback_pace_s)` → `(gap, pace)`. It contains ZERO
+webapp-specific machinery — no FastAPI, no request objects; "webapp-only" is about who calls
+it, not what it needs. It composes cleanly as an optional `rival: Optional[str]` parameter on
+a canonical builder (exactly as `build_race_state` already exposes it at line 61).
+
+### F3. radio_msgs / rcm_events placement — VERIFIED (V5, V6 ✔)
+
+- **CLI**: builder returns them as schema defaults (empty lists); the main loop mutates the
+  built object at `scripts/run_simulation_cli.py:1744-1762` — `.extend()` of corpus radios
+  (1745-1748), SC-tracker re-injection (1756-1758), and the CLI-ONLY synthetic
+  `--radio-every` generator `_generate_radio_event`/`_generate_rcm_event` (1726-1737,
+  appended 1759-1762). Precedence rule at 1714-1720: corpus suppresses synthetic entirely.
+- **Arcade**: INSIDE the builder from instance state (`self._radio_runner` at
+  `src/arcade/strategy.py:680-688`, `self._sc_tracker` ingest+inject at 695-697).
+- **Backend**: optional keyword params (`race_state_builder.py:59-60`), populated by callers:
+  - `simulator.py::_local_build_race_state` (378-406) is CONFIRMED a thin wrapper over
+    `build_race_state` — passes `rcm_events` only, `radio_msgs` never (the SSE stream is
+    RCM-only by design, `_build_rcm_feed` docstring at 330-335); SC injection lives in its
+    caller-side helper `_rcm_events_for_lap` (357-375).
+  - `backend/api/v1/endpoints/strategy.py:1349-1357` passes `request.radio_msgs` +
+    `rcm_events` (with an RCM-autoload fallback at 1332-1336) + `rival=request.rival`.
+  - `backend/mcp_tools.py:595-604` passes `radio_msgs=None, rcm_events=None`.
+
+Three surfaces, three different SOURCES for the same two fields (corpus+synthetic via
+mutation / instance state / caller params). The parameter shape is the only one of the three
+that all others can be expressed in.
+
+### F4. Backend call sites of `build_race_state` — VERIFIED
+
+Exactly three: `simulator.py:400`, `endpoints/strategy.py:1349`, `mcp_tools.py:595`. All
+already use keyword-only params. A relocation of the canonical function changes ONE import
+line per site (or zero, if `backend/utils/race_state_builder.py` becomes a re-export shim).
+
+### F5. What `"UNKNOWN"` compound actually does downstream — VERIFIED (V8 ✔)
+
+`RaceState.compound` is a plain `str` (`src/agents/strategy_orchestrator.py:253`); the
+`Literal["SOFT","MEDIUM","HARD"]` at :271 constrains only OUTPUT fields (`compound_next`).
+Traced every consumer of `race_state.compound`:
+
+1. **Pace agent (N06)** — `strategy_orchestrator.py:1871` → `pace_agent.py:261`
+   `self.compound_id.get(compound, 1)`: unknown string silently encodes as id 1 ("most
+   common training value" per its docstring at 250-251). No crash, no log.
+2. **Tire agent (N26)** — via the synthetic `lap_state["driver"]["compound"]` at
+   `strategy_orchestrator.py:2435` → `tire_agent.py:785-811` `_compound_name_to_id`:
+   "UNKNOWN" is not in the map → falls back to `'C3'` (:804/:811); then
+   `_add_compound_cols` (:667-687) LOGS A WARNING (:681-683) and encodes C3/SOFT defaults.
+   No crash. `'C3'` is a real routing_config key, so bundle lookup survives.
+3. **Pit agent (N28)** — `pit_strategy_agent.py:394-412` `_compound_to_id("UNKNOWN")` → `''`
+   from the JSON map → `_COMPOUND_FALLBACK.get("UNKNOWN", 3)` → 3. Additionally
+   `_N15_COMPOUND_ORDER` (:117-120) maps unknowns to `-1`, which IS the notebook's own
+   trained `.fillna(-1)` bucket — for N15 specifically, "UNKNOWN" is in-distribution.
+4. **RAG question** — `strategy_orchestrator.py:2028` → `:1496-1514`: free text ("changing
+   to UNKNOWN compound"); degraded question, no crash.
+5. **LLM prompt** — `:1734` renders `Compound: UNKNOWN` — honest to the model.
+
+**Conclusion:** "UNKNOWN" never crashes; every numeric consumer degrades to a mid-range
+encoding (roughly what "MEDIUM" would produce anyway), one path warns loudly, and the LLM
+sees the truth instead of a fabricated MEDIUM. "MEDIUM" produces nearly the same numbers
+while asserting knowledge that does not exist — and MEDIUM is a value the code CAN
+legitimately find, which is precisely the project's sentinel-collision doctrine violation.
+
+**However — the default is nearly DEAD on the RSM path** (see F6): `RaceStateManager`
+emits `"compound": str(r.get("Compound", ""))` (`race_state_manager.py:352`) — the key is
+ALWAYS present. When FastF1 has no compound the value is `""` or `"nan"`, and `.get`'s
+default never fires (the very trap in CLAUDE.md §11, 2026-07-16, `Series.get`). So the
+real-world "unknown compound" string on the RSM path is `""`/`"nan"`, not any builder
+default. The canonical builder should therefore normalise falsy/`"nan"` → the chosen
+default, or the chosen literal is a decision about an almost-unreachable branch.
+
+### F6. `session_meta` producers and `total_laps` — VERIFIED (V9 ✔, with one real hole)
+
+Producers found (grep `"session_meta"` across all .py):
+- `src/simulation/race_state_manager.py:518` — `"total_laps": self.total_laps`,
+  unconditional; `self.total_laps = int(enriched["LapNumber"].max())` at :130. ✔ always present.
+- `backend/api/v1/endpoints/strategy.py:592-598` (the /lap-state family) — includes
+  `total_laps` (:597, from `int(gp_df["LapNumber"].max())` at :585). ✔
+- `backend/api/v1/endpoints/strategy.py:942-948` (the single-agent lap_state producer) —
+  includes `total_laps` (:947). ✔
+- `strategy_orchestrator.py:2448-2454` (run_lap's internal adapter) — includes
+  `total_laps` from `race_state.total_laps`. ✔
+- **The hole:** `/recommend` (`endpoints/strategy.py:1349`) builds from
+  `request.lap_state` — ARBITRARY CLIENT JSON over HTTP. A client may legally omit
+  `session_meta` entirely (`race_state_builder.py:79` guards with `.get("session_meta", {})`).
+  This is the one reachable path where the CLI's fail-loud direct index would raise and the
+  backend's `.get(..., 57)` actually fires. So: fail-loud is safe for CLI/Arcade (RSM-fed),
+  but the canonical builder must keep SOME defined behavior for the HTTP boundary.
+- Precedent: `src/agents/_shared_defaults.py:19` already defines `DEFAULT_TOTAL_LAPS = 57`
+  with a documented rationale (median/mode of the 71-race 2023-2025 dataset), consolidated
+  from six agent-side call sites. A canonical builder that defaults should import THIS, not
+  restate 57.
+
+### F7 (early). `simulator.py::_compute_gap_ahead` IS a genuine 4th copy — VERIFIED (V7 ✔)
+
+`src/telemetry/backend/services/simulation/simulator.py:245-279`. Same algorithm as the two
+inline copies: `next(r for r in rivals if r.get("position") == our_pos - 1)`, then
+`interval None → GAP_UNKNOWN_FALLBACK_S`, `abs(interval)` otherwise, 0.0 when no car ahead.
+Differences from CLI/Arcade: it returns 0.0 (instead of raising) on `our_pos is None`
+(264-265) — safe only because `_lap_skip_reason` (296-321) filters those laps first, as its
+own docstring admits at 257-259. Its docstring at 248-250 states the duplication is
+INTENTIONAL ("kept inline here because the two copies are short and intentionally
+decoupled") — that rationale is exactly what this design gate is deciding to overturn, so
+unification should absorb it (analysis in F9).
+
+### F8. The layering evidence: why the "independence" framing is load-bearing — VERIFIED (V10, V11 ✔)
+
+- **Backend → parent is the ONLY existing direction.** Bare-metal: `mcp_tools.py:33`,
+  `simulator.py:45`, `endpoints/strategy.py:33` all `sys.path.insert(0, get_repo_root())`,
+  and `backend/core/paths.py:27-41` walks up for a `.git` DIRECTORY (skipping the submodule
+  gitlink file — the #27 fix), landing on the parent root. Docker:
+  `src/telemetry/docker-compose.yml:16` mounts `../../src:/app/src:ro` and paths.py falls
+  back to `/app` (:24, :41) — so `src.agents.*` resolves inside the container too. The
+  backend depends on the parent's `src/` tree in BOTH deployment modes, today, by design.
+- **Parent → backend does not exist anywhere.** Grep over `scripts/`, `src/agents/`,
+  `src/arcade/`, `src/simulation/`, `src/strategy/`, `src/f1_strat_manager/`, `tests/` for
+  `from backend.` / `import backend` / `telemetry.backend`: **zero matches**.
+- **The install contract makes that a feature, not an accident.** `INSTALL.md:37-59`
+  installs CLI and Arcade via `uv tool install git+...` or `uv sync` on a source checkout,
+  with NO submodule step; `--recurse-submodules` is documented as required ONLY for the
+  webapp flow (`INSTALL.md:89-95`). There is no `src/telemetry/__init__.py` and no
+  `src/__init__.py` (checked on disk), so nothing guarantees the backend package chain is
+  even importable from the parent side without a NEW mirrored sys.path shim onto
+  `src/telemetry` (backend modules import each other as top-level `backend.*`, e.g.
+  `endpoints/strategy.py:1323`). The arcade docstring's rejection of that shim
+  (`src/arcade/strategy.py:600-606`) reflects this real invariant.
+- Parent CI checks out submodules (`.github/workflows/ci.yml:52-54`), so parent-side tests
+  CAN see backend files — relevant to option (c) — but a user checkout is not CI.
+
+### F9. `_compute_gap_ahead` absorption — YES, with one behavioral note
+
+Deleting it and letting the canonical builder compute the gap internally is safe IF the
+canonical API treats "caller did not supply a gap" as "compute from rivals":
+- `simulator.py:877-879` calls `_local_build_race_state` only after `_lap_skip_reason`
+  (:870-873) has excluded `position is None` laps (:315-316), so `_compute_gap_ahead`'s
+  lenient `return 0.0` on None position (:264-265) is unreachable on the live path — the
+  canonical builder's fail-loud ValueError is behavior-identical where it matters.
+- Only one caller exists (`simulator.py:402`); no test or other module references it.
+- NOT the same thing: `endpoints/strategy.py:472-476` computes a gap from cumulative
+  session times over the DataFrame — that is a lap_state PRODUCER computation (different
+  inputs, before rivals exist as dicts), a cousin, not a fifth copy. Leave it out of scope,
+  but note it in the issue so nobody "unifies" it into the wrong layer later.
+
+### F10. Executed evidence for the literal recommendations
+
+Measured directly on the shipped parquets (2026-08-02):
+
+```
+TyreLife  2023 min 2.0 · 2024 min 2.0 · 2025 min 1.0 · rows with TyreLife==0: ZERO in all seasons
+Compound  values found: HARD/MEDIUM/SOFT/INTERMEDIATE/WET + the STRINGS 'None' (2023, 2025)
+          and 'nan' (2025); 'UNKNOWN': ZERO rows in all three seasons
+TrackTemp (2023+2024; the 2025 featured parquet carries no weather cols)
+          mean 35.3 · median 35.0 · p10 24.5 · p90 46.5
+AirTemp   mean 23.9 · median 24.1
+```
+
+Consequences:
+- `tyre_life=0` is a value the data can NEVER legitimately contain; `tyre_life=1` collides
+  with real fresh-tyre laps (2025 has them). Doctrine picks 0.
+- `compound="UNKNOWN"` collides with nothing in this corpus (0 rows; FastF1's API does
+  define UNKNOWN as a possible label, but the 2023-2025 data never emits it — flag, not
+  blocker). Meanwhile the REAL missing-compound strings that already flow out of
+  `race_state_manager.py:352` (`str()` of NaN/None) are `'nan'`/`'None'`/`''` — none of the
+  three builders normalises them, so today an incomplete row reaches the models as the
+  literal string `"nan"` regardless of which default was chosen.
+- `track_temp=35.0` IS the dataset median; the CLI's 40.0 corresponds to nothing measured.
+- `air_temp=25.0` ≈ median 24.1; all three already agree. Keep.
+
+### F11. Which defaults are actually live vs nearly dead (the honest stakes)
+
+> **CORRECTION (2026-08-02, from the follow-up gate in `GATE_weather_path_findings.md`).**
+> The claim below that the weather defaults are a "genuinely LIVE divergence" because they fire
+> "when `weather.parquet` is missing for a race" is **FALSE**. An executed scan found all 71 race
+> directories carry a readable `weather.parquet` with zero NaN `AirTemp`/`TrackTemp` rows, so on
+> the replay path (CLI and Arcade, both via `RaceReplayEngine`, which passes the frame at
+> `replay_engine.py:137`) that branch is unreachable with the shipped data. This is the same
+> mistake `CLAUDE.md` §11 records about the Arcade's temperatures on 2026-07-16.
+>
+> The **decision** (canonical 35.0) still stands, on the measured-median argument alone: 35.0 is
+> the dataset median and the CLI's 40.0 corresponds to nothing measured. Only this section's
+> justification was wrong.
+>
+> What the same gate found instead IS live, and is bigger: the backend's `lap_state` producer
+> emits `None` per weather key on 2025 laps (those parquets carry no weather columns), which the
+> old consumer passed to `float()` — a `TypeError` caught as a 422 on **every** 2025 lap of
+> `/recommend`. Filed as #788; fixed by this change's present-but-`None` handling.
+
+
+`dict.get(key, default)` fires only on a MISSING KEY (CLAUDE.md §11 2026-07-16 lesson).
+Checked against every producer:
+- `compound` / `tyre_life` / `position` / `driver` / `lap_number`: RSM ALWAYS emits the keys
+  (`race_state_manager.py:316-374, 596`), backend producers too (`endpoints/strategy.py:479,
+  588, 905-906, 945`). On RSM-fed paths the compound/tyre_life defaults are DEAD; the live
+  hazard is present-with-None / string-coerced NaN (F10). The defaults only breathe on
+  hand-built lap_states: HTTP clients of `/recommend` and test fixtures.
+- `total_laps`: same, except the /recommend client-JSON hole is real (F6).
+- **weather is the exception — genuinely LIVE divergence:** `get_weather_state` with no
+  `weather_df` returns ONLY `{"track_status": ...}` (`race_state_manager.py:470-472`), so
+  when `weather.parquet` is missing for a race, the KEYS are absent and every default
+  fires. On that same race the CLI feeds N14 `track_temp=40.0` and Arcade/backend feed
+  `35.0` — a real, reachable, surface-dependent model-input divergence today.
+- Present-with-None weather values (NaN row → None at :478-479) crash all three builders
+  (Pydantic float rejects None; arcade/backend `float(None)` TypeError) — caught by per-lap
+  try/except on CLI/arcade, a 422/500 on the backend. The canonical builder should treat
+  None-as-missing for weather (an `x if x is not None else DEFAULT` read), a strict
+  robustness gain, behavior-identical on every lap that works today.
+
+### F12. Option (a) — resolve the shim downward: REJECTED
+
+Three independent kills, each sufficient:
+1. **It breaks a documented install contract.** f1-sim/f1-arcade run today from a checkout
+   with `src/telemetry` EMPTY (INSTALL.md:37-59 vs :89-95; zero parent→backend imports,
+   F8). Under (a) the PMV would ImportError on every clone made without
+   `--recurse-submodules` and every `uv tool install` where the submodule content is
+   absent or unpackaged (no `__init__.py` chain, F8).
+2. **Layering inversion.** The parent's UNTOUCHABLE PMV would depend on a submodule pointer
+   versioned in another repo; a backend refactor could break the CLI, and fixing it would
+   require the commit-then-bump dance for what is today a parent-only file.
+3. **Import-name schizophrenia.** Backend code is imported as top-level `backend.*` (its
+   internal absolute imports demand it). The parent would need a mirrored
+   `sys.path.insert(src/telemetry)`; the same file could then be materialised twice under
+   two module names in one process — double side effects, the exact hazard class the
+   arcade docstring rejected (`src/arcade/strategy.py:600-606`).
+
+### F13. Option (c) — accept the copies + parity test: REJECTED (fallback only)
+
+- A parity test in the parent can only run when the submodule is checked out; on a
+  contributor clone without it, it silently skips — and in the SUBMODULE's own repo/CI
+  (where backend edits actually happen, per the commit-first rule) the parent-side test
+  does not exist at all. The guard is absent precisely where the drift originates.
+- Literal parity is the WEAK half of the problem. The drift that actually bit (#750
+  pace_delta axis, #465 dead position default, #633 gap zero-conflation) was LOGIC drift;
+  a field-by-field literal diff would have caught none of those bugs' next instances. To
+  assert logic parity the test must call all three builders — which needs the submodule
+  present AND importable, i.e. the same machinery (c) exists to avoid.
+- Precedent says convergence is the direction already chosen: the shared
+  `GAP_UNKNOWN_FALLBACK_S` import and `_shared_defaults.DEFAULT_TOTAL_LAPS` are both
+  fragments of (b) that already shipped.
+
+### F14. Option (b) — canonical module in `src/agents/`: RECOMMENDED, with the exact shape
+
+**Location:** `src/agents/race_state_builder.py` (new module — ADDITIVE, which even the
+strict CLAUDE.md §0.2 reading permits). Rationale: the output type `RaceState` is owned by
+`src/agents/strategy_orchestrator.py`; the two constants the builder needs already live in
+`src/agents` (`position_projection.GAP_UNKNOWN_FALLBACK_S`,
+`_shared_defaults.DEFAULT_TOTAL_LAPS`); and the backend's reverse shim + Docker mount
+already deliver exactly this path (F8). `src/simulation/` was considered and rejected: it
+would create a simulation→agents dependency that does not exist today.
+**Leaf-module constraint (hard):** import `RaceState` LAZILY inside the function, exactly
+as `backend/utils/race_state_builder.py:75` and the arcade (:616) do —
+`strategy_orchestrator` drags LangChain/LangGraph, and the builder must stay importable
+without paying that (mirror the discipline documented in `_shared_defaults.py:3-4`).
+
+**Canonical API (design, not code):**
+```
+build_race_state(
+    lap_state, *,
+    driver=None,            # CLI's explicit driver_code override; None → driver dict → "UNK"
+    gap_ahead_s=None,       # None → compute positional-car-ahead gap (absorbs _compute_gap_ahead)
+    pace_delta_s=None,      # None → compute vs car ahead per the #750 contract
+    risk_tolerance=0.5,
+    radio_msgs=None, rcm_events=None,   # None → []
+    rival=None,             # #431 targeting — _targeting_against_rival moves here verbatim
+) -> RaceState
+```
+`None`-means-compute keeps every existing caller byte-compatible: the /recommend endpoint
+keeps passing `request.gap_ahead_s` (client-override semantics unchanged), mcp_tools keeps
+its `or GAP_UNKNOWN_FALLBACK_S`, the simulator passes nothing and drops
+`_compute_gap_ahead`, CLI/Arcade pass nothing and lose their inline copies.
+
+**#431 stays clean (V13):** `_targeting_against_rival` (`race_state_builder.py:7-50`) is a
+pure `(lap_state, rival, fallbacks) → (gap, pace)` function with zero webapp imports;
+`rival: Optional[str] = None` on the canonical API leaks nothing — CLI/Arcade simply never
+pass it (the CLI's `--rival` is display-only today, `run_simulation_cli.py:1694-1700`, and
+wiring it later becomes a feature (b) enables for free, not a cost).
+
+**radio_msgs / rcm_events: PARAMETERS, not built internally.** Decision + justification:
+- The three surfaces have three different SOURCES (F3): CLI corpus+synthetic with a
+  precedence rule, Arcade instance state, backend caller params. Only the parameter shape
+  expresses all three without importing any surface's machinery into the shared module.
+- The CLI keeps its post-construction `.extend()/.append()` block UNCHANGED (RaceState list
+  fields are mutable; `scripts/run_simulation_cli.py:1744-1762` works identically on a
+  canonically-built object). The `--radio-every` synthetic generator, the corpus-suppresses-
+  synthetic rule and the SC tracker stay in the main loop where they live: zero PMV rewrite.
+- Arcade's builder becomes a thin wrapper: compute `radio_msgs`/`rcm_events` from
+  `self._radio_runner`/`self._sc_tracker` exactly as today (:678-697), then pass them as
+  params. The SC-injection LOGIC stays arcade-side (stateful, per-surface).
+- Building them INSIDE the canonical function would require it to hold a
+  RadioPipelineRunner and an SC tracker — instance state, Whisper deps, per-surface policy.
+  Rejected.
+
+**CLI surgical-edit test (the PMV constraint): PASSES.** The entire CLI change is (1) one
+import, (2) replace the BODY of `_build_race_state` (:1338-1373) with a delegation
+`return build_race_state(lap_state, driver=driver_code)` keeping the local function and its
+call site (:1711) untouched, (3) lines 1710-1764 stay byte-identical. The behavioral deltas
+are exactly the approved canonical literals, each validated with a real `f1-sim` run per
+the PMV rule — the same class of edit as the already-landed #750 fix to this function.
+
+**Submodule sequence (the commit-first rule):**
+1. **Parent PR** — add `src/agents/race_state_builder.py`; switch CLI + Arcade to it; unit
+   tests for the canonical builder land in parent `tests/` (they run WITHOUT the
+   submodule); real `f1-sim` run. Backend untouched and unbroken (its copy still works).
+2. **Submodule commit** (F1_Telemetry_Manager) — `backend/utils/race_state_builder.py`
+   becomes a re-export (`from src.agents.race_state_builder import build_race_state`,
+   preserving the public name so `simulator.py:400`, `endpoints/strategy.py:1349`,
+   `mcp_tools.py:595` need ZERO changes); delete `_compute_gap_ahead` (:245-279) and stop
+   passing `gap_ahead_s` from `_local_build_race_state` (:402). Note: the module ALREADY
+   imports `src.agents.*` at module top (:3), so the re-export adds no failure mode that
+   does not exist today.
+3. **Parent PR** — bump the submodule pointer. Until 3 lands the backend runs its old copy:
+   the drift window stays open between 1 and 3, so keep all three in one sprint.
+
+**Residual risks accepted (stated, not hidden):**
+- Between steps 1 and 3 the twin exists again, briefly and knowingly.
+- A future editor may top-level-import RaceState in the canonical module and slow every
+  surface's boot — guard with the module docstring + a cheap test asserting the module
+  imports without `langchain` appearing in `sys.modules`.
+- The canonical literals CHANGE observable CLI behavior on the weather-missing path
+  (40.0 → 35.0) — that is the point, but it must be named in the PR body.
+
+## Recommended canonical literals — one decision per row, each overridable
+
+| Field | Recommend | Grounds | Trade-off if overridden |
+|---|---|---|---|
+| `total_laps` | `session_meta.get("total_laps")`; missing → `DEFAULT_TOTAL_LAPS` (import from `_shared_defaults`, never restate 57) + `logger.warning` | Every internal producer supplies it (F6); the only reachable miss is client JSON at /recommend, and downstream agents ALREADY fall back to the same 57 — a builder stricter than its consumers buys a crash, not correctness. The warning keeps it loud. | Fail-loud (CLI today) is doctrine-purer; costs turning working (if sloppy) API calls into 422s. Defensible if the human prefers it. |
+| `compound` | `"UNKNOWN"`, PLUS normalise `""`/`"nan"`/`"None"`/absent → `"UNKNOWN"` | Never crashes (F5: pace encodes id-1 silently, tire warns + C3, N15 maps to its own trained −1 bucket, LLM prompt sees the truth); zero collisions in 71 races (F10); "MEDIUM" is a findable value = the sentinel-collision doctrine violation, and it lies to the prompt. The normalisation is what makes the choice REAL — today `"nan"` flows through regardless (F10). | "MEDIUM" yields near-identical model encodings and never prints an odd word in the UI. If "UNKNOWN" on screen is unacceptable, fix the DISPLAY, not the state. |
+| `tyre_life` | `0` | TyreLife==0 occurs ZERO times in 2023-2025 (executed, F10) → non-colliding sentinel; 1 collides with real fresh-tyre laps. Fires only on hand-built states (key missing), so the slightly out-of-distribution input is a corner, not a path. | `1` keeps the model strictly in-distribution at the cost of being indistinguishable from a real fresh tyre — the #428/#465 bug shape. |
+| `track_temp` | `35.0`; also treat present-but-None as missing | Measured dataset median is exactly 35.0 (F10); the divergence is LIVE today (fires whenever weather.parquet is absent, F11); 40.0 matches nothing measured. | Any float here is fabricated (schema forces float; `Optional[float]` is the honest long-term fix but a RaceState contract change, same as gap_ahead_s per the arcade's own comment :646-651). Choosing 40.0 needs a reason nobody has produced. |
+| `air_temp` | `25.0` (keep) | All three agree; ≈ dataset median 24.1. | — |
+| `lap` | top-level `lap_state["lap_number"]`, fallback driver dict, then default 1 + warning | RSM emits both (:596, :319); behavior-identical on all real paths; CLI's driver-dict direct index crashes on a hand-built state the other two accept. | Fail-loud purism, same argument as total_laps. |
+| `position` | keep fail-loud ValueError (all three agree); unify the message, cite #628+#465 | Already converged; the guard is load-bearing (#428 shape). | none |
+
+## What I tried to break and could not (option b)
+
+1. **"src/agents is untouchable, so (b) is forbidden."** Fails: the constraint is "additive
+   entry points only" (CLAUDE.md §0.2), and a NEW leaf module is the additive case —
+   `_shared_defaults.py` is the exact shipped precedent, created for the same
+   consolidate-the-restated-constant reason.
+2. **"The backend can't import it in Docker."** Fails: `docker-compose.yml:16` mounts
+   `../../src:/app/src:ro` and `paths.py` resolves `/app` — the canonical module ships into
+   the container by the SAME mechanism `position_projection` already does. The backend
+   image copies only `backend/` (Dockerfile:17); `src/` is a mount, so no rebuild semantics
+   change.
+3. **"It forces a CLI rewrite via the radio/RCM block."** Fails — but ONLY because of the
+   parameters-not-internal decision plus RaceState's mutable list fields. If a future
+   refactor freezes RaceState, the CLI's post-construction mutation breaks — record this in
+   the canonical module's docstring.
+4. **"A circular import: agents ↔ builder."** Fails: the builder imports
+   `strategy_orchestrator` lazily; nothing in `src/agents` imports the builder; Arcade and
+   CLI already import `src.agents.*` today (:615-616, :158).
+5. **"The submodule's standalone context breaks on `src.agents`."** Fails to be NEW:
+   `backend/utils/race_state_builder.py:3` already imports `src.agents.position_projection`
+   at module import time. Whatever handles that today handles the re-export identically —
+   a pre-existing property of the submodule, not a cost introduced by (b).
+6. **Could NOT fully close:** (i) whether every `uv` version users run fetches submodules
+   on `uv tool install git+...` — irrelevant to (b) (nothing parent-side will import
+   backend), decisive only against (a), which has two other independent kills; (ii) whether
+   any consumer outside this repo pair imports `backend.utils.race_state_builder` (MCP
+   clients call tools, not modules — none found); (iii) the hypothetical frozen-RaceState
+   future (risk recorded in 3).
+
+## Bottom line
+
+**Option (b).** One canonical `build_race_state` in `src/agents/race_state_builder.py`
+(leaf module, lazy RaceState import), radio/rcm/risk/rival as optional parameters,
+gap/pace computed internally when not supplied (absorbing `_compute_gap_ahead`),
+`_targeting_against_rival` moved verbatim, the backend file kept as a thin re-export so its
+three call sites do not change, the CLI edit strictly surgical (delegate the body, main
+loop untouched), landed as parent-PR → submodule-commit → pointer-bump in one sprint.
+Every literal above is a separate human decision — approve or override per row.

--- a/documents/audits/GATE_final_correctness.md
+++ b/documents/audits/GATE_final_correctness.md
@@ -1,0 +1,107 @@
+# GATE — Final correctness gate before push (#784 epic + #788 fix + partial #789)
+
+**Date:** 2026-08-02 · **Branch:** `refactor/single-source-race-state-builder` (parent, uncommitted) · **Submodule:** `7f394a8` (committed inside, pointer bumped in the parent working tree)
+**Role:** final adversarial correctness gate. Success = finding what is STILL broken. No repository file modified except this report, written incrementally.
+
+## Checklist (updated as verified)
+
+- [x] A. CLI edit surgical; radio/RCM main-loop block byte-identical — CONFIRMED (executed)
+- [x] B. Three surfaces build identical RaceState; shim IS the canonical function object — CONFIRMED (executed + Qatar gate's cross-surface table)
+- [x] C. `reading_or_default` correct + exactly equivalent to pace_agent's old inline guard — CONFIRMED (executed, 8-case table)
+- [x] D. tire_agent/no_llm compound/tyre_life canonicalisation changes no previously-sane model input — CONFIRMED SAFE (executed, see verdict)
+- [x] E. `startswith('C')` guard still routes "UNKNOWN" correctly; nothing assumed "MEDIUM" — CONFIRMED (executed)
+- [x] F. No import cycle; leaf-module guarantee holds — CONFIRMED (executed, both import orders)
+- [x] G. Every comment/docstring claim in the diff verified against code and data — mostly TRUE; two false-at-ship comments (F1) + one mechanism nit (F5)
+- [x] Tests: coverage of the agent-side changes; wrong-reason passes — coverage gap is F2; no wrong-reason pass found
+- [x] Submodule commit still correct after parent-side rename; no old-name references — CONFIRMED (grep at 7f394a8)
+- [x] git status: nothing rides along that should not — one unrelated PNG (F6)
+
+## Claim-by-claim verdicts (executed evidence)
+
+**A. CONFIRMED.** `git diff scripts/run_simulation_cli.py` = exactly two hunks (`@@ -1287,18 +1287,14 @@`, `@@ -1306,71 +1302,24 @@`). Byte-compare of `git show HEAD:` vs working tree: every line from old L1400 to EOF is identical modulo the 51-line shift — which covers the radio/RCM block (old 1710-1764) byte for byte. `def _build_race_state(` and the call site (`race_state = _build_race_state(lap_state, args.driver, prev_lap_time)`, old :1711 -> new :1660) are character-identical.
+
+**B. CONFIRMED.** Executed: `backend.utils.race_state_builder.build_race_state IS src.agents.race_state_builder.build_race_state` -> True (parent venv, sys.path = root + src/telemetry), with zero langchain/langgraph/torch modules loaded by the shim import. CLI delegates as `build_race_state(lap_state, driver=driver_code)`; Arcade as `build_race_state(lap_state, risk_tolerance=..., radio_msgs=..., rcm_events=...)` — each surface passes only what it owns. The field-by-field cross-surface agreement on real data is the Qatar gate's executed Task-1 table (this session); every DIFFER there has a named owner.
+
+**C. CONFIRMED.** Property test (executed, this venv): old inline `wx.get(k) if wx.get(k) is not None else d` vs `reading_or_default(wx,k,d)` on {absent, present-None, 0.0, False, True, 25.3, NaN, "25.3"} — identical on ALL eight, including the #633-sensitive falsy cases (0.0/False pass through untouched; the helper tests `is None`, not truthiness). Migrating `pace_agent` changed its behaviour NOT AT ALL, absent key included. The three call sites keep their per-agent defaults (pace 25/35/50; tire + race_situation 28/38/50), which #789 deliberately leaves unreconciled.
+
+**D. CONFIRMED SAFE — this was attacked hardest; the verdict is NOT a regression.**
+- The old key-absent defaults (`"MEDIUM"`, `1`) were DEAD on every real path: RSM always emits both keys (`race_state_manager.py:352-355`, compound as `str(...)`, tyre_life as int-or-None) and so does the backend producer (`endpoints/strategy.py:489-491`). The live degraded inputs were the STRING `'nan'`/`'None'` and present-`None` — which the old defaults never caught.
+- Compound: executed `_compound_name_to_id` on Miami/Lusail/Spa-Francorchamps/unknown-GP 2025: `'nan'`, `'None'`, `''` and `'UNKNOWN'` ALL map to `'C3'`. So on every real lap where the old code fed the model 'nan', the new code produces the SAME compound id. Zero model-input delta.
+- Stint window: featured 2025 carries 379 `Compound=='nan'` rows (Miami L4-24, 19 drivers) + 53 `'None'` rows (Spa L30-44) and EVERY one of them also has TyreLife NaN (executed groupby: `tl_ok=0` everywhere). The `TyreLife <= x` clause therefore empties the window in BOTH worlds (executed on pandas 2.3.3: `Series <= None` -> 0 True rows, no exception; `<= 0` -> 0 rows; NaN satisfies neither) -> old = conservative stub, new = conservative stub. **No lap that previously produced a sane TCN prediction produces a different one.**
+- Raw 2025: ZERO NaN-compound laps pass the replay guards (Position + LapTime present; executed over all 24 files) — the replay surfaces never even see the changed path.
+- "Is 0 in-distribution for the TCN?" — **0 never reaches the TCN.** The scalar tyre_life only (a) bounds the stint window (`TyreLife <= 0` is empty by construction, season min 1.0, so the tool returns "No laps found" -> conservative stub) and (b) lands on `TireOutput.current_tyre_life`, whose only consumers are display (`agent_formatters.py:150`, `reasoning_tabs.py:121`) and the backend response model `current_tyre_life: int` (`endpoints/strategy.py:141`) — where 0 is valid and the old `None` was a latent Pydantic failure. The TCN's features come from the window ROWS (real TyreLife values), never from the scalar.
+- The one reachable behavioural change is an improvement: on the 451 TyreLife-NaN 2025 rows via /recommend and MCP, old no-llm CRASHED (LangChain tool `tyre_life: int` + None -> ValidationError, sweep E1) where new returns the stub; old LLM prompted "tyre life None laps" where new says 0 and lands on the same empty-window stub.
+
+**E. CONFIRMED.** `'UNKNOWN'.startswith('C')` is False -> `_compound_name_to_id` -> `'C3'` (executed, incl. an unknown GP; the fallback dict has no UNKNOWN/NAN keys, `.get(..., 'C3')` covers it). Nothing downstream assumed the old strings: `_get_driver_stint`'s own `'MEDIUM'` fallback fires only when `session_meta` lacks `f'{driver}_compound'`, which `run_from_state` always sets; the orchestrator's synthetic lap_state path is idempotent (`normalise_compound('UNKNOWN') == 'UNKNOWN'`, tyre_life 0 stays 0 — executed). Grep for the old private name `_normalise_compound` across parent src/scripts/tests: zero matches.
+
+**F. CONFIRMED.** Fresh-interpreter import of the builder pulls zero langchain/langgraph/torch/xgboost/lightgbm/transformers/whisper modules (executed; also enforced by the new subprocess test). Both import orders work: builder-first (probe 1) and tire_agent-first (probe 3 — `tire_agent` -> `race_state_builder` at module top completes because the builder never imports agent modules at module scope; `strategy_orchestrator` stays a call-time lazy import). No cycle exists at runtime.
+
+**G. Mostly TRUE; the false ones are F1, the nit is F5.** Re-executed independently this gate: "every 2025 laps parquet ships without weather columns" (featured 48-col + all 24 raw: zero weather cols — TRUE); "all 71 race dirs carry a readable weather.parquet with zero NaN AirTemp/TrackTemp rows" (71/71 readable, non-empty, zero NaN — TRUE); dataset medians (TrackTemp median exactly 35.0, mean 35.3; AirTemp median 24.1, mean 23.9 — TRUE); TyreLife==0 zero rows, 2025 min 1.0 — TRUE. The twin narrative (pace was the only guarded copy, with a trap comment) verified against `git show HEAD:src/agents/pace_agent.py` — TRUE. The 2.3-lap cliff figure is consistently quoted from the Qatar gate's executed measurement (10.5 vs 8.2; post-fix 7.9 vs 8.1) — not re-measured here. One nuance, not false: `_shared_defaults.py`'s "it crashed /recommend ... (#788) via race_situation_agent" is the executed truth of THIS branch's intermediate state; on `main` the same conflict crashes one layer earlier (the backend builder consumer #788's own text names). A parenthetical would make it bulletproof.
+
+## Tests and suites (executed in THIS working tree, all agent-side changes included)
+
+- `tests/agents/test_race_state_builder.py` -> **29 passed** (18.6s).
+- `tests/agents/ tests/audit/ tests/simulation/` -> **192 passed** (178.3s) — matches the IMPL baseline+29 with zero new failures, now WITH changes 4/5 present (the IMPL number predates them).
+- `tests/engine/ tests/mc/ tests/surfaces/ tests/infra/` -> result appended below; note the IMPL log never re-ran engine/mc after `no_llm.py` changed — this gate closes that hole.
+- Wrong-reason scan: the builder tests assert EFFECTS on the constructed RaceState (defaults fire on key-absent states, warnings captured via caplog, explicit 0.0 honoured, rival fallback lands on positional values); the literal-via-constant convention is documented and is a wiring assertion by design, not an empty-set pass. No assertion found that passes on a band that never fires.
+
+## Submodule cross-check
+
+- `git show 7f394a8:backend/utils/race_state_builder.py`: 24-line shim, imports ONLY `build_race_state` (public, exists). Executed: shim object IS the canonical function.
+- Grep at `7f394a8` for `_normalise_compound` / `normalise_compound` / `UNKNOWN_TYRE_LIFE` / `_targeting_against_rival` / `_compute_gap_ahead`: the only hit is a prose docstring in `simulator.py:350` accurately describing the absorbed copy. The parent-side `normalise_compound` publication postdates the commit and nothing in the submodule references either spelling. The commit remains correct.
+- Submodule working tree: only untracked local dirs (`.claude/`, `docs/migration/streamlit-reference/`) — cannot ride the pointer bump.
+
+## What I tried to break and could NOT
+
+1. **`reading_or_default` vs the old pace inline** — 8-case executed property table including 0.0/False/NaN: byte-equivalent behaviour, no #633 conflation, no change on absent keys.
+2. **A real lap whose tyre prediction changes under claim D** — hunted across featured+raw 2025: every `'nan'`/`'None'`-compound row also has TyreLife NaN, both worlds' stint windows come out empty, `_compound_name_to_id` maps old and new degraded spellings to the same `'C3'`, and zero NaN-compound laps pass the replay guards. Could not construct a single regression from shipped data.
+3. **The leaf/cycle constraint** — fresh-interpreter import, shim import, and the tire_agent-first order: no langchain/torch leak, no cycle.
+4. **The PMV byte-identity** — compared the full tail (old L1400-EOF) programmatically, not just hunk headers.
+5. **The doc/data claims** — independently re-executed the 71-file weather scan, the medians, the TyreLife facts and the "every 2025 laps parquet" claim; all held.
+6. **`Series <= None` semantics** — pandas 2.3.3 returns all-False, no exception (confirms stub-not-crash equivalence for the old tyre_life=None path).
+7. **The orchestrator's synthetic lap_state round-trip** — `normalise_compound` is idempotent on "UNKNOWN" and tyre_life 0 survives unchanged; no double-degradation.
+
+## Could not verify here
+
+- `/recommend` over real HTTP with the LLM profile end-to-end (no OpenAI connectivity in this environment — `APIConnectionError` is environmental; the deterministic profile exercising the exact crash-site code is the IMPL log's executed evidence).
+- The 2.3-lap cliff figure itself (accepted the Qatar gate's executed measurement; internally consistent across two documents).
+- The submodule suite under a submodule-local venv (the IMPL log's known `fastmcp` skip).
+
+## Findings (appended as confirmed)
+
+<!-- appended incrementally -->
+
+### [MEDIUM / docs-in-code] F1 — Two shipped comments claim "the backend still runs its own copy", in the same tree that bumps the pointer to the shim (EXECUTED evidence: git state)
+
+- `scripts/run_simulation_cli.py:1290-1296` (new comment block): "The telemetry backend still runs its own copy until #786 lands its re-export shim, which needs a submodule commit and a pointer bump; until then this is a two-way unification, not a three-way one."
+- `src/arcade/strategy.py:~600-612` (new `_build_race_state` docstring): same claim — "the telemetry backend still runs its own copy until #786 lands its re-export shim ... This is a two-way unification today, not yet the three-way one" — inside a paragraph that itself preaches "a comment claiming a closed drift is worse than no comment".
+
+Both statements were true when #785 was implemented and are FALSE in the tree being pushed: submodule commit `7f394a8` (the re-export shim; verified `git show 7f394a8:backend/utils/race_state_builder.py` — 24-line shim importing the canonical function) is committed inside the submodule AND the parent working tree carries the pointer bump `82f6382 -> 7f394a8` (`git diff src/telemetry`). Executed proof that the claim is false in this tree: `backend.utils.race_state_builder.build_race_state IS src.agents.race_state_builder.build_race_state` -> **True**. Whoever reads the merged code will be told the drift is open when it is closed — the exact claim-vs-tree mismatch class this session already corrected twice (the shim-before-it-existed docstring and the weather-path premise). Milder echo: `src/agents/race_state_builder.py:49` "a re-export shim once #784's submodule half lands" (future tense for a landed thing).
+
+It is also an INTERNAL CONTRADICTION in the CLI file itself: ten lines below that comment, the new `_build_race_state` docstring (`run_simulation_cli.py:1308`) says the delegation is "the single canonical mapping shared with the arcade and the telemetry backend" — the same file asserts both that the backend shares the mapping and that it still runs its own copy. The docstring is the true one at ship time.
+
+Fix: rewrite both to present tense before committing (comment-only edits inside already-touched blocks; the CLI one is inside the comment block this branch already replaced, so the PMV surgical constraint is not re-opened).
+
+### [MEDIUM / test coverage] F2 — The agent-side half of the ship (changes 4 and 5) has ZERO test coverage
+
+Verified by grep over `tests/` (executed): no test imports or exercises `reading_or_default`; no test covers `tire_agent.run_from_state` / `no_llm._tire_no_llm`'s new `normalise_compound` + `UNKNOWN_TYRE_LIFE` derivation; no test feeds any agent a present-`None` weather dict. `tests/agents/test_race_state_builder.py` (29 tests, green in 18.6s, executed) covers the BUILDER surface only — including present-None weather — but the #788 crash site was one layer below the builder, in the agents' RAW-lap_state adapters, and that layer's fix ships untested. Given that this exact bug class regressed once already in this same session ("the fix moved the crash one layer down"), the migrated reads are one refactor away from silently reverting: a test that runs `race_situation_agent.run_from_state`-level session_meta building (or just `reading_or_default` + the three call sites' output on a `{'air_temp': None}` dict) would pin it. Cheap to add; nothing pins it today.
+
+### [RESOLVED — not a finding] F3 — The sweep's R1 crash (TyreLife NaN -> `int()` ValueError) survives by DELIBERATE scoping and IS tracked
+
+`src/agents/race_situation_agent.py:914-915` still crashes on the 451 shipped featured-2025 rows with TyreLife NaN (re-measured this gate), reachable via `/recommend` and MCP. I initially drafted this as "untracked" — WRONG: **issue #790 exists** ("fix(agents): int(NaN) on TyreLife crashes N27's overtake tool on 451 real 2025 laps"), filed from the sweep, correctly citing the guarded twin at `pit_strategy_agent.py:983-999`. Survives the push knowingly and with a paper trail. No action needed.
+
+### [LOW] F4 — `pace_agent` left `rainfall` on the two-arg get its siblings just migrated off
+
+`src/agents/pace_agent.py:650` keeps `_rainfall = wx.get('rainfall', 0)` while the same diff migrates `tire_agent` to `float(reading_or_default(wx, 'rainfall', 0.0))`. Latent-only (executed sweep evidence: no producer emits `rainfall` as None — RSM emits `False`, backend emits int), but it is a fresh inconsistent twin of the exact shape this branch exists to kill. One-line alignment.
+
+### [LOW / nit] F5 — A test docstring misstates the CLI's old crash mechanism
+
+`tests/agents/test_race_state_builder.py:182-185`: "All three pre-#784 builders crashed here via float(None)". The old CLI builder had NO `float()` wrap (`air_temp=weather.get("air_temp", 25.0)`, verified in `git show HEAD`); it crashed via Pydantic float validation rejecting None. Arcade/backend did crash via `float(None)`. 2 of 3; the conclusion (all three crashed) is right, the named mechanism is wrong for one — the same "comment naming the wrong mechanism" class recorded in the errors-gates-caught file.
+
+### [LOW / hygiene] F6 — An unrelated PNG is sitting untracked next to the work
+
+`notebooks/strategy/overtake_probability/outputs/n12b_scoreboard.png` (untracked; the IMPL log itself calls it "an unrelated PNG"). A `git add -A` would ship it inside this refactor PR. Exclude it or commit it separately.
+
+### [LOW / docs] F7 — The shipped SWEEP doc still describes the tyre_life/compound twins as UNFIXED, but this branch fixed them after the sweep ran
+
+`documents/audits/SWEEP_present_none_traps.md` F1/F2 and its closing verdict ("tire_agent.run_from_state still reads tyre_life (:1479) with the two-arg get") describe the pre-change-5 tree; the working tree now derives both via `normalise_compound`/`UNKNOWN_TYRE_LIFE` (verified at `tire_agent.py:1485-1487`, `no_llm.py:139-141`). The IMPL log records the closure, but the SWEEP file itself carries no correction note — unlike DESIGN §F11, which got one when it went stale. A reader grepping the audits later will believe :1479 is still broken. One-line addendum in the SWEEP (F1/F2 tyre_life+compound halves fixed on this branch; R1 -> #790 and R4 remain live) closes it.

--- a/documents/audits/GATE_qatar_lap7_cross_surface.md
+++ b/documents/audits/GATE_qatar_lap7_cross_surface.md
@@ -1,0 +1,190 @@
+# GATE — Qatar (Lusail 2025) lap 7 cross-surface RaceState verification (#787, over #784/#786)
+
+**Date:** 2026-08-02 · **Branch:** `refactor/single-source-race-state-builder` (working tree, uncommitted) · **Submodule:** `7f394a8` (committed in submodule, pointer not yet bumped in parent)
+
+**Role:** adversarial gate. Success = finding what is still broken. Every claim below is backed by executed evidence unless explicitly marked CODE-READ.
+
+## Scope verified on disk (not trusted from the summary)
+
+- `src/agents/race_state_builder.py` — NEW, untracked. Canonical builder, lazy `RaceState` import, `None`-means-compute for `gap_ahead_s`/`pace_delta_s`, `rival` targeting, position `ValueError` guard. CONFIRMED present.
+- `scripts/run_simulation_cli.py` — `git diff` shows exactly two hunks (L1287-1297 comment + `_build_race_state` body at L1300-1322). **The main loop has zero hunks — the byte-identical requirement on L1710-1764 holds** (verified via `git diff`, not by eye).
+- `src/arcade/strategy.py` — `_build_race_state` (L599-654) now delegates; keeps radio sourcing + stateful SC re-injection. The position `ValueError` moved AFTER `sc_tracker.ingest` (see Suspicion 1).
+- Submodule `7f394a8`: `backend/utils/race_state_builder.py` is a 24-line re-export shim; `simulator.py::_compute_gap_ahead` deleted; `_local_build_race_state` passes `pace_delta_s=0.0`, omits `gap_ahead_s`. CONFIRMED by `git show 7f394a8`.
+
+## Findings (appended as confirmed)
+
+<!-- findings appended below as they are confirmed -->
+
+### [CORE DELIVERABLE] Task 1 — field-by-field cross-surface diff, Lusail 2025 lap 7, NOR/McLaren (EXECUTED)
+
+Reference case confirmed from data, not guessed: McLaren at Lusail 2025 = **NOR (P2)** and **PIA (P1, the car ahead)**; NOR used (the thesis/memory reference driver). Lap 7 ground truth from `RaceStateManager`: lap_time 100.154, PIA 98.466, `interval_to_driver_s` −6.001, compound MEDIUM, tyre_life 7, weather.parquet real readings air 23.4 / track 29.5, **real "SAFETY CAR DEPLOYED" corpus message AT lap 7** (the V7 case is live in this data).
+
+Harness (`scratchpad/gate_harness.py`) drove the REAL paths: `run_simulation_cli._build_race_state` + the main loop's exact post-build radio/SC mutation replicated per-lap for laps 1–7; a real `SimConnector` instance through its own `_lap_skip_reason` → `_build_race_state` loop; the submodule's `_local_build_race_state` via the `backend.utils.race_state_builder` shim mirroring the SSE loop; and `/recommend`'s exact builder call with `RecommendRequest` defaults.
+
+| RaceState field | CLI (no-radios) | CLI (corpus) | Arcade | Backend SSE | /recommend defaults | Verdict |
+|---|---|---|---|---|---|---|
+| driver | NOR | NOR | NOR | NOR | NOR | AGREE |
+| lap | 7 | 7 | 7 | 7 | 7 | AGREE |
+| total_laps | 57 | 57 | 57 | 57 | 57 | AGREE |
+| position | 2 | 2 | 2 | 2 | 2 | AGREE |
+| compound | MEDIUM | MEDIUM | MEDIUM | MEDIUM | MEDIUM | AGREE |
+| tyre_life | 7 | 7 | 7 | 7 | 7 | AGREE |
+| gap_ahead_s | 6.001 | 6.001 | 6.001 | 6.001 | **2.0** | DIFFER — owned |
+| pace_delta_s | 1.688 | 1.688 | 1.688 | **0.0** | **0.0** | DIFFER — owned |
+| air_temp | 23.4 | 23.4 | 23.4 | 23.4 | 23.4 | AGREE (real reading, not default) |
+| track_temp | 29.5 | 29.5 | 29.5 | 29.5 | 29.5 | AGREE (real reading, not default) |
+| rainfall | False | False | False | False | False | AGREE |
+| risk_tolerance | 0.5 | 0.5 | 0.5 | 0.5 | 0.5 | AGREE |
+| radio_msgs | [] | [] | [] | [] | [] | AGREE (harness ran RCM-only runners — see limitation below) |
+| rcm_events | [] | 5 events | 5 events | 5 events | 5 events | DIFFER — owned |
+
+Every DIFFER has a named owner:
+- **pace_delta_s 1.688 vs 0.0** — hand-checked: 100.154 − 98.466 = 1.688 (rival-relative, #750 axis). The backend SSE pins 0.0 deliberately (`simulator.py::_local_build_race_state`, "the schema's documented neutral... switching is a separate behavioural decision"); `/recommend` forwards `RecommendRequest.pace_delta_s` whose default is 0.0. Both recorded in #784's design.
+- **gap_ahead_s 2.0 on /recommend defaults only** — `RecommendRequest.gap_ahead_s: float = GAP_UNKNOWN_FALLBACK_S` (endpoint `strategy.py:110`); the endpoint always passes an explicit float, so the canonical `None`-means-compute derivation NEVER runs on that surface even though `lap_state.rivals` carries the real 6.001. Owned difference (the webapp client supplies the value), but see the observation below.
+- **rcm_events** — surface-owned sourcing by design (builder module docstring): the CLI `--no-real-radios` profile has none; the other four carry the **byte-identical** 5-event list (verified `==` across surfaces), including the real `SAFETY CAR DEPLOYED` at lap 7. Trackers on all three stateful surfaces ended lap 7 in the same state: `active=True kind=SC deployed=7`.
+
+**Harness limitation stated plainly:** the radio-transcript half (Whisper) was not exercised in the harness — all runners ran `disable_transcription=True`, so `radio_msgs` is [] everywhere above. The rcm.parquet half (what the SC override consumes) is the real path. Real runs in Task 2 cover the rest.
+
+### [OBSERVATION / LOW] `/recommend` can never use the canonical gap derivation
+
+Not introduced by #784 (the request default predates it), but #784 built exactly the machinery (`gap_ahead_s=None` → compute from rivals) that this surface cannot reach: `RecommendRequest.gap_ahead_s` is non-Optional with a fabricated 2.0 default, so a client that omits the field gets 2.0 while the true 6.001 sits in the same request's `lap_state.rivals`. Making the request field `Optional[float] = None` would let the canonical builder derive it. Same shape in `mcp_tools.py:599`: `driver_state.get("gap_ahead_s") or GAP_UNKNOWN_FALLBACK_S` — an `or` that also maps a genuinely-measured 0.0 (leader) to 2.0, the #633 conflation in miniature, acknowledged in the builder docstring as "byte-compatible" preservation. Both recorded decisions; flagged so the follow-up is deliberate, not forgotten.
+
+### [VERIFIED-SAFE] Suspicion 1 — the Arcade's reordered `sc_tracker.ingest` cannot corrupt later laps (EXECUTED)
+
+`src/arcade/strategy.py:645` now runs `ingest` BEFORE the builder's position `ValueError` (old code raised before radio/SC sourcing). Executed experiment (`probe_tracker.py`, real `RaceControlStateTracker`, pre-classified events):
+
+- **Deploy lands on the breached lap**: breached ordering goes SC-active and injects for laps N+1..N+7; counterfactual (guard worked) never sees the SC at all. Divergence bounded by the safety valve `_MAX_SC_LAPS = 8` (`rcm_state.py:36`) — clears at deploy+8, verified by execution. The breached trajectory is the more TRUTHFUL one: the deploy was a real FIA message, so the spurious ingest adds real information, it cannot invent a neutralisation.
+- **Release on the breached lap**: breached ordering clears immediately; the counterfactual keeps injecting a stale SC until the valve. Again breached = more accurate.
+- **Malformed lap number** (arcade's `lap_state.get("lap_number", 1) or 1` falls back to 1 mid-race): the spurious `ingest(1, [])` does NOT clear an active SC (negative delta never satisfies the `>= 8` valve check) and does not touch `deployed_lap`; the valve still clears at deploy+8. Only artefact: `last_seen_lap=1` makes the next synthetic event's cosmetic `lap` field read 1 until the next real ingest.
+- **Self-feeding ruled out**: all three surfaces feed the tracker the RAW rcm list and append the synthetic to a copy (`arcade:645-647`, `run_simulation_cli.py:1705-1707`, `simulator.py:333-336`, `strategy.py endpoint:1299-1303`), so `deployed_lap` never refreshes and the valve always fires. Executed: after deploy at 5 + 10 empty ingests, tracker is cleared.
+
+Residual asymmetry worth knowing (CODE-READ): in the breach case the CLI's ordering (build raises BEFORE ingest, `run_simulation_cli.py:1660` vs `:1705`) drops the lap's real RCM from its tracker while the arcade's keeps it — a cross-surface divergence that exists ONLY when the skip-guard invariant is already broken, is bounded by the 8-lap valve, and where the arcade side is the truthful one. Not a defect; recorded so nobody "fixes" the arcade back.
+
+### [VERIFIED] Leaf-import constraint holds (EXECUTED)
+
+`import src.agents.race_state_builder` in a fresh interpreter pulls **zero** `langchain`/`langgraph`/`torch`/`xgboost`/`transformers`/`lightgbm` modules. Constants confirmed live: track 35.0 / air 25.0 / "UNKNOWN" / tyre_life 0.
+
+### [VERIFIED] Suspicion 2 — explicit `0.0` is honoured; no falsy-vs-None trap (EXECUTED)
+
+`probe_defaults.py`, real builder, synthetic lap_state with a car ahead at 6.0 s / 2.0 s pace delta:
+
+- `None`-means-compute: gap=6.0, pace=2.0 (derived). `pace_delta_s=0.0` passed: pace stays **0.0**, gap still derived (6.0). `gap_ahead_s=0.0` passed: gap stays **0.0**. Both 0.0: both stay 0.0 and the rivals lookup is skipped (`needs_car_ahead` is False).
+- The backend's deliberate pin therefore survives: `_local_build_race_state`'s `pace_delta_s=0.0` is never overwritten (`race_state_builder.py:313-316` uses `is None`, executed-verified, and the lap-7 harness shows backend pace 0.0 vs CLI/arcade 1.688).
+- `rival` targeting: present rival recomputes (VER → 2.5/1.0); absent rival falls back to the ALREADY-RESOLVED values including pinned 0.0s (executed: rival absent + pinned → 0.0/0.0, no fabrication).
+- Repo-wide grep for the trap pattern (`not pace_delta`, `pace_delta_s or`, `gap_ahead_s ... or`): the only `or`-fallbacks on these concepts are `mcp_tools.py:599` (recorded decision, see observation above) and two offline eval tools (`scripts/prompt_ab/gen_inputs.py:62`, `src/strategy/eval/decision_modes.py:303`) — none on the three runtime surfaces.
+
+### [VERIFIED] Task 3 — every accepted behavioural delta lands where claimed and nowhere else (EXECUTED)
+
+- **track_temp 40.0 → 35.0**: fires on weather-key-absent, temps-key-absent AND temps-present-None (the pre-#784 CLI would have crashed `float(None)` on present-None, and used 40.0 otherwise). Lusail is NOT perturbed: real readings 23.4/29.5 flow through on all five surface variants (harness) and in the real CLI run.
+- **compound**: `None`/`""`/`"nan"`/`"NaN"`/`"None"`/`"none"`/missing-key → `"UNKNOWN"`; `"SOFT"` and `" MEDIUM "` (stripped) pass through. Lusail lap 7 real `MEDIUM` untouched.
+- **tyre_life**: None/missing → 0; real 1 passes (no collision with fresh tyres).
+- **total_laps**: missing AND present-None → 57 with the warning logged (captured live). Lusail real 57 comes from session_meta, not the fallback (verified: no warning on the harness path).
+- **lap ladder**: top-level → driver-dict → 1-with-warning, all three rungs executed.
+- **position None fails loud on ALL surfaces**: canonical builder, CLI `_build_race_state`, Arcade `_build_race_state`, backend `_local_build_race_state`, backend shim — all raise the same `ValueError` (executed). The shim `is` the canonical function object (no second implementation).
+
+### [SELF-CORRECTED, not a finding] The `gp="Qatar"` RadioPipelineRunner rejection was this gate's own harness error
+
+First harness pass fed `gp="Qatar"` to the backend RCM feed and got "Unknown GP 'Qatar'" → zero rcm_events. Verified against the real wiring before archiving: the arcade's `app.py:358-359 _resolve_gp_name()` maps the menu label through `GP_TO_LOCATION` ("Qatar"→"Lusail") BEFORE building the DTO, so the real arcade and webapp pass "Lusail". Harness re-run with "Lusail".
+
+## Task 2 — real runs (second gate session, 2026-08-02)
+
+Scope: Arcade driven for real (offscreen Qt dashboard fed by a real `SimConnector` + real TCP stream) and the telemetry backend over real HTTP (`/lap-state`, `/recommend`, `/simulate` SSE, #788 regression proof, 2024 control). The CLI (`f1-sim`) run is owned by the orchestrating session and is NOT duplicated here. Findings appended below as they are confirmed.
+
+### [MEDIUM / env-docs] The documented backend launch command fails on a clean `uv sync` venv (EXECUTED)
+
+`PYTHONPATH="." .venv/Scripts/python.exe -m uvicorn backend.main:app --app-dir src/telemetry --port 8000` (CLAUDE.md/memory wording) died at import: `backend/mcp_tools.py:24 → ModuleNotFoundError: No module named 'fastmcp'`. `fastmcp==3.2.0` is pinned ONLY in the submodule's `requirements.txt` (Docker path) and is absent from the parent `pyproject.toml`/`uv.lock`, so any `uv sync` prunes it. This gate installed `uv pip install fastmcp==3.2.0` (environment change, no repo file touched) to proceed. Backend then started clean: `Application startup complete`, `/docs` 200.
+
+### [VERIFIED] #788 producer side, over real HTTP
+
+`GET /api/v1/strategy/lap-state?gp=Lusail&driver=NOR&lap=7&year=2025` → **200**, and the body carries exactly the #788 producer shape: `weather = {air_temp: None, track_temp: None, track_temp_start: None, humidity: None, rainfall: 0}` while every ground-truth field matches Task 1 (lap_time 100.154, position 2, MEDIUM, tyre_life 7, gap_ahead 6.001, PIA interval −6.001). 2024 control (`year=2024`, same GP/driver/lap) → **200** with REAL weather `{air_temp: 19.0, track_temp: 22.9, humidity: 54.0}`.
+
+### [VERIFIED] #788 old-vs-new builder, executed against the real HTTP payloads
+
+The pre-change builder (`git show 7f394a8^:backend/utils/race_state_builder.py`, loaded as a module — no branch switch) vs the exact `lap_state` served over HTTP:
+
+- OLD on 2025 lap 7: **raises `TypeError: float() argument must be a string or a real number, not 'NoneType'`** (`float(weather.get("air_temp", 25.0))` — present-None defeats the default). The live `/recommend` handler maps `TypeError` → 422, so this is the #788 mechanism.
+- OLD on 2024 lap 7: OK (air 19.0 / track 22.9) — the bug was 2025-only, as the issue states.
+- NEW (via the committed shim, `shim is canonical fn: True`): 2025 → OK with defaults air 25.0 / track 35.0, gap derived 6.001, pace 1.688; 2024 → OK with the real readings passing through untouched.
+
+### [HIGH] #788 is NOT fixed end-to-end: `POST /recommend` still returns 422 on the 2025 reference lap (EXECUTED, real HTTP)
+
+`POST /api/v1/strategy/recommend` with the real `/lap-state` body (Lusail 2025 lap 7 NOR, `gp_name="Lusail"`, `year=2025`) → **HTTP 422 in 56.4 s**, body:
+`{"detail":{"error":"TypeError","agent":"orchestrator","detail":"float() argument must be a string or a real number, not 'NoneType'"}}`.
+
+The canonical builder DID build the RaceState (verified in isolation above) — the crash is downstream. In-process reproduction with full traceback (same lap_state, same laps_df scoping as the endpoint):
+
+- `race_situation_agent.py:1193 predict_sc_tool` → `:1009 _build_sc_features` → `:681 _compute_weather_features` → `float(session_meta.get('TrackTemp', 38.0))` → `TypeError`.
+- The None enters at `race_situation_agent.py:1402-1404` (`run_from_state`'s session_meta build): `'AirTemp': wx.get('air_temp', 28.0)` etc. — the same present-key-None-value trap the canonical builder just fixed one layer up. Line 1416 right next to them IS guarded (`wx.get('track_temp_start') or 38.0`), and `pace_agent.py:642-644` guards the identical read with an explicit comment about this exact trap — the classic one-twin-fixed pattern.
+- Second unguarded twin, silent-wrong class: `tire_agent.py:1512-1514` stores the same Nones into its session_meta; `_add_weather_cols` (tire_agent.py:582) then fills the 2025 frame's absent AirTemp/TrackTemp/Humidity columns with **None instead of the intended race averages** — no crash, silently degraded features (probe below).
+
+Consequence: on this branch, `/recommend` for 2025 still fails — the fix moved the crash from the builder into N27. The orchestrator burns ~56 s of model warmup + sub-agent work (pace and tire complete) before dying. #788's "fixed by the canonical builder" claim holds for the BUILDER surface only, not for the endpoint the issue is actually about.
+
+### [CORE DELIVERABLE] Task A — the Arcade, driven for real (EXECUTED; what was and was not rendered, stated plainly)
+
+**What ran for real:** the full arcade strategy layer exactly as `F1ArcadeView._init_strategy_layer` wires it — a real `SimConnector` thread (model warmup, real radio corpus `qatar` with Whisper transcription ENABLED: "24 radios + 66 rcms", per-lap `run_strategy_pipeline` with real OpenAI LLM calls, laps 1–7), a real `TelemetryStreamServer` on 127.0.0.1:9998, and the REAL PySide6 dashboard (`MainWindow` + `TelemetryWindow`, the exact `__main__` wiring) in a separate process under `QT_QPA_PLATFORM=offscreen` + `QT_QPA_FONTDIR=C:/Windows/Fonts`, subscribing over real TCP and grabbed via Qt `grab()` at lap 7 + finished. Screenshots + machine payload: scratchpad `arcade_dashboard_lap7.png`, `arcade_telemetry_lap7.png`, `dashboard_last_payload.json`, `arcade_final_state.json`.
+
+**What was NOT rendered — said prominently:** the pyglet/arcade REPLAY WINDOW (track, cars, leaderboard) was not created (no GL context headless), so `current_lap_provider=None` (the documented CLI/smoke path — no playback gating) and `lap_range=(1,7)`. The TelemetryWindow rendered its LAP 7 frame but with EMPTY speed/brake/throttle traces, because per-frame telemetry comes from the pyglet replay that was not running. Every strategy-side pixel, however, is the real dashboard rendering real pipeline output.
+
+**The lap-7 rendered decision (READ from the PNG, not inferred):** header "Lusail · 2025 NOR · Connected · L 7"; orchestrator card **STAY OUT, confidence 88%**, Pace: MANAGE, Risk: BALANCED, "Pit: L12 · Next: HARD · UCUT: PIA"; scenario scores STAY +0.30 / PIT +0.21 / UCUT · OCUT "--"; PACE card pred 90.05s (chart shows the real lap-7 spike to ~100 s); TIRE "Cliff ~8 laps · L7" C2; **SITUATION "Threat HIGH", overtake 0%, safety car 100%"**; **PIT "pit 2.93s → HARD · SC", UCUT 64% → PIA**; **RADIO card: "YELLOW FLAG SECTOR · YELLOW FLAG SECTOR · SAFETY CAR DEPLOYED", "0 radios · 5 rcm", "RCM L7 SAFETY_CAR_DEPLOYED"**; **RAG "regulation loaded … no tyre changes … Art. 54.3"**; reasoning text cites the confirmed SC and Art. 54.3 overriding N28's reactive UNDERCUT.
+
+**Answer to the attack question — the SC is NOT lost:** corpus → tracker → RaceState → N27 (`sc_prob_3lap=1.0`, `threat_level=HIGH`, `overtake_prob` forced 0 per Art. 55.8) → routing (`active=['N28','N30']`, pit `sc_reactive=True` proposing UNDERCUT) → Layer-3 synthesis reasoning about Art. 54.3 → rendered card. End-to-end on the REAL rendered surface.
+
+**Lap-by-lap decisions (laps 1–7):** STAY_OUT ×7, confidence 0.98/0.97/0.98/0.94/0.95/0.91/0.88 — declining as the SC lap approaches. `finished=True`, `error=None`.
+
+**vs the CLI's owned differences:** arcade lap-7 gap_ahead_s 6.001, lap_time 100.154, MEDIUM/7, P2 — all equal to the CLI-side ground truth; radio corpus real (0 radio_msgs at lap 7 is the corpus truth for NOR, not a wiring gap — 24 radios exist for the GP); risk_tolerance 0.5 both. Decision-level comparison with the orchestrating session's `f1-sim` run is left to the orchestrator, with the arcade's numbers above as this gate's half of the diff. Note the Layer-3 non-determinism warning below before reading any confidence delta as a contract break.
+
+**Warnings captured in the arcade run (reported, not filtered):**
+1. `WARNING src.agents.tire_agent: Tire tool output did not parse for C2 (tyre_life=1) — using conservative defaults instead of a 0.0 cliff` (lap 1).
+2. `WARNING src.agents.strategy_orchestrator: Layer 3 temperature=0.0 was discarded by the client for model 'gpt-5.4-mini'. The orchestrator is sampling at the provider default, not running deterministically` — consecutive-lap confidences (and any CLI-vs-arcade decision diff) carry sampling noise by construction.
+3. `Clamping LLM expected_stint_end 12 to anchor 50 (cliff_p50=57.0)` and `… to anchor 20 (cliff_p50=8.4)` (#433) — twice.
+4. At interpreter exit: `qdrant_client … __del__ → ImportError: sys.meta_path is None, Python is likely shutting down` — benign-looking teardown noise from the RAG client lacking an explicit close; it would appear on real arcade exits too.
+
+**[LOW / explained] N27's OUTPUT gap 0.0 while RaceState carried 6.001:** the situation card shows "gap 0.0s · Δpace +0.00s/lap". Cause found at `race_situation_agent.py:752-779 _parse_tool_outputs`: output gap/pace are regex-parsed from the overtake TOOL's message; under a confirmed SC the tool text doesn't yield them and they default to 0.0. The RaceState itself carried 6.001/1.688 (Task 1). Pre-existing output convention (the endpoint's `SituationResult` docstring already owns the 0.0-vs-None tension, #633) — recorded so nobody misreads the card as a builder regression.
+
+### [VERIFIED] Task B — `/simulate` SSE, real HTTP, laps 1–7 with LLM (EXECUTED)
+
+`POST /api/v1/strategy/simulate` (`{"year":2025,"gp":"Lusail","driver":"NOR","team":"McLaren","lap_range":[1,7],"no_llm":false,"provider":"openai"}`) → **HTTP 200 in 117.8 s**, well-formed SSE: `start`, 7 `lap` events, `summary` with `{"ok_laps": 7, "error_laps": 0}`. Zero `error` events. **Lap 7's event**: STAY_OUT conf 0.98, pos 2, gap 6.001, lap_time 100.154, MEDIUM/7, reasoning citing "a confirmed Safety Car deployment from radio/RCM" + Art. 54.3 — the SC context survives this surface too (its lap_state comes from `RaceStateManager`, real weather 23.4/29.5, so the N27 crash above does NOT fire here).
+
+**Measured consequence of the owned `pace_delta_s=0.0` pin, on the reference lap:** the SSE lap-7 reasoning literally argues "the pace delta is only +0.000s, so there is no evidence of a performance falloff" and lands pit_lap_target=30, while the arcade (real pace_delta 1.688) reasons "+1.688s/lap off pace … tyre cliff P50 is lap 8.4" and lands pit_lap_target=12. Same lap, same models — the recorded "neutral" pin visibly changes the tactical plan. Not a #784 defect (the pin is a recorded decision), but its cost is now measured, not hypothetical. Confidence deltas (0.98 vs 0.88) additionally carry the documented Layer-3 sampling noise (temperature=0.0 discarded for 'gpt-5.4-mini').
+
+### [MEDIUM] The SSE payload is blind to the sub-agents on the LLM path: `agent_alerts` always [], `agents_fired.pit/radio` always 0 (EXECUTED + file:line)
+
+Observed on the real stream: lap 7 `agent_alerts=[]` and summary `agents_fired={"pit": 0, "rag": 1, "radio": 0}` — while the arcade, same lap, same rcm list, rendered 3 alerts (YELLOW ×2 + SAFETY_CAR_DEPLOYED) and an active N28 (`sc_reactive=True`). Not a routing divergence: `simulator.py::_parse_lap_decision` extracts `agent_alerts`/`_radio_out` only `if isinstance(result, dict)` (simulator.py:484-503) and the pit/radio counters only increment on the dict path (simulator.py:625-632) — the dict shape is the NO-LLM path, so with `no_llm=false` these fields are structurally empty regardless of what the agents did (`rag: 1` survives via the object-path `regulation_context` check at :634-635). The webapp's SSE consumer cannot see the SC alerts the arcade dashboard shows. Pre-existing (not introduced by #784); surfaced here because Task 1's "byte-identical rcm on four surfaces" made the empty alerts look like a lost SC — it is a payload-construction gap, with the routing itself verified equal.
+
+### [VERIFIED] Task B — 2024 control over real HTTP (EXECUTED)
+
+`POST /api/v1/strategy/recommend?year=2024` with the real 2024 lap_state → **HTTP 200 in 12.6 s**: STAY_OUT conf 0.92, pit_lap_target 13, compound_next HARD. The fix is not a 2025-only patch that broke the control case. (Backend log: Lusail 2024 radio/RCM parquets absent → ran without RCM, degraded gracefully as designed.)
+
+### [LOW-MEDIUM / latent] `/recommend`'s laps_df year is a QUERY param that can silently disagree with the body's `year`
+
+`require_laps_df(year: int = 2025)` is a FastAPI dependency, so `/recommend` exposes `?year=` (confirmed in the live openapi.json: `[('year','query',2025)]`) while `RecommendRequest.year` travels in the body. A client POSTing a 2024 body without `?year=2024` gets the 2025 frame silently — the agents then look up the driver's laps in the wrong SEASON's GP frame (the #429 family, one axis over). Pre-existing, not #784; this gate's own 2024 control had to pass BOTH to be correct.
+
+### [MEDIUM] Even after the N27 crash is fixed, the backend-producer path silently degrades the tire model on every 2025 lap (EXECUTED probe)
+
+`tire_agent.run_from_state` on the REAL backend lap_state (weather all-None) vs the same lap_state with the real RSM readings (23.4/29.5), same laps_df, same agent instance:
+
+- weather=None (backend shape): deg_rate −0.3085, **cliff P10/P50/P90 = 10.1/10.5/10.9**
+- weather=real readings: deg_rate −0.3085, **cliff P10/P50/P90 = 7.8/8.2/8.6**
+
+No crash, no warning — the Nones from `tire_agent.py:1512-1514` flow through `_add_weather_cols` (:582, `df[col] = session_meta.get(col, 0.0)` — present-None defeats the 0.0 too) into the TCN's feature frame, and the cliff estimate comes out **2.3 laps more optimistic** on the reference lap. Optimistic-wrong is the dangerous direction (delays the pit call). Scope: any 2025 request whose lap_state came from the backend producer (`/lap-state` consumers, webapp strategy tab, MCP chat tools); the SSE and arcade paths are unaffected (RSM weather is real).
+
+### Warnings inventory (both surfaces, reported unfiltered)
+
+Arcade run: tire tool parse failure lap 1 (conservative defaults); Layer-3 temperature discarded for 'gpt-5.4-mini' (non-deterministic synthesis, documented); #433 clamps ×2; qdrant_client `__del__` ImportError at interpreter shutdown (no explicit close). Backend run: same tire parse + temperature + #433 clamps (×2, different anchors) during SSE; `F1_API_KEY not set` (expected, localhost); Lusail 2024 radio/RCM parquets missing (graceful); the #788 orchestrator TypeError (the HIGH finding). Nothing else appeared in either log.
+
+### Environment deviations made by this gate (disclosed)
+
+1. `uv pip install fastmcp==3.2.0` into the parent venv (see the env-docs finding; no repo file changed).
+2. Arcade harness: no pyglet window (offscreen), `current_lap_provider=None`, `lap_range=(1,7)` — detailed in Task A above.
+3. Old-builder proof loaded `7f394a8^` module content from git history — no branch switch, working tree untouched.
+
+## What I tried to break and could not (Task 2)
+
+- **The SC chain on the arcade, end-to-end on the RENDERED surface**: corpus (Whisper ENABLED this time, 24 radios + 66 rcms) → tracker → builder → N27 forced sc_prob 1.0 / overtake 0 → N28 sc_reactive + N30 Art. 54.3 → Layer-3 override of the UNDERCUT → the STAY OUT card in the real PySide6 pixels. Held at every link.
+- **The SC chain on the SSE surface**: lap 7's event carries the confirmed-SC reasoning and Art. 54.3. Held (the alerts FIELD is blind — see the MEDIUM — but the decision itself sees the SC).
+- **The canonical builder against the real backend payloads**: 2025 all-None weather → defaults, 2024 real weather → pass-through, shim `is` the canonical function, explicit-0.0 semantics all re-confirmed against live HTTP payloads rather than synthetic dicts.
+- **The 2024 control**: could not make it regress — 200, sane recommendation, graceful no-RCM degrade.
+- **A crash or error event anywhere in the SSE stream**: 7/7 laps ok, stream well-formed, heartbeat logic untriggered (<15 laps).
+- **Cross-surface lap-7 disagreement beyond the owned differences**: every numeric field either agreed or traced to a named owner (pace pin, alerts payload gap, Layer-3 sampling). The scary-looking `agents_fired.pit=0` and `gap 0.0s` on the situation card both dissolved into located, pre-existing payload conventions (simulator.py:484-503/:625-632, race_situation_agent.py:752-779) — verified, not assumed.
+
+What I could NOT verify: the pyglet replay window itself (never rendered — stated prominently in Task A); the radio-transcript half beyond corpus load (no NOR radio lands on lap 7, so N29's transcript path stayed data-empty end-to-end); the CLI side of the decision-level diff (owned by the orchestrating session, `f1-sim` not duplicated here per instructions).

--- a/documents/audits/GATE_weather_path_findings.md
+++ b/documents/audits/GATE_weather_path_findings.md
@@ -1,0 +1,285 @@
+# GATE — Weather path findings (issue #784, branch `refactor/single-source-race-state-builder`)
+
+Adversarial verification gate, 2026-08-02. Read-only except this file; written incrementally.
+
+Claims under test:
+1. §F11's justification for the track_temp decision ("weather.parquet missing → keys absent → defaults fire" as a LIVE divergence) may be a false statement.
+2. A live backend crash: `/lap-state` for 2025 emits `weather.air_temp/track_temp = None` (key present), and `backend/utils/race_state_builder.py:114-115` does `float(weather.get(...))` → `float(None)` TypeError.
+3. A fifth undocumented default pair (25/40) at `endpoints/strategy.py:933-941`; inventory ALL default-temperature sites.
+
+## Checklist
+
+- [x] Weather parquet coverage 2023/2024/2025
+- [x] Weather parquet row counts + NaN temp rows (present-with-None reachability)
+- [x] `get_weather_state` key-emission behavior (code)
+- [x] 2025 featured parquet columns, empirically
+- [x] `augment_featured_laps` restores weather? (code + executed)
+- [x] `Series.get` + `_safe_none` empirical behavior on real row
+- [x] `build_race_state` crash reproduction on real data (true end-to-end)
+- [x] Webapp / MCP reachability of the crash
+- [x] Full default-temperature inventory (claim 3)
+
+## Verdicts (summary)
+
+- **Claim 1: CONFIRMED — the §F11 justification is a false statement in this checkout.** The
+  decision (canonical 35.0) remains right for the median reason; the "reachable today" claim is not.
+- **Claim 2: CONFIRMED — live, total outage of /recommend for 2025 races**, born 2026-07-18
+  (#465 wave), predating #784. The branch's canonical builder fixes it (proven by execution).
+- **Claim 3: CONFIRMED and EXTENDED** — the :933-941 site is real (25/40, a PRODUCER), and there
+  are two MORE pairs nobody listed: debug_agent (28/45) and arcade overlays (18/45). Five distinct
+  value pairs in the working tree.
+
+## Evidence log (appended as confirmed)
+
+### E1. Every race directory has a weather.parquet — the "missing file" premise of §F11 is counterfactual in this checkout
+
+Executed (bash file count over `data/raw/`):
+
+```
+2023: 23 race dirs, 23 with weather.parquet
+2024: 24 race dirs, 24 with weather.parquet
+2025: 24 race dirs, 24 with weather.parquet
+```
+
+No race directory lacks the file. The only dirs without one are `data/raw/radio_audio/*` (not races).
+
+### E2. Code path facts (cited, verified by reading this checkout)
+
+- `src/simulation/replay_engine.py:80-90` — loads `weather.parquet` whenever it exists (degrades to `None` only on read failure, with a stderr warning); `:137` passes `self._weather_df` into `rsm.get_lap_state(lap, self._weather_df)` on every lap. Both CLI and Arcade replay go through this.
+- `src/simulation/race_state_manager.py:470-472` — with `weather_df=None` OR an EMPTY frame (`not weather_df.empty` guard), the weather dict is `{"track_status": ...}` only → temperature KEYS ABSENT.
+- `race_state_manager.py:478-482` — with a non-empty weather_df, keys are ALWAYS present; values become `None` only when the selected row's reading `pd.isna(...)` — present-with-None, which the consumer `.get(key, default)` does NOT catch.
+
+So the default-firing branch on the replay path requires: weather.parquet missing, unreadable, or zero-row. E1 rules out "missing" for every race in the dataset. Row counts and NaN scan below.
+
+### E3. Backend flow facts (cited)
+
+- `backend/utils/laps_cache.py:29-40` (`get_laps_df`) DOES call `augment_featured_laps` — the CLAUDE.md "every consumer" rule holds here.
+- `src/f1_strat_manager/laps_augment.py` `RAW_COLUMNS_TO_RESTORE = {"Time": "Time_s", "TrackStatus": "TrackStatus"}` — weather columns are NOT restored by augmentation.
+- `/lap-state` producer `endpoints/strategy.py:574-583`: `weather = {"air_temp": _safe_none(r.get("AirTemp")), "track_temp": _safe_none(r.get("TrackTemp")), ...}` — keys unconditionally present.
+- `backend/utils/race_state_builder.py:114-115`: `float(weather.get("air_temp", 25.0))` / `float(weather.get("track_temp", 35.0))` — default fires only on MISSING key. Lines 89-103 of the SAME FILE document this exact dead-default class for `position` (#465) and fix it there — but not for weather. The twin that never got the fix.
+- Reachability chain 1 (webapp): `webapp/src/features/strategy/queries.ts:160-161` — `fetchLapState(...)` then `runRecommend(lapState, ...)`; `lib/api/strategy.ts:322` GETs `lap-state`, `:352` posts `lap_state: lapState` verbatim to `/recommend`; `endpoints/strategy.py:1349` feeds it to `build_race_state`. No sanitisation between.
+- Reachability chain 2 (chat/MCP): `backend/mcp_tools.py:397-413` `_build_lap_state` delegates to the SAME `get_lap_state` producer; `:583-595` `recommend_strategy` feeds it to `build_race_state`.
+
+### E4. Claim 2 empirics — CONFIRMED on real data (executed `uv run python`, script `gate_claim2.py`)
+
+```
+featured parquet columns (pre-augment):
+  2023: 53 cols, 22106 rows, weather cols present: [AirTemp, TrackTemp, Humidity, Rainfall]
+  2024: 53 cols, 23256 rows, weather cols present: [AirTemp, TrackTemp, Humidity, Rainfall]
+  2025: 48 cols, 22760 rows, weather cols present: NONE          <- #782 confirmed
+after augment_featured_laps(df25, 2025): 50 cols, weather cols: NONE
+  columns ADDED by augmentation: ['Time_s', 'TrackStatus']       <- augmentation does NOT restore weather
+
+Lusail 2025 NOR lap 30 (real row through the producer's exact code):
+  r.get('AirTemp')            -> None   (pandas Series.get on a missing index label returns None)
+  _safe_none(r.get('AirTemp')) -> None
+  producer weather dict: {'air_temp': None, 'track_temp': None, 'humidity': None, 'rainfall': 0}
+  'air_temp' in weather: True
+  weather.get('air_temp', 25.0) -> None   <- the .get default does NOT fire (key present)
+  float(weather.get('air_temp', 25.0))    -> TypeError: float() argument must be ... not 'NoneType'
+
+2024 row (Austin): r.get('AirTemp') -> 28.1, TrackTemp -> 47.2   <- 2023/2024 paths get real floats
+raw fallback data/raw/2025/Lusail/laps.parquet: 35 cols, weather cols: NONE
+  <- the raw-parquet fallback branch of /lap-state ALSO emits None weather for 2025;
+     there is no branch of this producer that yields a temperature for a 2025 race.
+```
+
+So for EVERY 2025 lap served by `/lap-state` (featured or raw fallback), `weather.air_temp` and
+`weather.track_temp` are key-present-value-None, and the current backend builder's
+`float(weather.get(...))` at `backend/utils/race_state_builder.py:114-115` raises TypeError.
+
+Severity nuance: `/recommend` wraps the call in `except (KeyError, TypeError, ValueError)` at
+`endpoints/strategy.py:1365-1367` -> HTTP 422 "orchestrator validation error", NOT a 500 traceback.
+It is a total functional outage of /recommend for 2025 races (the year the webapp defaults to,
+`year: int = 2025` at `:411`), presented as a client-input error.
+
+### E5. Claim 2 — TRUE end-to-end executed (real producer -> real builder, no replication)
+
+```
+get_lap_state(gp='Lusail', driver='NOR', lap=30, year=2025)   [the real backend function]
+  weather emitted: {'air_temp': None, 'track_temp': None, 'track_temp_start': None,
+                    'humidity': None, 'rainfall': 0}
+backend.utils.race_state_builder.build_race_state(that_lap_state)
+  -> TypeError: float() argument must be a string or a real number, not 'NoneType'
+
+CONTROL get_lap_state(..., year=2024): weather {'air_temp': 18.6, 'track_temp': 22.5, ...}
+  -> RaceState built OK (air_temp=18.6, track_temp=22.5)
+
+NEW canonical builder (src/agents/race_state_builder.py, this branch) on the SAME 2025 state:
+  -> NO crash; air_temp=25.0, track_temp=35.0, rainfall=False
+```
+
+### E6. Claim 2 — when the crash was born (submodule git archaeology)
+
+- `float(weather.get("air_temp"...))` builder shape: commit `ff44813` 2026-04-10.
+- `_safe_none(r.get("AirTemp"))` in the /lap-state producer: commit `84b561e` 2026-07-18
+  ("harden the strategy backend against the Fable audit", the #465 wave).
+- BEFORE 84b561e the producer read `float(_safe(r.get("AirTemp", 25)))` /
+  `float(_safe(r.get("TrackTemp", 40)))` (84b561e^ lines 485-486): for 2025 the missing
+  column made `Series.get`'s default fire -> every 2025 lap got a FABRICATED 25/40, no crash.
+- So: pre-2026-07-18 = silent fabrication bug; post-2026-07-18 = hard 422 outage. The crash
+  PREDATES #784 (it is on `main` of the submodule today) and was INTRODUCED by the #465 fix,
+  which honoured the None contract in the producer but never updated the consumer 100 lines
+  away in the same repo — `backend/utils/race_state_builder.py:89-103` fixed exactly this
+  class for `position` in the SAME commit wave and left `air_temp`/`track_temp` at :114-115
+  untouched. Textbook twin-not-fixed.
+- Blast radius: webapp Strategy tab pins `const YEAR = 2025` (`webapp/src/lib/api/strategy.ts:244`)
+  and `RACE_YEAR = 2025` (`race.ts:17`) -> the DEFAULT year of the surface is the broken one.
+  MCP chat `recommend_strategy` defaults `year: int = 2025` (`mcp_tools.py:570`) -> same.
+  2023/2024 unaffected (featured parquets carry real weather columns, E4).
+
+**CLAIM 2 VERDICT: CONFIRMED**, and it is a PRE-EXISTING live bug (born 2026-07-18, #465 wave),
+not introduced by #784. The branch's canonical builder demonstrably fixes it (E5). Reproduction:
+POST /api/v1/strategy/recommend with the verbatim output of GET /lap-state?gp=Lusail&driver=NOR&lap=30&year=2025
+-> 422 "orchestrator validation error" on every 2025 lap of every 2025 GP.
+
+### E7. Claim 1 — the replay-path default branch is UNREACHABLE with the shipped dataset
+
+Executed scan of all 71 `data/raw/<year>/<gp>/weather.parquet` files (script `gate_claim1.py`):
+
+```
+scanned: 71 weather parquets; unreadable: 0; empty: 0
+files with NaN/absent AirTemp:  NONE
+files with NaN/absent TrackTemp: NONE
+files whose FIRST row TrackTemp is NaN (track_temp_start=None risk): NONE
+row counts: min 108, max 223
+```
+
+Combined with the code path (E2):
+
+- Keys-ABSENT (the branch §F11 says "fires every default") requires weather.parquet missing,
+  unreadable, or zero-row (`race_state_manager.py:472` guards `is not None and not empty`).
+  In this checkout: 71/71 present (E1), 71/71 readable, 71/71 non-empty. **Unreachable.**
+- Present-with-None (`:478-479`, NaN reading -> None) requires a NaN temperature in the selected
+  row. Zero NaN readings exist in any of the 71 files. **Also unreachable today** — but F11's
+  characterisation of THAT branch (crashes the pre-branch builders; `.get` default cannot catch
+  it) is CORRECT as a hazard class, and the canonical builder's None-as-missing read fixes it.
+- `replay_engine.py:82-90` treats weather as optional BY DESIGN (a future race dir without the
+  file, a corrupt download, a live feed without weather would take the degraded branch), so the
+  branch is latent-defensive, not dead code. But it is NOT "a real, reachable, surface-dependent
+  model-input divergence today" on any of the 71 races the project ships. The CLI's 40.0 (dev
+  `scripts/run_simulation_cli.py:1370-1371`) vs Arcade's 35.0 (dev `src/arcade/strategy.py:709-710`)
+  never actually diverged on shipped data: on every race both received real temperatures.
+
+**Where a 40-vs-35 divergence IS real today:** not on the replay path but between backend
+endpoints for 2025 — `/pace-range` fabricates track_temp=40.0 (E8 site #6) while `/pace` via
+/lap-state + the pace agent's None-safe default yields 35.0 for the same lap.
+
+**Verdict:** the DECISION (35.0 canonical) is right and stands on the measured-median argument
+(35.0 IS the dataset median, 40.0 matches nothing measured). The recorded JUSTIFICATION — "when
+weather.parquet is missing for a race ... every default fires", presented as reachable today — is
+counterfactual for every race in `data/`, exactly the failure mode CLAUDE.md §11 (2026-07-16)
+already recorded for this same path. §F11's weather bullet and any echo of it in issue #784 need
+rewording from "live divergence today" to "latent divergence on degraded/foreign inputs; the live
+divergences are on the backend surfaces (E8)". The false premise has already propagated: the NEW
+module's own docstring repeats it (`src/agents/race_state_builder.py:7`, "races with no weather
+parquet").
+
+### E8. Claim 3 — complete inventory of default air/track temperature sites
+
+Legend: PRODUCER = fabricates a reading into a lap_state/feature source before the contract;
+CONSUMER = fills a gap after reading it. None-safe = catches present-with-None; dead-.get =
+fires on missing key only.
+
+**Pair (25.0, 35.0):**
+1. `src/agents/race_state_builder.py:78-79, 336-337` — canonical, this branch; CLI
+   (`run_simulation_cli.py:1287-1305`) and arcade (`src/arcade/strategy.py:599-649`) now
+   delegate here. CONSUMER, None-safe (`_weather_reading` :201).
+2. `src/telemetry/backend/utils/race_state_builder.py:114-115` — CONSUMER, dead-.get -> the E5
+   crash. Same file fixed this exact class for `position` at :89-103 and left weather untouched.
+3. `src/agents/pace_agent.py:642-643` — CONSUMER, None-safe.
+4. `scripts/prompt_ab/gen_inputs.py:65-66` — CONSUMER, None-safe (`or`).
+5. `src/strategy/eval/decision_modes.py:304-305` — CONSUMER, None-safe (`or`).
+
+**Pair (25, 40):**
+6. `src/telemetry/backend/api/v1/endpoints/strategy.py:934-935` (`_build_lap_state_from_row`
+   :890; sole caller `/pace-range` :695) — PRODUCER. For 2025 the columns are absent, so
+   `Series.get`'s default DOES fire: every 2025 lap of the Lab pace chart runs the pace model
+   with fabricated track_temp=40.0, while `/pace` uses 35.0 for the same lap (via the None-safe
+   consumer #3). Also carries `_s` NaN->0 on 2023/24 NaN rows (none shipped).
+7. (dev, pre-branch) `scripts/run_simulation_cli.py:1370-1371` — CONSUMER, dead-.get; replaced
+   on this branch by #1.
+8. (historical) the /lap-state producer until submodule commit `84b561e` 2026-07-18
+   (`84b561e^` :485-486) — PRODUCER, fabricated 25/40 for every 2025 lap until #465 honoured None.
+
+**Pair (28.0, 38.0):**
+9. `src/agents/tire_agent.py:1440-1442` (run() path) — CONSUMER, dead-.get, float-wrapped.
+10. `src/agents/tire_agent.py:1512-1514` (run_from_state) — CONSUMER, dead-.get, NO float wrap:
+    a present-None (every 2025 backend lap_state) passes THROUGH the 28.0/38.0 default as None
+    into the TCN feature dict — silent None/NaN feature, no crash. Same class as E5, different
+    symptom.
+11. `src/agents/race_situation_agent.py:681-684` — CONSUMER of session_meta (backend
+    session_meta carries no temps -> fires for real; `track_temp_start` cascades to 38.0 ->
+    track_temp_delta=0, the #486 residue).
+12. `src/agents/race_situation_agent.py:1316-1319` (run(), FastF1 path) — PRODUCER-side
+    fabrication when the live weather frame lacks the column.
+13. `src/agents/race_situation_agent.py:1402-1405` (run_from_state) — CONSUMER, dead-.get,
+    same None-passthrough as #10.
+14. `src/telemetry/backend/api/v1/endpoints/strategy.py:1022-1025` (`/tire-range`) — PRODUCER:
+    UNCONDITIONALLY fabricates `agent.session_meta` AirTemp=28.0/TrackTemp=38.0 for EVERY year,
+    even 2023/24 where real readings exist in the very gp_df scoped two lines above.
+
+**Pair (28.0, 45.0)** — MISSED by the known-so-far list:
+15. `scripts/debug_agent.py:179-180` and `:306-307` — CONSUMER (debug harness). track 45.0
+    matches nothing else in the repo.
+
+**Pair (18.0, 45.0)** — MISSED by the known-so-far list:
+16. `src/arcade/overlays.py:129-130` — CONSUMER, display-only (weather HUD): shows 45.0 C track /
+    18.0 C air when a frame lacks weather. Never reaches a model.
+
+**Count: FIVE distinct value pairs in the working tree** — (25,35), (25,40), (28,38), (28,45),
+(18,45). The claim's ":933-941 is a fifth set" is right that the site is real and undocumented,
+but its pair (25/40) DUPLICATES the old CLI pair; the genuinely new pairs are #15 and #16.
+Producer sites (#6, #14, #12) fabricate before the contract and are NOT #784's scope (a builder
+cannot undo an upstream fabrication). Consumer site #2 (the crash) IS fixed by #784; #10/#13
+need the same None-as-missing treatment or an upstream weather restore.
+
+**The #486 history, briefly:** N14's `track_temp_delta = track_temp - track_temp_start` is its
+5th-most-important feature. `track_temp_start` used to live only in session_meta while the
+consumer read `wx['track_temp_start']`, so it fell back to "current track_temp" and the delta
+was 0.0 on every lap — a live feature reading a constant. The fix shipped it in the weather dict
+at every producer (`race_state_manager.py:483-499`, `endpoints/strategy.py:577-580, 936-938`).
+The 38.0 at `race_situation_agent.py:684` is the residual session_meta-path default — and on
+2025 backend paths `_session_track_temp_start` (`endpoints/strategy.py:785`) returns None (no
+TrackTemp column), so the #486 symptom (delta=0.0) is BACK on the season the webapp serves, via
+the same missing-columns root cause as E4 (#782).
+
+## What I tried to break and could NOT
+
+1. **The canonical builder's None handling** — fed it the real, crashing 2025 lap_state (E5):
+   built RaceState with 25.0/35.0/rainfall=False. No counterexample found.
+2. **The "augmentation restores weather" escape for claim 2** — executed `augment_featured_laps`
+   on the real 2025 parquet: adds only Time_s + TrackStatus. The CLAUDE.md "every consumer calls
+   augment" rule IS honoured by `laps_cache.py:24-40`; it just does not restore weather.
+3. **The raw-fallback escape** — all 24 `data/raw/2025/*/laps.parquet` lack AirTemp/TrackTemp
+   (executed scan): no /lap-state branch can produce a 2025 temperature.
+4. **A sanitising layer between /lap-state and /recommend** — `queries.ts:160-161`,
+   `lib/api/strategy.ts:322,352`, `mcp_tools.py:397-413,583-595`: the dict passes verbatim on
+   both surfaces.
+5. **Claim 1's rescue** — searched for ANY missing/empty/corrupt weather.parquet, any NaN
+   temperature, any zero-row frame across all 71 races (executed): none. I could not make the
+   replay-path weather defaults fire with shipped data.
+6. **A 2023/2024 instance of the claim-2 crash** — those featured parquets carry real weather
+   values (control: Lusail 2024 18.6/22.5 builds fine); not reproducible there.
+
+## Recommendations for #784
+
+1. **Correct §F11's weather bullet and any issue text quoting it**: the replay-path divergence is
+   latent (degraded/foreign inputs), not "reachable today"; the 35.0 decision stands on the
+   median argument alone. Also fix the same premise in the new module's docstring
+   (`src/agents/race_state_builder.py:7`).
+2. **Upgrade #784's backend claim**: migrating the backend builder is not just deduplication —
+   it FIXES a live 422 outage of /recommend for every 2025 lap on the webapp Strategy tab
+   (YEAR=2025 pinned, `lib/api/strategy.ts:244`, `search.ts:22`) and MCP chat (default year
+   2025). That deserves its own bug issue (pre-existing, born in the #465 wave, 2026-07-18)
+   closed by the #784 PR, with the E5 reproduction as the body.
+3. **File separately (NOT #784 scope):** (a) /pace-range's 25/40 producer fabrication (site #6)
+   and /tire-range's unconditional 28/38 session_meta (site #14); (b) the None-passthrough in
+   tire/race_situation run_from_state (sites #10/#13) silently degrading every 2025 backend
+   call; (c) the #486 regression-by-data (track_temp_delta=0 on 2025). All three share the root
+   cause of E4 — the featured-2025 parquet's missing weather columns (#782); restoring those
+   columns (or augmenting them from weather.parquet) would heal (a), (b), (c) AND reduce the
+   blast radius of any future dead-default twin.
+4. Sites #15/#16 (debug 28/45, HUD 18/45) are cosmetic; one-line follow-up at most.
+
+

--- a/documents/audits/IMPL_race_state_single_contract.md
+++ b/documents/audits/IMPL_race_state_single_contract.md
@@ -1,0 +1,298 @@
+# IMPL LOG — Single canonical RaceState builder (#784, parent-repo half)
+
+**Date:** 2026-08-02 · **Branch:** `refactor/single-source-race-state-builder` (off `dev`)
+**Scope:** parent repo only. `src/telemetry/` (submodule) untouched by design — its re-export
+shim is the separate next step.
+
+Progress is appended as it happens, per the incremental-persistence rule.
+
+## Plan
+
+1. New leaf module `src/agents/race_state_builder.py` (lazy `RaceState` import).
+2. Rewire `src/arcade/strategy.py::_build_race_state` → delegation (radio/RCM sourcing stays).
+3. Rewire `scripts/run_simulation_cli.py::_build_race_state` → body-only delegation (PMV surgical).
+4. `tests/agents/test_race_state_builder.py`.
+5. Verify: new tests · suite deltas vs baseline · ruff · real `f1-sim Budapest NOR McLaren`.
+
+## Log
+
+- **[start]** Branch confirmed `refactor/single-source-race-state-builder`; working tree clean
+  except the design doc + an unrelated PNG. Baseline
+  `uv run pytest tests/agents/ tests/audit/ tests/simulation/ -q` launched in background BEFORE
+  any edit, to have a real delta reference.
+- Read and confirmed against the design gate: backend builder at
+  `src/telemetry/backend/utils/race_state_builder.py` (`_targeting_against_rival` at :7-50,
+  builder at :53-120), arcade at `src/arcade/strategy.py:599-715`, CLI at
+  `scripts/run_simulation_cli.py:1304-1373` + post-construction radio block :1710-1764.
+  CLI's `_GAP_UNKNOWN_FALLBACK_S` import (:1299-1301) is used ONLY inside the body being
+  replaced → it and its now-false comment block (:1290-1298) get replaced by the new import,
+  not left orphaned.
+- **BASELINE:** `uv run pytest tests/agents/ tests/audit/ tests/simulation/ -q` →
+  **163 passed**, 169.89s, exit 0.
+- **[1. new module]** `src/agents/race_state_builder.py` written. Constants
+  (`UNKNOWN_COMPOUND` + marker set, `UNKNOWN_TYRE_LIFE=0`, `DEFAULT_AIR_TEMP_C=25.0`,
+  `DEFAULT_TRACK_TEMP_C=35.0`) each carry their F10 measurement in a comment;
+  `total_laps` imports `DEFAULT_TOTAL_LAPS` from `_shared_defaults` (57 never restated).
+  `_targeting_against_rival` ported VERBATIM (docstring included). Helpers:
+  `_car_ahead`, `_gap_to_car_ahead` (two-zeros rationale + honest-2.0 caveat moved here
+  from the arcade comment), `_pace_delta_vs_car_ahead` (#750 wording preserved from the
+  CLI comment), `_normalise_compound`, `_weather_reading` (present-but-None as missing,
+  same pattern as `pace_agent.py:642-643`), `_resolve_lap`, `_resolve_total_laps` (both
+  loud on fallback). `RaceState` imported lazily inside `build_race_state`. The
+  frozen-RaceState/CLI-mutation coupling is recorded in the module docstring, plus a
+  WHERE-TO-CHANGE consumer list.
+- **[2. arcade]** `src/arcade/strategy.py::_build_race_state` rewired: keeps the
+  radio/RCM sourcing from `self._radio_runner` + the stateful SC re-injection
+  (byte-identical logic), then delegates with
+  `risk_tolerance=self._request.risk_tolerance` and the two lists as params. The false
+  "duplicate ... so the arcade stays independent of backend.utils.race_state_builder"
+  docstring replaced with the accurate delegation one; `prev_lap_time` paragraph kept
+  as-is (out of scope). The long gap/pace comments moved to the canonical module, not
+  deleted. Lazy imports of `GAP_UNKNOWN_FALLBACK_S`/`RaceState` dropped (no longer used).
+  **One deliberate ordering note:** the position fail-loud now fires INSIDE the builder,
+  i.e. AFTER the radio/SC-tracker sourcing, whereas the old body raised before it. That
+  path is only reachable when `_lap_skip_reason`'s invariant already broke (the method's
+  own contract), so one extra `sc_tracker.ingest` on an errored lap is the only delta;
+  the audit test covering exactly this path still passes (below).
+- **[3. CLI]** `scripts/run_simulation_cli.py`: import block :1290-1301 (comment +
+  `_GAP_UNKNOWN_FALLBACK_S`) replaced by an accurate comment + `from
+  src.agents.race_state_builder import build_race_state  # noqa: E402`; the body of
+  `_build_race_state` replaced by `return build_race_state(lap_state, driver=driver_code)`
+  with the docstring updated (delegation + where the reasoning lives + the kept
+  `prev_lap_time` note). Signature and call site (:1711) untouched. **Surgical-edit
+  proof:** `git diff scripts/run_simulation_cli.py` shows exactly TWO hunks
+  (`@@ -1287,18 +1287,12 @@` and `@@ -1306,71 +1300,24 @@`); the radio/RCM main-loop
+  block 1710-1764 is byte-identical (no hunk touches it).
+- **[4. tests]** `tests/agents/test_race_state_builder.py` — 29 tests, two tiers:
+  pure-helper + leaf-guard tests run with no models/submodule; `build_race_state` tests
+  carry the sibling `data/models/lap_time` skipif (same convention as
+  `test_prev_lap_default_is_single_sourced.py`). The leaf test runs a FRESH subprocess
+  (`sys.executable -c`) asserting no `langchain*`/`langgraph*` module is loaded by
+  importing the builder. Every literal asserted against the module constant, never a
+  restated number.
+
+## Verification evidence (all executed)
+
+1. `uv run pytest tests/agents/test_race_state_builder.py -v` → **29 passed** in 12.01s.
+2. `uv run pytest tests/agents/ tests/audit/ tests/simulation/ -q` → **192 passed**
+   (baseline 163 + 29 new, **zero new failures**), 176.79s.
+3. `uvx ruff check src/agents/race_state_builder.py src/arcade/strategy.py
+   scripts/run_simulation_cli.py tests/agents/test_race_state_builder.py` →
+   "All checks passed!". (`ruff format` deliberately not run on `src/agents/**` — the
+   pyproject excludes it from formatting.)
+4. **Real PMV run:** `uv run f1-sim Budapest NOR McLaren --no-real-radios --no-llm` →
+   exit 0, "**All 70 lap(s) OK**", positions **P5 → P1 (+4)**, actions
+   **STAY_OUT·61 / PIT_NOW·5 / UNDERCUT·4**, final stint HARD/40, 1 compound switch,
+   wallclock 39.3s (0.6s/lap), best lap 79.918s. No `[ERROR]` rows.
+5. **Arcade (no GUI run, architectural evidence instead):**
+   `tests/audit/test_engine_scope_defaults.py::test_build_race_state_fails_loudly_instead_of_defaulting_position`
+   constructs a real `SimConnector` and calls the rewired `_build_race_state` end-to-end
+   (radio sourcing path with runner=None, SC tracker ingest, delegation, ValueError with
+   "position" in the message) — green in run 2. Grep confirms no other caller of the
+   arcade method and no test matching the old error-message strings.
+6. **Extra safety:** `uv run pytest tests/surfaces/ tests/infra/ -q` → **89 passed,
+   5 skipped** (missing optional deps + missing Qatar parquets). The PROCESS exits
+   -1073740004 (native crash during interpreter teardown, AFTER the full green summary).
+   **Verified pre-existing:** stashing only `run_simulation_cli.py` + `strategy.py` and
+   re-running reproduces the identical exit code with identical 89 passed/5 skipped —
+   unrelated to this change (test_dep_imports imports torch/whisper/onnx; known
+   teardown-crash shape on Windows).
+
+## Not done / open
+
+- `src/telemetry/**` untouched (by design): the backend still runs its own copy until
+  the submodule re-export commit + pointer bump land. The twin exists knowingly until
+  step 3 of the #784 sequence.
+- No commit, no push — working tree left dirty for orchestrator review.
+- The submodule showed `modified: src/telemetry (untracked content)` at session START —
+  pre-existing, not created here, not touched.
+
+---
+
+# Submodule half (#786) — `src/telemetry` (F1_Telemetry_Manager)
+
+Appended by the #786 implementation agent, 2026-08-02. Parent half above untouched.
+
+## What changed (2 files, +35/−168)
+
+1. **`backend/utils/race_state_builder.py` → re-export shim.** The whole local
+   implementation (module `_targeting_against_rival` + `build_race_state`) is replaced by
+   `from src.agents.race_state_builder import build_race_state` plus a docstring
+   explaining the seam. Before deleting, `_targeting_against_rival` was AST-extracted
+   from both files and compared: **source-identical, byte for byte** (`IDENTICAL SOURCE:
+   True`), so nothing was silently discarded. No other module imports
+   `_targeting_against_rival` (grep across the submodule: only its own definition/use).
+2. **`services/simulation/simulator.py`** — deleted `_compute_gap_ahead` (the fourth gap
+   copy, old lines 245-279) and its now-dead `GAP_UNKNOWN_FALLBACK_S` import (old line
+   30, used nowhere else in the file); `_local_build_race_state` stops passing
+   `gap_ahead_s` so the canonical builder derives it (None-means-compute), and its
+   docstring now says so instead of claiming it computes the gap from the rivals list.
+   `pace_delta_s` stays pinned at `0.0` (the #750 neutral) — the canonical builder could
+   now derive the rival-relative delta, but that is a real behavioural change to the
+   prompt and deliberately NOT taken under #786.
+
+## The `position is None` reachability question — answered
+
+The design gate's claim holds, and the concern is doubly moot:
+
+- `_local_build_race_state` has **exactly one caller** in the entire submodule:
+  `simulator.py:877` (grep over `src/telemetry/**`; no test imports it). That caller is
+  guarded at `:870` by `_lap_skip_reason`, which returns
+  `"incomplete lap (position is None)"` and `continue`s BEFORE the builder.
+- Even on a hypothetical breach of that guard, **the old code raised too**: the pre-#786
+  submodule `build_race_state` itself raised `ValueError` on `position is None` (old
+  lines 98-103). Old flow: `_compute_gap_ahead` returned a silent `0.0`, which was then
+  fed into a builder that raised anyway. So "silent 0.0 → raised exception" was never a
+  real delta — the 0.0 never survived to a `RaceState`. The per-lap
+  `try/except Exception` at `:875/:926` turns it into an SSE `error` event either way.
+
+## Call-site compatibility (the three untouched sites, argument-by-argument)
+
+- `simulator.py:~395` (`_local_build_race_state`): passes `pace_delta_s=0.0`,
+  `risk_tolerance`, `rcm_events` as kwargs → all exist on the canonical signature;
+  `gap_ahead_s` intentionally dropped (see above); `radio_msgs` omitted → `[]` both
+  before and after.
+- `api/v1/endpoints/strategy.py:1349` (`/recommend`): passes
+  `gap_ahead_s=request.gap_ahead_s`, `pace_delta_s=request.pace_delta_s` —
+  `RecommendRequest` declares both as **non-Optional floats with defaults**
+  (`strategy.py:110-111`), so they are never `None` and the canonical builder uses them
+  unchanged (client-override semantics identical). `risk_tolerance`, `radio_msgs`,
+  `rcm_events`, `rival` all map 1:1.
+- `mcp_tools.py:595`: `gap_ahead_s=driver_state.get("gap_ahead_s") or
+  GAP_UNKNOWN_FALLBACK_S` (never None), `pace_delta_s=0.0`, `radio_msgs=None` /
+  `rcm_events=None` → canonical maps None → `[]`, same as the old `or []`. Maps 1:1.
+
+All three call by keyword only; the canonical signature's extra `driver=None` kwarg is
+inert for them. **Zero changes needed — none made.**
+
+## Behavioural deltas the backend inherits by adoption (named, intended per #784)
+
+- `compound`: missing-key default `"MEDIUM"` → `"UNKNOWN"`, **plus** normalisation of
+  the live `"nan"`/`""`/`"None"` spellings (the delta that fires on real data).
+- `tyre_life` missing-key default `1` → `0`; `lap` resolution gains the driver-dict
+  fallback + `int()` cast; `total_laps` literal `57` → `DEFAULT_TOTAL_LAPS` (verified
+  `== 57`) + warning; present-but-`None` weather values now fall back instead of
+  crashing `float(None)`.
+- The `ValueError` message for position-None laps changes text (old: "Cannot build
+  RaceState: driver position is unknown…"; canonical: "build_race_state: driver position
+  is None…(#628, #465)"). `/recommend` returns it inside the 422 detail, so API clients
+  see the new wording. No submodule test asserts on the old string (grepped).
+
+## Verification (executed, real outputs)
+
+1. Shim identity, from parent root with `.venv/Scripts/python.exe` (sys.path = parent
+   root + `src/telemetry`): `backend.utils.race_state_builder.build_race_state IS
+   src.agents.race_state_builder.build_race_state` → **True**; `langchain` NOT in
+   `sys.modules` after the shim import (leaf discipline preserved).
+2. Submodule suite: `cd src/telemetry && PYTHONPATH="../..;." ../../.venv/Scripts/python.exe
+   -m pytest tests/ -q` → **116 passed, 1 skipped, 1 xfailed** in 9.44s. The skip is
+   `test_strategy_audit_fixes.py` at collection: `could not import 'fastmcp'` — the
+   parent venv does not carry the submodule-only `fastmcp` dep. **Pre-existing, not
+   caused by this change** (the skip guard is the module's own `importorskip`, present
+   on `main`). Not re-run under a submodule-local venv — noted as the one thing not
+   verified here; the submodule's own CI will run it deps-lite (where it skips on
+   pandas by design).
+3. End-to-end exercise of the absorbed gap logic through the real
+   `_local_build_race_state`: car ahead at −1.8 s → `gap_ahead_s=1.8`; interval `None` →
+   `GAP_UNKNOWN_FALLBACK_S=2.0` (the #633 distinction survives); leader → `0.0`;
+   `pace_delta_s=0.0` pinned. `hasattr(simulator, '_compute_gap_ahead')` → False.
+4. Ruff, submodule has no config of its own (no `[tool.ruff]`, no ruff.toml — CI runs
+   `--select=E9,F63,F7,F82`): CI-parity select → "All checks passed!"; full default
+   select on both touched files → "All checks passed!".
+
+## Not done / open (submodule half)
+
+- Commit made inside the submodule on `main`; **not pushed**; parent pointer NOT bumped
+  (orchestrator's step 3).
+- The real-run acceptance item (`/simulate` SSE + `/recommend` on Qatar 2025) belongs to
+  #787 per the issue text — not run here.
+- Untracked `.claude/` and `docs/migration/streamlit-reference/` in the submodule left
+  untouched, as instructed.
+
+---
+
+## CLI real runs on the Qatar 2025 reference case (orchestrator, #787 Task 2)
+
+Race directory `data/raw/2025/Lusail`, driver NOR, McLaren. Note the CLI takes the
+LOCATION name (`Lusail`), not the menu label (`Qatar`) — `GP_TO_LOCATION` maps the latter
+only inside the Arcade/webapp entry points.
+
+| Run | Command | Result |
+|---|---|---|
+| Deterministic, corpus disabled | `f1-sim Lusail NOR McLaren --no-real-radios --no-llm` | exit 0 · all 57 laps OK · P3 → P4 · STAY_OUT·55 UNDERCUT·2 · 0 errors · 99.2 s |
+| Deterministic, **real corpus** | `f1-sim Lusail NOR McLaren --no-llm` | exit 0 · all 57 laps OK · P3 → P4 · STAY_OUT·52 **PIT_NOW·3** UNDERCUT·2 · radio alerts 20 · **radio src corpus/24r·66rcm** · 253.3 s |
+
+The second run is the one that matters, and the first is why. `--no-real-radios` disables the
+OpenF1 corpus, which is exactly where lap 7's real `SAFETY CAR DEPLOYED` message lives — so the
+first run exercised the builder but NOT the reference case. Re-running with the corpus enabled
+ingested 24 radios and 66 RCM events and moved the decision distribution (three `PIT_NOW` laps
+appear that the corpus-disabled run never produced). That difference is the evidence that
+`radio_msgs`/`rcm_events` still reach the agents after the builder stopped populating them
+itself: the parameter-not-internal decision preserved the path end to end.
+
+Verified as NOT a regression from this change:
+- `Tire tool output did not parse for C2 (tyre_life=1)` appears 3 times in 57 laps. Traced to
+  `src/agents/tire_agent.py:1618-1620`, the pre-existing #436 conservative-stub fallback for a
+  tool-output regex miss. Unrelated to the lap_state -> RaceState mapping.
+
+Found while running, NOT caused by this change and NOT fixed here: `f1-sim` exits **0** after
+printing `[FATAL] Race directory not found` for an unknown GP. A CI harness checking the exit
+code would score that run as a pass. Worth its own issue; deliberately out of this epic's scope.
+
+Lint over every touched parent file (`ruff check src/agents/race_state_builder.py
+src/arcade/strategy.py scripts/run_simulation_cli.py tests/agents/test_race_state_builder.py`):
+All checks passed. Test suite `tests/agents tests/audit tests/simulation`: 192 passed.
+
+---
+
+## The fix was incomplete: #788 was NOT closed by the builder alone (orchestrator, 2026-08-02)
+
+The Arcade/backend gate proved over real HTTP that `/recommend` still returned **422 on the 2025
+reference lap** after the canonical builder landed. The builder no longer crashed; the crash had
+moved one layer DOWN, into the agents that read the RAW `lap_state` instead of the `RaceState`:
+
+- `race_situation_agent.py` `run_from_state` built its `session_meta` with `wx.get('air_temp', 28.0)`,
+  so the producer's present-`None` flowed to `_compute_weather_features` -> `float(None)` -> TypeError.
+  Line 1416 immediately below it WAS guarded, and `pace_agent.py:641-645` guarded the identical read
+  with a comment naming this exact crash. One twin fixed, two not.
+- `tire_agent.py` did the same, without crashing: the `None`s reached `_add_weather_cols` and the
+  TCN's feature frame.
+
+Fixed by lifting `pace_agent`'s working guard into a shared `reading_or_default` helper in
+`_shared_defaults.py` and migrating all three agents onto it, pace included — so there is one
+implementation rather than one guarded copy plus a helper for the others. The per-caller `default`
+argument is deliberate: pace uses 25/35 and tire/race_situation use 28/38, and reconciling those
+numbers is a modelling decision tracked in #789, not something to smuggle in behind a crash fix.
+
+A separate gap the sweep found and this session also closed: `tire_agent.run_from_state` and its
+twin `src/strategy/inference/no_llm.py::_tire_no_llm` re-derive `compound`/`tyre_life` from the RAW
+`lap_state` with the pre-#784 defaults (`"MEDIUM"`, `1`), bypassing the canonical builder entirely.
+Both now use `normalise_compound` and `UNKNOWN_TYRE_LIFE` (the normaliser was made public for this).
+
+### Executed evidence
+
+Deterministic no-llm path on the real backend producer's 2025 lap_state (zero LLM calls):
+
+```
+PRODUCER weather: {'air_temp': None, 'track_temp': None, 'track_temp_start': None,
+                   'humidity': None, 'rainfall': 0}
+build_race_state -> MEDIUM 7 25.0 35.0 6.001
+run_lap(profile="no-llm") -> STAY_OUT        # previously raised TypeError here
+```
+
+Tyre cliff on the same lap, before vs after:
+
+| lap_state weather | cliff P50 before (gate-measured) | cliff P50 after |
+|---|---|---|
+| `None` (backend producer, every 2025 lap) | 10.5 | 7.9 |
+| Real RSM readings 23.4 / 29.5 | 8.2 | 8.1 |
+
+The silent 2.3-lap optimistic error collapses to 0.2 laps. The residual 0.2 is honest — it is the
+distance between the declared default (28/38) and the real readings, i.e. the #782 data gap — and
+sits inside the TCN's own MC-Dropout variance.
+
+**Not verified here:** `/recommend` over real HTTP end to end. The LLM path needs an OpenAI
+connection that this environment does not currently have (`openai.APIConnectionError` on the
+ReAct call, an environment condition, not a code path). The deterministic profile exercises the
+exact feature-building code that raised, which is the crash site; the HTTP-level 200 should be
+re-confirmed once connectivity is available.

--- a/documents/audits/SWEEP_present_none_traps.md
+++ b/documents/audits/SWEEP_present_none_traps.md
@@ -1,0 +1,228 @@
+# SWEEP — present-`None` traps (`dict.get(k, default)` / `Series.get(k, default)` / `x.get(k) or DEFAULT`)
+
+**Date:** 2026-08-02 · **Branch:** `refactor/single-source-race-state-builder` · **Scope:** parent repo + `src/telemetry` submodule.
+**Role:** adversarial gate + inventory. No repository file modified except this report.
+
+## Bug class
+
+`dict.get(key, default)` fires its default only when the KEY is missing. The producers below deliberately emit
+unmeasured readings as key-present-holding-`None`, so a consumer's `.get(k, default)` returns `None` and the
+default silently never fires. Confirmed prior consequences: #788 (crash, `/recommend` 422 on every 2025 lap) and
+the tire_agent cliff estimate moving 2.3 laps optimistic.
+
+## Producers that emit present-`None` (verified at file:line)
+
+| Producer | Keys that can be `None` |
+|---|---|
+| `src/simulation/race_state_manager.py:282` `get_driver_state` | `lap_time_s`, `prev_lap_time`, `sector1_s..3_s`, `position`, `gap_to_leader_s`, `compound_id`, `tyre_life`, `stint`, `stint_baseline_tyre_life`, `speed_i1/i2/fl/st`, `fuel_load` |
+| `src/simulation/race_state_manager.py:376` `get_rival_states` | `position`, `lap_time_s`, `tyre_life`, `stint`, `speed_st`, `gap_to_leader_s`, `interval_to_driver_s` |
+| `src/simulation/race_state_manager.py:446` `get_weather_state` | `air_temp`, `track_temp`, `humidity`, `wind_speed`, `track_temp_start` (note: `rainfall` defaults to `False`, never `None`; keys absent entirely when `weather_df is None`) |
+| `src/telemetry/backend/api/v1/endpoints/strategy.py:372` `_safe_none` | backend lap-state fields: TyreLife, weather (AirTemp/TrackTemp/Humidity), SpeedST, Position |
+
+## Method
+
+AST-based scan (not grep): every two-arg `.get(...)` call, every `x.get(k) or DEFAULT`, and every
+`float(...)/int(...)` wrapping a `.get(...)`, across `src/agents/`, `src/simulation/`, `src/arcade/`,
+`src/strategy/`, `scripts/`, `src/f1_strat_manager/`, and the whole `src/telemetry/backend/` submodule.
+Each candidate then verified by hand against the producer that feeds it; reachability claims verified by
+executing Python against the shipped parquets / real producers.
+
+## Findings
+
+<!-- appended incrementally as confirmed -->
+
+### Batch 1 — code-level confirmations (reachability experiments follow in Batch 2)
+
+**F1. `src/agents/tire_agent.py:1479` — `tyre_life = d.get('tyre_life', 1)` in `run_from_state` — the unfixed twin INSIDE the just-fixed function.**
+The same `run_from_state` that this branch migrated to `reading_or_default` for the four weather keys (lines 1518-1521) still reads
+`tyre_life` with the two-arg get four lines above. Producers that emit `tyre_life` as present-`None`: RSM `get_driver_state`
+(race_state_manager.py:354, NaN -> None) and the backend `/lap-state` builder (strategy.py:491 `_safe_none(r.get("TyreLife"))`).
+The `None` flows into `_run_core(driver, compound_id, tyre_life, gp_name)` -> prompt "tyre life None laps" (LLM path), and on the
+no-LLM path `_get_driver_stint(driver, None)` evaluates `self.laps_df['TyreLife'] <= None` (tire_agent.py:1083) -> TypeError.
+Guards that DO exist upstream: the backend simulator skips such laps (`_lap_skip_reason`, simulator.py:279) and the CLI mirrors it —
+but `/recommend` (backend strategy.py:1317) and MCP `recommend_strategy` (mcp_tools.py:566) have NO such guard: they only refuse
+position-None laps (via `build_race_state`'s ValueError). Consequence: CRASH (422/500 on /recommend) or LLM-mediated SILENT-WRONG,
+IF a shipped row has Position present and TyreLife NaN — measured in Batch 2.
+
+**F2. `src/strategy/inference/no_llm.py:135-136` — `compound = d.get("compound", "MEDIUM")` / `tyre_life = d.get("tyre_life", 1)` — second twin pair.**
+`_tire_no_llm` re-derives the same two values `run_from_state` derives (its own docstring says so), with the same two-arg get.
+`tyre_life=None` is pre-bound into the tool args and `_NullReActRunner.invoke` (no_llm.py:92-99) executes `tool.invoke(kwargs)` with
+no exception handling -> pydantic tool-args validation error or the same `<=` TypeError. `compound=None` would crash one line later
+at `compound.startswith("C")` (AttributeError), but no current producer emits compound as None (RSM: `str(...)` at
+race_state_manager.py:352; backend: `str(...)` at strategy.py:489/912) — compound-None is LATENT (hand-built lap_state only);
+tyre_life-None is as reachable as F1 on any no-guard no-llm path.
+
+**F3. `src/agents/race_situation_agent.py:918` + `src/agents/pit_strategy_agent.py:1053-1067` — the recorded CLAUDE.md §11 `Series.get` sites are still live expressions.**
+`float(x_row.get('Position', 10))`, `float(x_row.get('TyreLife', 10))` (pit, N16 undercut features) and
+`float(driver_x_lap.get('SpeedST', 300.0))` (situation, N12 overtake features) read pandas Series rows: a stored NaN is returned
+as NaN, never the default, and `float(NaN)` = nan flows into the LightGBM feature frame (LightGBM treats NaN as missing — model-
+defined branch, silently). The #462 liveness guard prevents the retired-car case, but NaN on a LIVE car's row is unguarded.
+Adjacent and harder: race_situation_agent.py:914-915 `int(driver_x_lap['TyreLife'])` raises ValueError on NaN — a crash site
+one line above the silent one. Reachability measured in Batch 2 (NaN counts on featured frames).
+
+**F4. Backend has TWO lap-state producers and they answer "missing weather" differently.**
+`/lap-state` (strategy.py:574-583) emits `air_temp/track_temp/humidity` via `_safe_none` -> honest present-`None` (the #788 shape).
+`_build_lap_state_from_row` (strategy.py:890-949, used by /pace-range at line 695) emits
+`float(_s(row.get("AirTemp", 25)))` (25/40/50 fabricated when the 2025 columns are ABSENT — Series.get default fires on a missing
+column) and, worse, `_s` coerces a present NaN to **0** -> `air_temp: 0.0` degC on any 2023/24 row with NaN weather. Also
+`speed_st`: `_safe_none` on /lap-state (None) vs `_s(...,0)` here (0.0). Only the pace agent consumes this second producer today,
+and its `d.get('speed_st') or 300.0` happens to absorb the 0.0 — the 25-vs-None weather divergence feeds
+`run_pace_agent_from_state`'s `reading_or_default(wx,'air_temp',25.0)` equally (default==fabrication, coincidentally identical),
+so TODAY the consequence is nil; the trap is structural (next consumer of this producer inherits fabricated readings).
+
+**F5. `src/telemetry/backend/mcp_tools.py:599` — `driver_state.get("gap_ahead_s") or GAP_UNKNOWN_FALLBACK_S` — #633-class zero-swallow, or-form inventory.**
+The /lap-state producer ALWAYS emits `gap_ahead_s` as a float and uses `0.0` both for "leader, honest" (drv_pos==1) and for
+"cum-times unresolved" (strategy.py:472-476). The `or` then rewrites the LEADER's honest 0.0 into the 2.0 fallback, so every MCP
+`recommend_strategy` call for the race leader hands the orchestrator a fabricated 2.0 s gap to a car that does not exist.
+Reachable today on any P1 request. SILENT-WRONG (prompt + MC read gap_ahead_s), or-form class.
+
+**F6. `strategy_orchestrator.py:1874/1875/1888/1891` — flat-lap_state two-arg gets (`laps_since_pit`, `fuel_load`, `prev_speed_st`, `humidity`) — LATENT.**
+These live in `_run_always_on_agents` (the FastF1 flat path). Its only production caller is `run_strategy_orchestrator`
+(strategy_orchestrator.py:2269), which no shipped surface calls (grep: only notebooks/tests); every surface routes through
+`run_lap`/`_run_always_on_agents_from_state`, whose adapters guard. If a caller ever feeds the flat path a dict carrying
+`humidity: None` etc., the None reaches `run_pace_agent` unguarded. Latent, inventory only.
+
+### Batch 2 — executed evidence (venv python, pandas 2.3.3, langgraph 1.2.5)
+
+**E1. Semantics, proven in this environment:**
+- `pd.Series([1.0,5.0,nan]) <= None` -> `[False, False, False]` — NO TypeError in pandas 2.3.3. So `_get_driver_stint`'s
+  `TyreLife <= None` (tire_agent.py:1083) yields an EMPTY window -> tool returns "No laps found" -> `_conservative_stub`.
+  F1's consequence is therefore SILENT degradation to the stub, not a crash, on this pandas.
+- `Series.get('SpeedST', 300.0)` with stored NaN -> returns `nan` (default dead); with ABSENT key -> default fires. (CLAUDE.md §11 confirmed.)
+- LangChain `@tool ... tyre_life: int` invoked with `tyre_life=None` -> `ValidationError` (proven). That is the no-llm
+  `_tire_no_llm` path's failure mode — but both no-llm surfaces (CLI, /simulate) guard tyre_life-None laps out first.
+- `int(float('nan'))` -> `ValueError: cannot convert float NaN to integer`.
+- langgraph 1.2.5 `_default_handle_tool_errors`: returns a message ONLY for `ToolInvocationError` (arg validation);
+  **any exception raised inside the tool body is RE-RAISED**. A ValueError inside `predict_overtake_tool` therefore
+  aborts the whole ReAct invoke — on `/recommend` that surfaces as a 422 (`except (KeyError, TypeError, ValueError)`
+  at backend strategy.py:1365), the exact #788 failure shape via a different field.
+
+**E2. Shipped-data holes (the reachability driver), measured:**
+- `laps_featured_2025.parquet`: 48 cols vs 53 in 2023/2024. Missing: `AirTemp, TrackTemp, Humidity, Rainfall` (the #782/#788
+  root) **plus `lap_time_pct_of_race_fastest`** — the latter is recomputed unconditionally by its consumers
+  (tire_agent.py:752, eval scripts rebuild it), so no extra blast radius from that column.
+- **`TyreLife` NaN with Position PRESENT: 451 rows in featured 2025** — Miami laps 4-24 (379 rows, 19 drivers = the whole
+  field), Spa-Francorchamps laps 28-44 (70 rows: ANT/ALO/HUL/COL/SAI), Melbourne 42-43 (BEA). `Stint` NaN on 379 of them.
+  Featured 2023: 35 rows (TSU, Montreal 36+). Featured 2024: ZERO. Raw frames: 561 rows across 79,032; plus 101 Position-NaN
+  and 6,872 SpeedST-NaN raw rows (featured: 1,889-2,068 SpeedST NaN per season). Raw Compound NaN/empty: 538 rows.
+- All 71 `data/raw/<year>/<race>/weather.parquet` files: **zero NaN in every column** (confirms race_state_builder's claim and
+  makes the arcade weather-panel trap latent with shipped data).
+
+**E3. The concrete reachable scenario for the race_situation crash:** Spa-Francorchamps 2025, laps 31-33: COL runs P19 with
+TyreLife NaN in BOTH the raw and featured frames while HAD sits P20 with a clean row (TyreLife 11/12/13). HAD passes every
+surface's own-driver guard; N27 derives rival_ahead=COL; `predict_overtake_tool` reads COL's row and
+`int(driver_y_lap['TyreLife'])` (race_situation_agent.py:915) raises ValueError. no-llm: `_situation_no_llm` invokes the tool
+directly -> per-lap ERROR event. rich: langgraph re-raises -> lap aborts (422 on /recommend). At Miami 2025 laps 4-24 the
+OWN-driver row is NaN for 19 drivers, so /recommend and MCP (no guard) hit the same ValueError via driver_x for nearly any
+driver/lap in that window; the three replay surfaces instead skip those laps wholesale (INCOMPLETE), which is its own
+degradation: ~21 laps of Miami 2025 produce no strategy call at all.
+
+### Correction to F3 (pit half) — the pit agent is GUARDED; race_situation is the twin that never got the fix
+
+`pit_strategy_agent.py:983-996` refuses undercut scoring when Position OR TyreLife is NaN on either car (its comment even
+cites the same 561-row measurement reproduced above), so the `.get('Position', 10)` defaults at 1053-1067 are documented
+dead code, not a live trap. **`race_situation_agent._build_overtake_features` has NO equivalent guard**: `predict_overtake_tool`
+(race_situation_agent.py:1112-1154) checks lap range and liveness only, then `int(driver_x_lap['TyreLife'])` at :914-915
+crashes and `float(...get('SpeedST', 300.0))` at :917-918 silently feeds NaN. One twin fixed, the other not — the recorded
+CLAUDE.md §11 / twin-that-never-got-the-fix shape, live today.
+
+## Inventory
+
+### 1. Reachable today with shipped data
+
+| # | Site | Consequence | Evidence |
+|---|---|---|---|
+| R1 | `race_situation_agent.py:914-915` `int(driver_x_lap['TyreLife'])` (and `driver_y`) | **CRASH** — ValueError aborts the lap; 422 on `/recommend`, ERROR event on `/simulate` no-llm and CLI --no-llm; rich replay surfaces abort the lap too (langgraph re-raises) | E3: Spa 2025 laps 31-33 HAD-behind-COL (all surfaces); Miami 2025 laps 4-24 any driver via /recommend and MCP (E2: 451 featured rows) |
+| R2 | `tire_agent.py:1479` `d.get('tyre_life', 1)` + `no_llm.py:136` twin | **SILENT-WRONG** — prompt reads "tyre life None laps"; window mask empties (E1) -> conservative stub presented every affected lap; backend also emits `stint: 0` (`_safe`, strategy.py:492/915) which empties the stint filter regardless | Reachable via `/recommend` + MCP `recommend_strategy` (no guard); same 451 rows. Replay surfaces guarded (CLI run_simulation_cli.py:1596-1616, arcade strategy.py:399, simulator.py:258-283) |
+| R3 | `race_situation_agent.py:917-918` `float(Series.get('SpeedST', 300.0))` | **SILENT-WRONG** — stored NaN (never the 300.0) into N12's `speed_trap_delta`; LightGBM routes it down the missing branch | 1,889 SpeedST-NaN rows in featured 2025 (E2); reaches the model whenever the paired rows survive the R1 crash line (both TyreLife present, one SpeedST NaN) |
+| R4 | `mcp_tools.py:599` `driver_state.get("gap_ahead_s") or GAP_UNKNOWN_FALLBACK_S` | **SILENT-WRONG (or-form, #633 class)** — /lap-state emits the LEADER's honest `gap_ahead_s: 0.0` (strategy.py:472); `or` rewrites it to 2.0, a fabricated car ahead of P1 | Reachable on any MCP recommend for the P1 driver; producer always emits the key as a float |
+| R5 | Featured-2025 data holes beyond weather | TyreLife/Stint NaN holes (Miami 4-24 field-wide, Spa 28-44, Melbourne 42-43) are the reachability driver for R1/R2 and also cost the replay surfaces ~21 laps of Miami outright | E2; #782's blast radius is wider than the four weather columns |
+
+### 2. Latent (unguarded read, no current producer emits the value)
+
+- `no_llm.py:135` + `tire_agent.py:1478` + `pit_strategy_agent.py:1460` `compound` present-None -> `.startswith`/`.upper()` AttributeError. Both producers emit `str(...)` (RSM :352, backend :489/:912) — only hand-built lap_state JSON on /recommend reaches it.
+- `strategy_orchestrator.py:1874/1875/1888/1891` flat-path two-arg gets (`laps_since_pit`, `fuel_load`, `prev_speed_st`, `humidity`) — the FastF1 flat entry `run_strategy_orchestrator` has no production caller (grep: notebooks/tests only).
+- **`src/arcade/data.py:597-603` + `src/arcade/overlays.py:129-134` — the weather panel trap, with a docstring that lies**: `_weather_row_to_dict` deliberately emits present-`None` on a NaN FastF1 weather sample and its docstring claims the panel's `.get(key, default)` default then fires — it does not; `f"{None:.1f}"` raises TypeError in `WeatherPanel.draw`. Latent only because shipped weather has zero NaN (E2); a live FastF1 feed with one NaN sample crashes the arcade overlay.
+- `tire_agent.py:1440-1448` (FastF1 `run()` path): `session.weather_data.mean()` of an all-NaN column -> stored NaN via `Series.get('AirTemp', 28.0)` -> `float(nan)` into session_meta. Notebook/FastF1 path only.
+- `tire_agent.py:586` `_add_weather_cols` `session_meta.get(col, 0.0)` — every current caller sets all four keys (run :1440, run_from_state :1518, /tire-range :1022); a future caller that omits one fabricates 0.0 degC.
+- `scripts/debug_agent.py:306-308` `lap_state["weather"].get("air_temp", 28.0)` — debug harness, same trap shape if fed RSM weather with None.
+- `race_situation_agent.py:681-684` + `pit_strategy_agent.py:892-894` session_meta two-arg gets — all production adapters populate these guarded; FastF1/hand-built paths could pass None through.
+- Backend `_build_lap_state_from_row` (strategy.py:890-949): fabricates 25/40/50 weather when columns are absent and `_s` coerces present NaN to 0 (`air_temp: 0.0`); today only /pace-range consumes it and the pace agent's guards/defaults happen to absorb everything — the next consumer inherits fabricated readings. (F4.)
+- Arcade dashboard formatters (`agent_formatters.py:94-98/146-150/206-210`, `reasoning_tabs.py:120-165`): two-arg gets over dataclass-serialized outputs whose fields are non-Optional floats today; `TireOutput.current_tyre_life=None` (from `_conservative_stub` under R2) would render as the string "None" — cosmetic.
+- CLI display gets (`run_simulation_cli.py:1258-1262/1803-1805`): `rival_data.get("position", "?")` renders `None` instead of `?` for a position-less rival — cosmetic only (RSM sorts them to the back).
+
+### 3. Harmless / correctly guarded (verified, do not re-audit)
+
+- `src/agents/race_state_builder.py` — every read guarded: `_weather_reading` handles present-None; position None raises by design; `tyre_life`/compound normalised; `rainfall` `bool(None)` -> False is the honest degradation. Verified line by line.
+- `pace_agent.py:626-704` (`run_from_state`) — the migrated site is correct; every remaining read is `or`-form or deliberately honest (`position` passes None to XGBoost's native-missing path). `tyre_life or 1` cannot swallow a real 0: TyreLife==0 occurs zero times in 2023-2025 (race_state_builder.py:77 measurement).
+- `race_situation_agent.py:1406-1420` + `tire_agent.py:1518-1521` — the two migrated weather blocks are correct; `wx.get('track_temp_start') or 38.0` correctly None-safe (0.0 degC track temp does not occur in the dataset).
+- `pit_strategy_agent.py:983-996` — NaN guard makes the 1053-1067 Series.get defaults dead code (documented as such in-file).
+- `race_state_manager.py` `r.get(...)` sites — all wrapped in `pd.notna(...)` ternaries; this IS the producer's honest-None pattern.
+- `position_projection.py` — all `(x or {})` chains; `_finite_or_none` collapses None/NaN/inf at the boundary (strategy_orchestrator.py:913-928).
+- `strategy_orchestrator.py:829-830/1163` — `or`-guarded context reads; `rival.get("is_pitting", False)` wrapped in `bool()` so the backend's present-None is read as False (honest: unknown != pitting is a documented degradation).
+- Static-map/env/display gets across arcade dashboard, CLI tables, backend chat/llm_service, eval CLIs, radio/NLP/rag payloads — defaults on dicts the same module builds, or pure display.
+- `simulation/__main__.py`, `replay_engine.py`, `stint_history.py:144` — display/string sites, `or`-guarded where numeric.
+- Guards confirmed present and equivalent on all three replay surfaces: CLI (:1596-1616), arcade (strategy.py:394-402), backend simulator (:258-283).
+- eval-only `or`-forms (`decision_modes.py:301-305`, `prompt_ab/gen_inputs.py:60-66`): `gap_ahead_s or 2.0` would swallow a legitimate 0.0 gap, but their states come from RSM `get_driver_state`, which never emits `gap_ahead_s` at all (key absent) — #633-class only if ever fed backend states; tyre_life handled the honest way in decision_modes (:302).
+
+## The three already-fixed sites: verdict
+
+`pace_agent.py:647-649`, `tire_agent.py:1518-1521`, `race_situation_agent.py:1406-1408` all correctly route through
+`reading_or_default`, which handles both absent-key and present-None (read and verified). The helper's docstring is accurate.
+**But the fix is incomplete IN THE SAME FUNCTIONS**: `tire_agent.run_from_state` still reads `tyre_life` (:1479) with the
+two-arg get 39 lines above its fixed weather block, and the same producers that motivated the weather fix emit `tyre_life`
+as present-None on 451 shipped 2025 rows. `race_state_builder` guards `RaceState`, but the sub-agent adapters read the raw
+`lap_state` directly, so the builder's `UNKNOWN_TYRE_LIFE` never protects them.
+
+## What I tried to break and could not
+
+- `race_state_builder.build_race_state`: tried weather-None, rainfall-None, compound "nan"/None, tyre_life None, missing
+  lap_number/total_laps, empty rivals — every path lands on a guard, a warning, or the deliberate position ValueError.
+- The `pd.Series <= None` crash I expected for `_get_driver_stint`: pandas 2.3.3 returns all-False instead of raising
+  (executed), so that specific crash claim in my own Batch 1 draft did not survive its own verification.
+- `pit_strategy_agent` undercut scoring with NaN rows: the :983 guard refuses before any NaN reaches the model.
+- The five missing 2025 featured columns beyond weather: `lap_time_pct_of_race_fastest` is recomputed by every consumer.
+- Shipped `weather.parquet` NaN (would arm the arcade panel trap and the RSM weather-None path): zero NaN in all 71 races,
+  every column.
+- `rainfall`: no producer emits it as None (RSM: False; backend: int; builder wraps in bool()).
+
+## Could not determine
+
+- Whether the LIVE FastF1 feed (arcade SessionLoader, `session.weather_data`) ever carries NaN samples — shipped parquets
+  do not, but they are a different artifact from the FastF1 cache the arcade reads; the panel trap's reachability in a live
+  session is unmeasured.
+- Rich-mode LLM behaviour when the prompt says "tyre life None laps" (what integer the model invents) — bounded by the
+  empty-window stub either way, but the exact numbers shown to the orchestrator vary per call.
+- End-to-end HTTP confirmation of the /recommend 422 at Spa/Miami (server runs are owned elsewhere); the chain is proven at
+  module level: data row -> producer emission (`_safe_none`) -> unguarded read -> exception semantics (E1).
+
+---
+
+## Addendum (2026-08-02, after this sweep was written)
+
+Two of the sites recorded above as unfixed were closed on the same branch, AFTER this
+sweep ran. This note exists because a reader grepping the audit trail later would
+otherwise believe they are still open.
+
+- **F1/F2 (`tire_agent.run_from_state` `tyre_life` at :1479 and `compound` at :1478, plus
+  the twin in `src/strategy/inference/no_llm.py::_tire_no_llm`)** — FIXED. Both now derive
+  through the canonical `normalise_compound` and `UNKNOWN_TYRE_LIFE` from
+  `src/agents/race_state_builder.py` instead of restating the pre-#784 defaults
+  (`"MEDIUM"`, `1`). Verified safe by the final correctness gate: every 2025 row carrying
+  a degraded compound spelling also carries a NaN `TyreLife`, both the old and new paths
+  produce an empty stint window and therefore the same conservative stub, and the scalar
+  `tyre_life` never reaches the TCN (it only bounds the window and lands on a display
+  field). No lap that previously produced a sane prediction produces a different one.
+- **The weather half** — FIXED via the shared `reading_or_default` helper, with
+  `pace_agent` (the one copy that had been correct) migrated onto it too so there is a
+  single implementation rather than one good copy plus a helper for the stragglers.
+
+Still live and deliberately out of the branch's scope:
+
+- **R1** — `int(NaN)` on `TyreLife` at `race_situation_agent.py:914-915`. Filed as **#790**.
+  Not fixed here because the mechanical part is trivial but the policy is not: the guarded
+  twin (`pit_strategy_agent.py:983-999`) REFUSES the prediction rather than defaulting, and
+  applying that to N27 means the orchestrator loses its overtake probability on ~451 laps.
+- **R3** (`SpeedST` NaN into N12) and **R4** (the `or`-form in `mcp_tools.py:599` rewriting a
+  leader's honest 0.0 gap to a fabricated 2.0) — recorded in #790's body and #789
+  respectively.

--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -1287,18 +1287,13 @@ def _make_inference_panel(
 # RaceState builder
 # ---------------------------------------------------------------------------
 
-# Imported, not redeclared. Its rationale and its honest limitation live with it.
-#
-# Be precise about how far this got, because a comment claiming a closed drift is
-# worse than no comment: the CLI and the arcade now share one constant, and the
-# telemetry BACKEND does not. It is a git submodule and cannot be changed from this
-# commit, and an adversarial gate counted SIX surviving copies of this convention
-# there and here, including one in `strategy.py` that defaults the same concept to
-# 2.0 on one request model and 0.0 on its sibling in the same file. Tracked, not
-# closed (#628).
-from src.agents.position_projection import (  # noqa: E402
-    GAP_UNKNOWN_FALLBACK_S as _GAP_UNKNOWN_FALLBACK_S,
-)
+# The lap_state -> RaceState mapping is imported, not restated: the canonical
+# builder in src/agents/race_state_builder.py is shared by all three surfaces
+# (#784) — this CLI, the arcade, and the telemetry backend, which reaches it
+# through a re-export shim (#786). So the defaults the models receive, the gap
+# fallback and the #750 pace-delta axis can no longer drift per surface. Their
+# rationale and honest limitations live with the builder.
+from src.agents.race_state_builder import build_race_state  # noqa: E402
 
 
 def _build_race_state(
@@ -1306,71 +1301,24 @@ def _build_race_state(
     driver_code: str,
     prev_lap_time: float,
 ) -> RaceState:
-    """Map RaceStateManager's lap_state dict → RaceState Pydantic model.
+    """Map RaceStateManager's lap_state dict -> RaceState Pydantic model.
+
+    Thin delegation to ``src.agents.race_state_builder.build_race_state``
+    (#784), the single canonical mapping shared with the arcade and the
+    telemetry backend. The #628 position guard, the #750 pace-delta axis and
+    the gap fallback rationale all live there now. ``radio_msgs`` /
+    ``rcm_events`` stay schema defaults here on purpose: the main loop below
+    mutates them after construction (corpus radios, the SC tracker, the
+    --radio-every synthetic generator), and that precedence rule is CLI policy,
+    not builder policy.
 
     ``prev_lap_time`` is accepted but no longer read here: ``pace_delta_s`` used
-    to be computed from it and that was the wrong axis (#750, fixed below). Left
-    in the signature rather than removed, since the caller's per-lap bookkeeping
+    to be computed from it and that was the wrong axis (#750). Left in the
+    signature rather than removed, since the caller's per-lap bookkeeping
     that produces it (`run()`'s ``prev_lap_time`` loop variable) serves no other
     purpose today and dropping it is a small cleanup outside this fix's scope.
     """
-    driver_st = lap_state["driver"]
-    rivals = lap_state.get("rivals", [])
-    weather = lap_state.get("weather", {})
-
-    our_pos = driver_st.get("position")
-    # The incomplete-lap guard in run()'s main loop (`_pos_raw is None or ...`)
-    # already skips any lap where the driver's position is unknown before
-    # _build_race_state is ever called. Reaching here with a None position
-    # means that invariant broke. Fail loudly instead of defaulting to a
-    # searchable P99: a fabricated position is exactly the value the
-    # `our_pos - 1` lookup below searches by, so an unknown position and a
-    # genuinely-last car would silently resolve to the same rival — the #428
-    # bug shape. Mirrors src/arcade/strategy.py's _build_race_state (fixed for
-    # the identical shape under #465); the caller's per-lap try/except (in
-    # run()) turns this into an [ERROR] row for the lap, not a crashed run.
-    if our_pos is None:
-        raise ValueError(
-            "_build_race_state: driver position is None; the incomplete-lap "
-            "guard should have skipped this lap before it reached "
-            "_build_race_state (#628)"
-        )
-    car_ahead = next((r for r in rivals if r.get("position") == our_pos - 1), None)
-    if car_ahead is not None:
-        _interval = car_ahead.get("interval_to_driver_s")
-        gap_ahead_s = abs(_interval) if _interval is not None else _GAP_UNKNOWN_FALLBACK_S
-    else:
-        gap_ahead_s = 0.0
-
-    cur_lap_time = driver_st.get("lap_time_s") or 0.0
-    # pace_delta_s is contractually RIVAL-relative (this driver's lap time minus
-    # the car directly ahead's SAME lap, negative = we are faster) per
-    # race_situation_agent.py:292/904, the schema N27 itself computes. The old
-    # formula compared cur_lap_time against our OWN previous lap instead, a
-    # same-car same-driver quantity that reported roughly -20s of phantom "pace
-    # gain" on the lap after a pit stop, a green lap read against our own
-    # out-lap. car_ahead is already resolved above for gap_ahead_s, so no extra
-    # lookup is needed; 0.0 when it or its lap time is unknown is the schema's
-    # documented neutral, not a guess in either direction (#750).
-    ahead_lap_time = car_ahead.get("lap_time_s") if car_ahead is not None else None
-    if ahead_lap_time is not None and cur_lap_time:
-        pace_delta_s = cur_lap_time - float(ahead_lap_time)
-    else:
-        pace_delta_s = 0.0
-
-    return RaceState(
-        driver=driver_code,
-        lap=driver_st["lap_number"],
-        total_laps=lap_state["session_meta"]["total_laps"],
-        position=our_pos,
-        compound=driver_st.get("compound", "UNKNOWN"),
-        tyre_life=driver_st.get("tyre_life", 0),
-        gap_ahead_s=gap_ahead_s,
-        pace_delta_s=pace_delta_s,
-        air_temp=weather.get("air_temp", 25.0),
-        track_temp=weather.get("track_temp", 40.0),
-        rainfall=bool(weather.get("rainfall", False)),
-    )
+    return build_race_state(lap_state, driver=driver_code)
 
 
 # ---------------------------------------------------------------------------

--- a/src/agents/_shared_defaults.py
+++ b/src/agents/_shared_defaults.py
@@ -1,10 +1,12 @@
-"""Fallback constants shared by the agent modules when session_meta arrives incomplete.
+"""Fallbacks shared by the agent modules when session_meta or weather arrives incomplete.
 
-A leaf module — no other agent internals, no heavy imports — so pulling in this one
-constant never drags in model weights (same reasoning as ``tire_parsing.py``).
+A leaf module — no other agent internals, no heavy imports — so pulling these in never
+drags in model weights (same reasoning as ``tire_parsing.py``).
 """
 
 from __future__ import annotations
+
+from typing import Any, Mapping
 
 # RaceStateManager.get_session_meta() always supplies total_laps (CLAUDE.md section 6,
 # "lap_state is the single contract"; race_state_manager.py's own get_session_meta sets
@@ -17,3 +19,36 @@ from __future__ import annotations
 # consolidated here so a future change updates every caller at once instead of drifting
 # one site at a time.
 DEFAULT_TOTAL_LAPS: int = 57
+
+
+def reading_or_default(source: Mapping[str, Any], key: str, default: float) -> float:
+    """Read a numeric reading that may be ABSENT or PRESENT-AND-``None``.
+
+    ``dict.get(key, default)`` only fires its default when the KEY is missing. Our
+    producers deliberately report an unmeasured reading as the key present with a
+    ``None`` value -- ``_safe_none`` in the telemetry backend and
+    ``race_state_manager.get_weather_state`` both do this on purpose, so that an absent
+    measurement never becomes a searchable sentinel (#465). The two conventions meet
+    badly: ``wx.get('air_temp', 28.0)`` returns ``None``, and the ``float()`` one layer
+    down raises ``TypeError``.
+
+    That is not hypothetical. Every 2025 laps parquet ships without weather columns, so
+    the backend's producer emits ``None`` for all four readings on every 2025 lap. It
+    crashed ``/recommend`` with a 422 for the whole default season (#788) via
+    ``race_situation_agent``, and it silently moved ``tire_agent``'s cliff estimate 2.3
+    laps in the optimistic direction -- the dangerous one, since it delays the pit call.
+
+    The bug shape is a twin that never got the fix: ``pace_agent`` had guarded this read
+    with an inline conditional and a comment describing the exact crash, while the
+    identical reads in ``tire_agent`` and ``race_situation_agent`` had not. Hence one
+    named function rather than a fourth inline copy.
+
+    ``default`` stays a per-caller argument on purpose: the agents disagree on the
+    fallback temperatures (pace uses 25/35, tire and race_situation use 28/38) and
+    reconciling those numbers is a modelling decision tracked in #789, not something to
+    smuggle in behind a crash fix.
+    """
+    value = source.get(key)
+    if value is None:
+        return default
+    return value

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -29,6 +29,8 @@ import numpy as np
 import pandas as pd
 import xgboost as xgb
 
+from src.agents._shared_defaults import reading_or_default
+
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent
 while not (_REPO_ROOT / '.git').exists():
@@ -638,11 +640,14 @@ class PaceAgent:
         #     "DataFrame.dtypes for data must be int, float, bool or category"
         # That is exactly the crash observed on mid-stint laps. The ``or``
         # pattern handles both missing-key and None-value cases in one step.
+        # This file's inline guard was the ONLY one of the three agents that handled
+        # present-and-None, and it is now the shared helper the other two adopted rather
+        # than a fourth copy of the pattern (#788).
         _speed_st  = d.get('speed_st')   or 300.0
-        _air_temp  = wx.get('air_temp')  if wx.get('air_temp')  is not None else 25.0
-        _trk_temp  = wx.get('track_temp') if wx.get('track_temp') is not None else 35.0
-        _humidity  = wx.get('humidity')  if wx.get('humidity')  is not None else 50.0
-        _rainfall  = wx.get('rainfall', 0)
+        _air_temp  = reading_or_default(wx, 'air_temp',   25.0)
+        _trk_temp  = reading_or_default(wx, 'track_temp', 35.0)
+        _humidity  = reading_or_default(wx, 'humidity',   50.0)
+        _rainfall  = reading_or_default(wx, 'rainfall', 0)
 
         return self.run(
             driver_number  = d.get('driver_number') or 0,

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -28,7 +28,7 @@ import joblib
 import numpy as np
 import pandas as pd
 
-from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS
+from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS, reading_or_default
 
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent
@@ -1399,9 +1399,13 @@ class RaceSituationAgent:
             'total_laps':       total_laps,
             'fastest_lap_s':    float(self.laps_df['LapTime'].dt.total_seconds().min())
                                 if len(self.laps_df) > 0 else 90.0,
-            'AirTemp':          wx.get('air_temp',   28.0),
-            'TrackTemp':        wx.get('track_temp', 38.0),
-            'Humidity':         wx.get('humidity',   50.0),
+            # reading_or_default, not .get(key, default): the producers report an
+            # unmeasured reading as the key PRESENT holding None, which .get's default
+            # never catches, and _compute_weather_features' float() then raises. That
+            # 422'd /recommend on every 2025 lap (#788) — see the helper's docstring.
+            'AirTemp':          reading_or_default(wx, 'air_temp',   28.0),
+            'TrackTemp':        reading_or_default(wx, 'track_temp', 38.0),
+            'Humidity':         reading_or_default(wx, 'humidity',   50.0),
             # The session's FIRST track temp, which the RSM now supplies. This used to
             # read `track_temp` — the CURRENT one — so `track_temp_delta` came out 0.0 on
             # every lap of every race, on every shipping path (CLI, arcade, backend,

--- a/src/agents/race_state_builder.py
+++ b/src/agents/race_state_builder.py
@@ -1,0 +1,360 @@
+"""Single canonical builder of ``RaceState`` from the ``lap_state`` contract (#784).
+
+Why this module exists: the CLI (``scripts/run_simulation_cli.py``), the Arcade
+(``src/arcade/strategy.py``) and the telemetry backend
+(``backend/utils/race_state_builder.py``) each carried their own copy of the same
+lap_state -> RaceState mapping, and the copies disagreed on values the models
+actually receive (track_temp 40.0 vs 35.0, compound "UNKNOWN" vs "MEDIUM",
+tyre_life 0 vs 1, three different sources for the lap number).
+
+Be precise about which of those divergences is REACHABLE, because an earlier
+draft of this docstring was not: on the replay path (CLI and Arcade, both via
+RaceReplayEngine) the temperature defaults are effectively dead with the shipped
+data. All 71 race directories carry a readable weather.parquet with zero NaN
+AirTemp/TrackTemp rows, so the keys are always present and always non-None, and
+40.0-vs-35.0 never actually reached a model there. The value below is chosen on
+the measured-median argument alone, not on a live-divergence one. What IS live is
+the present-but-None case this builder now handles: see DEFAULT_TRACK_TEMP_C.
+
+The drift that actually bit this codebase was LOGIC drift, not just
+literals: the #750 pace-delta axis, the #465 dead position default, the #633 gap
+zero-conflation. One implementation is the fix; a parity test was rejected because
+it cannot run where the drift originates. Full per-field decision record: issue
+#784 and ``documents/audits/DESIGN_race_state_single_contract.md``.
+
+Leaf-module constraint (HARD): ``RaceState`` is imported LAZILY inside
+``build_race_state`` because it lives in ``strategy_orchestrator``, which drags
+LangChain/LangGraph and every sub-agent's model artefacts at import time.
+Importing THIS module must stay cheap - the same discipline
+``_shared_defaults.py`` documents - and a test asserts that importing it does not
+pull ``langchain`` into ``sys.modules``. Do not add a top-level
+``strategy_orchestrator`` import here.
+
+``radio_msgs`` / ``rcm_events`` are PARAMETERS, never built here: the three
+surfaces have three different sources (the CLI's OpenF1 corpus plus its
+``--radio-every`` synthetic generator with a precedence rule, the Arcade's
+``RadioPipelineRunner`` instance state, the backend's request payloads). Building
+them here would drag Whisper and per-surface policy into a shared leaf module.
+
+Known coupling, recorded on purpose: the CLI mutates the built object's
+``radio_msgs`` / ``rcm_events`` lists AFTER construction (its main loop owns the
+corpus-suppresses-synthetic rule). If ``RaceState`` is ever frozen, that
+post-construction mutation breaks; the fix then is for the CLI to pass the lists
+as parameters here instead.
+
+--- WHERE TO CHANGE IF THE CONTRACT CHANGES ---
+Consumers of this builder: ``scripts/run_simulation_cli.py::_build_race_state``
+(pure delegation), ``src/arcade/strategy.py::_build_race_state`` (delegation plus
+arcade-side radio/RCM sourcing), and the telemetry backend's
+``backend/utils/race_state_builder.py`` (a re-export shim, #786; its call sites are
+``simulator.py``, ``endpoints/strategy.py`` and ``mcp_tools.py``, none of which
+needed changing because the shim preserves the public name).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS
+from src.agents.position_projection import GAP_UNKNOWN_FALLBACK_S
+
+logger = logging.getLogger(__name__)
+
+# Canonical defaults. Each literal below was measured on the shipped 2023-2025
+# parquets (71 races) before being chosen; the numbers are in the #784 decision
+# table and in documents/audits/DESIGN_race_state_single_contract.md (F10).
+
+# Zero rows carry the literal "UNKNOWN" in any season, so it can never collide
+# with a real reading. The strings that DO appear when FastF1 has no compound are
+# ""/"nan"/"None": race_state_manager.py:352 emits `str(r.get("Compound", ""))`,
+# so a stored NaN reaches this builder as the STRING "nan" with the key present,
+# where a dict.get default never fires (the Series.get lesson, CLAUDE.md
+# section 11). `normalise_compound` folds all of them into this one honest marker.
+UNKNOWN_COMPOUND = "UNKNOWN"
+_MISSING_COMPOUND_MARKERS = frozenset({"", "nan", "none"})
+
+# TyreLife == 0 occurs ZERO times in 2023/2024/2025 (season minimums 2.0/2.0/1.0),
+# so 0 is a non-colliding sentinel. The old arcade/backend default of 1 collides
+# with real fresh-tyre laps, which is the #428 bug shape: a default the code can
+# also legitimately find.
+UNKNOWN_TYRE_LIFE = 0
+
+# Dataset medians (2023+2024 weather columns; the 2025 featured parquet carries
+# none): air median 24.1 C, track median exactly 35.0 C. The CLI's old 40.0 track
+# default corresponded to nothing measured, which is the whole reason to pick a
+# canonical value here.
+#
+# Where these actually fire, measured rather than assumed: NOT on the replay path
+# (all 71 race dirs ship a readable weather.parquet with zero NaN temperature
+# rows, so get_weather_state always emits real readings). They fire on the
+# BACKEND's producer path, where the 2025 laps parquets carry no weather columns
+# at all and the producer honours that as an explicit None per key. That case
+# used to reach `float(None)` and raise TypeError; treating present-but-None as
+# missing is what makes these constants load-bearing.
+DEFAULT_AIR_TEMP_C = 25.0
+DEFAULT_TRACK_TEMP_C = 35.0
+
+
+def _targeting_against_rival(
+    lap_state: Dict[str, Any],
+    rival: str,
+    fallback_gap_s: float,
+    fallback_pace_s: float,
+) -> Tuple[float, float]:
+    """Gap and pace delta of our driver measured against a chosen ``rival``.
+
+    Returns ``(gap_ahead_s, pace_delta_s)`` framed around the rival the user
+    picked in the Strategy tab, so the recommendation reasons about the duel the
+    user actually asked for instead of about whichever car happens to sit one
+    position ahead (#431). Both values land on the RaceState, which feeds N27's
+    overtake scoring inputs and the orchestrator's synthesis prompt.
+
+    gap_ahead_s is the absolute on-track interval to the rival, read from the
+    rival's ``interval_to_driver_s`` (rival elapsed time minus ours: the sign
+    encodes ahead/behind, the magnitude is the gap). This is the same
+    driver-relative interval RaceStateManager already emits per rival, mirrored
+    onto the /lap-state rivals so both callers carry it.
+
+    pace_delta_s is our last lap time minus the rival's, matching N27's
+    convention (negative = we are faster).
+
+    Falls back to the caller-supplied values when the rival is absent from this
+    lap (e.g. it crashed out and the liveness filter dropped it, #428/#430) or
+    when a lap time is missing, so a stale selection degrades to current
+    behaviour rather than to a fabricated zero.
+    """
+    rivals = lap_state.get("rivals", []) or []
+    match = next((r for r in rivals if r.get("driver") == rival), None)
+    if match is None:
+        return fallback_gap_s, fallback_pace_s
+
+    interval = match.get("interval_to_driver_s")
+    gap_ahead_s = abs(float(interval)) if interval is not None else fallback_gap_s
+
+    driver_lap_s = lap_state.get("driver", {}).get("lap_time_s")
+    rival_lap_s = match.get("lap_time_s")
+    if driver_lap_s and rival_lap_s:
+        pace_delta_s = float(driver_lap_s) - float(rival_lap_s)
+    else:
+        pace_delta_s = fallback_pace_s
+
+    return round(gap_ahead_s, 3), round(pace_delta_s, 3)
+
+
+def _car_ahead(lap_state: Dict[str, Any], our_position: int) -> Optional[Dict[str, Any]]:
+    """The rival sitting exactly one position ahead of us, or None when we lead.
+
+    Presence in the ``rivals`` list is the liveness signal: a retired car simply
+    has no row this lap (#428/#430). No age threshold, no fabricated positions.
+    """
+    rivals = lap_state.get("rivals", []) or []
+    match = next((r for r in rivals if r.get("position") == our_position - 1), None)
+    return match
+
+
+def _gap_to_car_ahead(car_ahead: Optional[Dict[str, Any]]) -> float:
+    """Absolute interval to the car ahead, without conflating two zeros.
+
+    No car ahead means we lead, and 0.0 is honest there. A car ahead whose
+    ``interval_to_driver_s`` was never measured is NOT a zero gap: 0.0 reads as
+    side by side, which the orchestrator's clean-air band and N27's sub-1.0s DRS
+    window both act on (#633). It degrades to ``GAP_UNKNOWN_FALLBACK_S`` instead.
+
+    Be honest about what that fallback still is: 2.0 is fabricated, and a real
+    2.0 s gap is common, so it does not satisfy the rule that a default must
+    never be a value the code can also legitimately find. It is less harmful
+    than 0.0, not correct. The real fix is ``RaceState.gap_ahead_s`` becoming
+    ``float | None``, which ``RivalState`` in position_projection.py already is
+    and whose consumers already guard with ``is not None``. That is a Pydantic
+    contract change, tracked under #628.
+    """
+    if car_ahead is None:
+        return 0.0
+    interval = car_ahead.get("interval_to_driver_s")
+    if interval is None:
+        return GAP_UNKNOWN_FALLBACK_S
+    return abs(float(interval))
+
+
+def _pace_delta_vs_car_ahead(
+    driver_state: Dict[str, Any],
+    car_ahead: Optional[Dict[str, Any]],
+) -> float:
+    """Our lap time minus the car ahead's SAME-lap time, negative = we are faster.
+
+    pace_delta_s is contractually RIVAL-relative (this driver's lap time minus
+    the car directly ahead's SAME lap) per race_situation_agent.py:292/904, the
+    schema N27 itself computes. The formula this replaced compared the current
+    lap against our OWN previous lap instead, a same-car same-driver quantity
+    that reported roughly -20 s of phantom "pace gain" on the lap after a pit
+    stop, a green lap read against our own out-lap. 0.0 when the car ahead or
+    either lap time is unknown is the schema's documented neutral, not a guess
+    in either direction (#750).
+    """
+    our_lap_time = driver_state.get("lap_time_s") or 0.0
+    ahead_lap_time = car_ahead.get("lap_time_s") if car_ahead is not None else None
+    if ahead_lap_time is not None and our_lap_time:
+        return float(our_lap_time) - float(ahead_lap_time)
+    return 0.0
+
+
+def normalise_compound(raw: Any) -> str:
+    """Fold every spelling of "no compound" into the one honest marker.
+
+    Matching is case-insensitive so pandas' "nan"/"NaN" spellings and Python's
+    "None" all land on ``UNKNOWN_COMPOUND`` (see the marker-set comment above for
+    why these strings exist at all). A real reading passes through untouched; the
+    producers already emit canonical casing, so no re-casing happens here.
+    """
+    if raw is None:
+        return UNKNOWN_COMPOUND
+    text = str(raw).strip()
+    if text.lower() in _MISSING_COMPOUND_MARKERS:
+        return UNKNOWN_COMPOUND
+    return text
+
+
+def _weather_reading(weather: Dict[str, Any], key: str, default: float) -> float:
+    """Read one weather float, treating a present-but-None value as missing.
+
+    ``get_weather_state`` can emit a weather key whose VALUE is None (a NaN
+    weather row, race_state_manager.py:478-479); ``weather.get(key, default)``
+    passes that None straight into ``float()`` and crashes, which is exactly what
+    all three pre-#784 builders did. The ``is not None`` read is the same pattern
+    pace_agent's own from_state adapter uses for these fields.
+    """
+    value = weather.get(key)
+    reading = float(value) if value is not None else default
+    return reading
+
+
+def _resolve_lap(lap_state: Dict[str, Any], driver_state: Dict[str, Any]) -> int:
+    """Lap number from the top-level key, then the driver dict, then 1 loudly.
+
+    RaceStateManager emits both copies, so every real path takes the first read;
+    the fallbacks only breathe on hand-built lap_states (HTTP clients of
+    /recommend, test fixtures). The pre-#784 CLI read ONLY the driver dict and
+    crashed on states the other two surfaces accepted.
+    """
+    lap = lap_state.get("lap_number")
+    if lap is None:
+        lap = driver_state.get("lap_number")
+    if lap is None:
+        logger.warning(
+            "lap_state carries no lap_number (top-level or driver dict); defaulting to lap 1"
+        )
+        return 1
+    return int(lap)
+
+
+def _resolve_total_laps(session_meta: Dict[str, Any]) -> int:
+    """total_laps from session_meta, else ``DEFAULT_TOTAL_LAPS`` loudly.
+
+    Every internal producer supplies total_laps unconditionally; the one
+    reachable miss is arbitrary client JSON at /recommend. The downstream agents
+    already fall back to the same ``DEFAULT_TOTAL_LAPS``, so a builder stricter
+    than its own consumers would buy a crash, not correctness. The warning keeps
+    the gap visible without turning a sloppy-but-working API call into a 500.
+    """
+    total = session_meta.get("total_laps")
+    if total is None:
+        logger.warning(
+            "session_meta carries no total_laps; falling back to DEFAULT_TOTAL_LAPS=%d",
+            DEFAULT_TOTAL_LAPS,
+        )
+        return DEFAULT_TOTAL_LAPS
+    return int(total)
+
+
+def build_race_state(
+    lap_state: Dict[str, Any],
+    *,
+    driver: Optional[str] = None,
+    gap_ahead_s: Optional[float] = None,
+    pace_delta_s: Optional[float] = None,
+    risk_tolerance: float = 0.5,
+    radio_msgs: Optional[List[dict]] = None,
+    rcm_events: Optional[List[dict]] = None,
+    rival: Optional[str] = None,
+):
+    """Construct the canonical ``RaceState`` from a raw ``lap_state`` dict.
+
+    The single lap_state -> RaceState mapping shared by the CLI, the Arcade and
+    the telemetry backend (#784). The defaults are the per-field canonical
+    literals decided in that issue; the module constants above carry each
+    measurement.
+
+    ``None`` means "compute it here" for ``gap_ahead_s`` / ``pace_delta_s``. When
+    a caller supplies a value it is used unchanged - the /recommend endpoint
+    forwards the client's ``gap_ahead_s`` and mcp_tools substitutes its own
+    fallback, and both stay byte-compatible. When left as None, the builder
+    resolves the positional car ahead once and derives both values from it
+    (absorbing the backend simulator's ``_compute_gap_ahead`` copy).
+
+    ``driver`` is the CLI's explicit code override; when None the driver dict's
+    own code is used, then "UNK".
+
+    ``rival`` (#431): when set, gap and pace are recomputed against that specific
+    car rather than the positional car ahead, with the already-resolved values as
+    fallbacks, so a stale selection degrades to positional behaviour rather than
+    to a fabricated zero.
+
+    Raises:
+        ValueError: when the driver's position is None. A fabricated position is
+            exactly the value the car-ahead lookup searches by
+            (``position == our_pos - 1``), so an unknown position and a
+            genuinely-last car would silently resolve to the same rival - the
+            #428 bug shape. All three surfaces converged on failing loud here
+            (the CLI under #628, the Arcade and backend under #465); every
+            caller's per-lap guard skips these laps first, and its try/except
+            turns a breach of that invariant into a surfaced per-lap error, not
+            a crashed run.
+    """
+    from src.agents.strategy_orchestrator import RaceState
+
+    driver_state = lap_state.get("driver", {}) or {}
+    weather = lap_state.get("weather", {}) or {}
+    session_meta = lap_state.get("session_meta", {}) or {}
+
+    position = driver_state.get("position")
+    if position is None:
+        raise ValueError(
+            "build_race_state: driver position is None for this lap (an incomplete "
+            "or out-lap the caller's guard should have skipped); refusing to "
+            "fabricate a searchable position (#628, #465)"
+        )
+
+    needs_car_ahead = gap_ahead_s is None or pace_delta_s is None
+    car_ahead = _car_ahead(lap_state, position) if needs_car_ahead else None
+    if gap_ahead_s is None:
+        gap_ahead_s = _gap_to_car_ahead(car_ahead)
+    if pace_delta_s is None:
+        pace_delta_s = _pace_delta_vs_car_ahead(driver_state, car_ahead)
+
+    if rival:
+        gap_ahead_s, pace_delta_s = _targeting_against_rival(
+            lap_state,
+            rival,
+            float(gap_ahead_s),
+            float(pace_delta_s),
+        )
+
+    tyre_life = driver_state.get("tyre_life")
+    race_state = RaceState(
+        driver=driver or driver_state.get("driver") or "UNK",
+        lap=_resolve_lap(lap_state, driver_state),
+        total_laps=_resolve_total_laps(session_meta),
+        position=position,
+        compound=normalise_compound(driver_state.get("compound")),
+        tyre_life=tyre_life if tyre_life is not None else UNKNOWN_TYRE_LIFE,
+        gap_ahead_s=float(gap_ahead_s),
+        pace_delta_s=float(pace_delta_s),
+        air_temp=_weather_reading(weather, "air_temp", DEFAULT_AIR_TEMP_C),
+        track_temp=_weather_reading(weather, "track_temp", DEFAULT_TRACK_TEMP_C),
+        rainfall=bool(weather.get("rainfall", False)),
+        radio_msgs=radio_msgs if radio_msgs is not None else [],
+        rcm_events=rcm_events if rcm_events is not None else [],
+        risk_tolerance=float(risk_tolerance),
+    )
+    return race_state

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -32,7 +32,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS
+from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS, reading_or_default
+from src.agents.race_state_builder import UNKNOWN_TYRE_LIFE, normalise_compound
 from src.agents.tire_parsing import parse_tool_outputs
 
 # ── Repo root (module-relative) ───────────────────────────────────────────────
@@ -1475,8 +1476,15 @@ class TireAgent:
         wx   = lap_state.get('weather', {})
 
         driver      = meta['driver']
-        compound    = d.get('compound', 'MEDIUM')
-        tyre_life   = d.get('tyre_life', 1)
+        # This adapter reads the RAW lap_state, not the RaceState, so the canonical
+        # builder's normalisation does not reach it — it has to apply the same rules
+        # itself or the unification stops at the object boundary (#784). Both of the
+        # old two-arg defaults were also dead on the RSM path and wrong when they did
+        # fire: the key is always present, so a stored NaN arrives as the STRING "nan"
+        # and a None arrives as None, neither of which .get's default catches.
+        compound    = normalise_compound(d.get('compound'))
+        raw_tyre_life = d.get('tyre_life')
+        tyre_life   = UNKNOWN_TYRE_LIFE if raw_tyre_life is None else raw_tyre_life
         gp_name     = meta.get('gp_name', '')
         total_laps  = meta.get('total_laps', DEFAULT_TOTAL_LAPS)
         year        = meta.get('year', 2025)
@@ -1509,10 +1517,16 @@ class TireAgent:
             'cluster_id':         self.cfg.circuit_cluster_map.get(gp_name, 0),
             'team_id':            _encode_team_id(self.cfg.team_id_map, team),
             'year':               year,
-            'AirTemp':   wx.get('air_temp',   28.0),
-            'TrackTemp': wx.get('track_temp', 38.0),
-            'Humidity':  wx.get('humidity',   50.0),
-            'Rainfall':  float(wx.get('rainfall', 0)),
+            # reading_or_default, not .get(key, default): the producers report an
+            # unmeasured reading as the key PRESENT holding None, which .get's default
+            # never catches. These Nones do not crash here — they flow through
+            # _add_weather_cols into the TCN's feature frame and moved the cliff estimate
+            # 2.3 laps OPTIMISTIC on the 2025 reference lap, silently. Optimistic is the
+            # dangerous direction: it delays the pit call. See the helper's docstring.
+            'AirTemp':   reading_or_default(wx, 'air_temp',   28.0),
+            'TrackTemp': reading_or_default(wx, 'track_temp', 38.0),
+            'Humidity':  reading_or_default(wx, 'humidity',   50.0),
+            'Rainfall':  float(reading_or_default(wx, 'rainfall', 0.0)),
             f'{driver}_compound': compound,
             # The stint we are actually in, and the lap we are actually on. N10 trained
             # on windows grouped by ['Year','GP_Name','DriverNumber','Stint'], and the

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -597,82 +597,30 @@ class SimConnector(threading.Thread):
         return candidate  # report the primary miss so error messaging stays clean
 
     def _build_race_state(self, lap_state: dict[str, Any], prev_lap_time: float):
-        """Duplicate of ``_local_build_race_state`` from simulator.py, small
-        enough to inline so the arcade stays independent of
-        ``backend.utils.race_state_builder`` (which requires a sys.path
-        shim that only the FastAPI startup provides). Populates
-        ``radio_msgs`` / ``rcm_events`` from the ``RadioPipelineRunner``
-        corpus so the Radio agent sees the real OpenF1 team messages
-        (same as the CLI); empty lists when the corpus could not load.
+        """Delegate to the canonical builder, keeping only the arcade-side inputs.
+
+        The lap_state -> RaceState mapping lives in
+        ``src.agents.race_state_builder.build_race_state`` (#784): one
+        implementation shared by all three surfaces — this arcade, the CLI, and
+        the telemetry backend, which reaches it through a re-export shim (#786)
+        rather than keeping the copy it used to carry. So the defaults the
+        models receive no longer drift per surface.
+        The #465 position guard, the gap fallback rationale and
+        the #750 pace-delta axis are all documented there now. What stays here
+        is exactly what needs arcade instance state: sourcing ``radio_msgs`` /
+        ``rcm_events`` from the ``RadioPipelineRunner`` corpus so the Radio
+        agent sees the real OpenF1 team messages (same as the CLI; empty lists
+        when the corpus could not load), and the stateful Safety-Car
+        re-injection. Both are passed to the builder as parameters.
 
         ``prev_lap_time`` is accepted but no longer read here: ``pace_delta_s``
-        used to be computed from it and that was the wrong axis (#750, fixed
-        below). Left in the signature rather than removed, since the caller's
-        per-lap bookkeeping that produces it (``_step_once`` /
-        ``_lap_time_from_state``) serves no other purpose today and dropping it
-        is a small cleanup outside this fix's scope.
+        used to be computed from it and that was the wrong axis (#750, now
+        enforced by the canonical builder). Left in the signature rather than
+        removed, since the caller's per-lap bookkeeping that produces it
+        (``_step_once`` / ``_lap_time_from_state``) serves no other purpose
+        today and dropping it is a small cleanup outside this fix's scope.
         """
-        from src.agents.position_projection import GAP_UNKNOWN_FALLBACK_S
-        from src.agents.strategy_orchestrator import RaceState
-
-        driver_st = lap_state.get("driver", {})
-        weather = lap_state.get("weather", {})
-        meta = lap_state.get("session_meta", {})
-        cur_lap_time = driver_st.get("lap_time_s") or 0.0
-
-        rivals = lap_state.get("rivals", [])
-        our_pos = driver_st.get("position")
-        # `_lap_skip_reason` (the DNF/incomplete-lap guard the driver loop runs before
-        # `_step_once` -> `_build_race_state`) already filters out laps where position
-        # is None, so reaching here with an unknown position means that invariant broke.
-        # Fail loudly instead of fabricating a searchable P99 car (the #428 bug shape:
-        # a sentinel that collides with a real rival's `position - 1`) — the caller's
-        # `except Exception` wraps this into a surfaced `state.error`, it does not crash
-        # the driver thread (#465).
-        if our_pos is None:
-            raise ValueError(
-                "_build_race_state: driver position is None; the incomplete-lap guard "
-                "should have skipped this lap before calling _build_race_state (#465)"
-            )
-        car_ahead = next((r for r in rivals if r.get("position") == our_pos - 1), None)
-        # Two different zeros used to hide under one expression. No car ahead means we
-        # lead, and 0.0 is honest there. A car ahead whose interval was never measured
-        # is NOT a zero gap: 0.0 reads as side by side, which the orchestrator's
-        # clean-air band and N27's sub-1.0s DRS window both act on. It degrades to
-        # GAP_UNKNOWN_FALLBACK_S instead, which the CLI now shares. The telemetry
-        # backend still has its own copies and is a submodule, so this is a two-way
-        # unification, not the three-way one an earlier draft of this comment claimed.
-        #
-        # Be honest about what that fallback still is: 2.0 is fabricated, and a real
-        # 2.0s gap is common, so it does not satisfy the rule that a default must never
-        # be a value the code can also legitimately find. It is less harmful than 0.0,
-        # not correct. The real fix is RaceState.gap_ahead_s becoming `float | None`,
-        # which RivalState in position_projection.py already is and whose consumers
-        # already guard with `is not None`. That is a Pydantic contract change.
-        if car_ahead is None:
-            gap_ahead_s = 0.0
-        else:
-            measured_interval = car_ahead.get("interval_to_driver_s")
-            if measured_interval is None:
-                gap_ahead_s = GAP_UNKNOWN_FALLBACK_S
-            else:
-                gap_ahead_s = abs(measured_interval)
-
-        # pace_delta_s is contractually RIVAL-relative (this driver's lap time
-        # minus the car directly ahead's SAME lap, negative = we are faster) per
-        # race_situation_agent.py:292/904, the schema N27 itself computes. The
-        # old formula compared cur_lap_time against our OWN previous lap
-        # instead, a same-car same-driver quantity that reported roughly -20s
-        # of phantom "pace gain" on the lap after a pit stop, a green lap read
-        # against our own out-lap. car_ahead is already resolved above for
-        # gap_ahead_s, so no extra lookup is needed; 0.0 when it or its lap
-        # time is unknown is the schema's documented neutral, not a guess in
-        # either direction (#750).
-        ahead_lap_time = car_ahead.get("lap_time_s") if car_ahead is not None else None
-        if ahead_lap_time is not None and cur_lap_time:
-            pace_delta = cur_lap_time - float(ahead_lap_time)
-        else:
-            pace_delta = 0.0
+        from src.agents.race_state_builder import build_race_state
 
         lap_num = int(lap_state.get("lap_number", 1) or 1)
         radio_msgs: list[dict] = []
@@ -696,22 +644,11 @@ class SimConnector(threading.Thread):
         if self._sc_tracker.should_inject(lap_num):
             rcm_events = list(rcm_events) + [self._sc_tracker.synthetic_event()]
 
-        return RaceState(
-            driver=driver_st.get("driver", "UNK"),
-            lap=lap_num,
-            # 57 = median/mode race length across the dataset; the shared strategy fallback.
-            total_laps=meta.get("total_laps", 57),
-            position=our_pos,
-            compound=driver_st.get("compound", "MEDIUM"),
-            tyre_life=driver_st.get("tyre_life", 1),
-            gap_ahead_s=float(gap_ahead_s),
-            pace_delta_s=float(pace_delta),
-            air_temp=float(weather.get("air_temp", 25.0)),
-            track_temp=float(weather.get("track_temp", 35.0)),
-            rainfall=bool(weather.get("rainfall", False)),
+        return build_race_state(
+            lap_state,
+            risk_tolerance=self._request.risk_tolerance,
             radio_msgs=radio_msgs,
             rcm_events=rcm_events,
-            risk_tolerance=float(self._request.risk_tolerance),
         )
 
 

--- a/src/strategy/inference/no_llm.py
+++ b/src/strategy/inference/no_llm.py
@@ -32,6 +32,7 @@ import pandas as pd
 
 from src.agents.pace_agent import run_pace_agent_from_state
 from src.agents.race_situation_agent import RaceSituationAgent
+from src.agents.race_state_builder import UNKNOWN_TYRE_LIFE, normalise_compound
 from src.agents.radio_agent import RadioOutput, _build_alerts, run_pipeline, run_rcm_pipeline
 from src.agents.strategy_orchestrator import (
     RaceState,
@@ -132,8 +133,12 @@ def _tire_no_llm(lap_state: dict[str, Any], laps_df: pd.DataFrame):
     driver = lap_state["session_meta"]["driver"]
     d = lap_state["driver"]
     meta = lap_state["session_meta"]
-    compound = d.get("compound", "MEDIUM")
-    tyre_life = d.get("tyre_life", 1)
+    # Same rules as tire_agent.run_from_state: this path also reads the RAW lap_state
+    # rather than the RaceState, so it applies the canonical normalisation itself
+    # instead of restating the pre-#784 defaults its twin used to carry.
+    compound = normalise_compound(d.get("compound"))
+    raw_tyre_life = d.get("tyre_life")
+    tyre_life = UNKNOWN_TYRE_LIFE if raw_tyre_life is None else raw_tyre_life
     gp_name = meta.get("gp_name", "")
     year = meta.get("year", 2025)
     compound_id = (

--- a/tests/agents/test_race_state_builder.py
+++ b/tests/agents/test_race_state_builder.py
@@ -1,0 +1,290 @@
+"""#784 — the canonical RaceState builder replaces three drifted per-surface copies.
+
+Two tiers, split by what each test needs to import. The pure-helper tests and the
+leaf-module guard import only ``src.agents.race_state_builder`` (cheap by
+contract) and run everywhere, including CI without ``data/models`` and without the
+``src/telemetry`` submodule. The tests that CALL ``build_race_state`` construct a
+real ``RaceState``, whose lazy import pulls in ``strategy_orchestrator`` and
+therefore model artefacts, so they carry the same models-present guard as the
+sibling agent tests.
+
+Every canonical literal asserted here is asserted against the module's own
+constant, never a restated number, so a deliberate future change to a default
+fails exactly one definition away from this file.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS
+from src.agents.position_projection import GAP_UNKNOWN_FALLBACK_S
+from src.agents.race_state_builder import (
+    DEFAULT_AIR_TEMP_C,
+    DEFAULT_TRACK_TEMP_C,
+    UNKNOWN_COMPOUND,
+    UNKNOWN_TYRE_LIFE,
+    build_race_state,
+    normalise_compound,
+)
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "lap_time").is_dir()
+
+needs_models = pytest.mark.skipif(
+    not _HAS_MODELS, reason="building a RaceState imports the agents, which load model artefacts"
+)
+
+
+def _lap_state(**overrides):
+    """A minimal-but-complete lap_state shaped like RaceStateManager emits it.
+
+    Our driver is P3; VER sits one position ahead with a measured interval and a
+    same-lap time, so both the gap and the #750 pace delta have known expected
+    values (gap 1.8, pace 92.5 - 92.1 = +0.4). Overrides replace TOP-LEVEL keys.
+    """
+    state = {
+        "lap_number": 30,
+        "driver": {
+            "driver": "NOR",
+            "lap_number": 30,
+            "position": 3,
+            "compound": "MEDIUM",
+            "tyre_life": 8,
+            "lap_time_s": 92.5,
+        },
+        "rivals": [
+            {"driver": "VER", "position": 2, "interval_to_driver_s": -1.8, "lap_time_s": 92.1},
+            {"driver": "LEC", "position": 4, "interval_to_driver_s": 2.4, "lap_time_s": 93.0},
+        ],
+        "weather": {"air_temp": 22.0, "track_temp": 31.5, "rainfall": False},
+        "session_meta": {"total_laps": 57},
+    }
+    state.update(overrides)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — pure helpers and the leaf guarantee (no models, no submodule)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw", ["", "nan", "None", "NaN", "NONE", "  ", None])
+def test_missing_compound_spellings_normalise_to_unknown(raw):
+    """Every spelling of "no compound" folds into the one honest marker.
+
+    race_state_manager.py emits `str(r.get("Compound", ""))`, so a stored NaN
+    reaches the builder as the STRING "nan" with the key present — a dict.get
+    default never fires on it. This normalisation is the substantive half of the
+    "UNKNOWN" decision; without it the canonical default is a choice about an
+    almost-unreachable branch.
+    """
+    assert normalise_compound(raw) == UNKNOWN_COMPOUND
+
+
+@pytest.mark.parametrize("real", ["SOFT", "MEDIUM", "HARD", "INTERMEDIATE", "WET"])
+def test_real_compound_passes_through_untouched(real):
+    assert normalise_compound(real) == real
+
+
+def test_module_import_is_a_leaf_and_never_drags_langchain():
+    """The guard that keeps every surface's boot cheap.
+
+    ``build_race_state`` imports ``RaceState`` lazily because
+    ``strategy_orchestrator`` drags LangChain/LangGraph and model artefacts. A
+    future editor hoisting that import to module level would slow the CLI, the
+    arcade and the backend at once — this subprocess check (a fresh interpreter,
+    so no module already cached by other tests can mask the leak) fails the
+    moment that happens.
+    """
+    probe = (
+        "import sys; import src.agents.race_state_builder; "
+        "leaked = sorted(m for m in sys.modules "
+        "if m.startswith('langchain') or m.startswith('langgraph')); "
+        "assert not leaked, f'leaf module dragged: {leaked}'"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — the canonical field behaviour, end to end (needs model artefacts)
+# ---------------------------------------------------------------------------
+
+
+@needs_models
+def test_canonical_defaults_fire_when_keys_are_absent(caplog):
+    """Each approved default fires on a lap_state that omits its key."""
+    state = _lap_state(
+        driver={"position": 1, "lap_time_s": 92.5},
+        rivals=[],
+        weather={},
+        session_meta={},
+    )
+    del state["lap_number"]
+
+    with caplog.at_level("WARNING", logger="src.agents.race_state_builder"):
+        rs = build_race_state(state)
+
+    assert rs.driver == "UNK"
+    assert rs.lap == 1
+    assert rs.total_laps == DEFAULT_TOTAL_LAPS
+    assert rs.compound == UNKNOWN_COMPOUND
+    assert rs.tyre_life == UNKNOWN_TYRE_LIFE
+    assert rs.air_temp == DEFAULT_AIR_TEMP_C
+    assert rs.track_temp == DEFAULT_TRACK_TEMP_C
+    assert rs.rainfall is False
+    assert rs.radio_msgs == []
+    assert rs.rcm_events == []
+    assert rs.risk_tolerance == 0.5
+    # Both silent-fallback holes must be loud, not quiet (#784 decision table).
+    warnings = " ".join(r.getMessage() for r in caplog.records)
+    assert "total_laps" in warnings
+    assert "lap_number" in warnings
+
+
+@needs_models
+def test_explicit_driver_param_wins_over_the_driver_dict():
+    rs = build_race_state(_lap_state(), driver="PIA")
+    assert rs.driver == "PIA"
+
+
+@needs_models
+def test_lap_falls_back_to_the_driver_dict_before_defaulting():
+    """The middle rung of the lap ladder: top-level absent, driver dict present."""
+    state = _lap_state()
+    del state["lap_number"]
+    rs = build_race_state(state)
+    assert rs.lap == 30
+
+
+@needs_models
+def test_compound_nan_string_is_normalised_end_to_end():
+    """The live RSM path: key PRESENT with the literal string "nan"."""
+    state = _lap_state()
+    state["driver"]["compound"] = "nan"
+    rs = build_race_state(state)
+    assert rs.compound == UNKNOWN_COMPOUND
+
+
+@needs_models
+def test_present_but_none_weather_lands_on_defaults_without_crashing():
+    """A NaN weather row emits keys whose VALUE is None (race_state_manager.py).
+
+    All three pre-#784 builders crashed here, though not by the same mechanism: the
+    arcade and backend copies wrapped the read in float(), so they raised TypeError,
+    while the CLI passed the None straight to Pydantic, which rejected it; the canonical
+    builder treats present-but-None as missing, identical behaviour on every lap
+    that worked before.
+    """
+    state = _lap_state(weather={"air_temp": None, "track_temp": None, "rainfall": None})
+    rs = build_race_state(state)
+    assert rs.air_temp == DEFAULT_AIR_TEMP_C
+    assert rs.track_temp == DEFAULT_TRACK_TEMP_C
+    assert rs.rainfall is False
+
+
+@needs_models
+def test_position_none_raises_value_error():
+    """The one converged fail-loud guard: never fabricate a searchable position."""
+    state = _lap_state()
+    state["driver"]["position"] = None
+    with pytest.raises(ValueError, match="position is None"):
+        build_race_state(state)
+
+
+@needs_models
+def test_gap_is_zero_when_no_car_ahead():
+    """P1 with no rival at position 0: leading, and 0.0 is honest there."""
+    state = _lap_state()
+    state["driver"]["position"] = 1
+    rs = build_race_state(state)
+    assert rs.gap_ahead_s == 0.0
+
+
+@needs_models
+def test_gap_falls_back_when_the_interval_is_unmeasured():
+    """A car ahead with interval None is NOT a zero gap (#633)."""
+    state = _lap_state(
+        rivals=[{"driver": "VER", "position": 2, "interval_to_driver_s": None}],
+    )
+    rs = build_race_state(state)
+    assert rs.gap_ahead_s == GAP_UNKNOWN_FALLBACK_S
+
+
+@needs_models
+def test_gap_is_the_absolute_measured_interval():
+    rs = build_race_state(_lap_state())
+    assert rs.gap_ahead_s == pytest.approx(1.8)
+
+
+@needs_models
+def test_pace_delta_is_rival_relative_same_lap():
+    """The #750 contract: our lap time minus the car ahead's SAME-lap time."""
+    rs = build_race_state(_lap_state())
+    assert rs.pace_delta_s == pytest.approx(92.5 - 92.1)
+
+
+@needs_models
+def test_pace_delta_is_neutral_zero_when_the_ahead_lap_time_is_unknown():
+    state = _lap_state(
+        rivals=[{"driver": "VER", "position": 2, "interval_to_driver_s": -1.8}],
+    )
+    rs = build_race_state(state)
+    assert rs.pace_delta_s == 0.0
+
+
+@needs_models
+def test_pace_delta_is_neutral_zero_when_our_lap_time_is_unknown():
+    state = _lap_state()
+    state["driver"]["lap_time_s"] = None
+    rs = build_race_state(state)
+    assert rs.pace_delta_s == 0.0
+
+
+@needs_models
+def test_explicit_gap_and_pace_override_the_internal_computation():
+    """None-means-compute is what keeps the backend call sites byte-compatible.
+
+    /recommend forwards the client's gap_ahead_s and mcp_tools substitutes its
+    own fallback; both must land unchanged even when rivals are present and the
+    internal computation would produce different numbers (1.8 / +0.4 here).
+    """
+    rs = build_race_state(_lap_state(), gap_ahead_s=7.7, pace_delta_s=-0.3)
+    assert rs.gap_ahead_s == 7.7
+    assert rs.pace_delta_s == -0.3
+
+
+@needs_models
+def test_rival_targeting_recomputes_both_values():
+    """#431: gap and pace framed around the chosen rival, not the car ahead."""
+    rs = build_race_state(_lap_state(), rival="LEC")
+    assert rs.gap_ahead_s == pytest.approx(2.4)
+    assert rs.pace_delta_s == pytest.approx(92.5 - 93.0)
+
+
+@needs_models
+def test_rival_absent_from_the_lap_falls_back_to_positional_values():
+    """A stale rival selection degrades to positional behaviour, never to zero."""
+    rs = build_race_state(_lap_state(), rival="XXX")
+    assert rs.gap_ahead_s == pytest.approx(1.8)
+    assert rs.pace_delta_s == pytest.approx(92.5 - 92.1)
+
+
+@needs_models
+def test_radio_and_rcm_parameters_land_on_the_state():
+    """The parameter shape is the surface-neutral one (F3 in the design gate)."""
+    radios = [{"lap": 30, "message": "box box"}]
+    rcms = [{"lap": 30, "category": "SafetyCar"}]
+    rs = build_race_state(_lap_state(), radio_msgs=radios, rcm_events=rcms)
+    assert rs.radio_msgs == radios
+    assert rs.rcm_events == rcms

--- a/tests/agents/test_weather_reading_guard.py
+++ b/tests/agents/test_weather_reading_guard.py
@@ -1,0 +1,78 @@
+"""#788 — the present-``None`` guard on the agents' raw-lap_state weather reads.
+
+The canonical builder (#784) protects the ``RaceState``. These tests protect the layer
+BELOW it: the agents that re-read the raw ``lap_state`` dict and build their own
+``session_meta`` from it. That distinction is the whole reason these tests exist —
+#788 was declared fixed once when only the builder had been fixed, and an adversarial
+gate found ``/recommend`` still returning 422 because the crash had simply moved down
+here.
+
+The producers emit an unmeasured reading as the key PRESENT holding ``None``
+(``_safe_none`` in the telemetry backend, ``get_weather_state`` in the RSM), which is
+exactly what ``dict.get(key, default)`` does not catch. Every 2025 laps parquet ships
+without weather columns, so this is the shape those agents actually receive today.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from src.agents._shared_defaults import reading_or_default
+
+# The dict the backend producer really emits for a 2025 lap, verified over real HTTP
+# (documents/audits/GATE_qatar_lap7_cross_surface.md, Task 2).
+PRODUCER_WEATHER_2025 = {
+    "air_temp": None,
+    "track_temp": None,
+    "track_temp_start": None,
+    "humidity": None,
+    "rainfall": 0,
+}
+
+
+def test_present_none_falls_back_where_two_arg_get_does_not():
+    """The bug in one assertion: .get's default does not fire, the helper's does."""
+    assert PRODUCER_WEATHER_2025.get("air_temp", 28.0) is None
+    assert reading_or_default(PRODUCER_WEATHER_2025, "air_temp", 28.0) == 28.0
+
+
+def test_absent_key_also_falls_back():
+    assert reading_or_default({}, "track_temp", 38.0) == 38.0
+
+
+@pytest.mark.parametrize("value", [0.0, 0, False])
+def test_a_legitimate_falsy_reading_survives(value):
+    """Not an ``or`` fallback: a real 0.0 is a measurement, not an absence.
+
+    Rewriting 0.0 to a default is the #633 conflation — a different bug, and the one
+    an ``or`` would have introduced here.
+    """
+    assert reading_or_default({"track_temp": value}, "track_temp", 38.0) == value
+
+
+def test_a_real_reading_passes_through():
+    assert reading_or_default({"air_temp": 23.4}, "air_temp", 28.0) == 23.4
+
+
+def test_the_three_agents_agree_on_this_read():
+    """All three sub-agents route this read through one implementation (#788).
+
+    They keep DIFFERENT default temperatures on purpose — pace 25/35, tire and
+    race_situation 28/38 — because reconciling those numbers is a modelling decision
+    tracked in #789. What must not differ again is the None handling: pace was the only
+    one of the three that had it right, and its guard is now the shared helper.
+    """
+    for default in (25.0, 28.0, 35.0, 38.0):
+        assert reading_or_default(PRODUCER_WEATHER_2025, "track_temp", default) == default
+
+
+def test_the_producer_shape_never_reaches_float_as_none():
+    """float() over every weather key of a real producer payload must not raise.
+
+    ``float(None)`` is the exact TypeError that 422'd /recommend on every 2025 lap.
+    """
+    for key, default in (("air_temp", 28.0), ("track_temp", 38.0), ("humidity", 50.0)):
+        value = float(reading_or_default(PRODUCER_WEATHER_2025, key, default))
+        assert math.isfinite(value)


### PR DESCRIPTION
## What

One canonical `lap_state` -> `RaceState` builder, replacing three independent implementations that had drifted apart, plus a fourth copy of the car-ahead gap logic. Then the same unification applied one layer down, to the agents that read the raw `lap_state` rather than the built object — which is where a live production crash turned out to be hiding.

Closes #785, #786, #787, #788. Part of #784.

## Why

The CLI, the Arcade and the telemetry backend each built the same Pydantic object from the same input contract, and they disagreed on more than the four fields the earlier cleanup audit had recorded: `compound`, `tyre_life`, `track_temp`, `total_laps`, `lap`, `driver` and `risk_tolerance` all had per-surface behaviour, and the Safety-Car re-injection sat at a different layer in each.

The drift that actually bit this codebase was never literal drift — it was logic drift. #750 (a pace delta measured against the wrong car), #465 (a default that could never fire), #633 (an unknown gap conflated with zero) were each fixed in one copy at a time. That is the argument against the cheap option: a parity test diffing literals would have caught none of them, and it cannot run inside the submodule's own repo where backend edits actually happen.

## Approach

Options are recorded in `documents/audits/DESIGN_race_state_single_contract.md`.

Making the CLI and Arcade import the backend's copy was rejected: `f1-sim` and `f1-arcade` run today from a checkout with `src/telemetry` empty (`INSTALL.md:37-59` documents no submodule step) and there are zero parent-side `backend.*` imports. That install contract is a feature, not an accident.

So the canonical implementation lives in the parent at `src/agents/race_state_builder.py` and the backend imports **up** into it — the direction it already used. `backend/utils/race_state_builder.py:3` has imported `src.agents.position_projection` at module scope all along, and `docker-compose.yml:16` mounts `../../src` into the container.

## What changed

- **New** `src/agents/race_state_builder.py` — a leaf module. `RaceState` is imported lazily inside the function because `strategy_orchestrator` drags LangChain, LangGraph and every sub-agent's model artefacts; a test asserts in a fresh interpreter that importing the builder pulls none of them. `_targeting_against_rival` (the #431 rival targeting) moved here.
- `scripts/run_simulation_cli.py` — the PMV. Two hunks: an import and the function body. The function, signature and call site are unchanged, and the radio/RCM main-loop block has no hunk at all — verified by a programmatic byte-compare of the whole file tail, not by eye.
- `src/arcade/strategy.py` — delegates. Keeps exactly what needs arcade instance state: the `RadioPipelineRunner` corpus and the stateful Safety-Car re-injection, both passed to the builder as parameters.
- `src/telemetry` (submodule) — `backend/utils/race_state_builder.py` becomes a re-export shim, so `simulator.py`, `endpoints/strategy.py` and `mcp_tools.py` need zero changes; `_compute_gap_ahead` is deleted.
- `src/agents/_shared_defaults.py` — gains `reading_or_default`, and `pace_agent`, `tire_agent` and `race_situation_agent` all migrate onto it (see #788 below).
- `tire_agent.run_from_state` and `src/strategy/inference/no_llm.py::_tire_no_llm` re-derived `compound`/`tyre_life` from the RAW `lap_state` with the pre-#784 defaults, bypassing the canonical rules entirely. Both now use `normalise_compound` and `UNKNOWN_TYRE_LIFE`.

`radio_msgs`/`rcm_events` are parameters rather than built internally: the three surfaces have three different sources — the CLI's corpus plus its `--radio-every` synthetic generator with a precedence rule, the Arcade's instance state, the backend's request payloads — and only the parameter shape expresses all three without dragging a `RadioPipelineRunner` and Whisper into a shared leaf module. It is also what keeps the CLI edit surgical.

## Canonical values

Each decided individually against measured evidence. Full table in #784.

`compound` `"UNKNOWN"` with `""`/`"nan"`/`"None"` normalised into it, because zero rows carry `"UNKNOWN"` in 71 races while `"MEDIUM"` is a value the code can legitimately find — and because `race_state_manager.py:352` means a missing compound already arrives as the literal string `"nan"` regardless of any default. `tyre_life` `0`, which occurs zero times in 2023-2025 while `1` collides with real fresh-tyre laps. `track_temp` `35.0`, the dataset median. `total_laps` from `_shared_defaults.DEFAULT_TOTAL_LAPS` rather than a restated literal.

## #788 — and a correction to how it was first reported

`/recommend` returned a 422 on **every lap of every 2025 race**, the default season: the producer emits `None` per weather key (2025 parquets carry no weather columns) and the consumer did `float(weather.get("air_temp", 25.0))`, where `.get`'s default never fires because the key is present.

This PR originally claimed the canonical builder fixed that. **It did not.** An adversarial gate drove the real endpoint and got the same 422 — the builder no longer crashed, but the crash had moved one layer down into `race_situation_agent`, which re-reads the raw weather to build its own `session_meta`. The same trap, one floor below the one just closed.

`pace_agent` was the one copy of that read that was already correct, with a comment naming this exact crash. Its guard is now the shared `reading_or_default`, and all three agents use it — pace included, so there is one implementation rather than one good copy plus a helper for the stragglers. The per-caller `default` argument is deliberate: pace uses 25/35 and its siblings 28/38, and reconciling those numbers is a modelling decision tracked in #789.

A second, non-crashing instance of the same trap moved the tyre cliff estimate **2.3 laps in the optimistic direction** — the dangerous one, since it delays the pit call. Measured on the reference lap, cliff P50 goes from 10.5 to 7.9 against 8.1 with real readings; the residual 0.2 is the honest distance to the missing measurement (#782) and sits inside the TCN's own MC-Dropout variance.

## Verification

- Cross-surface field-by-field diff on Qatar 2025 lap 7 (the thesis/demo reference case, which carries a real `SAFETY CAR DEPLOYED` at that lap): all five code paths agree on every field except three with named owners.
- Real `f1-sim` on Lusail, both with and without the radio corpus. The corpus run ingests 24 radios and 66 RCM events and produces three `PIT_NOW` laps the corpus-disabled run never does — evidence the radio path survives the builder no longer populating it.
- Real Arcade: the PySide6 dashboard rendered offscreen and was read from the PNG. Lap 7 shows STAY OUT 88%, threat HIGH, safety car 100%, the RCM card carrying `SAFETY_CAR_DEPLOYED`, and RAG citing Art. 54.3. The pyglet replay window itself was not rendered (no GL context headless) and is stated as such in the gate report.
- Real backend: `/lap-state` 200, `/simulate` SSE 200 with 7/7 laps and zero error events, 2024 control 200.
- 200 tests green.
- Four adversarial gates, all recorded under `documents/audits/`. Two of them refuted claims made earlier in this same work, including the #788 one above; both corrections are in the record rather than quietly dropped.

## Known and deliberately not fixed here

#790 — `int(NaN)` on `TyreLife` crashes N27's overtake tool on 451 real 2025 laps. The mechanical part is trivial; the policy is not. The guarded twin (`pit_strategy_agent.py:983-999`) refuses the prediction rather than defaulting, and applying that to N27 costs the orchestrator its overtake probability on those laps.

#789 — five distinct air/track temperature pairs exist across the two repos, some in `lap_state` producers that fabricate readings before the contract, which no downstream unification can correct.
