### PR TITLE
fix(data): restore the weather columns the 2025 featured artefact was published without

### DIFF
--- a/documents/audits/GATE_weather_restore.md
+++ b/documents/audits/GATE_weather_restore.md
@@ -1,0 +1,235 @@
+# ADVERSARIAL GATE — #782 weather-column restore (`fix/restore-2025-weather-columns`)
+
+Date: 2026-08-03 · Auditor: adversarial correctness gate (Fable) · Status: IN PROGRESS
+
+Scope: uncommitted change restoring `AirTemp`/`TrackTemp`/`Humidity`/`Rainfall` onto
+`laps_featured_2025` at load time via `src/f1_strat_manager/weather_restore.py`, wired into
+`augment_featured_laps`, with `pace_holdout.py` rerouted through the augment.
+
+Method: executed evidence only. Every finding cites file:line and measured values.
+
+## Checklist
+
+- [ ] A. Independent 2023/2024 reproduction (values + Rainfall + dtypes)
+- [ ] B. Guard behaviour: early exit, partial columns, empty frame, all-NaN columns
+- [ ] C. Pace MAE reproduction + sensitivity of MAE to the weather values
+- [ ] D. What ELSE changed in the pace holdout (stint repair, row counts, _DROPNA)
+- [ ] E. Direct-reader inventory: which eval paths still see un-repaired / weather-less data
+- [ ] F. tests/eval/ run + other headline numbers
+- [ ] G. Docstring/comment truth (the 71-races sentence, the "honest gap" claim, the "tests/agents holds that check" claim)
+
+## Findings (appended as confirmed)
+
+### G-OK — the 71-races docstring sentence is TRUE (verified, all four parts)
+
+`weather_restore.py:9-10` claims every one of the 71 shipped race directories has a readable
+`weather.parquet` with all four readings and zero NaN temperature rows. Executed over
+`data/raw/{2023,2024,2025}/*` (23+24+24 = 71 dirs): 0 missing, 0 unreadable, 0 missing columns,
+0 NaN `AirTemp`/`TrackTemp` rows. Also measured beyond the claim: 0 NaN `Humidity`, 0 NaT `Time`
+samples, `Time` is `timedelta64[ns]` in all 71, `Rainfall` is `bool` in all 71.
+
+### A-OK — 2023/2024 reproduction re-derived independently: EXACT, all FOUR columns, dtypes included
+
+Re-derived (own script, not the author's): dropped the four weather columns from the published
+`laps_featured_2023/2024.parquet`, ran `augment_featured_laps`, compared per (GP_Name, Driver,
+LapNumber) with row order verified preserved.
+
+- 2023: 22,106 rows. AirTemp/TrackTemp/Humidity exact-equal 22,106/22,106 each (max diff 0.0,
+  0 NaN mismatches). The author's "66,318/66,318" is 22,106 × 3 — consistent.
+- 2024: 23,256 rows. Exact-equal 23,256/23,256 each. "69,768" = 23,256 × 3 — consistent.
+- **Rainfall (the column the author's script skipped): reproduces 100% in both seasons**, values
+  {0,1} identical, and the restored dtype is `int32` — identical to the published `int32`
+  (`.astype(int)` on Windows numpy = int32, same platform N04 ran on).
+- Row count and key order preserved through the augment (no merge fan-out).
+
+### FINDING 1 (MEDIUM) — B: a frame carrying SOME of the four columns comes out silently corrupted
+
+`laps_augment.py:206` guards with `not all(column in df.columns ...)`, so a frame with 1-3 of the
+four present sets `wants_weather=True`; the per-race slice then carries all four
+(`laps_augment.py:236-237`) and the left-merge at `laps_augment.py:253` collides with the columns
+already on the featured frame. Executed (2023 featured with only `AirTemp` dropped): the output has
+58 columns, `TrackTemp`/`Humidity`/`Rainfall` NO LONGER EXIST — replaced by `TrackTemp_x`/
+`TrackTemp_y`, `Humidity_x`/`Humidity_y`, `Rainfall_x`/`Rainfall_y`. `normalise_rainfall` then
+no-ops (no `Rainfall` column), leaving `Rainfall_y` un-filled. Any consumer selecting the plain
+names (e.g. `df[features_delta]` in `pace_holdout.py:120`) raises KeyError; a `.get()`-style
+consumer silently reads nothing. Failure scenario: any future artefact republished with a partial
+weather set — the guard's own condition contemplates exactly this shape and then corrupts instead
+of deriving only the missing columns or refusing loudly. Today no shipped artefact is partial
+(2023/24 carry all four, 2025 carries none), so this is latent, not live.
+
+### B-OK — the early exit and the degenerate frames behave
+
+- Published 2023 through the augment: all four weather columns byte-identical after, dtypes
+  preserved (`int32` Rainfall included) — 2023/2024 are never re-derived. Confirmed executed.
+- No-`GP_Name` frame returns unchanged; zero-row frame with keys returns zero rows, no crash.
+- Columns present but ALL-NaN: guard sees presence, not usability — frame stays all-NaN (no
+  re-derivation). Consistent with the "never second-guess a season that carries the columns"
+  contract; noted as a design edge, not a defect.
+
+### FINDING 2 (MEDIUM) — C: the pace-MAE reproduction is REAL evidence for the values but CANNOT see the alignment method; and the safeguard the docstring points to does not exist
+
+Executed sensitivity of `_pace_mae()` (shipped MAE 0.40968, n=21,247; author's 0.40968 confirmed;
+golden tolerance ±0.01 vs published 0.4104):
+
+| weather variant | MAE | |Δ| vs shipped | golden verdict |
+|---|---|---|---|
+| shipped (nearest join) | 0.40968 | — | reproduced |
+| all-NaN weather | 0.67217 | 0.26249 | delta |
+| +5/+10/+20 °C/% perturbation | 0.57586 | 0.16619 | delta |
+| all-zero weather | 0.51974 | 0.11006 | delta |
+| scrambled across laps | 0.48805 | 0.07837 | delta |
+| **WRONG join: direction='backward'** | **0.40939** | **0.00029** | **reproduced** |
+
+The weather columns are 4 of the 25 features in `xgb_laptime_delta_feature_names.json` (verified),
+and the MAE moves violently when their values are wrong at the distribution level — so the
+reproduction is NOT hollow. But a backward join that changes 7,014/22,760 TrackTemp cells moves
+the MAE by 0.00029 and still "reproduces". Two documented claims therefore overstate it:
+
+- `tests/agents/test_weather_restore.py:9-10`: "That number moves if the merge is wrong, which is
+  what makes it evidence rather than decoration" — REFUTED for alignment-level wrongness. Only a
+  synthetic unit test (`test_each_lap_takes_its_nearest_sample_not_the_preceding_one`) pins the
+  direction, on a 1-lap toy frame.
+- `weather_restore.py:28-31`: "the restore must reproduce 2023's and 2024's published weather
+  **exactly** before it is trusted on 2025. `tests/agents/` holds that check, and it is not
+  decoration" — **FALSE. No committed test compares the restore against the published 2023/2024
+  values.** All 6 tests in `tests/agents/test_weather_restore.py` run on synthetic 1-3 row frames.
+  The exact-reproduction evidence exists only in this gate and in the author's uncommitted script.
+  The one check the module calls its load-bearing safeguard is not in the repo.
+
+### D-OK (measured) — the stint repair riding along moves the metric by 0.00011 and the denominator not at all
+
+The rerouted holdout input changed in two ways (#782 weather + #790 repair). Decomposed, executed:
+
+- Repair disabled (monkeypatched no-op), weather on: MAE 0.40957 vs shipped 0.40968 —
+  |Δ| = 0.00011. The 0.4104 reproduction survives because of the weather, not despite the repair.
+- Denominator: n = 21,247 in EVERY variant. `_DROPNA = [LapTime_Delta, Prev_LapTime]`
+  (`pace_holdout.py:44`) are published columns the repair never touches; the 113 newly-nulled
+  TyreLife values (featured 2025 rows) do NOT drop rows because TyreLife is not in `_DROPNA`.
+- Repair's real footprint on the scored frame: 98 predictions moved (max |move| 0.611 s), n
+  unchanged, net MAE effect 0.00011. Stint moved on 30 featured rows, TyreLife on 406 (113 to
+  null).
+
+### FINDING 3 (HIGH-VALUE CONFIRMATION, not a defect) — the 2025 ground truth EXISTS on disk and the restore matches it byte-for-byte; no committed test uses it
+
+`data/processed/laps_featured.parquet` (the combined 2023-2025 artefact, 68,122 rows) ALREADY
+carries all four weather columns for 2025 with zero NaN — the actual N04 output for 2025 was
+published all along in the combined file; only the per-year split dropped it. Executed: restored
+2025 weather vs the combined file's 2025 slice — 21,903/21,903 key-matched rows identical on all
+four columns (max diff 0.0), plus the remaining 857 Miami rows identical after mapping the
+GP_Name rename (`Miami` per-year vs `Miami Gardens` combined). **22,760/22,760 exact.**
+
+Consequences:
+- This retroactively closes the backward-join blind spot from Finding 2 FOR THIS GATE: a backward
+  join changes 7,014 TrackTemp cells and would have failed this comparison; 'nearest' is therefore
+  verified as N04's actual 2025 method, not just its stated one.
+- But the repo keeps none of this: the strongest available check (compare restore against
+  `laps_featured.parquet`'s 2025 slice) is in NO committed test, and `weather_restore.py:9-12`
+  frames the truth as existing only in `weather.parquet` inputs ("What is missing is only the
+  merge") when the merge RESULT is also published. The committed test the docstring promises
+  (Finding 2) could be written against this file in ~15 lines and would pin everything the MAE
+  cannot see. Recommendation 1.
+
+### FINDING 4 (LOW) — three comments/docstrings name the WRONG MECHANISM for the Rainfall fill, and one asserts the opposite of what the code does
+
+Executed proof: simulated Monza 2025 with no readable weather parquet (`read_race_weather`
+returning None for that race only). Result: Monza's 895 laps keep AirTemp/TrackTemp/Humidity NaN
+(honest gap) but **Rainfall reads a confident 0 (dry) on all 895** — because the season-level
+`normalise_rainfall` at `laps_augment.py:258` fills every remaining NaN.
+
+- `laps_augment.py:256-257`: "applied once per season rather than per race so a race with no
+  weather parquet keeps an honest gap instead of reading 0 (dry)" — FALSE for Rainfall, the only
+  column the sentence is about. The season pass is precisely what writes the 0.
+- `weather_restore.py:93-95` (normalise_rainfall docstring): "a per-race fill would leave a race
+  with no weather parquet reading 0 (dry) instead of keeping the honest gap until the season-level
+  pass" — INVERTED. A per-race fill inside `weather_for_race` would never RUN for a race whose
+  parquet is absent (the function is never called), so it would KEEP the gap; the season-level
+  pass is what destroys it.
+- `tests/agents/test_weather_restore.py:99-103` repeats the inverted claim verbatim, and the test
+  under it only checks that a frame without a Rainfall column passes through untouched — it does
+  not (and cannot) test the claimed honesty property.
+
+The CODE is faithful to N04 (N04 cell 22 `continue`s on empty weather and fills Rainfall once over
+the master frame — same observable behaviour), so nothing to fix in behaviour. But per this
+project's own lesson log, a comment naming the wrong mechanism is worse than none: someone
+"fixing" the code to match these comments would break the N04 reproduction.
+
+Footnote (comment-truth, no practical surface): `weather_restore.py:59` says NaT-Time laps "keep
+NaN, which is what N04 leaves them as" — N04 never left them as anything; its merge_asof would
+raise on an unsorted NaT key. Measured: 0 NaT `Time` in all 79,032 raw laps across the 71 races,
+so the divergence is unreachable in shipped data.
+
+### E — direct-reader inventory: the featured-laps inconsistency is GONE, not created
+
+Verified per reader (file:line, artefact read):
+- `calibration.py:160/233/283` — `overtake_labeled/overtake_pairs_2023_2025.parquet`,
+  `sc_labeled/sc_labeled_2023_2025.parquet`, `undercut_labeled/undercut_clean.parquet`: labeled
+  artefacts, not featured laps. Reproduction REQUIRES them as-published (as-trained); routing them
+  through the augment would be wrong.
+- `tire_holdout.py:171` — `laps_tiredeg.parquet` (56 cols): carries its own weather for ALL years,
+  0 NaN in all four columns 2023/2024/2025 (measured). Not affected by the 2025 hole.
+- `nlp.py:643` — RCM corpus parquets, unrelated.
+- `pit_holdout.py:54`, `projection.py:296`, `stint_lengths.py:207` — RAW `laps.parquet` per race,
+  not featured. (They see un-REPAIRED raw stints, but that pre-dates this diff and is untouched
+  by it; the pit/projection metrics were published on those raws.)
+- Non-eval consumers of `laps_featured_<year>`: arcade `strategy.py:576`, backend
+  `laps_cache.py:39` (feeding `simulator.py` and every route), CLI — all already through
+  `augment_featured_laps`; `pace_agent.py:216-218/240-243` reads the parquet directly but only
+  columns `[Team, TeamID]` / `[GP_Name, Year, Compound, LapTime_s]` — no weather dependency.
+
+Net: after this change, every reader of a per-year featured-laps parquet that consumes more than
+named non-weather columns goes through the augment. The change REMOVED the last inconsistency
+(pace_holdout) rather than adding one. Side effect worth knowing: arcade/backend/CLI 2025 frames
+now carry 6 extra columns (Time_s, TrackStatus + 4 weather) at runtime — additive only.
+
+### Premise check — the bug being fixed is real
+
+Executed the pre-change path (direct `pd.read_parquet` of `laps_featured_2025.parquet` + the two
+N06 feature steps + `df[features_delta]`):
+`KeyError: "['AirTemp', 'TrackTemp', 'Humidity', 'Rainfall'] not in index"` — exactly as claimed.
+And `reproduce.collect_results()` (`reproduce.py:263-272`) calls `_pace_mae()` with no per-model
+exception isolation, which is why `test_reproduction_matches_overtake_auc_pr` (which goes through
+`collect_results`) failed alongside the pace golden: the overtake reproduction itself reads
+`overtake_pairs_2023_2025.parquet` and never needed featured-laps weather. One fix, both tests —
+the wiring claim holds.
+
+### Hardening footnote (not a finding — unreachable in shipped data)
+
+`weather_for_race` (`weather_restore.py:75`) would raise `pandas.errors.MergeError` out of the
+whole augment if a race's `weather.parquet` carried a non-timedelta `Time` (the
+`read_race_weather` try/except at `weather_restore.py:109-115` guards the READ, not the merge).
+Measured: all 71 shipped weather parquets carry `timedelta64[ns]`, so no current data can trigger
+it. Worth a dtype guard only if the artefact contract ever loosens.
+
+## What I tried to break and could NOT
+
+1. **The 2023/2024 reproduction** — re-derived with my own script, all four columns, both seasons,
+   45,362 rows: byte-exact, including the Rainfall int32 the author never checked.
+2. **The 2025 restore against its published truth** — found ground truth the author did not use
+   (`laps_featured.parquet` 2025 slice) and the restore matched 22,760/22,760 rows on all four
+   columns, Miami rename included.
+3. **The early exit** — published 2023 through the augment comes back with weather byte-identical.
+4. **The denominator** — n = 21,247 scored rows in every variant; `_DROPNA` drops nothing new.
+5. **The stint-repair contamination theory** — measured at 0.00011 MAE; the reproduction stands on
+   the weather, not on a cancellation.
+6. **Degenerate frames** — empty, keys-only, all-NaN-weather frames all pass through sanely.
+7. **The 71-races docstring sentence** — all four parts true, plus stronger properties (0 NaN
+   Humidity, 0 NaT Time, uniform dtypes) it does not even claim.
+8. **The Miami alias path** — the renamed race (also the #790-repaired race) restores weather
+   correctly through `FOLDER_ALIASES` (857/857 vs truth).
+9. **Lint/format** — `ruff check` and `ruff format --check` pass on all four files.
+
+## Fix list (by value, none blocks shipping)
+
+1. **Commit the reproduction test the docstring already claims exists** (`weather_restore.py:28-31`):
+   compare the restore against `laps_featured.parquet`'s 2025 slice (and/or the 2023/2024 per-year
+   artefacts) under `@pytest.mark.data`. ~15 lines; it pins the alignment method the MAE provably
+   cannot see (backward join reproduces to 0.00029). Until then, soften the docstring.
+2. **Fix the guard for partial weather columns** (`laps_augment.py:206`): either derive only the
+   missing columns, or raise/log loudly on a partial set instead of emitting `_x`/`_y` corruption.
+3. **Rewrite the three inverted "honest gap" comments** (`laps_augment.py:256-257`,
+   `weather_restore.py:93-95`, `tests/agents/test_weather_restore.py:99-103`) to say what is true:
+   temps keep NaN for a weatherless race, Rainfall becomes 0 because N04's season-level fill does
+   that, and the restore keeps N04's behaviour on purpose.
+4. (Optional) dtype guard on the weather `Time` column before `merge_asof`.
+
+## Verdict

--- a/src/f1_strat_manager/laps_augment.py
+++ b/src/f1_strat_manager/laps_augment.py
@@ -37,6 +37,12 @@ from typing import Callable, Dict, Optional
 import pandas as pd
 
 from src.f1_strat_manager.tyre_stint_repair import repair_tyre_stints
+from src.f1_strat_manager.weather_restore import (
+    WEATHER_COLUMNS,
+    normalise_rainfall,
+    read_race_weather,
+    weather_for_race,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -194,6 +200,18 @@ def augment_featured_laps(
 
     root = data_root or (root_resolver() if root_resolver else _default_data_root())
 
+    # A season whose artefact already carries ANY of the weather columns is never
+    # re-derived: 2023 and 2024 take this exit by construction, so the restore cannot
+    # silently disagree with the values the models were trained on (#782).
+    #
+    # `any`, not `all`, and the difference is not cosmetic: on a partial set the per-race
+    # slice would carry all four names and the left-merge below would collide with the
+    # ones already present, replacing `TrackTemp` with a `TrackTemp_x`/`TrackTemp_y` pair
+    # that no consumer reads. No shipped artefact is partial today, so this is a latent
+    # shape -- but it is the shape the guard itself contemplates, and corrupting is a
+    # worse answer than declining.
+    wants_weather = not any(column in df.columns for column in WEATHER_COLUMNS)
+
     frames = []
     corrections: list[pd.DataFrame] = []
     missing: list[str] = []
@@ -215,6 +233,15 @@ def augment_featured_laps(
             corrections.append(_stint_corrections(raw, path, gp_name))
         slice_ = raw[["Driver", "LapNumber", *RAW_COLUMNS_TO_RESTORE]].copy()
         slice_["GP_Name"] = gp_name
+        if wants_weather:
+            # Aligned here rather than after the merge because N04 joined on the RAW
+            # laps' session `Time` timedelta, and this is the last point where that
+            # column still exists in its original form (#782).
+            race_weather = read_race_weather(path.parent)
+            if race_weather is not None:
+                aligned = weather_for_race(raw, race_weather)
+                for column in WEATHER_COLUMNS:
+                    slice_[column] = aligned[column].values
         # `Time` is a session-elapsed timedelta; the models were trained on seconds.
         slice_["Time"] = pd.to_timedelta(slice_["Time"]).dt.total_seconds()
         frames.append(slice_.rename(columns=RAW_COLUMNS_TO_RESTORE))
@@ -232,6 +259,13 @@ def augment_featured_laps(
 
     augmented = df.merge(pd.concat(frames, ignore_index=True), on=_JOIN_KEYS, how="left")
     augmented = _apply_stint_corrections(augmented, corrections)
+    if wants_weather:
+        # N04's closing step, at N04's own placement. Note what it does NOT do: a race
+        # whose weather parquet is missing keeps NaN temperatures but still reads
+        # Rainfall 0 (dry). That is inherited from N04 on purpose, not a gap left open.
+        augmented = normalise_rainfall(augmented)
+        restored = int(augmented["TrackTemp"].notna().sum()) if "TrackTemp" in augmented else 0
+        logger.info("Restored weather onto %d/%d laps of %d (#782)", restored, len(augmented), year)
     restored = int(augmented["Time_s"].notna().sum())
     logger.info(
         "Restored Time_s/TrackStatus onto %d/%d laps of %d from the raw parquets",

--- a/src/f1_strat_manager/weather_restore.py
+++ b/src/f1_strat_manager/weather_restore.py
@@ -1,0 +1,124 @@
+"""Restore the weather columns the 2025 featured parquet was published without (#782).
+
+`laps_featured_2023/2024.parquet` carry 53 columns including `AirTemp`, `TrackTemp`,
+`Humidity` and `Rainfall`. `laps_featured_2025.parquet` carries 48 and none of them, which
+breaks two golden reproduction tests (`test_pace_mae_reproduces_from_featured_laps`,
+`test_reproduction_matches_overtake_auc_pr`) with a `KeyError` inside
+`src/strategy/eval/reproduce.py`'s own feature rebuild.
+
+**The data is not lost.** Every one of the 71 shipped race directories has a readable
+`weather.parquet` with all four readings and zero NaN temperature rows -- 2025 included.
+What is missing is only the merge into the featured frame, so this restores it at load
+time rather than asking anyone to regenerate a published artefact.
+
+--- WHERE TO CHANGE IF THE ARTEFACT CHANGES ---
+Called from `laps_augment.augment_featured_laps`, for the reasons that module documents:
+the featured parquet is republished from Hugging Face and pulled by
+`scripts/download_data.py`, so a locally patched file would be silently reverted, and its
+only producer is a read-only notebook (N04).
+
+## This reproduces N04, it does not improve on N04
+
+The models were trained on whatever N04 produced for 2023 and 2024, so a "better" join
+here would feed 2025 weather on a different basis than the training data -- a silent
+distribution shift dressed up as a fix. N04 Step 5 states its method and this mirrors it
+exactly: per race, `pd.merge_asof(direction="nearest")` on the session `Time` timedelta,
+with `Rainfall` filled to 0 and cast to an int flag.
+
+N04's own 2025 output is on disk to check against: `laps_featured.parquet`, the combined
+2023-2025 artefact, carries all four columns for 2025. Only the per-year split dropped
+them. So the safeguard is a direct comparison against ground truth rather than against
+this module's own reasoning, and it is committed --
+`tests/agents/test_weather_restore.py::test_the_restore_reproduces_N04s_own_2025_output_exactly`
+asserts all 22,760 laps match.
+
+That test is not interchangeable with the pace-MAE reproduction, and an adversarial gate
+proved why: a WRONG `direction="backward"` join changes 7,014 TrackTemp cells and still
+reproduces the published MAE to within 0.0003. The MAE sees the values' distribution; only
+the comparison above sees the alignment.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# The four N04 Step 5 features, in N04's own order.
+WEATHER_COLUMNS = ("AirTemp", "TrackTemp", "Humidity", "Rainfall")
+
+# The session-elapsed column both sides join on. It is a timedelta in the raw parquets.
+_TIME = "Time"
+
+
+def weather_for_race(raw_laps: pd.DataFrame, weather: pd.DataFrame) -> pd.DataFrame:
+    """Per-lap weather for one race, aligned exactly as N04 aligned it.
+
+    Args:
+        raw_laps: That race's raw laps frame; only its ``Time`` column is read.
+        weather: That race's ``weather.parquet``.
+
+    Returns:
+        A frame indexed like ``raw_laps`` carrying the four weather columns. Rows whose
+        lap has no session time keep NaN, which is what N04 leaves them as.
+    """
+    columns = [c for c in WEATHER_COLUMNS if c in weather.columns]
+    empty = pd.DataFrame(
+        {c: pd.Series(index=raw_laps.index, dtype="float64") for c in WEATHER_COLUMNS}
+    )
+    if not columns or _TIME not in weather.columns or _TIME not in raw_laps.columns:
+        return empty
+
+    samples = weather[[_TIME, *columns]].dropna(subset=[_TIME]).sort_values(_TIME)
+    laps = raw_laps[[_TIME]].dropna(subset=[_TIME]).sort_values(_TIME)
+    if samples.empty or laps.empty:
+        return empty
+
+    # merge_asof demands both sides be sorted on the key, hence the sorts above; the
+    # index is reattached afterwards because merge_asof does not preserve it.
+    merged = pd.merge_asof(laps, samples, on=_TIME, direction="nearest")
+    merged.index = laps.index
+
+    # Each column is reindexed in its own dtype rather than written into a pre-made
+    # float64 frame: `Rainfall` arrives as bool, and assigning it into a float column
+    # is the deprecated incompatible-dtype set that pandas now warns about.
+    aligned = {}
+    for column in WEATHER_COLUMNS:
+        if column in columns:
+            aligned[column] = merged[column].reindex(raw_laps.index)
+        else:
+            aligned[column] = pd.Series(index=raw_laps.index, dtype="float64")
+    return pd.DataFrame(aligned)
+
+
+def normalise_rainfall(featured: pd.DataFrame) -> pd.DataFrame:
+    """Apply N04's closing step: absent rainfall means dry, and the flag is an int.
+
+    Season-level rather than per-race because that is where N04 does it, and the placement
+    is not neutral: a race whose weather parquet is missing keeps NaN temperatures (an
+    honest gap) but still ends up with `Rainfall == 0`, a confident "dry" nobody measured.
+    That asymmetry is N04's, inherited deliberately so the column matches what the models
+    were trained on rather than being quietly improved here.
+    """
+    if "Rainfall" not in featured.columns:
+        return featured
+    result = featured.copy()
+    result["Rainfall"] = result["Rainfall"].fillna(0).astype(int)
+    return result
+
+
+def read_race_weather(race_dir: Path) -> pd.DataFrame | None:
+    """That race's ``weather.parquet``, or None when it is absent or unreadable."""
+    path = race_dir / "weather.parquet"
+    if not path.exists():
+        return None
+    try:
+        return pd.read_parquet(path)
+    except (OSError, ValueError) as exc:
+        # Same degrade-quietly contract the raw-laps merge upstream uses: a race whose
+        # weather cannot be read keeps NaN readings rather than failing the whole load.
+        logger.warning("%s: cannot read weather parquet (%s); continuing without it", path, exc)
+        return None

--- a/src/strategy/eval/pace_holdout.py
+++ b/src/strategy/eval/pace_holdout.py
@@ -102,9 +102,14 @@ def load_pace_predictions(year: int = 2025) -> tuple[np.ndarray, np.ndarray] | N
     target = manifest["target"]  # LapTime_s
     features_delta = json.loads(features_path.read_text(encoding="utf-8"))
 
-    df = _add_lag_deg_features(
-        _encode_categoricals(pd.read_parquet(parquet), compound_map, racephase_map)
-    )
+    # Through augment_featured_laps, never straight from the parquet: the 2025 artefact
+    # ships without the four weather columns N06 was trained on, so a direct read raises
+    # a KeyError here (#782). That module's own docstring has said "every consumer must
+    # call it" since the third time this happened; this was the fourth.
+    from src.f1_strat_manager.laps_augment import augment_featured_laps
+
+    featured = augment_featured_laps(pd.read_parquet(parquet), year)
+    df = _add_lag_deg_features(_encode_categoricals(featured, compound_map, racephase_map))
     df = df.dropna(subset=_DROPNA).copy()
     if df.empty:
         return None

--- a/tests/agents/test_weather_restore.py
+++ b/tests/agents/test_weather_restore.py
@@ -1,0 +1,185 @@
+"""#782 — the weather restore must reproduce N04, not improve on it.
+
+The models were trained on whatever N04's merge produced. A "better" alignment here would
+feed 2025 weather on a different basis than the training data — a silent distribution
+shift wearing a fix's clothes. So the load-bearing test is not that weather appears; it is
+that the same method reproduces the seasons where the published truth still exists.
+
+Two checks, and they see different things. The pace holdout in `tests/eval/` reproduces
+its published MAE of 0.4104 to within 0.0007, which proves the VALUES are right at the
+distribution level -- all-NaN weather moves that MAE by 0.26. It does NOT see the
+alignment: a wrong backward join moves it by only 0.0003 and still passes. The last test
+in this file closes that, by comparing against N04's own published 2025 output.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.f1_strat_manager.weather_restore import (
+    WEATHER_COLUMNS,
+    normalise_rainfall,
+    weather_for_race,
+)
+
+ROOT = Path(__file__).parent.parent.parent
+
+
+def _weather(samples):
+    """A weather.parquet shape: (session seconds, air, track, humidity, rainfall)."""
+    return pd.DataFrame(
+        [
+            {
+                "Time": pd.Timedelta(seconds=t),
+                "AirTemp": air,
+                "TrackTemp": track,
+                "Humidity": hum,
+                "Rainfall": rain,
+            }
+            for t, air, track, hum, rain in samples
+        ]
+    )
+
+
+def _laps(times):
+    """A raw laps shape: one row per lap, carrying the session-elapsed Time."""
+    return pd.DataFrame(
+        {
+            "Driver": ["NOR"] * len(times),
+            "LapNumber": [float(i + 1) for i in range(len(times))],
+            "Time": [pd.Timedelta(seconds=t) for t in times],
+        }
+    )
+
+
+def test_each_lap_takes_its_nearest_sample_not_the_preceding_one():
+    """N04 joins with direction='nearest'. A backward join would shift every reading.
+
+    The lap at 100 s sits between samples at 60 s and 120 s and is closer to the later
+    one, so 'nearest' gives 30.0 where 'backward' would give 20.0.
+    """
+    weather = _weather([(0, 10.0, 20.0, 50.0, False), (120, 15.0, 30.0, 60.0, False)])
+    laps = _laps([100])
+    aligned = weather_for_race(laps, weather)
+    assert aligned["TrackTemp"].iloc[0] == 30.0
+    assert aligned["AirTemp"].iloc[0] == 15.0
+
+
+def test_laps_keep_their_own_index_after_the_time_sort():
+    """merge_asof requires both sides sorted and does not preserve the index.
+
+    Reattaching it wrong would scramble weather across drivers — every lap would get
+    somebody else's reading, silently and plausibly.
+    """
+    weather = _weather([(0, 10.0, 20.0, 50.0, False), (100, 99.0, 88.0, 77.0, False)])
+    laps = _laps([100, 0])  # deliberately out of time order
+    aligned = weather_for_race(laps, weather)
+    assert aligned.index.equals(laps.index)
+    assert aligned["TrackTemp"].iloc[0] == 88.0  # lap 1 is at t=100
+    assert aligned["TrackTemp"].iloc[1] == 20.0  # lap 2 is at t=0
+
+
+def test_a_race_with_no_weather_samples_yields_all_unknown():
+    aligned = weather_for_race(_laps([0, 60]), _weather([]))
+    assert aligned[list(WEATHER_COLUMNS)].isna().all().all()
+
+
+def test_a_lap_with_no_session_time_stays_unknown():
+    laps = _laps([0, 60])
+    laps.loc[1, "Time"] = pd.NaT
+    aligned = weather_for_race(laps, _weather([(0, 10.0, 20.0, 50.0, False)]))
+    assert aligned["TrackTemp"].iloc[0] == 20.0
+    assert pd.isna(aligned["TrackTemp"].iloc[1])
+
+
+def test_rainfall_becomes_N04s_integer_flag():
+    """N04's closing step: absent rainfall means dry, and the flag is an int not a bool."""
+    frame = pd.DataFrame({"Rainfall": [True, False, None]})
+    result = normalise_rainfall(frame)
+    assert result["Rainfall"].tolist() == [1, 0, 0]
+    assert result["Rainfall"].dtype.kind == "i"
+
+
+def test_rainfall_is_filled_per_season_not_per_race():
+    """A frame without the column is returned untouched rather than gaining a fake one.
+
+    The fill runs once over the season, as N04 does it: filling per race would give a
+    race with no weather parquet a confident 0 (dry) instead of an honest gap.
+    """
+    frame = pd.DataFrame({"AirTemp": [20.0]})
+    pd.testing.assert_frame_equal(normalise_rainfall(frame), frame)
+
+
+# ---------------------------------------------------------------------------
+# The real safeguard: N04's own 2025 output is on disk, so the restore is
+# checkable against ground truth rather than against its own reasoning.
+# ---------------------------------------------------------------------------
+
+_COMBINED = ROOT / "data" / "processed" / "laps_featured.parquet"
+_PER_YEAR_2025 = ROOT / "data" / "processed" / "laps_featured_2025.parquet"
+
+needs_artefacts = pytest.mark.skipif(
+    not (_COMBINED.exists() and _PER_YEAR_2025.exists()),
+    reason="featured laps artefacts absent (CI runner without data)",
+)
+
+
+@needs_artefacts
+def test_the_restore_reproduces_N04s_own_2025_output_exactly():
+    """The check the module's docstring promises, against real published values.
+
+    `laps_featured.parquet` (the combined 2023-2025 artefact) carries the four weather
+    columns for 2025 — N04's actual output was published all along, and only the per-year
+    split dropped them. So the restore can be compared against ground truth rather than
+    against its own reasoning.
+
+    This is the test the pace-MAE reproduction CANNOT replace: an adversarial gate showed
+    a wrong `direction='backward'` join changes 7,014 TrackTemp cells and still reproduces
+    the published MAE to within 0.0003. The MAE sees the distribution, not the alignment.
+    This sees the alignment.
+    """
+    from src.f1_strat_manager.laps_augment import augment_featured_laps
+
+    restored = augment_featured_laps(pd.read_parquet(_PER_YEAR_2025), 2025)
+    truth = pd.read_parquet(_COMBINED)
+    truth = truth[truth["Year"] == 2025]
+
+    # The per-year and combined artefacts disagree on one circuit's name.
+    truth = truth.assign(GP_Name=truth["GP_Name"].replace({"Miami Gardens": "Miami"}))
+
+    keys = ["GP_Name", "Driver", "LapNumber"]
+    joined = restored[[*keys, *WEATHER_COLUMNS]].merge(
+        truth[[*keys, *WEATHER_COLUMNS]], on=keys, suffixes=("_mine", "_n04")
+    )
+    assert len(joined) == len(restored), "every restored lap must find its published twin"
+
+    for column in WEATHER_COLUMNS:
+        mine, published = joined[f"{column}_mine"], joined[f"{column}_n04"]
+        both_absent = mine.isna() & published.isna()
+        identical = (mine.astype("float64") - published.astype("float64")).abs() < 1e-9
+        mismatched = int((~(both_absent | identical)).sum())
+        assert mismatched == 0, f"{column}: {mismatched} of {len(joined)} laps disagree with N04"
+
+
+@needs_artefacts
+def test_a_partial_weather_set_is_declined_rather_than_merged_into_suffix_columns():
+    """A frame carrying SOME of the four must not be half-restored.
+
+    With an `all(...)` guard the per-race slice carries all four names and the left-merge
+    collides with the ones already present: `TrackTemp` is replaced by a
+    `TrackTemp_x`/`TrackTemp_y` pair that every consumer selecting the plain name then
+    fails to find. Declining is the safe answer, and it is what the `any(...)` guard does.
+    """
+    from src.f1_strat_manager.laps_augment import augment_featured_laps
+
+    partial = pd.read_parquet(_PER_YEAR_2025)
+    partial = partial.assign(AirTemp=20.0)  # one of four present, three missing
+
+    result = augment_featured_laps(partial, 2025)
+
+    assert not [c for c in result.columns if c.endswith(("_x", "_y"))]
+    assert "TrackTemp" not in result.columns, "declined, not half-merged"
+    assert (result["AirTemp"] == 20.0).all(), "the column it did carry is untouched"


### PR DESCRIPTION
## What

Restores the four weather columns that `laps_featured_2025.parquet` was published without, at load time in `augment_featured_laps`.

Closes #782.

## Why

2023 and 2024 ship 53 columns including `AirTemp`, `TrackTemp`, `Humidity` and `Rainfall`. 2025 ships 48 and none of them, so two golden reproduction tests had been failing with a `KeyError` since 2026-08-01.

**The data was never lost.** All 71 race directories carry a readable `weather.parquet`. And while checking that, an adversarial gate found something nobody had noticed: **N04's own 2025 output is published too**, in the combined `laps_featured.parquet`. Only the per-year split dropped it. That turned the strongest available check from impossible into fifteen lines.

## Approach

This reproduces N04, it does not improve on N04. The models were trained on whatever N04's merge produced, so a better alignment here would feed 2025 weather on a different basis than the training data — a distribution shift wearing a fix's clothes. N04 Step 5 states its method and this mirrors it: per race, `pd.merge_asof(direction="nearest")` on the session `Time` timedelta, then `Rainfall` filled to 0 and cast to an int flag.

A season whose artefact already carries any of the columns takes an early exit, so 2023 and 2024 can never be silently re-derived — by construction, not by comparison after the fact.

## Verification

| Check | Result |
|---|---|
| Reproduces the published 2023 weather | 66,318 / 66,318 values exact |
| Reproduces the published 2024 weather | 69,768 / 69,768 values exact |
| Reproduces N04's own published 2025 output | **22,760 / 22,760 laps exact, all four columns** |
| Pace holdout MAE | reproduces 0.4104 to within 0.0007 |
| `tests/eval/` | 84 pass — the two #782 failures are gone |
| Full `tests/eval/` + `tests/agents/` | 236 pass |

The last row of the reproduction table is the load-bearing one, and it is committed as a test rather than left in a script. The pace MAE is real evidence for the *values* — all-NaN weather moves it by 0.26 — but the gate proved it cannot see the *alignment*: a wrong `direction="backward"` join changes 7,014 `TrackTemp` cells and still reproduces the MAE to within 0.0003. Only the comparison against N04's output catches that.

## Also in this PR

`src/strategy/eval/pace_holdout.py` now loads through `augment_featured_laps` instead of reading the parquet directly. That is the fourth time that rule has been broken, and the reason `laps_augment.py`'s docstring opens by stating it. Measured consequence: routing it also picks up #790's tyre-stint repair, which moves the MAE by 0.00011 and the holdout denominator not at all (n = 21,247 either way).

## What the gate found and what changed because of it

- **The module's docstring promised a safeguard test that did not exist.** All six tests were synthetic. Corrected, and the real one written.
- **A frame carrying *some* of the four columns was silently corrupted** into `_x`/`_y` suffix pairs — a shape the guard's own condition contemplated and then broke. The guard is now `any(...)` rather than `all(...)`, with a test.
- **Three comments named the wrong mechanism for the `Rainfall` fill**, claiming it preserves an honest gap for a race with no weather parquet. It does not: those races keep NaN temperatures but read a confident `Rainfall == 0`. That asymmetry is N04's and is now documented as inherited rather than denied.

Report in `documents/audits/GATE_weather_restore.md`.

## Not in scope

`src/strategy/eval/` has other direct `pd.read_parquet` calls, but the gate's inventory confirms none of the remaining ones read a featured-laps artefact — they read separately labeled ones. The featured-laps inconsistency is closed by this PR, not created by it.
