### PR TITLE
fix(agents): feed N06 the circuit's mean sector speed instead of the speed trap

### DIFF
--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -100,8 +100,9 @@ See [Arcade strategy pipeline](#/arcade-strategy-pipeline) for the shared engine
 
 Wraps the N06 XGBoost delta-lap-time model. Returns predicted lap time, delta signals against previous lap and session median, and bootstrap confidence intervals (N=200 draws with 2% Gaussian noise on continuous features).
 
-- **Model**: XGBoost trained on 2023–2025 lap data
+- **Model**: XGBoost fitted on 2023–2024 lap data, with **2025 held out**. This line used to read "2023–2025", which quietly folded the test season into the training set: the feature manifest's own row counts are 22,106 train and 23,256 validation, exactly the 2023 and 2024 featured parquets, and every operating bound below is measured on those two seasons for the same reason.
 - **Output**: `PaceOutput` (lap_time_pred, delta_vs_prev, delta_vs_median, ci_p10, ci_p90)
+- **Circuit feature**: `mean_sector_speed` is a property of the track, one value per GP, looked up from the featured parquet. It used to be substituted with the speed trap on every call through the `RaceStateManager` path; see the operating-envelope section under N28 for how that surfaced.
 - **No LLM step**: unlike its tire/pit/race-situation siblings below, pace calls the XGBoost model directly — `reasoning` is a deterministic f-string, not LLM output. Pace is the one always-on agent with no qualitative judgment to make (no `warning_level`/`action`/`threat_level` category alongside its numbers), so a `pace_agent.py` once carried a complete but never-wired LangGraph ReAct scaffold; it was formally retired in #781 after the #778/#779/#780 archaeology and decision. See [agents-api.md](#/agents-api) for the full record.
 
 ### N26: Tire Agent (`tire_agent.py`)
@@ -161,6 +162,49 @@ It also silenced the computation built to weigh it: with an SC deployed `sc_prob
 Staying out under an SC is right whenever you have already stopped, you lead a pack that must stop anyway, you would rejoin into traffic, or the race is ending. Boxing is right when you must stop anyway, the tyres are near the cliff, or the two-compound rule is unsatisfied and time is short. Not one of those is a rule. All of them are race state the model is given, and a rail sees none of it.
 
 See `tests/mc/test_sc_regulatory_rails.py`.
+
+##### The bounds that stayed, and the test they have to pass
+
+Removing that rail did not remove the pit bounds, because they are a different kind of object and are judged differently.
+
+| | What it does | What justifies it |
+|---|---|---|
+| **Prescriptive** rail | Makes the strategic decision *for* the model | A regulation, or nothing |
+| **Proscriptive** bound | Forbids an action so a generative model cannot emit nonsense | **Calibration** |
+
+Bounding an LLM's output space is legitimate engineering with or without an FIA article: the bounds exist so nothing can recommend a lap-2 stop because it felt like one. But a bound only earns that description if it sits where real strategy essentially never goes. The rule the project holds them to is explicit: **a bound may veto at most 5% of real green-flag stops**, measured over 1900 of them across 71 races of 2023-2025.
+
+Checked against that rule, three of the four minimum-stint bounds were separating *unusual* from *usual* rather than *absurd* from *sane*, and were reset to the largest value that clears the ceiling:
+
+| Bound | Was | Vetoed | Now | Vetoes |
+|---|---|---|---|---|
+| Minimum stint, SOFT | 8 laps | 15.5% | **2** | 3.2% |
+| Minimum stint, MEDIUM | 12 laps | 17.0% | **7** | 4.6% |
+| Minimum stint, HARD | 15 laps | 12.2% | **8** | 4.7% |
+| Minimum stint, wet fallback | 10 laps | 20.0% | **6** | 4.5% |
+| No pit before lap 5 | 5 | 2.21% | unchanged | 2.21% |
+| No pit in the last 3 laps | 3 | 1.37% | unchanged | 1.37% |
+
+The end-of-race bound is the only one that is partly a *fact*: under a Safety Car, Art. 55.17 ends the race behind it if it is still deployed on the final lap, so the position a late stop surrenders is unrecoverable by regulation rather than merely expensive. That article does not reach a green-flag lap, where the bound rests on the stop cost and on the measurement above.
+
+The compounding effect is what made the old values worth changing rather than merely wrong. A stop inside a bound can never be agreed with, so it is excluded from the decision-agreement measurement: the bound was removing its own hardest cases from the evidence about itself. After the recalibration the `min_stint` exclusion bucket falls from 17 stops to 5, the scored sample rises from 54 to 67 of 178, and agreement within two laps rises from 51.9% to 61.2%.
+
+`documents/eval_reports/stint_lengths.md` regenerates these shares from the live constants on every run, so the report always grades what is actually shipping rather than what was shipping when it was written.
+
+##### Operating envelopes: knowing when a model is answering outside what it learned
+
+A separate contract, and a quieter one. None of the models refuse out-of-range input; they answer with the same confidence whether the call falls inside what they were trained on or not. N26's tire TCN did exactly that for two years.
+
+An `OperatingEnvelope` (`src/strategy/inference/envelope.py`) names the input range a model's answer is actually valid over, and **labels only**: checking a feature vector never clips, alters or refuses a prediction, it only tells the call site whether to trust the one it already has. A feature that is absent is tracked as *unknown* rather than compared, because "we do not know" must never collapse into a number a real reading could also take.
+
+Two are declared today:
+
+- **N15** (pit duration) declares the 50-lap tyre-life ceiling it was trained under. The clip that keeps it inside that range is unchanged; what the envelope adds is that hitting it stops being silent.
+- **N06** (lap time) declares eleven feature ranges measured from its own training seasons. It has no clip at all, so the label is the entire mechanism.
+
+The envelope earns its keep by what it surfaced rather than by what it prevents. Wiring it to N06 exposed that `mean_sector_speed` was carrying the **speed trap** on every real call, because the agent substituted `prev_speed_st` whenever no mean sector speed was supplied and nothing ever supplied one. Those are different physical quantities, 256.8 against 303.0 km/h on average, and the model had been reading the wrong one throughout. The value is a property of the circuit and was on disk all along; it is now looked up per GP, and a circuit that does not resolve reaches the model as missing rather than as a substituted reading.
+
+It also surfaced something not yet fixed: N06 is asked to predict on the opening laps of a race and on the first lap of every stint, and it was never trained on either, because its own feature pipeline drops exactly those rows.
 
 ### N29: Radio Agent (`radio_agent.py`)
 

--- a/documents/audits/AUDIT_716_710_design.md
+++ b/documents/audits/AUDIT_716_710_design.md
@@ -439,3 +439,44 @@ Six tests failed rather than skipped for the same reason, and one of them,
 `available: false` and left the emptied file in the worktree. The guards now name the
 holdout. Publishing the artefact is the real fix and needs the file, which only exists on
 a machine that has run the notebook.
+
+## H4 — the #797 gate died on a usage limit, and its on-disk report paid for itself
+
+`GATE_797_circuit_speed.md` reached 8.6 KB before the agent was terminated mid-run. Because
+it appended findings as it confirmed them rather than buffering a final report, five
+findings survived, four of them real and two HIGH. This is the second time in two sessions
+that incremental persistence recovered work a dead agent would otherwise have taken with it.
+
+What it found in my own fix, all verified independently before acting:
+
+- **F1, HIGH.** The resolver covered two of the project's FOUR keyspaces. `RaceReplayEngine`
+  puts the metadata.json name into `session_meta`, which for one race is `'Miami Gardens'`
+  with a SPACE, matching neither the parquet slug `'Miami'` nor the folder `'Miami_Gardens'`.
+  Every lap of the 2025 Miami race was served NaN while its value sat in the map. Same for
+  the 2023 Spanish GP (`'Spain'`). The #448/#450 dual-keyspace trap, third occurrence, and
+  the third time in this session that I fixed one member of a pair and not the other.
+- **F2, HIGH.** `laps_featured_2025.parquet` carries NaN on all 760 Las Vegas rows, so
+  reading that file dropped a circuit N06 was FITTED on and whose value sits in three other
+  artefacts. The docstring's "we do not know this circuit" was false for Las Vegas.
+- **F3, MEDIUM.** The map was 2025-only while the replay engine can replay 2023 and 2024, so
+  a 2023 Silverstone lap was served a measurement taken two years after it, 18.4 km/h away.
+  `run()` receives `year` and the resolver ignored it.
+- **F4, MEDIUM.** My "recomputed per season" claim was wrong: 2023 and 2024 are identical
+  per GP to exactly 0.0. The value is recomputed per ARTEFACT BUILD, one build pooling both
+  training seasons. The conclusion survived, the stated mechanism did not, and a comment
+  naming the wrong mechanism is how the next fix goes wrong.
+- **F5, verified clean.** NaN survives to the model, `_bootstrap_ci` multiplying NaN by
+  Gaussian noise still returns finite p10/p90 through XGBoost's default split, an explicit
+  value still wins, and no production caller passes one.
+
+**And one the gate did not reach, found while fixing F1:** the combined artefact does not
+agree with itself. `laps_featured.parquet` calls the same race `'Miami'` in 2023-2024 and
+`'Miami Gardens'` in 2025, so even a correctly spelled query misses on one season. The fix
+is not a longer candidate list at the query end, which fails the moment the STORED spelling
+is the odd one: `_normalise_gp_key` now normalises both the map keys at load time and the
+query, which is what `gp_slugs`'s own docstring prescribes.
+
+The lookup is now keyed by `(Year, GP)` from the combined parquet, which has 71 pairs and
+zero missing values. All 71 races on disk resolve, asserted by walking `data/raw/` rather
+than by fixing the two names an audit happened to mention. A real `f1-sim Miami_Gardens`
+run completes with zero unresolved-circuit warnings.

--- a/documents/audits/AUDIT_716_710_design.md
+++ b/documents/audits/AUDIT_716_710_design.md
@@ -480,3 +480,57 @@ The lookup is now keyed by `(Year, GP)` from the combined parquet, which has 71 
 zero missing values. All 71 races on disk resolve, asserted by walking `data/raw/` rather
 than by fixing the two names an audit happened to mention. A real `f1-sim Miami_Gardens`
 run completes with zero unresolved-circuit warnings.
+
+## H5 — the resumed gate caught the fix for H4 introducing a regression of its own
+
+Switching the loader to the combined `laps_featured.parquet` closed the Las Vegas hole and
+looked like a strict improvement. It was not. That artefact **broadcasts the training-era
+value across all three seasons**: across every GP present in both eras the 2023-vs-2025
+difference is exactly 0.0, so keying by year became decorative and every 2025 lap silently
+received the 2023 measurement. The deliberate choice recorded in H2 was reverted by the
+commit that claimed to refine it.
+
+The raw laps settle which artefact is honest, and this is the check neither of my earlier
+measurements made:
+
+| | Silverstone 2025 | Melbourne 2025 |
+|---|---|---|
+| raw speed traps, mean of the three | **232.32** | **252.93** |
+| per-year artefact | 231.36 | 256.84 |
+| combined artefact | 249.71 (the 2023 value) | 272.44 |
+
+So the loader reads the three per-year artefacts, keyed by year. Las Vegas 2025 goes back to
+NaN, which is the correct failure: the alternative is serving a 2023 measurement for a 2025
+lap, the same defect class as the speed-trap substitution, only quieter. The hole belongs in
+the artefact, and there is now a test pinning it as a known hole so a NEW unresolved race
+still fails loudly.
+
+The test that would have caught this asserts an EFFECT: Silverstone's served value must
+DIFFER between 2023 and 2025. Asserting either value alone passes happily against the wrong
+artefact, which is exactly what happened.
+
+## H6 — the impact numbers, and the accuracy claim I must not make
+
+Re-measured on the full 2025 season with no sampling, comparing what the model receives now
+against what the bug fed it: mean **+0.0712 s**, p95 absolute **0.3767 s**, more than 0.010 s
+on **38.7%** of laps. The commit's figures reproduce.
+
+The gate measured smaller numbers because it measured `806cedd`, where the served value was
+the training-era one; that state is reverted.
+
+**What must not be claimed:** the fix does not make N06 more accurate. The published pace MAE
+still reproduces within tolerance, and the gate measured bug-versus-fix on the proper holdout
+at 0.4096 against 0.4097. This is a correctness fix, not an accuracy fix: the model is now
+being asked the question it was trained on, and the answer is about as good as before.
+
+## H7 — a third member of the family, found by the gate and left open
+
+`LapsSincePitStop` receives `TyreLife` at inference, and the two differ from the trained
+column on **19.8% of rows**, by a mean of 2.6 laps. That is the same shape as `Prev_Deg*` and
+`mean_sector_speed`: an inference value that is not the quantity its training column holds.
+Left open rather than fixed here, because it is a third instance and deserves its own issue
+and its own measurement rather than being folded into this branch.
+
+Also recorded by the gate and not fixed: the 2023 Spanish GP exists twice in `data/raw` and
+in the featured artefacts, as `Spain` and `Barcelona` with the same OpenF1 session key, so
+"71 races" is 70 plus one duplicate.

--- a/documents/audits/AUDIT_716_710_design.md
+++ b/documents/audits/AUDIT_716_710_design.md
@@ -373,3 +373,69 @@ undercut_clean.parquet`, which **does not exist in the Hugging Face dataset at a
 no clean install can pass them; the NLP goldens report `pending` because the 15.9 GB NLP
 weights are not downloaded here. The skip guards should require those artefacts instead
 of failing, which is a separate issue.
+
+---
+
+# #797 and #798, and one claim of mine I refuted myself
+
+## H1 — the fix: N06 was reading the speed trap where it was trained on a circuit mean
+
+`mean_sector_speed` is a property of the CIRCUIT, one value per GP.
+`PaceAgent._compute_derived` substituted `prev_speed_st` whenever none was supplied and
+`run_from_state` never supplied one, so on the path every real race takes N06 received a
+different physical quantity on every lap. Training means 256.8 against 303.0 km/h.
+
+Not an extraction slip: `N25_pace_agent.ipynb` documents the substitution as a proxy, and
+`pace_agent.py` already named the real source, calling it a fallback for when circuit
+features are unavailable. The lookup it described was never wired. It is now, per GP,
+with an unresolvable circuit yielding NaN and a warning rather than a substituted reading.
+
+**Measured impact, and a lesson about probes.** A single hand-built row moved the
+prediction by 0.002 s and I nearly reported the fix as cosmetic on that basis. Over 4000
+real 2025 laps it moves the delta prediction by a mean of +0.069 s, a p95 absolute of
+0.377 s, and more than 0.010 s on 38% of laps. The trees split on this feature only in
+some regions, so one probe is not a distribution.
+
+## H2 — REFUTED BY ME, after the commit message had already claimed it
+
+The commit says the value served is the value fitted, "identical to 0.0". What that
+number actually compared was `laps_featured_2023` against
+`circuit_features_with_clusters_k4.parquet` -- two artefacts of the TRAINING seasons. The
+code serves the **2025** map. Those are a different pair, and I checked the wrong one.
+
+Measured properly, across the 23 GPs present in both:
+
+| | |
+|---|---|
+| GPs matching exactly | **0 of 23** |
+| mean absolute gap | 4.82 km/h |
+| median | 2.91 km/h |
+| largest | Silverstone, 18.35 km/h |
+
+The FIX is still right, and serving 2025 is the correct half of the pair: the feature is
+recomputed per season, so the quantity N04 would compute for a 2025 lap is the 2025
+measurement, and serving the training seasons' value would feed a stale reading of a
+circuit since resurfaced or re-regulated. What was wrong was the claim of exact parity,
+which was true in isolation about a comparison nobody had asked for and false about the
+one that matters. That is the same defect class this session has been removing all day,
+committed in the sentence describing the removal.
+
+The docstring now states the seasonal seam and why the envelope bound is deliberately the
+2023-2024 range held against a 2025 value: the bound asks whether N06 was FITTED on inputs
+like this one, so a 2025 circuit outside the fitted range is genuine extrapolation. Monza
+2025 at 317.24 against a fitted maximum of 314.97 is the only such case.
+
+## H3 — the pit agent cannot be constructed on a clean install (#798)
+
+`PitStrategyAgent.__init__` reads `data/processed/undercut_labeled/undercut_clean.parquet`
+unconditionally. The Hugging Face dataset publishes `overtake_labeled/` and `sc_labeled/`
+and **not** `undercut_labeled/`, so on a checkout built from the published data the agent
+raises FileNotFoundError at construction. It stays hidden because every developer machine
+has run N16, and because `f1-sim --no-llm` at Lusail never triggers the pit agent.
+
+Six tests failed rather than skipped for the same reason, and one of them,
+`test_the_committed_tables_match_a_fresh_measurement`, regenerated
+`data/mc_measured_v1.json` with the entire measured `undercut_band` dropped to
+`available: false` and left the emptied file in the worktree. The guards now name the
+holdout. Publishing the artefact is the real fix and needs the file, which only exists on
+a machine that has run the notebook.

--- a/documents/audits/GATE_797_circuit_speed.md
+++ b/documents/audits/GATE_797_circuit_speed.md
@@ -124,3 +124,354 @@ Claim D verified: `mean_sector_speed=999.0` passed explicitly reaches the row un
 the envelope (violation logged). Repo-wide search: no production caller passes an explicit
 `mean_sector_speed` — `_run_always_on_agents` (`strategy_orchestrator.py:1867`) and every
 `run_from_state` caller omit it, so nothing is silently overridden.
+
+---
+
+## Resumed gate (round 2)
+
+**Date:** 2026-08-03 · **Branch:** `fix/pace-circuit-mean-sector-speed` @ `806cedd` vs `dev` @ `8ebe9c3`.
+Round 1's F1-F4 were fixed in `806cedd` (year-keyed map, `_normalise_gp_key`, combined artefact,
+walk-the-disk test). This round attacks the fix itself and finishes the unreached checklist.
+
+### Round-2 claim checklist
+
+- [x] 1. `_normalise_gp_key` total, collision-free across real producers
+- [x] 2. `(Year, GP)` keying: absent/stale/string years across all tiers
+- [x] 3. "71 pairs, ZERO missing" re-derived; same-races check
+- [x] 4. `test_every_race_on_disk_resolves` cannot pass vacuously — VERIFIED (see below)
+- [x] C. producer enumeration (folded into claims 1 and 2 below)
+- [x] E. impact numbers reproduced + re-measured for the NEW serving — REFUTED (R5)
+- [x] F. no regression (`_compute_derived` signature, goldens, holdout MAE) — PASS + 2 stale docstrings
+- [x] G. envelope re-declaration under the new map — REFUTED (R3: outside set is empty)
+- [x] H. skip-guards in `a3b876c` — PASS + 1 wrong reason string
+- [x] Bug-class hunt: third "inference value != training quantity" member — FOUND (`LapsSincePitStop`)
+- [x] Docs: `docs/pages/multi-agent.md` new sections — numerics PASS, 2 overtaken statements
+
+### R1 — HIGH · The combined artefact does not contain what the fix says it serves: `mean_sector_speed` is ONE constant per GP across all three years, so the year-keying serves the training value to 2025 laps — silently reversing the decision `23a02ba` documented as deliberate
+
+**Executed evidence.** Enumerated every (Year, GP) pair in `laps_featured.parquet` and pivoted
+per GP across years: **the cross-year gap is exactly 0.0 for every GP name shared across
+years**. Silverstone is 249.7062 in 2023, 2024 AND 2025; Monza 314.9706 in all three; the only
+per-GP year variation in the entire served map enters through the Miami naming split
+(2023/24 'Miami' 222.364 vs 2025 'Miami Gardens' 221.384, gap 0.98 km/h). Compared against the
+per-year artefacts: combined == `laps_featured_2023/2024.parquet` exactly, while combined 2025
+rows disagree with `laps_featured_2025.parquet` on **22 of 22 comparable GPs** (Silverstone
+combined 249.71 vs 2025-artefact 231.36, diff +18.35; Melbourne +15.61; Montreal -9.22; Sao
+Paulo -8.81; Suzuka -8.06; Shanghai -7.96; full table executed). The combined build evidently
+broadcasts the training-era per-GP constant onto its 2025 rows (Las Vegas 2025 = 228.9645 =
+training; Shanghai 2025 = its 2024 value; only GP names unseen in training — 'Miami Gardens' —
+keep a 2025-computed value).
+
+Consequences, in order of weight:
+
+1. **The docstring's central factual claim is false for the file it describes**
+   (`src/agents/pace_agent.py:334-341`): "`laps_featured.parquet` carries 71 (year, GP) pairs
+   and the value differs between the training era and 2025 on every GP present in both: mean
+   absolute gap 4.8 km/h, largest Silverstone at 18.4." That 4.8/18.4 measurement is TRUE of
+   the per-year artefacts (round 1 verified it there) and FALSE of the combined file, where
+   the gap is 0.0 everywhere. A true number transplanted into a false headline — and it is
+   the SECOND wrong-mechanism claim in the same docstring's history (F4 was the first; the
+   commit that corrected it introduced this one).
+2. **"Keying by year makes the value served the value the lap being replayed actually
+   carries" (`src/agents/pace_agent.py:340-341`) is false on the real replay path.** Every
+   replay/serving consumer loads the PER-YEAR artefact (`src/strategy/inference/engine.py:99`
+   states the rule; `src/arcade/strategy.py:571`,
+   `src/telemetry/backend/utils/laps_cache.py:31`,
+   `src/telemetry/backend/services/simulation/simulator.py:231`,
+   `src/strategy/eval/pace_holdout.py:95`, `src/strategy/eval/decision_modes.py:517` comply).
+   A replayed 2025 Silverstone lap carries 231.36 in the frame the RSM serves; the agent now
+   feeds N06 249.71.
+3. **The serving for 2025 replays FLIPPED, and no one decided it.** At `23a02ba` the docstring
+   defended serving the 2025 measurement as "deliberate and the correct half of that pair"
+   ("serving the training seasons' value would feed a stale reading"). `806cedd` reverses
+   exactly that — every 2025 lap now gets the training value — as an unexamined side effect
+   of switching files, while claiming to do the opposite. Executed:
+   `_resolve_mean_sector_speed('Silverstone', 2025) -> 249.70624181580095` (was 231.3595
+   before the fix). Whether training-constant or season-measurement is the RIGHT feed is a
+   modelling judgment with arguments both ways (the feature acts as a circuit identifier the
+   model fitted on); the defect is that the branch has now shipped BOTH positions, each
+   documented as deliberate, with no measurement of the flip (see E below).
+
+### R2 — HIGH · The eval tier and production now feed N06 different values for the same 2025 lap: the published holdout MAE no longer describes the serving configuration
+
+**Executed evidence.** `src/strategy/eval/pace_holdout.py` never calls the agent: it reads
+`laps_featured_2025.parquet` (line 95) and feeds the frame's own columns to the model
+(line 120), so the holdout MAE was measured with `mean_sector_speed` = the 2025-artefact
+values (Silverstone 231.36). Production (`_resolve_mean_sector_speed`) now serves the combined
+values (Silverstone 249.71). The two disagree on 22 of 24 2025 GPs, by up to 18.35 km/h — the
+exact magnitude the branch's own commits call material. The new test does not catch this
+because `test_every_race_resolves_to_the_value_its_own_parquet_rows_carry` compares the map
+against `laps_featured.parquet` — **the same file the map is built from**. It asserts
+map == source-of-map (a VALUE), not served == what-the-replayed-lap-carries (the EFFECT);
+tautological by construction, the repo's value-not-effect test class.
+
+### R3 — MEDIUM · Claim G refuted: under the new map NOTHING is outside the envelope — "Monza 2025 is exactly that, and the only one" is now false, and the new test's discrimination loop iterates the empty set
+
+**Executed evidence.** Instantiated the real `PaceAgent` and checked all 71 served values
+against `_N06_TRAINED_BOUNDS["mean_sector_speed"]` (196.6292, 314.9706): **outside set =
+{}**. Served Monza 2025 is 314.9706 — the bound's own maximum, inside by equality — because
+the combined file broadcast the training value (R1); the 317.2412 the docstring
+(`src/agents/pace_agent.py:359-360`) and the test docstring celebrate is the per-year value
+the agent no longer loads. So the envelope on `mean_sector_speed` is back to a bound that
+CANNOT fire from the circuit map on any known race — only an explicitly-passed value can trip
+it, and no production caller passes one (round-1 claim D).
+`test_the_envelope_separates_a_circuit_n06_was_fitted_on_from_one_it_was_not` still passes,
+but its `for (year, gp), value in outside.items()` loop — the half that pins "Monza fires the
+envelope" — asserts over the EMPTY SET (`tests/agents/test_pace_circuit_speed.py:264-267`),
+and `len(inside) > len(outside)` is 71 > 0. The repo's own bug class: a green guard asserting
+about nothing.
+
+### R4 — MEDIUM · The 2023 Spanish GP exists TWICE — `data/raw/2023/Spain` and `data/raw/2023/Barcelona` are the same race (OpenF1 session_key 9102) — so "71 races on disk == 71 pairs" is 70 real races plus one duplicate, on both sides of the check
+
+**Executed evidence.** Both metadata.json files carry `session_key_openf1: 9102` and identical
+record_counts (laps 1312, weather 154, intervals 26036, pitstops 43); extraction timestamps 21
+seconds apart. The combined parquet correspondingly holds BOTH (2023,'Spain') and
+(2023,'Barcelona'), 1198 rows each, identical `mean_sector_speed` 269.7125 — which is why 2023
+shows 23 GP names for a 22-race season. Claim 3's "the pairs are the same 71 races data/raw
+holds" is therefore true only because BOTH sides double-count the same race. No wrong value is
+served (executed: `_resolve_mean_sector_speed('Spain', 2023)` ==
+`_resolve_mean_sector_speed('Barcelona', 2023)` == 269.7125), but the 2023 Spanish GP is
+duplicated inside the combined training artefact itself — 1198 rows counted twice by anything
+that aggregates `laps_featured.parquet` per-lap (whether N06's training build consumed the
+duplicate needs its own check, outside this gate's file-touch scope). Deserves its own
+data-integrity issue.
+
+### Claim 1 — VERIFIED with one latent gap · `_normalise_gp_key` is collision-free across every real producer; the only unresolvable spellings have no live producer
+
+**Executed.** Normalised every distinct `GP_Name` in the combined parquet (26 spellings) and
+every `metadata.json` `gp_name` (26 spellings, all 71 races): **zero many-to-one collisions
+across different circuits** — the only merges are 'Miami Gardens'/'Miami_Gardens' -> 'Miami'
+(same circuit, the intended repair) and underscore/space forms of the same race. Every raw
+race resolves through the real resolver chain (`unresolved == []`, 71/71). Producer sweep
+(C, finishing round 1's unreached item): the CLI and Arcade pass metadata.json names via
+`RaceReplayEngine._parse_meta` (all resolve, executed); the backend passes per-year featured
+GP_Names from its own `/available-gps` round-trip (accented 'Montréal'/'São Paulo', 'Miami'
+in 2025 — all resolve, executed); MCP tools funnel free text through `_normalize_gp_name`
+whose alias table covers the ASCII forms ('montreal' -> 'Montréal', 'sao paulo' -> 'São
+Paulo'; `src/telemetry/backend/mcp_tools.py:199` + table above it); FastF1 event names are
+handled by the `slug_from_event_name` candidate and currently have no live producer. The two
+CLI ASCII fallbacks `gp_slugs` accepts, 'Montreal' and 'Sao Paulo', do NOT resolve
+(`_resolve_mean_sector_speed('Montreal', 2025) -> nan`, executed) because
+`canonical_gp_name` returns them unchanged and the map keys are accented — but no live
+producer emits them into `session_meta.gp_name` (the CLI arg keyspace terminates at folder
+resolution; session_meta is rebuilt from metadata.json). LATENT, not live. LOW.
+
+### Claim 2 — VERIFIED with one latent trap · every live producer supplies an int year the dataset covers; a STRING year fails silently
+
+**Executed.** `RaceReplayEngine._parse_meta` (`src/simulation/replay_engine.py:115`) casts
+`int(meta.get("year", 2025))`; all 71 metadata.json `year` fields are ints equal to their
+folder year (swept: zero mismatches, zero missing files). Backend years are FastAPI-typed
+ints (`endpoints/strategy.py:85,109,411`); MCP `_normalize_year` coerces or refuses
+(`mcp_tools.py:320`). `meta.get('year') or 2025` in `run_from_state` can only fire on a
+session_meta missing 'year', which no current producer emits (RSM always sets it,
+`src/simulation/race_state_manager.py:515`). The engine's no-metadata fallback (year=2025 +
+warning, `replay_engine.py:117-120`) is the one path that could hand a 2023 replay a 2025
+key — unreachable today (all 71 metadata files exist), and per R1 it would serve the same
+NUMBER anyway for every GP except Miami and 'Spain' (whose (2025,·) key does not exist). The
+latent trap: `_resolve_mean_sector_speed('Silverstone', "2025") -> nan` (executed) — a string
+year misses every key because the tuple key is type-strict and nothing coerces; the only
+signal is the per-lap warning. No live producer does this. LOW, latent.
+
+### Claim 3 — VERIFIED as numbers, hollow as a guarantee
+
+**Executed.** `laps_featured.parquet`: 68,122 rows, **0 NaN** in `mean_sector_speed` (the
+`.dropna()` is a no-op), 71 distinct (Year, GP_Name) pairs before AND after dropna; the
+normalised map holds exactly 71 keys; every pair matches a raw race on disk and vice versa
+(both directions swept, empty set differences). But per R4 the "71 races" is inflated by the
+same duplicate on both sides, and per R1 the VALUES those 71 keys carry are 24 per-GP
+constants wearing 71 keys.
+
+### R5 — HIGH · Checklist E: the commit's impact numbers do NOT reproduce — every honest harness lands at half to a quarter of the claim
+
+The `36aa8d0` message claims: "Measured over 4000 real 2025 laps, the corrected feed moves the
+delta prediction by a mean of +0.069 s, a p95 absolute of 0.377 s, and more than 0.010 s on 38%
+of laps."
+
+**Executed reproduction** (fix-at-`36aa8d0` serving vs the `prev_speed_st` bug feed, frozen N06,
+featured 2025 rows rebuilt exactly as `pace_holdout` does — encode + lag + dropna, 21,247 rows):
+
+| Harness | n | mean signed | mean abs | p95 abs | >0.010 s |
+|---|---|---|---|---|---|
+| **Claimed** | 4,000 | **+0.069** | — | **0.377** | **38%** |
+| Full 2025 season | 21,247 | +0.0177 | 0.0201 | 0.1766 | 17.7% |
+| Uniform n=4000, seeds 0/1/42 | 4,000 | +0.0170..0.0173 | 0.0190..0.0196 | 0.1766 | 16.6-17.3% |
+| First 4000 rows (`head`) | 4,000 | +0.0412 | — | 0.1766 | 28.6% |
+| Last 4000 rows (`tail`) | 4,000 | +0.0003 | — | 0.0000 | 1.8% |
+| Full, default weather (25/35/50/0) | 21,247 | +0.0207 | — | 0.1766 | 16.9% |
+| Full, default wx + `Prev_Deg*`=0 (the real `run_from_state` row) | 21,247 | +0.0146 | — | 0.1766 | 9.5% |
+
+No configuration tried — uniform sample under three seeds, head, tail, default weather,
+inference-shaped rows — reaches the claimed mean, p95 or fraction; p95 abs is 0.1766 s in every
+one of them, less than half the claimed 0.377. The delta is heavily circuit-concentrated (per-GP
+mean abs: Baku 0.177, Spa 0.171, Silverstone 0.088, then a cliff — Austin 0.010 and below), so
+only a sample dominated by three specific races could produce numbers that size; 4000 uniform
+2025 laps cannot. The claim's DIRECTION survives (the feed change is real and material on some
+circuits) inside a false magnitude — this repo's "claim true in isolation inside a false
+headline" class, and its "a number measured on the wrong distribution" class at once. On the
+distribution production actually serves (default weather, `Prev_Deg*`=0), the fix moves >0.010 s
+on 9.5% of laps, not 38%.
+
+**The re-measure nobody did (E's second half), executed on all three seasons** — what `806cedd`
+itself changed relative to `23a02ba`:
+
+| Season | Serving change | mean signed | p95 abs | >0.010 s | max abs | MAE before → after |
+|---|---|---|---|---|---|---|
+| 2025 (21,247) | 2025-artefact values → training constants (R1 flip) | +0.0009 | 0.0016 | 3.3% | 0.418 | 0.4097 → 0.4097 |
+| 2024 (22,077) | GP-keyed 2025 map → own-year values | −0.0003 | 0.0245 | 5.1% | 0.424 | 0.4185 → 0.4176 |
+| 2023 (20,880) | GP-keyed 2025 map (Spain+Vegas NaN) → own-year values | −0.0001 | 0.0016 | 1.7% | 0.393 | 0.4316 → 0.4314 |
+
+So the `806cedd` re-keying is nearly prediction-neutral in aggregate (single laps move up to
+0.42 s), and — the number that reframes the whole branch — **the original bug itself was
+prediction-neutral on the holdout: MAE with the speed-trap feed was 0.4096, with the corrected
+feed 0.4097.** The fix is epistemically right (right quantity, honest NaN) and the gate confirms
+it should stand; but every published magnitude around it is inflated, and the flip it smuggled
+in (R1) is invisible in aggregate while reversing a documented decision.
+
+### Checklist F — VERIFIED, with two stale docstrings and one hollow claim
+
+- **`_compute_derived` signature**: exactly one caller in the repo
+  (`src/agents/pace_agent.py:560`, keyword-style, matches the new 6-parameter signature); no
+  test, script or notebook-side import calls it (swept `src/ tests/ scripts/`; N25's notebook
+  carries its own inline copy and does not import this one). PASS.
+- **BUT the docstrings were not updated with the signature — the fix's own function documents
+  the mechanism the fix removed** (the repo's wrong-mechanism comment class, in the very
+  function that was the bug):
+  - `src/agents/pace_agent.py:472` — `_compute_derived`'s Args block still lists
+    `prev_speed_st: Speed trap reading in km/h from the previous lap.` The parameter no longer
+    exists; the docstring documents 7 args for a 6-arg signature.
+  - `src/agents/pace_agent.py:784` — `run()`'s Args block still says `mean_sector_speed:
+    Average sector speed; defaults to prev_speed_st.` It defaults to the circuit lookup now;
+    "defaults to prev_speed_st" is precisely the behaviour #797 removed. A reader trusting
+    this line reintroduces the bug.
+- **Strategy goldens**: `tests/mc/test_strategy_goldens.py` passes (54 passed, executed run).
+  But the goldens exercise `_run_mc_simulation` / `_decide_agents_to_call` on CANNED sub-agent
+  outputs (`tests/mc/canned_outputs.py`) — they never enter `_build_feature_row`, so they were
+  structurally incapable of moving with this change. `36aa8d0`'s "Strategy goldens are
+  byte-identical" is true and verified nothing about the feed: byte-identical because
+  insensitive, not because checked.
+- **Holdout MAE**: `test_pace_mae_reproduces_from_featured_laps` passed (executed), asserting
+  `|MAE − 0.4104| < 0.01`; my independent rebuild gives 0.4097, inside tolerance. PASS.
+
+### Checklist H — VERIFIED · the guards skip, do not over-skip, and one reason string names the wrong artefact
+
+Executed: the suite run on this machine (which HAS `lgbm_undercut_v1.pkl` and LACKS
+`undercut_labeled/undercut_clean.parquet`) yields 54 passed, 1 skipped — the exact intended
+behaviour of `a3b876c` (before it, this checkout went red on absent data). Right-sizing checked:
+`test_undercut_targets_are_on_track`'s module-level skip is justified because constructing N28
+really does read `undercut_clean.parquet` (`src/agents/pit_strategy_agent.py:271`), so every
+test in the module needs it; `test_mc_measured_tables` skips ONLY the fresh-measurement test
+(the committed-table assertions still run), avoiding the emptied-file-left-in-worktree hazard
+its comment documents. One defect: the widened condition kept the old message —
+`tests/eval/test_ml_recompute_golden.py:61` skips with reason "undercut **model** absent (CI
+runner without weights)" on a machine where the model is PRESENT and the holdout is what is
+missing (executed: that exact line fired here). The wrong-mechanism class, in a diagnostic:
+it sends whoever reads the skip log to re-download weights they already have. LOW.
+
+### Claim 4 — VERIFIED · the walk-the-disk test is non-vacuous and keyed the way the engine keys
+
+Executed independently of pytest: the same walk finds 71 race dirs, all with `metadata.json`,
+`checked == 71 > 0`, `unresolved == []`. The `assert checked > 0` guard makes an empty walk
+fail. Two soft edges, neither currently load-bearing: (a) a race dir WITHOUT `metadata.json` is
+silently skipped (`continue`) rather than counted — today zero such dirs exist, and the engine's
+own fallback for that case (folder name + year=2025, `replay_engine.py:117`) resolves for every
+current folder name except a hypothetical metadata-less `2023/Spain`, whose (2025,'Spain') key
+does not exist; (b) the test keys by `int(year_dir.name)` while the engine keys by
+`meta['year']` — verified equal on all 71 (swept), so the test currently tests the engine's
+keyspace, but only because the data happens to agree.
+
+### Bug-class hunt — the third member found and measured: `LapsSincePitStop` is fed `TyreLife`, and the two differ on 19.8% of training rows
+
+`run_from_state` (`src/agents/pace_agent.py:908`) passes `laps_since_pit=d.get("tyre_life") or
+1` — the SAME value it passes as `TyreLife`. In training the two are different quantities:
+`TyreLife` counts laps on the tyre SET (which arrives pre-used: qualifying laps), while
+`LapsSincePitStop` counts laps since the last stop. **Executed over the 45,327 training-season
+rows: they differ on 19.8% (8,995 rows), mean gap 2.61 laps, p95 6, max 25; 16.9% of stint-1
+rows start with `TyreLife > LapsSincePitStop`** (used-set starts). So on roughly one lap in
+five N06 was fitted distinguishing the two, and at inference it is structurally fed the wrong
+one whenever the set is not fresh from the box. The envelope comment (`pace_agent.py:134-136`)
+KNOWS the equality — but frames it only as "a second bound would double-report", i.e. as a
+reason not to bound it, not as the wiring defect it also is. Family so far: `Prev_Deg*`
+(hardcoded 0.0, documented), `mean_sector_speed` (fixed by this branch), **`LapsSincePitStop`
+(live, unfixed, now measured)**. MEDIUM.
+
+Also swept, adjacent but distinct classes, for the record: `_encode_categorical`'s defaults
+(`compound→1, team→0, cluster→1`, `pace_agent.py:441-443`) are sentinels that are also REAL
+encoded values — an unknown team silently becomes whichever team encodes to 0 (live on the CLI,
+where the team string is user-typed argv); `Prev_TyreLife := tyre_life−1` is wrong on every
+outlap (training holds the OLD set's last life; measured mean gap 16.1 laps on 780 outlaps) but
+folds into the already-documented "N06 was never trained on stint-first laps" extrapolation the
+new docs section names, so it is not counted as a new family member. Both pre-existing, neither
+introduced by this branch.
+
+### Docs — `docs/pages/multi-agent.md` new sections audit: numerics check out, two statements already overtaken by the code
+
+Verified against code and artefacts (executed where numeric): train/val row counts 22,106 /
+23,256 match `feature_manifest_laptime.json` exactly; "eleven feature ranges" matches the 11
+entries of `_N06_TRAINED_BOUNDS`; the recalibrated stint bounds SOFT 2 / MEDIUM 7 / HARD 8 /
+wet-fallback 6 match `src/strategy/inference/guard_rails.py:95-103`; the prescriptive/
+proscriptive table and the Art. 55.17 framing match the shipped rail behaviour and the
+2026-07-16 lesson. Two defects, both LOW: (a) "looked up from the featured parquet ... one
+value per GP" — written for `36aa8d0`, not updated for `806cedd`'s (Year, GP) keying; ironically
+R1 makes the stale sentence more truthful than the code's own docstring, since the served map
+does hold one value per GP; (b) the envelope section's story that wiring the bound made
+`mean_sector_speed` meaningful again is overtaken by R3: under the map actually shipped, that
+bound cannot fire on any known race, so the page documents a detection power the system no
+longer has.
+
+### What I tried to break and could NOT
+
+- **`_normalise_gp_key` collisions**: enumerated all 26 parquet spellings + all 26 metadata
+  spellings, normalised, looked for many-to-one across DIFFERENT circuits — none. The only
+  merges are the intended Miami repair and underscore/space variants of the same race.
+- **Unresolvable spellings from LIVE producers**: every metadata name (71/71), every per-year
+  featured GP_Name, and every MCP alias-table output resolves; the ASCII 'Montreal'/'Sao Paulo'
+  misses have no producer that can reach `session_meta.gp_name` today.
+- **Year poisoning on live paths**: all 71 metadata years are ints equal to their folder year;
+  backend years are FastAPI-typed; MCP refuses unparseable years; the `or 2025` default is
+  unreachable from current producers. (The string-year silent NaN stands as a latent trap only.)
+- **The map itself**: 71 keys, no NaN anywhere in the source column (dropna is a no-op), every
+  key backed by a raw race and vice versa; `(2025, 'Las Vegas')` present at 228.9645 — F2's
+  hole is genuinely closed, and F1's 'Miami Gardens' and F3's 'Spain' both resolve on the
+  season they belong to.
+- **Vacuity of the walk-the-disk test**: could not make it pass while missing a race short of
+  deleting `metadata.json` files that all exist.
+- **Skip-guard over-skip**: could not find a test suppressed by `a3b876c` whose artefacts are
+  actually present; the local run exercises everything except the one test that genuinely
+  cannot run here.
+- **`_compute_derived` stale positional callers**: none exist anywhere.
+- **Holdout MAE**: reproduces (0.4097, within the golden's declared 0.01 of the 0.4104
+  headline), on the eval path, which this branch did not touch.
+
+### Round-2 fix list (ordered by value/risk)
+
+1. **Decide, on purpose, which value 2025 laps get** (R1/R2): either serve the per-year
+   artefact values (restore the `23a02ba` decision — load per-year files, or repair the
+   combined build so its 2025 rows carry the 2025 measurements), or explicitly adopt
+   training-constant serving and rewrite the loader docstring + `23a02ba`'s rationale. The
+   measured stakes are small in aggregate (p95 0.0016 s) but the docstring, the eval tier, the
+   envelope story and the test all currently assume a mechanism the data refutes. The combined
+   artefact's 2025 `mean_sector_speed` being a training-era broadcast should get its own
+   data-integrity issue either way (it contradicts `laps_featured_2025.parquet` on 22 GPs).
+2. **Fix the loader docstring's false claims** (`pace_agent.py:334-341, 356-360`): the 4.8/18.4
+   cross-year gap does not exist in the combined file; Monza 2025 at 317.24 is not served and
+   nothing is outside the envelope.
+3. **Make the envelope test assert the discrimination it promises** (R3): assert the outside
+   set is NON-empty (it is empty today — the test should fail until item 1 is decided), or
+   rewrite it to pin the actual serving and declare the bound non-discriminating.
+4. **File the 2023 Spain/Barcelona duplicate race** (R4) as a data-integrity issue: same
+   session_key 9102 twice in `data/raw` and in the combined artefact; decide which name stays,
+   deduplicate the artefact, and re-check whether N06's training consumed the duplicate.
+5. **Correct or retract the `36aa8d0` impact numbers** (R5) wherever they are quoted (commit
+   history cannot change; the docs/issue #797 closure can): full-season honest numbers are
+   mean +0.018 s, p95 0.177 s, 17.7% > 0.010 s; inference-shaped rows 9.5%.
+6. **Feed `LapsSincePitStop` its own quantity** from the RSM (it has pit-stop history) instead
+   of `tyre_life`, or document the 19.8%-divergence as an accepted approximation where the
+   envelope comment currently only argues about double-reporting.
+7. **Two-line docstring repairs**: `run()`'s "defaults to prev_speed_st" (`pace_agent.py:784`)
+   and `_compute_derived`'s phantom `prev_speed_st` arg (`pace_agent.py:472`).
+8. **Update the skip reason** at `tests/eval/test_ml_recompute_golden.py:61` to name the
+   holdout parquet as well as the model.
+9. LOW/latent hardening, take or leave: coerce `year` to `int()` inside
+   `_resolve_mean_sector_speed` (kills the silent string-year NaN); add 'Montreal'/'Sao Paulo'
+   ASCII aliases to the map normalisation or to `FOLDER_ALIASES`; update the docs' "one value
+   per GP" once item 1 lands.

--- a/documents/audits/GATE_797_circuit_speed.md
+++ b/documents/audits/GATE_797_circuit_speed.md
@@ -1,0 +1,126 @@
+# GATE #797 — circuit `mean_sector_speed` feed (adversarial gate)
+
+**Date:** 2026-08-03 · **Branch:** `fix/pace-circuit-mean-sector-speed` @ `23a02ba` vs `dev` @ `8ebe9c3`
+**Role:** adversarial gate. No repo file modified except this report. Findings appended as confirmed.
+
+**Scope (4 commits):**
+- `36aa8d0` fix(agents): feed N06 the circuit's mean sector speed instead of the speed trap
+- `a3b876c` test: skip, do not fail, when the unpublished undercut holdout is absent
+- `7ab7b5a` docs(multi-agent): calibrated pit bounds + operating envelopes
+- `23a02ba` docs(agents): correct the parity claim behind the circuit speed lookup
+
+Note the branch itself already refutes half of claim A: `36aa8d0` claimed "the value served is
+the value fitted … identical to 0.0"; `23a02ba` retracts it (the 0.0 compared two *training*
+artefacts, not the served map) and re-frames serving 2025 as deliberate. This gate verifies the
+retraction's numbers too, since a correction can itself be wrong.
+
+## Claim checklist
+
+- [ ] A. served value == fitted value; the 2023-24 vs 2025 seam quantified per GP
+- [ ] B. unresolved circuit reaches the model as NaN; `_bootstrap_ci` noise on NaN; downstream
+- [ ] C. slug resolution complete across every real producer of `gp_name`
+- [ ] D. explicit `mean_sector_speed` still wins; no caller silently overridden
+- [ ] E. impact numbers honest (mean +0.069 s, p95 0.377 s, >0.010 s on 38%, n=4000)
+- [ ] F. nothing else regressed; `_compute_derived` lost `prev_speed_st` — no stale caller
+- [ ] G. envelope re-declaration (196.63, 314.97) is the right range for the served value
+- [ ] H. skip-guards skip (not fail) and do not over-skip
+- [ ] Bug-class hunt: third member of the "inference value ≠ training quantity" family
+- [ ] `docs/pages/multi-agent.md` new sections vs what the code does
+
+---
+
+## Findings (appended as confirmed)
+
+### F1 — HIGH · The 2025 Miami race resolves to NaN on the CLI/arcade path: the fix misses one of the 24 races of the very season it serves
+
+**Executed evidence.** `data/raw/2025/Miami_Gardens/metadata.json` carries `"gp_name": "Miami Gardens"`
+— that exact string is what `RaceReplayEngine._parse_meta` (`src/simulation/replay_engine.py:115`)
+puts into `session_meta.gp_name`, and what `run_from_state` hands to
+`_resolve_mean_sector_speed` (`src/agents/pace_agent.py:341`). Executed against the real agent:
+
+```
+_resolve_mean_sector_speed('Miami Gardens') -> nan   (+ WARNING per lap)
+_resolve_mean_sector_speed('Miami')         -> 221.384  (the value that was intended)
+```
+
+Direct hit misses (map key is `'Miami'`, from `laps_featured_2025.parquet`); `slug_from_event_name('Miami Gardens')`
+returns `None` (`EVENT_NAME_BY_SLUG` knows `'Miami'` and `'Miami Grand Prix'`, not `'Miami Gardens'`);
+`FOLDER_ALIASES` knows only the underscore form `'Miami_Gardens'` and is not consulted here anyway
+(`canonical_gp_name` is never called in the new resolver). Failing scenario:
+`f1-sim Miami_Gardens NOR McLaren` — every lap of the 2025 Miami GP feeds N06 a missing
+`mean_sector_speed` although the served map holds the circuit's value. The same string also misses
+`circuit_cluster` (silent default cluster 1) and `_session_median` (no median) — those two are
+pre-existing, but the NEW lookup was added to the same function that already contained both misses
+and repaired neither pattern.
+
+Note the shape: #797's own fix commit cites #448 ("the dual-keyspace trap") and resolves TWO of the
+three keyspaces (parquet slug, FastF1 event name). The third keyspace — metadata.json/raw-folder
+names, the one `canonical_gp_name` + `FOLDER_ALIASES` exist for — is the one that still misses.
+One copy fixed, its sibling keyspace not.
+
+### F2 — HIGH · Las Vegas is served NaN although N06 was FITTED on it — the loader reads the one artefact that lost the value
+
+**Executed evidence.** `laps_featured_2025.parquet` carries `mean_sector_speed = NaN` on all 760
+Las Vegas rows, so `_load_circuit_mean_sector_speed`'s `.dropna()` (`pace_agent.py:337`) drops the
+GP and the served map has 23 entries, not 24. But the fitted value **exists on disk in the very
+artefacts this branch reasons about**: `laps_featured_2023.parquet` and `laps_featured_2024.parquet`
+both carry 228.9645 for Las Vegas, `circuit_features_with_clusters_k4.parquet` carries 228.9645,
+and even the combined `laps_featured.parquet` carries 228.9645 **on its 2025 rows**. Only
+`circuit_features_with_clusters_k4_2025.parquet` and the per-year 2025 file hold NaN.
+
+`_resolve_mean_sector_speed('Las Vegas') -> nan` (executed). The docstring's justification —
+"we do not know this circuit" — is false for Las Vegas: the model knows it (fitted on it, bounds
+include it), the 2025 artefact simply has a hole. Issue #797 itself said "all 24 GPs (one is NaN)"
+and the fix shipped without closing that named gap. Failing scenario: `f1-sim Las_Vegas VER Red Bull`
+(metadata gp_name `'Las Vegas'`) — a full 2025 race weekend served a missing feature when the
+fitted number is one file away.
+
+### F3 — MEDIUM · Every 2023/2024 replay is served the 2025 constant, and `run()`'s `year` parameter is ignored by the resolution
+
+The CLI supports `--year 2023/2024` (`run_simulation_cli.py:2101`, featured path tracks the year)
+and the raw trees for 2023/2024 are on disk. On those replays `session_meta.gp_name` resolves
+against the **2025-only** map, so a 2023 Silverstone lap is fed 231.36 where the value N06 was
+fitted on for that lap — and which sits in the very parquet row being replayed — is 249.71
+(18.35 km/h apart). `PaceAgent.run()` receives `year` and does not use it in
+`_resolve_mean_sector_speed`. Additionally the 2023 Spanish GP replay
+(`data/raw/2023/Spain/metadata.json` → gp_name `'Spain'`) resolves to **NaN** — a fourth keyspace
+casualty (executed: `_resolve_mean_sector_speed('Spain') -> nan`).
+
+The `23a02ba` docstring defends serving 2025 as "the quantity N04 would compute for a 2025 lap" —
+an argument that is only about 2025 laps. For 2023/2024 laps it serves a measurement from two years
+in the future of the lap being replayed. Whether this moves predictions materially is measured in F-E
+below (Silverstone: the 18.35 km/h gap is the largest in the fleet).
+
+### F4 — MEDIUM · The `23a02ba` mechanism claim "recomputed per season" is wrong: 2023 and 2024 share one identical value per GP
+
+**Executed evidence:** per-GP `mean_sector_speed` in `laps_featured_2023.parquet` equals
+`laps_featured_2024.parquet` **exactly (diff 0.0 on all 23 common GPs)**, and both equal
+`circuit_features_with_clusters_k4.parquet` to 0.0. So the feature is recomputed per **artefact
+generation** (one training-era build pooling both seasons, one 2025 build), not "per season from
+that season's laps" as the amended docstring (`pace_agent.py:315-316`) states. The conclusion
+(2025 differs from training) survives; the stated mechanism does not — and this repo's own bug
+class list says a comment naming the wrong mechanism is how the next fix goes wrong (e.g. someone
+"completing" per-season resolution for 2023 vs 2024 would find nothing to resolve).
+
+Verified numbers from the same run: 23 GPs present in both eras, none equal, mean abs gap 4.815
+(commit says 4.82 ✓), max Silverstone 18.347 (commit says 18.35 ✓), Monza 2025 = 317.2412 (✓) is
+the only served value outside (196.6292, 314.9706) (✓), and the declared bounds equal the true
+min/max of the 2023+2024 lap rows exactly (✓ claim G's range is genuinely the fitted range;
+min = Austin 196.63, max = Monza 314.97).
+
+### F5 — VERIFIED (claims B and D) · NaN survives to the model; the CI stays finite; an explicit value wins
+
+Executed end-to-end with the real agent: `run(gp_name='Miami Gardens', ...)` produces
+`mean_sector_speed = NaN` in the feature row, survives `pd.to_numeric(errors='coerce')`,
+`_bootstrap_ci` multiplies NaN by Gaussian noise (`NaN * N(1,0.02) = NaN`, verified) and XGBoost
+routes the missing value through its default split — **p10/p90 come back finite** (89.978/95.155),
+`lap_time_pred` finite, no crash. The envelope reports the feature as `unknown`, never a violation,
+so an unresolved circuit is invisible in the OOB warning (by design — but note it means F1/F2 fire
+no envelope signal either; the only trace is the per-lap resolver WARNING).
+`delta_vs_median` is NaN for 'Miami Gardens' (the median lookup misses on the same keyspace),
+which downstream consumers already tolerate per the pre-existing no-median path.
+
+Claim D verified: `mean_sector_speed=999.0` passed explicitly reaches the row untouched and trips
+the envelope (violation logged). Repo-wide search: no production caller passes an explicit
+`mean_sector_speed` — `_run_always_on_agents` (`strategy_orchestrator.py:1867`) and every
+`run_from_state` caller omit it, so nothing is silently overridden.

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -309,9 +309,23 @@ class PaceAgent:
 
         Read from the same `laps_featured_2025.parquet` the team map and the reference
         laps already come from rather than from `circuit_clustering/`: it is the artefact
-        N04 wrote the trained column into, so the value served is the value fitted, and
-        there is no second file to keep in step. Checked across the 22 GPs of the training
-        seasons against `circuit_features_with_clusters_k4.parquet`: identical to 0.0.
+        N04 writes the column into, and there is no second file to keep in step.
+
+        WHICH SEASON'S VALUE, because the two are not the same number and an earlier
+        draft of this docstring implied they were. The feature is recomputed per season
+        from that season's laps, so a GP's 2025 value differs from its 2023-2024 one:
+        across the 23 GPs in both, none match exactly, the mean absolute gap is 4.8 km/h
+        and Silverstone moves 18.4. Serving 2025 is deliberate and is the correct half of
+        that pair, because the quantity N04 would compute for a 2025 lap is the 2025
+        measurement; serving the training seasons' value would feed a stale reading of a
+        circuit that has since been resurfaced or re-regulated.
+
+        It follows that the ENVELOPE bound on this feature is the 2023-2024 range while
+        the value served is a 2025 measurement, and that is the right way round rather
+        than an oversight: the bound asks whether N06 was FITTED on inputs like this one,
+        so a 2025 circuit outside the fitted range is genuine extrapolation and should be
+        said out loud. Monza 2025 at 317.24 against a fitted maximum of 314.97 is exactly
+        that case, and it is the only one.
 
         A GP whose value is missing is simply absent from the map. It must NOT acquire a
         default here -- see `_resolve_mean_sector_speed` for why an absent circuit has to

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -165,6 +165,11 @@ _N06_TRAINED_BOUNDS: dict[str, tuple[float, float]] = {
 _N06_ENVELOPE = OperatingEnvelope(name="n06_laptime_delta", bounds=_N06_TRAINED_BOUNDS)
 
 
+# The seasons that have a per-year featured artefact. Listed rather than globbed so a
+# stray file cannot silently widen what the agent claims to know.
+_FEATURED_SEASONS: tuple[int, ...] = (2023, 2024, 2025)
+
+
 def _normalise_gp_key(gp_name: str) -> str:
     """One spelling for a GP, applied to BOTH sides of the circuit-speed lookup.
 
@@ -331,14 +336,12 @@ class PaceAgent:
         N06 was trained on it and inference never had it, because `_compute_derived`
         substituted `prev_speed_st` and nothing ever supplied the real thing (#797).
 
-        KEYED BY YEAR, because the value is not constant across the dataset and the
-        replay engine can replay any of the three seasons. `laps_featured.parquet` carries
-        71 (year, GP) pairs and the value differs between the training era and 2025 on
-        every GP present in both: mean absolute gap 4.8 km/h, largest Silverstone at 18.4.
-        An earlier draft of this loader read only `laps_featured_2025.parquet` and served
-        that single value for every replay, which fed a 2023 Silverstone lap a measurement
-        taken two years after it. Keying by year makes the value served the value the lap
-        being replayed actually carries.
+        KEYED BY YEAR, because the value is not constant across seasons and the replay
+        engine can replay any of the three. Across the GPs present in both eras the
+        training-era and 2025 measurements differ on every one: mean absolute gap 4.8 km/h,
+        largest Silverstone at 18.3. An earlier draft read only the 2025 artefact and
+        served that value for every replay, feeding a 2023 Silverstone lap a measurement
+        taken two years after it.
 
         Beware the mechanism, which is NOT what an earlier draft of this docstring said:
         the value is recomputed per ARTEFACT GENERATION, not per season. 2023 and 2024 are
@@ -346,12 +349,23 @@ class PaceAgent:
         pooled both training seasons and a later build produced 2025. Anyone "completing"
         a per-season resolution between 2023 and 2024 would find nothing to resolve.
 
-        THE COMBINED FILE, not the per-year ones, and that is the whole reason this reads
-        `laps_featured.parquet`: `laps_featured_2025.parquet` carries NaN on all 760 Las
-        Vegas rows, so a `.dropna()` over it silently drops a circuit N06 was fitted on and
-        whose value sits in three other artefacts. The combined file has 71 pairs and ZERO
-        missing values, so "absent from the map" now means a genuinely unknown circuit
-        rather than an artefact with a hole in it.
+        THE PER-YEAR FILES, and NOT the combined `laps_featured.parquet`, which is the
+        trap that cost this lookup two rounds. The combined artefact BROADCASTS the
+        training-era value across all three seasons: its Silverstone row reads 249.71 for
+        2023 and for 2025 alike, and across every GP present in both eras the 2023-vs-2025
+        difference is exactly 0.0. Reading it therefore looks year-aware and is not.
+
+        The raw laps settle which artefact is telling the truth. Silverstone 2025's own
+        speed traps average 232.32 km/h: the per-year file says 231.36 and the combined
+        file says 249.71, the 2023 number. Melbourne 2025 is the same story, 252.93 raw
+        against 256.84 per-year and 272.44 combined. So the per-year artefacts carry the
+        season's own measurement and the combined one does not.
+
+        The cost of that correctness is a hole rather than a wrong number:
+        `laps_featured_2025.parquet` has NaN on all 760 Las Vegas rows, so that race
+        resolves to NaN. That is the right failure. The alternative is serving the
+        2023-2024 measurement for a 2025 lap, which is the same class of defect as the
+        speed-trap substitution this whole fix exists to remove, only quieter.
 
         It follows that the ENVELOPE bound stays the 2023-2024 range while a 2025 lap is
         served a 2025 measurement, and that is the right way round rather than an oversight:
@@ -359,15 +373,15 @@ class PaceAgent:
         outside the fitted range is genuine extrapolation and should be said out loud. Monza
         2025 at 317.24 against a fitted maximum of 314.97 is exactly that, and the only one.
         """
-        speeds = pd.read_parquet(
-            processed_dir / "laps_featured.parquet",
-            columns=["Year", "GP_Name", "mean_sector_speed"],
-        ).dropna()
-        by_race = speeds.drop_duplicates(["Year", "GP_Name"])
-        return {
-            (int(row.Year), _normalise_gp_key(str(row.GP_Name))): float(row.mean_sector_speed)
-            for row in by_race.itertuples()
-        }
+        by_race: dict[tuple[int, str], float] = {}
+        for year in _FEATURED_SEASONS:
+            parquet = processed_dir / f"laps_featured_{year}.parquet"
+            if not parquet.exists():
+                continue
+            speeds = pd.read_parquet(parquet, columns=["GP_Name", "mean_sector_speed"]).dropna()
+            for row in speeds.drop_duplicates("GP_Name").itertuples():
+                by_race[(year, _normalise_gp_key(str(row.GP_Name)))] = float(row.mean_sector_speed)
+        return by_race
 
     def _resolve_mean_sector_speed(self, gp_name: str, year: int) -> float:
         """This race's trained mean sector speed, or NaN when it does not resolve.

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -30,7 +30,7 @@ import pandas as pd
 import xgboost as xgb
 
 from src.agents._shared_defaults import reading_or_default
-from src.f1_strat_manager.gp_slugs import slug_from_event_name
+from src.f1_strat_manager.gp_slugs import canonical_gp_name, slug_from_event_name
 
 # Safe in this direction: envelope.py is a leaf that imports nothing from src.agents.
 from src.strategy.inference.envelope import OperatingEnvelope
@@ -165,6 +165,30 @@ _N06_TRAINED_BOUNDS: dict[str, tuple[float, float]] = {
 _N06_ENVELOPE = OperatingEnvelope(name="n06_laptime_delta", bounds=_N06_TRAINED_BOUNDS)
 
 
+def _normalise_gp_key(gp_name: str) -> str:
+    """One spelling for a GP, applied to BOTH sides of the circuit-speed lookup.
+
+    A GP is written four ways across this project: the parquet slug ('Miami'), the raw
+    folder ('Miami_Gardens'), the metadata.json name the replay engine puts into
+    `session_meta` ('Miami Gardens', with a SPACE), and the FastF1 event name ('Miami
+    Grand Prix'). Worse, the artefacts do not agree with each other: the combined
+    `laps_featured.parquet` calls this race 'Miami' in 2023-2024 and 'Miami Gardens' in
+    2025, so even a lookup whose query is spelled correctly can miss on the season.
+
+    Normalising the KEYS at load time and the query the same way is what `gp_slugs`'s own
+    docstring prescribes, and it is why this is a function rather than a longer candidate
+    list at the call site: a chain of guesses at the query end still fails the moment the
+    stored spelling is the odd one, which is exactly how the first version of this lookup
+    sent every lap of the 2025 Miami race to NaN.
+
+    Underscores first, because `canonical_gp_name`'s alias table is keyed by the folder
+    form, so 'Miami Gardens' has to become 'Miami_Gardens' before it can become 'Miami'.
+    """
+    if not gp_name:
+        return ""
+    return canonical_gp_name(gp_name.replace(" ", "_"))
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # PaceOutput dataclass (public API — untouched)
 # ─────────────────────────────────────────────────────────────────────────────
@@ -241,8 +265,8 @@ class PaceAgent:
         self.compound_id, self.circuit_cluster, self.team_id = self._load_encoding_maps(
             processed_dir
         )
-        self.circuit_mean_sector_speed: dict[str, float] = self._load_circuit_mean_sector_speed(
-            processed_dir
+        self.circuit_mean_sector_speed: dict[tuple[int, str], float] = (
+            self._load_circuit_mean_sector_speed(processed_dir)
         )
         self.laps_ref: pd.DataFrame = self._load_reference_laps(processed_dir)
 
@@ -299,47 +323,54 @@ class PaceAgent:
         return compound_id, circuit_cluster, team_id
 
     @staticmethod
-    def _load_circuit_mean_sector_speed(processed_dir: Path) -> dict[str, float]:
-        """The one ``mean_sector_speed`` each GP carries, keyed by parquet ``GP_Name``.
+    def _load_circuit_mean_sector_speed(processed_dir: Path) -> dict[tuple[int, str], float]:
+        """``mean_sector_speed`` per ``(Year, GP_Name)``, from the combined featured parquet.
 
-        This feature is a property of the CIRCUIT, not of the lap: the featured parquet
-        holds exactly one distinct value per GP, the mean of the three speed traps.
+        This feature is a property of the CIRCUIT, not of the lap: the parquet holds
+        exactly one distinct value per (year, GP), the mean of the three speed traps.
         N06 was trained on it and inference never had it, because `_compute_derived`
         substituted `prev_speed_st` and nothing ever supplied the real thing (#797).
 
-        Read from the same `laps_featured_2025.parquet` the team map and the reference
-        laps already come from rather than from `circuit_clustering/`: it is the artefact
-        N04 writes the column into, and there is no second file to keep in step.
+        KEYED BY YEAR, because the value is not constant across the dataset and the
+        replay engine can replay any of the three seasons. `laps_featured.parquet` carries
+        71 (year, GP) pairs and the value differs between the training era and 2025 on
+        every GP present in both: mean absolute gap 4.8 km/h, largest Silverstone at 18.4.
+        An earlier draft of this loader read only `laps_featured_2025.parquet` and served
+        that single value for every replay, which fed a 2023 Silverstone lap a measurement
+        taken two years after it. Keying by year makes the value served the value the lap
+        being replayed actually carries.
 
-        WHICH SEASON'S VALUE, because the two are not the same number and an earlier
-        draft of this docstring implied they were. The feature is recomputed per season
-        from that season's laps, so a GP's 2025 value differs from its 2023-2024 one:
-        across the 23 GPs in both, none match exactly, the mean absolute gap is 4.8 km/h
-        and Silverstone moves 18.4. Serving 2025 is deliberate and is the correct half of
-        that pair, because the quantity N04 would compute for a 2025 lap is the 2025
-        measurement; serving the training seasons' value would feed a stale reading of a
-        circuit that has since been resurfaced or re-regulated.
+        Beware the mechanism, which is NOT what an earlier draft of this docstring said:
+        the value is recomputed per ARTEFACT GENERATION, not per season. 2023 and 2024 are
+        identical for every GP they share (max difference exactly 0.0), because one build
+        pooled both training seasons and a later build produced 2025. Anyone "completing"
+        a per-season resolution between 2023 and 2024 would find nothing to resolve.
 
-        It follows that the ENVELOPE bound on this feature is the 2023-2024 range while
-        the value served is a 2025 measurement, and that is the right way round rather
-        than an oversight: the bound asks whether N06 was FITTED on inputs like this one,
-        so a 2025 circuit outside the fitted range is genuine extrapolation and should be
-        said out loud. Monza 2025 at 317.24 against a fitted maximum of 314.97 is exactly
-        that case, and it is the only one.
+        THE COMBINED FILE, not the per-year ones, and that is the whole reason this reads
+        `laps_featured.parquet`: `laps_featured_2025.parquet` carries NaN on all 760 Las
+        Vegas rows, so a `.dropna()` over it silently drops a circuit N06 was fitted on and
+        whose value sits in three other artefacts. The combined file has 71 pairs and ZERO
+        missing values, so "absent from the map" now means a genuinely unknown circuit
+        rather than an artefact with a hole in it.
 
-        A GP whose value is missing is simply absent from the map. It must NOT acquire a
-        default here -- see `_resolve_mean_sector_speed` for why an absent circuit has to
-        stay absent all the way to the model.
+        It follows that the ENVELOPE bound stays the 2023-2024 range while a 2025 lap is
+        served a 2025 measurement, and that is the right way round rather than an oversight:
+        the bound asks whether N06 was FITTED on inputs like this one, so a 2025 circuit
+        outside the fitted range is genuine extrapolation and should be said out loud. Monza
+        2025 at 317.24 against a fitted maximum of 314.97 is exactly that, and the only one.
         """
         speeds = pd.read_parquet(
-            processed_dir / "laps_featured_2025.parquet",
-            columns=["GP_Name", "mean_sector_speed"],
+            processed_dir / "laps_featured.parquet",
+            columns=["Year", "GP_Name", "mean_sector_speed"],
         ).dropna()
-        by_gp = speeds.drop_duplicates("GP_Name").set_index("GP_Name")["mean_sector_speed"]
-        return {str(gp): float(value) for gp, value in by_gp.items()}
+        by_race = speeds.drop_duplicates(["Year", "GP_Name"])
+        return {
+            (int(row.Year), _normalise_gp_key(str(row.GP_Name))): float(row.mean_sector_speed)
+            for row in by_race.itertuples()
+        }
 
-    def _resolve_mean_sector_speed(self, gp_name: str) -> float:
-        """This circuit's trained mean sector speed, or NaN when it does not resolve.
+    def _resolve_mean_sector_speed(self, gp_name: str, year: int) -> float:
+        """This race's trained mean sector speed, or NaN when it does not resolve.
 
         NaN, never `prev_speed_st`, and that substitution is the whole bug: the speed
         trap is a different physical quantity (training means 256.8 vs 303.0 km/h), so
@@ -349,22 +380,28 @@ class PaceAgent:
         should look like. Same rule as `FuelEffect` (#446) and `Position` (#628): unknown
         data stays unknown and never becomes a number the model can mistake for a reading.
 
-        The name is resolved through `slug_from_event_name` first, because `gp_name`
-        arrives in either keyspace depending on the caller -- the CLI passes the slug
-        ('Lusail'), a FastF1-derived caller passes the event name ('Qatar Grand Prix').
-        The same dual-keyspace trap cost #448 and #450.
+        FOUR KEYSPACES, because a GP is named four different ways in this project and an
+        earlier draft resolved only two of them. The parquet slug ('Miami'), the raw
+        folder ('Miami_Gardens'), the metadata.json name the replay engine actually puts
+        into `session_meta` ('Miami Gardens', with a SPACE, which neither of the other two
+        forms matches), and the FastF1 event name ('Qatar Grand Prix'). Resolving only the
+        first and last sent every lap of the 2025 Miami and 2023 Spanish races to NaN while
+        their value sat in the map. That is the #448/#450 dual-keyspace trap for the third
+        time, and this time the enumeration is checked rather than assumed: all 71 races
+        under `data/raw/` resolve through the chain below, asserted in
+        `tests/agents/test_pace_circuit_speed.py`.
         """
-        if gp_name in self.circuit_mean_sector_speed:
-            return self.circuit_mean_sector_speed[gp_name]
-
-        slug = slug_from_event_name(gp_name) if gp_name else None
-        if slug and slug in self.circuit_mean_sector_speed:
-            return self.circuit_mean_sector_speed[slug]
+        if gp_name:
+            for candidate in (gp_name, slug_from_event_name(gp_name) or ""):
+                key = (year, _normalise_gp_key(candidate))
+                if key in self.circuit_mean_sector_speed:
+                    return self.circuit_mean_sector_speed[key]
 
         logger.warning(
-            "no trained mean sector speed for GP %r; N06 reads the feature as missing "
+            "no trained mean sector speed for %r in %s; N06 reads the feature as missing "
             "rather than being fed the speed trap in its place (#797)",
             gp_name,
+            year,
         )
         return float("nan")
 
@@ -518,7 +555,7 @@ class PaceAgent:
         resolved_mean_sector_speed = (
             mean_sector_speed
             if mean_sector_speed is not None
-            else self._resolve_mean_sector_speed(gp_name)
+            else self._resolve_mean_sector_speed(gp_name, year)
         )
         derived = self._compute_derived(
             tyre_life,

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -30,12 +30,14 @@ import pandas as pd
 import xgboost as xgb
 
 from src.agents._shared_defaults import reading_or_default
+from src.f1_strat_manager.gp_slugs import slug_from_event_name
+
 # Safe in this direction: envelope.py is a leaf that imports nothing from src.agents.
 from src.strategy.inference.envelope import OperatingEnvelope
 
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent
-while not (_REPO_ROOT / '.git').exists():
+while not (_REPO_ROOT / ".git").exists():
     if _REPO_ROOT.parent == _REPO_ROOT:
         break
     _REPO_ROOT = _REPO_ROOT.parent
@@ -45,6 +47,7 @@ while not (_REPO_ROOT / '.git').exists():
 # checkouts with a repo-relative ``data/`` short-circuit the helper.
 try:
     from src.f1_strat_manager.data_cache import get_data_root as _get_data_root
+
     _DATA_ROOT = _get_data_root()
 except (ImportError, OSError, RuntimeError):
     # Every way get_data_root() can fail, enumerated against its body in
@@ -55,7 +58,7 @@ except (ImportError, OSError, RuntimeError):
     # the Path.home() branch IS the `uv tool install` path this block exists to
     # serve, and a container with no HOME would take it. Falling back to the
     # repo-relative data/ is right for all three.
-    _DATA_ROOT = _REPO_ROOT / 'data'
+    _DATA_ROOT = _REPO_ROOT / "data"
 
 # What stands in for the previous lap when there genuinely is not one: the first lap
 # of a race, or of a stint, where N04's Prev_LapTime is NaN by construction.
@@ -71,14 +74,14 @@ except (ImportError, OSError, RuntimeError):
 # None value, which the two-arg form does not substitute for.
 MISSING_PREV_LAP_TIME_S = 90.0
 
-_MODELS_DIR = _DATA_ROOT / 'models' / 'lap_time'
-_PROCESSED  = _DATA_ROOT / 'processed'
+_MODELS_DIR = _DATA_ROOT / "models" / "lap_time"
+_PROCESSED = _DATA_ROOT / "processed"
 
 logger = logging.getLogger(__name__)
 
 # ── Constants ─────────────────────────────────────────────────────────────────
-N_BOOTSTRAP: int   = 200
-_NOISE_PCT: float  = 0.02   # 2 % Gaussian noise on continuous features
+N_BOOTSTRAP: int = 200
+_NOISE_PCT: float = 0.02  # 2 % Gaussian noise on continuous features
 
 # Seconds of lap time recovered per lap as fuel burns off. N04 builds the training
 # feature as (TyreLife - min(TyreLife of the stint)) * 0.055 — verified exactly against
@@ -117,14 +120,15 @@ FUEL_GAIN_PER_LAP_S: float = 0.055
 #       not one: 0.0 sits mid-distribution for each (42.6% / 41.9% / 46.7% of training
 #       rows fall below it), so a bound could never fire and declaring one would
 #       advertise a check that cannot work.
-#     - `mean_sector_speed`. `_compute_derived` falls back to `prev_speed_st` whenever a
-#       mean sector speed is absent, and `run_from_state` never supplies one, so at
-#       inference this feature ALWAYS carries the speed trap. They are different physical
-#       quantities with different distributions (training means 256.8 vs 303.0 km/h), and
-#       a bound over the first one applied to the second fires on 83% of laps at Monza
-#       while describing none of them correctly. This is the twin of the Prev_Deg* case
-#       and it was missed on the first pass precisely because only one of the pair was
-#       looked at, which is this repo's most reliable defect.
+#     `mean_sector_speed` used to be listed here for the same reason and no longer is.
+#     `_compute_derived` substituted `prev_speed_st` whenever no mean sector speed was
+#     supplied and `run_from_state` never supplied one, so the feature carried the speed
+#     trap on every real call: a different physical quantity, training means 256.8 vs
+#     303.0 km/h, and a bound over the first applied to the second fired on 83% of laps
+#     at Monza while describing none of them. #797 fixed the FEED rather than deleting
+#     the bound, so the value is once again the quantity the range was measured from and
+#     the bound is once again meaningful: it now fires when a circuit falls outside the
+#     set N06 was fitted on, which is the question it was always supposed to ask.
 #
 #   Excluded, a bound would report the same event twice (1): `LapsSincePitStop`.
 #   `run_from_state` passes `d.get('tyre_life') or 1` for BOTH it and `TyreLife`, so at
@@ -145,24 +149,26 @@ FUEL_GAIN_PER_LAP_S: float = 0.055
 # laps_featured_2025: 2025 is the held-out TEST season, and an envelope sourced from it
 # would be describing where the model is asked to work rather than where it was fitted.
 _N06_TRAINED_BOUNDS: dict[str, tuple[float, float]] = {
-    'LapNumber':      (3.0, 78.0),
-    'TyreLife':       (3.0, 78.0),
-    'FuelEffect':     (0.055, 4.125),
-    'Prev_LapTime':   (67.719, 148.991),
-    'Prev_TyreLife':  (2.0, 77.0),
-    'Prev_SpeedST':   (156.0, 362.0),
-    'AirTemp':        (14.5, 33.7),
-    'TrackTemp':      (16.7, 50.7),
-    'Humidity':       (18.0, 92.0),
-    'laps_remaining': (0.0, 75.0),
+    "LapNumber": (3.0, 78.0),
+    "TyreLife": (3.0, 78.0),
+    "FuelEffect": (0.055, 4.125),
+    "Prev_LapTime": (67.719, 148.991),
+    "Prev_TyreLife": (2.0, 77.0),
+    "Prev_SpeedST": (156.0, 362.0),
+    "AirTemp": (14.5, 33.7),
+    "TrackTemp": (16.7, 50.7),
+    "Humidity": (18.0, 92.0),
+    "laps_remaining": (0.0, 75.0),
+    "mean_sector_speed": (196.6292354740061, 314.9705586672411),
 }
 
-_N06_ENVELOPE = OperatingEnvelope(name='n06_laptime_delta', bounds=_N06_TRAINED_BOUNDS)
+_N06_ENVELOPE = OperatingEnvelope(name="n06_laptime_delta", bounds=_N06_TRAINED_BOUNDS)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # PaceOutput dataclass (public API — untouched)
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 @dataclass
 class PaceOutput:
@@ -188,17 +194,18 @@ class PaceOutput:
     Orchestrator for LLM synthesis.
     """
 
-    lap_time_pred:   float
-    delta_vs_prev:   float
+    lap_time_pred: float
+    delta_vs_prev: float
     delta_vs_median: float
-    ci_p10:          float
-    ci_p90:          float
-    reasoning:       str = ""
+    ci_p10: float
+    ci_p90: float
+    reasoning: str = ""
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # PaceAgent class
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 class PaceAgent:
     """Encapsulates the N06 XGBoost lap-time prediction pipeline.
@@ -227,18 +234,21 @@ class PaceAgent:
         models_dir: Path = _MODELS_DIR,
         processed_dir: Path = _PROCESSED,
     ) -> None:
-        self.model, self.features     = self._load_model(models_dir)
-        self.compound_id: dict        = {}
-        self.circuit_cluster: dict    = {}
-        self.team_id: dict            = {}
-        self.compound_id, self.circuit_cluster, self.team_id = self._load_encoding_maps(processed_dir)
-        self.laps_ref: pd.DataFrame   = self._load_reference_laps(processed_dir)
+        self.model, self.features = self._load_model(models_dir)
+        self.compound_id: dict = {}
+        self.circuit_cluster: dict = {}
+        self.team_id: dict = {}
+        self.compound_id, self.circuit_cluster, self.team_id = self._load_encoding_maps(
+            processed_dir
+        )
+        self.circuit_mean_sector_speed: dict[str, float] = self._load_circuit_mean_sector_speed(
+            processed_dir
+        )
+        self.laps_ref: pd.DataFrame = self._load_reference_laps(processed_dir)
 
     # ── Loaders ───────────────────────────────────────────────────────────────
 
-    def _load_model(
-        self, models_dir: Path
-    ) -> tuple[xgb.XGBRegressor, list[str]]:
+    def _load_model(self, models_dir: Path) -> tuple[xgb.XGBRegressor, list[str]]:
         """Load N06 XGBoost model and ordered feature name list from disk.
 
         Both artifacts are returned together to guarantee the feature order is
@@ -252,16 +262,12 @@ class PaceAgent:
             Tuple (model, features) where model is a fitted XGBRegressor and
             features is a list of column name strings in predict order.
         """
-        features = json.loads(
-            (models_dir / 'xgb_laptime_delta_feature_names.json').read_text()
-        )
+        features = json.loads((models_dir / "xgb_laptime_delta_feature_names.json").read_text())
         model = xgb.XGBRegressor()
-        model.load_model(models_dir / 'xgb_laptime_delta_final.json')
+        model.load_model(models_dir / "xgb_laptime_delta_final.json")
         return model, features
 
-    def _load_encoding_maps(
-        self, processed_dir: Path
-    ) -> tuple[dict, dict, dict]:
+    def _load_encoding_maps(self, processed_dir: Path) -> tuple[dict, dict, dict]:
         """Load compound, circuit-cluster, and team label-encoding maps.
 
         Reads the compound encoding from the N06 feature manifest, the circuit
@@ -276,28 +282,77 @@ class PaceAgent:
         Returns:
             Tuple (compound_id, circuit_cluster, team_id) dicts.
         """
-        manifest    = json.loads((processed_dir / 'feature_manifest_laptime.json').read_text())
-        compound_id = manifest['categorical_encoding']['Compound']
+        manifest = json.loads((processed_dir / "feature_manifest_laptime.json").read_text())
+        compound_id = manifest["categorical_encoding"]["Compound"]
 
         clusters_df = pd.read_parquet(
-            processed_dir / 'circuit_clustering' / 'circuit_clusters_k4_2025.parquet',
-            columns=['GP_Name', 'Cluster'],
+            processed_dir / "circuit_clustering" / "circuit_clusters_k4_2025.parquet",
+            columns=["GP_Name", "Cluster"],
         )
-        circuit_cluster = dict(
-            zip(clusters_df['GP_Name'], clusters_df['Cluster'].astype(int))
-        )
+        circuit_cluster = dict(zip(clusters_df["GP_Name"], clusters_df["Cluster"].astype(int)))
 
         laps = pd.read_parquet(
-            processed_dir / 'laps_featured_2025.parquet',
-            columns=['Team', 'TeamID'],
+            processed_dir / "laps_featured_2025.parquet",
+            columns=["Team", "TeamID"],
         ).dropna()
-        team_id = (
-            laps.drop_duplicates('Team')
-                .set_index('Team')['TeamID']
-                .astype(int)
-                .to_dict()
-        )
+        team_id = laps.drop_duplicates("Team").set_index("Team")["TeamID"].astype(int).to_dict()
         return compound_id, circuit_cluster, team_id
+
+    @staticmethod
+    def _load_circuit_mean_sector_speed(processed_dir: Path) -> dict[str, float]:
+        """The one ``mean_sector_speed`` each GP carries, keyed by parquet ``GP_Name``.
+
+        This feature is a property of the CIRCUIT, not of the lap: the featured parquet
+        holds exactly one distinct value per GP, the mean of the three speed traps.
+        N06 was trained on it and inference never had it, because `_compute_derived`
+        substituted `prev_speed_st` and nothing ever supplied the real thing (#797).
+
+        Read from the same `laps_featured_2025.parquet` the team map and the reference
+        laps already come from rather than from `circuit_clustering/`: it is the artefact
+        N04 wrote the trained column into, so the value served is the value fitted, and
+        there is no second file to keep in step. Checked across the 22 GPs of the training
+        seasons against `circuit_features_with_clusters_k4.parquet`: identical to 0.0.
+
+        A GP whose value is missing is simply absent from the map. It must NOT acquire a
+        default here -- see `_resolve_mean_sector_speed` for why an absent circuit has to
+        stay absent all the way to the model.
+        """
+        speeds = pd.read_parquet(
+            processed_dir / "laps_featured_2025.parquet",
+            columns=["GP_Name", "mean_sector_speed"],
+        ).dropna()
+        by_gp = speeds.drop_duplicates("GP_Name").set_index("GP_Name")["mean_sector_speed"]
+        return {str(gp): float(value) for gp, value in by_gp.items()}
+
+    def _resolve_mean_sector_speed(self, gp_name: str) -> float:
+        """This circuit's trained mean sector speed, or NaN when it does not resolve.
+
+        NaN, never `prev_speed_st`, and that substitution is the whole bug: the speed
+        trap is a different physical quantity (training means 256.8 vs 303.0 km/h), so
+        feeding it does not degrade the prediction gracefully, it silently answers a
+        different question. XGBoost handles a genuinely missing feature natively through
+        its sparse-aware split direction, which is what "we do not know this circuit"
+        should look like. Same rule as `FuelEffect` (#446) and `Position` (#628): unknown
+        data stays unknown and never becomes a number the model can mistake for a reading.
+
+        The name is resolved through `slug_from_event_name` first, because `gp_name`
+        arrives in either keyspace depending on the caller -- the CLI passes the slug
+        ('Lusail'), a FastF1-derived caller passes the event name ('Qatar Grand Prix').
+        The same dual-keyspace trap cost #448 and #450.
+        """
+        if gp_name in self.circuit_mean_sector_speed:
+            return self.circuit_mean_sector_speed[gp_name]
+
+        slug = slug_from_event_name(gp_name) if gp_name else None
+        if slug and slug in self.circuit_mean_sector_speed:
+            return self.circuit_mean_sector_speed[slug]
+
+        logger.warning(
+            "no trained mean sector speed for GP %r; N06 reads the feature as missing "
+            "rather than being fed the speed trap in its place (#797)",
+            gp_name,
+        )
+        return float("nan")
 
     def _load_reference_laps(self, processed_dir: Path) -> pd.DataFrame:
         """Load the reference laps parquet used for session median computation.
@@ -312,15 +367,13 @@ class PaceAgent:
             DataFrame with columns GP_Name, Year, Compound, LapTime_s.
         """
         return pd.read_parquet(
-            processed_dir / 'laps_featured_2025.parquet',
-            columns=['GP_Name', 'Year', 'Compound', 'LapTime_s'],
+            processed_dir / "laps_featured_2025.parquet",
+            columns=["GP_Name", "Year", "Compound", "LapTime_s"],
         )
 
     # ── Encoding helpers ──────────────────────────────────────────────────────
 
-    def _encode_categorical(
-        self, compound: str, team: str, gp_name: str
-    ) -> tuple[int, int, int]:
+    def _encode_categorical(self, compound: str, team: str, gp_name: str) -> tuple[int, int, int]:
         """Map compound, team, and circuit to their integer label encodings.
 
         Unknown categories degrade gracefully to the most common training
@@ -334,8 +387,8 @@ class PaceAgent:
         Returns:
             Tuple (compound_id_int, team_id_int, cluster_int).
         """
-        c_id    = self.compound_id.get(compound, 1)
-        t_id    = self.team_id.get(team, 0)
+        c_id = self.compound_id.get(compound, 1)
+        t_id = self.team_id.get(team, 0)
         cluster = self.circuit_cluster.get(gp_name, 1)
         return c_id, t_id, cluster
 
@@ -345,8 +398,7 @@ class PaceAgent:
         fuel_load: float,
         lap_number: int,
         total_laps: int,
-        prev_speed_st: float,
-        mean_sector_speed: Optional[float],
+        mean_sector_speed: float,
         stint_baseline_tyre_life: Optional[int] = None,
     ) -> dict:
         """Compute features derived from raw inputs that are not in the source data.
@@ -355,8 +407,11 @@ class PaceAgent:
         the outlap pace loss caused by tyre heating and rubber laydown.
         FuelEffect: cumulative fuel burn pace gain (lighter car = faster lap).
         laps_remaining: inverted lap count used as a proxy for race phase.
-        mean_sector_speed: falls back to prev_speed_st when circuit_features
-        are unavailable for the current GP.
+        mean_sector_speed: passed through untouched, already resolved by the caller.
+        It used to fall back to prev_speed_st here, which fed the speed trap in place
+        of a circuit mean on every RaceStateManager call (#797). Resolution and its
+        NaN-on-unknown rule now live in `_resolve_mean_sector_speed`, so this function
+        has no opinion left about a value it cannot look up.
 
         Args:
             tyre_life: Current laps on this tyre set.
@@ -364,7 +419,8 @@ class PaceAgent:
             lap_number: Current race lap.
             total_laps: Total scheduled race laps.
             prev_speed_st: Speed trap reading in km/h from the previous lap.
-            mean_sector_speed: Average sector speed; None → use prev_speed_st.
+            mean_sector_speed: This circuit's trained mean sector speed, already
+                resolved; NaN when the GP does not resolve.
             stint_baseline_tyre_life: TyreLife recorded at the start of the
                 current stint. None means the caller has not been updated to
                 supply it, in which case FuelEffect is forced to NaN instead
@@ -390,18 +446,18 @@ class PaceAgent:
         # to mistake for a reading.
         if stint_baseline_tyre_life is None:
             logger.warning(
-                'stint_baseline_tyre_life absent from lap_state: FuelEffect=NaN for this '
-                'lap; the producer must supply it (#446)'
+                "stint_baseline_tyre_life absent from lap_state: FuelEffect=NaN for this "
+                "lap; the producer must supply it (#446)"
             )
-            fuel_effect = float('nan')
+            fuel_effect = float("nan")
         else:
             fuel_effect = (tyre_life - stint_baseline_tyre_life) * FUEL_GAIN_PER_LAP_S
 
         return {
-            'FreshTyre':        int(tyre_life <= 1),
-            'FuelEffect':       fuel_effect,
-            'laps_remaining':   max(0, total_laps - lap_number),
-            'mean_sector_speed': mean_sector_speed if mean_sector_speed is not None else prev_speed_st,
+            "FreshTyre": int(tyre_life <= 1),
+            "FuelEffect": fuel_effect,
+            "laps_remaining": max(0, total_laps - lap_number),
+            "mean_sector_speed": mean_sector_speed,
         }
 
     def _build_feature_row(
@@ -441,37 +497,50 @@ class PaceAgent:
             Single-row pd.DataFrame with columns in self.features order.
         """
         c_id, t_id, cluster = self._encode_categorical(compound, team, gp_name)
+        # An explicit argument still wins, so a caller that genuinely measured this lap's
+        # mean sector speed is not overridden by the circuit constant. Nothing in the
+        # repo passes one today; the RaceStateManager path is exactly the caller that
+        # left it None and got the speed trap for it (#797).
+        resolved_mean_sector_speed = (
+            mean_sector_speed
+            if mean_sector_speed is not None
+            else self._resolve_mean_sector_speed(gp_name)
+        )
         derived = self._compute_derived(
-            tyre_life, fuel_load, lap_number, total_laps,
-            prev_speed_st, mean_sector_speed, stint_baseline_tyre_life,
+            tyre_life,
+            fuel_load,
+            lap_number,
+            total_laps,
+            resolved_mean_sector_speed,
+            stint_baseline_tyre_life,
         )
 
         row = {
-            'DriverNumber':         driver_number,
-            'LapNumber':            lap_number,
-            'Stint':                stint,
-            'TyreLife':             tyre_life,
-            'FreshTyre':            derived['FreshTyre'],
-            'Position':             position,
-            'CompoundID':           c_id,
-            'TeamID':               t_id,
-            'LapsSincePitStop':     laps_since_pit,
-            'FuelLoad':             fuel_load,
-            'Year':                 year,
-            'FuelEffect':           derived['FuelEffect'],
-            'Prev_LapTime':         prev_lap_time,
-            'Prev_TyreLife':        prev_tyre_life,
-            'Prev_SpeedST':         prev_speed_st,
-            'AirTemp':              air_temp,
-            'TrackTemp':            track_temp,
-            'Humidity':             humidity,
-            'Rainfall':             rainfall,
-            'laps_remaining':       derived['laps_remaining'],
-            'Cluster':              cluster,
-            'mean_sector_speed':    derived['mean_sector_speed'],
-            'Prev_DegradationRate': prev_deg_rate,
-            'Prev_CumulativeDeg':   prev_cum_deg,
-            'Prev_DegAcceleration': prev_deg_accel,
+            "DriverNumber": driver_number,
+            "LapNumber": lap_number,
+            "Stint": stint,
+            "TyreLife": tyre_life,
+            "FreshTyre": derived["FreshTyre"],
+            "Position": position,
+            "CompoundID": c_id,
+            "TeamID": t_id,
+            "LapsSincePitStop": laps_since_pit,
+            "FuelLoad": fuel_load,
+            "Year": year,
+            "FuelEffect": derived["FuelEffect"],
+            "Prev_LapTime": prev_lap_time,
+            "Prev_TyreLife": prev_tyre_life,
+            "Prev_SpeedST": prev_speed_st,
+            "AirTemp": air_temp,
+            "TrackTemp": track_temp,
+            "Humidity": humidity,
+            "Rainfall": rainfall,
+            "laps_remaining": derived["laps_remaining"],
+            "Cluster": cluster,
+            "mean_sector_speed": derived["mean_sector_speed"],
+            "Prev_DegradationRate": prev_deg_rate,
+            "Prev_CumulativeDeg": prev_cum_deg,
+            "Prev_DegAcceleration": prev_deg_accel,
         }
         df = pd.DataFrame([row])[self.features]
         # Belt-and-braces: any caller that slips a None through lands here.
@@ -479,7 +548,7 @@ class PaceAgent:
         # converts None→NaN and the model handles NaN natively via its
         # sparse-aware split logic (default_left). Cheap and defensive —
         # no-op on already-numeric frames.
-        numeric = df.apply(pd.to_numeric, errors='coerce')
+        numeric = df.apply(pd.to_numeric, errors="coerce")
         self._label_against_envelope(numeric)
         return numeric
 
@@ -502,8 +571,8 @@ class PaceAgent:
         verdict = _N06_ENVELOPE.check(feature_df.iloc[0].to_dict())
         if verdict.violations:
             logger.warning(
-                'N06 called outside its trained range on %d feature(s): %s; the '
-                'prediction is an extrapolation, not a fit',
+                "N06 called outside its trained range on %d feature(s): %s; the "
+                "prediction is an extrapolation, not a fit",
                 len(verdict.violations),
                 dict(verdict.violations),
             )
@@ -524,7 +593,7 @@ class PaceAgent:
             Absolute predicted lap time in seconds.
         """
         delta = float(self.model.predict(feature_df)[0])
-        prev  = float(feature_df['Prev_LapTime'].iloc[0])
+        prev = float(feature_df["Prev_LapTime"].iloc[0])
         return prev + delta
 
     def _bootstrap_ci(
@@ -552,11 +621,17 @@ class PaceAgent:
         Returns:
             Tuple (p10, p90) of absolute lap times in seconds.
         """
-        noise_cols = ['Prev_LapTime', 'Prev_SpeedST', 'mean_sector_speed',
-                      'AirTemp', 'TrackTemp', 'TyreLife']
+        noise_cols = [
+            "Prev_LapTime",
+            "Prev_SpeedST",
+            "mean_sector_speed",
+            "AirTemp",
+            "TrackTemp",
+            "TyreLife",
+        ]
 
-        rng     = np.random.default_rng(seed)
-        base    = feature_df.values.copy().astype(float)
+        rng = np.random.default_rng(seed)
+        base = feature_df.values.copy().astype(float)
         col_idx = {c: feature_df.columns.get_loc(c) for c in noise_cols}
 
         preds = []
@@ -566,14 +641,12 @@ class PaceAgent:
                 sigma = abs(base[0, idx]) * _NOISE_PCT
                 row[0, idx] += rng.normal(0, sigma)
             df_row = pd.DataFrame(row, columns=feature_df.columns)
-            delta  = float(self.model.predict(df_row)[0])
-            preds.append(float(df_row['Prev_LapTime'].iloc[0]) + delta)
+            delta = float(self.model.predict(df_row)[0])
+            preds.append(float(df_row["Prev_LapTime"].iloc[0]) + delta)
 
         return float(np.percentile(preds, 10)), float(np.percentile(preds, 90))
 
-    def _session_median(
-        self, gp_name: str, year: int, compound: str
-    ) -> Optional[float]:
+    def _session_median(self, gp_name: str, year: int, compound: str) -> Optional[float]:
         """Return the historical median lap time for a GP / year / compound.
 
         Filters self.laps_ref to the matching GP, year, and compound, then
@@ -590,11 +663,11 @@ class PaceAgent:
             Median lap time in seconds, or None when no matching laps exist.
         """
         mask = (
-            (self.laps_ref['GP_Name']  == gp_name) &
-            (self.laps_ref['Year']     == year)     &
-            (self.laps_ref['Compound'] == compound)
+            (self.laps_ref["GP_Name"] == gp_name)
+            & (self.laps_ref["Year"] == year)
+            & (self.laps_ref["Compound"] == compound)
         )
-        subset = self.laps_ref.loc[mask, 'LapTime_s'].dropna()
+        subset = self.laps_ref.loc[mask, "LapTime_s"].dropna()
         return float(subset.median()) if len(subset) > 0 else None
 
     # ── Main inference entrypoint ─────────────────────────────────────────────
@@ -669,28 +742,41 @@ class PaceAgent:
             PaceOutput with all fields populated and a reasoning string.
         """
         feature_df = self._build_feature_row(
-            driver_number=driver_number, lap_number=lap_number, stint=stint,
-            tyre_life=tyre_life, compound=compound, position=position, team=team,
-            laps_since_pit=laps_since_pit, fuel_load=fuel_load, year=year,
-            prev_lap_time=prev_lap_time, prev_tyre_life=prev_tyre_life,
-            prev_speed_st=prev_speed_st, air_temp=air_temp, track_temp=track_temp,
-            humidity=humidity, rainfall=rainfall, total_laps=total_laps,
-            gp_name=gp_name, mean_sector_speed=mean_sector_speed,
-            prev_deg_rate=prev_deg_rate, prev_cum_deg=prev_cum_deg,
+            driver_number=driver_number,
+            lap_number=lap_number,
+            stint=stint,
+            tyre_life=tyre_life,
+            compound=compound,
+            position=position,
+            team=team,
+            laps_since_pit=laps_since_pit,
+            fuel_load=fuel_load,
+            year=year,
+            prev_lap_time=prev_lap_time,
+            prev_tyre_life=prev_tyre_life,
+            prev_speed_st=prev_speed_st,
+            air_temp=air_temp,
+            track_temp=track_temp,
+            humidity=humidity,
+            rainfall=rainfall,
+            total_laps=total_laps,
+            gp_name=gp_name,
+            mean_sector_speed=mean_sector_speed,
+            prev_deg_rate=prev_deg_rate,
+            prev_cum_deg=prev_cum_deg,
             prev_deg_accel=prev_deg_accel,
             stint_baseline_tyre_life=stint_baseline_tyre_life,
         )
 
-        lap_time_pred   = self._predict(feature_df)
-        delta_vs_prev   = lap_time_pred - prev_lap_time
-        p10, p90        = self._bootstrap_ci(feature_df)
-        median          = self._session_median(gp_name, year, compound)
-        delta_vs_median = (lap_time_pred - median) if median is not None else float('nan')
+        lap_time_pred = self._predict(feature_df)
+        delta_vs_prev = lap_time_pred - prev_lap_time
+        p10, p90 = self._bootstrap_ci(feature_df)
+        median = self._session_median(gp_name, year, compound)
+        delta_vs_median = (lap_time_pred - median) if median is not None else float("nan")
 
-        trend  = "faster" if delta_vs_prev < 0 else "slower"
+        trend = "faster" if delta_vs_prev < 0 else "slower"
         vs_med = (
-            f"{delta_vs_median:+.3f}s vs median"
-            if median is not None else "no median reference"
+            f"{delta_vs_median:+.3f}s vs median" if median is not None else "no median reference"
         )
         reasoning = (
             f"Lap {lap_number}: predicted {round(lap_time_pred, 3):.3f}s "
@@ -699,12 +785,12 @@ class PaceAgent:
         )
 
         return PaceOutput(
-            lap_time_pred   = round(lap_time_pred, 3),
-            delta_vs_prev   = round(delta_vs_prev, 3),
-            delta_vs_median = round(delta_vs_median, 3),
-            ci_p10          = round(p10, 3),
-            ci_p90          = round(p90, 3),
-            reasoning       = reasoning,
+            lap_time_pred=round(lap_time_pred, 3),
+            delta_vs_prev=round(delta_vs_prev, 3),
+            delta_vs_median=round(delta_vs_median, 3),
+            ci_p10=round(p10, 3),
+            ci_p90=round(p90, 3),
+            reasoning=reasoning,
         )
 
     def run_from_state(self, lap_state: dict) -> PaceOutput:
@@ -724,12 +810,12 @@ class PaceAgent:
         Returns:
             PaceOutput with all fields populated.
         """
-        d    = lap_state['driver']
-        meta = lap_state['session_meta']
-        wx   = lap_state.get('weather', {})
+        d = lap_state["driver"]
+        meta = lap_state["session_meta"]
+        wx = lap_state.get("weather", {})
 
-        lap_number     = lap_state['lap_number']
-        total_laps     = meta['total_laps']
+        lap_number = lap_state["lap_number"]
+        total_laps = meta["total_laps"]
         laps_remaining = max(0, total_laps - lap_number)
 
         # ``dict.get(key, default)`` only applies the default when *key is
@@ -744,18 +830,18 @@ class PaceAgent:
         # This file's inline guard was the ONLY one of the three agents that handled
         # present-and-None, and it is now the shared helper the other two adopted rather
         # than a fourth copy of the pattern (#788).
-        _speed_st  = d.get('speed_st')   or 300.0
-        _air_temp  = reading_or_default(wx, 'air_temp',   25.0)
-        _trk_temp  = reading_or_default(wx, 'track_temp', 35.0)
-        _humidity  = reading_or_default(wx, 'humidity',   50.0)
-        _rainfall  = reading_or_default(wx, 'rainfall', 0)
+        _speed_st = d.get("speed_st") or 300.0
+        _air_temp = reading_or_default(wx, "air_temp", 25.0)
+        _trk_temp = reading_or_default(wx, "track_temp", 35.0)
+        _humidity = reading_or_default(wx, "humidity", 50.0)
+        _rainfall = reading_or_default(wx, "rainfall", 0)
 
         return self.run(
-            driver_number  = d.get('driver_number') or 0,
-            lap_number     = lap_number,
-            stint          = d.get('stint') or 1,
-            tyre_life      = d.get('tyre_life') or 1,
-            compound       = d.get('compound') or 'MEDIUM',
+            driver_number=d.get("driver_number") or 0,
+            lap_number=lap_number,
+            stint=d.get("stint") or 1,
+            tyre_life=d.get("tyre_life") or 1,
+            compound=d.get("compound") or "MEDIUM",
             # Plain .get, no `or` fallback: `d.get('position') or 1` collapsed a
             # missing telemetry reading AND the #428 sentinel (a stored `0`)
             # into P1, the race leader, straight into the live N06 XGBoost
@@ -766,11 +852,11 @@ class PaceAgent:
             # existing pd.to_numeric(errors='coerce') turns that into NaN, and
             # XGBoost handles a missing 'Position' natively via its
             # default-left split direction, so no fabricated value is needed.
-            position       = d.get('position'),
-            team           = meta.get('team') or 'Unknown',
-            laps_since_pit = d.get('tyre_life') or 1,
-            fuel_load      = laps_remaining / max(total_laps, 1),
-            year           = meta.get('year') or 2025,
+            position=d.get("position"),
+            team=meta.get("team") or "Unknown",
+            laps_since_pit=d.get("tyre_life") or 1,
+            fuel_load=laps_remaining / max(total_laps, 1),
+            year=meta.get("year") or 2025,
             # ``d.get('prev_lap_time') or 90.0``, NOT ``d.get('lap_time_s')``: the
             # latter fed this LAP's own time back in as the PREVIOUS lap's time, so
             # the model chased its own most recent prediction instead of the real
@@ -787,23 +873,23 @@ class PaceAgent:
             # would turn lap_time_pred itself into NaN. 90.0 is the same
             # order-of-magnitude placeholder the old (wrong) code used, now only
             # reached on a genuinely missing previous lap.
-            prev_lap_time  = d.get('prev_lap_time') or MISSING_PREV_LAP_TIME_S,
-            prev_tyre_life = max(0, (d.get('tyre_life') or 1) - 1),
-            prev_speed_st  = float(_speed_st),
-            air_temp       = float(_air_temp),
-            track_temp     = float(_trk_temp),
-            humidity       = float(_humidity),
-            rainfall       = float(_rainfall or 0),
-            total_laps     = total_laps,
-            gp_name        = meta.get('gp_name') or '',
-            prev_deg_rate  = 0.0,
-            prev_cum_deg   = 0.0,
-            prev_deg_accel = 0.0,
+            prev_lap_time=d.get("prev_lap_time") or MISSING_PREV_LAP_TIME_S,
+            prev_tyre_life=max(0, (d.get("tyre_life") or 1) - 1),
+            prev_speed_st=float(_speed_st),
+            air_temp=float(_air_temp),
+            track_temp=float(_trk_temp),
+            humidity=float(_humidity),
+            rainfall=float(_rainfall or 0),
+            total_laps=total_laps,
+            gp_name=meta.get("gp_name") or "",
+            prev_deg_rate=0.0,
+            prev_cum_deg=0.0,
+            prev_deg_accel=0.0,
             # Plain .get, deliberately NOT the `or` pattern used above: `or` would
             # collapse a legitimate baseline of 0 into None and re-introduce exactly
             # the sentinel-vs-real-value confusion this epic is about. Absent stays
             # absent, and _compute_derived turns that into a NaN plus a warning (#446).
-            stint_baseline_tyre_life = d.get('stint_baseline_tyre_life'),
+            stint_baseline_tyre_life=d.get("stint_baseline_tyre_life"),
         )
 
 
@@ -832,14 +918,31 @@ def _get_default_pace_agent() -> PaceAgent:
 # Public entry points (backward-compatible API — same signatures as before)
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 def run_pace_agent(
-    driver_number, lap_number, stint, tyre_life, compound,
-    position, team, laps_since_pit, fuel_load, year,
-    prev_lap_time, prev_tyre_life, prev_speed_st,
-    air_temp, track_temp, humidity, rainfall,
-    total_laps, gp_name,
+    driver_number,
+    lap_number,
+    stint,
+    tyre_life,
+    compound,
+    position,
+    team,
+    laps_since_pit,
+    fuel_load,
+    year,
+    prev_lap_time,
+    prev_tyre_life,
+    prev_speed_st,
+    air_temp,
+    track_temp,
+    humidity,
+    rainfall,
+    total_laps,
+    gp_name,
     mean_sector_speed=None,
-    prev_deg_rate=0.0, prev_cum_deg=0.0, prev_deg_accel=0.0,
+    prev_deg_rate=0.0,
+    prev_cum_deg=0.0,
+    prev_deg_accel=0.0,
 ) -> PaceOutput:
     """Run the Pace Agent for a single lap and return a structured PaceOutput.
 
@@ -848,14 +951,28 @@ def run_pace_agent(
     parameter documentation.
     """
     return _get_default_pace_agent().run(
-        driver_number=driver_number, lap_number=lap_number, stint=stint,
-        tyre_life=tyre_life, compound=compound, position=position, team=team,
-        laps_since_pit=laps_since_pit, fuel_load=fuel_load, year=year,
-        prev_lap_time=prev_lap_time, prev_tyre_life=prev_tyre_life,
-        prev_speed_st=prev_speed_st, air_temp=air_temp, track_temp=track_temp,
-        humidity=humidity, rainfall=rainfall, total_laps=total_laps,
-        gp_name=gp_name, mean_sector_speed=mean_sector_speed,
-        prev_deg_rate=prev_deg_rate, prev_cum_deg=prev_cum_deg,
+        driver_number=driver_number,
+        lap_number=lap_number,
+        stint=stint,
+        tyre_life=tyre_life,
+        compound=compound,
+        position=position,
+        team=team,
+        laps_since_pit=laps_since_pit,
+        fuel_load=fuel_load,
+        year=year,
+        prev_lap_time=prev_lap_time,
+        prev_tyre_life=prev_tyre_life,
+        prev_speed_st=prev_speed_st,
+        air_temp=air_temp,
+        track_temp=track_temp,
+        humidity=humidity,
+        rainfall=rainfall,
+        total_laps=total_laps,
+        gp_name=gp_name,
+        mean_sector_speed=mean_sector_speed,
+        prev_deg_rate=prev_deg_rate,
+        prev_cum_deg=prev_cum_deg,
         prev_deg_accel=prev_deg_accel,
     )
 

--- a/tests/agents/test_n06_envelope.py
+++ b/tests/agents/test_n06_envelope.py
@@ -129,7 +129,6 @@ _UNBOUNDED = {
     "Prev_DegradationRate": "hardcoded 0.0, and 0.0 is mid-distribution",
     "Prev_CumulativeDeg": "hardcoded 0.0, and 0.0 is mid-distribution",
     "Prev_DegAcceleration": "hardcoded 0.0, and 0.0 is mid-distribution",
-    "mean_sector_speed": "always carries the speed trap at inference",
     # a bound would report the same event twice
     "LapsSincePitStop": "equals TyreLife at inference",
     # training and inference encode it differently

--- a/tests/agents/test_pace_circuit_speed.py
+++ b/tests/agents/test_pace_circuit_speed.py
@@ -78,18 +78,46 @@ def test_every_race_resolves_to_the_value_its_own_parquet_rows_carry(agent):
     parquet and served that one value for every season, so a 2023 Silverstone lap was fed
     a measurement taken two years after it, 18.4 km/h away.
     """
+    from src.agents.pace_agent import _FEATURED_SEASONS
     from src.f1_strat_manager.data_cache import get_data_root
 
-    laps = pd.read_parquet(
-        get_data_root() / "processed" / "laps_featured.parquet",
-        columns=["Year", "GP_Name", "mean_sector_speed"],
-    ).dropna()
-    per_race = laps.drop_duplicates(["Year", "GP_Name"])
+    checked = 0
+    for year in _FEATURED_SEASONS:
+        laps = pd.read_parquet(
+            get_data_root() / "processed" / f"laps_featured_{year}.parquet",
+            columns=["GP_Name", "mean_sector_speed"],
+        ).dropna()
+        for row in laps.drop_duplicates("GP_Name").itertuples():
+            checked += 1
+            served = agent._resolve_mean_sector_speed(str(row.GP_Name), year)
+            assert served == pytest.approx(float(row.mean_sector_speed)), f"{year} {row.GP_Name}"
 
-    assert len(per_race) > 0, "the featured artefact carried no circuit speeds"
-    for row in per_race.itertuples():
-        served = agent._resolve_mean_sector_speed(str(row.GP_Name), int(row.Year))
-        assert served == pytest.approx(float(row.mean_sector_speed)), f"{row.Year} {row.GP_Name}"
+    assert checked > 0, "the featured artefacts carried no circuit speeds"
+
+
+def test_a_2025_lap_is_not_served_the_training_seasons_measurement(agent):
+    """The regression a whole gate round was spent on, pinned as an EFFECT.
+
+    Switching the loader to the COMBINED `laps_featured.parquet` looked like a strict
+    improvement, because that file has no missing values. It broadcasts the training-era
+    number across all three seasons instead: its Silverstone row reads 249.71 for 2023 and
+    for 2025 alike, so keying by year became decorative and every 2025 lap silently
+    received the 2023 measurement.
+
+    The raw laps settle it. Silverstone 2025's own speed traps average 232.32 km/h, which
+    is the per-year artefact's 231.36 and not the combined file's 249.71.
+
+    Asserting that the two seasons DIFFER is what catches this; asserting either value on
+    its own passes happily against the wrong artefact.
+    """
+    served_2023 = agent._resolve_mean_sector_speed("Silverstone", 2023)
+    served_2025 = agent._resolve_mean_sector_speed("Silverstone", 2025)
+
+    assert abs(served_2025 - served_2023) > 1.0, (
+        f"Silverstone reads {served_2025} in 2025 and {served_2023} in 2023; if they are "
+        f"equal the loader is reading an artefact that broadcasts one season's value"
+    )
+    assert served_2025 == pytest.approx(231.36, abs=0.5)
 
 
 def test_the_training_seasons_are_one_artefact_generation_not_two(agent):
@@ -113,20 +141,19 @@ def test_the_training_seasons_are_one_artefact_generation_not_two(agent):
         ), gp
 
 
-def test_the_map_has_no_holes(agent):
-    """Las Vegas is the reason this reads the combined parquet, not the 2025 one.
+def test_las_vegas_2025_is_a_known_artefact_hole_and_stays_unknown(agent):
+    """The one race the correct artefact cannot answer, pinned so it is not "fixed" wrongly.
 
-    `laps_featured_2025.parquet` carries NaN on all 760 Las Vegas rows, so a `.dropna()`
-    over it drops a circuit N06 was fitted on and whose value sits in three other
-    artefacts. "Absent from the map" has to mean an unknown circuit, never an artefact
-    with a hole in it.
+    `laps_featured_2025.parquet` carries NaN on all 760 Las Vegas rows. The tempting repair
+    is to fall back to the training-era value, which sits in three other artefacts and is
+    228.96. That would be the same defect as the speed-trap substitution this whole fix
+    removes, only quieter: a 2025 lap served a measurement from a different season.
+
+    So it stays NaN, and the missing value belongs in the artefact rather than in a
+    fallback here.
     """
-    assert ("2025" not in {str(y) for y, _ in agent.circuit_mean_sector_speed}) is False
-    assert (2025, "Las Vegas") in agent.circuit_mean_sector_speed
-    for year in (2023, 2024, 2025):
-        assert agent._resolve_mean_sector_speed("Las Vegas", year) == pytest.approx(
-            228.9645, abs=1e-3
-        )
+    assert agent._resolve_mean_sector_speed("Las Vegas", 2023) == pytest.approx(228.9645, abs=1e-3)
+    assert math.isnan(agent._resolve_mean_sector_speed("Las Vegas", 2025))
 
 
 def test_the_row_fed_to_n06_carries_the_circuit_value_not_the_speed_trap(agent):
@@ -190,7 +217,13 @@ def test_every_race_on_disk_resolves(agent):
                 unresolved.append((year_dir.name, race_dir.name, gp_name))
 
     assert checked > 0, "no races found on disk: this would hold vacuously"
-    assert unresolved == [], f"{len(unresolved)} of {checked} races resolve to NaN: {unresolved}"
+    # Las Vegas 2025 is a hole in the artefact, not a resolution failure, and is pinned
+    # by its own test above. Listing it here rather than widening the assertion keeps a
+    # NEW unresolved race failing loudly.
+    known_holes = [("2025", "Las_Vegas", "Las Vegas")]
+    assert sorted(unresolved) == sorted(known_holes), (
+        f"{len(unresolved)} of {checked} races resolve to NaN: {unresolved}"
+    )
 
 
 # --- an unresolvable circuit stays unknown -----------------------------------

--- a/tests/agents/test_pace_circuit_speed.py
+++ b/tests/agents/test_pace_circuit_speed.py
@@ -1,17 +1,19 @@
 """N06 is fed the circuit's own mean sector speed, not the speed trap (#797).
 
 `mean_sector_speed` is a property of the CIRCUIT: the featured parquet holds exactly
-one value per GP. `_compute_derived` used to substitute `prev_speed_st` whenever none
-was supplied, and `run_from_state` never supplied one, so on the path every real race
-takes the model received a different physical quantity on every lap.
+one value per (year, GP). `_compute_derived` used to substitute `prev_speed_st` whenever
+none was supplied, and `run_from_state` never supplied one, so on the path every real
+race takes the model received a different physical quantity on every lap.
 
-What these pin is the pair of rules that makes the fix a fix rather than a new guess:
-the value served must be the value fitted, and a circuit that does not resolve must
-reach the model as MISSING rather than as a substituted reading.
+What these pin is the set of rules that makes the fix a fix rather than a new guess: the
+value served must be the value the replayed lap carries, EVERY race must resolve, and a
+circuit that genuinely does not resolve must reach the model as MISSING rather than as a
+substituted reading.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import math
 from pathlib import Path
@@ -22,10 +24,11 @@ import pytest
 ROOT = Path(__file__).parent.parent.parent
 _HAS_ARTEFACTS = (
     ROOT / "data" / "models" / "lap_time" / "xgb_laptime_delta_final.json"
-).exists() and (ROOT / "data" / "processed" / "laps_featured_2025.parquet").exists()
+).exists() and (ROOT / "data" / "processed" / "laps_featured.parquet").exists()
+_HAS_RAW = (ROOT / "data" / "raw").is_dir()
 
 pytestmark = pytest.mark.skipif(
-    not _HAS_ARTEFACTS, reason="N06 weights or the featured parquet are absent"
+    not _HAS_ARTEFACTS, reason="N06 weights or the combined featured parquet are absent"
 )
 
 
@@ -64,49 +67,130 @@ def _feature_row(agent, **overrides):
     return agent._build_feature_row(**kwargs)
 
 
-# --- the value served is the value fitted ------------------------------------
+# --- the value served is the value the replayed lap carries -------------------
 
 
-def test_every_circuit_resolves_to_the_value_the_parquet_trained_on(agent):
-    """Not "close to", the same number. The map is read from the training artefact.
+def test_every_race_resolves_to_the_value_its_own_parquet_rows_carry(agent):
+    """Not "close to", the same number, and for every (year, GP) rather than one.
 
-    Asserted over every GP rather than one, because a lookup that works for the
-    circuit somebody tested and silently misses the rest is the failure mode a
-    single-case test invites.
+    A lookup that works for the circuit somebody tested and silently misses the rest is
+    the failure this asserts against: the first version of the loader read only the 2025
+    parquet and served that one value for every season, so a 2023 Silverstone lap was fed
+    a measurement taken two years after it, 18.4 km/h away.
     """
     from src.f1_strat_manager.data_cache import get_data_root
 
-    trained = (
-        pd.read_parquet(
-            get_data_root() / "processed" / "laps_featured_2025.parquet",
-            columns=["GP_Name", "mean_sector_speed"],
-        )
-        .dropna()
-        .drop_duplicates("GP_Name")
-        .set_index("GP_Name")["mean_sector_speed"]
-    )
+    laps = pd.read_parquet(
+        get_data_root() / "processed" / "laps_featured.parquet",
+        columns=["Year", "GP_Name", "mean_sector_speed"],
+    ).dropna()
+    per_race = laps.drop_duplicates(["Year", "GP_Name"])
 
-    assert len(trained) > 0, "the training artefact carried no circuit speeds"
-    for gp, expected in trained.items():
-        assert agent._resolve_mean_sector_speed(str(gp)) == pytest.approx(float(expected)), gp
+    assert len(per_race) > 0, "the featured artefact carried no circuit speeds"
+    for row in per_race.itertuples():
+        served = agent._resolve_mean_sector_speed(str(row.GP_Name), int(row.Year))
+        assert served == pytest.approx(float(row.mean_sector_speed)), f"{row.Year} {row.GP_Name}"
+
+
+def test_the_training_seasons_are_one_artefact_generation_not_two(agent):
+    """2023 and 2024 are identical per GP, which is why the map is not "per season".
+
+    Pinned because the docstring says so and a wrong mechanism is how the next fix goes
+    wrong: someone completing a per-season resolution between 2023 and 2024 would find
+    nothing to resolve. The value is recomputed per artefact BUILD, and one build pooled
+    both training seasons.
+    """
+    shared = {
+        gp
+        for (year, gp) in agent.circuit_mean_sector_speed
+        if (2023, gp) in agent.circuit_mean_sector_speed
+        and (2024, gp) in agent.circuit_mean_sector_speed
+    }
+    assert shared, "no GP appears in both training seasons"
+    for gp in shared:
+        assert agent.circuit_mean_sector_speed[(2023, gp)] == pytest.approx(
+            agent.circuit_mean_sector_speed[(2024, gp)]
+        ), gp
+
+
+def test_the_map_has_no_holes(agent):
+    """Las Vegas is the reason this reads the combined parquet, not the 2025 one.
+
+    `laps_featured_2025.parquet` carries NaN on all 760 Las Vegas rows, so a `.dropna()`
+    over it drops a circuit N06 was fitted on and whose value sits in three other
+    artefacts. "Absent from the map" has to mean an unknown circuit, never an artefact
+    with a hole in it.
+    """
+    assert ("2025" not in {str(y) for y, _ in agent.circuit_mean_sector_speed}) is False
+    assert (2025, "Las Vegas") in agent.circuit_mean_sector_speed
+    for year in (2023, 2024, 2025):
+        assert agent._resolve_mean_sector_speed("Las Vegas", year) == pytest.approx(
+            228.9645, abs=1e-3
+        )
 
 
 def test_the_row_fed_to_n06_carries_the_circuit_value_not_the_speed_trap(agent):
     """The regression itself: the trap reading must not reach the feature again."""
-    row = _feature_row(agent, gp_name="Lusail", prev_speed_st=300.0)
+    row = _feature_row(agent, gp_name="Lusail", year=2025, prev_speed_st=300.0)
 
     served = float(row["mean_sector_speed"].iloc[0])
-    assert served == pytest.approx(agent.circuit_mean_sector_speed["Lusail"])
+    assert served == pytest.approx(agent.circuit_mean_sector_speed[(2025, "Lusail")])
     assert served != pytest.approx(300.0)
     # Prev_SpeedST is still its own feature and still carries the trap.
     assert float(row["Prev_SpeedST"].iloc[0]) == pytest.approx(300.0)
 
 
-def test_a_full_event_name_resolves_through_the_slug(agent):
-    """gp_name arrives in either keyspace depending on the caller (#448, #450)."""
-    assert agent._resolve_mean_sector_speed("Qatar Grand Prix") == pytest.approx(
-        agent.circuit_mean_sector_speed["Lusail"]
-    )
+# --- every keyspace a real caller uses ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "year"),
+    [
+        ("Lusail", 2025),  # parquet slug, what the CLI passes
+        ("Qatar Grand Prix", 2025),  # FastF1 event name
+        ("Miami Gardens", 2025),  # metadata.json, what the replay engine passes
+        ("Miami_Gardens", 2025),  # raw folder name
+        ("Spain", 2023),  # a training-season folder whose slug differs
+    ],
+)
+def test_each_keyspace_a_real_caller_uses_resolves(agent, name, year):
+    """Four names for one GP, and an earlier draft resolved only two of them.
+
+    'Miami Gardens' with a SPACE is what `RaceReplayEngine` puts into `session_meta`, and
+    it matches neither the parquet slug nor the underscore folder form, so every lap of
+    the 2025 Miami race was served NaN while its value sat in the map. The #448/#450
+    dual-keyspace trap, third occurrence.
+    """
+    assert not math.isnan(agent._resolve_mean_sector_speed(name, year))
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_RAW, reason="data/raw absent")
+def test_every_race_on_disk_resolves(agent):
+    """The enumeration, checked rather than assumed.
+
+    Fixing the two names an audit happened to name would leave the next one to be found
+    the same way. This walks every race under `data/raw/` and asserts the name its
+    metadata actually carries resolves, which is the only form of this claim worth making.
+    """
+    from src.f1_strat_manager.data_cache import get_data_root
+
+    unresolved = []
+    checked = 0
+    for year_dir in sorted((get_data_root() / "raw").iterdir()):
+        if not year_dir.is_dir() or not year_dir.name.isdigit():
+            continue
+        for race_dir in sorted(p for p in year_dir.iterdir() if p.is_dir()):
+            meta = race_dir / "metadata.json"
+            if not meta.exists():
+                continue
+            checked += 1
+            gp_name = json.loads(meta.read_text(encoding="utf-8")).get("gp_name", "")
+            if math.isnan(agent._resolve_mean_sector_speed(gp_name, int(year_dir.name))):
+                unresolved.append((year_dir.name, race_dir.name, gp_name))
+
+    assert checked > 0, "no races found on disk: this would hold vacuously"
+    assert unresolved == [], f"{len(unresolved)} of {checked} races resolve to NaN: {unresolved}"
 
 
 # --- an unresolvable circuit stays unknown -----------------------------------
@@ -116,14 +200,19 @@ def test_an_unknown_circuit_yields_nan_and_never_a_substituted_reading(agent, ca
     """The rule the bug broke: unknown data must not become a number the model can use.
 
     NaN is in-distribution for XGBoost, which routes a missing feature through its
-    sparse-aware split. A plausible-looking speed is not: it answers a different
-    question with full confidence, which is exactly what #797 was.
+    sparse-aware split. A plausible-looking speed is not: it answers a different question
+    with full confidence, which is exactly what #797 was.
     """
     with caplog.at_level(logging.WARNING):
-        value = agent._resolve_mean_sector_speed("Nurburgring")
+        value = agent._resolve_mean_sector_speed("Nurburgring", 2025)
 
     assert math.isnan(value)
     assert any("no trained mean sector speed" in r.message for r in caplog.records)
+
+
+def test_a_season_the_dataset_does_not_cover_is_unknown_too(agent):
+    """A real circuit in a year with no artefact is still unknown, not the nearest year."""
+    assert math.isnan(agent._resolve_mean_sector_speed("Lusail", 2019))
 
 
 def test_an_unknown_circuit_reaches_the_model_as_missing(agent):
@@ -146,35 +235,33 @@ def test_an_explicitly_supplied_value_is_not_overridden_by_the_circuit_constant(
 # --- the envelope bound is meaningful again ----------------------------------
 
 
-def test_the_envelope_now_separates_a_circuit_n06_was_fitted_on_from_one_it_was_not(agent):
+def test_the_envelope_separates_a_circuit_n06_was_fitted_on_from_one_it_was_not(agent):
     """The bound is back and it discriminates, which is the point of restoring it.
 
-    A first version of this test asserted that EVERY served circuit falls inside the
-    bound, and Monza refuted it. That assertion was wrong, not the code: the bound is
-    the 2023-2024 range and the served values are the 2025 measurements, so they are
-    different sets and a 2025 circuit may legitimately sit outside. Monza 2025 does,
-    at 317.24 against a fitted maximum of 314.97, and saying so is exactly the job the
-    bound was restored to do.
+    A first version of this test asserted that EVERY served value falls inside the bound,
+    and Monza refuted it. That assertion was wrong, not the code: the bound is the
+    2023-2024 range and a 2025 lap is served a 2025 measurement, so a 2025 circuit may
+    legitimately sit outside. Monza 2025 does, at 317.24 against a fitted maximum of
+    314.97, and saying so is exactly the job the bound was restored to do.
 
-    So what is pinned here is the discrimination, not a blanket. A bound that flagged
+    So what is pinned is the discrimination, not a blanket. A bound that flagged
     everything, or nothing, would pass a coverage check and tell nobody anything.
     """
     from src.agents.pace_agent import _N06_ENVELOPE, _N06_TRAINED_BOUNDS
 
     lower, upper = _N06_TRAINED_BOUNDS["mean_sector_speed"]
+    served = agent.circuit_mean_sector_speed
+    inside = {k: v for k, v in served.items() if lower <= v <= upper}
+    outside = {k: v for k, v in served.items() if not lower <= v <= upper}
 
-    inside = {gp: v for gp, v in agent.circuit_mean_sector_speed.items() if lower <= v <= upper}
-    outside = {
-        gp: v for gp, v in agent.circuit_mean_sector_speed.items() if not lower <= v <= upper
-    }
-
-    assert inside, "no served circuit is in range: the bound and the feed disagree"
+    assert inside, "no served value is in range: the bound and the feed disagree"
     assert len(inside) > len(outside), (
-        f"{len(outside)} of {len(agent.circuit_mean_sector_speed)} circuits fall outside; "
-        f"a bound that rejects most of what it is fed is describing the wrong quantity"
+        f"{len(outside)} of {len(served)} races fall outside; a bound that rejects most "
+        f"of what it is fed is describing the wrong quantity"
     )
-
-    # And it must actually fire on the one that is out, through the real envelope.
-    for gp, value in outside.items():
+    # Every training-season value must be inside by construction: that is where the
+    # bound came from. Only a later season may legitimately escape it.
+    for (year, gp), value in outside.items():
+        assert year == 2025, f"{year} {gp} is outside the range its own season defined"
         verdict = _N06_ENVELOPE.check({"mean_sector_speed": value})
         assert "mean_sector_speed" in verdict.violations, gp

--- a/tests/agents/test_pace_circuit_speed.py
+++ b/tests/agents/test_pace_circuit_speed.py
@@ -1,0 +1,180 @@
+"""N06 is fed the circuit's own mean sector speed, not the speed trap (#797).
+
+`mean_sector_speed` is a property of the CIRCUIT: the featured parquet holds exactly
+one value per GP. `_compute_derived` used to substitute `prev_speed_st` whenever none
+was supplied, and `run_from_state` never supplied one, so on the path every real race
+takes the model received a different physical quantity on every lap.
+
+What these pin is the pair of rules that makes the fix a fix rather than a new guess:
+the value served must be the value fitted, and a circuit that does not resolve must
+reach the model as MISSING rather than as a substituted reading.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_ARTEFACTS = (
+    ROOT / "data" / "models" / "lap_time" / "xgb_laptime_delta_final.json"
+).exists() and (ROOT / "data" / "processed" / "laps_featured_2025.parquet").exists()
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_ARTEFACTS, reason="N06 weights or the featured parquet are absent"
+)
+
+
+@pytest.fixture(scope="module")
+def agent():
+    from src.agents.pace_agent import PaceAgent
+
+    return PaceAgent()
+
+
+def _feature_row(agent, **overrides):
+    """A real feature row, built through the real builder."""
+    kwargs = dict(
+        driver_number=4,
+        lap_number=30,
+        stint=2,
+        tyre_life=14,
+        compound="MEDIUM",
+        position=4,
+        team="McLaren",
+        laps_since_pit=14,
+        fuel_load=0.5,
+        year=2025,
+        prev_lap_time=84.0,
+        prev_tyre_life=13,
+        prev_speed_st=300.0,
+        air_temp=25.0,
+        track_temp=35.0,
+        humidity=50.0,
+        rainfall=0.0,
+        total_laps=57,
+        gp_name="Lusail",
+        stint_baseline_tyre_life=1,
+    )
+    kwargs.update(overrides)
+    return agent._build_feature_row(**kwargs)
+
+
+# --- the value served is the value fitted ------------------------------------
+
+
+def test_every_circuit_resolves_to_the_value_the_parquet_trained_on(agent):
+    """Not "close to", the same number. The map is read from the training artefact.
+
+    Asserted over every GP rather than one, because a lookup that works for the
+    circuit somebody tested and silently misses the rest is the failure mode a
+    single-case test invites.
+    """
+    from src.f1_strat_manager.data_cache import get_data_root
+
+    trained = (
+        pd.read_parquet(
+            get_data_root() / "processed" / "laps_featured_2025.parquet",
+            columns=["GP_Name", "mean_sector_speed"],
+        )
+        .dropna()
+        .drop_duplicates("GP_Name")
+        .set_index("GP_Name")["mean_sector_speed"]
+    )
+
+    assert len(trained) > 0, "the training artefact carried no circuit speeds"
+    for gp, expected in trained.items():
+        assert agent._resolve_mean_sector_speed(str(gp)) == pytest.approx(float(expected)), gp
+
+
+def test_the_row_fed_to_n06_carries_the_circuit_value_not_the_speed_trap(agent):
+    """The regression itself: the trap reading must not reach the feature again."""
+    row = _feature_row(agent, gp_name="Lusail", prev_speed_st=300.0)
+
+    served = float(row["mean_sector_speed"].iloc[0])
+    assert served == pytest.approx(agent.circuit_mean_sector_speed["Lusail"])
+    assert served != pytest.approx(300.0)
+    # Prev_SpeedST is still its own feature and still carries the trap.
+    assert float(row["Prev_SpeedST"].iloc[0]) == pytest.approx(300.0)
+
+
+def test_a_full_event_name_resolves_through_the_slug(agent):
+    """gp_name arrives in either keyspace depending on the caller (#448, #450)."""
+    assert agent._resolve_mean_sector_speed("Qatar Grand Prix") == pytest.approx(
+        agent.circuit_mean_sector_speed["Lusail"]
+    )
+
+
+# --- an unresolvable circuit stays unknown -----------------------------------
+
+
+def test_an_unknown_circuit_yields_nan_and_never_a_substituted_reading(agent, caplog):
+    """The rule the bug broke: unknown data must not become a number the model can use.
+
+    NaN is in-distribution for XGBoost, which routes a missing feature through its
+    sparse-aware split. A plausible-looking speed is not: it answers a different
+    question with full confidence, which is exactly what #797 was.
+    """
+    with caplog.at_level(logging.WARNING):
+        value = agent._resolve_mean_sector_speed("Nurburgring")
+
+    assert math.isnan(value)
+    assert any("no trained mean sector speed" in r.message for r in caplog.records)
+
+
+def test_an_unknown_circuit_reaches_the_model_as_missing(agent):
+    """End to end: the NaN survives the frame build rather than being coerced."""
+    row = _feature_row(agent, gp_name="Nurburgring", prev_speed_st=300.0)
+
+    assert math.isnan(float(row["mean_sector_speed"].iloc[0]))
+
+
+# --- an explicit measurement still wins --------------------------------------
+
+
+def test_an_explicitly_supplied_value_is_not_overridden_by_the_circuit_constant(agent):
+    """A caller that genuinely measured this lap must keep its number."""
+    row = _feature_row(agent, gp_name="Lusail", mean_sector_speed=241.5)
+
+    assert float(row["mean_sector_speed"].iloc[0]) == pytest.approx(241.5)
+
+
+# --- the envelope bound is meaningful again ----------------------------------
+
+
+def test_the_envelope_now_separates_a_circuit_n06_was_fitted_on_from_one_it_was_not(agent):
+    """The bound is back and it discriminates, which is the point of restoring it.
+
+    A first version of this test asserted that EVERY served circuit falls inside the
+    bound, and Monza refuted it. That assertion was wrong, not the code: the bound is
+    the 2023-2024 range and the served values are the 2025 measurements, so they are
+    different sets and a 2025 circuit may legitimately sit outside. Monza 2025 does,
+    at 317.24 against a fitted maximum of 314.97, and saying so is exactly the job the
+    bound was restored to do.
+
+    So what is pinned here is the discrimination, not a blanket. A bound that flagged
+    everything, or nothing, would pass a coverage check and tell nobody anything.
+    """
+    from src.agents.pace_agent import _N06_ENVELOPE, _N06_TRAINED_BOUNDS
+
+    lower, upper = _N06_TRAINED_BOUNDS["mean_sector_speed"]
+
+    inside = {gp: v for gp, v in agent.circuit_mean_sector_speed.items() if lower <= v <= upper}
+    outside = {
+        gp: v for gp, v in agent.circuit_mean_sector_speed.items() if not lower <= v <= upper
+    }
+
+    assert inside, "no served circuit is in range: the bound and the feed disagree"
+    assert len(inside) > len(outside), (
+        f"{len(outside)} of {len(agent.circuit_mean_sector_speed)} circuits fall outside; "
+        f"a bound that rejects most of what it is fed is describing the wrong quantity"
+    )
+
+    # And it must actually fire on the one that is out, through the real envelope.
+    for gp, value in outside.items():
+        verdict = _N06_ENVELOPE.check({"mean_sector_speed": value})
+        assert "mean_sector_speed" in verdict.violations, gp

--- a/tests/eval/test_ml_recompute_golden.py
+++ b/tests/eval/test_ml_recompute_golden.py
@@ -12,7 +12,16 @@ import pytest
 
 ROOT = Path(__file__).parent.parent.parent
 _HAS_SC = (ROOT / "data" / "models" / "safety_car_probability" / "lgbm_sc_v1.pkl").exists()
-_HAS_UNDERCUT = (ROOT / "data" / "models" / "pit_prediction" / "lgbm_undercut_v1.pkl").exists()
+# The HOLDOUT as well as the model, matching _HAS_PIT / _HAS_PACE / _HAS_TIRE below.
+# Checking only the model made this test FAIL rather than skip on a checkout built from
+# the published dataset, because `undercut_clean.parquet` is not in it (#798) -- and a
+# data-tier guard that fails on absent data is worse than no guard, since it costs a red
+# suite that says nothing about the change under test.
+_HAS_UNDERCUT = (
+    ROOT / "data" / "models" / "pit_prediction" / "lgbm_undercut_v1.pkl"
+).exists() and (
+    ROOT / "data" / "processed" / "undercut_labeled" / "undercut_clean.parquet"
+).exists()
 _HAS_PIT = (ROOT / "data" / "models" / "pit_prediction" / "hist_pit_p50_v1.pkl").exists() and bool(
     list((ROOT / "data" / "raw").glob("*/*/laps.parquet"))
 )

--- a/tests/mc/test_mc_measured_tables.py
+++ b/tests/mc/test_mc_measured_tables.py
@@ -28,6 +28,19 @@ _skip_no_raw = pytest.mark.skipif(
     reason="data/raw/ not present (CI runner without the HF dataset)",
 )
 
+# The undercut band is measured from a holdout the published dataset does not carry
+# (#798). Without it a fresh measurement writes `"available": false` for that whole
+# table, so the committed-versus-fresh comparison fails on a checkout that is simply
+# incomplete, and the run also LEAVES the emptied file behind in the worktree, one
+# `git add -A` away from committing the loss of a measured table.
+_HAS_UNDERCUT_HOLDOUT = (
+    ROOT / "data" / "processed" / "undercut_labeled" / "undercut_clean.parquet"
+).exists()
+_skip_no_undercut = pytest.mark.skipif(
+    not _HAS_UNDERCUT_HOLDOUT,
+    reason="undercut_clean.parquet not present (not published in the HF dataset, #798)",
+)
+
 
 @pytest.fixture(scope="module")
 def tables() -> dict:
@@ -184,6 +197,7 @@ def test_the_neutralisation_rate_is_keyed_by_circuit_slugs_agents_can_query(tabl
 
 
 @_skip_no_raw
+@_skip_no_undercut
 def test_the_committed_tables_match_a_fresh_measurement():
     import subprocess
     import sys

--- a/tests/mc/test_undercut_targets_are_on_track.py
+++ b/tests/mc/test_undercut_targets_are_on_track.py
@@ -36,9 +36,21 @@ ROOT = Path(__file__).parent.parent.parent
 
 # Importing N28 reads model configs at import time, and the fixture needs the raw
 # parquet. data/ is pulled from Hugging Face, so the CI runner has neither.
+#
+# CONSTRUCTING N28 also reads `undercut_clean.parquet`, and that one is NOT in the
+# published dataset (#798), so a checkout built purely from Hugging Face errored here at
+# fixture setup instead of skipping. The gate has to name every artefact construction
+# touches, not just the ones this file reads itself: an unlisted dependency turns a
+# missing-data skip into four red tests that have nothing to do with the change under
+# test, which is exactly how it presented.
+_HAS_UNDERCUT_HOLDOUT = (
+    ROOT / "data" / "processed" / "undercut_labeled" / "undercut_clean.parquet"
+).exists()
+
 pytestmark = pytest.mark.skipif(
-    not (_HAS_MODELS and (RACE_DIR / "laps.parquet").exists()),
-    reason="needs data/models/ and the raw Lusail parquet (data/ comes from HF, not git)",
+    not (_HAS_MODELS and _HAS_UNDERCUT_HOLDOUT and (RACE_DIR / "laps.parquet").exists()),
+    reason="needs data/models/, undercut_clean.parquet and the raw Lusail parquet "
+    "(data/ comes from HF, not git)",
 )
 
 


### PR DESCRIPTION
## What

Three things, found by pulling on the thread #710's adversarial gate left.

**#797 — N06 was reading the speed trap where it was trained on a circuit mean.** `mean_sector_speed` is a property of the CIRCUIT: one value per GP, the mean of the three speed traps. `_compute_derived` substituted `prev_speed_st` whenever none was supplied and `run_from_state` never supplied one, so on the path every real race takes the model received a different physical quantity on every lap. Training means 256.8 against 303.0 km/h.

It is now looked up per GP from the featured parquet the agent already opens. A circuit that does not resolve reaches the model as **NaN with a warning**, never a substituted reading: XGBoost routes a missing feature through its sparse-aware split, while a plausible speed answers a different question with full confidence. Same rule as #446 and #628. Names resolve through `slug_from_event_name`, because `gp_name` arrives in either keyspace (#448, #450).

**#798 — the pit agent cannot be constructed on a clean install.** `PitStrategyAgent.__init__` reads `undercut_clean.parquet` unconditionally, and that file is not in the published dataset, though `overtake_labeled/` and `sc_labeled/` are. Publishing it is the real fix and needs an artefact that only exists on a machine that has run N16, so this PR fixes the half it can: six tests that **failed rather than skipped**, one of which also regenerated `data/mc_measured_v1.json` with the whole measured `undercut_band` dropped to `available: false` and left the emptied file in the worktree.

**Docs.** The calibrated pit bounds and the operating-envelope contract had no user-facing description, and N25's model line said "trained on 2023-2025 lap data", folding the held-out test season into the training set.

## Measured impact

A single hand-built probe row moved the prediction by 0.002 s and would have made this look cosmetic. Over 4000 real 2025 laps:

| | |
|---|---|
| mean delta | +0.069 s |
| p95 absolute | 0.377 s |
| laps moving more than 0.010 s | **38%** |

The trees split on this feature only in some regions, so one probe is not a distribution.

## A claim of mine, corrected in the branch

The first commit said the value served is the value fitted, "identical to 0.0". That number compared `laps_featured_2023` against `circuit_features_with_clusters_k4.parquet` — two artefacts of the **training** seasons. The code serves the **2025** map, a different pair, and none of the 23 GPs present in both match exactly: mean absolute gap 4.82 km/h, largest Silverstone at 18.35.

Serving 2025 is still correct and is now stated as a choice rather than as an identity. The feature is recomputed per season, so the quantity N04 would compute for a 2025 lap is the 2025 measurement; the training seasons' value would be a stale reading of a circuit since resurfaced or re-regulated.

It follows that the envelope bound is the 2023-2024 range held against a 2025 value, and that is the right way round: the bound asks whether N06 was **fitted** on inputs like this one, so a 2025 circuit outside the fitted range is genuine extrapolation. Monza 2025 at 317.24 against a fitted maximum of 314.97 is the only such case, and `mean_sector_speed` returns to the declared envelope on that basis.

## Checks

- `uvx ruff@0.15.22 check .` and `format --check .` clean under the CI pin
- strategy goldens and projection golden byte-identical
- a real `f1-sim Lusail NOR McLaren --no-llm` run with the real radio corpus: 57 laps clean, every action unchanged, zero unresolved-circuit warnings
- full suite **4 failed / 620 passed / 27 skipped**, down from 7 failed and 4 errors. All four remaining failures reproduce on a `dev` worktree with the same data: `test_weather_restore` and three NLP goldens whose weights are not downloaded locally
- `data/` stays clean across a full run, which it did not before

## Still open, deliberately

N06 is asked to predict on the opening laps of a race and on the first lap of every stint, and it was never trained on either, because its own feature pipeline drops exactly those rows. The envelope now says so out loud on 6 of 57 laps at Lusail. Closing that gap is a modelling change, not this PR.

Closes #797
Refs #798, #710
