### PR TITLE
fix(rails): recalibrate the pit bounds against real stint lengths, and give the pace agent an operating envelope

### DIFF
--- a/documents/audits/AUDIT_716_710_design.md
+++ b/documents/audits/AUDIT_716_710_design.md
@@ -1,0 +1,375 @@
+# Design diagnosis — #716 (pit bounds) + #710 (operating envelope)
+
+Session of 2026-08-03. Written before any code change, appended as findings land.
+Read-only until the direction is agreed.
+
+## D1 — #716's acceptance criterion #1 encodes the test Víctor himself refuted, 42 seconds after the issue was filed
+
+The issue body argues: no FIA minimum-stint article exists, therefore
+`_MIN_STINT_LAPS` is an opinion, therefore
+`[[feedback_rails_encode_rules_not_opinions]]` forbids it. Acceptance criterion
+#1 follows from that: *"Every surviving rail cites the regulation article that
+makes it a fact, or it stops being a rail."*
+
+That is the wrong test for this rail, and the correction is already in the repo.
+
+**Timeline, from timestamps rather than recollection:**
+
+| When (UTC, 2026-07-29) | What |
+|---|---|
+| 09:10:38 | Issue #716 created, body carrying the provenance argument |
+| 09:18:09 | Issue **title** updated to "**Recalibrate** the anti-hallucination pit bounds…" |
+| 09:18:51 | `feedback_rails_encode_rules_not_opinions` gains its `⚠️ ESSENTIAL REFINEMENT` section |
+
+The refinement says, verbatim: *"I got this wrong and Víctor corrected me: I used
+this memory to argue that N28's minimum-stint bound 'encodes an opinion' and
+should cite a regulation. **Wrong test.**"*
+
+| | What it does | Needs a regulation? |
+|---|---|---|
+| **Prescriptive** (the rejected SC `PIT_NOW` rail, #464) | Makes the decision *for* the model | **YES** |
+| **Proscriptive** (min stint, no-pit-before-5, no-pit-last-3) | Bounds the output so the model cannot emit nonsense | **NO** — anti-hallucination guard |
+
+And the prescribed remedy, also verbatim: *"If it catches a meaningful share of
+what professionals actually do … it is separating unusual from usual rather than
+absurd from sane — so **move the threshold, do not delete the bound.**"*
+
+So the title was updated to the corrected doctrine and **the body was not**. The
+body is the stale half. Two shipped files already encode the corrected doctrine
+and both point at #716 for the measurement:
+
+- `src/strategy/inference/guard_rails.py:16-23` — *"A proscriptive bound on a
+  generative model's output is legitimate with or without a regulation behind it;
+  the test it must pass is CALIBRATION."*
+- `tests/mc/test_guard_rails.py:8-12` — same statement, as the test module's
+  reason for existing.
+
+**Consequence for scope:** the deliverable is a recalibration plus a written
+justification per bound, not a deletion plus a migration into the Monte Carlo
+cost. Criterion #1 should be restated as *"every surviving bound states either
+the article that makes it a fact or the measured calibration that makes it a
+bound"*.
+
+## D2 — the issue's suggested direction (move it into MC scoring) is a sprint, not a session, and AUDIT_A2 already measured why
+
+`documents/audits/AUDIT_A2_min_stint_veto.md` F5: neither Monte Carlo scorer has
+any tyre-life or compound input today. `_run_mc_simulation`
+(`strategy_orchestrator.py`) dispatches to `simulate_lap_window` (legacy,
+seconds-based) or `_run_projection_mc` (position projection, the path real races
+take). Threading a stint-freshness cost means changing both, plus their tests,
+plus every test pinning exact MC scores.
+
+F4 adds that `src/strategy/eval/decision_modes.py` is a string-matching consumer
+of the rail's exact `reason` text and its whole exclusion methodology assumes a
+categorical veto. Removing the veto changes published, checked-in report numbers
+and breaks 5+ named tests by contract, not by assertion value.
+
+## D3 — two of AUDIT_A2's findings are now STALE; the constant propagates by itself
+
+A2/F1 claimed three hand-typed copies of 8/12/15 (guard_rails, N28 prompt, N31
+prompt) with no test binding them. Verified today: **both prompts now render the
+constant through an f-string.**
+
+- `src/agents/pit_strategy_agent.py:663-665` — `{_MIN_STINT_LAPS['SOFT']}` etc.
+- `src/agents/strategy_orchestrator.py:1695` — `SOFT >= {_MIN_STINT_LAPS['SOFT']}`
+- `tests/agents/test_prompt_constants_match_tables.py:176-183` — parses the
+  rendered prompt and asserts it against `_MIN_STINT_LAPS`.
+
+So a change to the constant reaches all three sites with no manual edit, and a
+regression is caught by an existing test. The "twin that never got the fix" risk
+A2 raised for this specific rail has been closed since the audit ran.
+
+Also closed: the prompt/mirror SC divergence A2 and the issue title both name.
+`apply_guard_rails` now takes `sc_active` (`af3a24a`, 2026-07-29) and
+`tests/mc/test_guard_rails.py` pins which bounds it suspends and which it does
+not.
+
+## D4 — the calibration evidence that already exists
+
+`documents/eval_reports/stint_lengths.md`, generated 2026-07-29 over 1785 real
+green-flag stints across 71 races (2023-2025 raw laps):
+
+| compound | n | threshold | shorter than threshold | min | p1 | p5 | p10 | p25 | median |
+|---|---|---|---|---|---|---|---|---|---|
+| SOFT | 341 | 8 | **15.5%** | 1.0 | 1.0 | 2.0 | 5.0 | 9.0 | 15.0 |
+| MEDIUM | 896 | 12 | **17.0%** | 1.0 | 1.0 | 7.0 | 9.0 | 14.0 | 19.0 |
+| HARD | 548 | 15 | **12.2%** | 1.0 | 1.9 | 8.0 | 13.0 | 18.0 | 24.0 |
+
+A bound that must sit "where real strategy essentially never goes" currently
+sits at the 12th-17th percentile. That is one real stop in six. The bound fails
+its own calibration test on the repo's own measurement — which is the finding
+that justifies moving it, independently of any argument about FIA articles.
+
+## D5 — #710's pit half is already merged on `dev`; only pace remains
+
+Commit `cfe3ae0` "refactor(agents): declare N15 tyre-life ceiling as an operating
+envelope" is on `dev`. `pit_strategy_agent.py:133-136` declares
+`_N15_TYRE_LIFE_ENVELOPE`, and `_tyre_life_in` (line 845) labels the call
+**before** clipping, so the out-of-range moment is logged rather than silent.
+
+The remaining target is `pace_agent.py`, which has no range check at all.
+
+**One acceptance line in #710 needs restating before it is checked off:** *"No
+hand-placed clip survives that the envelope now covers."* Taken literally that
+contradicts `envelope.py`'s own LABELLING ONLY contract (*"Checking a feature
+vector against an envelope must NEVER touch, clip, or refuse a prediction by
+itself"*). The clip at `pit_strategy_agent.py:853` must survive: N15 trained on
+clipped input, so removing the clip would feed it values it never saw. The line
+means "no clip survives *undeclared*", and that is satisfied.
+
+---
+
+# Measurements taken this session
+
+## M1 — all four minimum-stint bounds calibrated on one sample
+
+`f1-eval stint-lengths`, 2023-2025 raw laps, 1900 real green-flag stops across 71
+races. Criterion agreed with Víctor: **a bound may veto at most 5% of real stops**,
+and each value is the largest integer that clears it.
+
+| bound | was | vetoed | now | vetoes |
+|---|---|---|---|---|
+| `_MIN_STINT_LAPS["SOFT"]` | 8 | 15.5% (341) | **2** | 3.2% |
+| `_MIN_STINT_LAPS["MEDIUM"]` | 12 | 17.0% (896) | **7** | 4.6% |
+| `_MIN_STINT_LAPS["HARD"]` | 15 | 12.2% (548) | **8** | 4.7% |
+| `_DEFAULT_MIN_STINT` (wet) | 10 | **20.0%** (110) | **6** | 4.5% |
+| `_NO_PIT_BEFORE_LAP` | 5 | **2.21%** | 5 unchanged | 2.21% |
+| `_NO_PIT_LAST_N_LAPS` | 3 | **1.37%** | 3 unchanged | 1.37% |
+
+**Two corrections to the issue.** It reports the last two bounds as blocking "4 real
+stops" each and puts them in scope for review. That count comes from the six-race
+`decision-modes` subset (198 stops). Measured on the full sample they veto 2.21% and
+1.37%, both already inside the ceiling, so neither needed changing and neither was
+changed. The bound that did need changing worst was `_DEFAULT_MIN_STINT`, which the
+issue does not mention at all.
+
+## M2 — why nobody had measured the worst bound: a comment naming the wrong mechanism
+
+`stint_lengths.py` carried, above `_WET_COMPOUNDS`:
+
+> Wet compounds run no minimum-stint rule at all (`_MIN_STINT_LAPS.get(compound,
+> _DEFAULT_MIN_STINT)` never fires the SOFT/MEDIUM/HARD boundaries for them)
+
+The headline is false and the parenthetical is true, which is exactly how it
+survived review. Wet compounds miss the three named entries and land on the
+FALLBACK, which is a minimum-stint rule like any other. On that claim the report
+counted 110 wet stops only to drop them, so the one bound this file existed to check
+was the one bound it never checked, and it was the worst calibrated of the four.
+
+The wet sample is now a fourth row of the same table, graded against the same bound
+the rail resolves, via a `_bound_for()` helper that calls the rail's own lookup
+rather than mirroring it.
+
+## M3 — a docstring in `decision_modes.py` promised an invariant the code did not enforce
+
+`guard_rail_block`'s docstring: *"the probe passes a life that satisfies every
+minimum"*. The expression was `max(_MIN_STINT_LAPS.values())`, which ignores
+`_DEFAULT_MIN_STINT` — and the fallback is not a spare branch here, it is the bound
+the probe meets in exactly the case the probe exists for, since an unknown compound
+reaches `apply_guard_rails` as `""` two lines down. True today at 8 vs 6 and true
+before at 15 vs 10, false the first time anyone ordered them the other way. Now
+`max(*_MIN_STINT_LAPS.values(), _DEFAULT_MIN_STINT)`.
+
+## M4 — #710: the pace envelope, and two claims of mine the measurement refuted
+
+Bounds measured by rebuilding 2023 + 2024 through `augment_featured_laps` plus the
+two N06 feature steps `pace_holdout.py` already owns, then taking each column's
+min/max over the resulting 42,957 rows. Twelve continuous features; identifiers and
+flags excluded because a code has no range.
+
+**Refuted claim 1 — the three hardcoded zeros are NOT an envelope finding.**
+`run_from_state` pins `prev_deg_rate` / `prev_cum_deg` / `prev_deg_accel` at `0.0` on
+every real call. That reads exactly like the N26 out-of-range defect, and I was ready
+to declare bounds that would "catch" it. Measured, 0.0 sits mid-distribution for all
+three: 42.6% / 41.9% / 46.7% of training rows fall below it. An envelope could never
+fire on the pinned value, and declaring one would have shipped a check that looked
+like coverage and was not. Feeding a constant where the model saw a distribution is a
+real defect; it is a different defect and needs its own instrument.
+
+**Refuted claim 2 — the range in the code comment is the wrong season.**
+`pace_agent.py` records FuelEffect as `range 0..3.685 s`, "verified exactly against
+laps_featured_2025". 2025 is the held-out TEST season. The TRAINING range is
+`0.055..4.125`. An envelope sourced from the test season describes where the model is
+asked to work, not where it was fitted.
+
+Out-of-range rates on the 2025 holdout frame: FuelEffect 4.96%, mean_sector_speed
+3.93%, TyreLife 2.87%, AirTemp 1.96%, TrackTemp 1.64%, LapNumber 1.17%, FuelLoad
+1.17%, Humidity 0.18%, Prev_TyreLife 0.06%, Prev_SpeedST 0.01%, Prev_LapTime 0.00%,
+laps_remaining 0.00%.
+
+**CORRECTION, from the real run (M6): those rates understate it and I quoted them as
+if they did not.** See below.
+
+## M5 — a pre-existing gate that does not cover what it guards
+
+`tests/agents/test_prompt_constants_match_tables.py` skips on
+`HAS_TIRE_MODELS`, but importing the pit agent pulls the NLP stack, so on a checkout
+with tire weights and no `data/models/nlp/bert_sentiment_v1/` the file ERRORS instead
+of skipping. Verified identical on the unmodified baseline, so it is pre-existing and
+out of scope here, but it means the prompt-versus-rail guard can fail for a reason
+that has nothing to do with prompts. Recorded, not fixed.
+
+
+## M6 — the real run, and a third claim of mine it refuted
+
+`f1-sim Lusail NOR McLaren --no-llm`, real radio corpus (24 radios, 66 rcm), 57 laps,
+completed clean. Run twice on the branch with identical results, so the comparison
+below is a behaviour change and not run-to-run noise.
+
+**#716, behaviour moved by exactly one call.**
+
+| | STAY_OUT | PIT_NOW | UNDERCUT |
+|---|---|---|---|
+| baseline (`dev`) | 52 | 3 | 2 |
+| branch | **51** | 3 | **3** |
+
+One lap flips STAY_OUT to UNDERCUT: the loosened bound releasing a call it used to
+veto, in the expected direction and at the expected scale. Final position unchanged
+(P3 to P4), final stint unchanged (HARD/13), best lap identical to the millisecond.
+
+**#710, and the claim I got wrong.** M4 above says the log is "quiet enough to be
+worth reading" on the strength of holdout rates of roughly 1-5%. On the real run the
+envelope warned on **14 of 57 laps, about 25%**. Violations by feature: mean_sector_speed
+10, TyreLife 6, Prev_TyreLife 6, FuelEffect 3, LapNumber 2, FuelLoad 2.
+
+The holdout understates it **because it is the wrong frame to have measured on**, and
+the reason is structural rather than incidental: the holdout has N06's own `_DROPNA`
+applied, which removes the first lap of every stint and the opening laps of every
+race. Those are precisely the rows where inference goes out of range, because
+`run_from_state` passes `tyre_life or 1` and `prev_tyre_life = max(0, tyre_life - 1)`
+against declared bounds of TyreLife [3, 78] and Prev_TyreLife [2, 77]. I measured the
+noise on a frame that had already deleted the noisy rows.
+
+What the warnings say is true, and is the most useful thing the envelope surfaced:
+**N06 is asked to predict on the opening laps of a race and on the first lap of every
+stint, and it was never trained on either**, because N06 dropped exactly those rows.
+That was completely silent before this change. `mean_sector_speed` is a second, separate
+finding: Lusail is fast enough to exceed the trained maximum of 314.97 on ten laps.
+
+Left as is rather than suppressed. Whether a warning on a quarter of laps is the right
+volume is a fair challenge and is put to the correctness gate rather than settled here.
+
+## M7 — #710's "one real run per agent" was not satisfied by the pit half, and now is
+
+The acceptance line reads: *"A real `f1-sim` run per agent, not one run for both"*,
+with *"one agent at a time with an `f1-sim` run in between"*.
+
+`cfe3ae0`, the merged pit half, justifies itself with *"125 tests in tests/mc pass
+including the strategy goldens, and 400 real rows from Lusail 2025 go through the
+feature builder with no warning while a forced 88-lap stint announces itself"*. That
+is good evidence and it is not the evidence this criterion asks for: a feature-builder
+replay is not a run of the simulator. Inheriting that as satisfied would have ticked a
+box nobody had earned.
+
+The two runs this session close it, in the required order and separated by the pace
+change rather than batched:
+
+| run | tree | agent under test | result |
+|---|---|---|---|
+| `sim_before` | `dev` (pit envelope present, pace envelope absent) | **pit / N15** | 57 laps clean, zero envelope warnings |
+| `sim_after` | branch (both) | **pace / N06** | 57 laps clean, 14 warning laps |
+
+Zero warnings in the first run is the CORRECT result rather than a missing signal: no
+stint at Lusail approaches N15's 50-lap ceiling, so the in-range path is what should
+have been exercised, and `tests/agents/test_n15_envelope.py` covers the firing case
+that this race cannot produce.
+
+---
+
+# The adversarial gates, and what they broke
+
+Two gates ran read-only against the branch and wrote their own reports:
+`GATE_716_calibration.md` and `GATE_710_pace_envelope.md`. What follows is what
+survived verification, including where a gate was itself wrong.
+
+## G1 — CONFIRMED, HIGH, and mine: the recalibration silently rewrote an unrelated rule
+
+Both prompts rendered the FLOOR of the MEDIUM compound-suitability band from
+`_MIN_STINT_LAPS['MEDIUM']`:
+
+```
+MEDIUM: suitable for {_MIN_STINT_LAPS['MEDIUM']}-{_STINT_CAPACITY_LAPS['MEDIUM']} remaining laps.
+```
+
+Two different rules sharing the number 12 by accident. One asks whether a set has run
+long enough to be worth replacing; the other asks whether enough race is left for the
+compound to make sense. Recalibrating the first to 7 turned the second into "MEDIUM:
+suitable for **7**-30 remaining laps" on the DEFAULT LLM path, a rule #716 never
+touched and nobody reviewed.
+
+The existing prompt-versus-table test could not see it: it asserts the prompt agrees
+with the constant, and a re-coupled prompt agrees with the WRONG constant. Fixed with
+its own `_MEDIUM_SUITABILITY_FLOOR_LAPS = 12` and a test that asserts the rendered
+floor against THAT constant, which fails on a re-coupling.
+
+## G2 — CONFIRMED, HIGH, and the same defect class twice in one session
+
+`mean_sector_speed` should never have been bounded. `_compute_derived` falls back to
+`prev_speed_st` when no mean sector speed is supplied and `run_from_state` never
+supplies one, so at inference the feature ALWAYS carries the speed trap: training
+means 256.8 vs 303.0 km/h, different physical quantities. The bound fired on 83% of
+laps at Monza while describing none of them.
+
+This is the exact twin of the `Prev_Deg*` case in M4 — a feature whose inference value
+is not the quantity the range describes. I reasoned it through carefully for one member
+of the pair and did not look for the other. That is the repo's most reliable defect and
+I committed it inside the change that documents it.
+
+`FuelLoad` came out for a related reason: the artefact stores it rounded to four
+decimals (max 0.9615) while inference computes it live and unrounded, so a 78-lap race
+gives 0.96153... and the bound fires on a lap class the model trained on.
+
+Ten bounds remain. The unbounded fifteen are now enumerated with a reason each, and a
+test asserts the two sets partition N06's feature list exactly, because the first
+version of that comment accounted for 22 of 25 and the three it skipped are where the
+mistake lived.
+
+## G3 — CONFIRMED: the noise claim, twice corrected
+
+M4's holdout rates were the wrong frame (M6). The gate then measured 31% of laps
+warning across five circuits, worse than my Lusail figure. After G2's two removals,
+the real run gives **6 of 57 laps (10.5%)**: TyreLife 6, Prev_TyreLife 6, FuelEffect 3,
+LapNumber 2, co-occurring on six distinct laps. Every one is true and structural: N06
+never trained on a race start or a stint opener, because its own `_DROPNA` removes
+them. Left at WARNING; the train/serve gap it exposes deserves its own issue rather
+than a quieter log.
+
+## G4 — CONFIRMED, smaller
+
+- `guard_rails.py` attributed the six-race subset's four excluded stops to the
+  early-race bound. Measured, that bound excludes NONE there and `decision_modes.md`
+  carries no `opening_laps` row; the four are the closing bound's (Monaco VER, Lusail
+  STR and HAD, Monza OCO). Corrected.
+- "the ceiling every bound is set from and held to" overstated it. All four are HELD
+  to it; only the two that failed were SET from it. The lap bounds are not maximal
+  under the rule and were deliberately left alone.
+- The provenance pointer for the two lap-based shares was false: `stint_lengths.md`
+  regenerates the four minimum-stint shares, not those two. Now labelled a dated
+  finding rather than a reproducible artefact.
+- The ceiling test could hold vacuously if a bucket left the measurement. It now pins
+  the bucket set before filtering, so WET cannot silently stop being graded.
+- `_DEFAULT_MIN_STINT` has no prose copy in either prompt: the offline path enforces a
+  wet bound the LLM path was never told about. Written down, not closed, because
+  closing it means new prompt text on the default path.
+- `data/mc_measured_v1.json` had lost its measured `undercut_band` in the worktree
+  (regeneration on a checkout missing the source parquet). Never committed; restored.
+
+## G5 — REFUTED, verified by me
+
+- The #716 gate reported that the committed `stint_lengths.py` fails
+  `ruff format --check` under CI's pin. It does not: `uvx ruff@0.15.22 format --check .`
+  reports 140 files already formatted, re-run after the finding.
+- The #716 gate's own verification of every number in `guard_rails.py` reproduced them
+  independently from `data/raw` without importing repo eval code, and predicted
+  `min_stint = 5` before the regeneration produced exactly 5.
+
+## G6 — the suite failures are not this change
+
+7 failed / 4 errors on the full run, all pre-existing in this environment and confirmed
+by running the ambiguous ones on a `dev` worktree with the same data: `test_weather_restore`,
+`test_ml_recompute_golden` and both `test_mc_measured_tables` failures reproduce on the
+baseline. Root cause for six of them is a single file, `data/processed/undercut_labeled/
+undercut_clean.parquet`, which **does not exist in the Hugging Face dataset at all**, so
+no clean install can pass them; the NLP goldens report `pending` because the 15.9 GB NLP
+weights are not downloaded here. The skip guards should require those artefacts instead
+of failing, which is a separate issue.

