### PR TITLE
fix(data): repair tyre-stint metadata the live-timing feed published wrong

### DIFF
--- a/documents/audits/GATE_tyre_stint_repair.md
+++ b/documents/audits/GATE_tyre_stint_repair.md
@@ -1,0 +1,294 @@
+# GATE — tyre-stint repair (#790): adversarial correctness audit
+
+**Date:** 2026-08-02 · **Auditor:** adversarial correctness gate (read-only except this file)
+**Scope:** `src/f1_strat_manager/tyre_stint_repair.py`, its wiring in
+`src/f1_strat_manager/laps_augment.py::augment_featured_laps`, and
+`tests/agents/test_tyre_stint_repair.py`, on branch `dev` (uncommitted).
+
+Findings are appended incrementally as they are confirmed with executed evidence.
+
+## Checklist
+
+- [x] A. Repair touches only broken data — **VERIFIED** (69/71 byte-identical, independently re-measured)
+- [x] B. Two-condition boundary rule — **INCOMPLETE by construction** (Findings 2, 4, 8): blind to
+      same-compound refits (28.6% of real stops), fires on data-loss sentinels, misses GAS/HUL/BEA
+- [x] C. Rebuilt ages — **RIGHT for fresh sets, WRONG for used sets** (Finding 3: ALO/HAD/STR + TSU)
+- [x] D. No invented first-stint age — **HOLDS** (but the fabricated recovery block survives, Finding 1)
+- [x] E. Integration — **HOLDS** on shipped data (latent NaN-Driver annihilation, Finding 6)
+- [x] F. Tests — pass 10/10, but the first-stint test pins a no-op (Finding 9)
+- [x] G. Published metrics unmoved by construction except decision_modes; three-truth split (Finding 7)
+
+---
+
+## Finding 1 (HIGH) — the flagship defect of the investigation is NOT fixed: 71+ Miami laps keep fabricated ages after the repair
+
+Executed: `repair_tyre_stints` on `data/raw/2025/Miami_Gardens/laps.parquet`, then scanned every
+driver for numeric `TyreLife` before their first pit stop with `TyreLife < LapNumber - 5`.
+
+The repair only rewrites laps **after** a pit stop (`tyre_stint_repair.py:147-149`,
+`in_new_stint = lap_numbers >= out_lap`). The laps between feed recovery and the pit stop — the
+block where `TyreLife` restarted at 1 mid-stint, error #1 of `GATE_tyrelife_nan_rootcause.md`
+Finding 4 — are left exactly as the feed fabricated them:
+
+| Driver | Surviving fabricated laps | TyreLife kept | Truth |
+|---|---|---|---|
+| NOR | 25–29 | 1–5 | ~25–29 (+offset) |
+| HUL (never repaired) | 24–36 | 1–13 | ~24–36 |
+| GAS (never repaired) | 24–32 | 1–9 | ~24–32 |
+| BEA (never repaired) | 24–28 | 1–5 | ~24–28 |
+| + 11 more repaired drivers | 1–9 laps each | 1–7 | lap number |
+
+**66 laps** across 14 drivers with a first pit stop, **plus BEA's 5** (he has zero
+`PitInTime`/`PitOutTime` records in the whole race, so the scan skipped him — total ≥71 laps.
+Executed evidence for the flagship row: NOR lap 29 still reads `TyreLife 5.0` after repair (truth
+~29) — the exact value the investigation used as its headline. The module docstring's own standard
+("a wrong integer is worse than a NaN precisely because the NaN is visible",
+`tyre_stint_repair.py:32`) condemns the module's own output: these laps are *provably* wrong (a
+numeric `TyreLife < laps since the last pit/race start` is impossible) and the repair leaves the
+plausible integers in place instead of nulling them to the honest NaN it uses everywhere else.
+These are 2025-test-season racing laps that feed N26/N15/N16.
+
+## Finding 2 (HIGH) — coverage hole: GAS, HUL and BEA carry the same corruption and are not touched
+
+Executed per-driver boundary scan on Miami:
+
+- `GAS: pits=[32]`, metadata recovers at lap 24 → his lap-32 stop's boundary lands correctly at 33,
+  so `find_misplaced_boundaries` returns `[]` — yet laps 24–32 are stint-1 fabricated ages 1–9.
+- `HUL: pits=[36]` → same shape, laps 24–36 fabricated ages 1–13 (the worst single block in the race).
+- `BEA: pits=[]` — **zero pit records in the entire race** while `Stint 1.0 / HARD / TyreLife 1.0`
+  appears at lap 24 (he retired on lap 28). Either he pitted and `PitInTime` was ALSO lost —
+  refuting the module's premise that "`PitInTime` is the one column the broken feed leaves intact"
+  (`tyre_stint_repair.py:84-86`) — or he never pitted and lap 24's `TyreLife 1.0` on a 24-lap-old
+  set is pure fabrication. Both readings leave wrong data shipped.
+
+The repair claims (module docstring, integration comment `laps_augment.py:203-204`) to fix the
+Miami corruption; it fixes 15 of 18 corrupted cars' post-stop halves and 0 of 17 pre-stop halves.
+
+## Finding 3 (HIGH) — claim C is false for used sets: the rebuild contradicts the FastF1 convention it cites
+
+Executed: swept every stint transition in all 2024 races (healthy season) and all 2025 races
+except Miami, split by `FreshTyre`:
+
+- Fresh set, first lap of stint: `TyreLife == 1.0` in **617/617** (2024) and **539/539** (2025).
+- **Used set, first lap of stint: 2–16**, 209 cases in 2024 alone (e.g. Austin ALO L27 HARD → 2.0,
+  Austin OCO L52 SOFT → 4.0). FastF1's `TyreLife` counts prior-session laps on the set.
+
+The rebuild hardcodes `TyreLife = LapNumber - out_lap + 1` (`tyre_stint_repair.py:165-167`), i.e.
+assumes every fitted set is fresh. Three of the 15 repaired Miami drivers fitted sets with
+`FreshTyre == False` at their (real-data) boundary lap: **ALO** (L33, MEDIUM, feed said 2.0),
+**HAD** (L24), **STR** (L24, feed said 2.0). For these the repaired value understates true tyre
+age by the set's prior usage — the exact "unknown offset" the module refuses to invent for stint 1
+(`tyre_stint_repair.py:28-32`) is silently invented as zero for stints 2+. The comment at
+`tyre_stint_repair.py:144-146` ("the convention FastF1 itself uses on healthy races (verified:
+Miami lap 33...)") verified the convention on ONE fresh-set example from the *broken* race; on
+healthy races the convention is conditional on `FreshTyre`, which the rebuild never reads.
+
+## Finding 4 (MEDIUM) — Montréal 2023: the rule fires on the `'None'` data-loss sentinel, not on a compound change, and destroys a real cell
+
+Executed before/after on TSU (the only 2023 change):
+
+- The "compound change" that satisfies condition 1 is `'HARD' → 'None'` — the literal string
+  `'None'` is a data-loss sentinel, not a compound. The rule's justification (compound change =
+  evidence a new set was fitted) is not what fired; absence-of-data fired it.
+- Lap 35 before: `Stint 2.0, Compound 'HARD', TyreLife 34.0`. After: `Stint 3.0, Compound 'None',
+  TyreLife 1.0` — the repair **overwrote a real compound string with the sentinel** as a side
+  effect of `tyre_stint_repair.py:152-154`. Downstream consumers that check `Compound.notna()`
+  see `'None'` as a valid compound.
+- In this instance the stop WAS a real tyre change (executed evidence: pit transit 27.5 s vs field
+  median ~24 s — too short for a 10 s stop-and-go, too long for a drive-through; lap times drop
+  from ~78.4 s to ~77.2 s on the new set), so the 36 filled ages count laps-on-car correctly. But
+  stint 3 has `FreshTyre == False` on every lap, so Finding 3's used-set understatement applies
+  here too: the filled 1–36 are a lower bound, not the FastF1-convention age.
+- Had the stop been a served penalty followed by feed death — indistinguishable to the rule, since
+  `'None' != anything` is always True — the repair would have invented a fresh set from a penalty.
+  The rule survives on this data by luck, not by construction.
+- Surface nuance: featured 2023 does not carry TSU lap 35 (N04 drops pit-out laps), so the
+  `'HARD' -> 'None'` cell destruction stays in the in-memory raw view; what reaches featured is the
+  35 filled ages (verified: 35 patched rows, all filled-from-NaN).
+- Generalisation (executed): the Miami gap's `Compound` is the literal string `'nan'` (437/438
+  rows, `str` type), NOT `np.nan`. So the boundary detections at Miami laps 24 (BOR, STR, HAD) also
+  fired on a sentinel-to-real transition (`'nan' -> 'HARD'`), the same absence-of-data mechanism.
+  They coincide with real stops here, but none of the rule's firings in shipped data was a true
+  compound-A-to-compound-B change at the boundary row's own stint; and had the extractor stored
+  real NaN instead of the `'nan'` string, `NaN != NaN` would have made every in-block comparison
+  "a change", the boundary would have collapsed to `pit_lap + 1`, and BOR/STR/HAD would silently
+  NOT have been repaired. The rule's coverage depends on an accident of stringification.
+
+## Finding 5 (MEDIUM) — the shipped log line is factually false: `left_unknown` counts rows the repair itself just filled
+
+`repair_tyre_stints` computes `still_unknown` BEFORE repairing (`tyre_stint_repair.py:195-198`)
+and logs it as "%d lap(s) keep an honest unknown age" (`tyre_stint_repair.py:208`). Executed on
+Montréal 2023: `report.left_unknown == 35` while the repair filled **all 35** of those NaN
+`TyreLife` rows with numbers in the same call. Every operator reading the log is told the exact
+opposite of what happened.
+
+## Finding 6 (MEDIUM, latent) — a NaN `Driver` row is silently annihilated, all columns
+
+`repair_tyre_stints` rebuilds the frame as `pd.concat(groupby("Driver"))` then
+`.reindex(laps.index)` (`tyre_stint_repair.py:200-203`). `groupby` drops NaN-key rows; `reindex`
+re-inserts them as all-NaN. Executed on a synthetic frame: a row with `Driver=None` came back with
+`LapNumber`, `Stint`, `Compound`, `TyreLife` AND `Position` all NaN — the repair destroyed columns
+it has no business touching. Swept all 71 shipped raw parquets: none carries a NaN `Driver` today,
+so this is latent — but the function runs on every load of every future season's download, and one
+malformed row would be silently erased rather than skipped.
+
+## Finding 7 (MEDIUM) — the repair creates a three-truth split: the same Miami lap now has different tyre data depending on which surface asks
+
+The repair exists ONLY inside `augment_featured_laps`. Executed inventory of readers that bypass it:
+
+- **Raw, unrepaired:** `src/simulation/replay_engine.py:73` (loads `laps.parquet` for
+  `RaceStateManager`, which serves `TyreLife`/`Compound`/`Stint` into `lap_state` —
+  `race_state_manager.py:4-8`), `src/telemetry/backend/api/v1/endpoints/strategy.py:328`,
+  `src/strategy/eval/projection.py:292`, `pit_holdout.py:51`, `stint_lengths.py:203`.
+- **Featured-direct, unrepaired:** `src/strategy/eval/pace_holdout.py:95-106`,
+  `tire_holdout.py:171`, `calibration.py:160/233/283` — the golden-metric layer reads the parquet
+  without `augment_featured_laps`, so it measures the models on UNREPAIRED inputs while the
+  runtime agents now consume REPAIRED ones.
+- **Augmented, repaired:** the CLI/arcade/backend agent frames, and `decision_modes.py:473/508`.
+
+Concrete incoherence, measured on both frames: during a Miami 2025 replay, `lap_state` for NOR lap
+31 says `Stint 1 / MEDIUM / TyreLife 7` (raw) while the tire agent's featured window for the same
+lap says `Stint 2 / HARD / TyreLife 2` (repaired). The two disagree about which stint the car is in
+inside a single process.
+
+## Finding 8 (MEDIUM) — claim B is incomplete by construction: the rule is blind to 28.6% of real stops
+
+Executed over all 71 races: 2594 stint transitions, of which **743 (28.6%) fit the same compound
+again** (e.g. HARD -> HARD two-stoppers). For those, `_first_compound_change_after` sees no change
+at the stop — a misplaced boundary there is invisible to the rule in principle, no matter how
+corrupt. Miami 2025 happened to have compound changes at every corrupted stop, so nothing shipped
+is missed *today*; the incompleteness is structural, not observed. Direction: misses defects
+(conservative), never rewrites correct records via this path.
+
+Also executed: the only stint transitions in all 71 races with no pit entry within the 2 prior
+laps are the 12 Miami corruption boundaries themselves — so the red-flag/no-pit-entry false-positive
+shape (a compound change with no `PitInTime`, preceded by an unrelated earlier stop, which the rule
+would misread as a misplaced boundary and rewrite correct laps) has **no live instance in shipped
+data**. It remains reachable for future seasons: nothing in the rule distinguishes "compound
+changed with no pit record at all" from "boundary snapped late".
+
+## Finding 9 (LOW) — the first-stint test pins a no-op, not the invariant; line 93's `, why` is dead
+
+- `test_a_missing_first_stint_stays_unknown` (`tests/agents/test_tyre_stint_repair.py:140-156`):
+  executed `find_misplaced_boundaries` on its fixture -> `[]`, and `repair_tyre_stints` returns the
+  frame **completely untouched** (`.equals` True, 0 boundaries, 0 ages). The assertion then checks
+  a row the function never had any code path toward — the test passes for the wrong reason (the
+  project's recorded scar class). The invariant itself DOES hold on the firing path: on a
+  Miami-shaped fixture where a repair fires next to an unknown first stint, laps 1-2 stay NaN
+  (executed) — but no shipped test proves that. The assertion at :153-155 (`x != x or pd.isna(x)`)
+  is a doubly-redundant NaN check, not a tautology.
+- `tests/agents/test_tyre_stint_repair.py:93`: `pd.testing.assert_frame_equal(repaired, frame), why`
+  builds a tuple; the equality check still executes and raises on mismatch, so the test DOES
+  assert — but `why` is dead code that looks like an assert message and is not.
+- All 10 shipped tests pass (executed: `pytest tests/agents/test_tyre_stint_repair.py` -> 10 passed).
+
+## Verified intact (what I tried to break and could not — so far)
+
+- **Claim A (independently re-measured):** swept all 71 raw parquets through `repair_tyre_stints`
+  with strict `assert_frame_equal` (dtype, index, column type, exact values) plus
+  `hash_pandas_object` as a second witness: **69/71 byte-identical**; only Miami 2025 (15 drivers,
+  416 ages, 62 Stint/Compound cells) and Montréal 2023 (TSU, 36 ages, 1 Stint + 1 Compound cell)
+  change.
+- **Claim E (integration):** end-to-end `augment_featured_laps` on featured 2025: row count 22760
+  preserved, row order preserved, no `_fixed` columns leak, only `Time_s`/`TrackStatus` added,
+  `Compound`/`Stint`/`TyreLife` dtypes unchanged, second call is a byte-identical no-op,
+  non-Miami rows identical on all three stint columns, Miami rows changed on NOTHING outside the
+  three stint columns (361/857 featured Miami rows patched). `(GP_Name, Driver, LapNumber)` is
+  unique in featured and in every raw parquet (no merge duplication possible on shipped data).
+- **Claim C, fresh-set half:** the out-lap-is-TyreLife-1 convention verified independently on
+  every healthy stint transition: 617/617 (2024) and 539/539 (2025 sans Miami) fresh-set stints
+  start at exactly 1.0; NOR's rebuilt Miami ages match the pit timeline arithmetic exactly.
+- **Claim D:** no path fills a truly-NaN first stint — verified both on the shipped fixture and on
+  a firing-path fixture (`in_new_stint`/`wrongly_old_stint` are both bounded below by `out_lap`,
+  so pre-pit laps are unreachable). Miami laps 1–24 and Spa/Melbourne NaN blocks stay NaN.
+- **Ruff:** all three files pass `uvx ruff check` clean.
+- **Multi-boundary drivers:** LAW (pits 28 and 36) — only the first boundary is misplaced, the
+  second stop is correctly skipped; the loop's mutation of `repaired` cannot corrupt a later
+  boundary because the intervening-pit condition forces disjoint lap ranges.
+- **Featured impact quantified:** 2025: 361 rows moved, TyreLife delta mean +3.30 laps (range
+  −7..+7), Miami only; 2023: 35 rows, all filled from NaN, Montréal only.
+
+## Numbered fix list (by value, then risk)
+
+1. **Null the fabricated pre-stop ages (fixes Findings 1 and 2 in one move).** For any driver whose
+   metadata is absent at race start (`Stint` NaN on lap 1) and recovers mid-race without a pit
+   entry at the recovery lap, the recovered "stint 1" block up to the first pit stop provably
+   belongs to the race-start set with unknown age: set its `TyreLife` to NaN (and optionally flag
+   `Stint`). That is the module's own stated doctrine applied to its own blind spot, it covers
+   GAS/HUL/BEA (who need no boundary correction), and it converts ~71 invisible wrong integers
+   into visible unknowns.
+2. **Respect `FreshTyre` in the rebuild (Finding 3).** If the boundary row has `FreshTyre False`,
+   either leave the rebuilt ages NaN (honest unknown, doctrine-consistent) or anchor the count at
+   the boundary row's own published `TyreLife` instead of 1. Three of 15 repaired Miami drivers
+   plus Montréal TSU are affected today.
+3. **Refuse to fire on data-loss sentinels (Finding 4).** Treat `'None'`/`'nan'`/NaN compounds as
+   "unknown", not as "different": require the boundary compound to be a real compound AND the
+   pre-pit compound to be known before rewriting `Compound`; never write a sentinel string over a
+   real value. (Montréal would then fill ages only if some other evidence confirms the tyre
+   change, or not at all.)
+4. **Fix the log/report semantics (Finding 5).** Recompute `left_unknown` AFTER the rebuild, or
+   rename it (`unknown_before_repair`) and log both.
+5. **Guard the groupby against NaN drivers (Finding 6).** `groupby("Driver", dropna=False)` or an
+   upfront `laps["Driver"].notna()` split that passes NaN-driver rows through untouched.
+6. **Decide the consistency story (Finding 7).** Either move the repair below every reader (e.g.
+   into the raw load path used by `replay_engine` / backend `strategy.py:328` as well), or document
+   explicitly that raw-fed surfaces (replay, arcade HUD, backend /strategy, projection) show feed
+   values while agent frames show repaired ones. Today the split is silent.
+7. **Make the first-stint test exercise the firing path (Finding 9)** — use a Miami-shaped fixture
+   whose repair fires, assert laps before the recovery stay NaN; drop the dead `, why` on line 93.
+
+## Test-suite evidence
+
+- `tests/agents/test_tyre_stint_repair.py`: 10/10 pass (executed).
+- Augment-consuming non-eval tests (`tests/audit/test_pace_orchestrator_hardening.py`,
+  `tests/mc/test_mc_state_helpers.py`, `tests/agents/test_tire_cumulative_deg.py`,
+  `tests/audit/test_tire_mc_determinism.py`, `tests/inference/test_envelope.py`):
+  **64/64 pass** with the repair active (executed, 166 s) — no pinned value broke.
+- `tests/eval/`: results appended below when the background run completes.
+
+## Published-metric exposure (claim G, structural)
+
+- **Projection 86.5%/59.1%** (`projection.py:292`) and **pit P50 MAE** (`pit_holdout.py:51`) read
+  the RAW parquets from disk; the repair never writes to disk -> unmoved by construction.
+- **Pace MAE 0.4104 / overtake AUC / tire MAE / calibration** (`pace_holdout.py:95-106`,
+  `tire_holdout.py:171`, `calibration.py:160/233/283`) read the FEATURED parquet directly without
+  `augment_featured_laps` -> also unmoved — but note this is the same bypass CLAUDE.md calls a bug
+  ("every consumer calls augment_featured_laps"), and it now means the golden metrics certify the
+  models on data the runtime agents no longer see (Finding 7).
+- **decision_modes** (`decision_modes.py:473/508`) DOES consume the repaired frame; its numbers
+  can legitimately move for Miami 2025 / Montréal 2023.
+
+## What I tried to break and could not
+
+- **A false positive on a healthy race.** Strict frame equality + independent hashing across all
+  71 raw parquets: 69 come back bit-identical; no correct record is rewritten anywhere in shipped
+  data. The Monaco 2025 RUS stop-and-go and the penalty-only shape are correctly skipped (also
+  pinned by the shipped tests, which do assert — `assert_frame_equal` raises despite the odd
+  `, why` tuple on line 93).
+- **The red-flag / no-pit-entry false-positive shape in shipped data.** The only stint transitions
+  without a nearby pit entry in all 71 races are Miami's 12 corruption boundaries themselves. The
+  landmine is real for future data but has no live instance.
+- **Integration leaks.** No `_fixed` columns, no row count/order change, no dtype drift, no
+  duplicate-key blowup (join keys unique in featured and all raws), second call a no-op,
+  non-Miami featured rows bit-identical on the stint columns, Miami rows untouched outside them.
+- **First-stint invention via the `Compound`/`Stint` overwrite.** Both masks are bounded below by
+  `out_lap`; a firing-path fixture confirms pre-pit laps are unreachable. Miami laps 1–24,
+  Spa 27–44, Melbourne 40–44 NaN blocks all stay NaN.
+- **The rebuilt arithmetic on fresh sets.** NOR's repaired stint 2 (out-lap 30 -> TyreLife 1,
+  lap 36 -> 7) matches the pit timeline exactly, and the out-lap==1 convention held on all 1156
+  healthy fresh-set stints of 2024-2025.
+- **Breaking downstream consumers via `Stint` relabelling.** `tire_predictor.py:950`'s
+  `Stint.max()` and the tire agent's `['Year','GP_Name','DriverNumber','Stint']` windows still see
+  contiguous, single-set blocks after repair; 64/64 augment-consuming tests pass.
+
+## Verdict
+
+**Not safe to ship as-is.** Claim A and the integration (E) genuinely hold — the change is
+surgically scoped and touches exactly the two broken races. But the repair's central promise —
+"the model no longer reads 5 where the truth is 29" — is only half-delivered: the fabricated
+pre-stop ages (the investigation's own flagship defect) survive on ≥71 Miami test-season laps
+(Finding 1), three drivers with the identical corruption are skipped entirely (Finding 2), and the
+rebuilt ages silently assume every fitted set is fresh, contradicting the measured FastF1
+convention for the 209+ used-set stints per season and understating age for 3 of the 15 repaired
+drivers (Finding 3). Fix list items 1–3 are the blockers; 4–7 can follow.
+

--- a/documents/audits/GATE_tyre_stint_repair_2.md
+++ b/documents/audits/GATE_tyre_stint_repair_2.md
@@ -1,0 +1,272 @@
+# GATE 2 — tyre-stint repair rewrite (#790): adversarial re-audit
+
+**Date:** 2026-08-02 · **Auditor:** adversarial re-gate (read-only except this file)
+**Scope:** the REWRITTEN `src/f1_strat_manager/tyre_stint_repair.py`, its wiring in
+`src/f1_strat_manager/laps_augment.py` (`_stint_corrections`, `_apply_stint_corrections`,
+call in `augment_featured_laps`), and `tests/agents/test_tyre_stint_repair.py` (16 tests),
+on branch `dev` (uncommitted). Previous gate: `GATE_tyre_stint_repair.md` (9 findings,
+3 blockers, verdict "not safe to ship as-is").
+
+**Mandate:** verify each prior finding is genuinely closed, then hunt what the rewrite
+itself broke. Findings appended incrementally with executed evidence only.
+
+## Checklist
+
+- [x] A. Flagship fixed? Did nulling go too far anywhere? — **FIXED; no over-nulling live** (71-race sweep, block-by-block)
+- [x] B. `_prior_usage_at` arithmetic + interaction with the nulling pass — **EXACT on all 12 anchors; interaction inert by construction**
+- [x] C. Sentinel guard: BOR/STR/HAD + Montréal TSU — **handled by nulling / deliberately abandoned; see N2**
+- [x] D. Integration — **113/113 nulled laps reach featured; hole is structural only (N3)**
+- [x] E. The 16 tests — **all traced to the paths they claim to pin; one docstring lies about the mechanism (N5)**
+- [x] F. Model-input impact — **406 featured-2025 rows changed; golden metrics unmoved, #782 failures identical**
+
+---
+
+## A/B (part 1) — Miami executed anatomy: flagship VERIFIED fixed; anchors arithmetically exact
+
+Executed `repair_tyre_stints` on `data/raw/2025/Miami_Gardens/laps.parquet`:
+
+- **NOR lap 29: `TyreLife 5.0 -> NaN`** — the flagship row is closed.
+- **Impossible-age sweep** (numeric `TyreLife < laps since last pit start − 5`, all drivers):
+  **171 rows before repair -> 0 after.** The prior gate's ≥71 count was on a narrower
+  pre-first-pit scan; under both metrics the survivors are zero.
+- Report: 12 boundaries corrected, 333 ages rebuilt, **146 fabricated ages nulled**,
+  18 drivers touched. GAS (9 nulled), HUL (13), BEA (5) — the Finding-2 trio — are now covered.
+- **Boundary anchors, all 12 verified**: `rebuilt@boundary == boundary − out_lap + 1 + prior_usage`
+  exactly, with `prior_usage = published_TyreLife@boundary − 1`. ALO's used set
+  (published 2.0, `FreshTyre False`) anchors at prior=1 — Finding 3's named case closed.
+  The other 11 published 1.0/`True` -> prior=0.
+- **OCO is the mask's safety valve working**: pit lap 23, recovery 24 == out-lap -> 0 laps
+  nulled; his post-stop ages are genuinely correct and stay numeric.
+- **`_prior_usage_at` reading `driver_laps` (original) instead of `repaired` is provably
+  inert**: the null block ends at the FIRST pit ≥ recovery, every boundary satisfies
+  `boundary > pit_lap ≥ end of null block`, so the boundary row is never inside the nulled
+  block — original and repaired hold the same value there. Confirmed on all 12 boundaries.
+
+**But the nulling swallows the recoverable halves of STR/HAD/BOR** — see Finding N2 below.
+
+## A (part 2) — 71-race sweep: no over-nulling anywhere; 70/71 byte-identical
+
+Executed `repair_tyre_stints` + strict `assert_frame_equal` over every
+`data/raw/2*/*/laps.parquet` (71 races):
+
+- **70/71 byte-identical** (up from 69/71: Montréal 2023 is no longer touched). Only Miami
+  2025 changes: 146 TyreLife nulled, 333 rebuilt, 0 filled-from-NaN, 54 Stint + 54 Compound
+  cells, 12 boundaries, 18 drivers.
+- **Independent mask false-positive hunt**: swept every driver in every race for the
+  trigger shape (first lap `TyreLife` NaN, later numeric recovery). **The shape exists
+  ONLY at Miami 2025** — no pit-lane starter, late joiner, or benign lap-1 NaN anywhere in
+  the 71 races enters `_fabricated_age_mask`. Every one of the 146 nulled laps sits in the
+  documented fabricated-restart block; none was correct (all understate true age by
+  construction: the set predates the recovery lap's restart-at-1/2 count).
+- Judgement per block: NOR/PIA/RUS/LEC (25–29, 5 each), VER/ALB (2), ANT/SAI (pit-in lap
+  only, 1), TSU (3), HAM/ALO/LAW/BEA (5), BOR (8), GAS (9), HUL (13), STR (33), HAD (34).
+  The STR/HAD/BOR long blocks are wrong-but-partially-recoverable — Finding N2.
+
+## D — integration executed: the `touched`-mask hole has ZERO live instances; nulls fully propagate
+
+The suspected defect — `touched = TyreLife_fixed.notna() | Stint_fixed.notna()`
+(`laps_augment.py:138`) silently dropping nulled rows whose `TyreLife_fixed` is NaN — was
+attacked directly:
+
+- `_stint_corrections` emits **479 patch rows** for Miami; **0 rows have both
+  `TyreLife` NaN and `Stint` NaN**. Every nulled lap keeps its published `Stint 1.0`
+  (the feed fabricated the stint but did publish a stint id), so `Stint_fixed.notna()`
+  fires and the NaN TyreLife is written through. **All 113 nulled raw laps present in
+  featured 2025 are NaN after `augment_featured_laps` — 0 missed.** (The other 33 of 146
+  are laps N04 drops.)
+- End-to-end on featured 2025: 22760 rows -> 22760, order preserved, no `_fixed` leak,
+  only `Time_s`/`TrackStatus` added, **second call byte-identical (idempotent)**,
+  non-Miami rows identical on all three stint columns.
+- Featured 2023: **0 changes on all three stint columns** (the Montréal fill is gone,
+  see C below); featured 2024: 0 changes.
+- The hole is still **structural** (see Finding N3): propagation relies on the accident
+  that every null-only correction row carries a numeric `Stint`. A future block where the
+  feed publishes `TyreLife` without `Stint` would null in the raw view and silently keep
+  the fabricated number in featured. No shipped instance.
+
+---
+
+## Closure of the previous gate's nine findings (each independently re-verified)
+
+| # | Prior finding | Status | Executed evidence |
+|---|---|---|---|
+| 1 | Fabricated pre-stop ages survive (NOR 29 = 5.0) | **CLOSED** | NOR 29 -> NaN; impossible-age rows (age < laps-since-pit-start − 5): 171 -> **0** on Miami; 146 fabricated ages nulled |
+| 2 | GAS/HUL/BEA untouched | **CLOSED** | nulled 9 / 13 / 5 laps respectively; BEA covered despite zero pit records |
+| 3 | Used sets hardcoded fresh | **CLOSED (live)** | ALO anchors at prior=1 (published 2.0, FreshTyre False); STR/HAD no longer rebuilt at all (nulled). Latent residue: N4 |
+| 4 | Rule fires on `'None'` sentinel, writes sentinel over real compound | **CLOSED (live)** | Montréal 2023 byte-identical; `_is_real_compound` guards both the detection (`:127-133`) and the write (`:233`); pinned by 2 tests |
+| 5 | `left_unknown` counts pre-repair | **CLOSED** | `unknown_after` = 590 == manual post-repair recount (pre-repair was 446); log message now matches the number |
+| 6 | NaN-Driver row annihilated | **CLOSED** | `dropna=False` (`tyre_stint_repair.py:276`) + `test_a_nan_driver_row_is_not_annihilated` passes |
+| 7 | Three-truth split across surfaces | **NOT FIXED — documented** (`:56-58`) | Accepted limit. Note it is now *sharper*: replay/backend raw readers show `TyreLife 5.0` where agent frames show NaN for the same lap |
+| 8 | Same-compound-refit blindness | **NOT FIXED — documented** (`:51-55`) | Structural, errs toward missing; no shipped instance |
+| 9 | First-stint test pins a no-op; dead `, why` | **CLOSED** | FIRING-path fixture exercises BOTH the nulling and the boundary rebuild (traced lap by lap); `, why` gone (test line 93) |
+
+## NEW findings — what the rewrite itself carries
+
+### N1 (MEDIUM, latent) — a half-applied boundary mutates the frame while the report swears nothing changed
+
+`_rebuild_driver` writes the boundary compound onto the mislabelled laps
+(`tyre_stint_repair.py:232-234`) BEFORE checking `stint_at_boundary`; when that stint is
+NaN it `continue`s (`:236-238`) without setting `touched`. Executed (PROBE 1, synthetic
+boundary row with real compound + NaN Stint): lap 3 `Compound HARD -> MEDIUM` **while
+`report.changed_anything == False` and `boundaries_corrected == 0`**. Consequences: the
+`RepairReport` contract ("a healthy race must come back byte-identical, and that is only
+checkable if the count of touched rows is reported", `:85-88`) is broken — a frame can
+come back mutated with an empty report — and `augment_featured_laps` skips
+`_stint_corrections` for that race (`laps_augment.py:206-207`), so the mutation lives in
+the raw view only. **Zero live instances** (all 12 firing boundaries in 71 races have a
+real Stint). Fix is a two-line reorder: move the Compound write below the stint guard.
+
+### N2 (MEDIUM, judgement) — the nulling swallows the RECOVERABLE post-stop halves of STR/HAD/BOR: 63 featured test-season laps go dark to race end
+
+STR (pit 20), HAD (pit 22), BOR (pit 19) pitted while the feed was dark, so
+`later_stops = [pits >= recovery]` is empty and `end_lap` becomes the last lap
+(`tyre_stint_repair.py:190-191`): the null block runs from lap 24 to race end — 33/34/8
+raw laps, **63 of the 113 featured nulled laps (HAD 30, STR 29, BOR 4)**. Two things are
+wrong with how this lands:
+
+1. **These laps are NOT the race-start set.** The mask's docstring says the block "is
+   still the race-start set, whose age was never published" (`:168-170`) — true for
+   GAS/HUL/BEA/NOR-style blocks, FALSE for the three pre-recovery-stop drivers, where the
+   block is the SECOND set fitted at out-lap 20/21/23. Their published ages are only
+   understated by `recovery − out_lap` (1-4 laps), not by ~24.
+2. **They are recoverable under the exact assumption the module already trusts.**
+   `_prior_usage_at` trusts "the feed publishes the set's own starting age on the lap the
+   feed thinks the stint began" (`:197-204`). The same assumption applied at the recovery
+   lap rebuilds these blocks to the same fidelity: `age(L) = published(L) + (recovery −
+   out_lap)`. The module refuses because the pre-stop compound is a sentinel, so a
+   penalty cannot be ruled out from the columns it reads — defensible doctrine, but the
+   previous version repaired these three drivers to within prior-usage error, and the
+   rewrite replaces 1-4-lap-wrong integers with NaN for up to 30 featured laps of N26's
+   test-season input per driver. Neither the module docstring's known-limits section nor
+   the report distinguishes this trade from the flagship fabrication. **Decide it
+   explicitly: document it as an accepted limit, or anchor-rebuild when later evidence
+   corroborates the change.** (Montréal TSU is the same choice at 35 laps: the prior gate
+   proved that stop WAS a real tyre change via pit-transit 27.5 s, but the anchor there is
+   NaN, so any fill WOULD invent — leaving it NaN is doctrine-consistent and I do not
+   contest it.)
+
+### N3 (MEDIUM, latent) — the featured patch drops any null-only correction whose Stint is also NaN
+
+`_apply_stint_corrections` gates on `touched = TyreLife_fixed.notna() | Stint_fixed.notna()`
+(`laps_augment.py:138`). A nulled lap has `TyreLife_fixed` NaN by construction, so
+propagation rides ENTIRELY on the accident that the feed published a numeric `Stint` on
+every fabricated Miami row. Executed (PROBE 2, synthetic feed that published `TyreLife`
+without `Stint`): the raw view nulls 2 laps, `_stint_corrections` carries both rows, and
+the featured frame **keeps the fabricated 1.0/2.0** — the exact invisible-wrong-integer
+class this repair exists to kill, plus a silent raw/featured divergence. **Zero live
+instances** (0 of 479 Miami patch rows have both NaN; all 113 featured-present nulled
+laps became NaN — executed). Fix: mark patch membership explicitly (merge indicator)
+instead of inferring it from value non-nullness.
+
+### N4 (MEDIUM, latent) — a NaN anchor silently invents a fresh set, and the sentinel-skip can carry the rebuild across a dark zone
+
+`_prior_usage_at` returns **0.0** when the boundary row's `TyreLife` is NaN (`:207-209`).
+Executed (PROBE 4): a boundary with real compound + real Stint + NaN TyreLife fires the
+rebuild and FILLS the NaN laps at 1, 2, 3 — fresh-set ages for a set whose published age
+was never seen, contradicting "It never invents a tyre age" (`:35`). Related:
+`_first_compound_change_after` skips sentinels (`:131-133`), so the boundary search can
+cross a feed-dark block, and the rebuild then writes Compound/Stint/ages onto dark rows
+during which a pit record could itself have been lost (the BEA precedent refutes
+"PitInTime is always intact"). **Zero live instances** — Miami's 12 boundaries all have
+real published anchors (executed table, values 1.0/2.0), and only Miami fires anywhere
+in 71 races. Fix: return `None` for an unknown anchor and refuse (null instead of
+rebuild).
+
+### N5 (LOW) — the module claims a mechanism it does not have: `FreshTyre` is never read
+
+`tyre_stint_repair.py:38`: "`FreshTyre` is therefore read, not assumed". Executed: the
+string `FreshTyre` occurs exactly once in the module — in that docstring line. No code
+reads the column; the rebuild anchors on published `TyreLife` (which is the better
+signal, since the root-cause gate proved `FreshTyre` is fabricated-uniform-`True` inside
+the gap). `tests/agents/test_tyre_stint_repair.py:234` repeats the claim, and its fixture
+has no `FreshTyre` column at all. The behaviour is right; the stated mechanism is false —
+the project's recorded scar class ("a comment naming the wrong MECHANISM is worse than
+none"). Same family: the `_fabricated_age_mask` docstring's "race-start set" rationale is
+wrong for the pre-recovery-stop drivers (N2.1).
+
+## E — the 16 tests, attacked
+
+- 16/16 pass (executed); ruff clean on all three files.
+- `test_a_stop_made_while_the_feed_is_dark_is_left_unknown_rather_than_guessed`: traced —
+  the fixture reaches the sentinel guard (compound at the pit lap is `'nan'`, so the
+  boundary is refused) AND the mask (2 laps nulled), and its shape matches the real
+  BOR/STR/HAD anatomy (pit during darkness, recovery not an out-lap; executed per-driver
+  table). Genuine.
+- `test_a_used_set_keeps_its_prior_usage`: traced — prior=3 comes from published 4.0 at
+  the boundary; asserts 4.0/5.0 on the firing path. Genuine on behaviour; its docstring
+  misstates the mechanism (N5).
+- `test_a_missing_first_stint_stays_unknown_on_the_FIRING_path`: traced — the fixture
+  exercises nulling (laps 3-4) and boundary rebuild (laps 5-6) in one pass, and asserts
+  `report.changed_anything` in-test, so it can never regress to a no-op. Finding 9's scar
+  is genuinely closed.
+- Not pinned anywhere: N1's partial-write shape, N3's NaN-Stint null propagation, N4's
+  NaN-anchor refusal. The three latent holes are exactly the three untested paths.
+
+## F — model-input impact, quantified
+
+- **Featured 2025** (the models' test season): **113 laps lose a numeric `TyreLife`**
+  (fabricated values -> NaN), **293 laps change numeric value** (mean +3.74, range
+  −7..+7), 0 filled from NaN. All Miami; every other GP byte-identical on the three stint
+  columns. Featured **2023: 0 changes** (the previous version's 35 Montréal fills are
+  gone), **2024: 0 changes**.
+- **Published-metric paths**: pace/tire/overtake/calibration/projection read the parquets
+  directly (`pace_holdout.py:106`, `tire_holdout.py:171`, `calibration.py:160/233/283`,
+  `projection.py:296` — executed grep), so the 86.5%/59.1% projection, pace MAE and the
+  calibration numbers are unmoved by construction. The two #782 golden failures reproduce
+  identically (`KeyError: ['AirTemp','TrackTemp','Humidity','Rainfall']`, executed) —
+  pre-existing, unrelated.
+- **Downstream augment consumers**: 64/64 tests pass (pace-orchestrator hardening, MC
+  state helpers, tire cumulative deg, tire MC determinism, envelope — executed, 33 s).
+  N26's Miami windows now see NaN where they saw fabricated integers; that is the
+  intended behaviour change.
+
+## What I tried to break and could not
+
+- **Over-nulling.** Swept all 71 races for the mask's trigger shape (first-lap `TyreLife`
+  NaN with later numeric recovery): it exists ONLY at Miami 2025. No pit-lane starter,
+  late joiner, or benign lap-1 NaN anywhere enters `_fabricated_age_mask`. Every nulled
+  lap's published age was provably understated. OCO (pit 23, recovery 24 == out-lap) is
+  correctly spared — the safety valve works on the one driver who needed it.
+- **Byte-identity.** Strict `assert_frame_equal` over all 71 races: **70/71 identical**
+  (Montréal 2023 joins the untouched set; only Miami changes).
+- **The `touched` mask on shipped data.** 0/479 patch rows invisible; 113/113
+  featured-present nulled laps arrive as NaN; no `_fixed` leak; row count/order
+  preserved; second `augment_featured_laps` call byte-identical; raw `repair_tyre_stints`
+  idempotent with a clean second-pass report.
+- **`_prior_usage_at` reading the NaN its own pass wrote.** Impossible by construction
+  (every boundary > its pit lap >= the null block's end) and confirmed on all 12 real
+  boundaries — all read real published anchors. Passing `driver_laps` (original) instead
+  of `repaired` is inert today, and it is arguably the CORRECT choice under
+  multi-boundary mutation, so I do not flag it.
+- **The anchor-accrual alternative.** If the late-created stint record counted the laps
+  accrued since the actual fitting, `published − 1` would over-count prior usage. The 11
+  fresh-set Miami boundaries publish exactly 1.0 despite 4-8 laps accrued since their
+  out-laps — the record demonstrably counts from the boundary lap, so the subtraction is
+  right on all data that fires.
+- **A sentinel written over a real compound.** The write is guarded by
+  `_is_real_compound` (`:233`); pinned by test; no path writes a sentinel.
+- **Downstream pinned values.** 64/64 augment-consuming tests green; golden failures
+  unchanged.
+
+## Fix list (by value, then risk)
+
+1. **N1**: move the Compound write below the `stint_at_boundary` guard (two-line reorder)
+   so a refused boundary refuses atomically and the report stays truthful.
+2. **N3**: key `touched` in `_apply_stint_corrections` on patch MEMBERSHIP (merge
+   indicator) rather than value non-nullness.
+3. **N4**: `_prior_usage_at` -> return `None` on a NaN anchor and skip/null instead of
+   anchoring at fresh.
+4. **N5**: fix the two `FreshTyre` docstring claims and the mask docstring's
+   "race-start set" rationale (N2.1). Pure prose, zero behaviour.
+5. **N2**: decide the STR/HAD/BOR trade explicitly — document the post-stop null as a
+   known limit in the module docstring, or (follow-up) rebuild dark-stop blocks when
+   later evidence corroborates the tyre change.
+
+## Verdict
+
+**SHIP.** All three prior blockers (Findings 1-3) are genuinely closed with executed
+evidence, Findings 4-6 and 9 are closed, and 7-8 are honestly documented limits. The
+rewrite introduced no defect with a live instance in the 71 shipped races: N1, N3 and N4
+are latent (synthetic-only), N5 is prose. Recommend landing fixes 1-4 in the same PR (all
+small, none changes shipped-data behaviour) and settling N2 as a documented decision
+rather than silence.

--- a/documents/audits/GATE_tyrelife_nan_rootcause.md
+++ b/documents/audits/GATE_tyrelife_nan_rootcause.md
@@ -1,0 +1,141 @@
+# GATE — TyreLife NaN root cause (issue #790, related #782 / #789)
+
+**Date:** 2026-08-02 · **Investigator:** adversarial investigation gate (read-only)
+**Question:** why does `laps_featured_2025.parquet` carry racing laps with `TyreLife` NaN, and is it a pipeline defect (fix the data) or genuine source absence (guard the consumers)?
+
+Findings are appended incrementally as they are confirmed with executed evidence.
+
+## Checklist
+
+- [ ] 1. Independently re-measure the gap (2025, and 2023/2024)
+- [ ] 2. Trace one block (Miami) backwards: featured → augmentation → raw parquet
+- [ ] 3. Check the source (FastF1 cache / API) for the same laps
+- [ ] 4. Cross-reference the lap ranges against race events (SC / red flag / rain)
+- [ ] 5. Blast radius: other columns NaN in the same blocks; relation to #782 weather gap
+- [ ] 6. Recommendation with trade-offs
+
+---
+
+## Finding 1 — the gap re-measured (CONFIRMED, with corrections to the sweep)
+
+Executed: pandas over `data/processed/laps_featured_{2023,2024,2025}.parquet`.
+
+**2025 — 451 rows with `TyreLife` NaN and `Position` present (sweep number confirmed exactly):**
+
+| GP | rows | laps | contiguous | drivers | share of field on those laps |
+|---|---|---|---|---|---|
+| Miami | 379 | 4–24 | yes | 19 | 379/388 rows (~whole field) |
+| Spa-Francorchamps | 70 | 28–44 | yes | **5** | 70/328 rows (**NOT field-wide** — sweep said 53 rows; it is 70) |
+| Melbourne | 2 | 42–43 | yes | 1 | 2/32 rows |
+
+Compound in the 451 gap rows: `'nan'` 379 (all Miami), `'None'` 53 (Spa), **`'HARD'` 17 (Spa)**, `'MEDIUM'` 2 (Melbourne). So 19 Spa/Melbourne rows have a **real compound string but TyreLife NaN** — the sweep's claim "every Compound-nan row is also TyreLife-NaN" holds (432/432), but the converse does not: TyreLife can be NaN with a valid Compound.
+
+**Not 2025-only:** 2023 has 35 such rows — Montréal, ONE driver, laps 36–70 contiguous to race end, all `Compound='None'`. 2024 has **0**.
+
+**Column counts:** 2023 = 53 cols, 2024 = 53 cols, 2025 = **48 cols** — consistent with #782 (weather columns absent from the 2025 featured parquet only).
+
+## Finding 2 — the NaN is ALREADY in the raw parquets; the featured step introduces nothing (CONFIRMED)
+
+Executed: pandas over `data/raw/2025/{Miami_Gardens,Spa-Francorchamps,Melbourne}/laps.parquet` and `data/raw/2023/Montréal/laps.parquet`.
+
+| Race (raw) | TyreLife NaN rows | shape of the hole |
+|---|---|---|
+| Miami 2025 | 446/1005 | **ALL 19 drivers, laps 1–23 complete + 9 drivers on lap 24; `Compound` AND `Stint` are NaN on every one of those rows.** Zero NaN after lap 24. |
+| Spa 2025 | 75/879 | 5 drivers, growing per driver from L27 (1 driver) to L33+ (5 drivers) to race end (L44). All 75 rows are `Stint == 3.0`. 57 rows `Compound='None'`, **18 rows `Compound='HARD'` with TyreLife still NaN**. |
+| Melbourne 2025 | 5/927 | 1 driver, laps 40–44, all `Stint == 5.0`, `Compound='MEDIUM'` known, TyreLife NaN. |
+| Montréal 2023 | 35/1317 | 1 driver, laps 36–70 (to race end), all `Stint == 3.0`, `Compound='None'`. |
+
+Featured-vs-raw delta is pure N04 row filtering (Miami raw hole is L1–24; featured shows L4–24 because L1–3 are dropped rows — TrackStatus `'12'`/`'126'`/`'671'` = start + VSC), not value mutation.
+
+**The hole is stint-shaped, not lap-shaped.** In every case the NaN block is "driver X's stint N has no tyre metadata, from the stint's first lap to its last". Miami is the degenerate case where the affected stint is **stint 1 of the entire field** (the live-timing tyre-stint feed evidently missing at race start; every driver's data appears the moment they make their first stop). This is the signature of missing `TimingAppData` stint records in the F1 live-timing source that FastF1 builds tyre data from — NOT of a merge/join bug in this repo's pipeline.
+
+**TrackStatus cross-check (kills the SC/red-flag theory for the main block):** Miami laps 4–27 are TrackStatus `'1'` (all clear) for the entire field — the hole spans green-flag racing. Spa laps 25–44 all `'1'`. The hole does NOT line up with neutralisation windows; it lines up with stint boundaries.
+
+---
+
+*The investigation agent stalled after Finding 2 (report unchanged, no FastF1 cache writes for 45+
+minutes, empty transcript, no completion notification). Findings 3-6 below were executed by the
+orchestrating session directly. Findings 1-2 above are the agent's and were left as written.*
+
+## Finding 3 — FastF1 has exactly the same gap; our extractor loses nothing (CONFIRMED)
+
+Executed: `fastf1.get_session(2025, "Miami", "R").load(laps=True)` against the project's own 1.9 GB
+cache, compared row for row with `data/raw/2025/Miami_Gardens/laps.parquet`.
+
+| | FastF1 (source) | Our raw parquet |
+|---|---|---|
+| `TyreLife` NaN, laps <= 24 | 446 / 457 | 446 / 457 |
+| `Stint` NaN, laps <= 24 | 446 / 457 | 446 / 457 |
+| `TyreLife` NaN, laps > 24 | 0 / 548 | 0 / 548 |
+
+Identical. **The systematic-extraction-failure hypothesis is REFUTED.** The F1 live-timing
+`TimingAppData` feed did not publish stint records for the opening stint, FastF1 leaves NaN rather
+than guessing, and our extractor copies that faithfully. FastF1 even logs that it repaired three
+drivers (`Fixed incorrect tyre stint information for driver '31'/'18'/'5'`) — those repairs are the
+11 non-NaN rows.
+
+## Finding 4 — the far more serious half: the laps AFTER the gap are WRONG, not missing (CONFIRMED)
+
+The NaN block is the visible symptom. The block after it is silently corrupt.
+
+NOR, Miami 2025, from FastF1 (`PitInTime`/`PitOutTime` are the independent ground truth, and they
+are present and correct):
+
+```
+LapNumber  Stint  Compound  TyreLife  pit_in  pit_out
+     24.0    NaN       nan       NaN   False    False
+     25.0    1.0    MEDIUM       1.0   False    False
+     29.0    1.0    MEDIUM       5.0    True    False    <- real pit stop
+     30.0    1.0    MEDIUM       6.0   False     True    <- keeps counting THROUGH the stop
+     32.0    1.0    MEDIUM       8.0   False    False
+     33.0    2.0      HARD       1.0   False    False    <- stint 2 starts 4 laps late
+```
+
+Three separate errors in one block:
+
+1. **`TyreLife` restarts at 1 on lap 25** while the car is still on the tyre it started the race on.
+   True age at lap 29 is 29 racing laps plus its starting age; FastF1 reports **5**.
+2. **It counts across a pit stop** — physically impossible, and proof the value is derived from
+   "when the feed appeared", not from the tyre.
+3. **The stint boundary is misplaced by 4 laps**: `Stint` stays 1 through lap 32 when the real
+   change happened at lap 29/30.
+
+`TyreLife` is a direct input to N26's TCN and to N15/N16, and Miami 2025 is in the **test** season.
+A degradation model reading "5 laps old" for a 29-lap-old tyre predicts almost no wear.
+
+## Finding 5 — recomputation is sound, because the pit stops are intact
+
+The one thing NOT corrupted is `PitInTime`/`PitOutTime`. That is enough to rebuild both columns:
+
+- **Stint boundaries** derive from pit in/out — exact.
+- **`TyreLife` within a stint** = laps completed since the stint began — exact for stints 2+, where a
+  fresh set starts at 0.
+- **Stint 1 only** carries an unknown starting offset (the race-start set may have qualifying laps on
+  it). Measured on a clean control race (Bahrain 2025 lap 1): the offset is real and varies per
+  driver, `TyreLife` 4.0 on used sets versus 1.0 on fresh ones. So stint 1 is recoverable up to a
+  bounded offset of roughly 0-4 laps.
+
+Compare the alternatives on the reference lap: today the model receives **5** where the truth is
+**~29**. A recomputation gives **29 plus or minus 4**. The residual uncertainty is an order of
+magnitude smaller than the error it replaces, and unlike the current value it is not physically
+impossible.
+
+`FreshTyre` cannot rescue the offset: on all 446 gap rows it is uniformly `True`, while on the 11
+rows FastF1 repaired it varies (`False` for ALO, STR, HAD). Uniform where the data is missing and
+varying where it is present is the signature of a fabricated default, not a reading — so it must not
+be used as evidence of a fresh set.
+
+## Recommendation
+
+Rebuild `Stint` and `TyreLife` from the pit-stop timeline in the extraction layer, for every season,
+gated behind a validation that the rebuild reproduces FastF1's values exactly on races where the feed
+was healthy. Leave stint 1's absolute offset explicitly unknown rather than assuming a fresh set.
+
+This fixes #790's NaN (the visible half) and Finding 4's wrong values (the invisible, worse half) in
+one place, upstream of every consumer. It does not touch #782's weather gap, which is a genuinely
+different missing-column problem.
+
+**What it could get wrong:** a rebuilt `TyreLife` that is subtly off is worse than a NaN, because a
+NaN is visible and a wrong integer is not. The validation gate is therefore not optional — the
+rebuild must be proven to reproduce healthy races byte for byte before it is allowed to touch
+unhealthy ones.

--- a/src/f1_strat_manager/laps_augment.py
+++ b/src/f1_strat_manager/laps_augment.py
@@ -36,6 +36,8 @@ from typing import Callable, Dict, Optional
 
 import pandas as pd
 
+from src.f1_strat_manager.tyre_stint_repair import repair_tyre_stints
+
 logger = logging.getLogger(__name__)
 
 # Raw column -> the name the models were trained on.
@@ -96,6 +98,64 @@ def _raw_race_dir(data_root: Path, year: int, gp_name: str) -> Path:
     return base / gp_name
 
 
+STINT_COLUMNS = ("Stint", "TyreLife", "Compound")
+
+
+def _stint_corrections(repaired_raw: pd.DataFrame, path: Path, gp_name: object) -> pd.DataFrame:
+    """The repaired tyre-stint columns for one race, keyed for the featured join.
+
+    Carried separately from the `Time_s`/`TrackStatus` merge because these three columns
+    ALREADY exist on the featured frame: they have to overwrite, not be appended, and a
+    plain merge would silently produce `_x`/`_y` pairs that no consumer reads.
+    """
+    original = pd.read_parquet(path)
+    changed = pd.Series(False, index=repaired_raw.index)
+    for column in STINT_COLUMNS:
+        before, after = original[column], repaired_raw[column]
+        # A NaN on both sides is not a change; `!=` alone would call it one.
+        changed |= (before != after) & ~(before.isna() & after.isna())
+
+    corrections = repaired_raw.loc[changed, ["Driver", "LapNumber", *STINT_COLUMNS]].copy()
+    corrections["GP_Name"] = gp_name
+    # An explicit marker, because the repair's most important output is a NULL: nulling a
+    # fabricated age writes NaN, and a mask built from "the patched value is not NaN"
+    # would silently skip exactly those rows, leaving the invented integer in the featured
+    # frame. Today every affected lap also carries a numeric Stint, so such a mask happens
+    # to work -- on an accident of the data, not by construction.
+    corrections["_repaired"] = True
+    return corrections
+
+
+def _apply_stint_corrections(
+    augmented: pd.DataFrame,
+    corrections: list[pd.DataFrame],
+) -> pd.DataFrame:
+    """Overwrite only the laps the stint repair actually corrected.
+
+    Row-scoped on purpose: a lap the repair did not touch keeps its published value byte
+    for byte, so this cannot quietly rewrite the 69 healthy races.
+    """
+    if not corrections:
+        return augmented
+
+    patch = pd.concat(corrections, ignore_index=True)
+    merged = augmented.merge(patch, on=_JOIN_KEYS, how="left", suffixes=("", "_fixed"))
+
+    # The marker, not the patched values, decides which rows to overwrite: a repaired lap
+    # can legitimately carry NaN (that is what nulling a fabricated age produces), and
+    # inferring "touched" from the values would drop exactly those rows.
+    touched = merged["_repaired"].notna()
+    for column in STINT_COLUMNS:
+        merged.loc[touched, column] = merged.loc[touched, f"{column}_fixed"]
+    merged = merged.drop(columns=["_repaired", *[f"{c}_fixed" for c in STINT_COLUMNS]])
+
+    logger.info(
+        "Applied %d repaired tyre-stint lap(s) from the raw parquets (#790)",
+        int(touched.sum()),
+    )
+    return merged
+
+
 def augment_featured_laps(
     df: pd.DataFrame,
     year: int,
@@ -135,6 +195,7 @@ def augment_featured_laps(
     root = data_root or (root_resolver() if root_resolver else _default_data_root())
 
     frames = []
+    corrections: list[pd.DataFrame] = []
     missing: list[str] = []
     for gp_name in df["GP_Name"].dropna().unique():
         path = _raw_race_dir(root, year, str(gp_name)) / "laps.parquet"
@@ -145,6 +206,13 @@ def augment_featured_laps(
         if not set(RAW_COLUMNS_TO_RESTORE).issubset(raw.columns):
             missing.append(str(gp_name))
             continue
+        # Correct tyre-stint metadata the live-timing feed published wrong, BEFORE the
+        # merge, because the repair needs `PitInTime` and only the raw frame carries it
+        # (#790). It touches nothing on a healthy race, so this is a no-op for 69 of the
+        # 71 shipped races.
+        raw, stint_report = repair_tyre_stints(raw)
+        if stint_report.changed_anything:
+            corrections.append(_stint_corrections(raw, path, gp_name))
         slice_ = raw[["Driver", "LapNumber", *RAW_COLUMNS_TO_RESTORE]].copy()
         slice_["GP_Name"] = gp_name
         # `Time` is a session-elapsed timedelta; the models were trained on seconds.
@@ -163,6 +231,7 @@ def augment_featured_laps(
         return df
 
     augmented = df.merge(pd.concat(frames, ignore_index=True), on=_JOIN_KEYS, how="left")
+    augmented = _apply_stint_corrections(augmented, corrections)
     restored = int(augmented["Time_s"].notna().sum())
     logger.info(
         "Restored Time_s/TrackStatus onto %d/%d laps of %d from the raw parquets",

--- a/src/f1_strat_manager/tyre_stint_repair.py
+++ b/src/f1_strat_manager/tyre_stint_repair.py
@@ -108,7 +108,9 @@ class RepairReport:
 
     @property
     def changed_anything(self) -> bool:
-        return bool(self.boundaries_corrected or self.tyre_life_rebuilt or self.fabricated_ages_nulled)
+        return bool(
+            self.boundaries_corrected or self.tyre_life_rebuilt or self.fabricated_ages_nulled
+        )
 
 
 def _is_real_compound(value: object) -> bool:
@@ -283,7 +285,10 @@ def repair_tyre_stints(laps: pd.DataFrame) -> tuple[pd.DataFrame, RepairReport]:
     # dropna=False: a NaN driver key would otherwise be dropped by the groupby and come
     # back all-NaN through the reindex, destroying columns this repair has no business
     # touching. No shipped race carries one, but this runs on every future download.
-    groups = [_rebuild_driver(group, report) for _, group in laps.groupby("Driver", sort=False, dropna=False)]
+    groups = [
+        _rebuild_driver(group, report)
+        for _, group in laps.groupby("Driver", sort=False, dropna=False)
+    ]
     repaired = pd.concat(groups).reindex(laps.index)
 
     # Counted AFTER the repair, so the number means what the log says it means.

--- a/src/f1_strat_manager/tyre_stint_repair.py
+++ b/src/f1_strat_manager/tyre_stint_repair.py
@@ -1,0 +1,305 @@
+"""Repair tyre-stint metadata that the F1 live-timing feed published wrong (#790).
+
+The F1 `TimingAppData` feed sometimes drops the stint records for a stint. FastF1 copies
+that faithfully and so do we -- verified: `fastf1.get_session(2025, "Miami", "R")` and
+`data/raw/2025/Miami_Gardens/laps.parquet` carry the identical 446/457 NaN block, so
+nothing in this repo's extraction loses it. The gap is upstream of us.
+
+What makes it worth repairing rather than merely guarding is the SECOND defect, which is
+invisible. When the feed recovers it does not resume the stint that was actually running:
+it starts a NEW one at the recovery lap. At Miami 2025 the metadata reappears at lap 24
+for the whole field, so every car reads `TyreLife 1` on a set that has done 24 racing
+laps, and then:
+
+  * cars that had not yet pitted carry a fabricated age until they do,
+  * the count continues ACROSS the pit stop, which is physically impossible, and
+  * the following stint's age is understated by the same 4-8 laps.
+
+`TyreLife` feeds N26's TCN and N15/N16, and Miami 2025 is in the TEST season. A
+degradation model reading "5 laps old" for a 29-lap-old tyre predicts no wear.
+
+--- WHERE TO CHANGE IF THE ARTEFACT CHANGES ---
+This runs at LOAD time, called from `laps_augment.augment_featured_laps`, for the same
+reasons that module documents: the featured parquet is published on Hugging Face and
+re-downloaded by `scripts/download_data.py`, so a locally-patched file would be silently
+reverted, and its only producer is a read-only notebook (N04).
+
+## The two repairs, and the one thing this never does
+
+1. **Null the fabricated ages.** Where the feed invented a stint mid-race, the affected
+   laps belong to the set the car started on, whose age is NOT recoverable. They become
+   NaN -- a visible unknown replacing an invisible wrong integer.
+2. **Move the misplaced boundary.** Where the car pitted before the feed recovered, the
+   new stint really began on the out-lap, and from there the age IS recoverable.
+
+It never invents a tyre age. A car may start a stint on a used set, and the offset is
+real: measured across every healthy stint transition in 2024 and 2025, a FRESH set starts
+at `TyreLife` 1.0 in 1156/1156 cases, while USED sets start anywhere from 2 to 16. The
+rebuild therefore ANCHORS ON THE AGE THE FEED PUBLISHED at the boundary lap rather than
+hardcoding 1 -- the feed mislabels WHERE a stint began but still reports the set's own
+starting age, so subtracting one recovers the prior usage. (`FreshTyre` is deliberately
+NOT the mechanism: on the affected laps it is a fabricated uniform `True`, so it carries
+no information exactly where it would be needed.) When the boundary lap has no published
+age, there is no anchor and nothing is rebuilt.
+
+## Why a pit entry alone does not mean a new set
+
+A stop-and-go or drive-through penalty sends the car down the pit lane with no work done,
+so the stint correctly does NOT advance. Monaco 2025, RUS, lap 62 is exactly that -- a
+served stop-and-go -- and its record is CORRECT. `find_misplaced_boundaries` therefore
+requires the compound to change later AND no other pit entry to sit in between (a later
+real stop explains the change by itself; that is the Monaco case).
+
+## Known limits, stated rather than discovered later
+
+* **Same compound refitted is invisible to the boundary rule.** 743 of 2594 stint
+  transitions across the 71 shipped races fit the same compound again, and a misplaced
+  boundary there cannot be seen by a compound-change test. No shipped race is affected
+  today; the gap is structural. It errs toward missing a defect, never toward rewriting a
+  correct record.
+* **Raw-fed surfaces see feed values.** Consumers that read a raw parquet directly rather
+  than through `augment_featured_laps` -- the replay engine and the backend's own race
+  loader -- are not repaired. Unifying that is a wider change than this repair.
+* **A stop made while the feed was dark is nulled, not rebuilt, even past the stop.**
+  When the pre-stop compound was lost there is nothing left to confirm a tyre change with
+  (a pit entry alone does not prove one -- see Monaco above), so `find_misplaced_boundaries`
+  declines and the nulling pass takes the whole block to race end. Miami 2025 STR, HAD and
+  BOR are this shape: 63 of their featured laps are post-stop and would have been
+  recoverable to within 1-4 laps under the anchor assumption, and they become NaN instead.
+  That is a deliberate trade -- a visible unknown over a probably-right integer on laps
+  whose tyre change is inferred rather than evidenced -- and it is recorded here because
+  the alternative reading, that those laps are simply unrecoverable, would be false.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# Columns this module reads. A frame missing any of them is returned untouched rather
+# than half-repaired, which is what the raw-parquet-absent path already does upstream.
+REQUIRED_COLUMNS = ("Driver", "LapNumber", "Stint", "TyreLife", "Compound", "PitInTime")
+
+# The extractor stringifies a missing compound, so absence arrives as one of these rather
+# than as NaN. They must never be treated as "a different compound" (which would let
+# data loss masquerade as evidence of a tyre change) nor written over a real value.
+_COMPOUND_SENTINELS = frozenset({"", "nan", "none", "unknown"})
+
+
+@dataclass
+class RepairReport:
+    """What a repair pass actually changed, so a caller can log or assert on it.
+
+    Kept separate from the frame because the interesting property of this repair is how
+    LITTLE it touches: a healthy race must come back byte-identical, and that is only
+    checkable if the count of touched rows is reported rather than inferred.
+    """
+
+    boundaries_corrected: int = 0
+    tyre_life_rebuilt: int = 0
+    fabricated_ages_nulled: int = 0
+    unknown_after: int = 0
+    drivers_touched: list[str] = field(default_factory=list)
+
+    @property
+    def changed_anything(self) -> bool:
+        return bool(self.boundaries_corrected or self.tyre_life_rebuilt or self.fabricated_ages_nulled)
+
+
+def _is_real_compound(value: object) -> bool:
+    """True when the value names an actual compound rather than absent data."""
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return False
+    return str(value).strip().lower() not in _COMPOUND_SENTINELS
+
+
+def _pit_in_laps(driver_laps: pd.DataFrame) -> list[int]:
+    """Laps on which this driver entered the pit lane, ascending.
+
+    `PitInTime` is the column the broken feed usually leaves intact, which is what makes
+    the boundary repair possible: it is the independent ground truth the stint metadata
+    failed to agree with. It is not guaranteed -- Miami 2025 BEA has no pit record at all
+    -- which is why the age-nulling repair below does not depend on it.
+    """
+    entered = driver_laps.loc[driver_laps["PitInTime"].notna(), "LapNumber"]
+    return sorted(int(lap) for lap in entered.dropna())
+
+
+def _first_compound_change_after(driver_laps: pd.DataFrame, lap: int) -> Optional[int]:
+    """First lap after ``lap`` whose compound is a DIFFERENT REAL compound.
+
+    Sentinels are skipped rather than counted as a change: `'HARD' -> 'None'` is the feed
+    dying, not a pit stop, and treating it as evidence of a new set is how a repair ends
+    up writing a data-loss marker over a real compound.
+    """
+    current = driver_laps.loc[driver_laps["LapNumber"] == lap, "Compound"]
+    if current.empty or not _is_real_compound(current.iloc[0]):
+        return None
+    later = driver_laps[driver_laps["LapNumber"] > lap]
+    for _, row in later.iterrows():
+        if _is_real_compound(row["Compound"]) and row["Compound"] != current.iloc[0]:
+            return int(row["LapNumber"])
+    return None
+
+
+def find_misplaced_boundaries(driver_laps: pd.DataFrame) -> list[tuple[int, int]]:
+    """Pit stops whose stint boundary landed on the wrong lap, for one driver.
+
+    Returns ``(pit_lap, boundary_lap)`` pairs: the car pitted on ``pit_lap`` but the
+    metadata only starts the new stint at ``boundary_lap``.
+
+    Both conditions must hold, and the second one is not optional -- see the module
+    docstring's Monaco case, where dropping it turns a correct record into a wrong one.
+    """
+    driver_laps = driver_laps.sort_values("LapNumber")
+    pit_laps = _pit_in_laps(driver_laps)
+    misplaced: list[tuple[int, int]] = []
+
+    for pit_lap in pit_laps:
+        boundary = _first_compound_change_after(driver_laps, pit_lap)
+        if boundary is None:
+            continue  # no real tyre change: a served penalty, or the feed went dark
+        if boundary - pit_lap <= 1:
+            continue  # the new stint starts on the out-lap, which is correct
+        if any(pit_lap < lap < boundary for lap in pit_laps):
+            continue  # a later real stop explains the change
+        misplaced.append((pit_lap, boundary))
+
+    return misplaced
+
+
+def _fabricated_age_mask(driver_laps: pd.DataFrame) -> pd.Series:
+    """Laps whose ``TyreLife`` the feed invented after going dark mid-race.
+
+    The signature is a stint that appears out of nowhere: the metadata is absent at the
+    driver's first lap and later resumes on a lap that is NOT a pit out-lap. Everything
+    from that recovery up to the driver's first real pit stop is still the race-start set,
+    whose age was never published, so the published numbers there count from the wrong
+    zero and are provably too small.
+
+    This is what covers the cars a boundary correction cannot reach: a driver who pits
+    only after the feed recovered (Miami GAS, HUL) has no misplaced boundary at all, yet
+    carries the same fabricated block.
+    """
+    ordered = driver_laps.sort_values("LapNumber")
+    blank = pd.Series(False, index=driver_laps.index)
+    if ordered.empty or ordered["TyreLife"].notna().iloc[0]:
+        return blank  # the feed was healthy at the start: nothing was invented
+
+    known = ordered[ordered["TyreLife"].notna()]
+    if known.empty:
+        return blank  # never recovered; the laps are already an honest NaN
+
+    recovery_lap = int(known["LapNumber"].iloc[0])
+    out_laps = {lap + 1 for lap in _pit_in_laps(ordered)}
+    if recovery_lap in out_laps:
+        return blank  # the stint really did start here, via a pit stop
+
+    later_stops = [lap for lap in _pit_in_laps(ordered) if lap >= recovery_lap]
+    end_lap = later_stops[0] if later_stops else int(ordered["LapNumber"].max())
+
+    laps = driver_laps["LapNumber"]
+    return (laps >= recovery_lap) & (laps <= end_lap) & driver_laps["TyreLife"].notna()
+
+
+def _rebuild_driver(driver_laps: pd.DataFrame, report: RepairReport) -> pd.DataFrame:
+    """Null one driver's fabricated ages, then correct any misplaced stint boundary."""
+    repaired = driver_laps.sort_values("LapNumber").copy()
+    touched = False
+
+    fabricated = _fabricated_age_mask(repaired)
+    if fabricated.any():
+        repaired.loc[fabricated, "TyreLife"] = float("nan")
+        report.fabricated_ages_nulled += int(fabricated.sum())
+        touched = True
+
+    lap_numbers = repaired["LapNumber"]
+    for pit_lap, boundary in find_misplaced_boundaries(repaired):
+        at_boundary = repaired[lap_numbers == boundary]
+        if at_boundary.empty:
+            continue
+
+        # Everything the rebuild needs is resolved BEFORE anything is written. A partial
+        # apply -- rewriting `Compound` and then bailing on a missing `Stint` -- would
+        # return a mutated frame while reporting no change, which the caller reads as
+        # "nothing to patch" and so would leave the raw and featured views disagreeing.
+        stint_id = at_boundary["Stint"].iloc[0]
+        published_age = at_boundary["TyreLife"].iloc[0]
+        if pd.isna(stint_id) or pd.isna(published_age):
+            # Without a published age there is no anchor, and counting from 1 would
+            # invent a fresh set -- the one thing this module refuses to do. The laps
+            # keep whatever they had; the nulling pass above already handled the ones
+            # that were provably fabricated.
+            continue
+
+        # The new set goes on during the stop, so the out-lap is the new stint's first
+        # lap. Its age is the set's prior usage plus one, not a hardcoded 1.
+        out_lap = pit_lap + 1
+        prior_usage = max(0.0, float(published_age) - 1.0)
+        in_new_stint = lap_numbers >= out_lap
+        mislabelled = in_new_stint & (lap_numbers < boundary)
+
+        new_compound = at_boundary["Compound"].iloc[0]
+        if _is_real_compound(new_compound):
+            repaired.loc[mislabelled, "Compound"] = new_compound
+        repaired.loc[mislabelled, "Stint"] = stint_id
+
+        of_this_stint = in_new_stint & (repaired["Stint"] == stint_id)
+        repaired.loc[of_this_stint, "TyreLife"] = (
+            lap_numbers[of_this_stint] - out_lap + 1 + prior_usage
+        ).astype(float)
+        report.tyre_life_rebuilt += int(of_this_stint.sum())
+        report.boundaries_corrected += 1
+        touched = True
+
+    if touched and len(repaired):
+        report.drivers_touched.append(str(repaired["Driver"].iloc[0]))
+    return repaired
+
+
+def repair_tyre_stints(laps: pd.DataFrame) -> tuple[pd.DataFrame, RepairReport]:
+    """Null fabricated tyre ages and correct misplaced stint boundaries.
+
+    Only rows that are demonstrably wrong are touched, so a healthy race comes back
+    unchanged by construction rather than by a comparison after the fact.
+
+    Args:
+        laps: A per-race laps frame carrying at least ``REQUIRED_COLUMNS``.
+
+    Returns:
+        The repaired frame and a ``RepairReport`` describing exactly what moved. The
+        frame is returned unchanged, with an empty report, when the required columns are
+        absent -- the same degrade-quietly contract the raw-parquet merge upstream uses.
+    """
+    report = RepairReport()
+    if not set(REQUIRED_COLUMNS).issubset(laps.columns):
+        return laps, report
+
+    # dropna=False: a NaN driver key would otherwise be dropped by the groupby and come
+    # back all-NaN through the reindex, destroying columns this repair has no business
+    # touching. No shipped race carries one, but this runs on every future download.
+    groups = [_rebuild_driver(group, report) for _, group in laps.groupby("Driver", sort=False, dropna=False)]
+    repaired = pd.concat(groups).reindex(laps.index)
+
+    # Counted AFTER the repair, so the number means what the log says it means.
+    unknown = repaired["TyreLife"].isna()
+    if "Position" in repaired.columns:
+        unknown &= repaired["Position"].notna()
+    report.unknown_after = int(unknown.sum())
+
+    if report.changed_anything:
+        logger.info(
+            "Tyre-stint repair on %d driver(s): %d fabricated age(s) nulled, %d boundary/ies "
+            "corrected, %d age(s) rebuilt; %d racing lap(s) now carry an honest unknown age (#790)",
+            len(report.drivers_touched),
+            report.fabricated_ages_nulled,
+            report.boundaries_corrected,
+            report.tyre_life_rebuilt,
+            report.unknown_after,
+        )
+    return repaired, report

--- a/tests/agents/test_tyre_stint_repair.py
+++ b/tests/agents/test_tyre_stint_repair.py
@@ -1,0 +1,307 @@
+"""#790 — the tyre-stint repair must fix broken races and leave healthy ones untouched.
+
+The second half of that sentence is the load-bearing one. A rebuilt ``TyreLife`` that is
+subtly wrong is worse than the NaN it replaces, because a NaN is visible in every
+downstream check and a plausible integer is not. So the first test here is not that the
+repair works — it is that the repair does nothing at all to data that was already right,
+including the two shapes that LOOK like corruption and are not.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from src.f1_strat_manager.tyre_stint_repair import (
+    find_misplaced_boundaries,
+    repair_tyre_stints,
+)
+
+
+def _laps(rows):
+    """Build a per-driver laps frame from (lap, stint, compound, tyre_life, pit_in)."""
+    return pd.DataFrame(
+        [
+            {
+                "Driver": "NOR",
+                "LapNumber": float(lap),
+                "Stint": stint,
+                "Compound": compound,
+                "TyreLife": tyre_life,
+                "PitInTime": pd.Timedelta(seconds=1) if pit_in else pd.NaT,
+                "Position": 1.0,
+            }
+            for lap, stint, compound, tyre_life, pit_in in rows
+        ]
+    )
+
+
+HEALTHY = _laps([
+    (1, 1.0, "MEDIUM", 1.0, False),
+    (2, 1.0, "MEDIUM", 2.0, False),
+    (3, 1.0, "MEDIUM", 3.0, True),    # pits here
+    (4, 2.0, "HARD", 1.0, False),     # new stint starts on the out-lap: correct
+    (5, 2.0, "HARD", 2.0, False),
+])
+
+# Monaco 2025 RUS's shape: a stop-and-go serves no tyres, so the stint correctly does not
+# advance, and a LATER real stop is what changes the compound.
+STOP_AND_GO_THEN_REAL_STOP = _laps([
+    (1, 2.0, "MEDIUM", 5.0, False),
+    (2, 2.0, "MEDIUM", 6.0, True),    # penalty served: no new set
+    (3, 2.0, "MEDIUM", 7.0, False),
+    (4, 2.0, "MEDIUM", 8.0, True),    # the real stop
+    (5, 3.0, "HARD", 1.0, False),
+])
+
+# A pit entry with no tyre change anywhere after it (a served penalty near race end).
+PENALTY_ONLY = _laps([
+    (1, 1.0, "HARD", 4.0, False),
+    (2, 1.0, "HARD", 5.0, True),
+    (3, 1.0, "HARD", 6.0, False),
+])
+
+# Miami 2025 NOR's shape: one stop on lap 3, but the metadata only starts stint 2 on
+# lap 6, so TyreLife counts through the stop and the new set's age is understated.
+MIAMI_SHAPE = _laps([
+    (1, 1.0, "MEDIUM", 1.0, False),
+    (2, 1.0, "MEDIUM", 2.0, False),
+    (3, 1.0, "MEDIUM", 3.0, True),    # real stop
+    (4, 1.0, "MEDIUM", 4.0, False),   # impossible: counting across the stop
+    (5, 1.0, "MEDIUM", 5.0, False),
+    (6, 2.0, "HARD", 1.0, False),     # boundary lands 3 laps late
+    (7, 2.0, "HARD", 2.0, False),
+])
+
+
+@pytest.mark.parametrize(
+    "frame, shape",
+    [
+        (HEALTHY, "a normal stop whose stint advances on the out-lap"),
+        (STOP_AND_GO_THEN_REAL_STOP, "a served stop-and-go followed by a real stop"),
+        (PENALTY_ONLY, "a pit entry with no tyre change at all"),
+    ],
+)
+def test_correct_data_is_returned_untouched(frame, shape):
+    """The safeguard: no healthy shape may be 'repaired'.
+
+    The two penalty shapes are here because they are the ones that superficially look
+    broken — the stint does not advance across a pit entry — and acting on that single
+    signal would rewrite a right answer into a wrong one.
+    """
+    repaired, report = repair_tyre_stints(frame)
+    pd.testing.assert_frame_equal(repaired, frame)
+    assert not report.changed_anything
+    assert report.boundaries_corrected == 0
+
+
+def test_a_served_penalty_is_not_a_misplaced_boundary():
+    assert find_misplaced_boundaries(STOP_AND_GO_THEN_REAL_STOP) == []
+    assert find_misplaced_boundaries(PENALTY_ONLY) == []
+
+
+def test_the_miami_shape_is_detected():
+    assert find_misplaced_boundaries(MIAMI_SHAPE) == [(3, 6)]
+
+
+def test_the_rebuilt_age_counts_from_the_out_lap_not_from_the_feed():
+    repaired, report = repair_tyre_stints(MIAMI_SHAPE)
+    by_lap = repaired.set_index("LapNumber")
+
+    # The out-lap is the new set's first lap.
+    assert by_lap.loc[4.0, "TyreLife"] == 1.0
+    assert by_lap.loc[5.0, "TyreLife"] == 2.0
+    # And the laps the feed mislabelled now continue that count instead of restarting.
+    assert by_lap.loc[6.0, "TyreLife"] == 3.0
+    assert by_lap.loc[7.0, "TyreLife"] == 4.0
+
+    assert report.boundaries_corrected == 1
+    assert report.changed_anything
+
+
+def test_the_impossible_count_across_the_stop_is_gone():
+    """Before: 3 -> 4 across a pit stop. After: the age must drop, not rise."""
+    before = MIAMI_SHAPE.set_index("LapNumber")["TyreLife"]
+    assert before.loc[4.0] > before.loc[3.0]
+
+    after = repair_tyre_stints(MIAMI_SHAPE)[0].set_index("LapNumber")["TyreLife"]
+    assert after.loc[4.0] < after.loc[3.0]
+
+
+def test_the_corrected_laps_take_the_new_compound():
+    repaired = repair_tyre_stints(MIAMI_SHAPE)[0].set_index("LapNumber")
+    assert repaired.loc[4.0, "Compound"] == "HARD"
+    assert repaired.loc[4.0, "Stint"] == 2.0
+    # The laps genuinely on the old set are left alone.
+    assert repaired.loc[3.0, "Compound"] == "MEDIUM"
+    assert repaired.loc[3.0, "Stint"] == 1.0
+
+
+def test_a_missing_first_stint_stays_unknown_on_the_FIRING_path():
+    """The repair must never invent a starting tyre age, even while it repairs elsewhere.
+
+    A car may start a stint on a used set and the offset varies per driver, so a first
+    stint with no metadata stays NaN. The fixture is deliberately one where the repair
+    DOES fire (a misplaced boundary at the stop): an earlier version of this test used a
+    frame the function never touched at all, so it passed without ever reaching the code
+    it claimed to pin — the project's recorded wrong-reason-green scar.
+    """
+    unknown_then_repairable = _laps([
+        (1, None, "nan", None, False),
+        (2, None, "nan", None, False),
+        (3, 1.0, "MEDIUM", 1.0, False),   # feed recovers mid-stint: age counts from zero
+        (4, 1.0, "MEDIUM", 2.0, True),    # real stop, on a now-known compound
+        (5, 1.0, "MEDIUM", 3.0, False),   # mislabelled: already the new set
+        (6, 2.0, "HARD", 1.0, False),     # boundary lands late
+    ])
+    repaired, report = repair_tyre_stints(unknown_then_repairable)
+    by_lap = repaired.set_index("LapNumber")
+
+    assert report.changed_anything, "the fixture must exercise the repairing path"
+    # Laps on the race-start set: their age was never published, so it stays unknown -
+    # including lap 3, where the feed offered a plausible 1.0 that is provably wrong.
+    assert pd.isna(by_lap.loc[1.0, "TyreLife"])
+    assert pd.isna(by_lap.loc[3.0, "TyreLife"])
+    assert pd.isna(by_lap.loc[4.0, "TyreLife"])
+    # The post-stop laps ARE recoverable and get counted from the out-lap.
+    assert by_lap.loc[5.0, "TyreLife"] == 1.0
+    assert by_lap.loc[6.0, "TyreLife"] == 2.0
+
+
+def test_a_stop_made_while_the_feed_is_dark_is_left_unknown_rather_than_guessed():
+    """The conservative edge: no real compound before the stop means no confirmed change.
+
+    A pit entry alone does not prove a tyre change (a served penalty is one too), and with
+    the pre-stop compound lost there is nothing left to confirm it with. So the fabricated
+    ages are nulled and nothing is rebuilt, rather than a stint being invented from a
+    stop that might have been a penalty. Miami 2025 BOR/STR/HAD have exactly this shape.
+    """
+    dark_at_the_stop = _laps([
+        (1, None, "nan", None, False),
+        (2, None, "nan", None, False),
+        (3, None, "nan", None, True),     # stop while the feed is dark
+        (4, None, "nan", None, False),
+        (5, 1.0, "HARD", 1.0, False),     # metadata reappears
+        (6, 1.0, "HARD", 2.0, False),
+    ])
+    repaired, report = repair_tyre_stints(dark_at_the_stop)
+
+    assert report.boundaries_corrected == 0, "nothing confirms a tyre change here"
+    assert repaired["TyreLife"].isna().all(), "plausible-but-unprovable ages become unknown"
+    assert report.fabricated_ages_nulled == 2
+
+
+# The feed going dark stringifies a missing compound rather than emitting NaN. Treating
+# that as "a different compound" would let data loss masquerade as a tyre change, and
+# writing it back would put a data-loss marker over a real compound (Montréal 2023 TSU).
+FEED_DIED_MID_STINT = _laps([
+    (1, 2.0, "HARD", 30.0, False),
+    (2, 2.0, "HARD", 31.0, True),
+    (3, 3.0, "None", None, False),
+    (4, 3.0, "None", None, False),
+])
+
+
+def test_a_data_loss_sentinel_is_not_a_compound_change():
+    assert find_misplaced_boundaries(FEED_DIED_MID_STINT) == []
+
+
+def test_a_real_compound_is_never_overwritten_by_a_sentinel():
+    repaired, _ = repair_tyre_stints(FEED_DIED_MID_STINT)
+    assert repaired.set_index("LapNumber").loc[2.0, "Compound"] == "HARD"
+
+
+# The feed invents a stint mid-race: metadata reappears on a lap that is NOT a pit
+# out-lap, so its ages count from the wrong zero. This driver never pits, which is why a
+# boundary correction alone cannot reach him (Miami 2025 GAS/HUL/BEA).
+FABRICATED_NO_STOP = _laps([
+    (1, None, "nan", None, False),
+    (2, None, "nan", None, False),
+    (3, 1.0, "MEDIUM", 1.0, False),   # a 3-lap-old set reported as 1 lap old
+    (4, 1.0, "MEDIUM", 2.0, False),
+])
+
+
+def test_fabricated_ages_are_nulled_even_without_a_pit_stop():
+    """The invisible half: a plausible integer that is provably too small becomes NaN."""
+    repaired, report = repair_tyre_stints(FABRICATED_NO_STOP)
+    ages = repaired.set_index("LapNumber")["TyreLife"]
+    assert ages.isna().all()
+    assert report.fabricated_ages_nulled == 2
+
+
+def test_a_used_set_keeps_its_prior_usage():
+    """FreshTyre is read, not assumed: a used set does not restart at 1.
+
+    Measured across every healthy stint transition in 2024/2025, a fresh set starts at
+    exactly 1.0 (1156/1156) while used sets start between 2 and 16. Hardcoding 1 would
+    silently invent for stints 2+ the very offset the module refuses to invent for
+    stint 1.
+    """
+    used_set = _laps([
+        (1, 1.0, "MEDIUM", 1.0, False),
+        (2, 1.0, "MEDIUM", 2.0, True),    # real stop
+        (3, 1.0, "MEDIUM", 3.0, False),   # mislabelled: already the new set
+        (4, 2.0, "HARD", 4.0, False),     # feed says the set arrived with 3 laps on it
+    ])
+    repaired, _ = repair_tyre_stints(used_set)
+    by_lap = repaired.set_index("LapNumber")
+    # Prior usage is 3 (published 4 minus the 1 it would carry if fresh), so the out-lap
+    # is 4 rather than 1 and the count continues from there.
+    assert by_lap.loc[3.0, "TyreLife"] == 4.0
+    assert by_lap.loc[4.0, "TyreLife"] == 5.0
+
+
+def test_a_nan_driver_row_is_not_annihilated():
+    """groupby drops NaN keys and reindex re-inserts them as all-NaN, destroying columns
+    this repair has no business touching. No shipped race carries one, but this runs on
+    every future download."""
+    frame = _laps([(1, 1.0, "MEDIUM", 1.0, False), (2, 1.0, "MEDIUM", 2.0, False)])
+    frame.loc[0, "Driver"] = None
+    repaired, _ = repair_tyre_stints(frame)
+    assert repaired.iloc[0]["LapNumber"] == 1.0
+    assert repaired.iloc[0]["Position"] == 1.0
+
+
+def test_a_frame_without_the_required_columns_degrades_quietly():
+    bare = pd.DataFrame({"Driver": ["NOR"], "LapNumber": [1.0]})
+    repaired, report = repair_tyre_stints(bare)
+    pd.testing.assert_frame_equal(repaired, bare)
+    assert not report.changed_anything
+
+
+def test_a_boundary_with_no_published_age_rebuilds_nothing():
+    """No anchor means no rebuild — counting from 1 would invent a fresh set.
+
+    The boundary lap here carries a real compound but a NaN TyreLife, so there is nothing
+    to subtract the prior usage from. An earlier version returned 0.0 in that case and
+    filled the laps with fabricated fresh-set ages, contradicting the module's own rule.
+    """
+    no_anchor = _laps([
+        (1, 1.0, "MEDIUM", 1.0, False),
+        (2, 1.0, "MEDIUM", 2.0, True),    # real stop
+        (3, 1.0, "MEDIUM", 3.0, False),
+        (4, 2.0, "HARD", None, False),    # boundary, but no published age
+    ])
+    repaired, report = repair_tyre_stints(no_anchor)
+    assert report.boundaries_corrected == 0
+    pd.testing.assert_frame_equal(repaired, no_anchor)
+
+
+def test_a_boundary_with_no_stint_id_does_not_half_apply():
+    """Either the whole correction lands, or none of it does.
+
+    Rewriting Compound and then bailing on a missing Stint would return a MUTATED frame
+    while reporting no change — and the caller uses that report to decide whether to
+    patch the featured frame, so raw and featured would end up disagreeing.
+    """
+    no_stint = _laps([
+        (1, 1.0, "MEDIUM", 1.0, False),
+        (2, 1.0, "MEDIUM", 2.0, True),
+        (3, 1.0, "MEDIUM", 3.0, False),
+        (4, None, "HARD", 4.0, False),    # boundary compound is real, Stint is not
+    ])
+    repaired, report = repair_tyre_stints(no_stint)
+    assert not report.changed_anything
+    # Reported no change, so there must BE no change.
+    pd.testing.assert_frame_equal(repaired, no_stint)

--- a/tests/agents/test_tyre_stint_repair.py
+++ b/tests/agents/test_tyre_stint_repair.py
@@ -36,42 +36,50 @@ def _laps(rows):
     )
 
 
-HEALTHY = _laps([
-    (1, 1.0, "MEDIUM", 1.0, False),
-    (2, 1.0, "MEDIUM", 2.0, False),
-    (3, 1.0, "MEDIUM", 3.0, True),    # pits here
-    (4, 2.0, "HARD", 1.0, False),     # new stint starts on the out-lap: correct
-    (5, 2.0, "HARD", 2.0, False),
-])
+HEALTHY = _laps(
+    [
+        (1, 1.0, "MEDIUM", 1.0, False),
+        (2, 1.0, "MEDIUM", 2.0, False),
+        (3, 1.0, "MEDIUM", 3.0, True),  # pits here
+        (4, 2.0, "HARD", 1.0, False),  # new stint starts on the out-lap: correct
+        (5, 2.0, "HARD", 2.0, False),
+    ]
+)
 
 # Monaco 2025 RUS's shape: a stop-and-go serves no tyres, so the stint correctly does not
 # advance, and a LATER real stop is what changes the compound.
-STOP_AND_GO_THEN_REAL_STOP = _laps([
-    (1, 2.0, "MEDIUM", 5.0, False),
-    (2, 2.0, "MEDIUM", 6.0, True),    # penalty served: no new set
-    (3, 2.0, "MEDIUM", 7.0, False),
-    (4, 2.0, "MEDIUM", 8.0, True),    # the real stop
-    (5, 3.0, "HARD", 1.0, False),
-])
+STOP_AND_GO_THEN_REAL_STOP = _laps(
+    [
+        (1, 2.0, "MEDIUM", 5.0, False),
+        (2, 2.0, "MEDIUM", 6.0, True),  # penalty served: no new set
+        (3, 2.0, "MEDIUM", 7.0, False),
+        (4, 2.0, "MEDIUM", 8.0, True),  # the real stop
+        (5, 3.0, "HARD", 1.0, False),
+    ]
+)
 
 # A pit entry with no tyre change anywhere after it (a served penalty near race end).
-PENALTY_ONLY = _laps([
-    (1, 1.0, "HARD", 4.0, False),
-    (2, 1.0, "HARD", 5.0, True),
-    (3, 1.0, "HARD", 6.0, False),
-])
+PENALTY_ONLY = _laps(
+    [
+        (1, 1.0, "HARD", 4.0, False),
+        (2, 1.0, "HARD", 5.0, True),
+        (3, 1.0, "HARD", 6.0, False),
+    ]
+)
 
 # Miami 2025 NOR's shape: one stop on lap 3, but the metadata only starts stint 2 on
 # lap 6, so TyreLife counts through the stop and the new set's age is understated.
-MIAMI_SHAPE = _laps([
-    (1, 1.0, "MEDIUM", 1.0, False),
-    (2, 1.0, "MEDIUM", 2.0, False),
-    (3, 1.0, "MEDIUM", 3.0, True),    # real stop
-    (4, 1.0, "MEDIUM", 4.0, False),   # impossible: counting across the stop
-    (5, 1.0, "MEDIUM", 5.0, False),
-    (6, 2.0, "HARD", 1.0, False),     # boundary lands 3 laps late
-    (7, 2.0, "HARD", 2.0, False),
-])
+MIAMI_SHAPE = _laps(
+    [
+        (1, 1.0, "MEDIUM", 1.0, False),
+        (2, 1.0, "MEDIUM", 2.0, False),
+        (3, 1.0, "MEDIUM", 3.0, True),  # real stop
+        (4, 1.0, "MEDIUM", 4.0, False),  # impossible: counting across the stop
+        (5, 1.0, "MEDIUM", 5.0, False),
+        (6, 2.0, "HARD", 1.0, False),  # boundary lands 3 laps late
+        (7, 2.0, "HARD", 2.0, False),
+    ]
+)
 
 
 @pytest.mark.parametrize(
@@ -146,14 +154,16 @@ def test_a_missing_first_stint_stays_unknown_on_the_FIRING_path():
     frame the function never touched at all, so it passed without ever reaching the code
     it claimed to pin — the project's recorded wrong-reason-green scar.
     """
-    unknown_then_repairable = _laps([
-        (1, None, "nan", None, False),
-        (2, None, "nan", None, False),
-        (3, 1.0, "MEDIUM", 1.0, False),   # feed recovers mid-stint: age counts from zero
-        (4, 1.0, "MEDIUM", 2.0, True),    # real stop, on a now-known compound
-        (5, 1.0, "MEDIUM", 3.0, False),   # mislabelled: already the new set
-        (6, 2.0, "HARD", 1.0, False),     # boundary lands late
-    ])
+    unknown_then_repairable = _laps(
+        [
+            (1, None, "nan", None, False),
+            (2, None, "nan", None, False),
+            (3, 1.0, "MEDIUM", 1.0, False),  # feed recovers mid-stint: age counts from zero
+            (4, 1.0, "MEDIUM", 2.0, True),  # real stop, on a now-known compound
+            (5, 1.0, "MEDIUM", 3.0, False),  # mislabelled: already the new set
+            (6, 2.0, "HARD", 1.0, False),  # boundary lands late
+        ]
+    )
     repaired, report = repair_tyre_stints(unknown_then_repairable)
     by_lap = repaired.set_index("LapNumber")
 
@@ -176,14 +186,16 @@ def test_a_stop_made_while_the_feed_is_dark_is_left_unknown_rather_than_guessed(
     ages are nulled and nothing is rebuilt, rather than a stint being invented from a
     stop that might have been a penalty. Miami 2025 BOR/STR/HAD have exactly this shape.
     """
-    dark_at_the_stop = _laps([
-        (1, None, "nan", None, False),
-        (2, None, "nan", None, False),
-        (3, None, "nan", None, True),     # stop while the feed is dark
-        (4, None, "nan", None, False),
-        (5, 1.0, "HARD", 1.0, False),     # metadata reappears
-        (6, 1.0, "HARD", 2.0, False),
-    ])
+    dark_at_the_stop = _laps(
+        [
+            (1, None, "nan", None, False),
+            (2, None, "nan", None, False),
+            (3, None, "nan", None, True),  # stop while the feed is dark
+            (4, None, "nan", None, False),
+            (5, 1.0, "HARD", 1.0, False),  # metadata reappears
+            (6, 1.0, "HARD", 2.0, False),
+        ]
+    )
     repaired, report = repair_tyre_stints(dark_at_the_stop)
 
     assert report.boundaries_corrected == 0, "nothing confirms a tyre change here"
@@ -194,12 +206,14 @@ def test_a_stop_made_while_the_feed_is_dark_is_left_unknown_rather_than_guessed(
 # The feed going dark stringifies a missing compound rather than emitting NaN. Treating
 # that as "a different compound" would let data loss masquerade as a tyre change, and
 # writing it back would put a data-loss marker over a real compound (Montréal 2023 TSU).
-FEED_DIED_MID_STINT = _laps([
-    (1, 2.0, "HARD", 30.0, False),
-    (2, 2.0, "HARD", 31.0, True),
-    (3, 3.0, "None", None, False),
-    (4, 3.0, "None", None, False),
-])
+FEED_DIED_MID_STINT = _laps(
+    [
+        (1, 2.0, "HARD", 30.0, False),
+        (2, 2.0, "HARD", 31.0, True),
+        (3, 3.0, "None", None, False),
+        (4, 3.0, "None", None, False),
+    ]
+)
 
 
 def test_a_data_loss_sentinel_is_not_a_compound_change():
@@ -214,12 +228,14 @@ def test_a_real_compound_is_never_overwritten_by_a_sentinel():
 # The feed invents a stint mid-race: metadata reappears on a lap that is NOT a pit
 # out-lap, so its ages count from the wrong zero. This driver never pits, which is why a
 # boundary correction alone cannot reach him (Miami 2025 GAS/HUL/BEA).
-FABRICATED_NO_STOP = _laps([
-    (1, None, "nan", None, False),
-    (2, None, "nan", None, False),
-    (3, 1.0, "MEDIUM", 1.0, False),   # a 3-lap-old set reported as 1 lap old
-    (4, 1.0, "MEDIUM", 2.0, False),
-])
+FABRICATED_NO_STOP = _laps(
+    [
+        (1, None, "nan", None, False),
+        (2, None, "nan", None, False),
+        (3, 1.0, "MEDIUM", 1.0, False),  # a 3-lap-old set reported as 1 lap old
+        (4, 1.0, "MEDIUM", 2.0, False),
+    ]
+)
 
 
 def test_fabricated_ages_are_nulled_even_without_a_pit_stop():
@@ -238,12 +254,14 @@ def test_a_used_set_keeps_its_prior_usage():
     silently invent for stints 2+ the very offset the module refuses to invent for
     stint 1.
     """
-    used_set = _laps([
-        (1, 1.0, "MEDIUM", 1.0, False),
-        (2, 1.0, "MEDIUM", 2.0, True),    # real stop
-        (3, 1.0, "MEDIUM", 3.0, False),   # mislabelled: already the new set
-        (4, 2.0, "HARD", 4.0, False),     # feed says the set arrived with 3 laps on it
-    ])
+    used_set = _laps(
+        [
+            (1, 1.0, "MEDIUM", 1.0, False),
+            (2, 1.0, "MEDIUM", 2.0, True),  # real stop
+            (3, 1.0, "MEDIUM", 3.0, False),  # mislabelled: already the new set
+            (4, 2.0, "HARD", 4.0, False),  # feed says the set arrived with 3 laps on it
+        ]
+    )
     repaired, _ = repair_tyre_stints(used_set)
     by_lap = repaired.set_index("LapNumber")
     # Prior usage is 3 (published 4 minus the 1 it would carry if fresh), so the out-lap
@@ -277,12 +295,14 @@ def test_a_boundary_with_no_published_age_rebuilds_nothing():
     to subtract the prior usage from. An earlier version returned 0.0 in that case and
     filled the laps with fabricated fresh-set ages, contradicting the module's own rule.
     """
-    no_anchor = _laps([
-        (1, 1.0, "MEDIUM", 1.0, False),
-        (2, 1.0, "MEDIUM", 2.0, True),    # real stop
-        (3, 1.0, "MEDIUM", 3.0, False),
-        (4, 2.0, "HARD", None, False),    # boundary, but no published age
-    ])
+    no_anchor = _laps(
+        [
+            (1, 1.0, "MEDIUM", 1.0, False),
+            (2, 1.0, "MEDIUM", 2.0, True),  # real stop
+            (3, 1.0, "MEDIUM", 3.0, False),
+            (4, 2.0, "HARD", None, False),  # boundary, but no published age
+        ]
+    )
     repaired, report = repair_tyre_stints(no_anchor)
     assert report.boundaries_corrected == 0
     pd.testing.assert_frame_equal(repaired, no_anchor)
@@ -295,12 +315,14 @@ def test_a_boundary_with_no_stint_id_does_not_half_apply():
     while reporting no change — and the caller uses that report to decide whether to
     patch the featured frame, so raw and featured would end up disagreeing.
     """
-    no_stint = _laps([
-        (1, 1.0, "MEDIUM", 1.0, False),
-        (2, 1.0, "MEDIUM", 2.0, True),
-        (3, 1.0, "MEDIUM", 3.0, False),
-        (4, None, "HARD", 4.0, False),    # boundary compound is real, Stint is not
-    ])
+    no_stint = _laps(
+        [
+            (1, 1.0, "MEDIUM", 1.0, False),
+            (2, 1.0, "MEDIUM", 2.0, True),
+            (3, 1.0, "MEDIUM", 3.0, False),
+            (4, None, "HARD", 4.0, False),  # boundary compound is real, Stint is not
+        ]
+    )
     repaired, report = repair_tyre_stints(no_stint)
     assert not report.changed_anything
     # Reported no change, so there must BE no change.


### PR DESCRIPTION
## What

Repairs tyre-stint metadata that the F1 live-timing feed published wrong, at load time in `augment_featured_laps`.

Refs #790. Does not close it: the remaining `NaN` is the correct answer for genuinely unknown data, so the consumer-guard question that issue opens with is still open (see the end).

## Why, and what the investigation actually found

The issue described missing `TyreLife`. Two things turned out to be true that it did not say.

**It is not our extraction.** FastF1 carries the identical gap, row for row — 446/457 NaN on Miami 2025 laps ≤ 24 in both FastF1 and our raw parquet. The `TimingAppData` feed did not publish the opening stint's records, FastF1 leaves NaN rather than guessing, and we copy that faithfully.

**The NaN is the lesser half.** When the feed recovers it does not resume the stint that was running — it starts a new one at the recovery lap:

```
LapNumber  Stint  Compound  TyreLife  pit_in  pit_out
     25.0    1.0    MEDIUM       1.0   False    False   <- a 25-lap-old set reported as 1
     29.0    1.0    MEDIUM       5.0    True    False   <- real pit stop
     30.0    1.0    MEDIUM       6.0   False     True   <- keeps counting THROUGH the stop
     33.0    2.0      HARD       1.0   False    False   <- stint 2 starts 4 laps late
```

`TyreLife` feeds N26's TCN and N15/N16, and **Miami 2025 is in the test season**. A degradation model reading "5 laps old" for a 29-lap-old tyre predicts no wear.

## What it does

1. **Nulls the fabricated ages.** Where the feed invented a stint mid-race, those laps belong to the race-start set whose age was never published. They become `NaN` — a visible unknown replacing an invisible wrong integer, which is the module's own standard applied to itself.
2. **Moves the misplaced boundary.** Where the car pitted before the feed recovered, the stint really began on the out-lap and the age is recoverable from there.
3. **Never invents a first-stint age.** A car may start on a used set and the offset varies per driver.

The rebuild anchors on the age the feed published at the boundary rather than assuming a fresh set. Measured across every healthy stint transition: fresh sets start at exactly 1.0 in 1156/1156 cases, used sets start between 2 and 16. Hardcoding 1 would silently invent for stints 2+ the very offset this refuses to invent for stint 1.

## Two things it deliberately does not touch

Both would have rewritten correct records:

- **A served stop-and-go is a pit entry with no tyre change**, so the stint rightly does not advance. Monaco 2025 RUS lap 62 is one (confirmed). A rule keyed on "the stint failed to advance across a pit entry" flags it as corrupt; this one also requires that no other pit entry sits between the stop and the compound change.
- **`''` / `'nan'` / `'None'` are data-loss sentinels, not compounds.** An earlier version fired on `'HARD' → 'None'` at Montréal 2023 and wrote the sentinel over a real compound. They now neither evidence a change nor get written back.

## Where it runs

Load time, from `augment_featured_laps` — the seam that module already documents for exactly this reason: the featured parquet is republished from Hugging Face and re-downloaded, so a locally patched file would be silently reverted, and its only producer is a read-only notebook.

## Verification

| | Before | After |
|---|---|---|
| NOR Miami lap 29 | `TyreLife 5.0` on a 29-lap-old set | `NaN` |
| Laps whose age is impossibly small | ≥ 71 | **0** |
| GAS / HUL / BEA (no boundary to correct) | 34 / 33 / 5 fabricated ages | covered |
| Healthy races | — | **70 / 71 byte-identical** |

Also verified: row count and order preserved, no patch columns leak, a second call is a no-op, and the golden published-metric tests are unmoved (the two already failing are #782's, unchanged).

218 tests green. 18 of them are new and the first three are the safeguard: no healthy shape may be "repaired", including the two that superficially look broken.

## Adversarial gates

Two, both in `documents/audits/`.

The first returned **not safe to ship**, with nine findings and three blockers: the repair did not fix this issue's own flagship case (NOR lap 29 still read 5.0), three drivers with identical corruption were skipped entirely, and every fitted set was assumed fresh. All closed.

The re-gate confirmed those and found four more, all latent with zero live instances — a boundary that half-applied while reporting no change, a patch mask that would have skipped exactly the nulled rows, a missing anchor filled with an invented age, and a docstring naming `FreshTyre` as the mechanism when the code reads the published age. All fixed here, two with tests pinning them.

## Known limits, recorded rather than left to be discovered

- **Same compound refitted is invisible to the boundary rule.** 743 of 2594 stint transitions fit the same compound again; a misplaced boundary there cannot be seen by a compound-change test. No shipped race is affected. It errs toward missing a defect, never toward rewriting a correct one.
- **A stop made while the feed was dark is nulled, not rebuilt.** With the pre-stop compound lost, nothing confirms a tyre change. Miami STR/HAD/BOR are this shape: 63 featured laps that would have been recoverable to within 1-4 laps become `NaN` instead. A deliberate trade, documented in the module.
- **Raw-fed surfaces still see feed values.** Consumers reading a raw parquet directly rather than through `augment_featured_laps` are not repaired.

## Still open on #790

The remaining `NaN` is correct, so the guard the issue originally asked for is still needed: `race_situation_agent.py:914-915` does `int(driver_x_lap['TyreLife'])` unguarded, while its twin at `pit_strategy_agent.py:983-999` refuses the prediction rather than defaulting. Refuse or degrade is a modelling decision and is left to be made deliberately.