--- a/documents/audits/GATE_710_pace_envelope.md
+++ b/documents/audits/GATE_710_pace_envelope.md
@@ -1,0 +1,328 @@
+# GATE — #710 pace envelope (branch `fix/recalibrate-pit-bounds` vs `dev`)
+
+**Gate opened:** 2026-08-03 · adversarial gate, findings appended as confirmed.
+**Merge base:** `fc73c53` (dev == merge base; all changes are uncommitted worktree edits).
+
+## Scope observed
+
+Diff vs dev touches MORE than the pace half:
+- `src/agents/pace_agent.py` (+79) — the nominal change (`_N06_TRAINED_BOUNDS`, `_N06_ENVELOPE`, `_label_against_envelope`).
+- `tests/agents/test_n06_envelope.py` (new, untracked).
+- `src/strategy/inference/guard_rails.py` (+65/-x) — NOT named in the task.
+- `src/strategy/eval/decision_modes.py`, `src/strategy/eval/stint_lengths.py`, `tests/eval/*`, `documents/eval_reports/stint_lengths.*` — NOT named in the task.
+
+## Checklist (claims A–I) — final verdicts
+
+- [x] A. **CONFIRMED** — byte-identical frames dev-vs-branch (executed A/B) + strategy goldens
+  PASS + pace-MAE golden reproduces (`test_pace_mae_reproduces_from_featured_laps` PASSED).
+- [x] B. **CONFIRMED** — all 12 bounds re-derived, exact match, n=42957.
+- [x] C. **CONFIRMED** — train frame contains Years {2023, 2024} only.
+- [x] D. **CONFIRMED** — 42.6% / 41.9% / 46.7% exact; 0 inside all three ranges.
+- [x] E. **PARTIAL — see F5**: identifiers/flags correctly excluded, but the comment's own
+  arithmetic covers 22 of 25 features; `LapsSincePitStop` (continuous, trained 3-77) is
+  unbounded with no stated reason and no test pinning the choice.
+- [x] F. **CONFIRMED mechanically** (NaN → `unknown`, never compared — executed), with two
+  residues: F6 (junk coerced to NaN is silently `unknown` on the `run()` path) and the fact
+  that `unknown` never occurred once in 284 real replayed laps (the cited producers currently
+  cannot fire on the RSM path).
+- [x] G. **CONFIRMED** — checks the exact post-coercion frame `_predict` receives, exactly once
+  per agent call (284 verdicts / 284 laps), every live caller routed through it; only the
+  offline eval harness (`pace_holdout`) bypasses, acceptably. Residue: F7 (bootstrap frames).
+- [x] H. **REFUTED AS PRESENTED — see F1/F2/F3**: the claimed per-feature rates reproduce only
+  on the no-dropna frame (not the recipe the bounds declare), and the real inference rate is
+  31.0% of laps (88/284 across five circuits; 83% at Monza), not the ~5%-per-feature story.
+  The `run_from_state` fabricated defaults are all envelope-invisible (F9).
+- [x] I. **CONFIRMED** — 14/14 pass including the data-tier re-measure (executed locally, not
+  skipped); firing tests assert the log EFFECT via caplog; the identity test asserts the frame.
+  One nuance: the data test re-runs the same `pace_holdout` recipe the bounds were measured
+  with (circular in isolation), anchored externally by the pace-MAE golden which pins that
+  recipe to the thesis headline 0.4104 — both passed in the same session, so the anchor holds.
+- [x] Traps: TyreLife/LapNumber lower bounds ARE dropna-frame artefacts that scream on ordinary
+  laps (F3, measured); no second N06 feature path exists (all callers routed, executed grep +
+  call-graph walk); sentinel-in-range trap found live (F9: 90.0/300.0/25.0/35.0/50.0 all
+  mid-envelope; `tyre_life or 1` masquerades as an outlap).
+
+## Test-suite evidence (executed this session, on the branch worktree)
+
+- `tests/agents/test_n06_envelope.py` — **14 passed** (data-tier included, ran, not skipped).
+- `tests/mc/test_strategy_goldens.py` + `test_guard_rails.py` + `tests/eval/test_stint_lengths.py`
+  + `test_decision_modes.py` + `tests/agents/test_n15_envelope.py` — **86 passed**.
+- Full targeted suite incl. `tests/eval/test_ml_recompute_golden.py` — **106 passed, 1 failed**:
+  `test_undercut_auc_pr_reproduces_exactly`. **Attributed OUTSIDE this diff**: the recompute
+  returns `pending` because `data/processed/undercut_labeled/undercut_clean.parquet` is absent
+  on this machine, and the test's skip-guard (`test_ml_recompute_golden.py:15`) checks only the
+  model pkl, not the holdout parquet — so it FAILS where it should SKIP. Nothing in the branch
+  diff touches eval/reproduce/calibration or data. Pre-existing test-guard gap, recorded for a
+  separate issue.
+
+## Evidence-integrity note
+
+The orchestrator stashed/popped the worktree mid-gate (~90 s on unmodified `dev`). Both of my
+parquet measurements imported `src.agents.pace_agent._N06_TRAINED_BOUNDS` successfully, which is
+impossible on `dev`, so neither ran inside the window. Tree re-verified after the pop:
+`_N06_ENVELOPE` present in `pace_agent.py`, `tests/agents/test_n06_envelope.py` present. No
+finding below predates a state I did not re-verify.
+
+## Verified (executed, not read)
+
+- **B — bounds are MEASURED: CONFIRMED exactly.** Rebuilt 2023+2024 through
+  `augment_featured_laps` → `_encode_categoricals` → `_add_lag_deg_features` → `dropna(_DROPNA)`.
+  All twelve declared (lower, upper) pairs match the measured min/max **exactly** (`==`, not
+  approx), including `mean_sector_speed`'s full-precision floats. FuelLoad's odd-looking 0.9615
+  is exact because the featured artefact stores FuelLoad rounded to 4 decimals.
+- **C — right seasons: CONFIRMED.** Rebuilt frame n=42957 (claimed 42957), `Year` values in the
+  frame = {2023, 2024} only.
+- **D — Prev_Deg* percentages: CONFIRMED.** Fraction of training rows strictly below 0.0:
+  Prev_DegradationRate 42.6%, Prev_CumulativeDeg 41.9%, Prev_DegAcceleration 46.7% (claimed
+  42.6/41.9/46.7). All three training ranges straddle 0.0, so a bound could indeed never fire on
+  the pinned 0.0. The exclusion reasoning holds for every live caller (both `run_from_state`
+  and the orchestrator dict path pin 0.0).
+
+- **A (first half) — labels and nothing else: CONFIRMED byte-for-byte.** Loaded `dev`'s
+  `pace_agent.py` via `git show dev:...` as a parallel module and compared
+  `_build_feature_row` output dev-vs-branch on three scenarios (ordinary lap, 4-feature
+  out-of-range stint opener, None-Position + absent-baseline NaN path):
+  `assert_frame_equal(check_exact=True)` passes, `to_numpy().tobytes()` equal, and
+  `_predict` returns the identical float to the last digit in all three
+  (83.269715090096 / 97.82824754714966 / 90.15864652395248 on both sides). Goldens run
+  separately (see below).
+- **G — placement: CONFIRMED.** The check runs on `numeric`, the exact frame `_predict`
+  receives, after `pd.to_numeric(errors='coerce')` (`src/agents/pace_agent.py:459-461`), and
+  exactly once per agent call: my replay recorder saw 57/53/78 verdicts for 57/53/78 laps at
+  Lusail/Monza/Monaco. Every live caller reaches it — `no_llm.py:264`, orchestrator dict path
+  `strategy_orchestrator.py:1866` (via `run_pace_agent` → `run`), backend
+  `strategy.py:632,698`, `mcp_tools.py:451`, `scripts/debug_agent.py:247` all route through
+  `PaceAgent.run` → `_build_feature_row`. The one N06 consumer that bypasses it is
+  `pace_holdout.load_pace_predictions` (`model.predict` directly), which is the offline eval
+  harness, not an inference surface — acceptable, noted so nobody "fixes" it.
+- **F (NaN mechanics) — CONFIRMED executed.** `np.nan` arriving through a pandas frame lands in
+  `unknown` (never compared: `_is_unknown` catches it because `np.float64` subclasses `float`),
+  while an out-of-range `np.float64` is a violation. Verified with a live
+  `OperatingEnvelope.check` call on a coerced frame.
+
+## Findings
+
+### F1 — HIGH · `mean_sector_speed` at inference is a SPEED-TRAP reading, and the envelope fires on 79% of Monza laps
+
+`run_from_state` never passes `mean_sector_speed`, so `_compute_derived`
+(`src/agents/pace_agent.py:381`) falls back to `prev_speed_st` — the speed-trap value — on
+**every** RSM-path call. Trained bound [196.63, 314.97] describes real mean sector speeds;
+speed traps at a fast circuit run 315-340. Measured by replaying real 2025 races through
+`RaceReplayEngine` → `run_pace_agent_from_state` with a verdict recorder:
+
+| race | laps | laps with ≥1 violation | mean_sector_speed violations |
+|---|---|---|---|
+| Lusail NOR | 57 | 14 (24.6%) | 10 |
+| **Monza NOR** | 53 | **44 (83.0%)** | **42** |
+| Monaco NOR | 78 | 7 (9.0%) | 0 |
+| Spa NOR | 44 | 14 (31.8%) | 12 |
+| Silverstone NOR | 52 | 9 (17.3%) | 3 |
+| **total** | **284** | **88 (31.0%)** | 67 |
+
+(The Lusail row independently reproduces the coordinator's `f1-sim --no-llm` run to the exact
+per-feature counts: mean_sector_speed 10 / TyreLife 6 / Prev_TyreLife 6 / FuelEffect 3 /
+LapNumber 2 / FuelLoad 2 over 14 of 57 laps.) Spa and Silverstone additionally fire
+`Prev_SpeedST` itself (2 and 3 laps: 2025 slipstream trap readings above the trained max of
+362 km/h) — those ones are honest circuit-drift labels, unlike the fallback-quantity fires.
+
+Concrete failing scenario: Monza lap 3, green flag, nothing unusual — trap 329 km/h → warning.
+Every subsequent representative lap warns again; the log is a siren, not a label. Two distinct
+defects compound here: (a) the claimed 3.93% rate (design doc M4) was measured on the holdout
+frame where the feature IS a real mean sector speed, so it measures circuit drift, not the
+fallback; (b) the fallback itself is the same defect class M4 explicitly excluded Prev_Deg* for
+("feeding the model a different quantity than it trained on needs its own instrument") — the
+Prev_Deg* copy got the analysis, its `mean_sector_speed` twin did not. Lusail outlaps also fire
+the LOWER bound (trap 180-181 km/h under pit-limiter vs lower bound 196.6).
+
+### F2 — HIGH · the claimed M4 "2025 out-of-range rates" do not come from the recipe the change itself declares
+
+Executed both ways over `laps_featured_2025` + `augment_featured_laps`:
+
+| feature | claimed (M4) | measured WITH `_DROPNA` (the declared bound recipe) | measured WITHOUT `_DROPNA` |
+|---|---|---|---|
+| FuelEffect | 4.96% | **0.00%** | 4.96% |
+| TyreLife | 2.87% | **0.03%** | 2.87% |
+| LapNumber | 1.17% | **0.00%** | 1.17% |
+| FuelLoad | 1.17% | **0.00%** | 1.17% |
+| mean_sector_speed | 3.93% | 4.04% | 3.93% |
+| AirTemp | 1.96% | 1.96% | 1.96% |
+
+The M4 numbers reproduce only on the frame **without** the dropna step, i.e. a different
+denominator (n=22760) than the one the bounds are defined on (n=21247 for 2025). The rates
+happen to be MORE realistic that way (the dropped rows are exactly where inference goes out of
+range), but the doc presents one recipe and quotes rates from another, and neither matches what
+the agent actually does at inference (24.6% of Lusail laps, 83% of Monza laps — see F1/F3).
+
+### F3 — MEDIUM · six of the twelve bounds are artefacts of the training frame's structural exclusions, and they fire deterministically on ordinary laps
+
+`TyreLife ≥ 3`, `Prev_TyreLife ≥ 2`, `LapNumber ≥ 3`, `FuelEffect ≥ 0.055`,
+`FuelLoad ≤ 0.9615`, `laps_remaining ≤ 75` all exist because the featured artefact drops
+pit-in/out and inaccurate laps and `_DROPNA` then drops each stint's first surviving row — so
+the training frame **cannot contain** a race start or a stint opener. At inference the sim runs
+from lap 1 and calls the agent on every outlap. Measured: lap 1 fires 5 features at once
+(6 at Monaco, where `laps_remaining` 77 > 75 joins in), lap 2 fires 4-5, every stint opener
+fires 3-4 (`TyreLife`, `Prev_TyreLife`, `FuelEffect`, often `mean_sector_speed` via the
+pit-limiter trap). Judgement, since the coordinator asked for it: these ARE genuine
+training-range facts — N06 truly never saw such a lap, the prediction there truly is an
+extrapolation, and surfacing that standing train/serve mismatch is the envelope doing its job.
+What fails is the CLAIM AROUND IT: the change's own test rationale says "a normal lap must be
+silent, or the signal is worth nothing on a 57-lap race"
+(`tests/agents/test_n06_envelope.py:88`), and a warning on every stint opener of every race
+forever — plus F1's trap substitution — is not a quiet log. The bound is right; the noise
+budget and the call-site decision (#710's remit) are unresolved, and the M4 "quiet enough"
+evidence did not measure the distribution that matters.
+
+### F4 — MEDIUM · FuelLoad false positive: bound measured on a 4-decimal-ROUNDED artefact, checked against an UNROUNDED computation
+
+Training FuelLoad is stored rounded (max stored value exactly 0.9615). `run_from_state`
+computes `fuel_load = laps_remaining / max(total_laps, 1)` unrounded
+(`src/agents/pace_agent.py:749`). Monaco lap 3: 75/78 = 0.9615384… > 0.9615 → **violation
+fired on a lap class the model trained on** (training's own Monaco lap-3 rows store 0.9615 and
+sit inside the bound). Concrete: any 78-lap race warns `FuelLoad` on lap 3 while the identical
+physical situation was in-distribution at training time. One-ULP-class mismatches between an
+artefact-derived bound and a live computation are exactly the kind of edge `pytest.approx`
+would not have saved either, because the declared value matches the artefact, not the formula.
+
+### F5 — MEDIUM · claim E is incomplete: the comment's arithmetic does not reach 25, and `LapsSincePitStop` is a continuous count left unbounded with no stated reason
+
+The model consumes 25 features (`xgb_laptime_delta_feature_names.json`, executed read). The
+comment (`src/agents/pace_agent.py:105-116`) justifies 12 bounded + 5 identifiers + 2 flags +
+3 Prev_Deg* = **22**. Unaccounted: `Stint` (trained range 1-8), `Position` (1-20), and
+`LapsSincePitStop` (trained range **3-77**, 75 distinct values — the same lap-count nature as
+TyreLife, which IS bounded). On the RSM path `laps_since_pit = tyre_life` so violations would
+co-fire with TyreLife, but the orchestrator dict path (`strategy_orchestrator.py:1876`) takes
+`laps_since_pit` from `lap_state` and `run()` is public. `test_no_bound_is_declared_over_an_identifier`
+covers only the 5 identifiers, so nothing pins whether these three are excluded on purpose.
+Position/Stint are defensible as rank/ordinal codes; LapsSincePitStop is not, and no text says why.
+
+### F6 — LOW · the `unknown` path is real but currently unreachable on the replay path, and `to_numeric(coerce)` can silently convert junk into `unknown`
+
+Across all 188 replayed laps, `EnvelopeVerdict.unknown` was empty on every call (executed:
+recorder counted zero) — RSM always supplies Position and the stint baseline, so the NaN
+producers the docstring cites never fired. The NaN path itself does reach `unknown` correctly
+(`envelope._is_unknown` catches float NaN; verified by the unit test run). The residual hole:
+in the `run()` direct path a non-numeric value (e.g. a string) survives to
+`pd.to_numeric(errors='coerce')`, becomes NaN, lands in `unknown`, and is never reported by
+`_label_against_envelope` — an INVALID value silently downgraded to "no value", with no
+producer warning covering it. Cannot happen via `run_from_state` (its `float(...)` casts raise
+first). Note, not a blocker.
+
+### F8 — MEDIUM-LOW · the two lap-based veto shares point at an artefact that does not contain them (pit half; numbers themselves independently confirmed)
+
+`src/strategy/inference/guard_rails.py:56-58`: "Measured shares are quoted per bound below and
+are reproducible from `documents/eval_reports/stint_lengths.md`". Executed check of the
+regenerated artefact (md, 42 lines, plus a full JSON key walk): it carries ONLY the four
+minimum-stint rows. The `_NO_PIT_BEFORE_LAP` (42/1900 = 2.21%) and `_NO_PIT_LAST_N_LAPS`
+(26/1900 = 1.37%) shares — and the 1900 denominator itself (the report says 1895 counted + 5
+dropped) — appear in no shipped artefact, and `tests/eval/test_stint_lengths.py` asserts the
+ceiling for the four min-stint bounds only. The values are CORRECT (the parallel
+`GATE_716_calibration.md` reproduced both by independent reimplementation), so this is not a
+wrong number — it is a comment restating a session measurement while claiming artefact
+backing, the exact pattern the same commit's docstrings warn about. If the raw laps are
+regenerated and either share drifts past the ceiling, nothing that runs re-measures it.
+
+### F9 — LOW · every fabricated default in `run_from_state` is envelope-invisible by construction, and the one that is not tells the wrong story
+
+The trap hunt asked for sentinels that are also real values. All of them are here, deliberately
+mid-range: `MISSING_PREV_LAP_TIME_S` 90.0 ∈ [67.7, 149.0], `speed_st or 300.0` ∈ [156, 362],
+air 25.0 ∈ [14.5, 33.7], track 35.0 ∈ [16.7, 50.7], humidity 50.0 ∈ [18, 92]. So the envelope
+gives ZERO protection against the fabricated-input bug class on the RSM path — a lap running
+entirely on defaults labels as fully in-range. The exception: `tyre_life or 1` on a
+present-but-None tyre_life produces TyreLife=1 → a violation — but one indistinguishable from
+a genuine stint opener, so the log would say "outlap extrapolation" when the truth is "telemetry
+lost tyre_life". Not a defect of this change (labelling cannot fix fabrication), but the
+docstring's implied coverage should not be read as covering it, and a reader of the warning
+stream will misattribute that case.
+
+### F7 — LOW · the 200 bootstrap frames per lap are never checked
+
+`_bootstrap_ci` (`src/agents/pace_agent.py:507`) perturbs the six noisiest features ±2% and
+calls the model 200 more times per lap on frames built directly (`pd.DataFrame(row, ...)`),
+bypassing `_build_feature_row` and therefore the envelope. A base value just inside a bound is
+pushed outside in a fraction of the 200 draws. By design (noise model), and labelling 200
+sub-calls would be absurd — but "the check sees the same values the model is about to receive"
+(claim G) is true for 1 of the 201 model calls per lap. Recorded for precision, not as a defect.
+
+## What I tried to break and could NOT
+
+1. **The byte-identity claim.** Dev's `pace_agent.py` loaded as a parallel module, three
+   scenarios including out-of-range and the None/NaN path: frames byte-equal
+   (`to_numpy().tobytes()`), predictions equal to the last digit. The labelling really is
+   read-only — `check` builds new objects and never touches the frame.
+2. **The twelve bound VALUES.** Re-derived independently from the parquets through the declared
+   recipe: every declared number matches the measured min/max exactly, n=42957, seasons
+   2023+2024 only. They are measured, not chosen — including the full-precision
+   `mean_sector_speed` pair. (The rounding hazard I went hunting for in `pytest.approx` does
+   not exist here because the artefact itself stores FuelLoad rounded; the hazard shows up at
+   INFERENCE instead — F4.)
+3. **The Prev_Deg* exclusion.** Percentages exact; 0.0 comfortably inside all three trained
+   ranges; both live entry paths pin 0.0, so a declared bound could truly never fire. The
+   exclusion argument survives attack.
+4. **A second, unlabelled N06 path.** Walked every consumer of `run_pace_agent`,
+   `run_pace_agent_from_state` and the model file: orchestrator (both paths), no_llm engine,
+   backend endpoints, MCP tools, debug script — all route through `PaceAgent.run` →
+   `_build_feature_row`. Only the offline eval harness bypasses, and it should.
+5. **Double-checking per lap.** Recorder counted exactly one verdict per agent call on 284 real
+   laps; the bootstrap loop does not re-trigger it.
+6. **The NaN → `unknown` mechanics.** np.float64 NaN from a coerced frame lands in `unknown`,
+   never compared (executed micro-test); the unit test asserting silence on a NaN feature
+   passes for the right reason.
+7. **The envelope class itself.** Inverted-bounds rejection, ignore-undeclared-keys, and
+   frozen/immutability behaviour all held under direct probing.
+8. **The pit half's recalibrated values** (context for this branch): the regenerated report and
+   the shipped constants agree, the ceiling test passes, and the parallel GATE_716_calibration
+   reproduced every share independently — I did not find a number in `guard_rails.py` that is
+   wrong; F8 is about a false provenance pointer, not a false value.
+9. **The stash window.** Both of my parquet measurements imported branch-only symbols, so
+   neither ran against the temporarily-reverted tree; the tree was re-verified afterwards.
+
+## Fix list (by value, then risk)
+
+1. **F1 — decide what `mean_sector_speed` means at inference before the envelope ships its
+   warning.** Options in rising cost: (a) exclude it from `_N06_TRAINED_BOUNDS` with a comment
+   naming the fallback-quantity defect (mirror of the Prev_Deg* paragraph — smallest change,
+   honest); (b) declare the bound against the distribution the feature ACTUALLY receives at
+   inference (the speed-trap range), which is a different envelope for a different pipeline;
+   (c) fix the fallback itself (feed a real mean sector speed or NaN) — that is a model-input
+   change with golden impact, its own issue. Shipping as-is means 42 warnings per driver-race
+   at Monza and a log nobody will read by lap 10.
+2. **F3/F2 — restate the noise budget honestly at the call site and in M4.** The warning fires
+   on every race start and every stint opener by construction (measured 9-31% of laps on
+   normal circuits). Either downgrade those structural fires to DEBUG (they are true but
+   carry no news) while keeping WARNING for the non-structural ones, or document that the
+   consumer of this log must expect them. Update AUDIT_716_710_design M4 to name the frame its
+   rates were measured on (no-dropna, n=22760) — as written it implies the bound recipe's frame
+   and understates inference reality by ~6x.
+3. **F4 — kill the FuelLoad rounding false-positive**: either round the inference computation
+   to 4 decimals to match the artefact (`round(laps_remaining / total_laps, 4)` — matches
+   training semantics exactly), or widen the declared upper bound to the unrounded formula
+   value. One line either way; without it every 78-lap race warns on a trained lap class.
+4. **F5 — account for the last three features.** One comment line each for Stint/Position
+   (rank/ordinal, excluded on the same "no range" argument) and a real decision for
+   `LapsSincePitStop` (bound it, or say why not); extend the two exclusion tests to pin all
+   thirteen unbounded names so the enumeration cannot drift silently.
+5. **F8 — either add the two lap-based veto shares to the stint-lengths artefact (they already
+   have a home: the report), or soften the guard_rails comment to say where they actually came
+   from.**
+6. **F6 — decide whether `run()`-path junk-to-NaN deserves a log line** (a one-line `elif
+   verdict.unknown:` DEBUG would do), or document that `unknown` is intentionally silent
+   everywhere, not just for the two named producers.
+7. **Pre-existing, separate issue: `test_ml_recompute_golden.py:15` skip-guard** should also
+   require `data/processed/undercut_labeled/undercut_clean.parquet`, so the data tier skips
+   instead of failing on checkouts without the labeled holdout (it failed exactly that way in
+   this session, on a change that touches nothing near it).
+
+## Coordinator's direct question, answered
+
+**"Is TyreLife ≥ 3 a genuine training-range fact or a dropna artefact?"** Both, and the
+distinction decides the fix: the featured artefact + `_DROPNA` structurally exclude race
+starts and stint openers, so N06 has genuinely never seen such a lap — the prediction there
+IS an extrapolation and the label is TRUE. But because the exclusion is structural, the
+warning is guaranteed on laps that occur in every race forever; it separates "laps the
+pipeline can't train on" from "laps the sim must serve", which is a standing train/serve gap,
+not an anomaly. A quarter of laps warning (my 5-circuit measurement: 9-83%, mean 31%) fails
+the change's own silence criterion — the bound should stay DECLARED (it is a fact) but the
+structural fires need a different volume than the genuinely anomalous ones (fix 2), and
+`mean_sector_speed` should not be in the declared set at all until its fallback is fixed
+(fix 1). The orchestrator's Lusail run is confirmed exactly; its ~5% holdout-based estimate
+was the wrong distribution, as suspected, and the right one is worse.

--- a/documents/audits/GATE_716_calibration.md
+++ b/documents/audits/GATE_716_calibration.md
@@ -1,0 +1,441 @@
+# GATE — #716 pit-bound recalibration (branch `fix/recalibrate-pit-bounds` vs `dev`)
+
+Adversarial gate, 2026-08-03. Read-only except this report; findings appended as
+confirmed, never buffered. Success condition: find what is STILL broken.
+
+Diff under audit (8 files): `guard_rails.py`, `stint_lengths.py`,
+`decision_modes.py`, `pace_agent.py`, `tests/eval/test_stint_lengths.py`,
+`tests/eval/test_decision_modes.py`, `documents/eval_reports/stint_lengths.{md,json}`.
+
+## Checklist
+
+- [ ] Claim A — recalibrated, not deleted; proscriptive shape kept
+- [ ] Claim B — criterion (largest integer with veto share <= 5%) applied consistently
+- [ ] Claim C — values re-derived independently from data/raw (2023-2025)
+- [ ] Claim D — lap-based bounds: 2.21% / 1.37%, correctly unchanged
+- [ ] Claim E — all prose copies derive from constants; hunt for a FOURTH copy
+- [ ] Claim F — the wet-fallback false-comment story checks out
+- [ ] Claim G — the new ceiling test asserts the EFFECT, cannot pass vacuously
+- [ ] Claim H — nothing else breaks (stale reports, goldens, old-threshold tests)
+- [ ] Trap: `guard_rail_block` probe change correct, no real-stop bucket moved by the probe itself
+- [ ] Trap: `decision_modes.md` staleness
+- [ ] Trap: `_CALIBRATION_CEILING` single-sourcing vs dead weight
+- [ ] Trap: arithmetic of every %/count comment in `guard_rails.py`
+- [ ] What I tried to break and could not
+
+## Findings log (chronological)
+
+### V1 — Claims C and D VERIFIED by independent re-derivation (executed, not read back)
+
+Independent script (own reimplementation of the population rule — `PitInTime`
+notna, lap or lap+1 not neutralised by TrackStatus 4/5/6, TyreLife/Compound read
+off the stop row — no import of `src.strategy.eval`), run against
+`data/raw/{2023,2024,2025}`:
+
+- races=71, counted=1895 by bucket (341/896/548/110), +5 missing = 1900 total. Matches.
+- SOFT: bound 2 vetoes 11/341 = 3.226%; bound 3 = 5.279% > 5%. **2 is the largest
+  integer under the ceiling.** Matches shipped and comment "3.2%".
+- MEDIUM: 7 → 41/896 = 4.576% ("4.6%" OK); 8 → 5.80%. **7 maximal.**
+- HARD: 8 → 26/548 = 4.745% ("4.7%" OK); 9 → 5.47%. **8 maximal.**
+- WET fallback: 6 → 5/110 = 4.545% ("4.55%" OK); 7 → 7.27%. **6 maximal.**
+- Old bounds re-measured: SOFT 8 → 15.54%, MEDIUM 12 → 16.96%, HARD 15 → 12.23%,
+  wet 10 → 20.00%. Every "was" percentage in `guard_rails.py` is correct.
+- "11 SOFT stints ran exactly one lap" — counted 11. Correct.
+- `_NO_PIT_BEFORE_LAP=5` → 42/1900 = 2.211% ("2.21%" OK).
+- `_NO_PIT_LAST_N_LAPS=3` (rail inequality `remaining <= 3`, total_laps = max
+  LapNumber per race) → 26/1900 = 1.368% ("1.37%" OK).
+- "overshot the ceiling by between two and four times": 12.2/5 = 2.4x to 20/5 =
+  4.0x. Correct.
+
+### F1 (MEDIUM-LOW) — Claim B is FALSE as stated: the "largest integer under the ceiling" criterion was NOT applied to the two lap-based bounds
+
+Measured on the same 1900 stops: `_NO_PIT_BEFORE_LAP` could be **8** under the
+stated criterion (lap < 8 vetoes 92/1900 = 4.84% <= 5%; lap < 9 = 6.47%), and
+`_NO_PIT_LAST_N_LAPS` could be **at least 8** (remaining <= 8 vetoes 56/1900 =
+2.95%). Shipped values 5 and 3 are inside the ceiling but nowhere near maximal.
+
+Two different criteria are actually in play: "largest integer under the ceiling"
+for the four minimum-stint bounds, "leave untouched if under the ceiling" for the
+lap-based two. The code comments state the narrow versions accurately
+(`guard_rails.py:56` "Unchanged by #716: it already cleared the ceiling";
+`guard_rails.py:72` scopes "largest integer" to `_MIN_STINT_LAPS` only), so the
+SHIPPED ARTIFACT is internally consistent — treating the ceiling as a maximum-harm
+constraint rather than a target is also the defensible engineering choice for a
+proscriptive bound. What is false is the headline claim that ONE criterion was
+applied consistently to every bound. Anyone later "finishing the job" by raising
+the lap bounds to their ceiling-maximal values (8 and 8) would triple/sextuple the
+real stops those rails veto while every test stays green (see F-pending on the
+one-sided test). No file change needed; the claim needs restating wherever it is
+made outside the code.
+
+### Note — evidence integrity re-check after the orchestrator's stash warning
+
+The orchestrator reported a temporary `git stash`/pop window during my run.
+Re-verified immediately after the warning: `guard_rails.py` shows
+`_MIN_STINT_LAPS = {"SOFT": 2, "MEDIUM": 7, "HARD": 8}`, `_DEFAULT_MIN_STINT = 6`,
+`_CALIBRATION_CEILING = 0.05` (lines 54-90), and
+`tests/agents/test_n06_envelope.py` exists on disk. Every finding above matches
+the post-warning re-read. V1's measurements are additionally immune: they came
+from my own script over gitignored `data/raw/` (a stash never touches it), and
+the bound values V1 grades against were re-confirmed post-warning. No finding
+struck.
+
+### F2 (HIGH) — the branch silently DELETES `data/mc_measured_v1.json`'s entire `undercut_band` block, and the filtered diff hid it
+
+`rtk git diff dev --stat` showed 8 files; the raw diff shows **9**:
+`data/mc_measured_v1.json | 88 +----` — the whole `undercut_band` measurement
+(attempts_matched 716/1032, per-gap-bin success rates with CIs) is REMOVED from a
+TRACKED data file, in a branch whose subject is recalibrating pit bounds. Neither
+`AUDIT_716_710_design.md` nor any comment in the diff mentions it. This is
+exactly the class the repo added a guard for five commits ago (fc73c53, "fail the
+build when a tracked data file vanishes from the worktree") — here the file
+survives but a measured block inside it vanishes. Concrete failing scenario:
+whatever consumes `undercut_band` (MC undercut scoring / measured tables) silently
+falls back to its no-data path on every lap after this merges, and no pit-bounds
+test would ever notice. Needs: either an explanation + regeneration in the PR
+body, or `git checkout dev -- data/mc_measured_v1.json` before committing.
+(Follow-up below on consumers.)
+
+### F3 (MEDIUM, process) — the branch is three concerns in one uncommitted worktree, and the one NEW test file is untracked
+
+`fix/recalibrate-pit-bounds` has NO commits; everything sits uncommitted on top of
+`dev` (`fc73c53`). The worktree mixes: (1) #716 recalibration, (2) #710's N06 pace
+envelope (`pace_agent.py`, has its own gate report `GATE_710_pace_envelope.md`),
+and (3) the F2 data deletion. `tests/agents/test_n06_envelope.py` — the test
+`pace_agent.py`'s new comment names as the thing that stops the envelope bounds
+"quietly becoming hand-typed numbers" — is `??` untracked: a `git add -u` commit
+of the modified files ships the comment's PROMISE while leaving the promised test
+behind. The commit command handed to Víctor must add it explicitly, and the two
+issues should land as two PRs per the repo's own single-concern rule.
+
+### F2 update — EXECUTED: the undercut_band deletion breaks two tests outright
+
+`pytest tests/mc/test_mc_measured_tables.py tests/mc/test_guard_rails.py
+tests/eval/test_decision_modes.py` on this worktree: **2 failed, 58 passed**.
+
+- `test_the_undercut_decays_with_the_gap_to_the_target` — KeyError
+  `'by_gap_bin_seconds'` (`tests/mc/test_mc_measured_tables.py:137`)
+- `test_the_undercut_band_is_a_usable_number_of_seconds` — KeyError `'u_band_s'`
+  (`tests/mc/test_mc_measured_tables.py:150`)
+
+Root cause confirmed: the worktree's `data/mc_measured_v1.json` now carries
+`"undercut_band": {"available": false, "reason": "missing undercut_clean.parquet"}`
+— someone re-ran `scripts/measure_mc_tables.py` on a checkout without
+`data/processed/undercut_labeled/undercut_clean.parquet`, and the regeneration
+overwrote the measured band (dev value: `u_band_s = 4.9132`, 716 matched attempts,
+per-bin success rates) with an unavailable marker. Claim H ("nothing else breaks")
+is REFUTED with executed evidence. Runtime blast radius is small only by luck:
+`measured_undercut_band_s()` (`src/agents/position_projection.py:308-311`) falls
+back to `DEFAULT_UNDERCUT_BAND_S = 4.91`, which was set FROM the 4.9132
+measurement — but the per-bin table and provenance are gone, and CI goes red.
+Fix: restore the file (`git checkout dev -- data/mc_measured_v1.json`) or
+regenerate on a checkout that has the parquet.
+
+All guard-rails and decision-modes tests pass against the NEW bounds (58 passed),
+including `test_block_agrees_with_the_rail_on_every_lap_of_a_race`.
+
+### F4 (MEDIUM-LOW) — the calibration CEILING has a hand-typed prose twin, in the very file whose headline is "never restated"
+
+`_CALIBRATION_CEILING` is consumed only by `tests/eval/test_stint_lengths.py:247`
+(correct single-sourcing for the ENFORCEMENT — not dead weight). But
+`stint_lengths.py` does NOT import it: `_render_table` hand-types "The ceiling the
+bounds are held to is **5%**" (`stint_lengths.py:319-320`), and the checked-in
+`stint_lengths.md` carries that prose. Meanwhile `guard_rails.py:50-53` claims the
+report "imports these constants rather than restating them". True for the bounds,
+false for the ceiling. Concrete failing scenario: tighten `_CALIBRATION_CEILING`
+to 0.03 — the test starts enforcing 3%, every regenerated report keeps printing
+"**5%**", and the module comment's reproducibility claim is now wrong. Same defect
+class as the 8/12/15 prose copies this change fixes, one level up. One-line fix:
+render the ceiling from the constant.
+
+### F5 (HIGH) — the recalibration silently rewrote a DIFFERENT rule: both prompts now teach "MEDIUM: suitable for 7-30 remaining laps"
+
+`pit_strategy_agent.py:684` and `strategy_orchestrator.py:1703` derive the
+COMPOUND-SUITABILITY window's lower edge from `_MIN_STINT_LAPS['MEDIUM']`:
+
+    MEDIUM: suitable for {_MIN_STINT_LAPS['MEDIUM']}-{_STINT_CAPACITY_LAPS['MEDIUM']} remaining laps.
+
+On dev this rendered "12-30". With `MEDIUM: 7` it renders "**7-30**". These are
+two semantically different rules sharing one constant because their values
+HAPPENED to coincide at 12: the minimum-stint bound says "you must have run the
+CURRENT set at least N laps before stopping off it" (a percentile of real stint
+lengths at the stop — #716's target); the suitability window says "MEDIUM is a
+sensible compound to bolt ON for this many REMAINING laps" (a durability
+property of the new set). #716's own measurement says a 7-lap MEDIUM stint is in
+the bottom 5% of what real pit walls ever did — and the prompt now presents 7 as
+the suitable LOWER EDGE for choosing MEDIUM. The coupling is pre-existing (#741
+era, when the prompts were derived from constants); this branch is the first one
+to move the constant, and nobody re-checked what else renders from it. Classic
+value-coincidence coupling, the numeric cousin of a sentinel collision.
+
+The proof the guard cannot see it: `tests/agents/test_prompt_constants_match_tables.py`
+asserts prompt numbers EQUAL the constants (`_MIN_STINT` regex matches only the
+">= N lap" phrasing; the capacity tests pin the upper edges) — "7-30" passes
+every assertion because 7 == the constant. The test pins consistency, not which
+rule a constant belongs to. Note the internal inconsistency as supporting
+evidence that the MEDIUM derivation is accidental: the same suitability rule
+takes SOFT's edge from `_STINT_CAPACITY_LAPS`, HARD's from a hand-typed "20+",
+and only MEDIUM's floor from `_MIN_STINT_LAPS`.
+
+Concrete failing scenario: rich mode (the DEFAULT path for CLI/arcade/backend
+live), lap with 9 remaining, MEDIUM available — before this branch both prompts
+told the LLM MEDIUM was unsuitable (<12); after it, both endorse it. A rich-mode
+compound-choice behaviour change shipped inside a "recalibrate anti-hallucination
+bounds" diff, unmeasured and unmentioned in `AUDIT_716_710_design.md`.
+
+Fix: give the suitability line its own constant (or derive its floor from the
+capacity/degradation table it conceptually belongs to), and re-render "12" —
+or justify the new window explicitly. Do not let it move as a side effect.
+
+### F6 (MEDIUM) — `_DEFAULT_MIN_STINT` has NO prose copy at all: the wet bound exists only in the mirror, never in the specification
+
+`guard_rails.py:12-13` declares "the prompt is the specification and this file is
+the copy". Grep across both prompts: `_DEFAULT_MIN_STINT` renders NOWHERE —
+`pit_strategy_agent.py:663-667` and `strategy_orchestrator.py:1695-1697` state
+minimums for SOFT/MEDIUM/HARD only. So in rich mode (the default), NOTHING even
+asks the LLM to respect a minimum stint on INTERMEDIATE/WET, while the no-llm
+mirror vetoes wet stops under 6 laps. The change just spent its M2 story on "the
+wet fallback was the worst-calibrated bound because nothing ever measured it" —
+and shipped it still being the only bound whose specification does not exist.
+Claim E is therefore true only vacuously for this bound: "all prose copies derive
+from the constants" because it has zero prose copies. The prompt-vs-rail test
+cannot cover it either (nothing to parse). Pre-existing, but #716 is the issue
+that named every bound, measured this one, and left the prompt half unwritten.
+Fix: one derived line in each prompt ("any other compound: >= {_DEFAULT_MIN_STINT}"),
+which also makes the existing regex able to see it.
+
+### F7 (MEDIUM) — `guard_rails.py:57` attributes the closing rail's four stops to the OPENING rail: a comment naming the wrong mechanism
+
+The comment on `_NO_PIT_BEFORE_LAP` reads: "The four stops it blocks in the
+six-race decision-modes subset read as a large share only because that subset is
+small". Measured on the actual subset (178 green-flag stops across 2025
+Barcelona/Monaco/Silverstone/Marina_Bay/Lusail/Monza): the opening rail
+(`lap < 5`) blocks **ZERO** stops there. The four stops belong to the CLOSING
+rail (`remaining <= 3`): Monaco VER 77/78, Lusail STR 55/57, Lusail HAD 55/57,
+Monza OCO 51/53 — exactly the `closing_laps | 4` row in
+`documents/eval_reports/decision_modes.md:21` (the bucket table has no
+`opening_laps` row at all). The comment inherited the ISSUE's claim ("the last
+two bounds block 4 real stops each", already half-corrected by the design doc's
+M1) without verifying which bound owned the four. The full-sample number in the
+same comment (42/1900 = 2.21%) is correct; the subset anecdote is attached to
+the wrong bound. This repo's own lesson list says a comment naming the wrong
+mechanism is worse than none — it teaches the next reader that the opening rail
+bites in that subset when it never fires there. Fix: move the anecdote to the
+`_NO_PIT_LAST_N_LAPS` comment (where the four genuinely live), or delete it.
+
+### F8 (MEDIUM-HIGH) — `documents/eval_reports/decision_modes.md` is now stale in a load-bearing way, and nothing asserts against it
+
+The checked-in report (generated 2026-07-31, harness `d97a54e`, OLD bounds) rests
+on `min_stint | 17` excluded stops. Re-measured on the same subset with the same
+bucket-priority rule: OLD bounds block 17 (exact match, validating the mirror),
+NEW bounds block **5** — twelve stops re-enter the gradeable population, so
+"Stops scored 54 of 178 (30.3%)", exact/within-1/within-2, mean signed error and
+the `masked` coverage verdict are all computed against an exclusion set the
+shipped rail no longer produces. No test reads `decision_modes.json` (only unit
+tests on `guard_rail_block`), so CI stays green while a published, checked-in
+eval report describes a rail that no longer exists. The same diff DID regenerate
+`stint_lengths.{md,json}` — the repo's own standard — but left the report whose
+headline depends on these bounds untouched. Fix: re-run `f1-eval decision-modes`
+after the bounds land (or in the same PR), and expect the headline block and the
+bucket table to move; until then the report needs a staleness note.
+
+### Note — the tree mutated mid-gate, and one probe of mine misfired harmlessly
+
+While this gate ran, the work was committed on the branch as `1427e35`
+(fix(rails): recalibrate...) + `06a8f32` (feat(agents): N06 envelope), and
+`f1-eval decision-modes` was re-run into the worktree. Consequences for the log
+above: (a) F3's untracked-test risk did NOT materialise —
+`tests/agents/test_n06_envelope.py` (186 lines) is in `06a8f32`; (b) the
+`data/mc_measured_v1.json` gutting (F2) was correctly EXCLUDED from both commits
+but still sits in the worktree. Separately, I attempted a stash/pop cycle to
+compare formatting against dev; it ran against an already-committed tree and had
+no net effect (stash list and worktree verified unchanged; the em-dashes stash
+`stash@{0}` was never popped). All dev-vs-branch comparisons below use
+`git show dev:...` / `git show 06a8f32:...` instead, which cannot touch the tree.
+
+### F2 reframe — the gutting is NOT in the commits, but the worktree copy still poisons every local test run
+
+`git diff dev 06a8f32 --stat` lists 9 files; `data/mc_measured_v1.json` is not
+among them. The 2 test failures in F2-update are worktree-only. Remaining risk:
+the file is still modified on disk, so (a) `pytest tests/mc` fails locally until
+restored, and (b) any future `git commit -a` / `git add -A` on this branch ships
+it. Fix stands: `git checkout dev -- data/mc_measured_v1.json`.
+
+### F8 update — the regenerated decision-modes report EXISTS but is UNCOMMITTED; the branch as committed still ships the stale one
+
+The worktree now holds a regenerated `documents/eval_reports/decision_modes.{md,json}`
+(harness `06a8f32`, 2026-08-03T09:01:49): `min_stint | 5` — exactly the count
+this gate independently measured BEFORE the regeneration ran (double
+confirmation) — scored 67/178 (37.6%), exact 31.3%, within-1 47.8%, within-2
+61.2%, MSE -1.52, MAE 1.97. But `06a8f32`'s tree does not contain it: the PR as
+committed still ships `min_stint | 17` against bounds that block 5. The
+regenerated pair must be committed onto the branch.
+
+### F9 (MEDIUM, breaks CI) — the committed `stint_lengths.py` fails `ruff format --check` under CI's exact pinned ruff
+
+Executed with the pin from `.github/workflows/ci.yml` (`RUFF_VERSION: "0.15.22"`,
+lint job runs `uvx ruff@0.15.22 format --check .`):
+
+- `git show dev:src/strategy/eval/stint_lengths.py` — passes
+- `git show 06a8f32:src/strategy/eval/stint_lengths.py` — "1 file would be
+  reformatted": one missing blank line after the new `_bound_for` helper
+  (line 86; two-blank-lines-after-top-level-def)
+
+So the branch turns the required `lint` context red the moment it is pushed.
+`ruff check` (lint proper) passes; only the formatter trips. Fix:
+`uvx ruff@0.15.22 format src/strategy/eval/stint_lengths.py` and commit.
+
+### F10 (MEDIUM-LOW) — Claim G holds at its core, but the new ceiling test is one-sided and can go PARTIALLY vacuous on the exact bucket this change is about
+
+Verified genuine: `test_no_minimum_stint_bound_vetoes_more_than_the_calibration_ceiling`
+asserts the EFFECT (measured share vs ceiling) over real data, passes today
+(21/21 in `tests/eval/test_stint_lengths.py`), and would fail on any raised
+bound — provably: SOFT at 3 measures 5.28% > 5% (V1), so the assertion trips
+with compound and share in the message. `assert graded` blocks the all-empty
+case. Two gaps survive:
+
+1. **Partial vacuity on a single bucket.** `graded` filters out empty buckets and
+   the guard only requires SOME bucket to carry data. If a future edit to
+   `green_flag_stops`/`_compound_bucket` silently re-drops wet stops — the exact
+   historical failure M2 documents — the WET row goes ungraded and the test stays
+   green on the three dry buckets. The bound whose non-measurement motivated this
+   change is the one bucket allowed to fall silently out of measurement. Fix:
+   assert every `_REPORTED_BUCKETS` entry has `sample_size > 0` (all four do:
+   341/896/548/110).
+2. **One-sided.** The test enforces `share <= ceiling` but nothing enforces the
+   "largest integer" half or even `bound >= 1`. Set every bound to 0 and ALL
+   tests stay green — including `tests/mc/test_guard_rails.py`, whose probes are
+   derived as `bound - 1` (tyre_life = -1 still trips `-1 < 0`) — while the rail
+   becomes unfireable on any real non-negative tyre life. The rail can be
+   silently deleted through its constants with a fully green suite. Fix: assert
+   maximality (`share(threshold + 1) > ceiling` on the same sample) or minimally
+   `threshold >= 1` plus one asserted real firing.
+
+### V2 — remaining claims verified (A, E, F, probe trap, ceiling trap)
+
+- **Claim A**: TRUE. The bounds survive as vetoes (`apply_guard_rails:155-160`
+  unchanged in shape), values recalibrated not deleted, and the module docstring
+  carries the proscriptive-needs-calibration doctrine correctly.
+- **Claim E**: TRUE for the three named bounds — both prompts render from
+  `_MIN_STINT_LAPS` f-strings (`pit_strategy_agent.py:664-665`,
+  `strategy_orchestrator.py:1695-1696`), and
+  `test_no_prompt_states_a_minimum_stint_the_rails_disagree_with` parses the
+  rendered prompts against the constants. The FOURTH-copy hunt came back clean:
+  `docs/pages/multi-agent.md:140` describes the SC exemption with no numbers;
+  `ROADMAP.md:311` names only the (unchanged) lap-window numbers; notebooks,
+  README, `src/telemetry` submodule: no numeric copies. The old 8/12/15 survive
+  only in audit files, the guard_rails "was" comment, and a test docstring
+  narrating history — all legitimately historical. BUT see F5 (the derivation
+  leaked into a different rule) and F6 (the fallback bound has no prose copy).
+- **Claim F**: TRUE. The dev version of `stint_lengths.py` carried the comment
+  "Wet compounds run no minimum-stint rule at all (...)"; the rail's
+  `.get(compound, _DEFAULT_MIN_STINT)` resolves INTERMEDIATE/WET to the
+  fallback, so the headline was false while its parenthetical was true; the dev
+  report dropped exactly 110 wet stops; measured today those 110 stops graded
+  20.0% below the old fallback of 10 — the worst of the four bounds.
+- **Probe trap**: the `guard_rail_block` change is correct and inert for real
+  stops: the probe only fires when `tyre_life is None`; under old values (probe
+  15 vs bounds 8/12/15/10) and new (probe 8 vs 2/7/8/6) the min-stint rail never
+  fires on the probe, and opening/closing rails ignore tyre_life. Executed
+  cross-check: my bucket mirror reproduced the checked-in report's 17 min_stint
+  stops exactly under old bounds, and the post-gate regeneration's 5 matches my
+  new-bounds count exactly. Bucket assignment moved only where the bound VALUES
+  moved it.
+- **Ceiling trap**: `_CALIBRATION_CEILING` is single-sourcing, not dead weight —
+  the enforcement (the test) imports it. The defect is F4 (hand-typed prose twin
+  in the renderer).
+- **Denominator nit (recorded, not a finding)**: `guard_rails.py:49` calls the
+  sample "1900 real green-flag stops"; the report counts 1895 graded + 5 dropped
+  for missing compound/tyre-life. The lap-based shares correctly use 1900 (a
+  lap-number veto needs no compound); the stint shares use per-compound n. Both
+  arithmetics check out; the prose just does not say the denominators differ.
+
+## Checklist — final state
+
+- [x] Claim A — VERIFIED (V2)
+- [x] Claim B — REFUTED as stated: two criteria in play; only the min-stint four are ceiling-maximal (F1)
+- [x] Claim C — VERIFIED by independent re-derivation; all four values maximal under the ceiling (V1)
+- [x] Claim D — VERIFIED: 42/1900 = 2.21%, 26/1900 = 1.37% (V1); see F1 (criterion asymmetry) and F7 (wrong-mechanism comment)
+- [x] Claim E — VERIFIED for existing copies; no fourth copy; residue = F5, F6
+- [x] Claim F — VERIFIED end to end (V2)
+- [x] Claim G — core VERIFIED, executed; F10 documents the gaps
+- [x] Claim H — REFUTED twice with executed evidence: F2 (worktree undercut_band gutting, 2 failing tests) and F9 (committed format regression under CI's pinned ruff); plus F8 (stale decision_modes in the committed tree)
+- [x] Trap: probe change — V2 · decision_modes.md — F8 · ceiling — V2/F4 · comment arithmetic — V1/F7
+- [x] What I tried to break and could not — below
+
+## Severity ranking
+
+| # | Finding | Severity |
+|---|---|---|
+| F5 | Recalibration silently rewrote the compound-suitability rule to "MEDIUM: 7-30 remaining laps" in BOTH prompts (rich mode = default path); the consistency test cannot see it | **HIGH** |
+| F2 | Worktree `data/mc_measured_v1.json` lost its measured `undercut_band` (regeneration side-effect); 2 tests fail on it; one `git add -A` from shipping | **HIGH** (uncommitted) |
+| F8 | Committed tree ships `decision_modes.md` with `min_stint 17` against bounds that block 5; regenerated report exists but is uncommitted | MEDIUM-HIGH |
+| F9 | `stint_lengths.py` as committed fails CI's pinned `ruff format --check` | MEDIUM (red CI, trivial fix) |
+| F7 | `guard_rails.py:57` attributes the closing rail's 4 subset stops to the opening rail | MEDIUM |
+| F6 | `_DEFAULT_MIN_STINT` has no prose copy: the wet bound exists only in the mirror, unspecified in the "specification" | MEDIUM |
+| F10 | Ceiling test one-sided + per-bucket partial vacuity (WET can silently fall out of measurement) | MEDIUM-LOW |
+| F1 | Claim B false as stated: lap-based bounds not ceiling-maximal; two unstated criteria | MEDIUM-LOW |
+| F4 | Calibration ceiling hand-typed as "5%" in the report renderer while the module claims the report restates nothing | MEDIUM-LOW |
+| — | `tests/mc/test_guard_rails.py` has no direct case for the fallback bound (only reached indirectly via the eval probe test) | LOW |
+
+## Fix list, ordered by value and risk
+
+1. Restore `data/mc_measured_v1.json` (`git checkout dev -- data/mc_measured_v1.json`);
+   if the regeneration was wanted, re-run `scripts/measure_mc_tables.py` on a
+   checkout that has `undercut_clean.parquet`. (F2 — before ANY further commit.)
+2. Decouple the compound-suitability floor from `_MIN_STINT_LAPS['MEDIUM']` in
+   both prompts; restore an explicit suitability window (own constant or the
+   capacity table) and state the intended value. (F5)
+3. `uvx ruff@0.15.22 format src/strategy/eval/stint_lengths.py`, commit. (F9)
+4. Commit the regenerated `decision_modes.{md,json}` onto this branch. (F8)
+5. Move the "four stops in the six-race subset" anecdote from
+   `_NO_PIT_BEFORE_LAP`'s comment to `_NO_PIT_LAST_N_LAPS`'s, where the four
+   live. (F7)
+6. Add one derived line per prompt for the fallback bound ("any other compound:
+   >= {_DEFAULT_MIN_STINT} laps"), which also lets the prompt-parsing regex
+   cover it. (F6)
+7. Harden the ceiling test: assert all four `_REPORTED_BUCKETS` are non-empty
+   and assert maximality or at least `threshold >= 1` + one real firing. (F10)
+8. Render the ceiling in `_render_table` from `_CALIBRATION_CEILING` instead of
+   the hand-typed "5%". (F4)
+9. State the two-criteria reality wherever Claim B is made (design doc / PR
+   body): failed bounds were reset to the ceiling-maximal integer; passing
+   bounds were deliberately left non-maximal. One sentence stops a future
+   "finish the job" tightening. (F1)
+10. Optional: one direct `test_guard_rails.py` case for the fallback bound and
+    its SC suspension. (LOW)
+
+## What I tried to break and could NOT
+
+- **The four recalibrated values themselves.** Independent reimplementation of
+  the population rule from raw parquets (no repo eval imports): every shipped
+  value is exactly the largest integer with veto share <= 5% on its bucket, per
+  V1's full tables. No off-by-one anywhere; strict `<` matches the rail.
+- **Every percentage and count in the `guard_rails.py` comments** — 15.5/17.0/
+  12.2/20.0 (old), 3.2/4.6/4.7/4.55 (new), 42/1900, 26/1900, "11 SOFT one-lap
+  stints", "two to four times the ceiling". All correct (V1). The single wrong
+  factual claim found in the comments is F7's mechanism attribution.
+- **The probe change in `guard_rail_block`.** Tried to construct a real stop
+  whose bucket moves because of the expression change: impossible — the probe
+  only exists for `tyre_life=None`, and neither the old nor the new probe value
+  can trip any bound. Mirror counts matched 17 (old) and 5 (new) exactly.
+- **The seasons trap.** Tried to catch the calibration measured on a subset or
+  the wrong season: the sample is genuinely all three seasons (71 races,
+  2023-2025), the test docstring explicitly defends measuring on the calibration
+  sample rather than 2025-only, and the six-race subset numbers are quoted only
+  as subset numbers.
+- **The wet-bucket grading.** `_bound_for` calls the rail's own lookup; the WET
+  row's 110/6/4.5% reproduce independently; INTERMEDIATE and WET both genuinely
+  resolve to the fallback today. (Residual: a hypothetical future
+  `_MIN_STINT_LAPS["INTERMEDIATE"]` key would make the joint WET bucket grade a
+  bound the rail no longer resolves for INTERMEDIATE — F10's class.)
+- **Stale-fixture hunt in `tests/mc/test_guard_rails.py` and
+  `tests/eval/test_decision_modes.py`.** Every probe derives from the constants
+  (`bound - 1`); both updated parametrisations are correct under the new values
+  (SOFT 1 < 2; None -> "" with 5 < 6); 58 tests passed there. No test pins an
+  old threshold outside historical docstrings.
+- **`no_llm.py` prose.** No restated stint numbers (0 grep hits) — it imports
+  the constants.
+- **A fourth live prose copy of 8/12/15 (or 2/7/8).** Swept docs/, documents/,
+  notebooks/, README, ROADMAP, the `src/telemetry` submodule: none beyond
+  history-narrating audit files and the "was" comment.

--- a/documents/eval_reports/decision_modes.json
+++ b/documents/eval_reports/decision_modes.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "d97a54e",
+    "harness_sha": "06a8f32",
     "dataset": "data/raw laps, stratified 6-race subset (RAW, not featured)",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-31T09:40:54+00:00",
+    "generated_at": "2026-08-03T09:26:58+00:00",
     "artifacts": {}
   },
   "status": "masked",
@@ -38,22 +38,22 @@
     }
   ],
   "agreement": {
-    "sample_size": 54,
+    "sample_size": 67,
     "eligible": 178,
-    "scored_share": 0.30337078651685395,
+    "scored_share": 0.37640449438202245,
     "races": 6,
-    "exact": 0.3333333333333333,
-    "within_one": 0.4444444444444444,
-    "within_two": 0.5185185185185185,
-    "mean_signed_error": -2.0,
-    "mean_absolute_error": 2.1481481481481484
+    "exact": 0.31343283582089554,
+    "within_one": 0.47761194029850745,
+    "within_two": 0.6119402985074627,
+    "mean_signed_error": -1.5223880597014925,
+    "mean_absolute_error": 1.9701492537313432
   },
   "buckets": {
     "closing_laps": 4,
-    "min_stint": 17,
+    "min_stint": 5,
     "no_boundary_in_window": 24,
-    "no_call_in_window": 79,
-    "scored": 54
+    "no_call_in_window": 78,
+    "scored": 67
   },
   "verdicts": [
     {
@@ -61,9 +61,9 @@
       "race": "Barcelona",
       "driver": "VER",
       "actual_lap": 13,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "chosen_lap": 16,
+      "offset_laps": 3,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -88,8 +88,8 @@
       "race": "Barcelona",
       "driver": "GAS",
       "actual_lap": 10,
-      "chosen_lap": 6,
-      "offset_laps": -4,
+      "chosen_lap": 13,
+      "offset_laps": 3,
       "bucket": "scored"
     },
     {
@@ -106,9 +106,9 @@
       "race": "Barcelona",
       "driver": "ANT",
       "actual_lap": 21,
-      "chosen_lap": 21,
-      "offset_laps": 0,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -135,7 +135,7 @@
       "actual_lap": 42,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -160,9 +160,9 @@
       "race": "Barcelona",
       "driver": "TSU",
       "actual_lap": 8,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
+      "chosen_lap": 7,
+      "offset_laps": -1,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -178,9 +178,9 @@
       "race": "Barcelona",
       "driver": "TSU",
       "actual_lap": 44,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 43,
+      "offset_laps": -1,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -232,8 +232,8 @@
       "race": "Barcelona",
       "driver": "LAW",
       "actual_lap": 18,
-      "chosen_lap": 15,
-      "offset_laps": -3,
+      "chosen_lap": 13,
+      "offset_laps": -5,
       "bucket": "scored"
     },
     {
@@ -259,8 +259,8 @@
       "race": "Barcelona",
       "driver": "OCO",
       "actual_lap": 43,
-      "chosen_lap": 43,
-      "offset_laps": 0,
+      "chosen_lap": 42,
+      "offset_laps": -1,
       "bucket": "scored"
     },
     {
@@ -277,18 +277,18 @@
       "race": "Barcelona",
       "driver": "NOR",
       "actual_lap": 48,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 44,
+      "offset_laps": -4,
+      "bucket": "scored"
     },
     {
       "year": 2025,
       "race": "Barcelona",
       "driver": "COL",
       "actual_lap": 14,
-      "chosen_lap": 11,
-      "offset_laps": -3,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -313,17 +313,17 @@
       "race": "Barcelona",
       "driver": "HAM",
       "actual_lap": 46,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 48,
+      "offset_laps": 2,
+      "bucket": "scored"
     },
     {
       "year": 2025,
       "race": "Barcelona",
       "driver": "BOR",
       "actual_lap": 19,
-      "chosen_lap": 17,
-      "offset_laps": -2,
+      "chosen_lap": 19,
+      "offset_laps": 0,
       "bucket": "scored"
     },
     {
@@ -331,8 +331,8 @@
       "race": "Barcelona",
       "driver": "BOR",
       "actual_lap": 49,
-      "chosen_lap": 49,
-      "offset_laps": 0,
+      "chosen_lap": 46,
+      "offset_laps": -3,
       "bucket": "scored"
     },
     {
@@ -349,8 +349,8 @@
       "race": "Barcelona",
       "driver": "SAI",
       "actual_lap": 34,
-      "chosen_lap": 34,
-      "offset_laps": 0,
+      "chosen_lap": 33,
+      "offset_laps": -1,
       "bucket": "scored"
     },
     {
@@ -448,9 +448,9 @@
       "race": "Monaco",
       "driver": "GAS",
       "actual_lap": 8,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
+      "chosen_lap": 8,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -475,9 +475,9 @@
       "race": "Monaco",
       "driver": "ALO",
       "actual_lap": 16,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 12,
+      "offset_laps": -4,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -502,9 +502,9 @@
       "race": "Monaco",
       "driver": "STR",
       "actual_lap": 17,
-      "chosen_lap": 14,
-      "offset_laps": -3,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -547,9 +547,9 @@
       "race": "Monaco",
       "driver": "HUL",
       "actual_lap": 12,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 10,
+      "offset_laps": -2,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -592,8 +592,8 @@
       "race": "Monaco",
       "driver": "OCO",
       "actual_lap": 28,
-      "chosen_lap": 24,
-      "offset_laps": -4,
+      "chosen_lap": 27,
+      "offset_laps": -1,
       "bucket": "scored"
     },
     {
@@ -603,7 +603,7 @@
       "actual_lap": 19,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -619,9 +619,9 @@
       "race": "Monaco",
       "driver": "COL",
       "actual_lap": 13,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
+      "chosen_lap": 8,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -691,9 +691,9 @@
       "race": "Monaco",
       "driver": "HAD",
       "actual_lap": 14,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 9,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -709,9 +709,9 @@
       "race": "Monaco",
       "driver": "RUS",
       "actual_lap": 53,
-      "chosen_lap": 49,
-      "offset_laps": -4,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -720,7 +720,7 @@
       "actual_lap": 62,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "min_stint"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -835,18 +835,18 @@
       "race": "Silverstone",
       "driver": "LEC",
       "actual_lap": 10,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
+      "chosen_lap": 10,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
       "race": "Silverstone",
       "driver": "LEC",
       "actual_lap": 42,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 43,
+      "offset_laps": 1,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -855,7 +855,7 @@
       "actual_lap": 10,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "min_stint"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -900,7 +900,7 @@
       "actual_lap": 9,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "min_stint"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -979,18 +979,18 @@
       "race": "Silverstone",
       "driver": "HAD",
       "actual_lap": 10,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
+      "chosen_lap": 10,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
       "race": "Silverstone",
       "driver": "RUS",
       "actual_lap": 10,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
+      "chosen_lap": 9,
+      "offset_laps": -1,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1024,9 +1024,9 @@
       "race": "Silverstone",
       "driver": "BEA",
       "actual_lap": 10,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
+      "chosen_lap": 8,
+      "offset_laps": -2,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1060,9 +1060,9 @@
       "race": "Marina_Bay",
       "driver": "GAS",
       "actual_lap": 51,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "chosen_lap": 53,
+      "offset_laps": 2,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1177,8 +1177,8 @@
       "race": "Marina_Bay",
       "driver": "HAM",
       "actual_lap": 24,
-      "chosen_lap": 19,
-      "offset_laps": -5,
+      "chosen_lap": 21,
+      "offset_laps": -3,
       "bucket": "scored"
     },
     {
@@ -1222,8 +1222,8 @@
       "race": "Marina_Bay",
       "driver": "RUS",
       "actual_lap": 25,
-      "chosen_lap": 22,
-      "offset_laps": -3,
+      "chosen_lap": 23,
+      "offset_laps": -2,
       "bucket": "scored"
     },
     {
@@ -1294,9 +1294,9 @@
       "race": "Lusail",
       "driver": "STR",
       "actual_lap": 24,
-      "chosen_lap": 19,
-      "offset_laps": -5,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -1438,9 +1438,9 @@
       "race": "Lusail",
       "driver": "PIA",
       "actual_lap": 24,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 24,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1467,7 +1467,7 @@
       "actual_lap": 40,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "min_stint"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -1476,7 +1476,7 @@
       "actual_lap": 41,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "min_stint"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -1492,9 +1492,9 @@
       "race": "Monza",
       "driver": "GAS",
       "actual_lap": 49,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "chosen_lap": 47,
+      "offset_laps": -2,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1528,9 +1528,9 @@
       "race": "Monza",
       "driver": "LEC",
       "actual_lap": 33,
-      "chosen_lap": 33,
-      "offset_laps": 0,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -1546,8 +1546,8 @@
       "race": "Monza",
       "driver": "TSU",
       "actual_lap": 19,
-      "chosen_lap": 18,
-      "offset_laps": -1,
+      "chosen_lap": 19,
+      "offset_laps": 0,
       "bucket": "scored"
     },
     {
@@ -1582,9 +1582,9 @@
       "race": "Monza",
       "driver": "NOR",
       "actual_lap": 46,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "chosen_lap": 46,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1636,8 +1636,8 @@
       "race": "Monza",
       "driver": "RUS",
       "actual_lap": 27,
-      "chosen_lap": 26,
-      "offset_laps": -1,
+      "chosen_lap": 27,
+      "offset_laps": 0,
       "bucket": "scored"
     },
     {

--- a/documents/eval_reports/decision_modes.md
+++ b/documents/eval_reports/decision_modes.md
@@ -1,17 +1,17 @@
 # decision_modes
 
-- harness `d97a54e` · schema v1 · generated 2026-07-31T09:40:54+00:00
+- harness `06a8f32` · schema v1 · generated 2026-08-03T09:26:58+00:00
 - era 2022-2025 · dataset data/raw laps, stratified 6-race subset (RAW, not featured) · seed deterministic · llm none
 - artifacts: —
 
 | Metric | Value | Meaning |
 | --- | --- | --- |
-| Stops scored | 54 of 178 (30.3%) | real green-flag stops the tier could grade |
-| Exact lap | 33.3% | chose the lap the team chose |
-| Within 1 lap | 44.4% | same call, one lap either side |
-| Within 2 laps | 51.9% | same strategic window |
-| Mean signed error | -2.00 laps | negative = earlier than the team. **Do not quote as a system property** — still moves with `DECISION_WINDOW_LAPS` (measured -0.33 / -1.29 / -2.50 at w=3/5/10 on one race), because a wider window admits more distant, and therefore earlier, transitions |
-| Mean absolute error | 2.15 laps | magnitude, same width caveat |
+| Stops scored | 67 of 178 (37.6%) | real green-flag stops the tier could grade |
+| Exact lap | 31.3% | chose the lap the team chose |
+| Within 1 lap | 47.8% | same call, one lap either side |
+| Within 2 laps | 61.2% | same strategic window |
+| Mean signed error | -1.52 laps | negative = earlier than the team. **Do not quote as a system property** — still moves with `DECISION_WINDOW_LAPS` (measured -0.33 / -1.29 / -2.50 at w=3/5/10 on one race), because a wider window admits more distant, and therefore earlier, transitions |
+| Mean absolute error | 1.97 laps | magnitude, same width caveat |
 | Coverage verdict | **masked** | `masked` when under 60% of eligible stops were scored |
 
 ### Buckets
@@ -19,10 +19,10 @@
 | Bucket | Stops |
 | --- | --- |
 | `closing_laps` | 4 |
-| `min_stint` | 17 |
+| `min_stint` | 5 |
 | `no_boundary_in_window` | 24 |
-| `no_call_in_window` | 79 |
-| `scored` | 54 |
+| `no_call_in_window` | 78 |
+| `scored` | 67 |
 
 `opening_laps` / `closing_laps` / `min_stint` are stops the guard rails make
 impossible to agree with, so they are excluded from the headline rather than

--- a/documents/eval_reports/stint_lengths.json
+++ b/documents/eval_reports/stint_lengths.json
@@ -1,24 +1,23 @@
 {
   "header": {
-    "harness_sha": "af96fb6",
+    "harness_sha": "fc73c53",
     "dataset": "data/raw laps 2023-2025 (RAW, not featured)",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-29T09:39:31+00:00",
+    "generated_at": "2026-08-03T08:32:16+00:00",
     "artifacts": {}
   },
   "sample": {
     "races": 71,
-    "total_counted": 1785,
-    "dropped_wet": 110,
+    "total_counted": 1895,
     "dropped_missing": 5,
     "compounds": {
       "SOFT": {
         "sample_size": 341,
-        "threshold": 8,
-        "share_below_threshold": 0.15542521994134897,
+        "threshold": 2,
+        "share_below_threshold": 0.03225806451612903,
         "min": 1.0,
         "p1": 1.0,
         "p5": 2.0,
@@ -30,8 +29,8 @@
       },
       "MEDIUM": {
         "sample_size": 896,
-        "threshold": 12,
-        "share_below_threshold": 0.16964285714285715,
+        "threshold": 7,
+        "share_below_threshold": 0.04575892857142857,
         "min": 1.0,
         "p1": 1.0,
         "p5": 7.0,
@@ -43,8 +42,8 @@
       },
       "HARD": {
         "sample_size": 548,
-        "threshold": 15,
-        "share_below_threshold": 0.12226277372262774,
+        "threshold": 8,
+        "share_below_threshold": 0.04744525547445255,
         "min": 1.0,
         "p1": 1.9399999999999995,
         "p5": 8.0,
@@ -53,6 +52,19 @@
         "median": 24.0,
         "p75": 30.0,
         "max": 72.0
+      },
+      "WET": {
+        "sample_size": 110,
+        "threshold": 6,
+        "share_below_threshold": 0.045454545454545456,
+        "min": 2.0,
+        "p1": 3.09,
+        "p5": 6.0,
+        "p10": 7.9,
+        "p25": 11.0,
+        "median": 12.0,
+        "p75": 19.0,
+        "max": 44.0
       }
     }
   }

--- a/documents/eval_reports/stint_lengths.md
+++ b/documents/eval_reports/stint_lengths.md
@@ -1,6 +1,6 @@
 # stint_lengths
 
-- harness `af96fb6` · schema v1 · generated 2026-07-29T09:39:31+00:00
+- harness `fc73c53` · schema v1 · generated 2026-08-03T08:32:16+00:00
 - era 2022-2025 · dataset data/raw laps 2023-2025 (RAW, not featured) · seed deterministic · llm none
 - artifacts: —
 
@@ -8,25 +8,35 @@
 
 Every completed stint that ended in a real green-flag pit stop, counted in
 tyre-age laps: the `TyreLife` reading at the moment of the stop, the exact
-field `apply_guard_rails` compares against `_MIN_STINT_LAPS`. A stint that
-ended because the race finished, or because the driver retired, is not a
+field `apply_guard_rails` compares against its minimum-stint bound. A stint
+that ended because the race finished, or because the driver retired, is not a
 decision to stop and is excluded by construction: neither ever produces a
 lap with `PitInTime` set.
 
+The last row is INTERMEDIATE and WET together. They carry no entry of their
+own in `_MIN_STINT_LAPS`, so the rail's `.get(compound, _DEFAULT_MIN_STINT)`
+resolves them to the fallback -- a minimum-stint bound like any other, and
+one this report used to drop rather than measure.
+
 | compound | n | threshold (laps) | shorter than threshold | min | p1 | p5 | p10 | p25 | median | p75 | max |
 |---|---|---|---|---|---|---|---|---|---|---|---|
-| SOFT | 341 | 8 | 15.5% | 1.0 | 1.0 | 2.0 | 5.0 | 9.0 | 15.0 | 21.0 | 50.0 |
-| MEDIUM | 896 | 12 | 17.0% | 1.0 | 1.0 | 7.0 | 9.0 | 14.0 | 19.0 | 25.0 | 55.0 |
-| HARD | 548 | 15 | 12.2% | 1.0 | 1.9 | 8.0 | 13.0 | 18.0 | 24.0 | 30.0 | 72.0 |
+| SOFT | 341 | 2 | 3.2% | 1.0 | 1.0 | 2.0 | 5.0 | 9.0 | 15.0 | 21.0 | 50.0 |
+| MEDIUM | 896 | 7 | 4.6% | 1.0 | 1.0 | 7.0 | 9.0 | 14.0 | 19.0 | 25.0 | 55.0 |
+| HARD | 548 | 8 | 4.7% | 1.0 | 1.9 | 8.0 | 13.0 | 18.0 | 24.0 | 30.0 | 72.0 |
+| WET | 110 | 6 | 4.5% | 2.0 | 3.1 | 6.0 | 7.9 | 11.0 | 12.0 | 19.0 | 44.0 |
 
 "shorter than threshold" is the share of real stints the current guard rail
 would have overridden to STAY_OUT had a strategist tried to make that exact
-call: `TyreLife < _MIN_STINT_LAPS[compound]`, the same strict inequality
-`apply_guard_rails` itself uses. Close to zero means the bound sits where
-real strategy essentially never goes; anywhere else means it is vetoing
-calls a real pit wall has actually made.
+call: `TyreLife < the bound`, the same strict inequality `apply_guard_rails`
+itself uses.
 
-- real green-flag stints counted: 1785 across 71 races
-- wet-compound stops dropped (INTERMEDIATE/WET is not a dry-tyre-life question): 110
+This share IS the calibration of a proscriptive bound, and the number the
+bounds are set from (#716). A bound exists so a generative model cannot emit
+nonsense, so it has to sit where real strategy essentially never goes; once it
+is vetoing a meaningful share of what professional pit walls actually did, it
+is separating unusual from usual rather than absurd from sane. The ceiling the
+bounds are held to is **5%**, and every row above is expected to clear it.
+
+- real green-flag stints counted: 1895 across 71 races
 - stops dropped for missing compound/tyre-life data: 5
 

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -30,6 +30,8 @@ import pandas as pd
 import xgboost as xgb
 
 from src.agents._shared_defaults import reading_or_default
+# Safe in this direction: envelope.py is a leaf that imports nothing from src.agents.
+from src.strategy.inference.envelope import OperatingEnvelope
 
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent
@@ -84,6 +86,55 @@ _NOISE_PCT: float  = 0.02   # 2 % Gaussian noise on continuous features
 # lives in tire_agent._add_fuel_cols; deliberately duplicated rather than shared, since
 # unifying constants across agent modules is a wider refactor than this fix (#446).
 FUEL_GAIN_PER_LAP_S: float = 0.055
+
+
+# ── N06's operating envelope (#710) ──────────────────────────────────────────
+# The range each continuous feature actually took across N06's training seasons,
+# so that a call outside it stops being silent. Until now this agent had no range
+# check of any kind, which is the condition the envelope contract was written for:
+# an XGBoost regressor answers an out-of-range call with exactly the confidence it
+# answers an in-range one, and N26 spent two years doing precisely that.
+#
+# MEASURED, NOT CHOSEN, and reproducible: rebuild 2023 + 2024 through
+# `augment_featured_laps`, apply the two N06 feature steps `pace_holdout.py` already
+# owns (`_encode_categoricals` then `_add_lag_deg_features`), drop the rows N06 drops,
+# and take the min/max of each column over the resulting 42,957 rows.
+# `tests/agents/test_n06_envelope.py` re-runs that measurement and fails if any bound
+# below has drifted from it, so these cannot quietly become hand-typed numbers.
+#
+# Why these twelve and not all twenty-five:
+#   - The identifiers and codes (DriverNumber, TeamID, CompoundID, Cluster, Year) and
+#     the flags (FreshTyre, Rainfall) have no range to be outside of. A bound on a
+#     label is a category check wearing the wrong contract.
+#   - The three Prev_Deg* features are excluded DELIBERATELY, and the reason matters
+#     because it is the opposite of what it looks like. `run_from_state` hardcodes all
+#     three to 0.0 on every real call, which reads like the textbook out-of-range bug.
+#     Measured, it is not one: 0.0 sits mid-distribution for all three (42%/42%/47% of
+#     training rows fall below it), so an envelope would never fire and declaring one
+#     here would advertise a check that cannot work. Feeding a model a CONSTANT where
+#     it was trained on a distribution is a real defect, but it is a different defect
+#     and it needs its own instrument, not this one.
+#
+# The bounds are TRAINING-season ranges (2023-2024). This is not the same thing as the
+# "range 0..3.685 s" recorded next to FUEL_GAIN_PER_LAP_S above, which was measured on
+# laps_featured_2025: 2025 is the held-out TEST season, and an envelope sourced from it
+# would be describing where the model is asked to work rather than where it was fitted.
+_N06_TRAINED_BOUNDS: dict[str, tuple[float, float]] = {
+    'LapNumber':         (3.0, 78.0),
+    'TyreLife':          (3.0, 78.0),
+    'FuelLoad':          (0.0, 0.9615),
+    'FuelEffect':        (0.055, 4.125),
+    'Prev_LapTime':      (67.719, 148.991),
+    'Prev_TyreLife':     (2.0, 77.0),
+    'Prev_SpeedST':      (156.0, 362.0),
+    'AirTemp':           (14.5, 33.7),
+    'TrackTemp':         (16.7, 50.7),
+    'Humidity':          (18.0, 92.0),
+    'laps_remaining':    (0.0, 75.0),
+    'mean_sector_speed': (196.6292354740061, 314.9705586672411),
+}
+
+_N06_ENVELOPE = OperatingEnvelope(name='n06_laptime_delta', bounds=_N06_TRAINED_BOUNDS)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -405,7 +456,34 @@ class PaceAgent:
         # converts None→NaN and the model handles NaN natively via its
         # sparse-aware split logic (default_left). Cheap and defensive —
         # no-op on already-numeric frames.
-        return df.apply(pd.to_numeric, errors='coerce')
+        numeric = df.apply(pd.to_numeric, errors='coerce')
+        self._label_against_envelope(numeric)
+        return numeric
+
+    @staticmethod
+    def _label_against_envelope(feature_df: pd.DataFrame) -> None:
+        """Say out loud when N06 is being asked to predict outside its trained range.
+
+        LABELS ONLY, and that is the contract, not a shortcut: nothing here clips,
+        refuses or alters a single value the model is fed, so the frame returned by
+        `_build_feature_row` is byte-identical to the one returned before this
+        existed and the strategy goldens cannot move (#710).
+
+        Only ``violations`` are reported, never ``unknown``. A feature that arrived
+        as NaN was not given a bad value, it was given no value, and the two must
+        stay distinguishable: the places that can produce a NaN here already warn
+        for themselves (`_compute_derived` on an absent stint baseline, and the
+        deliberate None-propagation of an unknown Position), so folding them in
+        would double-report the known cases and drown the one this exists to catch.
+        """
+        verdict = _N06_ENVELOPE.check(feature_df.iloc[0].to_dict())
+        if verdict.violations:
+            logger.warning(
+                'N06 called outside its trained range on %d feature(s): %s; the '
+                'prediction is an extrapolation, not a fit',
+                len(verdict.violations),
+                dict(verdict.violations),
+            )
 
     # ── Inference helpers ─────────────────────────────────────────────────────
 

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -102,36 +102,59 @@ FUEL_GAIN_PER_LAP_S: float = 0.055
 # `tests/agents/test_n06_envelope.py` re-runs that measurement and fails if any bound
 # below has drifted from it, so these cannot quietly become hand-typed numbers.
 #
-# Why these twelve and not all twenty-five:
-#   - The identifiers and codes (DriverNumber, TeamID, CompoundID, Cluster, Year) and
-#     the flags (FreshTyre, Rainfall) have no range to be outside of. A bound on a
-#     label is a category check wearing the wrong contract.
-#   - The three Prev_Deg* features are excluded DELIBERATELY, and the reason matters
-#     because it is the opposite of what it looks like. `run_from_state` hardcodes all
-#     three to 0.0 on every real call, which reads like the textbook out-of-range bug.
-#     Measured, it is not one: 0.0 sits mid-distribution for all three (42%/42%/47% of
-#     training rows fall below it), so an envelope would never fire and declaring one
-#     here would advertise a check that cannot work. Feeding a model a CONSTANT where
-#     it was trained on a distribution is a real defect, but it is a different defect
-#     and it needs its own instrument, not this one.
+# WHICH TEN OF THE TWENTY-FIVE, and why each of the other fifteen is out. A bound is a
+# claim that the value at inference is the same quantity, in the same units, as the
+# column the range was measured from. Where that is not true, a bound does not measure
+# extrapolation, it measures a wiring defect, and it reports it under the wrong name.
+#
+#   Excluded, no range to be outside of (8): DriverNumber, TeamID, CompoundID, Cluster,
+#   Year, Stint and Position are identifiers, codes or ranks; FreshTyre and Rainfall are
+#   flags. A bound on a label is a category check wearing the wrong contract.
+#
+#   Excluded, the value at inference is NOT the quantity the range describes (4):
+#     - The three Prev_Deg* features. `run_from_state` hardcodes all three to 0.0 on
+#       every real call, which reads like the textbook out-of-range bug. Measured, it is
+#       not one: 0.0 sits mid-distribution for each (42.6% / 41.9% / 46.7% of training
+#       rows fall below it), so a bound could never fire and declaring one would
+#       advertise a check that cannot work.
+#     - `mean_sector_speed`. `_compute_derived` falls back to `prev_speed_st` whenever a
+#       mean sector speed is absent, and `run_from_state` never supplies one, so at
+#       inference this feature ALWAYS carries the speed trap. They are different physical
+#       quantities with different distributions (training means 256.8 vs 303.0 km/h), and
+#       a bound over the first one applied to the second fires on 83% of laps at Monza
+#       while describing none of them correctly. This is the twin of the Prev_Deg* case
+#       and it was missed on the first pass precisely because only one of the pair was
+#       looked at, which is this repo's most reliable defect.
+#
+#   Excluded, a bound would report the same event twice (1): `LapsSincePitStop`.
+#   `run_from_state` passes `d.get('tyre_life') or 1` for BOTH it and `TyreLife`, so at
+#   inference they are the same number and a second bound is a second warning about one
+#   underlying cause.
+#
+#   Excluded, training and inference encode it differently (1): `FuelLoad`. The featured
+#   artefact stores it rounded to four decimals, giving a measured maximum of 0.9615,
+#   while inference computes `laps_remaining / total_laps` live and unrounded. A 78-lap
+#   race yields 0.96153..., above that maximum, so the bound would fire on a class of lap
+#   the model was trained on. Comparing two encodings of a quantity is not a range check.
+#
+# Feeding a model a constant, or the wrong quantity, or a differently-rounded one, are
+# all real defects. They are simply not THIS defect, and each needs its own instrument.
 #
 # The bounds are TRAINING-season ranges (2023-2024). This is not the same thing as the
 # "range 0..3.685 s" recorded next to FUEL_GAIN_PER_LAP_S above, which was measured on
 # laps_featured_2025: 2025 is the held-out TEST season, and an envelope sourced from it
 # would be describing where the model is asked to work rather than where it was fitted.
 _N06_TRAINED_BOUNDS: dict[str, tuple[float, float]] = {
-    'LapNumber':         (3.0, 78.0),
-    'TyreLife':          (3.0, 78.0),
-    'FuelLoad':          (0.0, 0.9615),
-    'FuelEffect':        (0.055, 4.125),
-    'Prev_LapTime':      (67.719, 148.991),
-    'Prev_TyreLife':     (2.0, 77.0),
-    'Prev_SpeedST':      (156.0, 362.0),
-    'AirTemp':           (14.5, 33.7),
-    'TrackTemp':         (16.7, 50.7),
-    'Humidity':          (18.0, 92.0),
-    'laps_remaining':    (0.0, 75.0),
-    'mean_sector_speed': (196.6292354740061, 314.9705586672411),
+    'LapNumber':      (3.0, 78.0),
+    'TyreLife':       (3.0, 78.0),
+    'FuelEffect':     (0.055, 4.125),
+    'Prev_LapTime':   (67.719, 148.991),
+    'Prev_TyreLife':  (2.0, 77.0),
+    'Prev_SpeedST':   (156.0, 362.0),
+    'AirTemp':        (14.5, 33.7),
+    'TrackTemp':      (16.7, 50.7),
+    'Humidity':       (18.0, 92.0),
+    'laps_remaining': (0.0, 75.0),
 }
 
 _N06_ENVELOPE = OperatingEnvelope(name='n06_laptime_delta', bounds=_N06_TRAINED_BOUNDS)

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -102,6 +102,22 @@ _COMPOUND_FALLBACK: dict[str, int] = {'HARD': 1, 'MEDIUM': 3, 'SOFT': 5}
 # the same standing as VSC_PIT_BONUS and WINDOW_LAPS in strategy_orchestrator.
 _STINT_CAPACITY_LAPS: dict[str, int] = {'SOFT': 18, 'MEDIUM': 30, 'HARD': 38}
 
+# The FLOOR of the MEDIUM suitability band in both prompts' "COMPOUND vs REMAINING
+# LAPS" rule: below this many laps left, fit a SOFT instead. Same standing as
+# _STINT_CAPACITY_LAPS above, a modelling assumption rather than a measurement.
+#
+# It exists as its own constant because it was previously rendered from
+# `_MIN_STINT_LAPS['MEDIUM']`, and those are two different rules that happened to
+# share the number 12. One asks "has this set run long enough to be worth
+# replacing?", the other asks "is there enough race left for this compound to make
+# sense?" — nothing ties them, and the coupling was invisible because the values
+# agreed. It surfaced when #716 recalibrated the minimum-stint bound to 7 against
+# real stint lengths and silently rewrote this unrelated rule to "MEDIUM: suitable
+# for 7-30 remaining laps" in the DEFAULT LLM path. 12 is what this band has always
+# said; the recalibration must not move it. Do NOT re-derive it from another
+# constant: a shared value is not a shared meaning.
+_MEDIUM_SUITABILITY_FLOOR_LAPS: int = 12
+
 # N16 trained Lap_gap as the offset between the two stops (lap_y - lap_x), never the
 # race lap. At inference we always score the canonical undercut: we box on this lap and
 # the rival responds on the next one, so the offset is 1 (#444).
@@ -681,7 +697,7 @@ MINIMUM STINT LENGTH before a pit makes sense:
 
 COMPOUND vs REMAINING LAPS:
   SOFT: recommend only if remaining laps <= {_STINT_CAPACITY_LAPS['SOFT']} (it won't last longer).
-  MEDIUM: suitable for {_MIN_STINT_LAPS['MEDIUM']}-{_STINT_CAPACITY_LAPS['MEDIUM']} remaining laps.
+  MEDIUM: suitable for {_MEDIUM_SUITABILITY_FLOOR_LAPS}-{_STINT_CAPACITY_LAPS['MEDIUM']} remaining laps.
   HARD: suitable for 20+ remaining laps.
   Picking SOFT with 25 laps to go forces an extra pit stop — factor that cost in.
 

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -79,6 +79,7 @@ from src.agents.race_situation_agent import (
 from src.agents.pit_strategy_agent import (
     run_pit_strategy_agent,
     run_pit_strategy_agent_from_state,
+    _MEDIUM_SUITABILITY_FLOOR_LAPS,
     _STINT_CAPACITY_LAPS,
 )
 
@@ -1700,7 +1701,7 @@ def _build_orchestrator_prompt(
         # deterministic selector's table (18 vs 15), so laps_remaining=16-18 had the
         # selector pass SOFT while both prompts told the LLM to refuse it (#741).
         f"  5. Compound must fit remaining laps: SOFT only if <= {_STINT_CAPACITY_LAPS['SOFT']} laps remain,\n"
-        f"     MEDIUM for {_MIN_STINT_LAPS['MEDIUM']}-{_STINT_CAPACITY_LAPS['MEDIUM']}, "
+        f"     MEDIUM for {_MEDIUM_SUITABILITY_FLOOR_LAPS}-{_STINT_CAPACITY_LAPS['MEDIUM']}, "
         f"HARD for 20+. Wrong compound forces an extra stop.\n"
         f"  6. Opening laps 1-3: threat levels from N27 are inflated by start chaos.\n"
         f"     Discount them one tier (HIGH→MEDIUM, MEDIUM→LOW) for decision-making.\n"

--- a/src/strategy/eval/decision_modes.py
+++ b/src/strategy/eval/decision_modes.py
@@ -84,6 +84,7 @@ from src.strategy.eval.report import build_header, write_report
 # loads model weights at import time, which would make this report — and every other
 # ``f1-eval`` subcommand next to it — impossible to even import without ``data/models/``.
 from src.strategy.inference.guard_rails import (
+    _DEFAULT_MIN_STINT,
     _MIN_STINT_LAPS,
     _NO_PIT_BEFORE_LAP,
     _PIT_ACTIONS,
@@ -232,8 +233,17 @@ def guard_rail_block(
     the probe passes a life that satisfies every minimum and only the lap-based
     rails apply. That is a stated assumption, not a sentinel: it never becomes a
     value the caller can mistake for a measurement.
+
+    ``_DEFAULT_MIN_STINT`` is folded into that maximum rather than assumed to sit
+    below it. It is not a spare branch here: an unknown compound arrives as ``""``
+    two lines down, so the fallback IS the bound this probe meets in exactly the
+    case the probe exists for. The two happen to be ordered correctly today (#716
+    left them at 8 and 6), and the docstring above would have been quietly false
+    the first time they were not.
     """
-    probe_life = max(_MIN_STINT_LAPS.values()) if tyre_life is None else tyre_life
+    probe_life = (
+        max(*_MIN_STINT_LAPS.values(), _DEFAULT_MIN_STINT) if tyre_life is None else tyre_life
+    )
     action, reason = apply_guard_rails(
         "PIT_NOW", actual_lap, total_laps, compound or "", probe_life
     )

--- a/src/strategy/eval/stint_lengths.py
+++ b/src/strategy/eval/stint_lengths.py
@@ -1,16 +1,21 @@
 """Eval report for the guard rail's own bound: how long do real stints actually run?
 
-``guard_rails.py`` refuses a pit call when ``tyre_life < _MIN_STINT_LAPS[compound]``
-(SOFT 8, MEDIUM 12, HARD 15 laps). Those numbers have never been checked against a
-single real race. This report answers the question that decides whether they are
-doing their job: over every green-flag pit stop in 2023-2025, what share of real
-stints were shorter than the bound that would have overridden them?
+``guard_rails.py`` refuses a pit call when ``tyre_life`` falls below the bound its
+``_MIN_STINT_LAPS.get(compound, _DEFAULT_MIN_STINT)`` lookup resolves. This report
+answers the question that decides whether those bounds are doing their job: over
+every green-flag pit stop in 2023-2025, what share of real stints were shorter than
+the bound that would have overridden them?
 
 If the answer is close to zero, the bound sits where professional strategy never
 goes and is a cheap safety net. If it is not close to zero, the bound is quietly
 vetoing calls a real pit wall has made, which is a very different finding from
-"the rail never fires" — this report exists because nobody had counted it either
-way.
+"the rail never fires". This report exists because nobody had counted it either way.
+
+It is now also the standing calibration check, not just a one-off measurement.
+`_MIN_STINT_LAPS` and `_DEFAULT_MIN_STINT` are IMPORTED, never restated, so every
+run re-measures the bounds actually shipping rather than the ones that were shipping
+when the report was written. #716 set them from this table against a 5% ceiling, and
+`tests/eval/test_stint_lengths.py` asserts that ceiling holds.
 
 WHAT COUNTS AS A STINT LENGTH
 ------------------------------
@@ -43,16 +48,40 @@ import numpy as np
 
 from src.strategy.eval.projection import _neutralised_laps, _raw_data_root, green_flag_stops
 from src.strategy.eval.report import build_header, write_report
-from src.strategy.inference.guard_rails import _MIN_STINT_LAPS
+from src.strategy.inference.guard_rails import _DEFAULT_MIN_STINT, _MIN_STINT_LAPS
 
 # Dry compounds the guard rail actually gates. Order also fixes the report's
 # row order, so a reader sees the softest, shortest-lived compound first.
 _COMPOUNDS: tuple[str, ...] = ("SOFT", "MEDIUM", "HARD")
 
-# Wet compounds run no minimum-stint rule at all (`_MIN_STINT_LAPS.get(compound,
-# _DEFAULT_MIN_STINT)` never fires the SOFT/MEDIUM/HARD boundaries for them), so a
-# wet stint answers a different question than the one this report asks.
+# INTERMEDIATE and WET, counted under the label of the bound they actually hit.
+#
+# This block used to claim wet compounds "run no minimum-stint rule at all", and
+# the report dropped their stints on that basis. The claim is false: the rail
+# resolves its bound with `_MIN_STINT_LAPS.get(compound, _DEFAULT_MIN_STINT)`, so
+# a wet compound misses the three named entries and lands on the FALLBACK, which
+# is a minimum-stint rule like any other. The parenthetical that followed was true
+# in isolation ("never fires the SOFT/MEDIUM/HARD boundaries"), and that is how the
+# wrong headline survived review. It cost this file its purpose on that one bound:
+# when every bound was finally calibrated (#716), the fallback was the worst of
+# them, and it was the only one nothing here had ever measured.
 _WET_COMPOUNDS: frozenset[str] = frozenset({"INTERMEDIATE", "WET"})
+_WET_BUCKET: str = "WET"
+
+# Every bucket the report measures, in row order: the three compounds the rail
+# names, then the fallback every other compound resolves to. Thresholds are read
+# back out of the rail's own lookup rather than restated here, so this report
+# cannot describe a bound the rail does not enforce.
+_REPORTED_BUCKETS: tuple[str, ...] = (*_COMPOUNDS, _WET_BUCKET)
+
+
+def _bound_for(bucket: str) -> int:
+    """The minimum-stint bound the rail resolves for this bucket.
+
+    The same expression `apply_guard_rails` evaluates, called here rather than
+    mirrored, because a retyped boundary has shipped wrong in this codebase before.
+    """
+    return _MIN_STINT_LAPS.get(bucket, _DEFAULT_MIN_STINT)
 
 # The eight points the task and the report both read: the extremes, the tails
 # that matter for a minimum-bound question, and the median. Kept as one ordered
@@ -119,33 +148,32 @@ class CompoundStints:
 
 @dataclass(frozen=True)
 class StintLengthSample:
-    """Completed green-flag stint lengths across the sampled seasons, by compound."""
+    """Completed green-flag stint lengths across the sampled seasons, by bucket."""
 
     by_compound: dict[str, CompoundStints]
-    dropped_wet: int
     dropped_missing: int
     races: int
 
     @property
     def total_counted(self) -> int:
-        """Real green-flag stints that fed one of the three dry-compound samples."""
+        """Real green-flag stints that fed one of the four measured samples."""
         return sum(stats.sample_size for stats in self.by_compound.values())
 
 
 def _compound_bucket(compound: str) -> str:
     """Which counting bucket a raw ``Compound`` reading belongs in.
 
-    Returns the compound name itself for a dry compound, ``"wet"`` for
+    Returns the compound name itself for a dry compound, ``"WET"`` for
     INTERMEDIATE/WET, or ``"unknown"`` for anything else (there is no other label
     on a real green-flag pit lap; this is a defensive catch-all, not a case this
-    dataset is expected to hit). Dataframe-free on purpose: this is the whole
-    rule behind "ignore wet compounds but report how many you dropped", and it
-    needs to be checkable without a parquet file.
+    dataset is expected to hit). Dataframe-free on purpose: this is the whole rule
+    behind which bound a stop is graded against, and it needs to be checkable
+    without a parquet file.
     """
     if compound in _COMPOUNDS:
         return compound
     if compound in _WET_COMPOUNDS:
-        return "wet"
+        return _WET_BUCKET
     return "unknown"
 
 
@@ -189,8 +217,7 @@ def measure_stint_lengths(years: tuple[int, ...] = (2023, 2024, 2025)) -> StintL
             "from the featured parquet)"
         )
 
-    lengths_by_compound: dict[str, list[float]] = {compound: [] for compound in _COMPOUNDS}
-    dropped_wet = 0
+    lengths_by_compound: dict[str, list[float]] = {bucket: [] for bucket in _REPORTED_BUCKETS}
     dropped_missing = 0
     races = 0
 
@@ -219,24 +246,21 @@ def measure_stint_lengths(years: tuple[int, ...] = (2023, 2024, 2025)) -> StintL
                         continue
 
                     bucket = _compound_bucket(compound)
-                    if bucket == "wet":
-                        dropped_wet += 1
-                    elif bucket == "unknown":
+                    if bucket == "unknown":
                         dropped_missing += 1
                     else:
                         lengths_by_compound[bucket].append(tyre_life)
 
     by_compound = {
-        compound: CompoundStints(
-            compound=compound,
-            lengths=np.array(lengths_by_compound[compound], dtype=float),
-            threshold=_MIN_STINT_LAPS[compound],
+        bucket: CompoundStints(
+            compound=bucket,
+            lengths=np.array(lengths_by_compound[bucket], dtype=float),
+            threshold=_bound_for(bucket),
         )
-        for compound in _COMPOUNDS
+        for bucket in _REPORTED_BUCKETS
     }
     return StintLengthSample(
         by_compound=by_compound,
-        dropped_wet=dropped_wet,
         dropped_missing=dropped_missing,
         races=races,
     )
@@ -267,27 +291,35 @@ def _render_table(sample: StintLengthSample | None) -> str:
         "",
         "Every completed stint that ended in a real green-flag pit stop, counted in",
         "tyre-age laps: the `TyreLife` reading at the moment of the stop, the exact",
-        "field `apply_guard_rails` compares against `_MIN_STINT_LAPS`. A stint that",
-        "ended because the race finished, or because the driver retired, is not a",
+        "field `apply_guard_rails` compares against its minimum-stint bound. A stint",
+        "that ended because the race finished, or because the driver retired, is not a",
         "decision to stop and is excluded by construction: neither ever produces a",
         "lap with `PitInTime` set.",
+        "",
+        "The last row is INTERMEDIATE and WET together. They carry no entry of their",
+        "own in `_MIN_STINT_LAPS`, so the rail's `.get(compound, _DEFAULT_MIN_STINT)`",
+        "resolves them to the fallback -- a minimum-stint bound like any other, and",
+        "one this report used to drop rather than measure.",
         "",
         f"| compound | n | threshold (laps) | shorter than threshold | {header_cells} |",
         f"|---|---|---|---|{divider_cells}",
     ]
-    lines += [_compound_row(sample.by_compound[compound]) for compound in _COMPOUNDS]
+    lines += [_compound_row(sample.by_compound[bucket]) for bucket in _REPORTED_BUCKETS]
     lines += [
         "",
         '"shorter than threshold" is the share of real stints the current guard rail',
         "would have overridden to STAY_OUT had a strategist tried to make that exact",
-        "call: `TyreLife < _MIN_STINT_LAPS[compound]`, the same strict inequality",
-        "`apply_guard_rails` itself uses. Close to zero means the bound sits where",
-        "real strategy essentially never goes; anywhere else means it is vetoing",
-        "calls a real pit wall has actually made.",
+        "call: `TyreLife < the bound`, the same strict inequality `apply_guard_rails`",
+        "itself uses.",
+        "",
+        "This share IS the calibration of a proscriptive bound, and the number the",
+        "bounds are set from (#716). A bound exists so a generative model cannot emit",
+        "nonsense, so it has to sit where real strategy essentially never goes; once it",
+        "is vetoing a meaningful share of what professional pit walls actually did, it",
+        "is separating unusual from usual rather than absurd from sane. The ceiling the",
+        "bounds are held to is **5%**, and every row above is expected to clear it.",
         "",
         f"- real green-flag stints counted: {sample.total_counted} across {sample.races} races",
-        "- wet-compound stops dropped (INTERMEDIATE/WET is not a dry-tyre-life "
-        f"question): {sample.dropped_wet}",
         f"- stops dropped for missing compound/tyre-life data: {sample.dropped_missing}",
         "",
     ]
@@ -312,7 +344,6 @@ def build_stint_lengths_report() -> dict[str, Any]:
             else {
                 "races": sample.races,
                 "total_counted": sample.total_counted,
-                "dropped_wet": sample.dropped_wet,
                 "dropped_missing": sample.dropped_missing,
                 "compounds": {
                     compound: {

--- a/src/strategy/inference/guard_rails.py
+++ b/src/strategy/inference/guard_rails.py
@@ -41,21 +41,29 @@ from __future__ import annotations
 
 _PIT_ACTIONS = frozenset({"PIT_NOW", "UNDERCUT", "OVERCUT", "REACTIVE_SC"})
 
-# THE CALIBRATION CEILING every bound below is set from and held to: a bound may
-# veto at most 5% of the real green-flag stops in the measured sample. Above that
-# it is separating unusual from usual rather than absurd from sane, which is the
-# one job an anti-hallucination bound has.
+# THE CALIBRATION CEILING every bound below is HELD TO: a bound may veto at most 5%
+# of the real green-flag stops in the measured sample. Above that it is separating
+# unusual from usual rather than absurd from sane, which is the one job an
+# anti-hallucination bound has.
 #
-# The sample is `f1-eval stint-lengths` over 2023-2025 raw laps: 1900 real
-# green-flag stops across 71 races. Measured shares are quoted per bound below and
-# are reproducible from `documents/eval_reports/stint_lengths.md`, which imports
-# these constants rather than restating them, so the report always grades what is
-# actually shipping. `tests/eval/test_stint_lengths.py` asserts the ceiling holds.
+# Held to, not necessarily set from. The two minimum-stint bounds failed the ceiling
+# and were reset to the largest value that clears it, so for them the ceiling is also
+# the derivation. The two lap-based bounds already cleared it and were left exactly
+# where they were; they are NOT maximal under the rule, and moving them up to the
+# largest passing value would be a change nobody asked for on evidence that only says
+# they are not currently wrong.
+#
+# The sample is 1900 real green-flag stops across 71 races of 2023-2025 raw laps.
+# `documents/eval_reports/stint_lengths.md` regenerates the four minimum-stint shares
+# from these constants on every run, so that report always grades what is actually
+# shipping, and `tests/eval/test_stint_lengths.py` asserts the ceiling holds on them.
+# The two lap-based shares below have no such home: they were measured once over the
+# same sample and are recorded here rather than in an artefact, so treat them as a
+# dated finding rather than as something a report re-checks.
 _CALIBRATION_CEILING = 0.05
 
 # Vetoes 42/1900 = 2.21% of real stops. Unchanged by #716: it already cleared the
-# ceiling. The four stops it blocks in the six-race decision-modes subset read as a
-# large share only because that subset is small; on the full sample it is not.
+# ceiling comfortably.
 _NO_PIT_BEFORE_LAP = 5
 
 # Vetoes 26/1900 = 1.37%. Also unchanged, and the one bound that is partly a FACT
@@ -63,6 +71,12 @@ _NO_PIT_BEFORE_LAP = 5
 # if it is still deployed on the final lap, so the position a late stop surrenders
 # is unrecoverable BY REGULATION. That article does not reach a green-flag lap,
 # where the bound rests on the ~22-25 s cost instead, and on this measurement.
+#
+# This is also the bound behind the four excluded stops in the six-race
+# `decision-modes` subset (Monaco VER, Lusail STR and HAD, Monza OCO). #716's issue
+# body attributes four stops to the early-race bound as well; measured on that
+# subset the early-race bound excludes NONE, and `decision_modes.md` carries no
+# `opening_laps` row at all.
 _NO_PIT_LAST_N_LAPS = 3
 
 _CLIFF_P10_SAFE = 2
@@ -87,6 +101,14 @@ _MIN_STINT_LAPS = {"SOFT": 2, "MEDIUM": 7, "HARD": 8}
 # comment claiming they ran no minimum-stint rule at all. They run this one.
 #
 #   6 -> 4.55% (110 wet stops)
+#
+# KNOWN DIVERGENCE, and it is the reverse of the usual one: this bound has NO prose copy
+# in either prompt. N28 and N31 both state the three dry minimums and say nothing about
+# what happens on an INTERMEDIATE or a WET, so the offline path enforces a bound the LLM
+# path was never told about. Documented rather than closed, because adding it means
+# writing new prompt text and that is a behaviour change on the default path, not a
+# recalibration. It matters most in exactly the races where it is least likely to be
+# noticed.
 _DEFAULT_MIN_STINT = 6
 
 

--- a/src/strategy/inference/guard_rails.py
+++ b/src/strategy/inference/guard_rails.py
@@ -17,8 +17,13 @@ a *prescriptive* rail that forces one (the Safety Car ``PIT_NOW`` rail, rejected
 in #464). A proscriptive bound on a generative model's output is legitimate with
 or without a regulation behind it; the test it must pass is CALIBRATION — the
 threshold has to sit where real strategy essentially never goes, so it separates
-absurd from sane rather than unusual from usual. See #716, where the
-minimum-stint threshold is measured against real stint lengths.
+absurd from sane rather than unusual from usual.
+
+#716 ran that test on all four bounds against 1900 real green-flag stops. The two
+lap-based ones passed untouched; the two minimum-stint ones overshot the ceiling by
+between two and four times and were reset from the measurement. Every bound now
+carries its measured veto share, or the article that makes it a fact, at its
+definition below. A bound with neither does not belong in this file.
 
 WHY THIS IS ITS OWN MODULE (#708):
 These rules used to live in ``no_llm.py``, which imports the agent stack and
@@ -35,11 +40,54 @@ the eval tier initially retyped ``remaining < 3`` against the rail's
 from __future__ import annotations
 
 _PIT_ACTIONS = frozenset({"PIT_NOW", "UNDERCUT", "OVERCUT", "REACTIVE_SC"})
+
+# THE CALIBRATION CEILING every bound below is set from and held to: a bound may
+# veto at most 5% of the real green-flag stops in the measured sample. Above that
+# it is separating unusual from usual rather than absurd from sane, which is the
+# one job an anti-hallucination bound has.
+#
+# The sample is `f1-eval stint-lengths` over 2023-2025 raw laps: 1900 real
+# green-flag stops across 71 races. Measured shares are quoted per bound below and
+# are reproducible from `documents/eval_reports/stint_lengths.md`, which imports
+# these constants rather than restating them, so the report always grades what is
+# actually shipping. `tests/eval/test_stint_lengths.py` asserts the ceiling holds.
+_CALIBRATION_CEILING = 0.05
+
+# Vetoes 42/1900 = 2.21% of real stops. Unchanged by #716: it already cleared the
+# ceiling. The four stops it blocks in the six-race decision-modes subset read as a
+# large share only because that subset is small; on the full sample it is not.
 _NO_PIT_BEFORE_LAP = 5
+
+# Vetoes 26/1900 = 1.37%. Also unchanged, and the one bound that is partly a FACT
+# rather than a calibration: under a Safety Car, Art. 55.17 ends the race behind it
+# if it is still deployed on the final lap, so the position a late stop surrenders
+# is unrecoverable BY REGULATION. That article does not reach a green-flag lap,
+# where the bound rests on the ~22-25 s cost instead, and on this measurement.
 _NO_PIT_LAST_N_LAPS = 3
+
 _CLIFF_P10_SAFE = 2
-_MIN_STINT_LAPS = {"SOFT": 8, "MEDIUM": 12, "HARD": 15}
-_DEFAULT_MIN_STINT = 10
+
+# Recalibrated by #716 from SOFT 8 / MEDIUM 12 / HARD 15, which vetoed 15.5% /
+# 17.0% / 12.2% of real stops: one stop in six, three times the ceiling. Each value
+# is now the largest integer whose veto share stays at or under 5%.
+#
+#   SOFT   2 -> 3.2% (341 stops)   MEDIUM 7 -> 4.6% (896)   HARD 8 -> 4.7% (548)
+#
+# SOFT lands lowest because real SOFT stints genuinely are the shortest: 11 of them
+# ran exactly one lap. The bound is not a model of degradation and must not be read
+# as one. It only forbids stopping on a set fitted so recently that no strategy
+# produced it, and where that line falls differs per compound because the evidence
+# differs per compound.
+_MIN_STINT_LAPS = {"SOFT": 2, "MEDIUM": 7, "HARD": 8}
+
+# The bound every compound with no entry above resolves to, which in practice means
+# INTERMEDIATE and WET. Recalibrated by #716 from 10, and it was the WORST of the
+# set at 20.0% of real wet stops vetoed, because it was also the only one nothing
+# had ever measured: the stint-length report dropped wet stops on the strength of a
+# comment claiming they ran no minimum-stint rule at all. They run this one.
+#
+#   6 -> 4.55% (110 wet stops)
+_DEFAULT_MIN_STINT = 6
 
 
 def apply_guard_rails(
@@ -53,9 +101,12 @@ def apply_guard_rails(
 ) -> tuple[str, str | None]:
     """Override *action* with STAY_OUT when a hard strategic constraint fires.
 
-    Rules: no pit before lap 5; no pit in the last 3 laps unless the cliff is
-    imminent (cliff_p10 < 2); minimum stint SOFT 8 / MEDIUM 12 / HARD 15. Returns
-    ``(action, reason)`` with ``reason=None`` when no rail fired.
+    Three bounds, in the order they are evaluated: the pit window is not open yet;
+    it is too late to matter unless the cliff is imminent; the set was fitted too
+    recently for any strategy to have produced this call. The numbers are the module
+    constants and are deliberately not restated here, because a retyped boundary has
+    shipped wrong in this codebase before. Returns ``(action, reason)`` with
+    ``reason=None`` when no bound fired.
 
     Args:
         sc_active: A neutralisation (Safety Car or VSC) is deployed right now.

--- a/tests/agents/test_n06_envelope.py
+++ b/tests/agents/test_n06_envelope.py
@@ -108,29 +108,65 @@ def test_a_missing_feature_is_not_reported_as_out_of_range(caplog):
 # --- the bounds describe features that have a range at all -------------------
 
 
-@pytest.mark.parametrize("labelled", ["DriverNumber", "TeamID", "CompoundID", "Cluster", "Year"])
-def test_no_bound_is_declared_over_an_identifier(labelled):
-    """A code is not a quantity: `TeamID` between 0 and 10 says nothing about range."""
+# Every N06 feature that carries NO bound, with the reason it carries none. Pinned as a
+# complete set rather than as a handful of examples, because the first version of this
+# file listed only eight of the fifteen and the gap is where the mistake lived: three
+# features were unbounded with no stated reason at all, and one of those (mean_sector_speed)
+# was bounded when it should not have been. An enumeration that does not add up is an
+# enumeration nobody has checked.
+_UNBOUNDED = {
+    # identifiers, codes and ranks: no range to be outside of
+    "DriverNumber": "identifier",
+    "TeamID": "code",
+    "CompoundID": "code",
+    "Cluster": "code",
+    "Year": "code",
+    "Stint": "ordinal",
+    "Position": "rank",
+    "FreshTyre": "flag",
+    "Rainfall": "flag",
+    # the value at inference is not the quantity the range describes
+    "Prev_DegradationRate": "hardcoded 0.0, and 0.0 is mid-distribution",
+    "Prev_CumulativeDeg": "hardcoded 0.0, and 0.0 is mid-distribution",
+    "Prev_DegAcceleration": "hardcoded 0.0, and 0.0 is mid-distribution",
+    "mean_sector_speed": "always carries the speed trap at inference",
+    # a bound would report the same event twice
+    "LapsSincePitStop": "equals TyreLife at inference",
+    # training and inference encode it differently
+    "FuelLoad": "artefact rounded to 4dp, inference computes it unrounded",
+}
+
+
+@pytest.mark.parametrize("feature", sorted(_UNBOUNDED))
+def test_the_unbounded_features_stay_unbounded(feature):
+    """Each of these is excluded on a stated reason, not by omission."""
     from src.agents.pace_agent import _N06_TRAINED_BOUNDS
 
-    assert labelled not in _N06_TRAINED_BOUNDS
+    assert feature not in _N06_TRAINED_BOUNDS, _UNBOUNDED[feature]
 
 
-@pytest.mark.parametrize(
-    "constant", ["Prev_DegradationRate", "Prev_CumulativeDeg", "Prev_DegAcceleration"]
-)
-def test_the_hardcoded_degradation_features_are_deliberately_unbounded(constant):
-    """`run_from_state` pins all three at 0.0, and 0.0 is INSIDE the trained range.
+def test_every_n06_feature_is_either_bounded_or_explicitly_unbounded():
+    """The two sets must partition the model's feature list exactly.
 
-    This reads like the classic out-of-range defect and is not one: roughly 42-47% of
-    training rows fall below zero for each, so a bound could never fire on the pinned
-    value. Declaring one would ship a check that looks like coverage and is not.
-    Feeding a constant where the model saw a distribution is a real problem with its
-    own shape, and this envelope is not the instrument for it.
+    This is the assertion the first version of this file lacked. Without it a feature can
+    be added to N06, or dropped from the bounds, and simply fall through: no test fails,
+    the enumeration comment goes stale, and the envelope quietly stops describing the
+    model it claims to describe.
     """
-    from src.agents.pace_agent import _N06_TRAINED_BOUNDS
+    import json
 
-    assert constant not in _N06_TRAINED_BOUNDS
+    from src.agents.pace_agent import _N06_TRAINED_BOUNDS
+    from src.f1_strat_manager.data_cache import get_models_root
+
+    names_path = get_models_root() / "lap_time" / "xgb_laptime_delta_feature_names.json"
+    if not names_path.exists():
+        pytest.skip("N06 feature-name artefact absent")
+    features = set(json.loads(names_path.read_text()))
+
+    accounted = set(_N06_TRAINED_BOUNDS) | set(_UNBOUNDED)
+    assert features - accounted == set(), "N06 features neither bounded nor excluded"
+    assert accounted - features == set(), "bounds or exclusions naming a feature N06 dropped"
+    assert set(_N06_TRAINED_BOUNDS).isdisjoint(_UNBOUNDED)
 
 
 # --- the one test that checks the bounds against the data they claim to describe ---

--- a/tests/agents/test_n06_envelope.py
+++ b/tests/agents/test_n06_envelope.py
@@ -1,0 +1,186 @@
+"""N06's trained range, now declared as an operating envelope (#710).
+
+The pace agent had no range check of any kind. These pin the two things that
+makes it worth adding and the one thing that would make it dangerous:
+
+1. It LABELS. Not a single value N06 is fed may change, or the strategy goldens
+   move and a real regression becomes indistinguishable from this commit.
+2. It fires on a value outside the trained range, and stays silent inside it. A
+   check that never speaks and a check that always speaks are equally useless.
+3. The bounds are MEASURED, not typed. The data-tier test at the bottom rebuilds
+   the training seasons through N06's own feature recipe and fails if any declared
+   bound has drifted from the range it claims to describe.
+
+Most of this file needs no model weights: the labelling step is a staticmethod
+over a plain frame, so it runs on a bare CI checkout, which is where a silent
+regression would otherwise hide.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_TRAINING_DATA = all(
+    (ROOT / "data" / "processed" / f"laps_featured_{year}.parquet").exists()
+    for year in (2023, 2024)
+)
+
+
+def _row(**overrides) -> pd.DataFrame:
+    """A one-row frame sitting comfortably inside every declared bound."""
+    from src.agents.pace_agent import _N06_TRAINED_BOUNDS
+
+    row = {name: (lo + hi) / 2 for name, (lo, hi) in _N06_TRAINED_BOUNDS.items()}
+    row.update(overrides)
+    return pd.DataFrame([row])
+
+
+def _label(frame: pd.DataFrame) -> None:
+    from src.agents.pace_agent import PaceAgent
+
+    PaceAgent._label_against_envelope(frame)
+
+
+# --- it labels, it never touches ---------------------------------------------
+
+
+def test_labelling_does_not_alter_a_single_value():
+    """The whole licence for this change: the model is fed exactly what it was fed."""
+    frame = _row(TyreLife=500.0, AirTemp=-40.0)
+    before = frame.copy(deep=True)
+
+    _label(frame)
+
+    pd.testing.assert_frame_equal(frame, before)
+
+
+# --- it fires outside, and only outside --------------------------------------
+
+
+def test_a_value_above_the_trained_range_is_announced(caplog):
+    from src.agents.pace_agent import _N06_TRAINED_BOUNDS
+
+    _lower, upper = _N06_TRAINED_BOUNDS["TyreLife"]
+    with caplog.at_level(logging.WARNING):
+        _label(_row(TyreLife=upper + 1))
+
+    assert any("outside its trained range" in r.message for r in caplog.records)
+    assert any("TyreLife" in str(r.args) for r in caplog.records)
+
+
+def test_a_value_below_the_trained_range_is_announced(caplog):
+    """Both directions. A lower bound that is never checked is a lower bound in name only."""
+    from src.agents.pace_agent import _N06_TRAINED_BOUNDS
+
+    lower, _upper = _N06_TRAINED_BOUNDS["Prev_LapTime"]
+    with caplog.at_level(logging.WARNING):
+        _label(_row(Prev_LapTime=lower - 1))
+
+    assert any("outside its trained range" in r.message for r in caplog.records)
+
+
+def test_an_in_range_call_says_nothing(caplog):
+    """A normal lap must be silent, or the signal is worth nothing on a 57-lap race."""
+    with caplog.at_level(logging.WARNING):
+        _label(_row())
+
+    assert not [r for r in caplog.records if "trained range" in r.message]
+
+
+def test_a_missing_feature_is_not_reported_as_out_of_range(caplog):
+    """Unknown is not a violation, and this file must not be the place that conflates them.
+
+    A NaN feature was given no value, not a bad one. The producers that can emit one
+    already warn for themselves, so reporting it again here would bury the case this
+    check exists for under the cases something else already covers.
+    """
+    with caplog.at_level(logging.WARNING):
+        _label(_row(FuelEffect=float("nan")))
+
+    assert not [r for r in caplog.records if "trained range" in r.message]
+
+
+# --- the bounds describe features that have a range at all -------------------
+
+
+@pytest.mark.parametrize("labelled", ["DriverNumber", "TeamID", "CompoundID", "Cluster", "Year"])
+def test_no_bound_is_declared_over_an_identifier(labelled):
+    """A code is not a quantity: `TeamID` between 0 and 10 says nothing about range."""
+    from src.agents.pace_agent import _N06_TRAINED_BOUNDS
+
+    assert labelled not in _N06_TRAINED_BOUNDS
+
+
+@pytest.mark.parametrize(
+    "constant", ["Prev_DegradationRate", "Prev_CumulativeDeg", "Prev_DegAcceleration"]
+)
+def test_the_hardcoded_degradation_features_are_deliberately_unbounded(constant):
+    """`run_from_state` pins all three at 0.0, and 0.0 is INSIDE the trained range.
+
+    This reads like the classic out-of-range defect and is not one: roughly 42-47% of
+    training rows fall below zero for each, so a bound could never fire on the pinned
+    value. Declaring one would ship a check that looks like coverage and is not.
+    Feeding a constant where the model saw a distribution is a real problem with its
+    own shape, and this envelope is not the instrument for it.
+    """
+    from src.agents.pace_agent import _N06_TRAINED_BOUNDS
+
+    assert constant not in _N06_TRAINED_BOUNDS
+
+
+# --- the one test that checks the bounds against the data they claim to describe ---
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_TRAINING_DATA, reason="laps_featured_2023/2024 absent")
+def test_every_declared_bound_matches_the_measured_training_range():
+    """Re-measure, do not re-read. A declared bound is a claim about the training data.
+
+    This is the assertion that keeps `_N06_TRAINED_BOUNDS` sourced rather than typed.
+    It rebuilds 2023 + 2024 exactly the way `pace_holdout.py` rebuilds the holdout
+    (augment, encode, lag, drop) and compares every bound against the range that
+    rebuild produces, so retraining N06 or restating a number fails here and names
+    the feature instead of silently widening what the agent will vouch for.
+    """
+    import json
+
+    from src.agents.pace_agent import _N06_TRAINED_BOUNDS
+    from src.f1_strat_manager.data_cache import get_data_root
+    from src.f1_strat_manager.laps_augment import augment_featured_laps
+    from src.strategy.eval.pace_holdout import (
+        _DROPNA,
+        _add_lag_deg_features,
+        _encode_categoricals,
+    )
+
+    root = get_data_root()
+    manifest = json.loads(
+        (root / "processed" / "feature_manifest_laptime.json").read_text(encoding="utf-8")
+    )
+    encoding = manifest["categorical_encoding"]
+
+    frames = []
+    for year in (2023, 2024):
+        featured = augment_featured_laps(
+            pd.read_parquet(root / "processed" / f"laps_featured_{year}.parquet"), year
+        )
+        encoded = _encode_categoricals(featured, encoding["Compound"], encoding["race_phase"])
+        frames.append(_add_lag_deg_features(encoded).dropna(subset=_DROPNA))
+    train = pd.concat(frames, ignore_index=True)
+
+    assert len(train) > 0, "the rebuilt training frame is empty: nothing below would mean anything"
+
+    for feature, (lower, upper) in _N06_TRAINED_BOUNDS.items():
+        values = pd.to_numeric(train[feature], errors="coerce").dropna()
+        assert values.size > 0, f"{feature} carried no values in the rebuilt training frame"
+        assert lower == pytest.approx(values.min()), (
+            f"{feature} declares a lower bound of {lower}, but N06 trained down to {values.min()}"
+        )
+        assert upper == pytest.approx(values.max()), (
+            f"{feature} declares an upper bound of {upper}, but N06 trained up to {values.max()}"
+        )

--- a/tests/agents/test_prompt_constants_match_tables.py
+++ b/tests/agents/test_prompt_constants_match_tables.py
@@ -224,3 +224,40 @@ def test_the_undercut_threshold_is_not_restated_at_all():
 
     assert "0.522" not in _PIT_STRATEGY_SYSTEM_PROMPT
     assert "score_undercut_tool reports" in _PIT_STRATEGY_SYSTEM_PROMPT
+
+
+# --- two rules, one number: the coupling #716 exposed ------------------------
+
+_MEDIUM_BAND = re.compile(r"MEDIUM\b[^.\n]*?\b(\d+)\s*-\s*\d+")
+
+
+def test_the_medium_suitability_floor_is_not_the_minimum_stint_bound():
+    """Both prompts state a MEDIUM suitability band. Its floor is its OWN constant.
+
+    These are two different questions that shared the number 12 by accident: the
+    minimum-stint bound asks whether a set has run long enough to be worth replacing,
+    the suitability floor asks whether enough race is left for the compound to make
+    sense. Nothing ties them, and while the values agreed the coupling was invisible.
+
+    It surfaced when #716 recalibrated the minimum-stint bound to 7 against real stint
+    lengths: because both prompts rendered the band floor from `_MIN_STINT_LAPS`, the
+    recalibration silently rewrote "MEDIUM: suitable for 12-30 remaining laps" into
+    "7-30" on the DEFAULT LLM path, a rule the issue never touched and nobody reviewed.
+
+    Asserting the floor against its own constant is what catches a re-coupling: point
+    the prompt back at `_MIN_STINT_LAPS['MEDIUM']` and this fails on the mismatch. The
+    prompt-versus-table tests above cannot see it, because they assert equality between
+    prompt and constant and a re-coupled prompt agrees with the WRONG constant.
+    """
+    from src.agents.pit_strategy_agent import _MEDIUM_SUITABILITY_FLOOR_LAPS
+    from src.strategy.inference.guard_rails import _MIN_STINT_LAPS
+
+    for name, prompt in _prompts().items():
+        floors = {int(m.group(1)) for m in _MEDIUM_BAND.finditer(prompt)}
+        assert floors, f"{name} states no MEDIUM band the pattern can see"
+        assert floors == {_MEDIUM_SUITABILITY_FLOOR_LAPS}, (
+            f"{name} states a MEDIUM suitability floor of {floors}, but the constant is "
+            f"{_MEDIUM_SUITABILITY_FLOOR_LAPS}. If it now reads "
+            f"{_MIN_STINT_LAPS['MEDIUM']}, the band has been re-coupled to the "
+            f"minimum-stint bound and moves whenever that is recalibrated."
+        )

--- a/tests/eval/test_decision_modes.py
+++ b/tests/eval/test_decision_modes.py
@@ -91,8 +91,8 @@ def test_importing_the_module_does_not_load_the_agent_stack():
     [
         (3, 57, "MEDIUM", 20, "opening_laps"),
         (56, 57, "MEDIUM", 20, "closing_laps"),
-        (30, 57, "SOFT", 5, "min_stint"),
-        (30, 57, None, 9, "min_stint"),
+        (30, 57, "SOFT", 1, "min_stint"),
+        (30, 57, None, 5, "min_stint"),
         (30, 57, "SOFT", 20, None),
         (30, 57, "MEDIUM", None, None),
     ],

--- a/tests/eval/test_stint_lengths.py
+++ b/tests/eval/test_stint_lengths.py
@@ -24,9 +24,11 @@ from src.strategy.eval.stint_lengths import (
     _PERCENTILE_POINTS,
     CompoundStints,
     StintLengthSample,
+    _bound_for,
     _compound_bucket,
     _render_table,
 )
+from src.strategy.inference.guard_rails import _CALIBRATION_CEILING
 from src.strategy.inference.guard_rails import _MIN_STINT_LAPS as RAIL_MIN_STINT_LAPS
 
 ROOT = Path(__file__).parent.parent.parent
@@ -101,8 +103,8 @@ def test_share_below_threshold_over_an_empty_sample_is_zero():
         ("SOFT", "SOFT"),
         ("MEDIUM", "MEDIUM"),
         ("HARD", "HARD"),
-        ("INTERMEDIATE", "wet"),
-        ("WET", "wet"),
+        ("INTERMEDIATE", "WET"),
+        ("WET", "WET"),
         ("UNKNOWN_TYRE", "unknown"),
         ("", "unknown"),
     ],
@@ -135,11 +137,10 @@ def test_every_dry_compound_has_a_rail_threshold():
 
 
 def _sample(
-    by_compound: dict[str, CompoundStints], dropped_wet=0, dropped_missing=0, races=1
+    by_compound: dict[str, CompoundStints], dropped_missing=0, races=1
 ) -> StintLengthSample:
     return StintLengthSample(
         by_compound=by_compound,
-        dropped_wet=dropped_wet,
         dropped_missing=dropped_missing,
         races=races,
     )
@@ -157,8 +158,8 @@ def test_render_reports_the_headline_share_and_the_drop_counts():
             "SOFT": _stints("SOFT", [5, 8, 10, 20], threshold=8),
             "MEDIUM": _stints("MEDIUM", [10, 12, 20], threshold=12),
             "HARD": _stints("HARD", [15, 18, 22], threshold=15),
+            "WET": _stints("WET", [11, 14], threshold=10),
         },
-        dropped_wet=7,
         dropped_missing=2,
         races=3,
     )
@@ -168,7 +169,6 @@ def test_render_reports_the_headline_share_and_the_drop_counts():
     # One of four SOFT stints (the 5-lap one) undercuts the 8-lap rail: 25.0%.
     assert "25.0%" in body
     assert "dropped" in body
-    assert "7" in body
     assert "2" in body
 
 
@@ -179,6 +179,7 @@ def test_render_states_the_field_it_measures():
             "SOFT": _stints("SOFT", [10], threshold=8),
             "MEDIUM": _stints("MEDIUM", [], threshold=12),
             "HARD": _stints("HARD", [], threshold=15),
+            "WET": _stints("WET", [], threshold=10),
         }
     )
     body = _render_table(sample)
@@ -204,8 +205,48 @@ def test_measured_sample_is_non_empty_before_any_figure_is_believed():
 
     assert sample.races > 0, "no races found under data/raw/2025"
     assert sample.total_counted > 0, "no real green-flag stints were counted: sample is empty"
-    for compound, stats in sample.by_compound.items():
-        assert stats.threshold == RAIL_MIN_STINT_LAPS[compound]
+    for bucket, stats in sample.by_compound.items():
+        assert stats.threshold == _bound_for(bucket)
         # Not every compound need appear at every circuit, but at least one must,
         # or this "distribution by compound" report has nothing to report.
     assert any(stats.sample_size > 0 for stats in sample.by_compound.values())
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_RAW, reason="data/raw absent (CI runner without the dataset)")
+def test_no_minimum_stint_bound_vetoes_more_than_the_calibration_ceiling():
+    """Every minimum-stint bound must still sit where real strategy essentially never goes.
+
+    This is the test #716 exists to leave behind, and it deliberately asserts the
+    EFFECT rather than the values. A test reading ``_MIN_STINT_LAPS["SOFT"] == 2``
+    would pass forever while saying nothing: the repo has shipped exactly that
+    before, a green assertion pinning a threshold that no longer did anything (see
+    #450, where a wired-in bound was compared against the wrong probability scale
+    and its test asserted the constant rather than a single firing).
+
+    What actually went wrong here is what this catches: SOFT 8 / MEDIUM 12 / HARD 15
+    vetoed 15.5% / 17.0% / 12.2% of real green-flag stops, and the wet fallback 20.0%
+    -- one real stop in six overridden by a bound whose entire licence to exist is
+    that real strategy does not go there. Raise any bound back above the ceiling and
+    this fails naming the compound and the share.
+
+    Measured over all three seasons rather than 2025 alone, because that is the
+    sample the bounds were set from; a single season would grade them against
+    evidence they were not calibrated on.
+    """
+    from src.strategy.eval.stint_lengths import measure_stint_lengths
+
+    sample = measure_stint_lengths()
+
+    graded = {
+        bucket: stats for bucket, stats in sample.by_compound.items() if stats.sample_size > 0
+    }
+    assert graded, "no bucket carried a sample: the ceiling would hold vacuously"
+
+    for bucket, stats in graded.items():
+        assert stats.share_below_threshold <= _CALIBRATION_CEILING, (
+            f"the {bucket} minimum-stint bound of {stats.threshold} laps vetoes "
+            f"{stats.share_below_threshold:.1%} of {stats.sample_size} real green-flag "
+            f"stops, above the {_CALIBRATION_CEILING:.0%} ceiling: it is separating "
+            f"unusual from usual, not absurd from sane"
+        )

--- a/tests/eval/test_stint_lengths.py
+++ b/tests/eval/test_stint_lengths.py
@@ -238,10 +238,23 @@ def test_no_minimum_stint_bound_vetoes_more_than_the_calibration_ceiling():
 
     sample = measure_stint_lengths()
 
+    # Pin the bucket set BEFORE filtering. Skipping empty buckets is right (a compound
+    # absent from the sample says nothing about its bound), but it is also how a bound
+    # stops being graded without anything failing: drop WET from the report and the
+    # ceiling would hold over three buckets while the fourth, the worst-calibrated one
+    # in #716, quietly left the measurement. The set is the claim; the shares come after.
+    from src.strategy.eval.stint_lengths import _REPORTED_BUCKETS
+
+    assert set(sample.by_compound) == set(_REPORTED_BUCKETS)
+    assert "WET" in sample.by_compound, "the fallback bound must stay measured"
+
     graded = {
         bucket: stats for bucket, stats in sample.by_compound.items() if stats.sample_size > 0
     }
-    assert graded, "no bucket carried a sample: the ceiling would hold vacuously"
+    assert set(graded) == set(_REPORTED_BUCKETS), (
+        f"only {sorted(graded)} carried a sample; a bound with no sample is a bound "
+        f"the ceiling holds over vacuously"
+    )
 
     for bucket, stats in graded.items():
         assert stats.share_below_threshold <= _CALIBRATION_CEILING, (


### PR DESCRIPTION
## What

Two issues that share one adversarial audit.

**#716 — recalibrate the anti-hallucination pit bounds.** All four minimum-stint bounds were measured against 1900 real green-flag stops across 71 races and reset to the largest integer that vetoes at most 5% of them.

| bound | was | vetoed | now | vetoes |
|---|---|---|---|---|
| SOFT | 8 | 15.5% | **2** | 3.2% |
| MEDIUM | 12 | 17.0% | **7** | 4.6% |
| HARD | 15 | 12.2% | **8** | 4.7% |
| wet fallback | 10 | **20.0%** | **6** | 4.5% |
| `_NO_PIT_BEFORE_LAP` | 5 | 2.21% | unchanged | — |
| `_NO_PIT_LAST_N_LAPS` | 3 | 1.37% | unchanged | — |

**#710 — roll the operating envelope out to the pace agent.** `pace_agent.py` had no range check of any kind. Ten continuous features now declare the range N06 actually trained on, labelling out-of-range calls without touching a single value the model is fed.

## Why

A proscriptive bound is legitimate without a regulation behind it, but only if it is CALIBRATED: it has to sit where real strategy essentially never goes. At the 12th to 17th percentile of real stint lengths these bounds were separating unusual from usual, and the wet fallback at 20% was the worst of the four.

That fallback was also the one nobody had measured, because `stint_lengths.py` carried a comment claiming wet compounds "run no minimum-stint rule at all". They miss the three named entries and land on the fallback, which is a minimum-stint rule like any other. The report counted 110 wet stops only to drop them.

## What moved

`f1-eval decision-modes`, re-run twice with byte-identical payloads:

| | before | after |
|---|---|---|
| `min_stint` bucket | 17 | **5** |
| stops scored | 54 of 178 (30.3%) | **67 (37.6%)** |
| within 1 lap | 44.4% | **47.8%** |
| within 2 laps | 51.9% | **61.2%** |
| exact lap | 33.3% | 31.3% |

Thirteen stops the old bound made impossible to agree with entered the scored sample, and window agreement improved on the wider sample. Exact-lap agreement is slightly down.

A real `f1-sim Lusail NOR McLaren --no-llm` run with the real radio corpus moves exactly one lap from STAY_OUT to UNDERCUT. Final position, final stint and best lap are unchanged. Strategy goldens are byte-identical.

## What the gates caught

Two adversarial gates ran read-only over the branch. The first found a HIGH defect this change introduced: both prompts rendered the floor of the MEDIUM compound-suitability band from `_MIN_STINT_LAPS['MEDIUM']`, two different rules sharing the number 12 by accident, so recalibrating the bound to 7 rewrote "MEDIUM: suitable for 12-30 remaining laps" into "7-30" on the default LLM path. The band now has its own constant and a test that fails on a re-coupling.

The second found that `mean_sector_speed` should never have been bounded: `_compute_derived` falls back to `prev_speed_st` and `run_from_state` never supplies a mean sector speed, so at inference the feature always carries the speed trap, a different physical quantity. That is the exact twin of the `Prev_Deg` case the change already documents, and only one of the pair had been examined. Removing it and `FuelLoad` (rounded in the artefact, computed unrounded at inference) cut the warning rate from 14 laps in 57 to 6.

Both reports are in `documents/audits/`, alongside the design diagnosis and every measurement.

## Out of scope

- Moving the minimum-stint preference into the Monte Carlo cost. `AUDIT_A2` measured that as a sprint: neither MC scorer has any tyre-life or compound input, and `decision_modes.py`'s exclusion methodology assumes a categorical veto.
- The wet fallback has no prose copy in either prompt, so the offline path enforces a bound the LLM path was never told about. Documented, not closed, because closing it means new prompt text on the default path.
- N06 is asked to predict on race starts and stint openers it was never trained on, because its own dropna removes them. The envelope now says so out loud; fixing the train/serve gap is its own issue.

## Checks

- `uvx ruff@0.15.22 check .` and `format --check .` clean under the CI pin
- strategy goldens and projection golden byte-identical
- full suite: 7 failures and 4 errors, all reproduced on a `dev` worktree with the same data. Six trace to `data/processed/undercut_labeled/undercut_clean.parquet`, which does not exist in the Hugging Face dataset at all; the NLP goldens report `pending` because the NLP weights are not downloaded locally.

Closes #716
Refs #710
