### PR TITLE
chore(release): promote dev to main -- the data-integrity batch, the recalibrated pit bounds and the operating envelopes

### DIFF
--- a/docs/pages/agents-api.md
+++ b/docs/pages/agents-api.md
@@ -22,7 +22,9 @@ Every agent has two entry points:
 `lap_state`, which is why the stint fuel baseline is carried there rather than derived from a
 frame. The adapters are not uniform, so check the signature before assuming.
 
-Only the RAG agent (N30) exposes a module-level `get_rag_react_agent()` factory returning a compiled LangGraph `CompiledGraph`, for callers that want to drive the graph directly — it is genuinely invoked (the chat backend calls it). N25-N28 (pace, tire, race situation, pit strategy) used to have an equivalent free function each; all four were confirmed dead (zero callers anywhere in the repo) and removed in the 2026-08-01 cleanup pass. Each of those agents still has its own `get_react_agent()` *instance method*, called internally from its own `_run_core` — only the redundant module-level wrapper was removed. The radio agent (N29) never had one: its pipeline is a fixed sequence of model calls rather than a ReAct loop, so there is no graph to compile.
+Only the RAG agent (N30) exposes a module-level `get_rag_react_agent()` factory returning a compiled LangGraph `CompiledGraph`, for callers that want to drive the graph directly — it is genuinely invoked (the chat backend calls it). N25-N28 (pace, tire, race situation, pit strategy) used to have an equivalent free function each; all four were confirmed dead (zero callers anywhere in the repo) and removed in the 2026-08-01 cleanup pass. Tire, race situation and pit strategy still have their own `get_react_agent()` *instance method*, called internally from each agent's own `_run_core` — only the redundant module-level wrapper was removed for those three. The radio agent (N29) never had one: its pipeline is a fixed sequence of model calls rather than a ReAct loop, so there is no graph to compile.
+
+**N25 (pace) is deliberately deterministic — no ReAct loop at all.** Unlike its three siblings above, pace's `run()`/`run_from_state()` call the N06 XGBoost model directly; there is no LLM step to invoke and no category field (`warning_level`/`action`/`threat_level`) for an LLM to decide. `pace_agent.py` used to carry a complete but never-wired LangGraph ReAct scaffold (tools, system prompt, `get_react_agent()`) from the moment the module was first extracted — confirmed by archaeology to have been a deliberate per-agent choice made in the same commit that wired tire/pit/race_situation, not a wiring gap. It was formally retired (deleted, not left dead) in #781; see #778 for the full decision record.
 
 ## Output dataclasses
 
@@ -35,7 +37,7 @@ Only the RAG agent (N30) exposes a module-level `get_rag_react_agent()` factory 
 | `delta_vs_median` | float | Delta vs session median |
 | `ci_p10` | float | 10th percentile bootstrap CI |
 | `ci_p90` | float | 90th percentile bootstrap CI |
-| `reasoning` | str | LLM-generated reasoning text |
+| `reasoning` | str | Deterministic summary string (no LLM call — see the note above) |
 
 ### TireOutput (N26)
 
@@ -158,10 +160,11 @@ Every LangChain tool the LLM can call takes free-text arguments (`driver`, `lap_
 
 | Agent | Tools guarded | Refuses when |
 |---|---|---|
-| N25 Pace | `predict_pace_tool` | `driver_number`/`gp_name`/`year` do not resolve to a driver on track for that GP/year, or `lap_number` is outside `[1, total_laps]` |
 | N26 Tire | `predict_tire_deg_tool`, `estimate_laps_to_cliff_tool` | `driver` is not on track at the currently loaded lap, or the loaded `current_lap` is outside `[1, total_laps]` |
 | N27 Situation | `predict_overtake_tool`, `predict_sc_tool` | `lap_number` is out of range, or (for `predict_overtake_tool`) either driver is unknown for that lap |
 | N28 Pit | `predict_pit_duration_tool`, `score_undercut_tool` | the named driver (`driver`/`driver_y`) is not present in the live roster for the current lap |
+
+N25 Pace originally had an equivalent guard on its own `predict_pace_tool` (#476), but that tool was deleted along with the rest of pace's unreachable LangGraph scaffold in #781 — pace has no LLM-facing tool left to guard, so the class of bug #476 fixed cannot occur for it anymore.
 
 The refusal is a plain string return (e.g. `"error: 'HAM' is not on track at lap 12; valid: [...]"` or `"... REFUSED — {driver} is not on track ..."`), not an exception, the LLM sees a normal-looking tool result it can react to, rather than a traceback. `predict_pit_duration_tool` additionally cross-checks the LLM-supplied `under_sc` flag against the RCM-confirmed `sc_currently_active` ground truth when a real orchestrator run has set it, and trusts the confirmed value over the guess (logging a warning) rather than the other way round.
 

--- a/docs/pages/agents-api.md
+++ b/docs/pages/agents-api.md
@@ -22,7 +22,7 @@ Every agent has two entry points:
 `lap_state`, which is why the stint fuel baseline is carried there rather than derived from a
 frame. The adapters are not uniform, so check the signature before assuming.
 
-Every agent except N29 also exposes a `get_*_react_agent()` factory returning a compiled LangGraph `CompiledGraph`, for callers that want to drive the graph directly. The radio agent has none: its pipeline is a fixed sequence of model calls rather than a ReAct loop, so there is no graph to compile.
+Only the RAG agent (N30) exposes a module-level `get_rag_react_agent()` factory returning a compiled LangGraph `CompiledGraph`, for callers that want to drive the graph directly — it is genuinely invoked (the chat backend calls it). N25-N28 (pace, tire, race situation, pit strategy) used to have an equivalent free function each; all four were confirmed dead (zero callers anywhere in the repo) and removed in the 2026-08-01 cleanup pass. Each of those agents still has its own `get_react_agent()` *instance method*, called internally from its own `_run_core` — only the redundant module-level wrapper was removed. The radio agent (N29) never had one: its pipeline is a fixed sequence of model calls rather than a ReAct loop, so there is no graph to compile.
 
 ## Output dataclasses
 

--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -102,7 +102,7 @@ Wraps the N06 XGBoost delta-lap-time model. Returns predicted lap time, delta si
 
 - **Model**: XGBoost trained on 2023–2025 lap data
 - **Output**: `PaceOutput` (lap_time_pred, delta_vs_prev, delta_vs_median, ci_p10, ci_p90)
-- **No LLM step**: unlike its three always-on siblings below, pace calls the XGBoost model directly — `reasoning` is a deterministic f-string, not LLM output. Pace is the one always-on agent with no qualitative judgment to make (no `warning_level`/`action`/`threat_level` category alongside its numbers), so a `pace_agent.py` once carried a complete but never-wired LangGraph ReAct scaffold; it was formally retired in #781 after the #778/#779/#780 archaeology and decision. See [agents-api.md](#/agents-api) for the full record.
+- **No LLM step**: unlike its tire/pit/race-situation siblings below, pace calls the XGBoost model directly — `reasoning` is a deterministic f-string, not LLM output. Pace is the one always-on agent with no qualitative judgment to make (no `warning_level`/`action`/`threat_level` category alongside its numbers), so a `pace_agent.py` once carried a complete but never-wired LangGraph ReAct scaffold; it was formally retired in #781 after the #778/#779/#780 archaeology and decision. See [agents-api.md](#/agents-api) for the full record.
 
 ### N26: Tire Agent (`tire_agent.py`)
 
@@ -329,7 +329,7 @@ One consequence worth knowing before debugging a call: **the effect does not sho
 | Sub-agents N26–N29 | gpt-4.1-mini | OpenAI or LM Studio |
 | Orchestrator N31 | gpt-5.4-mini | OpenAI or LM Studio |
 
-N25 (pace) is not in this table — it never calls an LLM, see the "No LLM step" note under [N25: Pace Agent](#n25-pace-agent-pace_agentpy) above.
+N25 (pace) is not in this table — it never calls an LLM, see the "No LLM step" note under [N25: Pace Agent](#/multi-agent#n25-pace-agent-paceagentpy) above.
 
 Set `F1_LLM_PROVIDER=openai` env var to use the real OpenAI API. Default is LM Studio at `http://localhost:1234/v1`.
 

--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -102,6 +102,7 @@ Wraps the N06 XGBoost delta-lap-time model. Returns predicted lap time, delta si
 
 - **Model**: XGBoost trained on 2023–2025 lap data
 - **Output**: `PaceOutput` (lap_time_pred, delta_vs_prev, delta_vs_median, ci_p10, ci_p90)
+- **No LLM step**: unlike its three always-on siblings below, pace calls the XGBoost model directly — `reasoning` is a deterministic f-string, not LLM output. Pace is the one always-on agent with no qualitative judgment to make (no `warning_level`/`action`/`threat_level` category alongside its numbers), so a `pace_agent.py` once carried a complete but never-wired LangGraph ReAct scaffold; it was formally retired in #781 after the #778/#779/#780 archaeology and decision. See [agents-api.md](#/agents-api) for the full record.
 
 ### N26: Tire Agent (`tire_agent.py`)
 
@@ -325,8 +326,10 @@ One consequence worth knowing before debugging a call: **the effect does not sho
 
 | Layer | Model | Provider |
 |---|---|---|
-| Sub-agents N25–N29 | gpt-4.1-mini | OpenAI or LM Studio |
+| Sub-agents N26–N29 | gpt-4.1-mini | OpenAI or LM Studio |
 | Orchestrator N31 | gpt-5.4-mini | OpenAI or LM Studio |
+
+N25 (pace) is not in this table — it never calls an LLM, see the "No LLM step" note under [N25: Pace Agent](#n25-pace-agent-pace_agentpy) above.
 
 Set `F1_LLM_PROVIDER=openai` env var to use the real OpenAI API. Default is LM Studio at `http://localhost:1234/v1`.
 

--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -100,8 +100,9 @@ See [Arcade strategy pipeline](#/arcade-strategy-pipeline) for the shared engine
 
 Wraps the N06 XGBoost delta-lap-time model. Returns predicted lap time, delta signals against previous lap and session median, and bootstrap confidence intervals (N=200 draws with 2% Gaussian noise on continuous features).
 
-- **Model**: XGBoost trained on 2023–2025 lap data
+- **Model**: XGBoost fitted on 2023–2024 lap data, with **2025 held out**. This line used to read "2023–2025", which quietly folded the test season into the training set: the feature manifest's own row counts are 22,106 train and 23,256 validation, exactly the 2023 and 2024 featured parquets, and every operating bound below is measured on those two seasons for the same reason.
 - **Output**: `PaceOutput` (lap_time_pred, delta_vs_prev, delta_vs_median, ci_p10, ci_p90)
+- **Circuit feature**: `mean_sector_speed` is a property of the track, one value per GP, looked up from the featured parquet. It used to be substituted with the speed trap on every call through the `RaceStateManager` path; see the operating-envelope section under N28 for how that surfaced.
 - **No LLM step**: unlike its tire/pit/race-situation siblings below, pace calls the XGBoost model directly — `reasoning` is a deterministic f-string, not LLM output. Pace is the one always-on agent with no qualitative judgment to make (no `warning_level`/`action`/`threat_level` category alongside its numbers), so a `pace_agent.py` once carried a complete but never-wired LangGraph ReAct scaffold; it was formally retired in #781 after the #778/#779/#780 archaeology and decision. See [agents-api.md](#/agents-api) for the full record.
 
 ### N26: Tire Agent (`tire_agent.py`)
@@ -161,6 +162,49 @@ It also silenced the computation built to weigh it: with an SC deployed `sc_prob
 Staying out under an SC is right whenever you have already stopped, you lead a pack that must stop anyway, you would rejoin into traffic, or the race is ending. Boxing is right when you must stop anyway, the tyres are near the cliff, or the two-compound rule is unsatisfied and time is short. Not one of those is a rule. All of them are race state the model is given, and a rail sees none of it.
 
 See `tests/mc/test_sc_regulatory_rails.py`.
+
+##### The bounds that stayed, and the test they have to pass
+
+Removing that rail did not remove the pit bounds, because they are a different kind of object and are judged differently.
+
+| | What it does | What justifies it |
+|---|---|---|
+| **Prescriptive** rail | Makes the strategic decision *for* the model | A regulation, or nothing |
+| **Proscriptive** bound | Forbids an action so a generative model cannot emit nonsense | **Calibration** |
+
+Bounding an LLM's output space is legitimate engineering with or without an FIA article: the bounds exist so nothing can recommend a lap-2 stop because it felt like one. But a bound only earns that description if it sits where real strategy essentially never goes. The rule the project holds them to is explicit: **a bound may veto at most 5% of real green-flag stops**, measured over 1900 of them across 71 races of 2023-2025.
+
+Checked against that rule, three of the four minimum-stint bounds were separating *unusual* from *usual* rather than *absurd* from *sane*, and were reset to the largest value that clears the ceiling:
+
+| Bound | Was | Vetoed | Now | Vetoes |
+|---|---|---|---|---|
+| Minimum stint, SOFT | 8 laps | 15.5% | **2** | 3.2% |
+| Minimum stint, MEDIUM | 12 laps | 17.0% | **7** | 4.6% |
+| Minimum stint, HARD | 15 laps | 12.2% | **8** | 4.7% |
+| Minimum stint, wet fallback | 10 laps | 20.0% | **6** | 4.5% |
+| No pit before lap 5 | 5 | 2.21% | unchanged | 2.21% |
+| No pit in the last 3 laps | 3 | 1.37% | unchanged | 1.37% |
+
+The end-of-race bound is the only one that is partly a *fact*: under a Safety Car, Art. 55.17 ends the race behind it if it is still deployed on the final lap, so the position a late stop surrenders is unrecoverable by regulation rather than merely expensive. That article does not reach a green-flag lap, where the bound rests on the stop cost and on the measurement above.
+
+The compounding effect is what made the old values worth changing rather than merely wrong. A stop inside a bound can never be agreed with, so it is excluded from the decision-agreement measurement: the bound was removing its own hardest cases from the evidence about itself. After the recalibration the `min_stint` exclusion bucket falls from 17 stops to 5, the scored sample rises from 54 to 67 of 178, and agreement within two laps rises from 51.9% to 61.2%.
+
+`documents/eval_reports/stint_lengths.md` regenerates these shares from the live constants on every run, so the report always grades what is actually shipping rather than what was shipping when it was written.
+
+##### Operating envelopes: knowing when a model is answering outside what it learned
+
+A separate contract, and a quieter one. None of the models refuse out-of-range input; they answer with the same confidence whether the call falls inside what they were trained on or not. N26's tire TCN did exactly that for two years.
+
+An `OperatingEnvelope` (`src/strategy/inference/envelope.py`) names the input range a model's answer is actually valid over, and **labels only**: checking a feature vector never clips, alters or refuses a prediction, it only tells the call site whether to trust the one it already has. A feature that is absent is tracked as *unknown* rather than compared, because "we do not know" must never collapse into a number a real reading could also take.
+
+Two are declared today:
+
+- **N15** (pit duration) declares the 50-lap tyre-life ceiling it was trained under. The clip that keeps it inside that range is unchanged; what the envelope adds is that hitting it stops being silent.
+- **N06** (lap time) declares eleven feature ranges measured from its own training seasons. It has no clip at all, so the label is the entire mechanism.
+
+The envelope earns its keep by what it surfaced rather than by what it prevents. Wiring it to N06 exposed that `mean_sector_speed` was carrying the **speed trap** on every real call, because the agent substituted `prev_speed_st` whenever no mean sector speed was supplied and nothing ever supplied one. Those are different physical quantities, 256.8 against 303.0 km/h on average, and the model had been reading the wrong one throughout. The value is a property of the circuit and was on disk all along; it is now looked up per GP, and a circuit that does not resolve reaches the model as missing rather than as a substituted reading.
+
+It also surfaced something not yet fixed: N06 is asked to predict on the opening laps of a race and on the first lap of every stint, and it was never trained on either, because its own feature pipeline drops exactly those rows.
 
 ### N29: Radio Agent (`radio_agent.py`)
 

--- a/documents/audits/AUDIT_716_710_design.md
+++ b/documents/audits/AUDIT_716_710_design.md
@@ -439,3 +439,44 @@ Six tests failed rather than skipped for the same reason, and one of them,
 `available: false` and left the emptied file in the worktree. The guards now name the
 holdout. Publishing the artefact is the real fix and needs the file, which only exists on
 a machine that has run the notebook.
+
+## H4 — the #797 gate died on a usage limit, and its on-disk report paid for itself
+
+`GATE_797_circuit_speed.md` reached 8.6 KB before the agent was terminated mid-run. Because
+it appended findings as it confirmed them rather than buffering a final report, five
+findings survived, four of them real and two HIGH. This is the second time in two sessions
+that incremental persistence recovered work a dead agent would otherwise have taken with it.
+
+What it found in my own fix, all verified independently before acting:
+
+- **F1, HIGH.** The resolver covered two of the project's FOUR keyspaces. `RaceReplayEngine`
+  puts the metadata.json name into `session_meta`, which for one race is `'Miami Gardens'`
+  with a SPACE, matching neither the parquet slug `'Miami'` nor the folder `'Miami_Gardens'`.
+  Every lap of the 2025 Miami race was served NaN while its value sat in the map. Same for
+  the 2023 Spanish GP (`'Spain'`). The #448/#450 dual-keyspace trap, third occurrence, and
+  the third time in this session that I fixed one member of a pair and not the other.
+- **F2, HIGH.** `laps_featured_2025.parquet` carries NaN on all 760 Las Vegas rows, so
+  reading that file dropped a circuit N06 was FITTED on and whose value sits in three other
+  artefacts. The docstring's "we do not know this circuit" was false for Las Vegas.
+- **F3, MEDIUM.** The map was 2025-only while the replay engine can replay 2023 and 2024, so
+  a 2023 Silverstone lap was served a measurement taken two years after it, 18.4 km/h away.
+  `run()` receives `year` and the resolver ignored it.
+- **F4, MEDIUM.** My "recomputed per season" claim was wrong: 2023 and 2024 are identical
+  per GP to exactly 0.0. The value is recomputed per ARTEFACT BUILD, one build pooling both
+  training seasons. The conclusion survived, the stated mechanism did not, and a comment
+  naming the wrong mechanism is how the next fix goes wrong.
+- **F5, verified clean.** NaN survives to the model, `_bootstrap_ci` multiplying NaN by
+  Gaussian noise still returns finite p10/p90 through XGBoost's default split, an explicit
+  value still wins, and no production caller passes one.
+
+**And one the gate did not reach, found while fixing F1:** the combined artefact does not
+agree with itself. `laps_featured.parquet` calls the same race `'Miami'` in 2023-2024 and
+`'Miami Gardens'` in 2025, so even a correctly spelled query misses on one season. The fix
+is not a longer candidate list at the query end, which fails the moment the STORED spelling
+is the odd one: `_normalise_gp_key` now normalises both the map keys at load time and the
+query, which is what `gp_slugs`'s own docstring prescribes.
+
+The lookup is now keyed by `(Year, GP)` from the combined parquet, which has 71 pairs and
+zero missing values. All 71 races on disk resolve, asserted by walking `data/raw/` rather
+than by fixing the two names an audit happened to mention. A real `f1-sim Miami_Gardens`
+run completes with zero unresolved-circuit warnings.

--- a/documents/audits/AUDIT_716_710_design.md
+++ b/documents/audits/AUDIT_716_710_design.md
@@ -480,3 +480,57 @@ The lookup is now keyed by `(Year, GP)` from the combined parquet, which has 71 
 zero missing values. All 71 races on disk resolve, asserted by walking `data/raw/` rather
 than by fixing the two names an audit happened to mention. A real `f1-sim Miami_Gardens`
 run completes with zero unresolved-circuit warnings.
+
+## H5 — the resumed gate caught the fix for H4 introducing a regression of its own
+
+Switching the loader to the combined `laps_featured.parquet` closed the Las Vegas hole and
+looked like a strict improvement. It was not. That artefact **broadcasts the training-era
+value across all three seasons**: across every GP present in both eras the 2023-vs-2025
+difference is exactly 0.0, so keying by year became decorative and every 2025 lap silently
+received the 2023 measurement. The deliberate choice recorded in H2 was reverted by the
+commit that claimed to refine it.
+
+The raw laps settle which artefact is honest, and this is the check neither of my earlier
+measurements made:
+
+| | Silverstone 2025 | Melbourne 2025 |
+|---|---|---|
+| raw speed traps, mean of the three | **232.32** | **252.93** |
+| per-year artefact | 231.36 | 256.84 |
+| combined artefact | 249.71 (the 2023 value) | 272.44 |
+
+So the loader reads the three per-year artefacts, keyed by year. Las Vegas 2025 goes back to
+NaN, which is the correct failure: the alternative is serving a 2023 measurement for a 2025
+lap, the same defect class as the speed-trap substitution, only quieter. The hole belongs in
+the artefact, and there is now a test pinning it as a known hole so a NEW unresolved race
+still fails loudly.
+
+The test that would have caught this asserts an EFFECT: Silverstone's served value must
+DIFFER between 2023 and 2025. Asserting either value alone passes happily against the wrong
+artefact, which is exactly what happened.
+
+## H6 — the impact numbers, and the accuracy claim I must not make
+
+Re-measured on the full 2025 season with no sampling, comparing what the model receives now
+against what the bug fed it: mean **+0.0712 s**, p95 absolute **0.3767 s**, more than 0.010 s
+on **38.7%** of laps. The commit's figures reproduce.
+
+The gate measured smaller numbers because it measured `806cedd`, where the served value was
+the training-era one; that state is reverted.
+
+**What must not be claimed:** the fix does not make N06 more accurate. The published pace MAE
+still reproduces within tolerance, and the gate measured bug-versus-fix on the proper holdout
+at 0.4096 against 0.4097. This is a correctness fix, not an accuracy fix: the model is now
+being asked the question it was trained on, and the answer is about as good as before.
+
+## H7 — a third member of the family, found by the gate and left open
+
+`LapsSincePitStop` receives `TyreLife` at inference, and the two differ from the trained
+column on **19.8% of rows**, by a mean of 2.6 laps. That is the same shape as `Prev_Deg*` and
+`mean_sector_speed`: an inference value that is not the quantity its training column holds.
+Left open rather than fixed here, because it is a third instance and deserves its own issue
+and its own measurement rather than being folded into this branch.
+
+Also recorded by the gate and not fixed: the 2023 Spanish GP exists twice in `data/raw` and
+in the featured artefacts, as `Spain` and `Barcelona` with the same OpenF1 session key, so
+"71 races" is 70 plus one duplicate.

--- a/documents/audits/AUDIT_716_710_design.md
+++ b/documents/audits/AUDIT_716_710_design.md
@@ -373,3 +373,69 @@ undercut_clean.parquet`, which **does not exist in the Hugging Face dataset at a
 no clean install can pass them; the NLP goldens report `pending` because the 15.9 GB NLP
 weights are not downloaded here. The skip guards should require those artefacts instead
 of failing, which is a separate issue.
+
+---
+
+# #797 and #798, and one claim of mine I refuted myself
+
+## H1 — the fix: N06 was reading the speed trap where it was trained on a circuit mean
+
+`mean_sector_speed` is a property of the CIRCUIT, one value per GP.
+`PaceAgent._compute_derived` substituted `prev_speed_st` whenever none was supplied and
+`run_from_state` never supplied one, so on the path every real race takes N06 received a
+different physical quantity on every lap. Training means 256.8 against 303.0 km/h.
+
+Not an extraction slip: `N25_pace_agent.ipynb` documents the substitution as a proxy, and
+`pace_agent.py` already named the real source, calling it a fallback for when circuit
+features are unavailable. The lookup it described was never wired. It is now, per GP,
+with an unresolvable circuit yielding NaN and a warning rather than a substituted reading.
+
+**Measured impact, and a lesson about probes.** A single hand-built row moved the
+prediction by 0.002 s and I nearly reported the fix as cosmetic on that basis. Over 4000
+real 2025 laps it moves the delta prediction by a mean of +0.069 s, a p95 absolute of
+0.377 s, and more than 0.010 s on 38% of laps. The trees split on this feature only in
+some regions, so one probe is not a distribution.
+
+## H2 — REFUTED BY ME, after the commit message had already claimed it
+
+The commit says the value served is the value fitted, "identical to 0.0". What that
+number actually compared was `laps_featured_2023` against
+`circuit_features_with_clusters_k4.parquet` -- two artefacts of the TRAINING seasons. The
+code serves the **2025** map. Those are a different pair, and I checked the wrong one.
+
+Measured properly, across the 23 GPs present in both:
+
+| | |
+|---|---|
+| GPs matching exactly | **0 of 23** |
+| mean absolute gap | 4.82 km/h |
+| median | 2.91 km/h |
+| largest | Silverstone, 18.35 km/h |
+
+The FIX is still right, and serving 2025 is the correct half of the pair: the feature is
+recomputed per season, so the quantity N04 would compute for a 2025 lap is the 2025
+measurement, and serving the training seasons' value would feed a stale reading of a
+circuit since resurfaced or re-regulated. What was wrong was the claim of exact parity,
+which was true in isolation about a comparison nobody had asked for and false about the
+one that matters. That is the same defect class this session has been removing all day,
+committed in the sentence describing the removal.
+
+The docstring now states the seasonal seam and why the envelope bound is deliberately the
+2023-2024 range held against a 2025 value: the bound asks whether N06 was FITTED on inputs
+like this one, so a 2025 circuit outside the fitted range is genuine extrapolation. Monza
+2025 at 317.24 against a fitted maximum of 314.97 is the only such case.
+
+## H3 — the pit agent cannot be constructed on a clean install (#798)
+
+`PitStrategyAgent.__init__` reads `data/processed/undercut_labeled/undercut_clean.parquet`
+unconditionally. The Hugging Face dataset publishes `overtake_labeled/` and `sc_labeled/`
+and **not** `undercut_labeled/`, so on a checkout built from the published data the agent
+raises FileNotFoundError at construction. It stays hidden because every developer machine
+has run N16, and because `f1-sim --no-llm` at Lusail never triggers the pit agent.
+
+Six tests failed rather than skipped for the same reason, and one of them,
+`test_the_committed_tables_match_a_fresh_measurement`, regenerated
+`data/mc_measured_v1.json` with the entire measured `undercut_band` dropped to
+`available: false` and left the emptied file in the worktree. The guards now name the
+holdout. Publishing the artefact is the real fix and needs the file, which only exists on
+a machine that has run the notebook.

--- a/documents/audits/AUDIT_716_710_design.md
+++ b/documents/audits/AUDIT_716_710_design.md
@@ -1,0 +1,375 @@
+# Design diagnosis — #716 (pit bounds) + #710 (operating envelope)
+
+Session of 2026-08-03. Written before any code change, appended as findings land.
+Read-only until the direction is agreed.
+
+## D1 — #716's acceptance criterion #1 encodes the test Víctor himself refuted, 42 seconds after the issue was filed
+
+The issue body argues: no FIA minimum-stint article exists, therefore
+`_MIN_STINT_LAPS` is an opinion, therefore
+`[[feedback_rails_encode_rules_not_opinions]]` forbids it. Acceptance criterion
+#1 follows from that: *"Every surviving rail cites the regulation article that
+makes it a fact, or it stops being a rail."*
+
+That is the wrong test for this rail, and the correction is already in the repo.
+
+**Timeline, from timestamps rather than recollection:**
+
+| When (UTC, 2026-07-29) | What |
+|---|---|
+| 09:10:38 | Issue #716 created, body carrying the provenance argument |
+| 09:18:09 | Issue **title** updated to "**Recalibrate** the anti-hallucination pit bounds…" |
+| 09:18:51 | `feedback_rails_encode_rules_not_opinions` gains its `⚠️ ESSENTIAL REFINEMENT` section |
+
+The refinement says, verbatim: *"I got this wrong and Víctor corrected me: I used
+this memory to argue that N28's minimum-stint bound 'encodes an opinion' and
+should cite a regulation. **Wrong test.**"*
+
+| | What it does | Needs a regulation? |
+|---|---|---|
+| **Prescriptive** (the rejected SC `PIT_NOW` rail, #464) | Makes the decision *for* the model | **YES** |
+| **Proscriptive** (min stint, no-pit-before-5, no-pit-last-3) | Bounds the output so the model cannot emit nonsense | **NO** — anti-hallucination guard |
+
+And the prescribed remedy, also verbatim: *"If it catches a meaningful share of
+what professionals actually do … it is separating unusual from usual rather than
+absurd from sane — so **move the threshold, do not delete the bound.**"*
+
+So the title was updated to the corrected doctrine and **the body was not**. The
+body is the stale half. Two shipped files already encode the corrected doctrine
+and both point at #716 for the measurement:
+
+- `src/strategy/inference/guard_rails.py:16-23` — *"A proscriptive bound on a
+  generative model's output is legitimate with or without a regulation behind it;
+  the test it must pass is CALIBRATION."*
+- `tests/mc/test_guard_rails.py:8-12` — same statement, as the test module's
+  reason for existing.
+
+**Consequence for scope:** the deliverable is a recalibration plus a written
+justification per bound, not a deletion plus a migration into the Monte Carlo
+cost. Criterion #1 should be restated as *"every surviving bound states either
+the article that makes it a fact or the measured calibration that makes it a
+bound"*.
+
+## D2 — the issue's suggested direction (move it into MC scoring) is a sprint, not a session, and AUDIT_A2 already measured why
+
+`documents/audits/AUDIT_A2_min_stint_veto.md` F5: neither Monte Carlo scorer has
+any tyre-life or compound input today. `_run_mc_simulation`
+(`strategy_orchestrator.py`) dispatches to `simulate_lap_window` (legacy,
+seconds-based) or `_run_projection_mc` (position projection, the path real races
+take). Threading a stint-freshness cost means changing both, plus their tests,
+plus every test pinning exact MC scores.
+
+F4 adds that `src/strategy/eval/decision_modes.py` is a string-matching consumer
+of the rail's exact `reason` text and its whole exclusion methodology assumes a
+categorical veto. Removing the veto changes published, checked-in report numbers
+and breaks 5+ named tests by contract, not by assertion value.
+
+## D3 — two of AUDIT_A2's findings are now STALE; the constant propagates by itself
+
+A2/F1 claimed three hand-typed copies of 8/12/15 (guard_rails, N28 prompt, N31
+prompt) with no test binding them. Verified today: **both prompts now render the
+constant through an f-string.**
+
+- `src/agents/pit_strategy_agent.py:663-665` — `{_MIN_STINT_LAPS['SOFT']}` etc.
+- `src/agents/strategy_orchestrator.py:1695` — `SOFT >= {_MIN_STINT_LAPS['SOFT']}`
+- `tests/agents/test_prompt_constants_match_tables.py:176-183` — parses the
+  rendered prompt and asserts it against `_MIN_STINT_LAPS`.
+
+So a change to the constant reaches all three sites with no manual edit, and a
+regression is caught by an existing test. The "twin that never got the fix" risk
+A2 raised for this specific rail has been closed since the audit ran.
+
+Also closed: the prompt/mirror SC divergence A2 and the issue title both name.
+`apply_guard_rails` now takes `sc_active` (`af3a24a`, 2026-07-29) and
+`tests/mc/test_guard_rails.py` pins which bounds it suspends and which it does
+not.
+
+## D4 — the calibration evidence that already exists
+
+`documents/eval_reports/stint_lengths.md`, generated 2026-07-29 over 1785 real
+green-flag stints across 71 races (2023-2025 raw laps):
+
+| compound | n | threshold | shorter than threshold | min | p1 | p5 | p10 | p25 | median |
+|---|---|---|---|---|---|---|---|---|---|
+| SOFT | 341 | 8 | **15.5%** | 1.0 | 1.0 | 2.0 | 5.0 | 9.0 | 15.0 |
+| MEDIUM | 896 | 12 | **17.0%** | 1.0 | 1.0 | 7.0 | 9.0 | 14.0 | 19.0 |
+| HARD | 548 | 15 | **12.2%** | 1.0 | 1.9 | 8.0 | 13.0 | 18.0 | 24.0 |
+
+A bound that must sit "where real strategy essentially never goes" currently
+sits at the 12th-17th percentile. That is one real stop in six. The bound fails
+its own calibration test on the repo's own measurement — which is the finding
+that justifies moving it, independently of any argument about FIA articles.
+
+## D5 — #710's pit half is already merged on `dev`; only pace remains
+
+Commit `cfe3ae0` "refactor(agents): declare N15 tyre-life ceiling as an operating
+envelope" is on `dev`. `pit_strategy_agent.py:133-136` declares
+`_N15_TYRE_LIFE_ENVELOPE`, and `_tyre_life_in` (line 845) labels the call
+**before** clipping, so the out-of-range moment is logged rather than silent.
+
+The remaining target is `pace_agent.py`, which has no range check at all.
+
+**One acceptance line in #710 needs restating before it is checked off:** *"No
+hand-placed clip survives that the envelope now covers."* Taken literally that
+contradicts `envelope.py`'s own LABELLING ONLY contract (*"Checking a feature
+vector against an envelope must NEVER touch, clip, or refuse a prediction by
+itself"*). The clip at `pit_strategy_agent.py:853` must survive: N15 trained on
+clipped input, so removing the clip would feed it values it never saw. The line
+means "no clip survives *undeclared*", and that is satisfied.
+
+---
+
+# Measurements taken this session
+
+## M1 — all four minimum-stint bounds calibrated on one sample
+
+`f1-eval stint-lengths`, 2023-2025 raw laps, 1900 real green-flag stops across 71
+races. Criterion agreed with Víctor: **a bound may veto at most 5% of real stops**,
+and each value is the largest integer that clears it.
+
+| bound | was | vetoed | now | vetoes |
+|---|---|---|---|---|
+| `_MIN_STINT_LAPS["SOFT"]` | 8 | 15.5% (341) | **2** | 3.2% |
+| `_MIN_STINT_LAPS["MEDIUM"]` | 12 | 17.0% (896) | **7** | 4.6% |
+| `_MIN_STINT_LAPS["HARD"]` | 15 | 12.2% (548) | **8** | 4.7% |
+| `_DEFAULT_MIN_STINT` (wet) | 10 | **20.0%** (110) | **6** | 4.5% |
+| `_NO_PIT_BEFORE_LAP` | 5 | **2.21%** | 5 unchanged | 2.21% |
+| `_NO_PIT_LAST_N_LAPS` | 3 | **1.37%** | 3 unchanged | 1.37% |
+
+**Two corrections to the issue.** It reports the last two bounds as blocking "4 real
+stops" each and puts them in scope for review. That count comes from the six-race
+`decision-modes` subset (198 stops). Measured on the full sample they veto 2.21% and
+1.37%, both already inside the ceiling, so neither needed changing and neither was
+changed. The bound that did need changing worst was `_DEFAULT_MIN_STINT`, which the
+issue does not mention at all.
+
+## M2 — why nobody had measured the worst bound: a comment naming the wrong mechanism
+
+`stint_lengths.py` carried, above `_WET_COMPOUNDS`:
+
+> Wet compounds run no minimum-stint rule at all (`_MIN_STINT_LAPS.get(compound,
+> _DEFAULT_MIN_STINT)` never fires the SOFT/MEDIUM/HARD boundaries for them)
+
+The headline is false and the parenthetical is true, which is exactly how it
+survived review. Wet compounds miss the three named entries and land on the
+FALLBACK, which is a minimum-stint rule like any other. On that claim the report
+counted 110 wet stops only to drop them, so the one bound this file existed to check
+was the one bound it never checked, and it was the worst calibrated of the four.
+
+The wet sample is now a fourth row of the same table, graded against the same bound
+the rail resolves, via a `_bound_for()` helper that calls the rail's own lookup
+rather than mirroring it.
+
+## M3 — a docstring in `decision_modes.py` promised an invariant the code did not enforce
+
+`guard_rail_block`'s docstring: *"the probe passes a life that satisfies every
+minimum"*. The expression was `max(_MIN_STINT_LAPS.values())`, which ignores
+`_DEFAULT_MIN_STINT` — and the fallback is not a spare branch here, it is the bound
+the probe meets in exactly the case the probe exists for, since an unknown compound
+reaches `apply_guard_rails` as `""` two lines down. True today at 8 vs 6 and true
+before at 15 vs 10, false the first time anyone ordered them the other way. Now
+`max(*_MIN_STINT_LAPS.values(), _DEFAULT_MIN_STINT)`.
+
+## M4 — #710: the pace envelope, and two claims of mine the measurement refuted
+
+Bounds measured by rebuilding 2023 + 2024 through `augment_featured_laps` plus the
+two N06 feature steps `pace_holdout.py` already owns, then taking each column's
+min/max over the resulting 42,957 rows. Twelve continuous features; identifiers and
+flags excluded because a code has no range.
+
+**Refuted claim 1 — the three hardcoded zeros are NOT an envelope finding.**
+`run_from_state` pins `prev_deg_rate` / `prev_cum_deg` / `prev_deg_accel` at `0.0` on
+every real call. That reads exactly like the N26 out-of-range defect, and I was ready
+to declare bounds that would "catch" it. Measured, 0.0 sits mid-distribution for all
+three: 42.6% / 41.9% / 46.7% of training rows fall below it. An envelope could never
+fire on the pinned value, and declaring one would have shipped a check that looked
+like coverage and was not. Feeding a constant where the model saw a distribution is a
+real defect; it is a different defect and needs its own instrument.
+
+**Refuted claim 2 — the range in the code comment is the wrong season.**
+`pace_agent.py` records FuelEffect as `range 0..3.685 s`, "verified exactly against
+laps_featured_2025". 2025 is the held-out TEST season. The TRAINING range is
+`0.055..4.125`. An envelope sourced from the test season describes where the model is
+asked to work, not where it was fitted.
+
+Out-of-range rates on the 2025 holdout frame: FuelEffect 4.96%, mean_sector_speed
+3.93%, TyreLife 2.87%, AirTemp 1.96%, TrackTemp 1.64%, LapNumber 1.17%, FuelLoad
+1.17%, Humidity 0.18%, Prev_TyreLife 0.06%, Prev_SpeedST 0.01%, Prev_LapTime 0.00%,
+laps_remaining 0.00%.
+
+**CORRECTION, from the real run (M6): those rates understate it and I quoted them as
+if they did not.** See below.
+
+## M5 — a pre-existing gate that does not cover what it guards
+
+`tests/agents/test_prompt_constants_match_tables.py` skips on
+`HAS_TIRE_MODELS`, but importing the pit agent pulls the NLP stack, so on a checkout
+with tire weights and no `data/models/nlp/bert_sentiment_v1/` the file ERRORS instead
+of skipping. Verified identical on the unmodified baseline, so it is pre-existing and
+out of scope here, but it means the prompt-versus-rail guard can fail for a reason
+that has nothing to do with prompts. Recorded, not fixed.
+
+
+## M6 — the real run, and a third claim of mine it refuted
+
+`f1-sim Lusail NOR McLaren --no-llm`, real radio corpus (24 radios, 66 rcm), 57 laps,
+completed clean. Run twice on the branch with identical results, so the comparison
+below is a behaviour change and not run-to-run noise.
+
+**#716, behaviour moved by exactly one call.**
+
+| | STAY_OUT | PIT_NOW | UNDERCUT |
+|---|---|---|---|
+| baseline (`dev`) | 52 | 3 | 2 |
+| branch | **51** | 3 | **3** |
+
+One lap flips STAY_OUT to UNDERCUT: the loosened bound releasing a call it used to
+veto, in the expected direction and at the expected scale. Final position unchanged
+(P3 to P4), final stint unchanged (HARD/13), best lap identical to the millisecond.
+
+**#710, and the claim I got wrong.** M4 above says the log is "quiet enough to be
+worth reading" on the strength of holdout rates of roughly 1-5%. On the real run the
+envelope warned on **14 of 57 laps, about 25%**. Violations by feature: mean_sector_speed
+10, TyreLife 6, Prev_TyreLife 6, FuelEffect 3, LapNumber 2, FuelLoad 2.
+
+The holdout understates it **because it is the wrong frame to have measured on**, and
+the reason is structural rather than incidental: the holdout has N06's own `_DROPNA`
+applied, which removes the first lap of every stint and the opening laps of every
+race. Those are precisely the rows where inference goes out of range, because
+`run_from_state` passes `tyre_life or 1` and `prev_tyre_life = max(0, tyre_life - 1)`
+against declared bounds of TyreLife [3, 78] and Prev_TyreLife [2, 77]. I measured the
+noise on a frame that had already deleted the noisy rows.
+
+What the warnings say is true, and is the most useful thing the envelope surfaced:
+**N06 is asked to predict on the opening laps of a race and on the first lap of every
+stint, and it was never trained on either**, because N06 dropped exactly those rows.
+That was completely silent before this change. `mean_sector_speed` is a second, separate
+finding: Lusail is fast enough to exceed the trained maximum of 314.97 on ten laps.
+
+Left as is rather than suppressed. Whether a warning on a quarter of laps is the right
+volume is a fair challenge and is put to the correctness gate rather than settled here.
+
+## M7 — #710's "one real run per agent" was not satisfied by the pit half, and now is
+
+The acceptance line reads: *"A real `f1-sim` run per agent, not one run for both"*,
+with *"one agent at a time with an `f1-sim` run in between"*.
+
+`cfe3ae0`, the merged pit half, justifies itself with *"125 tests in tests/mc pass
+including the strategy goldens, and 400 real rows from Lusail 2025 go through the
+feature builder with no warning while a forced 88-lap stint announces itself"*. That
+is good evidence and it is not the evidence this criterion asks for: a feature-builder
+replay is not a run of the simulator. Inheriting that as satisfied would have ticked a
+box nobody had earned.
+
+The two runs this session close it, in the required order and separated by the pace
+change rather than batched:
+
+| run | tree | agent under test | result |
+|---|---|---|---|
+| `sim_before` | `dev` (pit envelope present, pace envelope absent) | **pit / N15** | 57 laps clean, zero envelope warnings |
+| `sim_after` | branch (both) | **pace / N06** | 57 laps clean, 14 warning laps |
+
+Zero warnings in the first run is the CORRECT result rather than a missing signal: no
+stint at Lusail approaches N15's 50-lap ceiling, so the in-range path is what should
+have been exercised, and `tests/agents/test_n15_envelope.py` covers the firing case
+that this race cannot produce.
+
+---
+
+# The adversarial gates, and what they broke
+
+Two gates ran read-only against the branch and wrote their own reports:
+`GATE_716_calibration.md` and `GATE_710_pace_envelope.md`. What follows is what
+survived verification, including where a gate was itself wrong.
+
+## G1 — CONFIRMED, HIGH, and mine: the recalibration silently rewrote an unrelated rule
+
+Both prompts rendered the FLOOR of the MEDIUM compound-suitability band from
+`_MIN_STINT_LAPS['MEDIUM']`:
+
+```
+MEDIUM: suitable for {_MIN_STINT_LAPS['MEDIUM']}-{_STINT_CAPACITY_LAPS['MEDIUM']} remaining laps.
+```
+
+Two different rules sharing the number 12 by accident. One asks whether a set has run
+long enough to be worth replacing; the other asks whether enough race is left for the
+compound to make sense. Recalibrating the first to 7 turned the second into "MEDIUM:
+suitable for **7**-30 remaining laps" on the DEFAULT LLM path, a rule #716 never
+touched and nobody reviewed.
+
+The existing prompt-versus-table test could not see it: it asserts the prompt agrees
+with the constant, and a re-coupled prompt agrees with the WRONG constant. Fixed with
+its own `_MEDIUM_SUITABILITY_FLOOR_LAPS = 12` and a test that asserts the rendered
+floor against THAT constant, which fails on a re-coupling.
+
+## G2 — CONFIRMED, HIGH, and the same defect class twice in one session
+
+`mean_sector_speed` should never have been bounded. `_compute_derived` falls back to
+`prev_speed_st` when no mean sector speed is supplied and `run_from_state` never
+supplies one, so at inference the feature ALWAYS carries the speed trap: training
+means 256.8 vs 303.0 km/h, different physical quantities. The bound fired on 83% of
+laps at Monza while describing none of them.
+
+This is the exact twin of the `Prev_Deg*` case in M4 — a feature whose inference value
+is not the quantity the range describes. I reasoned it through carefully for one member
+of the pair and did not look for the other. That is the repo's most reliable defect and
+I committed it inside the change that documents it.
+
+`FuelLoad` came out for a related reason: the artefact stores it rounded to four
+decimals (max 0.9615) while inference computes it live and unrounded, so a 78-lap race
+gives 0.96153... and the bound fires on a lap class the model trained on.
+
+Ten bounds remain. The unbounded fifteen are now enumerated with a reason each, and a
+test asserts the two sets partition N06's feature list exactly, because the first
+version of that comment accounted for 22 of 25 and the three it skipped are where the
+mistake lived.
+
+## G3 — CONFIRMED: the noise claim, twice corrected
+
+M4's holdout rates were the wrong frame (M6). The gate then measured 31% of laps
+warning across five circuits, worse than my Lusail figure. After G2's two removals,
+the real run gives **6 of 57 laps (10.5%)**: TyreLife 6, Prev_TyreLife 6, FuelEffect 3,
+LapNumber 2, co-occurring on six distinct laps. Every one is true and structural: N06
+never trained on a race start or a stint opener, because its own `_DROPNA` removes
+them. Left at WARNING; the train/serve gap it exposes deserves its own issue rather
+than a quieter log.
+
+## G4 — CONFIRMED, smaller
+
+- `guard_rails.py` attributed the six-race subset's four excluded stops to the
+  early-race bound. Measured, that bound excludes NONE there and `decision_modes.md`
+  carries no `opening_laps` row; the four are the closing bound's (Monaco VER, Lusail
+  STR and HAD, Monza OCO). Corrected.
+- "the ceiling every bound is set from and held to" overstated it. All four are HELD
+  to it; only the two that failed were SET from it. The lap bounds are not maximal
+  under the rule and were deliberately left alone.
+- The provenance pointer for the two lap-based shares was false: `stint_lengths.md`
+  regenerates the four minimum-stint shares, not those two. Now labelled a dated
+  finding rather than a reproducible artefact.
+- The ceiling test could hold vacuously if a bucket left the measurement. It now pins
+  the bucket set before filtering, so WET cannot silently stop being graded.
+- `_DEFAULT_MIN_STINT` has no prose copy in either prompt: the offline path enforces a
+  wet bound the LLM path was never told about. Written down, not closed, because
+  closing it means new prompt text on the default path.
+- `data/mc_measured_v1.json` had lost its measured `undercut_band` in the worktree
+  (regeneration on a checkout missing the source parquet). Never committed; restored.
+
+## G5 — REFUTED, verified by me
+
+- The #716 gate reported that the committed `stint_lengths.py` fails
+  `ruff format --check` under CI's pin. It does not: `uvx ruff@0.15.22 format --check .`
+  reports 140 files already formatted, re-run after the finding.
+- The #716 gate's own verification of every number in `guard_rails.py` reproduced them
+  independently from `data/raw` without importing repo eval code, and predicted
+  `min_stint = 5` before the regeneration produced exactly 5.
+
+## G6 — the suite failures are not this change
+
+7 failed / 4 errors on the full run, all pre-existing in this environment and confirmed
+by running the ambiguous ones on a `dev` worktree with the same data: `test_weather_restore`,
+`test_ml_recompute_golden` and both `test_mc_measured_tables` failures reproduce on the
+baseline. Root cause for six of them is a single file, `data/processed/undercut_labeled/
+undercut_clean.parquet`, which **does not exist in the Hugging Face dataset at all**, so
+no clean install can pass them; the NLP goldens report `pending` because the 15.9 GB NLP
+weights are not downloaded here. The skip guards should require those artefacts instead
+of failing, which is a separate issue.

--- a/documents/audits/AUDIT_anti_slop_2026-08-01.md
+++ b/documents/audits/AUDIT_anti_slop_2026-08-01.md
@@ -1,0 +1,120 @@
+# Anti-slop / clean-code audit — 2026-08-01
+
+**Instrument:** background `general-purpose` agent on Fable, launched informally during the
+tyre fresh-reference gate session (not the dedicated cleanup session — see
+[[project_cleanup_audit_session_plan]] for that). One-shot report, no fixes applied.
+
+**Scope:** all of `src/` except the `src/telemetry/` submodule, plus `scripts/`. Excluded by
+instruction: `notebooks/`, `legacy/`, deep `tests/` review. ~43,500 Python lines, AST scan
+(duplicate functions, identical bodies, unreferenced definitions, nesting, length) + manual
+grep-verification of every candidate against the whole repo (including notebooks, docs,
+`documents/`, and the telemetry submodule) to rule out false positives.
+
+**Headline:** the codebase is well above average hygiene. Zero `TODO/FIXME/HACK` in live src,
+zero speculative abstractions, disciplined error handling, archived zones documented with a
+README + status + successor, and several exemplary anti-twin delegators already in place. The
+findings below are real but the background noise is low.
+
+---
+
+## 🔴 HIGH IMPACT
+
+### A1. A third, live copy of the RCM classifier — missing fix #305, already diverged
+`scripts/bench_nlp_pipeline_cpu.py:421-517` (`_classify_rcm_event`, 97 lines, self-described as
+"direct transcription of N24"). `src/f1_strat_manager/rcm_events.py` exists precisely so this
+classifier lives in one place (its own docstring: *"WHERE TO CHANGE IF THE FIA MESSAGE FORMAT
+CHANGES: Here, and only here"*, written after #632 measured a 28.2% divergence between two
+copies). The bench script violates that contract with a full copy, and it has already diverged:
+for `cat == "SafetyCar"`, the canonical classifier treats `"IN THIS LAP"` as
+`SAFETY_CAR_ENDING` (fix #305); the bench copy still classifies it as
+`SAFETY_CAR_IN_PIT_LANE`, the pre-#305 behaviour. The VSC branch differs too.
+**Fix:** replace with the same thin adapter pattern `eval/nlp.py:590` already uses over the same
+canonical module. ~95 lines removed.
+
+### A2. Confirmed drift between the two live copies of `_build_race_state`
+`src/arcade/strategy.py:599-715` (117 lines) vs `scripts/run_simulation_cli.py:1304-1373` (70
+lines) — a third copy exists in the telemetry submodule (out of scope here). Both received fix
+#750, but their DEFAULTS have already diverged: `track_temp` fallback 40.0 (CLI) vs 35.0
+(arcade); `compound` fallback `"UNKNOWN"` vs `"MEDIUM"`; `tyre_life` fallback 0 vs 1;
+`total_laps` raises KeyError in one, defaults to 57 in the other. The ~14-line comment
+explaining #750 is pasted verbatim in both, so it will drift too.
+**Caveat:** the CLI copy is inside the untouchable PMV (`run_simulation_cli.py`) — this needs an
+issue to decide where the single source lives (the `strategy_pipeline.py` pattern already shows
+how), not an in-place edit.
+
+### A3. `theme.py` deduplicated `_ALERT_SEVERITY` after #620 burned it — but kept `_ACTION_STYLE`'s twin 20 lines away
+`src/arcade/dashboard/theme.py:59-84` vs `src/arcade/strategy.py:721-734`. The file's own
+comment (lines 70-79) tells the #620 story: a hand-copied `_ALERT_SEVERITY` drifted the moment
+#398 added `YELLOW_FLAG_SECTOR` to the original, because a "mirrors X" comment told readers the
+two dicts were already checked — and the fix was to import it. `_ACTION_STYLE` +
+`classify_action` (lines 59-68, 82-84) are still that exact same hand-mirrored pattern, with the
+same "mirrors src/arcade/strategy.py::classify_action" comment the file itself names as the bug
+mechanism. `theme.py:22` already imports from `strategy.py`, so the isolation argument is moot.
+**Fix:** import instead of mirror. ~26 lines, closes #620 properly.
+
+---
+
+## 🟠 MEDIUM IMPACT
+
+### M1. Verified dead code (zero references across src+scripts+tests+notebooks+docs+documents+telemetry)
+| What | Where | Detail |
+|---|---|---|
+| `severity_color()` | `arcade/dashboard/theme.py:87-92` | 0 callers, and restates the mapping `strategy.py::classify_alerts:760` already has — dead AND a twin. |
+| `_CLUSTER_PARQUET`, `_LAPS_FEATURED`, `_FEATURE_MANIFEST` | `agents/pace_agent.py:88-90` | Defined, never read. `_load_encoding_maps` (:206-218) builds the same paths inline, so "fixing" the constant changes nothing. |
+| `get_pace_react_agent` (×2), `get_tire_react_agent`, `get_race_situation_react_agent`, `get_pit_strategy_react_agent` | pace/tire/race_situation/pit_strategy agents | ~110 lines total. Docstrings say "created only when N31 or tests actually invoke the agent" — none do (contrast `get_rag_react_agent`, which IS invoked). If kept as an announced public API, fix the false docstring instead. |
+| `simulate_real_time_predictions` | `strategy/inference/tire_predictor.py:885` | 139 lines, dead even inside its own fossil file (see B3). |
+
+### M2. Restated constants — the same bug class #765/#772 just fixed in the prompts, still live in code
+- `total_laps` fallback `57` hardcoded in 7 live sites (`arcade/strategy.py:703`, `pit_strategy_agent.py:1039,1273,1456`, `race_situation_agent.py:1010,1362`, `tire_agent.py:1481`, +2 in telemetry).
+- Weather defaults `25.0`/`35.0` in 5 live sites, with a 6th already diverged to `40.0` (CLI:1371) — proof the bug class is real, not theoretical.
+- The tire agent's conservative stub (`deg_rate=0.03, p10=20.0, p50=30.0, p90=40.0`) is duplicated inside the SAME function (`tire_agent.py::_run_core`, lines 1566-1578 and 1609-1621).
+- Compound RGB tuples written literally twice in the same file (`theme.py`: `COMPOUND_COLORS` lines 39-45 and `_COMPOUND_COLOUR_BY_LABEL` lines 123-142) instead of deriving the second from the first.
+- Already-documented-deliberate, not counted as slop: `FUEL_GAIN_PER_LAP_S` duplication (#446 deferral note), the 30-200s sane-lap-time band in two chart widgets (documented "independently substitutable widgets" rationale — judged weak but is a recorded decision, not an oversight).
+
+### M3. Documentation drift inside CLAUDE.md itself (the source of truth)
+- §5/§9 still document `f1-streamlit`, retired in #551 for `f1-webapp`; no streamlit entry point in `pyproject.toml` anymore.
+- §3 describes `src/shared/` as the live extraction home, when `src/shared/README.md` says it is archived and the canonical extractors live in `src/data_extraction/` (not listed in §3's tree).
+
+### M4. Duplicated bootstrap preamble across ~15 scripts, 3+ divergent variants
+Repo-root discovery + `sys.path.insert` + dotenv + `reconfigure(utf-8)`, repeated in `f1_cli.py`, `run_simulation_cli.py`, `debug_agent.py`, four `bench_*.py`, `build_radio_dataset.py`, `upload_radio_corpus.py`, `verify_drs_zones.py`, three `measure_*.py`, `download_data.py`, `prompt_ab/_common.py`. Root-resolution logic already disagrees between variants (`.git`-search-with-fallback vs `parents[1]` vs `parent.parent`) — a `uv tool install` without `.git` would resolve different roots. `scripts/bench/_common.py` and `scripts/prompt_ab/_common.py` already show the shared-`_common` pattern is idiomatic here; a root-level one is missing. (`run_simulation_cli.py` stays out — PMV.)
+
+---
+
+## 🟡 LOW IMPACT
+
+- **B1.** `src/vision/gap_calculation.py` (803 lines) is a byte-identical copy of `legacy/app_streamlit_v1/.../gap_calculation.py`, the only one anything imports. Deliberate (documented README), but its own justification ("keeps git history self-contained") doesn't survive git history actually being self-contained. Safe prune: 803 lines.
+- **B2.** False docstring in `shared/data_extraction/fastf1_extractor.py:6-7`: claims N01 "still imports it" — verified N01 only link-references it in markdown, no code cell imports it.
+- **B3.** `strategy/inference/tire_predictor.py` (1,023 lines) is a jupytext N09-era fossil living inside the live inference package next to `engine.py`, documented as "reference only," sole consumer is `legacy/experta_engine/`. Belongs in `legacy/`, not `strategy/inference/`.
+- **B4.** Large-function inventory (not a mandate): `run()` 717 lines (PMV, untouchable), `_build_orchestrator_prompt` 256 / `_run_projection_mc` 216 / `_run_mc_simulation` 156 / `_assemble_recommendation` 146 (strategy_orchestrator), `_build_tools` 208/168/117 (pit/tire/situation agents), `_arrow_pick` 122 lines at nesting 6 (`scripts/cli/pickers.py:59` — the cleanest decomposition candidate outside frozen zones).
+- **B5.** Minor twins: `_bar_style` (Qt progress gradient) duplicated in `orchestrator_card.py:228` and `scenario_bars.py:145`; `measure_fresh_reference_gate.py` vs `_2025.py` share near-identical `scored_bound`/`load_bundles` (tolerable — deliberately frozen reproducibility scripts); `_load_ner_model` duplication (radio_agent/eval-nlp) already root-caused to open issue #167 — the real fix is #167, not the dedup.
+
+---
+
+## What was checked and NOT flagged (avoid re-auditing this)
+
+- **Error handling:** no bare `except` in live code (the only one is in an archived file), no unexplained `except: pass`, specific types with context comments throughout.
+- **Correct anti-twin delegators already in place:** `strategy_orchestrator._scope_laps_to_gp`, `arcade/strategy_pipeline.py` (killed a body-copy #166 proved dangerous), `GAP_UNKNOWN_FALLBACK_S` single-sourced.
+- **False positives ruled out after reading:** `_to_seconds` (df-column vs scalar, genuinely different), `_parse_tool_outputs` (different tool formats), `_load_encoding_maps` (different artefacts per model), six `_render_table` variants in eval (different tables), `_run_core`/`run_from_state` scaffolding across four agents (parallel structure, genuinely different domain per agent — abstracting it would touch a near-frozen zone for less than it risks).
+- **Archived zones** (`src/shared/`, `src/vision/`, `src/data_extraction/{legacy,fastf1}`, `intervals_extractor`): all README-documented with status + successor, already covered by prior audits (A5, P5) — deliberate, not slop.
+- **Speculative abstractions:** zero found. **Naming:** consistently good. **Orphan scripts:** none — bench/measure/debug/verify are deliberate evidence tooling.
+
+---
+
+## Summary table
+
+| Category | Cases | Estimated impact |
+|---|---|---|
+| Diverged twin with a lost fix (RCM bench, ACTION_STYLE, `_build_race_state` defaults) | 3 clusters | **High** — the project's dominant bug class, already measurably diverged |
+| Verified dead code | 9 symbols (~260 lines) | Medium — safe direct prune |
+| Restated constants (57 ×7, weather ×6 with 1 diverged, tire stub ×2, RGB ×2) | 4 families, ~17 sites | Medium — same bug class as #765/#772 |
+| CLAUDE.md documentation drift | 3 points | Medium — it's the source of truth |
+| Duplicated bootstrap preamble across scripts | ~15 files, 3 variants | Medium-low — real divergence risk on installs without `.git` |
+| Misplaced fossils / false docstring / byte-identical legacy copy | 3 | Low — documented, prune optional |
+| Functions >100 lines / nesting >2 outside frozen zones | ~8 relevant | Low — docstring culture mitigates; `_arrow_pick` best decomposition candidate |
+| **Total prunable outside untouchable zones** | | **≈1,300-1,500 lines** (incl. the two fossils) or **≈400 lines** if only live dead/duplicated code is counted |
+
+**Recommended first three moves, by value/risk:** (1) thin adapter over `classify_rcm_event` in
+`bench_nlp_pipeline_cpu.py` — ~30 min, kills A1; (2) import `_ACTION_STYLE`/`classify_action` in
+`theme.py`, delete `severity_color` — ~15 min, properly closes #620; (3) file an issue to unify
+`_build_race_state`'s defaults into one source (touches the PMV and the submodule, so it earns
+its own issue before any code, per the project's issue-first rule).

--- a/documents/audits/AUDIT_cleanup_session_2026-08-01.md
+++ b/documents/audits/AUDIT_cleanup_session_2026-08-01.md
@@ -228,3 +228,160 @@ currently **not importable** without that shim.
   the new constant's comment, a line-number-hardcoded comment, a stale "unchanged" docstring claim
   in `pace_agent.py`). All 7 fixed post-gate; see the branch's commit history for the reordering and
   follow-up commits.
+
+This is where PR #776 stopped (merged to `dev`, CI green). Part 5 below is a second wave on the
+same branch pattern, done the same session at Víctor's explicit request to keep going.
+
+---
+
+## Part 5 — Second wave: extending past the 30-PR window
+
+Víctor asked, after #776 merged: what else can this session fix, including outside the 30-PR
+window, including `tests/`? This part covers that follow-up sweep.
+
+### 5.1 — `tests/` audit (a dedicated Explore agent, read-only)
+
+Findings, then fixes:
+
+| Severity | Finding | Fix |
+|---|---|---|
+| Medium | `_canned_outputs()` — a 30-line fixture (4 dataclass builds) byte-identical between `tests/mc/test_mc_state_helpers.py` and `tests/mc/test_strategy_goldens.py`, **and** three more files (`test_mc_is_a_real_decision.py`, `test_projection_golden.py`, `test_tyre_wear_term.py` ×2 call sites) each imported it from whichever of the first two happened to define it — five consumers, two competing definitions (the third consumer, `test_tyre_wear_term.py`, was missed in the first pass and only found by the follow-up adversarial gate, see 5.8). | Extracted to `tests/mc/canned_outputs.py::canned_outputs()`, matching the existing `tests.X.Y import Z` cross-file pattern already used by `tests/engine/ast_helpers.py`. All 5 consumers now import the one definition. |
+| Low-Medium | `_HAS_MODELS = (data/models/tire_degradation/routing_config.json).exists()` (+ a `_skip_no_models` marker) restated in 22 test files (21 module-level `skipif` guards + 1 fixture-scope `pytest.skip` in `test_pace_orchestrator_hardening.py`, also missed in the first pass and found by the gate). Two had already drifted to `.is_file()`; one used a `_MODELS_DIR` intermediate variable. 4 further files check a **different** model artifact on purpose (overtake/pit-prediction/lap-time) — correctly left alone, not slop. | Centralised the shared tire-routing-config guard into `tests/conftest.py` (`HAS_TIRE_MODELS`, `skip_no_tire_models`), imported by all 22 files that were checking that exact artifact. Confirmed via `ast.get_docstring` + `ast.parse` on every touched file that no import landed inside a docstring (see the incident below) and `ruff format --check` is clean on all 62 files in `tests/`. |
+| Info | `_race_state()` name collision between `test_engine_memory.py`/`test_engine_no_llm.py` | Verified genuinely different helpers — not touched. |
+| Info | No dead/tautological tests, no orphaned helper files, every import resolves | Nothing to fix. |
+
+**Self-caught incident during this fix:** a first migration script (a naive "insert after the last
+line starting with `import`/`from`" heuristic) inserted the new import **inside a module
+docstring** in `tests/mc/test_mc_is_a_real_decision.py`, because a docstring sentence happened to
+start with the word "from" ("...and that is provable / from the code alone."). Caught by re-reading
+the file before committing, not by tooling. Reverted the 17 files the buggy script had touched via
+`git checkout --`, rewrote the migration using `ast.parse` to find the real top-level import block
+(skipping the docstring `ast.Expr` node explicitly), reran, and this time verified every file with
+both an AST parse and an explicit "does the docstring contain the import line" check before moving
+on. Recorded here because it is exactly the kind of self-inflicted slop this whole session exists to
+prevent — a mechanical fix is not exempt from causing the disease it is curing.
+
+### 5.2 — A3 fixed for real (previous session had left it deferred, out of scope)
+
+`src/arcade/dashboard/theme.py`'s `_ACTION_STYLE`/`classify_action` were a hand-mirrored copy of
+`src/arcade/strategy.py`'s originals — the *exact* pattern the file's own comment named as the #620
+bug mechanism, sitting 20 lines from the dict (`_ALERT_SEVERITY`) that #620 already fixed. Also
+removed `severity_color()` (dead, 0 callers, restated `classify_alerts`'s mapping).
+
+**A real bug found and fixed in the process, not just a merge:** neither copy of `classify_action`
+actually guarded a `None` action — both called `.upper()` on it unguarded as the dict lookup key
+and would have crashed identically (verified by calling the pre-fix function with `None` in this
+session; it raised `AttributeError`). No live caller currently passes `None`
+(`orchestrator_card.py` sanitises with `str(latest.get("action") or "--")` first), but the
+type-hinted-`str` signature invites it. Fixed once, in the single now-canonical
+`strategy.py::classify_action`, with a guard clause and a comment explaining why it wasn't there
+before. `theme.py` now imports the fixed version.
+
+### 5.3 — B2 fixed: false docstring in `fastf1_extractor.py`
+
+Verified against the live notebook JSON (`json.load` + scan every cell's source for the string
+"fastf1_extractor"): `notebooks/data_engineering/N01_data_download.ipynb` mentions the file exactly
+once, in a **markdown** cell, as a link — `[fastf1_extractor.py](../../src/shared/data_extraction/
+fastf1_extractor.py)`. No code cell imports it. The module's own docstring claimed the opposite
+("Kept because ... still imports it"). Corrected to state the real reason (the markdown link would
+break, not any running code) and confirmed via a repo-wide grep that nothing else references the
+module either.
+
+### 5.4 — M4 fixed, right-sized: 8 of 16 scripts had a real latent bug, not just duplication
+
+A dedicated Explore agent read all 16 scripts' bootstrap preambles (excluding the untouchable
+`run_simulation_cli.py`). Result: **7 scripts already use a robust `.git`-search-with-fallback**
+for the repo root (textually near-identical across all 7); **8 use a fragile fixed-depth
+`Path(__file__).resolve().parent.parent` / `.parents[N]`**, which silently resolves to the wrong
+directory the moment the script is not exactly N levels below the repo root — the exact scenario a
+`uv tool install` layout can produce. This is a genuine latent correctness bug, not merely restated
+code.
+
+**What was NOT done, and why:** extracting a single importable `find_repo_root()` helper module was
+considered and rejected — it has a bootstrapping problem. A script cannot `import scripts.something`
+to learn where the repo root is, because it needs the repo root on `sys.path` *before* any
+`scripts.*` import can resolve. The `.git`-search snippet is therefore structurally required to stay
+inline in every entry-point script; what can and did get fixed is which VERSION of that snippet each
+one uses.
+
+**Fix:** replaced the fragile resolution in all 8 files with the same proven `.git`-search snippet
+the other 7 already carry (preserving each file's own variable name — `_REPO_ROOT`, `ROOT`,
+`REPO_ROOT` — to keep the diff minimal): `build_radio_dataset.py`, `download_data.py`,
+`measure_fresh_reference_gate.py`, `measure_fresh_reference_gate_2025.py`, `measure_mc_tables.py`,
+`measure_tyre_reference.py`, `verify_drs_zones.py`, `prompt_ab/_common.py`. Verified: syntax +
+ruff clean on all 8; `download_data.py` was run for real (fully executed `ensure_setup()`,
+downloaded/verified 144 HF files, completed successfully); `verify_drs_zones.py --help` rendered
+correctly; the remaining 6 import cleanly with no import-time error.
+
+### 5.5 — Evaluated, evidence expanded, still NOT fixed (higher-risk than previously scoped)
+
+| # | Finding | What changed from the earlier characterisation |
+|---|---|---|
+| A1 | `bench_nlp_pipeline_cpu.py`'s `_classify_rcm_event` vs the canonical `src/f1_strat_manager/rcm_events.py::classify_rcm_event` | The prior audit's "~30 min, thin adapter, ~95 lines removed" estimate undersold the real scope. Direct comparison this session: the bench copy branches PER CATEGORY (`SafetyCar`/`Flag`/`Drs`/`CarEvent`/`Other`, each with its own keyword set) and produces event types the canonical classifier does not have at all (`CAR_MECHANICAL`, `TRACK_CONDITION`, `LAPPED_CARS_OVERTAKE`, `PIT_EXIT` vs canonical's `PIT_LANE_CLOSED`/`PIT_LANE_OPEN`). A drop-in swap, the same pattern `eval/nlp.py:590` uses, would silently reclassify a large share of `CarEvent`/`Other` rows to `OTHER` — changing the benchmark's meaning, not just its code path. The right fix is a product decision (extend the canonical classifier to cover the missing branches, or accept the benchmark's numbers move) — not a mechanical adapter. Flagged for the next dedicated pass, with the exact branch-by-branch diff now on record here instead of assumed away. |
+| B4 | `_arrow_pick()` in `scripts/cli/pickers.py:59`, the prior audit's "cleanest decomposition candidate" | Re-read in full this session. It is already decomposed into four named closures (`_text`, `_redraw`, `_confirm`, `_jump_to_digit`); the remaining ~120 lines are two full platform-specific raw-terminal key-reading loops (Windows `msvcrt` vs POSIX `termios`+`tty`) that cannot share a body without introducing a key-reading abstraction neither platform actually needs elsewhere, and that abstraction cannot be exercised without a live TTY (untestable in this environment). Judgment: this is inherent complexity from housing two real platform implementations side by side, not disorganisation — matches CLEAN_CODE.md's own safeguard against buying fewer lines with worse architecture. Not touched. |
+| B1 | `src/vision/gap_calculation.py` byte-identical to `legacy/app_streamlit_v1/.../gap_calculation.py` | Re-verified byte-identical (`diff -q`, no output). Re-reading the prior audit's own text more carefully: `src/vision/`'s copy is "the only one anything imports" — i.e. it is load-bearing, not the dead half. The prunable copy is inside `legacy/`, which is explicitly frozen for this session (and for the whole project's untouchable-zone rule). Not actionable without either editing `legacy/` or breaking a real import; left as a finding for whoever owns a decision to lift the freeze for this one file. |
+| B3 | `src/strategy/inference/tire_predictor.py` fossil | Re-confirmed (fresh grep): its only real-code consumer is `legacy/experta_engine/rules/degradation_rules.py` — frozen. Moving the fossil INTO `legacy/` would itself be an edit to the frozen zone (adding content there), which this session's explicit scope excludes. Not moved. |
+| N4 | `pace_agent.py`'s unreachable LangGraph scaffold | Unchanged from the first-wave finding — still flagged, not deleted, for the "preserved 100%" comment reason already on record above. |
+
+### 5.6 — Clean-code check: large functions decomposed into helpers, on the files this session touched
+
+Explicit ask: does CLEAN_CODE.md's "functions >~30 lines should be orchestrators of small named
+helpers" rule hold for the files edited in this session? Checked `_build_tools` (208/168/117 lines
+across `pit_strategy_agent.py` / `tire_agent.py` / `race_situation_agent.py` — the largest functions
+in the three files this session edited most).
+
+**Verdict: already compliant, not a violation.** Read in full: each `_build_tools` is a container
+for 2-3 `@lc_tool`-decorated closures (required to close over `self` for the LangChain tool-calling
+framework — a module-level function cannot do this), and every closure's actual logic is already
+extracted into small, named, independently-callable instance methods (`agent._validate_driver_on_track`,
+`agent._get_driver_stint`, `agent._build_stint_tensor`, etc. — confirmed by reading
+`tire_agent.py:1172-1230`). The closures themselves are thin: parse tool args, delegate to a helper,
+format the LLM-facing response string. Their size comes from each tool's own docstring, which the
+project deliberately writes long and complete because it doubles as the tool's contract with the
+LLM (CLEAN_CODE.md's docstring section explicitly asks for this). This matches the earlier informal
+audit's own "docstring culture mitigates" judgment — independently re-verified here rather than
+taken on faith, on the specific functions this session's edits sit next to.
+
+### 5.7 — Second-wave verification
+
+- `ruff check` + `ruff format --check` on every touched file (3 Python files in `src/arcade/` +
+  `src/shared/`, 22 in `tests/`, 8 in `scripts/`, plus the 2 new `tests/` modules): clean.
+- Full syntax (`ast.parse`) + import smoke test on every touched module: clean.
+- `pytest tests/` (the full suite, all tiers): 554 passed, 4 skipped, 2 pre-existing failures
+  unrelated to this branch (see the note above).
+- `f1-sim` real run re-confirmed after the `theme.py`/`strategy.py` changes (arcade dashboard code
+  is not on the CLI's hot path, but `classify_action`'s home module, `strategy.py`, is imported by
+  both surfaces).
+- Full `pytest tests/` (all tiers, direct `uv run pytest`, not the `rtk` wrapper — see 5.8): 554
+  passed, 4 skipped (environment-gated), 2 failed. Both failures
+  (`tests/eval/test_ml_recompute_golden.py::test_pace_mae_reproduces_from_featured_laps`,
+  `tests/eval/test_registry_golden.py::test_reproduction_matches_overtake_auc_pr`) reproduce
+  identically on a clean `dev` checkout with none of this session's changes applied — confirmed by
+  checking out `dev`, stashing everything, and re-running just those two tests
+  (`KeyError: ['AirTemp', 'TrackTemp', 'Humidity', 'Rainfall'] not in index`, a pre-existing
+  data/schema issue in `tests/eval/`, a directory this session never touched). Pre-existing, not a
+  regression from this branch.
+
+### 5.8 — A second adversarial gate, on the second wave
+
+Same discipline as Part 4's gate: an independent Fable agent reviewed this wave's 6 commits before
+push. Full report: `documents/audits/AUDIT_cleanup_session_2026-08-01_GATE2.md`. It found real
+problems — all fixed before push, git history rewritten (`git reset --soft dev` + a clean re-commit
+in dependency order) rather than patched on top, since one of the findings was itself about commit
+ordering:
+
+| # | Sev | Finding | Fix |
+|---|---|---|---|
+| 1 | MEDIUM | The canned-outputs commit imported `tests.conftest` one commit before `tests/conftest.py` existed — bisect-hostile, and the split wasn't disclosed in either commit message. | Whole branch rebuilt from `dev` with commits in dependency order: the two new modules (`conftest.py`, `canned_outputs.py`) and every file that needs both land in one self-contained commit; everything downstream follows. |
+| 2 | MEDIUM | A **fifth** `_canned_outputs` consumer was missed in the first pass: `tests/mc/test_tyre_wear_term.py` (two call sites) still imported indirectly via `test_strategy_goldens`. Both fresh `# noqa: F401 -- re-exported for X` comments also named the WRONG consumer (both cited files that had already switched to direct imports). | Pointed `test_tyre_wear_term.py` at `tests.mc.canned_outputs` directly; removed both now-unnecessary `noqa` comments (the import is used locally in both files, so `F401` never fired — the annotation was dead weight with an inaccurate justification). |
+| 3 | MEDIUM | `theme.py`'s rewritten comment claimed "Both imported from src.arcade.strategy" — only `classify_action` is; the severity dict was never imported into `theme.py` in this wave. A wrong-mechanism comment, the project's own top-listed bug class, introduced by this session. | Rewrote the comment to describe only what the code actually does. |
+| 4 | MEDIUM (pre-existing, live) | `theme.py`'s `_FLAG_BG_BY_INTENT` — a third, independent severity-style mapping (for RCM/radio alert chips) — was missing `YELLOW_FLAG_SECTOR`, the exact key #398 already had to add to `_ALERT_SEVERITY` for the identical reason. Traced as a live path: `rcm_events.py` emits the event type → `radio_agent`'s alert generation → `flag_chip_html` misses the key → renders neutral grey instead of amber. | Added the missing key, with a comment naming both the mechanism and the #398 precedent. |
+| 5 | LOW (pre-existing, now fully exposed) | Deleting `severity_color` (its last caller) left `classify_alerts` + `_ALERT_SEVERITY` (`strategy.py`) with zero callers anywhere in the repo — an abandoned `agent_alerts`-banner feature, confirmed dead independently of the caller this wave removed. | Deleted both; this wave's own justification for removing `severity_color` had assumed `classify_alerts` was live, which the gate refuted. |
+| 6 | LOW | A 22nd copy of the tire-routing-config guard, in `test_pace_orchestrator_hardening.py`'s fixture body (an imperative `pytest.skip`, not a module-level marker) — missed by the original sweep because it doesn't match the `_HAS_MODELS = ...` textual pattern. | Migrated to `HAS_TIRE_MODELS` from `tests.conftest` like the other 21. |
+| 7 | LOW | Several shipped counts didn't reproduce: `tests/conftest.py`'s docstring said "26 copies" (actual 21 at the time, 22 after fix 6); this document said "~28 files" and "four consumers". | Corrected in this document (see 5.1) and in `tests/conftest.py`'s own docstring. |
+
+The gate's own verdict, after re-executing everything above: safe to push once these were fixed; ran
+its own full-suite `pytest tests/` invocation independently rather than trusting a cached number (its
+run was still in flight when the gate's summary was returned — the 554-passed/2-pre-existing-failed
+number above is this session's own separately-run, completed invocation, cross-checked against `dev`
+as described).

--- a/documents/audits/AUDIT_cleanup_session_2026-08-01.md
+++ b/documents/audits/AUDIT_cleanup_session_2026-08-01.md
@@ -72,6 +72,25 @@ site's own comment says "Fall back to the same conservative stub the wet/interme
 already uses" — the intent to share was explicit, the code never did. **Fixed** (Part 4): extracted
 `_conservative_tire_stub(...)` helper.
 
+### N4. `pace_agent.py`'s entire LangGraph ReAct scaffold is unreachable — flagged, not removed
+
+Beyond the dead `get_pace_react_agent()` free function (M1, fixed below), the whole
+subsystem it wrapped is unreachable too: the `get_react_agent()` instance method,
+`self._react_agent`, `PACE_TOOLS`, `predict_pace_tool`, `get_session_median_tool`, and
+`_PACE_SYSTEM_PROMPT` (`pace_agent.py:752-988`, confirmed via a repo-wide grep for
+`.get_react_agent(` — zero callers anywhere, unlike `tire_agent`/`race_situation_agent`/
+`pit_strategy_agent`, whose identical-shaped scaffolds ARE called internally from
+`_run_core`). `PaceAgent.run()`/`run_from_state()` call the XGBoost model directly and
+never touch any of it.
+
+**Not removed.** The section header directly above it reads `# LangGraph tools and ReAct
+agent (preserved 100% — no functional changes)` — a signal that a past change
+deliberately chose to keep this block untouched, most likely for eventual parity with
+the other three agents' ReAct capability. Deleting ~235 lines on the strength of "zero
+callers" alone would override that stated intent without knowing the reason behind it.
+Flagging for Víctor: either delete it (if the parity plan is abandoned) or wire it into
+`run()`/`run_from_state()` (if still planned) — this session does neither.
+
 ### N3. Weather-default divergence spans pace/tire/race_situation agents (3 different value sets) — folded into the architecture report
 
 `pace_agent.py` (`run_pace_agent_from_state`) defaults air/track temp to **25.0/35.0** reading the
@@ -105,16 +124,27 @@ over the shared `build_race_state` helper"), so it does not count as a fourth im
 | `track_temp` | `.get("track_temp", 40.0)` | `.get("track_temp", 35.0)` | `.get("track_temp", 35.0)` |
 | `position is None` | raises `ValueError` (#628) | raises `ValueError` (#465) | raises `ValueError` (#465) |
 | `gap_ahead_s` unknown fallback | `GAP_UNKNOWN_FALLBACK_S` (imported, single-sourced) | `GAP_UNKNOWN_FALLBACK_S` (imported, single-sourced) | `GAP_UNKNOWN_FALLBACK_S` (imported, single-sourced) |
-| `radio_msgs`/`rcm_events` | **not populated** (RaceState field left at its Pydantic default) | populated inline from `RadioPipelineRunner` | accepted as parameters, `None` → `[]` |
+| `radio_msgs`/`rcm_events` | left empty by `_build_race_state` itself, populated **370 lines later in the main loop** (`run_simulation_cli.py:1739-1762`, `.extend()`/`.append()` on the already-built `race_state` object) | populated **inline inside** `_build_race_state` from `RadioPipelineRunner` | accepted as **parameters** of `build_race_state`, `None` → `[]` |
 
 `compound` and `track_temp` are the two fields where CLI disagrees with BOTH other copies
 (`"UNKNOWN"` vs `"MEDIUM"`, `40.0` vs `35.0`), confirming the informal audit's claim with exact
 line numbers. `total_laps`'s CLI copy is actually the "more correct" one (fails loudly instead of
 guessing), which itself is a divergence in *error-handling philosophy*, not just in literal values.
-`radio_msgs`/`rcm_events` is a **new**, previously-unreported divergence this session found: the CLI
-path silently produces a `RaceState` with no radio/RCM context at all, while Arcade and the backend
-populate it — meaning the CLI's orchestrator input is missing information that the other two
-surfaces carry, not just different numbers for the same fields.
+
+**Correction (caught by this session's own adversarial gate, see the GATE report):** an earlier
+draft of this document claimed the CLI's `RaceState` ends up "radio-blind" — that claim was
+**refuted**. The CLI is not missing radio/RCM context: `run_simulation_cli.py`'s main loop mutates
+`race_state.radio_msgs`/`race_state.rcm_events` in place immediately after `_build_race_state`
+returns (lines 1739-1762 — real corpus radios/RCMs via `.extend()`, the SC-tracker's synthetic
+re-assertion, and simulated radios via `.append()`), and the arcade docstring's own words ("same as
+the CLI") already said as much. The real divergence is **structural, not functional**: Arcade and
+the backend build `radio_msgs`/`rcm_events` as part of the single `_build_race_state`/`build_race_state`
+call, while the CLI splits that responsibility — the builder returns an empty-list `RaceState` and a
+separate, later block in the caller fills it in. Whether that split is intentional (the CLI's
+main loop already owns the `sc_tracker`/`RadioPipelineRunner` instances for other reasons) or an
+artifact of the CLI predating the other two surfaces is exactly the kind of question the next
+dedicated session should resolve — but it is a "where does this responsibility live" question, not
+a missing-data one.
 
 ### The prior unification attempt, and its documented blocker
 
@@ -147,14 +177,15 @@ currently **not importable** without that shim.
    boundary (e.g. a new `src/shared_race_state.py` that the backend then imports, inverting today's
    direction), or (c) accept 3 copies and enforce parity with a test that diffs their literal
    defaults (cheapest, weakest).
-2. **`radio_msgs`/`rcm_events` in the CLI path** is a functional gap, not just a style one — worth
-   flagging to Víctor as its own question: is the CLI's `RaceState` deliberately radio-blind, or is
-   this an oversight from before Radio/RCM wiring existed?
-2. **`compound`/`track_temp`/`tyre_life`/`total_laps` fallback values** need one canonical answer
+2. **`radio_msgs`/`rcm_events` responsibility placement** — not a data gap (see the correction
+   above), but worth deciding: should the CLI's `_build_race_state` build these fields inline like
+   Arcade/backend do, or should Arcade/backend instead adopt the CLI's split (build empty, populate
+   from the caller)? Either answer removes one more structural difference between the three copies.
+3. **`compound`/`track_temp`/`tyre_life`/`total_laps` fallback values** need one canonical answer
    each — this session found the weather-default divergence extends further (`pace_agent.py`'s
    25.0/35.0 is a *fourth* value set for the same physical quantities, Part 2 §N3), so the "pick one
    number" scope is bigger than just the three `_build_race_state` copies.
-3. Whichever direction is chosen, it touches the untouchable CLI PMV (`run_simulation_cli.py`) and
+4. Whichever direction is chosen, it touches the untouchable CLI PMV (`run_simulation_cli.py`) and
    the `src/telemetry` submodule — per the project's issue-first rule for important/risky changes,
    file the issue before writing code, as `project_cleanup_audit_session_plan` already specifies.
 
@@ -162,4 +193,38 @@ currently **not importable** without that shim.
 
 ## Part 4 — Fixes applied in this session
 
-(Appended incrementally as each fix lands — see commit history on `fix/cleanup-anti-slop-scoped`.)
+| # | Finding | Fix | Files |
+|---|---|---|---|
+| 1 | M1: 3 dead constants (`_CLUSTER_PARQUET`, `_LAPS_FEATURED`, `_FEATURE_MANIFEST`) | Deleted — zero references anywhere in the repo, `_load_encoding_maps` builds the same paths inline | `src/agents/pace_agent.py` |
+| 2 | M1: 4 dead `get_*_react_agent()` free functions (~90 lines) | Deleted, plus their stale mentions in each file's own "Public API" module docstring | `pace_agent.py`, `tire_agent.py`, `race_situation_agent.py`, `pit_strategy_agent.py` |
+| 3 | M2: `total_laps` fallback literal `57` restated 6× across 3 files | Extracted `DEFAULT_TOTAL_LAPS` into a new leaf module `src/agents/_shared_defaults.py` (mirrors the existing `guard_rails.py` leaf-import pattern already used in `pit_strategy_agent.py`), imported everywhere | `pit_strategy_agent.py` (×3), `race_situation_agent.py` (×2), `tire_agent.py` (×1) |
+| 4 | N1: `race_situation_agent.py` disagreed with itself on `TrackTemp` fallback (35.0 vs 38.0) | Aligned `_compute_weather_features`'s fallback to 38.0, matching the file's own `run()`/`run_from_state()` | `src/agents/race_situation_agent.py` |
+| 5 | N2: `tire_agent.py::_run_core` restated the same "conservative stub" `TireOutput` twice | Extracted `_conservative_stub()` static helper, both call sites now pass only the differing `reason` string | `src/agents/tire_agent.py` |
+| 6 | M3: CLAUDE.md documented `f1-streamlit`/Streamlit (retired for `f1-webapp`/React SPA in #551) in 4 places, and described `src/shared/` as the live extraction home instead of the archived one | Updated §1 overview, §2 tech stack table, §3 project tree (added `data_extraction/`, marked `shared/` archived, corrected `telemetry/`'s description), §9 tooling note, §10 skills table | `CLAUDE.md` |
+
+### Findings detected but deliberately NOT fixed (flagged for follow-up, not silently dropped)
+
+| # | Finding | Why not fixed here |
+|---|---|---|
+| N4 | `pace_agent.py`'s entire LangGraph ReAct scaffold (~235 lines: `get_react_agent`, `_react_agent`, `PACE_TOOLS`, both tools, the system prompt) is unreachable — confirmed via repo-wide grep, zero callers | Its own section header says "preserved 100% — no functional changes", signalling deliberate intent (likely future parity with the other 3 agents). Deleting on "zero callers" alone would override that without knowing the reason. Flagged for Víctor to decide. |
+| N3 | Weather-default divergence across `pace_agent.py` (25.0/35.0) vs `tire_agent.py`/`race_situation_agent.py` (28.0/38.0) | Same disease as the architecture question (Part 3) — multiple independent "assemble race context with a plausible default" implementations. Picking one canonical value is a product decision, not a mechanical dedup; folded into the architecture report instead. |
+| A2/Part 3 | `_build_race_state` triplicated across CLI/Arcade/telemetry-backend | Explicit user instruction: detect and report only, fix in the dedicated follow-up session. |
+
+### Verification
+
+- `ruff check` on every touched Python file: clean (only `F821` is enforced inside `src/agents/**` per `pyproject.toml`'s deliberate per-file-ignores; nothing else applies there).
+- `ruff format --check` reports these files as "needs formatting" — **expected and not a regression**: `[tool.ruff.format]` explicitly excludes `src/agents/**` (deliberate hand-aligned `=` style), so this never runs in CI either.
+- AST parse + `importlib.import_module` on all 5 touched agent modules: clean.
+- `pytest tests/agents/ tests/audit/`: 129 passed.
+- `pytest tests/mc/ tests/simulation/ tests/eval/`: 286 passed.
+- Real `f1-sim Budapest NOR McLaren --no-real-radios --no-llm` run: all 70 laps OK, positions P5 → P1,
+  actions STAY_OUT·59 / PIT_NOW·5 / UNDERCUT·6, no errors.
+- Independent adversarial gate (Fable, separate agent, full details in
+  `documents/audits/AUDIT_cleanup_session_2026-08-01_GATE.md`): reproduced the test runs and the
+  real `f1-sim` run itself, re-verified every "zero callers" claim, confirmed all dedup sites
+  behaviourally identical, and found 1 HIGH (the radio_msgs/rcm_events claim corrected above), 3
+  MEDIUM (this branch's non-bisectable commit order, this section's then-unfilled placeholders, a
+  stale `docs/pages/agents-api.md` line), 3 LOW (a "2022-2025" vs "2023-2025" dataset-year slip in
+  the new constant's comment, a line-number-hardcoded comment, a stale "unchanged" docstring claim
+  in `pace_agent.py`). All 7 fixed post-gate; see the branch's commit history for the reordering and
+  follow-up commits.

--- a/documents/audits/AUDIT_cleanup_session_2026-08-01.md
+++ b/documents/audits/AUDIT_cleanup_session_2026-08-01.md
@@ -1,0 +1,165 @@
+# Dedicated clean-code / anti-slop cleanup session — 2026-08-01
+
+**Instrument:** foreground session (Fable), not a background agent. Method: `~/.claude/CLEAN_CODE.md`
+as the standard, `ponytail` doctrine as the "simplest thing that works" filter, then senior-dev
+judgment ("would a senior engineer keep this?"). This session both finds AND fixes the general
+AI-slop findings in scope; the single-contract/architecture question is detected and reported here,
+fixed in a separate dedicated session (per `project_cleanup_audit_session_plan`).
+
+**Scope, recomputed mechanically** (not the informal 2026-08-01 audit's broader scope):
+`git log --name-only aa1d274~1..HEAD` (aa1d274 = PR #730's merge commit), matching `gh pr list
+--state merged --limit 30`, i.e. the last 30 merged PRs, #730-#775, all landed 2026-07-29 to
+2026-08-01. Non-notebook, non-legacy files touched in that window:
+
+```
+scripts/measure_fresh_reference_gate.py, scripts/measure_fresh_reference_gate_2025.py,
+scripts/measure_tyre_reference.py, scripts/run_simulation_cli.py,
+src/agents/pace_agent.py, src/agents/pit_strategy_agent.py, src/agents/position_projection.py,
+src/agents/race_situation_agent.py, src/agents/strategy_orchestrator.py, src/agents/tire_agent.py,
+src/agents/tire_parsing.py, src/arcade/strategy.py, src/simulation/race_state_manager.py,
+src/strategy/eval/decision_modes.py, plus CLAUDE.md (checked on explicit instruction),
+documents/audits/*, documents/eval_reports/*, tests/**, pyproject.toml, uv.lock,
+.release-please-manifest.json, CHANGELOG.md
+```
+
+**Important scoping consequence:** this window is almost entirely the epic-724 decision-layer
+sprint + the tyre fresh-reference gate — a slice that already went through heavy adversarial
+scrutiny (FABLE_G1-G3, FABLE_S1-S5, MEASURE_*, AUDIT_A1-A5; see `project_epic724_scorecard`). Most
+of the informal 2026-08-01 audit's headline findings (A1 RCM-classifier bench-script fork, A3
+`theme.py`'s `_ACTION_STYLE` mirror, M4 bootstrap-preamble duplication across ~15 scripts, B1-B4
+legacy fossils) live in files **outside** this window (`bench_nlp_pipeline_cpu.py`, `theme.py`,
+`gap_calculation.py`, `tire_predictor.py`, `fastf1_extractor.py`) and are therefore **not touched in
+this session** — not because they stopped being valid, but because the user's explicit instruction
+was to scope this session to files touched in the last ~30 merged PRs, recomputed mechanically, not
+a fixed list. They remain open for a future sweep once a new 30-PR window covers them, or a
+deliberately widened scope.
+
+---
+
+## Part 1 — Verification of the 2026-08-01 informal audit against the recomputed scope
+
+| ID | Finding | In this scope? | Status |
+|---|---|---|---|
+| A1 | RCM classifier 3rd copy in `bench_nlp_pipeline_cpu.py` | No (`scripts/bench_nlp_pipeline_cpu.py` not touched in #730-#775) | Deferred, still valid per informal audit |
+| A2 | `_build_race_state` CLI vs Arcade divergence | **Yes** (`run_simulation_cli.py`, `arcade/strategy.py`) | **Confirmed, expanded — see Part 3 (architecture report)** |
+| A3 | `theme.py` `_ACTION_STYLE` mirror | No (`src/arcade/dashboard/theme.py` not touched) | Deferred, still valid per informal audit |
+| M1 | Dead code: pace_agent constants, 4× `get_*_react_agent`, `simulate_real_time_predictions` | Partially — pace_agent.py constants and all 4 `get_*_react_agent` fns are in scope; `tire_predictor.py` is not | **Fixed here (see Part 4)** for the in-scope pieces |
+| M2 | Restated constants: `total_laps=57`, weather defaults, tire stub duplication, compound RGB | **Yes**, all example files are in scope except `theme.py`'s RGB tuples | **Fixed here** for `total_laps` and the tire stub; weather defaults folded into the architecture report (see below) |
+| M3 | CLAUDE.md doc drift (`f1-streamlit`, `src/shared/`) | Yes, user named CLAUDE.md explicitly | **Fixed here** |
+| M4 | Bootstrap preamble duplication across ~15 scripts | No (only 3 of the ~15 scripts are in this window, and none is the divergence example) | Deferred |
+| B1-B4 | Legacy fossils, false docstrings | No (`src/vision/`, `strategy/inference/tire_predictor.py`, `fastf1_extractor.py` not touched) | Deferred |
+| B5 | Minor twins (`_bar_style`, `measure_*_gate*.py` near-identical harness, `_load_ner_model`) | `measure_fresh_reference_gate.py` vs `_2025.py` is in scope | Re-verified: still a deliberately-frozen reproducibility-script pair per the original audit's own judgment call — not touched |
+
+---
+
+## Part 2 — New findings from this session's deeper sweep (not in the informal audit)
+
+### N1. `race_situation_agent.py` disagrees with itself on the TrackTemp fallback
+
+`_compute_weather_features` (line 676) reads `session_meta.get('TrackTemp', 35.0)` — but the
+**same file's own** `run()` (line 1314) and `run_from_state()` (line 1401) build that very
+`session_meta['TrackTemp']` key with a fallback of **38.0** when the source weather is missing. If
+`_compute_weather_features` is ever called on a hand-built `session_meta` that omits `TrackTemp`
+(e.g. a test fixture), it silently produces a temperature 3°C different from what the rest of the
+file considers its own default — a same-file twin-that-never-got-the-fix, not a cross-file one.
+**Fixed** (Part 4): align to 38.0, the value the file's own constructors use.
+
+### N2. `tire_agent.py::_run_core` restates its own "conservative stub" twice, byte-for-byte except the message
+
+Lines 1566-1578 and 1609-1621 both construct an identical `TireOutput` (same `deg_rate=0.03`,
+`laps_to_cliff_p10/50/90=20.0/30.0/40.0`) with only the `reasoning` string differing. The second
+site's own comment says "Fall back to the same conservative stub the wet/intermediate branch above
+already uses" — the intent to share was explicit, the code never did. **Fixed** (Part 4): extracted
+`_conservative_tire_stub(...)` helper.
+
+### N3. Weather-default divergence spans pace/tire/race_situation agents (3 different value sets) — folded into the architecture report
+
+`pace_agent.py` (`run_pace_agent_from_state`) defaults air/track temp to **25.0/35.0** reading the
+raw `weather` sub-dict directly; `tire_agent.py` and `race_situation_agent.py` default to
+**28.0/38.0** reading their own already-transformed `session_meta['AirTemp'/'TrackTemp']`. This is
+the same disease as `_build_race_state`'s weather divergence (Part 3) — multiple independent
+"assemble race/session context with a plausible-looking default" implementations that were never
+reconciled — so it is reported as architecture evidence, not fixed here. Picking a single canonical
+value requires a product decision this session should not make unilaterally.
+
+---
+
+## Part 3 — Architecture question: is there duplicated "backend"/state-assembly logic that should be single-sourced?
+
+**Detected and reported only, per explicit instruction — not fixed in this session.**
+
+### The three confirmed independent implementations
+
+All three build a `src.agents.strategy_orchestrator.RaceState` from the same conceptual
+`lap_state` dict shape (`RaceStateManager.get_lap_state()`'s contract, CLAUDE.md §6). This is
+confirmed, not just "hinted at via a comment" — a fourth suspect, `simulator.py::_local_build_race_state`,
+turned out to be a genuine **thin wrapper** over the backend copy (its own docstring: "Thin wrapper
+over the shared `build_race_state` helper"), so it does not count as a fourth implementation.
+
+| Field | CLI `run_simulation_cli.py:1304-1373` | Arcade `src/arcade/strategy.py:599-715` | Backend `src/telemetry/backend/utils/race_state_builder.py:53-120` |
+|---|---|---|---|
+| `total_laps` | `lap_state["session_meta"]["total_laps"]` — **direct index, raises if absent** | `meta.get("total_laps", 57)` | `meta.get("total_laps", 57)` |
+| `compound` | `.get("compound", "UNKNOWN")` | `.get("compound", "MEDIUM")` | `.get("compound", "MEDIUM")` |
+| `tyre_life` | `.get("tyre_life", 0)` | `.get("tyre_life", 1)` | `.get("tyre_life", 1)` |
+| `air_temp` | `.get("air_temp", 25.0)` | `.get("air_temp", 25.0)` | `.get("air_temp", 25.0)` |
+| `track_temp` | `.get("track_temp", 40.0)` | `.get("track_temp", 35.0)` | `.get("track_temp", 35.0)` |
+| `position is None` | raises `ValueError` (#628) | raises `ValueError` (#465) | raises `ValueError` (#465) |
+| `gap_ahead_s` unknown fallback | `GAP_UNKNOWN_FALLBACK_S` (imported, single-sourced) | `GAP_UNKNOWN_FALLBACK_S` (imported, single-sourced) | `GAP_UNKNOWN_FALLBACK_S` (imported, single-sourced) |
+| `radio_msgs`/`rcm_events` | **not populated** (RaceState field left at its Pydantic default) | populated inline from `RadioPipelineRunner` | accepted as parameters, `None` → `[]` |
+
+`compound` and `track_temp` are the two fields where CLI disagrees with BOTH other copies
+(`"UNKNOWN"` vs `"MEDIUM"`, `40.0` vs `35.0`), confirming the informal audit's claim with exact
+line numbers. `total_laps`'s CLI copy is actually the "more correct" one (fails loudly instead of
+guessing), which itself is a divergence in *error-handling philosophy*, not just in literal values.
+`radio_msgs`/`rcm_events` is a **new**, previously-unreported divergence this session found: the CLI
+path silently produces a `RaceState` with no radio/RCM context at all, while Arcade and the backend
+populate it — meaning the CLI's orchestrator input is missing information that the other two
+surfaces carry, not just different numbers for the same fields.
+
+### The prior unification attempt, and its documented blocker
+
+The maintainers have **already reasoned about this exact question once**. `arcade/strategy.py:599-606`'s
+own docstring:
+
+> "Duplicate of `_local_build_race_state` from simulator.py, small enough to inline so the arcade
+> stays independent of `backend.utils.race_state_builder` (which requires a sys.path shim that only
+> the FastAPI startup provides)."
+
+And `arcade/strategy.py:641-644`:
+
+> "The telemetry backend still has its own copies and is a submodule, so this is a two-way
+> unification, not the three-way one an earlier draft of this comment claimed."
+
+So a **two-way** unification already happened for exactly one field (`GAP_UNKNOWN_FALLBACK_S`,
+imported from `src.agents.position_projection` in all three copies — genuinely single-sourced, not
+duplicated). A **three-way** unification of the whole function was considered and explicitly
+rejected, for a concrete, named reason: `src/telemetry` is a **git submodule** with its own FastAPI
+startup path that establishes a `sys.path` shim CLI/Arcade do not have, so importing
+`backend.utils.race_state_builder` from `src/arcade` or `scripts/` is not just a style choice, it is
+currently **not importable** without that shim.
+
+### What the next dedicated session needs to resolve
+
+1. **The import-boundary blocker is real and needs a design decision**, not a mechanical merge:
+   either (a) give CLI/Arcade a way to import the backend module (requires resolving the sys.path
+   shim, and accepting a dependency from `src/` onto the `src/telemetry` submodule — a layering
+   change), or (b) move the shared logic to a location both sides can import without the submodule
+   boundary (e.g. a new `src/shared_race_state.py` that the backend then imports, inverting today's
+   direction), or (c) accept 3 copies and enforce parity with a test that diffs their literal
+   defaults (cheapest, weakest).
+2. **`radio_msgs`/`rcm_events` in the CLI path** is a functional gap, not just a style one — worth
+   flagging to Víctor as its own question: is the CLI's `RaceState` deliberately radio-blind, or is
+   this an oversight from before Radio/RCM wiring existed?
+2. **`compound`/`track_temp`/`tyre_life`/`total_laps` fallback values** need one canonical answer
+   each — this session found the weather-default divergence extends further (`pace_agent.py`'s
+   25.0/35.0 is a *fourth* value set for the same physical quantities, Part 2 §N3), so the "pick one
+   number" scope is bigger than just the three `_build_race_state` copies.
+3. Whichever direction is chosen, it touches the untouchable CLI PMV (`run_simulation_cli.py`) and
+   the `src/telemetry` submodule — per the project's issue-first rule for important/risky changes,
+   file the issue before writing code, as `project_cleanup_audit_session_plan` already specifies.
+
+---
+
+## Part 4 — Fixes applied in this session
+
+(Appended incrementally as each fix lands — see commit history on `fix/cleanup-anti-slop-scoped`.)

--- a/documents/audits/AUDIT_cleanup_session_2026-08-01_GATE.md
+++ b/documents/audits/AUDIT_cleanup_session_2026-08-01_GATE.md
@@ -1,0 +1,276 @@
+# ADVERSARIAL GATE — cleanup session 2026-08-01 (branch `fix/cleanup-anti-slop-scoped`)
+
+**Instrument:** adversarial gate agent (Fable), read-only except this file. Success condition:
+find what is STILL broken or overclaimed in the cleanup diff (4 commits on top of `dev`) and the
+gitignored CLAUDE.md edit. Findings are appended incrementally as they are confirmed.
+
+**Commits under review:**
+
+```
+99f17eb fix(agents): add the leaf module backing DEFAULT_TOTAL_LAPS
+08864fb fix(agents): dedupe restated defaults across tire/race_situation/pit_...
+1fec855 fix(agents): remove pace_agent's dead ReAct scaffold entry point + ar...
+ea280e9 docs(audit): open the dedicated cleanup-session report
+```
+
+## Checklist (claims a-k)
+
+- [x] a) 4 `get_*_react_agent` free functions had ZERO callers — VERIFIED
+- [x] b) pace_agent's 3 deleted constants dead — VERIFIED
+- [x] c) `DEFAULT_TOTAL_LAPS=57` identical at all 6 sites; leaf verified by execution — VERIFIED
+- [x] d) TrackTemp 35.0→38.0 — VERIFIED (executed: empty session_meta → 38.0); caveat j-2
+- [x] e) `_conservative_stub()` identical values — VERIFIED
+- [x] f) deeper pace scaffold unreachable; keeping it was right — VERIFIED
+- [x] g) Part 3 table VERIFIED row-by-row; **radio-blind-CLI claim REFUTED (HIGH)**
+- [x] h) CLAUDE.md edits — VERIFIED, no overclaim
+- [x] i) ruff clean; tests/agents+audit 129 passed; smoke 5 passed/1 pre-existing data skip; mc/simulation/eval below
+- [x] j) new slop: j-1 bisect break (MED), j-4 uncommitted report + dangling placeholders (MED), j-7 stale docs page (MED), j-2/j-3/j-6 (LOW)
+- [x] k) no residual in-scope literals; no surviving removed symbols — VERIFIED
+
+## Findings
+
+### a) Dead free functions — VERIFIED
+
+Repo-wide ripgrep (src/, scripts/, tests/, notebooks/, documents/, docs/, and the `src/telemetry`
+submodule — 27,391 .py files on disk, so the submodule content WAS searched) for
+`get_pace_react_agent|get_tire_react_agent|get_race_situation_react_agent|get_pit_strategy_react_agent`:
+the ONLY hits are the two audit markdown files describing the deletion. `src/agents/__init__.py`
+read in full: `_EXPORTS` (lines 25-51) and the `TYPE_CHECKING` block (79-101) list only the
+`run_*`/`run_*_from_state` names plus dataclasses — no react-agent entry ever existed there.
+Methodology note: my first grep pass was silently broken (the RTK hook rewrote `rg` to a `grep`
+that rejects `--no-ignore`, and my `2>/dev/null` hid the error) — re-executed with a working
+ripgrep before trusting the zero.
+
+### b) pace_agent's 3 deleted constants — VERIFIED
+
+`_load_encoding_maps` (pace_agent.py:183-221) builds `feature_manifest_laptime.json`,
+`circuit_clustering/circuit_clusters_k4_2025.parquet` and `laps_featured_2025.parquet` inline from
+its `processed_dir` argument — byte-identical relative paths to the three deleted constants.
+Repo-wide grep for `_CLUSTER_PARQUET|_LAPS_FEATURED|_FEATURE_MANIFEST`: only the two audit docs.
+`_PROCESSED` (the module global the constants used) is NOT newly orphaned — still the default for
+`processed_dir` at line 148.
+
+### d) TrackTemp 35.0 → 38.0 — VERIFIED with caveats
+
+The changed line is genuinely inside `_compute_weather_features` (race_situation_agent.py:675-693;
+the git hunk header naming `_compute_rcm_features` is just git's nearest-context artifact). The
+same file's `run()` builds `'TrackTemp': ... else 38.0` at line 1317 (+ `track_temp_start` 38.0 at
+1319) and `run_from_state()` uses `wx.get('track_temp', 38.0)` at line 1403 — the claim holds
+against current code. `_compute_weather_features` has exactly one caller (line 1009, fed by
+run/run_from_state-built session_meta where the key always exists), so production behaviour is
+unchanged; only hand-built session_meta changes. No test asserts the old 35.0 fallback: the eight
+`35.0` hits in tests/ all SET `track_temp=35.0` explicitly on constructed states (pass-through, not
+fallback), and `test_race_situation_hardening.py:164` sets `"TrackTemp": 38.0` explicitly.
+**Caveat (LOW, see j-2):** the new comment hardcodes "lines ~1314/~1401" — actual lines today are
+1317/1403, and any edit above them rots the reference.
+
+### e) `_conservative_stub()` — VERIFIED
+
+Old inline constructors (diff, both sites): `deg_rate=0.03`, `laps_to_cliff_p10/50/90 =
+20.0/30.0/40.0`, `compound`/`current_tyre_life`/`gp_name` from locals, `reasoning` per-site. New
+helper reproduces exactly these fields; both call sites pass the same locals and only the `reason`
+string differs (site 2 still appends the parse-`reasoning` suffix, as before). No value drift.
+
+### f) pace_agent's deeper ReAct scaffold — VERIFIED (and keeping it was the right call)
+
+`.get_react_agent(` grep: 3 hits, all *self*-calls inside tire/race_situation/pit_strategy
+`_run_core` — none for pace. `PACE_TOOLS`: only pace_agent.py itself (798, 985, 988), the frozen
+notebook N25, and the audit docs. So the ~235-line scaffold is unreachable from outside, as
+claimed. Judgment: leaving it was correct — not because of the "preserved 100%" header alone, but
+because the other three siblings' identical-shaped scaffolds ARE live, so deleting pace's would
+make the four agents structurally asymmetric while the parity question is still open. Deleting is
+a one-commit follow-up once Víctor decides; resurrecting after deletion is also trivial via git.
+Either way it's a decision, not a cleanup, and the audit correctly routed it to the owner.
+
+### k) Residual literals — VERIFIED (with one honest-scope note)
+
+Repo-wide grep for `total_laps` near `57`: the only remaining *fallback* literals are
+`src/arcade/strategy.py:703` and `src/telemetry/backend/utils/race_state_builder.py:108` — exactly
+the two out-of-scope `_build_race_state` copies Part 3 defers to the architecture session, and the
+audit's Part 3 table already lists both. Everything else is tests/notebooks/docs passing 57 as an
+explicit VALUE, not a fallback. No in-scope site was missed. No removed symbol survives anywhere
+in code.
+
+### i) Test suites + lint — VERIFIED (executed by this gate, not read from the report)
+
+- `uv run ruff check` on all 5 touched files: "All checks passed!"
+- `uv run pytest tests/agents/ tests/audit/ -q`: **129 passed** in 165s (matches 08864fb's claim
+  exactly).
+- `uv run pytest tests/mc/ tests/simulation/ tests/eval/ -q`: **286 passed**, 627 warnings, 14:49.
+  This is the number the audit report's dangling "see below" never recorded (j-4) — recorded here.
+- `uv run pytest tests/infra/test_smoke.py -q`: 5 passed, 1 skipped ("Qatar 2025 parquets not
+  available in this environment" — pre-existing data-availability skip, unrelated to this diff).
+
+### g) Architecture report (Part 3) — table VERIFIED, but one headline claim REFUTED
+
+**Table: verified row by row against current code.** CLI (`run_simulation_cli.py:1304-1373`):
+`total_laps` direct index (raises), compound `"UNKNOWN"`, tyre_life `0`, air 25.0, track **40.0**,
+position-None → ValueError (#628), gap fallback imported `_GAP_UNKNOWN_FALLBACK_S`. Arcade
+(`strategy.py:599-715`): `.get("total_laps", 57)`, `"MEDIUM"`, `1`, 25.0, 35.0, ValueError (#465),
+imported fallback, radios from `RadioPipelineRunner`. Backend (`race_state_builder.py:53-120`):
+identical to Arcade's literals, radios as parameters `None → []`. Both quoted arcade comments exist
+verbatim (`strategy.py:600-603` sys.path-shim blocker; `strategy.py:642-644` "two-way unification,
+not the three-way one an earlier draft of this comment claimed"). `simulator.py:378-406`
+`_local_build_race_state` is a genuine thin wrapper delegating to `build_race_state`. Line ranges
+in the audit are exact.
+
+**REFUTED (HIGH, report-accuracy): "the CLI's orchestrator input is missing radio/RCM context".**
+The audit's self-described *new, previously-unreported divergence* — "the CLI path silently
+produces a `RaceState` with no radio/RCM context at all … the CLI's orchestrator input is missing
+information that the other two surfaces carry" — is false. `_build_race_state` indeed leaves the
+fields at their Pydantic default, but the CLI main loop then populates the SAME object before
+inference: `run_simulation_cli.py:1744-1762` extends `race_state.radio_msgs` with `real_radios`,
+`race_state.rcm_events` with `real_rcms`, appends the SC-tracker synthetic event, and appends
+simulated radio/rcm — 370 lines below the builder. The arcade's own docstring even says it
+populates radios "(same as the CLI)" (`strategy.py:604-606`), which the audit quoted around but
+did not reconcile. The divergence that EXISTS is only *where* population happens (inside the
+builder vs in the caller); the audit's follow-up question for Víctor ("is the CLI's RaceState
+deliberately radio-blind, or an oversight?") rests on a false premise and, uncorrected, would send
+the dedicated architecture session hunting a gap that does not exist — or "fixing" it into
+double-injection. This is the project's own documented failure shape: a claim written into the
+planning artifact without verifying against the consumer (cf. "a false claim inside an ISSUE is
+SCOPE").
+
+### h) CLAUDE.md edits — VERIFIED
+
+Live file (gitignored, read directly): `f1-webapp = "scripts.run_webapp:main"` IS in
+`pyproject.toml` `[project.scripts]` (line 124, alongside f1-strat/f1-sim/f1-arcade/f1-eval).
+`src/shared/README.md` opens "**Status: archived.**" and points at `src/data_extraction/` as
+canonical. `scripts/run_webapp.py`'s docstring says "post-race web app (FastAPI backend + React
+SPA)" served via docker compose. In CLAUDE.md: `grep -i streamlit` → **zero matches** (all 4
+stale references gone), line 55 adds `data_extraction/` as canonical, line 56 marks `shared/`
+ARCHIVED, line 99 documents `f1-webapp`, §9/§10 updated. No overclaim found in the CLAUDE.md edit.
+
+### j-0) No newly-orphaned code — VERIFIED
+
+`_get_default_pace_agent`/`_get_default_pit_agent`/`_get_default_situation_agent`/
+`_get_default_tire_agent` all retain live callers (each file's `run_*`/`run_*_from_state` free
+functions). `_PROCESSED` still used. Nothing the deletions touched became dead. The one sibling
+that must NOT be deleted, `get_rag_react_agent`, is untouched and still invoked
+(`rag_agent.py:134/195`) — the cleanup did not over-delete into the live twin.
+
+### c) `DEFAULT_TOTAL_LAPS` — VERIFIED
+
+All 6 call sites confirmed in the diff (pit_strategy ×3: 1037/1271/1452; race_situation ×2:
+1008/1360; tire ×1: 1478); every one is the same `meta.get('total_laps', <57>)` shape, value and
+`.get`-fallback semantics unchanged (race_situation's `int(...)` wrap kept). Leaf-module claim
+verified by execution, not reading: `importlib.import_module('src.agents._shared_defaults')` in a
+fresh interpreter returns 57 and loads NO heavy modules (torch/xgboost/lightgbm/transformers/
+langgraph/pandas all absent from `sys.modules`) — no import cycle, and the lazy `src/agents/
+__init__` stays lazy through it.
+
+### j-1) MEDIUM — non-bisectable commit order: 08864fb imports a module that does not exist until 99f17eb
+
+`git ls-tree 08864fb -- src/agents/_shared_defaults.py` → empty, while at that same commit
+pit_strategy/race_situation/tire all contain `from src.agents._shared_defaults import
+DEFAULT_TOTAL_LAPS` (git grep at 08864fb, 3 import sites). Checking out 08864fb gives
+`ModuleNotFoundError` on three agent modules; `git bisect` across this branch will land on a
+broken tree. The companion commit even says "Companion to the previous commit" — the order is
+simply inverted. Fix before pushing: reorder (add the leaf module first) via rebase, or squash
+99f17eb into 08864fb. CI on the PR head won't catch this; only bisect/checkout will.
+
+### j-2) LOW — the new TrackTemp comment hardcodes line numbers
+
+`race_situation_agent.py:678` says "(lines ~1314/~1401)"; actual lines today are 1317/1403 and
+any edit above them rots the pointer. The project's own style rule bans internal line references
+in comments. Name the functions (`run` / `run_from_state`), not the lines.
+
+### j-3) LOW — the new module's docstring perpetuates the "2022-2025 dataset" falsehood
+
+`_shared_defaults.py` says "57 is the median/mode race length across the 2022-2025 dataset".
+Executed check: `data/processed/laps_featured.parquet` holds years **[2023, 2024, 2025]**, 71
+races, median **57.0**, mode **57.0** — the NUMBER is right, the dataset naming is wrong, and
+CLAUDE.md §1 explicitly warns against exactly this conflation ("'2022–2025' names the
+ground-effect regulation ERA, not the data range … there is no 2022 season anywhere in `data/`").
+The error was inherited from the old inline comments (race_situation's deleted comment said
+"2022-2025 dataset (71 races)") — the consolidation was the one moment to correct it and instead
+promoted it into the single-sourced docstring. One-word fix: "2023-2025".
+
+### j-4) MEDIUM — the audit report's Part 4 + Verification section is UNCOMMITTED, and ends with two dangling "see below" placeholders
+
+`git status`: `documents/audits/AUDIT_cleanup_session_2026-08-01.md` is modified in the working
+tree (+44 lines vs HEAD) — the committed version (ea280e9) ends at "(Appended incrementally as
+each fix lands…)" and contains NEITHER the N4 finding, NOR the Part 4 fix/deferred tables, NOR
+the Verification section. Pushing the branch as-is ships a report missing its own results. Worse,
+even the working-tree version's Verification section still reads "`pytest tests/mc/
+tests/simulation/ tests/eval/`: **see below**" and "Real `f1-sim …` run: **see below**" — and the
+file ends there. The 70/70-laps real-run claim exists only in commit 08864fb's message, recorded
+nowhere with evidence. Fix: fill both placeholders with actual results and commit the report
+update as a fifth commit before pushing.
+
+### j-7) MEDIUM — the docs site still teaches the deleted API (the twin that never got the fix, docs edition)
+
+`docs/pages/agents-api.md:25`: "Every agent except N29 also exposes a `get_*_react_agent()`
+factory returning a compiled LangGraph `CompiledGraph`, for callers that want to drive the graph
+directly." After this diff that sentence is false for FOUR of the six agents — only N30's
+`get_rag_react_agent` survives. A reader following the docs site gets an `AttributeError`. The
+exact-name greps (mine included, first pass) miss it because the page names the *pattern*
+(`get_*_react_agent()`), not the identifiers — the literal instance of "grep is not an audit".
+This is the project's own codified lesson (CLAUDE.md §11, 2026-07-16): "cuando un fix cambia un
+contrato, la página que lo describe es parte del fix, no un follow-up". The audit's scope defense
+(agents-api.md wasn't touched in the 30-PR window) does not apply: the CLEANUP itself changed the
+contract the page describes, so the page became part of THIS fix. Update the sentence (only N30
+exposes a factory; the other four keep an internal `get_react_agent()` method — pace's unwired)
+in this same PR.
+
+### j-6) LOW — pace_agent's docstring header now makes a false claim this diff itself created
+
+`pace_agent.py:7` still titles its API list "Public API (**unchanged — backward compatible**)"
+— but this diff REMOVED a public function (`get_pace_react_agent`) from that very list. The
+parenthetical was written for an earlier refactor's promise; after this deletion it asserts the
+opposite of what the commit did. The sibling files are consistent (their docstrings just list the
+API without the "unchanged" claim). One-line fix: drop the parenthetical.
+
+### j-5) Commit-message honesty — VERIFIED otherwise
+
+1fec855's diff is exactly what it says (39 deletions, pace_agent only; explicitly discloses NOT
+removing the deeper scaffold). 08864fb's "four fixes bundled" matches its diff; its "129 passed"
+claim reproduced exactly by this gate. ea280e9's message matches its content (though that content
+carries the Part-3 radio-blind claim refuted in g). `_shared_defaults.py` is a justified
+extraction, not premature abstraction: 6 real call sites across 3 files, mirrors the existing
+`guard_rails.py` leaf pattern, and the leaf property was verified by execution (see c).
+
+### Real-run reproduction — VERIFIED
+
+`uv run f1-sim Budapest NOR McLaren --no-real-radios --no-llm`, executed by this gate on the
+post-diff tree: exit 0, "**All 70 lap(s) OK**", P5 → P1, actions STAY_OUT·59 / PIT_NOW·5 /
+UNDERCUT·6, wallclock 44.0s. Commit 08864fb's 70/70 claim is independently reproduced — it just
+needs to be RECORDED in the report's dangling placeholder (j-4).
+
+---
+
+## Severity ranking
+
+| # | Severity | Finding | Where | Fix effort |
+|---|---|---|---|---|
+| 1 | **HIGH** (report accuracy, not code) | Part 3's "CLI orchestrator input has no radio/RCM context" claim is FALSE — the CLI main loop populates `race_state.radio_msgs`/`rcm_events` at `run_simulation_cli.py:1744-1762`. Uncorrected, it aims the dedicated architecture session at a nonexistent gap (or a double-injection "fix"). | `AUDIT_cleanup_session_2026-08-01.md` Part 3 | Rewrite the paragraph: the divergence is WHERE population happens, not WHETHER. |
+| 2 | **MEDIUM** | Non-bisectable history: 08864fb imports `_shared_defaults`, created only in 99f17eb. Checkout/bisect at 08864fb = ModuleNotFoundError in 3 agent modules. | branch history | `git rebase -i` reorder or squash the two commits before pushing. |
+| 3 | **MEDIUM** | The audit report's Part 4 + Verification (+ N4) are UNCOMMITTED (+44 lines in working tree), and both "see below" placeholders are still dangling — the mc/sim/eval result and the real-run result are recorded nowhere. | working tree + report | Fill placeholders (286 passed measured by this gate) and commit as a 5th commit. |
+| 4 | **MEDIUM** | `docs/pages/agents-api.md:25` still says every agent except N29 exposes `get_*_react_agent()` — false for 4 of 6 after this diff. The project's own §11 lesson: the page describing a changed contract is part of the fix. | docs site | One-sentence rewrite in this PR. |
+| 5 | LOW | New docstring in `_shared_defaults.py` perpetuates "2022-2025 dataset" — data is 2023-2025 (verified: 71 races, years [2023,2024,2025]); CLAUDE.md §1 explicitly warns against this exact conflation. The 57 itself is correct (median 57.0, mode 57.0). | `_shared_defaults.py:14` | s/2022-2025/2023-2025/. |
+| 6 | LOW | New comment hardcodes "(lines ~1314/~1401)" (actual: 1317/1403) — banned internal line refs, rots on next edit. | `race_situation_agent.py:678` | Name the functions instead. |
+| 7 | LOW | `pace_agent.py:7` still claims "Public API (unchanged — backward compatible)" in the very diff that removed a public function from that list. | `pace_agent.py:7` | Drop the parenthetical. |
+
+No HIGH/MEDIUM **code-behaviour** defect was found: every code change in the diff is behaviourally
+identical to what it replaced (verified by diff, by execution, and by 420 passing tests).
+
+## What I tried to break and could NOT
+
+- **Hidden callers of the 4 deleted functions**: exact-name grep over the full tree including the
+  27k-file telemetry submodule, notebooks (.ipynb JSON), documents/, docs/, plus the lazy-loading
+  `__init__.py`'s `_EXPORTS` dict and `TYPE_CHECKING` block, plus a PATTERN-level grep
+  (`react_agent`) that caught what exact names couldn't (j-7 was found this way — in docs, not
+  code). No code caller exists. Also verified the one live twin (`get_rag_react_agent`) was not
+  over-deleted.
+- **Value drift in the dedup**: all 6 `DEFAULT_TOTAL_LAPS` sites diff-compared (same `.get`
+  semantics, same 57); `_conservative_stub` field-by-field identical at both sites; TrackTemp
+  fallback executed with an empty dict → 38.0/28.0/delta 0.0 exactly as claimed.
+- **Import-time regression**: fresh-interpreter import of `_shared_defaults` loads zero heavy
+  modules — the lazy-package property survives; no cycle.
+- **Test suite regressions**: 129 (agents+audit) + 286 (mc+simulation+eval) + 5 (smoke) all pass
+  post-diff on this machine; ruff clean on all 5 touched files.
+- **The architecture table**: re-derived every row from current code at the cited line ranges —
+  all values, both ValueError issue numbers, both quoted arcade comments, and the thin-wrapper
+  claim check out. The only thing that broke was the radio-blind interpretation (finding 1).
+- **A newly-dead orphan**: every helper the deleted code called (`_get_default_*`, `_PROCESSED`)
+  still has live callers.

--- a/documents/audits/AUDIT_cleanup_session_2026-08-01_GATE2.md
+++ b/documents/audits/AUDIT_cleanup_session_2026-08-01_GATE2.md
@@ -1,0 +1,337 @@
+# Adversarial gate 2 — second-wave cleanup (`fix/cleanup-anti-slop-wave2`)
+
+Date: 2026-08-01 · Gate model: Fable 5 · Branch: `fix/cleanup-anti-slop-wave2` (6 commits ahead of `dev`)
+Rules: no repository file modified except this report. Findings appended incrementally as executed.
+
+Commits under review:
+
+| # | SHA | Subject |
+|---|---|---|
+| 1 | `cd3f63f` | fix(tests): single-source the canned MC/golden sub-agent outputs |
+| 2 | `896d773` | fix(tests): single-source the tire-routing-config skip guard |
+| 3 | `906fcb1` | fix(arcade): import classify_action instead of mirroring it in theme.py |
+| 4 | `7ec75da` | docs(shared): correct fastf1_extractor.py's false import claim |
+| 5 | `d732e1d` | fix(scripts): use the robust repo-root search everywhere, not a fixed depth |
+| 6 | `c161d7f` | docs(audit): record the second-wave cleanup (post-#776) |
+
+## Checklist
+
+- [x] a) VERIFIED (24 files AST-parsed; caveat: wrong copy-count in conftest docstring; 1 residual fixture-level twin)
+- [x] b) VERIFIED inert (file on disk, 591 B; drift direction analysed)
+- [x] c) VERIFIED untouched (empty diff, own guards intact)
+- [x] d) VERIFIED (pre-fix crash executed ×2; post-fix executed ×6 inputs; caller sanitizes)
+- [x] e) VERIFIED WITH CAVEATS (wrong "Both imported" comment; dead `classify_alerts` island; `_FLAG_BG_BY_INTENT` missing YELLOW_FLAG_SECTOR — live pre-existing twin)
+- [x] f) VERIFIED (placement/uniqueness table; `_common.py` fallback correct; smoke-tested)
+- [x] g) VERIFIED (0 code cells, 1 markdown link, executed json scan; INFO: README attribution imprecise)
+- [x] h) VERIFIED WITH CAVEAT (fingerprint ×1; FIFTH consumer `test_tyre_wear_term.py` still on the old indirect path; both fresh noqa comments name wrong consumers)
+- [x] i) ruff check clean, ruff format clean (64 files); pytest: see below
+- [x] j) VERIFIED WITH CAVEATS (commit 1 leaves a broken intermediate tree — imports `tests.conftest` one commit before it exists; "two"→four miscount in commit 2's body)
+
+## Preliminary note — file-count reconciliation
+
+Commit 2's stat shows only 17 test files + `conftest.py`, while the audit doc claims "all 21 files".
+Resolved before treating it as a finding: the 4 `tests/mc/` consumer files
+(`test_mc_is_a_real_decision.py`, `test_mc_state_helpers.py`, `test_projection_golden.py`,
+`test_strategy_goldens.py`) received the guard migration folded into commit 1 (`cd3f63f`) because
+they were already being edited there. 17 + 4 = 21. A live grep for
+`skip_no_tire_models|HAS_TIRE_MODELS` returns exactly those 21 test files + `tests/conftest.py`.
+Not a defect, but the audit doc does not say the migration is split across two commits (see j).
+
+---
+
+## Findings
+
+### a) Docstring-corruption recovery — VERIFIED (with one documentation caveat)
+
+Executed: `ast.parse` + `ast.get_docstring` + leftover-definition regexes over **all 24 files**
+(21 migrated test files, `tests/conftest.py`, `tests/mc/canned_outputs.py`, and the 4 canned-outputs
+consumers, which overlap with the 21). Full list, each parsed OK:
+
+`tests/agents/`: test_agents.py, test_n15_envelope.py, test_orchestrator_prompt.py,
+test_prompt_constants_match_tables.py, test_tire_cumulative_deg.py ·
+`tests/audit/`: test_engine_scope_defaults.py, test_tire_agent_hardening.py,
+test_tire_mc_determinism.py · `tests/engine/`: test_engine.py, test_engine_memory.py,
+test_engine_no_llm.py, test_engine_threads_every_argument.py, test_memory_scope_is_deliberate.py ·
+`tests/mc/`: test_mc_is_a_real_decision.py, test_mc_state_helpers.py, test_projection_golden.py,
+test_sc_regulatory_rails.py, test_strategy_goldens.py, test_tyre_wear_term.py,
+test_undercut_targets_are_on_track.py, canned_outputs.py · `tests/simulation/`:
+test_simulation.py · plus `tests/conftest.py`.
+
+- No module docstring contains `tests.conftest` or `canned_outputs` as an import. 8 docstrings
+  contain the WORD "import" — all verified to be pre-existing prose ("importing the engine pulls…"),
+  zero import STATEMENTS inside any docstring (regex `^(from \S+ import |import \S+$)` over each
+  docstring: 0 hits across all 24).
+- No leftover `_HAS_MODELS = (...)` inline definition, no `_MODELS_DIR`, no
+  `_skip_no_models = pytest.mark...` definition anywhere in `tests/` (live grep). The surviving
+  `_skip_no_models` / `_HAS_MODELS` occurrences are the intentional import ALIASES
+  (`from tests.conftest import skip_no_tire_models as _skip_no_models`), which also keep the old
+  docstring prose accurate (e.g. `test_engine_no_llm.py:12` still names `_skip_no_models` — the
+  alias still exists at line 25, so the prose is not stale).
+- The corruption victim itself, `tests/mc/test_mc_is_a_real_decision.py`: docstring is 772 chars of
+  clean prose; the new import sits at line 30, outside the docstring.
+
+**Caveat (LOW, doc accuracy):** `tests/conftest.py:8` claims "26 near-identical copies of the
+tire-degradation-routing-config check alone", and the audit doc says "~28 test files". Executed
+count on `dev`: exactly **21** module-level `_HAS_MODELS = ...routing_config.json` guard copies
+(+ 4 different-artifact guards = 25 total `_HAS_MODELS` definitions, + 1 fixture-style runtime
+check, see below). Neither 26 nor 28 is reproducible. A shipped docstring carrying a wrong count is
+the project's own "comment naming the wrong mechanism" class — should say 21 (or 22).
+
+**Residual twin (LOW):** `tests/audit/test_pace_orchestrator_hardening.py:247` still hand-checks
+the same `routing_config.json` path inside its `clamp_fn` fixture (imperative `pytest.skip`, not a
+`skipif` marker). Functionally harmless and a different mechanism (fixture-scope lazy import), but
+it is a 22nd copy of the exact path expression the migration exists to single-source; it could
+import `HAS_TIRE_MODELS` from `tests.conftest`. The audit doc does not mention it.
+
+### b) `.exists()` vs `.is_file()` — VERIFIED inert
+
+- Executed on this machine: `data/models/tire_degradation/routing_config.json` → `exists()=True`,
+  `is_file()=True`, `is_dir()=False`, size 591 B. A regular file, so the two predicates agree.
+- The two drifters confirmed from the `dev` diff: `test_prompt_constants_match_tables.py:40` and
+  `test_tyre_wear_term.py:44` both used `.is_file()`; both now use the shared `.exists()` guard.
+- Divergence analysis: they differ only if the path exists as a **directory**. In that pathological
+  case the old `.is_file()` files would SKIP while the new guard says "models present" and the test
+  fails loudly at model-load. On CI (path absent) both are False → skip, identical. Failing loudly
+  on a corrupted layout is the better behaviour anyway. Inert in every real state; the change is
+  defensible even in the unreal one.
+- `test_agents.py`'s `_MODELS_DIR` intermediate was fully removed with no dangling reference
+  (grep: 0 hits outside the deleted line); `pytest` import still used (line 28 marker, parametrize).
+
+### c) 4 different-artifact-gated files — VERIFIED untouched
+
+`git diff dev..HEAD` over `tests/eval/test_hygiene_golden.py`, `tests/eval/test_registry_golden.py`,
+`tests/audit/test_pit_agent_hardening.py`, `tests/agents/test_prev_lap_default_is_single_sourced.py`
+is **empty**, and each still carries its own independent guard on HEAD (verified by live grep:
+overtake `model_config.json` ×2, pit_prediction `model_config.json`, lap_time `.is_dir()`). Exactly
+the 4 files the audit doc names, none accidentally collapsed into the tire-only guard.
+
+### d) `classify_action` None-fix — VERIFIED (executed)
+
+- (i) Both pre-fix bodies reconstructed from the `dev` diff and EXECUTED with `None`:
+  `strategy.py` old (`_ACTION_STYLE.get(action.upper(), (ACCENT, action.upper() or "--"))`) and
+  `theme.py` old (`_ACTION_STYLE.get(action.upper(), (ACCENT, (action or "--").upper()))`) both
+  raise `AttributeError: 'NoneType' object has no attribute 'upper'`. The audit doc's "crashed
+  identically" claim holds.
+- (ii) Post-fix `src.arcade.strategy.classify_action` executed with 6 inputs:
+  `None → ((167,139,250), '--')` · `'' → ((167,139,250), '--')` · `'PIT_NOW' → ((239,68,68),
+  'PIT NOW')` · `'pit_now' → same` (case-folding preserved) · `'banana' → ((167,139,250),
+  'BANANA')` · `'STAY_OUT' → ((16,185,129), 'STAY OUT')`. Every non-None result is identical to
+  what both old bodies produced (checked by construction against both old fallback expressions —
+  they only ever disagreed on nothing; `''` gave `(ACCENT, '--')` in both).
+- (iii) `orchestrator_card.py:155` sanitises with `str(latest.get("action") or "--")` before the
+  line-165 call, and imports `classify_action` via theme's re-export (`theme.py:23` noqa
+  comment matches reality). The fix hardens a latent path, it does not paper over a live crash.
+
+### e) theme.py orphan check — VERIFIED WITH CAVEATS (one wrong comment, one dead island, one live twin left behind)
+
+- `_ALERT_SEVERITY` is no longer imported by theme.py (old import line deleted); grep confirms no
+  use inside theme.py. ✓
+- `TEXT_TERTIARY` is NOT orphaned: still used at `theme.py:179` (`flag_chip_html` fallback) and
+  `:219` (status-bar stylesheet), plus re-exported to `orchestrator_card.py`. ✓
+- `severity_color`: zero callers repo-wide (only mentions are in the two audit .md files). ✓
+
+**CAVEAT 1 (MEDIUM, wrong comment in freshly-written code):** the rewritten block
+`theme.py:61-72` says "Action classification + severity — **Both imported** from
+src.arcade.strategy (not duplicated) … Importing both closes it." False: the import block
+(`theme.py:22-24`) imports ONLY `classify_action`. The severity dict is not imported anywhere in
+theme.py anymore (its only consumer, `severity_color`, was deleted in the same commit). The comment
+narrates a mechanism that does not exist — the project's own top-listed gate-caught bug class ("a
+comment naming the wrong MECHANISM is worse than none"), introduced by this wave.
+
+**CAVEAT 2 (LOW, dead island created):** deleting `severity_color` removed the LAST external
+consumer of `_ALERT_SEVERITY`. Executed grep (branch AND `dev`): `classify_alerts`
+(`strategy.py:763`) has **zero call sites anywhere in the repo** — it was already dead on `dev`,
+and `_ALERT_SEVERITY` now feeds only that dead function. The audit doc justifies the deletion as
+"restated `classify_alerts`'s mapping" as if `classify_alerts` were the live canonical; it is not
+live. The wave's cleanup is still correct, but strategy.py now carries a dead
+`classify_alerts` + `_ALERT_SEVERITY` island that the next cleanup should delete or wire up.
+
+**CAVEAT 3 (MEDIUM, pre-existing twin the wave walked past):** `theme.py:164-173`
+`_FLAG_BG_BY_INTENT` is a THIRD hand-maintained copy of the flag-severity semantics — and it lacks
+the `"YELLOW_FLAG_SECTOR"` key, the exact key whose absence WAS bug #398 in the severity dict
+(strategy.py's comment: "the form DOUBLE YELLOW resolves to"). The path is live and reachable:
+`rcm_events.py:144` emits `YELLOW_FLAG_SECTOR` → it is in `radio_agent.py`'s `_SAFETY_FLAGS`
+(alert-generating) → `agent_formatters.py:351` calls `flag_chip_html(intent)` → lookup misses →
+chip renders neutral grey (`TEXT_TERTIARY`). A sector/double yellow renders as an unstyled grey
+chip in the dashboard alerts card while the severity dict renders it amber — the same visual bug
+shape as #398, alive in the same file this commit edited, ~100 lines below a comment narrating that
+exact drift mechanism. Pre-existing on `dev` (not a wave regression), but this gate exists to find
+what the fixes walked past.
+
+### f) 8-script repo-root fix — VERIFIED
+
+Executed a placement/uniqueness scan over all 8 files. Per file: `.git`-search snippet line,
+occurrence count, `sys.path.insert` line, first `src.*`/`scripts.*` import line:
+
+| File | snippet | count | sys.path | first project import | order |
+|---|---|---|---|---|---|
+| build_radio_dataset.py | 105 | 1 | 109 | 111 | OK |
+| download_data.py | 33 | 1 | 36 | 38 | OK |
+| measure_fresh_reference_gate.py | 42 | 1 | 45 | 47 | OK |
+| measure_fresh_reference_gate_2025.py | 34 | 1 | 37 | 39 | OK |
+| measure_mc_tables.py | 75 | 1 | 78 | 80 | OK |
+| measure_tyre_reference.py | 50 | 1 | 53 | 55 | OK |
+| prompt_ab/_common.py | 28 | 1 | 32 | 58 | OK |
+| verify_drs_zones.py | 52 | 1 | 56 | none | OK |
+
+- No duplicated snippet; no orphaned `_SCRIPT_DIR`/`ROOT`/`_REPO_ROOT` (each `_SCRIPT_DIR` feeds
+  the snippet; each root var feeds `sys.path` and, in `measure_mc_tables.py`/`verify_drs_zones.py`,
+  later path construction — `verify_drs_zones.py:227` uses `_REPO_ROOT` for the fastf1 cache dir,
+  so the fix is load-bearing there beyond `sys.path`). `ruff check scripts/` clean (would flag
+  unused).
+- `prompt_ab/_common.py` fallback: `_SCRIPT_DIR = <root>/scripts/prompt_ab` →
+  `.parent.parent = <root>`. Matches the old `parents[2]` of the FILE path
+  (`[prompt_ab, scripts, root][2]`). Correct for its nesting depth.
+- Executed smoke: `uv run python scripts/verify_drs_zones.py --help` renders the argparse help.
+- Minor observation (INFO): `verify_drs_zones.py` imports no project module at all, so its
+  `sys.path.insert` block is inert scaffolding (pre-existing; the root var itself is still needed
+  for the cache path).
+
+### g) `fastf1_extractor.py` docstring — VERIFIED (one attribution imprecision)
+
+Independently executed `json.load` over `notebooks/data_engineering/N01_data_download.ipynb`:
+**0 code cells** reference `fastf1_extractor`; exactly **1 markdown cell** (cell 0) carries the
+link `- Legacy extraction: [fastf1_extractor.py](../../src/shared/data_extraction/fastf1_extractor.py)`.
+Repo-wide grep: no other reference outside `src/shared/README.md` and audit docs; **nothing in the
+whole repo imports `src.shared`** (grep for `from src.shared|import src.shared`: only README
+mentions). The corrected docstring is factually right.
+
+**INFO caveat:** the new docstring says "Kept per `src/shared/README.md`'s stated reason" — the
+README's actual stated reason is that deletion "would break the historical jupytext exports under
+`src/strategy/` and `src/vision/`", which for THIS file is itself inaccurate (nothing under either
+references it; only the N01 markdown link does). The docstring's own facts are correct; the
+attribution slightly launders a stale README claim.
+
+### h) References to deleted things — VERIFIED WITH CAVEAT (a fifth canned-outputs consumer was missed)
+
+- `severity_color`: 0 code references repo-wide (only the two audit .md narratives). ✓
+- Old inline `_HAS_MODELS`/`_skip_no_models` definitions: 0 left (see a). ✓
+- Canned-outputs body fingerprint `stop_duration_p05=2.2`: exactly **1** occurrence,
+  `tests/mc/canned_outputs.py:43`. ✓ No duplicate body anywhere.
+
+**CAVEAT (MEDIUM, the wave's own bug class inside its own fix):** the audit doc enumerates "four
+call sites"; there are **five**. `tests/mc/test_tyre_wear_term.py:317` and `:426` still import the
+fixture through the OLD indirect path — `from .test_strategy_goldens import _canned_outputs` —
+not from `tests.mc.canned_outputs`. It works (the chain resolves to the single body), but the
+canned_outputs docstring's claim that the extraction closed the "two different import paths"
+problem is not fully true: one indirect path survives. Worse, the two fresh `noqa` comments name
+the WRONG consumers:
+  - `test_mc_state_helpers.py:26` — `# noqa: F401 -- re-exported for test_mc_is_a_real_decision.py`:
+    false; that file now imports directly from `tests.mc.canned_outputs` (line 437). Nothing
+    re-imports from `test_mc_state_helpers` anymore; the noqa is also unnecessary (the alias is
+    used in-file at 218/245, so F401 cannot fire).
+  - `test_strategy_goldens.py:30` — `# noqa: F401 -- re-exported for test_projection_golden.py`:
+    false; `test_projection_golden.py:47` imports directly. The ACTUAL surviving dependent is
+    `test_tyre_wear_term.py` (317/426), which the comment does not name.
+This is precisely [[feedback_verify_the_enumeration_too]] + the wrong-mechanism-comment class: a
+reader following either comment will "clean up" the re-export and break `test_tyre_wear_term.py`,
+or keep a re-export nobody uses. Fix: point `test_tyre_wear_term.py`'s two imports at
+`tests.mc.canned_outputs`, then delete both stale noqa comments.
+
+### j) Commit hygiene — VERIFIED WITH CAVEATS (one broken intermediate tree, two wrong counts)
+
+Read all six full messages against their diffs:
+
+- `7ec75da`, `d732e1d`, `c161d7f`: honest and accurate. `d732e1d`'s verification claims
+  (ruff clean, `--help` renders) independently re-executed and confirmed here.
+- `906fcb1`: accurate on the None-crash and the dedup; minor: frames `classify_alerts` as the live
+  canonical of the severity mapping when it has 0 callers (see e, caveat 2).
+- `cd3f63f` (**MEDIUM — broken intermediate commit**): its diff ALSO performs the
+  `HAS_TIRE_MODELS`/`skip_no_tire_models` guard migration in the 4 mc files — importing
+  `from tests.conftest import ...` — but `tests/conftest.py` **does not exist at that commit**
+  (executed: `git show cd3f63f:tests/conftest.py` → "exists on disk, but not in cd3f63f"; the file
+  is born in `896d773`, the NEXT commit). At `cd3f63f` the entire `tests/mc/` golden tier fails at
+  collection with ImportError. Head of branch is fine, CI (which runs on the head) will be green,
+  but `git bisect` across this branch breaks, and the commit message never mentions the guard
+  migration it smuggles in. The dependency order between commits 1 and 2 is inverted; the guard
+  migration of those 4 files belonged in (or after) the conftest commit.
+- `896d773`: discloses the split but with the wrong count — "the **two** already touched for the
+  canned_outputs dedup are in the previous commit"; it was **four**
+  (state_helpers, strategy_goldens, mc_is_a_real_decision, projection_golden — all verified in
+  `cd3f63f`'s diff). Also says "~26 test files" restated the guard; actual total on `dev` is 25
+  `_HAS_MODELS` definitions (21 tire + 4 other-artifact). Tilde'd, tolerable — but
+  `tests/conftest.py:8`'s "26 copies of the tire check ALONE" (actual: 21) is not (see a).
+
+Structural check that could have made the explicit-conftest-import pattern subtly wrong and did
+not: `tests/` and every subdir have `__init__.py`, so pytest imports the conftest plugin as
+`tests.conftest` — the explicit `from tests.conftest import ...` binds the SAME module instance,
+no double evaluation of `HAS_TIRE_MODELS`. Verified via Glob + pyproject `testpaths`.
+
+### Audit-doc numeric accuracy (cross-cutting, LOW)
+
+The Part-5 narrative carries three unreproducible counts alongside the two already noted
+(conftest's "26 copies", commit 2's "two → four"):
+
+- §5.7: "13 Python files in `src/arcade/`, `src/shared/`" — actual second-wave `src/` diff is
+  **3** files (`theme.py`, `strategy.py`, `fastf1_extractor.py`; executed
+  `git diff dev..HEAD --name-only -- src/`).
+- §5.1: "~28 test files" restating the guard — actual `_HAS_MODELS` definitions on `dev`: **25**.
+- §5.1's "four consumers" of `_canned_outputs` — actual: **five** (see h).
+
+Verified-consistent counts, for contrast: "21 files" migrated ✓, "4 files different-artifact" ✓,
+"62 files in tests/" ruff-format-clean ✓ (re-executed: "62 files already formatted"), full branch
+scope = 23 tests + 8 scripts + 3 src + 1 audit doc = 35 files ✓ (matches `git diff --stat`), and
+no untouchable zone (`run_simulation_cli.py`, `src/agents/`, `notebooks/`, `legacy/`) appears in
+the diff. The project's own standard ("a false claim in an issue is scope") applies: these are
+narrative-only errors, but three of the five sit in SHIPPED artifacts (a docstring, a noqa
+comment, a commit body), not just the audit doc.
+
+### i) Test suite + lint — executed
+
+- `uv run ruff check tests/ src/arcade/ src/shared/ scripts/` → **All checks passed!**
+- `uv run ruff format --check tests/ src/arcade/dashboard/theme.py src/arcade/strategy.py` →
+  **64 files already formatted** (tests/ alone: 62).
+- `uv run pytest tests/ -q`: this gate's own invocation was still running when its findings were
+  handed off. Filled in afterward by the main session, from its own separate, completed
+  invocation: **554 passed, 4 skipped, 2 failed**. Both failures
+  (`tests/eval/test_ml_recompute_golden.py::test_pace_mae_reproduces_from_featured_laps`,
+  `tests/eval/test_registry_golden.py::test_reproduction_matches_overtake_auc_pr`) reproduce
+  identically on a clean `dev` checkout with none of this branch's commits applied — confirmed by
+  checking out `dev`, stashing all changes, and re-running just those two tests. Pre-existing, not a
+  regression from this wave. `tests/eval/` is a directory this wave never touched.
+
+---
+
+## Severity ranking (real problems only)
+
+| # | Sev | Finding | Where |
+|---|---|---|---|
+| 1 | MEDIUM | Commit `cd3f63f` leaves a broken intermediate tree: 4 files import `tests.conftest` one commit before the file exists — bisect-hostile, and the commit message hides the guard migration it carries | commits 1↔2 |
+| 2 | MEDIUM | Fifth `_canned_outputs` consumer missed (`test_tyre_wear_term.py:317,426` still imports via `test_strategy_goldens`), and BOTH fresh `noqa: F401 -- re-exported for X` comments name consumers that switched to direct imports; following either comment breaks or preserves the wrong thing | tests/mc |
+| 3 | MEDIUM | `theme.py:61-72` comment claims "Both imported from src.arcade.strategy" — only `classify_action` is; the severity dict is no longer imported there at all. Wrong-mechanism comment in freshly written code | src/arcade/dashboard/theme.py |
+| 4 | MEDIUM (pre-existing) | `_FLAG_BG_BY_INTENT` lacks `YELLOW_FLAG_SECTOR` — the exact #398 key — and the path is live (`rcm_events.py:144` → `_SAFETY_FLAGS` → `agent_formatters.py:351` → grey chip). Same file the wave edited | src/arcade/dashboard/theme.py:164 |
+| 5 | LOW (pre-existing, now fully orphaned) | `classify_alerts` + `_ALERT_SEVERITY` are a dead island (0 callers repo-wide, on `dev` too); the wave's own rationale treats `classify_alerts` as live | src/arcade/strategy.py:747-771 |
+| 6 | LOW | Shipped wrong counts: conftest docstring "26 copies" (actual 21), commit 2 "two" (actual four), audit doc "13 src files" (actual 3), "~28 files" (actual 25), "four consumers" (actual five) | conftest.py:8, commit bodies, audit doc |
+| 7 | LOW | Residual 22nd copy of the routing-config path check in `test_pace_orchestrator_hardening.py:247` (fixture-level `pytest.skip`) | tests/audit |
+| 8 | INFO | `fastf1_extractor.py` docstring attributes to `src/shared/README.md` a reason the README states differently (jupytext exports that don't reference this file) | src/shared |
+| 9 | INFO | `verify_drs_zones.py`'s `sys.path.insert` is inert (no project imports); root var still needed for the cache path | scripts |
+
+None of 1-9 blocks the branch at HEAD: the working tree is coherent, ruff/format clean, behaviour
+preserved everywhere I could execute it.
+
+## What I tried to break and could NOT
+
+- **Docstring corruption recovery**: parsed all 24 touched files with `ast.parse`; hunted for
+  import STATEMENTS inside every module docstring (regex over `ast.get_docstring` output) — zero.
+  The 8 docstrings containing the word "import" are all pre-existing prose.
+- **Leftover twin definitions**: regex-swept all touched files for inline `_HAS_MODELS = (`,
+  `_MODELS_DIR`, `_skip_no_models = pytest.mark` — zero survivors; live grep over `tests/` confirms
+  the only guard definition is `tests/conftest.py`.
+- **Behaviour drift in `classify_action`**: reconstructed BOTH pre-fix bodies from the dev diff and
+  executed them alongside the post-fix function on None/empty/known/lowercase/unknown inputs —
+  identical results everywhere the old code didn't crash; the crash is gone.
+- **`.exists()` vs `.is_file()` divergence**: checked the artifact on disk (regular file) and
+  reasoned both directions of the only divergent state (path-as-directory) — no real-world state
+  where the migration changes a skip decision.
+- **Wrong-order or duplicated bootstrap snippets**: scripted scan of all 8 scripts — every snippet
+  unique and ahead of both `sys.path.insert` and the first project import;
+  `prompt_ab/_common.py`'s fallback resolves to the repo root at its actual depth.
+- **Accidental scope creep**: full-branch `git diff --name-only` — exactly 35 files, no
+  untouchable zone touched (`run_simulation_cli.py`, `src/agents/`, `notebooks/`, `legacy/` clean).
+- **Double-evaluation of the shared guard**: `tests/` is a real package (`__init__.py`
+  everywhere), so pytest's conftest plugin and the explicit `tests.conftest` import are the same
+  module object.
+- **The `fastf1_extractor` claim**: independent `json.load` scan of every notebook cell — the
+  corrected docstring survives; zero code-cell references anywhere in the repo.
+- **Ruff/format regressions**: re-executed on all touched trees — clean.
+

--- a/documents/audits/AUDIT_pace_agent_react_archaeology_779.md
+++ b/documents/audits/AUDIT_pace_agent_react_archaeology_779.md
@@ -1,0 +1,218 @@
+# pace_agent ReAct archaeology (#779)
+
+Part of epic #778. Answers: why does `src/agents/pace_agent.py` carry a complete
+LangGraph ReAct scaffold that nothing calls, while the structurally identical
+scaffolds in `tire_agent.py` / `pit_strategy_agent.py` / `race_situation_agent.py`
+are genuinely wired into `run()`/`run_from_state()`?
+
+Method: read `notebooks/agents/N25_pace_agent.ipynb` and
+`notebooks/agents/N31_strategy_orchestrator.ipynb` in full (source-only dump,
+outputs stripped, via a throwaway script — no notebook file was edited), plus
+`git log -p --follow` / `git log -S` on `src/agents/pace_agent.py` and the
+GitHub history of issue #476. This report is the full finding; nothing here was
+buffered, the investigation is complete.
+
+## Summary verdict
+
+**The scaffold was born unreachable, then deliberately left unreachable at a
+later decision point, and never had a stated future-use commitment — only a
+"do not delete without knowing why" caution note added during last week's
+cleanup.** No PR description, commit message, issue, or notebook markdown was
+found promising to wire it. The one place a rationale IS on record
+(`N25_pace_agent.ipynb`, Step 5 markdown) argues pace's own case for an inner
+ReAct loop is weak by design, not that it was deferred.
+
+## Timeline
+
+### 1. 2026-03-31 — `88dfe40` — first extraction commit
+
+`pace_agent.py` is created from the notebook. The ReAct scaffold
+(`get_pace_react_agent`, `PACE_TOOLS`, `predict_pace_tool`,
+`get_session_median_tool`, `_PACE_SYSTEM_PROMPT`) exists from line 1 of the
+module's life, **alongside** `run_pace_agent()`, which already builds its
+`reasoning` field as a deterministic f-string — never a call into the ReAct
+agent. The two paths were born side by side and never unified.
+
+### 2. 2026-04-05 — `3f55c9f` — "agents: LangGraph fix + gpt-4.1-mini defaults..."
+
+**This is the pivotal commit.** It rewrites all four per-lap agents
+(`pace_agent.py`, `tire_agent.py`, `pit_strategy_agent.py`,
+`race_situation_agent.py`) in the *same commit*, converting each from
+free-function modules to an OOP `XAgent` class with a lazy `get_react_agent()`
+method. At the end of this exact commit:
+
+- `tire_agent.py`'s `run()`/`run_from_state()` call `self._run_core()`, which
+  calls `self.get_react_agent()` and `.invoke()`s it — confirmed by grepping
+  the commit's own tree state (`git show 3f55c9f:src/agents/tire_agent.py`).
+  Same for `pit_strategy_agent.py` and `race_situation_agent.py`.
+- `pace_agent.py`'s `run()`/`run_from_state()` build the feature row, call
+  `self._predict()`/`self._bootstrap_ci()`/`self._session_median()` directly,
+  and assemble the f-string `reasoning` — `self.get_react_agent()` is defined
+  but has **zero call sites** anywhere in the same commit's tree.
+
+So this was not incremental drift — in one sitting, three agents were wired to
+their ReAct scaffold and pace deliberately was not, even though its scaffold
+was written to the same level of completeness (tools, prompt, lazy singleton)
+as the other three. The same commit also renamed the section header above the
+scaffold from `# LangGraph ReAct agent` to
+`# LangGraph tools and ReAct agent (preserved 100% — no functional changes)` —
+in context this reads as "I touched everything else in this file in this
+refactor pass, this block's *behavior* is exactly what it was before", not as
+a forward-looking commitment to wire it later. It is refactor-commit hygiene,
+not a design promise.
+
+### 3. 2026-07-18 — `5f84218` — "fix(agents): validate LLM tool inputs..." (closes part of #476)
+
+A prior Fable-audit hardening pass added `PaceAgent._validate_pace_inputs()`
+and wired it into `predict_pace_tool`, explicitly treating pace's tool as
+LLM-facing: *"reuse the `_live_drivers` guard across the pit, tire, situation
+and pace agents so an off-track driver or out-of-range lap is refused instead
+of computed on"* (commit message). Issue #476 itself frames `predict_pace_tool`
+as the *"extreme"* case among the four agents' tools — 19 raw parameters, no
+`laps_df` closure — and says the "rich" (LLM) profile *"hands the same
+arguments to the LLM and never checks them back."*
+
+**This is significant: a previous audit session hardened pace's tool as if it
+were reachable by an LLM, without ever discovering that it wasn't.** The false
+belief "pace is wired like its siblings" did not start with Víctor in the
+2026-08-01 cleanup session — it was already latent in the codebase's own audit
+history three weeks earlier, and that audit pass reinforced it instead of
+catching it (its own fix touched all four agents' input-validation uniformly,
+which is exactly the kind of pattern-matched fix that would not surface a
+one-of-four wiring gap).
+
+### 4. 2026-08-01 — `1fec855` / `d5b6084` — this epic's origin
+
+The cleanup session removes the dead **wrapper** function `get_pace_react_agent()`
+(module-level, zero callers, distinct from the instance method
+`PaceAgent.get_react_agent()`), confirms the deeper scaffold is also dead, and
+explicitly declines to delete it because of the "preserved 100%" header —
+opening this epic instead.
+
+## What the notebooks actually say
+
+### N25_pace_agent.ipynb — Step 5 markdown (cell 31), the one on-record rationale
+
+> "This step wraps the inference functions from Steps 1–3 into a proper
+> LangGraph ReAct agent — the interface that N31 (Strategy Orchestrator) will
+> use to delegate pace queries."
+>
+> "**The key difference from `run_pace_agent` in Step 3**: the ReAct agent
+> lets the LLM decide which tools to call and can reason about the outputs
+> before responding. **For a deterministic single-tool workflow the two are
+> equivalent**; the agent pattern pays off in N31 where the supervisor LLM
+> selects which sub-agents to activate each lap."
+
+Two things follow from this, in the notebook author's own words, at design
+time:
+
+1. The *stated* intended consumer of pace's ReAct wrapping was N31's
+   *supervisor* calling pace's tools directly (a single flat ReAct with every
+   sub-agent's tools available to one outer LLM) — **not** an inner ReAct loop
+   private to `PaceAgent` the way tire/pit/situation ended up implementing.
+2. The notebook itself already flags that pace is a weak case for the pattern:
+   *"for a deterministic single-tool workflow the two are equivalent"* — i.e.
+   wrapping pace in ReAct was expected to buy nothing over calling it directly,
+   specifically because pace has no decision for an LLM to make.
+
+### N31_strategy_orchestrator.ipynb — the "LLM-as-router" design note (cell 7) that supersedes (1)
+
+N31's own Step 1 markdown contains an explicit, reasoned rejection of exactly
+the architecture N25 anticipated:
+
+> "**Why deterministic routing is the right choice here:** ... 4. *Latency* —
+> an LLM-as-router (e.g. ReAct-style planner deciding which agents to call)
+> adds one extra round-trip before any real computation starts. For a
+> real-time system making per-lap decisions every ~90 seconds, this matters."
+>
+> "**What could be made more complex (and why it's deferred):** ... *LLM-as-router*:
+> let the LLM itself decide which agents to invoke ... Rejected for latency
+> and non-determinism — a strategy call must be auditable and fast, not
+> dependent on an LLM reasoning about whether to call another LLM."
+
+N31's real `_decide_agents_to_call` is a plain deterministic `if`/`else`
+function. N31's own demo/production code (`_run_always_on_agents`) calls
+`run_pace_agent(...)` as an ordinary function with keyword arguments — never
+through a tool-call interface — and does the exact same thing for
+tire/situation (`run_tire_agent(lap_state)`, `run_race_situation_agent(lap_state)`),
+even though those two *do* internally spin up their own ReAct loop once called.
+
+**This is the resolving fact.** N31 was never going to be the "one supervisor
+ReAct with everyone's tools" that N25's Step 5 markdown anticipated — that
+architecture was explicitly designed away in N31 for auditability/latency
+reasons, for the routing decision specifically. What N31 actually calls is a
+plain function per agent; whether that function's *internal* implementation
+uses an LLM ReAct loop is a decision private to each agent module, made
+per-agent in commit `3f55c9f`. Pace's Step 5 rationale ("equivalent for a
+deterministic workflow") was never revisited against that outcome — it just
+turned out to still apply, because N31 changed the routing layer, not the
+individual agents' honesty about whether they have a qualitative judgment to
+make.
+
+## Corroborating architecture evidence (from the current codebase, not the notebooks)
+
+- `src/strategy/inference/no_llm.py` (`_NullReActRunner`, `run_no_llm_lap`)
+  calls `run_pace_agent_from_state(lap_state)` directly with **no** injection
+  seam — because there is no LLM step to null out. For tire and situation, the
+  same module has to inject a `_NullReActRunner` at the `_react_agent` cache
+  seam specifically because those two *do* run a live ReAct loop in normal
+  ("rich") mode. This file's own docstring states the asymmetry as a design
+  fact: *"N25/N26/N27/N29 produce REAL model numbers... pace via its public
+  XGBoost entry, tire/situation by injecting a deterministic tool-runner."*
+- `src/telemetry/backend/mcp_tools.py`'s chat-facing MCP tools
+  (`predict_pace`, `predict_tire`, `predict_situation`, `predict_pit`) are
+  *uniform* — each just calls that agent's `run_*_agent_from_state(...)` and
+  lets the agent's own implementation decide whether an inner LLM runs. The
+  outer chat LLM already can (and does) call pace today; the only missing
+  piece is whether `PaceAgent.run_from_state()` itself nests a second LLM call
+  the way tire/situation/pit do.
+- `TireOutput.warning_level` (the categorical judgment tire's siblings each
+  carry) is computed in `__post_init__` from a numeric threshold on
+  `laps_to_cliff_p10` — **not** by the LLM. The ReAct loop's real contribution
+  for tire is (a) which of 1–2 tools to call and in what order, and (b) a
+  natural-language `reasoning` sentence built from the tool outputs — not a
+  categorical decision the deterministic code couldn't make itself. Relevant
+  context for #780: the siblings' "qualitative judgment" is itself
+  post-hoc-deterministic; the LLM's value-add across all three is narrower
+  than "produces the category field" might suggest.
+
+## What was NOT found
+
+- No PR description, issue, or commit message stating an intended future date
+  or trigger for wiring pace's ReAct path.
+  the closest candidate, #476, hardens the tool as if reachable but never
+  states an intent to make it reachable.
+- No notebook cell, in either N25 or N31, that actually exercises
+  `pace_react_agent.invoke(...)` successfully — N25's own Step 5 demo cell
+  (cell 35) is wrapped in a `try/except` that falls back to the direct
+  `run_pace_agent()` call, "when the LLM is unavailable"; nothing in the
+  dumped notebook confirms it was ever run with a live LLM connected — but
+  we assume that never was tried given that we're focusing on Local LM Studio
+  for provider testing and OpenAI (paid) for chat testing.
+- No sign that a "future chat-style pace query, distinct from the per-lap
+  orchestrator loop" (the RAG-agent-shaped precedent named in the epic) was
+  ever planned for pace specifically — the actual chat surface
+  (`backend/mcp_tools.py::predict_pace`) already exists and bypasses the
+  scaffold entirely, calling the deterministic path like its three siblings'
+  MCP wrappers call theirs (the difference is only inside each agent's own
+  `run_from_state`).
+
+## Bearing on #780
+
+This archaeology does not resolve #780 — that is a product decision, not a
+historical fact, and it is Víctor's to make. What it does establish, for the
+decision conversation:
+
+1. The scaffold's existence is not itself evidence of a deferred plan — it was
+   written from a template shared with three other agents in one commit, and
+   whether to wire it was a call made per-agent in that same commit, not left
+   open.
+2. The one contemporaneous design rationale on record for pace specifically
+   (N25 Step 5) argues against wiring it, on the grounds that pace has no tool
+   arbitration or qualitative judgment for an LLM to add — a rationale that
+   was never contradicted by any later document.
+3. A previous audit pass (#476, 2026-07-18) hardened pace's tool inputs as if
+   it were live, which shows the "pace is wired" belief has already once
+   produced real (if harmless) engineering effort in the codebase based on a
+   false premise — a second data point, beyond Víctor's own belief, that this
+   gap is easy to miss by pattern-matching against the other three agents.

--- a/documents/audits/DESIGN_race_state_single_contract.md
+++ b/documents/audits/DESIGN_race_state_single_contract.md
@@ -1,0 +1,434 @@
+# DESIGN GATE — Single canonical `RaceState` builder (options a/b/c)
+
+**Date:** 2026-08-02
+**Role:** adversarial design gate, read-only. No implementation code. Success = finding what is
+still broken in the proposal, not approving it.
+**Scope:** the three (or four) independent builders of `src.agents.strategy_orchestrator.RaceState`
+from the `lap_state` contract, and the decision between options (a) shim-down import,
+(b) shared module in `src/`, (c) parity test over accepted copies.
+
+## Verification checklist (updated as each item is confirmed/refuted)
+
+- [x] V1. CLI `_build_race_state` — CONFIRMED, all defaults as briefed (F1)
+- [x] V2. Arcade `_build_race_state` — CONFIRMED, plus extra divergences the brief missed (F1)
+- [x] V3. Backend `build_race_state` — CONFIRMED (F1)
+- [x] V4. `GAP_UNKNOWN_FALLBACK_S` shared import — CONFIRMED in all three (F1)
+- [x] V5. CLI post-construction radio/rcm mutation + `--radio-every` — CONFIRMED (F3)
+- [x] V6. `_local_build_race_state` is a thin wrapper — CONFIRMED (F3)
+- [x] V7. `_compute_gap_ahead` is a genuine 4th copy — CONFIRMED (F7)
+- [x] V8. `compound` plain str; "UNKNOWN" traced through all consumers, never crashes (F5)
+- [x] V9. `total_laps` present from every internal producer; the ONE reachable hole is client JSON at /recommend (F6)
+- [x] V10. Shim direction — CONFIRMED: backend reaches UP (bare-metal shim + Docker `../../src` mount); reverse NOT wired; zero parent-side `backend` imports (F8)
+- [x] V11. "Independence" is a REAL, load-bearing install contract, not historical caution (F8)
+- [x] V12. CLI imports RaceState natively at `scripts/run_simulation_cli.py:158` — CONFIRMED
+- [x] V13. `_targeting_against_rival` is a pure function; composes as an optional param (F2)
+- [x] V14. TyreLife: measured on the real parquets — 0 NEVER occurs, 1 does (F10)
+
+## Findings
+
+### F1. The three builders and their literal divergences — VERIFIED (V1, V2, V3 ✔)
+
+All three re-read 2026-08-02. The brief's table is accurate, and it is INCOMPLETE — there are
+more divergences than the four it lists.
+
+| Field | CLI `scripts/run_simulation_cli.py:1361-1373` | Arcade `src/arcade/strategy.py:699-715` | Backend `src/telemetry/backend/utils/race_state_builder.py:105-120` |
+|---|---|---|---|
+| `driver` | `driver_code` param (line 1362) | `driver_st.get("driver", "UNK")` (700) | `drv.get("driver", "UNK")` (106) |
+| `lap` | `driver_st["lap_number"]` — from DRIVER dict, direct index (1363) | `int(lap_state.get("lap_number", 1) or 1)` — from TOP-LEVEL dict, default 1 (677, 701) | `lap_state.get("lap_number", 1)` — top-level, default 1, no int cast (107) |
+| `total_laps` | `lap_state["session_meta"]["total_laps"]` direct index → KeyError if absent (1364) | `meta.get("total_laps", 57)` (703) | `meta.get("total_laps", 57)` (108) |
+| `compound` | default `"UNKNOWN"` (1366) | default `"MEDIUM"` (705) | default `"MEDIUM"` (110) |
+| `tyre_life` | default `0` (1367) | default `1` (706) | default `1` (111) |
+| `air_temp` | `25.0` (1370) | `25.0` (709) | `25.0` (114) |
+| `track_temp` | `40.0` (1371) | `35.0` (710) | `35.0` (115) |
+| `position is None` | raise ValueError "#628" (1332-1337) | raise ValueError "#465" (632-636) | raise ValueError, no issue number in msg, #465 in comment (98-103) |
+| `gap_ahead_s` | no-car-ahead → 0.0; unknown interval → `GAP_UNKNOWN_FALLBACK_S` (1338-1343) | same shape (652-659) | value comes in as PARAMETER `gap_ahead_s: float = GAP_UNKNOWN_FALLBACK_S` (56) — the positional-car-ahead computation lives in the CALLER (`simulator.py::_compute_gap_ahead`) |
+| `pace_delta_s` | computed inline vs car ahead, #750 (1355-1359) | computed inline vs car ahead, #750 (671-675) | PARAMETER, default 0.0 (57); rival-targeted recompute if `rival` set (81-87) |
+| `radio_msgs`/`rcm_events` | NOT passed to constructor — schema defaults, main loop mutates after (see F3) | built INSIDE from `self._radio_runner`/`self._sc_tracker` (678-697) | optional params, `None → []` (59-60, 117-118) |
+| `risk_tolerance` | NOT passed (schema default) | `float(self._request.risk_tolerance)` (714) | param, default 0.5 (58, 119) |
+| SC re-injection (`should_inject`) | in the CLI main loop, not the builder | INSIDE the builder (695-697) | in the CALLER (`simulator.py::_rcm_events_for_lap` at ~357) |
+
+**Divergences the brief missed:** (i) the `lap` field has THREE different sources/behaviors —
+CLI reads `driver_st["lap_number"]` (fail-loud, from the driver dict), Arcade/backend read
+top-level `lap_state["lap_number"]` with default 1. A missing top-level `lap_number` would
+silently build "lap 1" state in Arcade/backend and crash the CLI. (ii) `driver` default
+"UNK" exists only in Arcade/backend. (iii) `risk_tolerance` plumbing differs in all three.
+(iv) The SC-tracker injection sits at a different layer in each surface (builder vs caller vs
+main loop). Any canonical builder has to decide (i)-(iv) too, not just the four fields flagged.
+
+**GAP_UNKNOWN_FALLBACK_S (V4 ✔):** all three import it from `src.agents.position_projection` —
+CLI at `scripts/run_simulation_cli.py:1299-1301`, Arcade at `src/arcade/strategy.py:615`,
+backend at `src/telemetry/backend/utils/race_state_builder.py:3`. So the backend ALREADY
+imports up into the parent repo's `src/agents` from this exact module — the (b) mechanism is
+proven at the exact file that would consume it.
+
+### F2. `_targeting_against_rival` (#431) — VERIFIED (V13 partially, see F8)
+
+`src/telemetry/backend/utils/race_state_builder.py:7-50`. Pure function of
+`(lap_state, rival, fallback_gap_s, fallback_pace_s)` → `(gap, pace)`. It contains ZERO
+webapp-specific machinery — no FastAPI, no request objects; "webapp-only" is about who calls
+it, not what it needs. It composes cleanly as an optional `rival: Optional[str]` parameter on
+a canonical builder (exactly as `build_race_state` already exposes it at line 61).
+
+### F3. radio_msgs / rcm_events placement — VERIFIED (V5, V6 ✔)
+
+- **CLI**: builder returns them as schema defaults (empty lists); the main loop mutates the
+  built object at `scripts/run_simulation_cli.py:1744-1762` — `.extend()` of corpus radios
+  (1745-1748), SC-tracker re-injection (1756-1758), and the CLI-ONLY synthetic
+  `--radio-every` generator `_generate_radio_event`/`_generate_rcm_event` (1726-1737,
+  appended 1759-1762). Precedence rule at 1714-1720: corpus suppresses synthetic entirely.
+- **Arcade**: INSIDE the builder from instance state (`self._radio_runner` at
+  `src/arcade/strategy.py:680-688`, `self._sc_tracker` ingest+inject at 695-697).
+- **Backend**: optional keyword params (`race_state_builder.py:59-60`), populated by callers:
+  - `simulator.py::_local_build_race_state` (378-406) is CONFIRMED a thin wrapper over
+    `build_race_state` — passes `rcm_events` only, `radio_msgs` never (the SSE stream is
+    RCM-only by design, `_build_rcm_feed` docstring at 330-335); SC injection lives in its
+    caller-side helper `_rcm_events_for_lap` (357-375).
+  - `backend/api/v1/endpoints/strategy.py:1349-1357` passes `request.radio_msgs` +
+    `rcm_events` (with an RCM-autoload fallback at 1332-1336) + `rival=request.rival`.
+  - `backend/mcp_tools.py:595-604` passes `radio_msgs=None, rcm_events=None`.
+
+Three surfaces, three different SOURCES for the same two fields (corpus+synthetic via
+mutation / instance state / caller params). The parameter shape is the only one of the three
+that all others can be expressed in.
+
+### F4. Backend call sites of `build_race_state` — VERIFIED
+
+Exactly three: `simulator.py:400`, `endpoints/strategy.py:1349`, `mcp_tools.py:595`. All
+already use keyword-only params. A relocation of the canonical function changes ONE import
+line per site (or zero, if `backend/utils/race_state_builder.py` becomes a re-export shim).
+
+### F5. What `"UNKNOWN"` compound actually does downstream — VERIFIED (V8 ✔)
+
+`RaceState.compound` is a plain `str` (`src/agents/strategy_orchestrator.py:253`); the
+`Literal["SOFT","MEDIUM","HARD"]` at :271 constrains only OUTPUT fields (`compound_next`).
+Traced every consumer of `race_state.compound`:
+
+1. **Pace agent (N06)** — `strategy_orchestrator.py:1871` → `pace_agent.py:261`
+   `self.compound_id.get(compound, 1)`: unknown string silently encodes as id 1 ("most
+   common training value" per its docstring at 250-251). No crash, no log.
+2. **Tire agent (N26)** — via the synthetic `lap_state["driver"]["compound"]` at
+   `strategy_orchestrator.py:2435` → `tire_agent.py:785-811` `_compound_name_to_id`:
+   "UNKNOWN" is not in the map → falls back to `'C3'` (:804/:811); then
+   `_add_compound_cols` (:667-687) LOGS A WARNING (:681-683) and encodes C3/SOFT defaults.
+   No crash. `'C3'` is a real routing_config key, so bundle lookup survives.
+3. **Pit agent (N28)** — `pit_strategy_agent.py:394-412` `_compound_to_id("UNKNOWN")` → `''`
+   from the JSON map → `_COMPOUND_FALLBACK.get("UNKNOWN", 3)` → 3. Additionally
+   `_N15_COMPOUND_ORDER` (:117-120) maps unknowns to `-1`, which IS the notebook's own
+   trained `.fillna(-1)` bucket — for N15 specifically, "UNKNOWN" is in-distribution.
+4. **RAG question** — `strategy_orchestrator.py:2028` → `:1496-1514`: free text ("changing
+   to UNKNOWN compound"); degraded question, no crash.
+5. **LLM prompt** — `:1734` renders `Compound: UNKNOWN` — honest to the model.
+
+**Conclusion:** "UNKNOWN" never crashes; every numeric consumer degrades to a mid-range
+encoding (roughly what "MEDIUM" would produce anyway), one path warns loudly, and the LLM
+sees the truth instead of a fabricated MEDIUM. "MEDIUM" produces nearly the same numbers
+while asserting knowledge that does not exist — and MEDIUM is a value the code CAN
+legitimately find, which is precisely the project's sentinel-collision doctrine violation.
+
+**However — the default is nearly DEAD on the RSM path** (see F6): `RaceStateManager`
+emits `"compound": str(r.get("Compound", ""))` (`race_state_manager.py:352`) — the key is
+ALWAYS present. When FastF1 has no compound the value is `""` or `"nan"`, and `.get`'s
+default never fires (the very trap in CLAUDE.md §11, 2026-07-16, `Series.get`). So the
+real-world "unknown compound" string on the RSM path is `""`/`"nan"`, not any builder
+default. The canonical builder should therefore normalise falsy/`"nan"` → the chosen
+default, or the chosen literal is a decision about an almost-unreachable branch.
+
+### F6. `session_meta` producers and `total_laps` — VERIFIED (V9 ✔, with one real hole)
+
+Producers found (grep `"session_meta"` across all .py):
+- `src/simulation/race_state_manager.py:518` — `"total_laps": self.total_laps`,
+  unconditional; `self.total_laps = int(enriched["LapNumber"].max())` at :130. ✔ always present.
+- `backend/api/v1/endpoints/strategy.py:592-598` (the /lap-state family) — includes
+  `total_laps` (:597, from `int(gp_df["LapNumber"].max())` at :585). ✔
+- `backend/api/v1/endpoints/strategy.py:942-948` (the single-agent lap_state producer) —
+  includes `total_laps` (:947). ✔
+- `strategy_orchestrator.py:2448-2454` (run_lap's internal adapter) — includes
+  `total_laps` from `race_state.total_laps`. ✔
+- **The hole:** `/recommend` (`endpoints/strategy.py:1349`) builds from
+  `request.lap_state` — ARBITRARY CLIENT JSON over HTTP. A client may legally omit
+  `session_meta` entirely (`race_state_builder.py:79` guards with `.get("session_meta", {})`).
+  This is the one reachable path where the CLI's fail-loud direct index would raise and the
+  backend's `.get(..., 57)` actually fires. So: fail-loud is safe for CLI/Arcade (RSM-fed),
+  but the canonical builder must keep SOME defined behavior for the HTTP boundary.
+- Precedent: `src/agents/_shared_defaults.py:19` already defines `DEFAULT_TOTAL_LAPS = 57`
+  with a documented rationale (median/mode of the 71-race 2023-2025 dataset), consolidated
+  from six agent-side call sites. A canonical builder that defaults should import THIS, not
+  restate 57.
+
+### F7 (early). `simulator.py::_compute_gap_ahead` IS a genuine 4th copy — VERIFIED (V7 ✔)
+
+`src/telemetry/backend/services/simulation/simulator.py:245-279`. Same algorithm as the two
+inline copies: `next(r for r in rivals if r.get("position") == our_pos - 1)`, then
+`interval None → GAP_UNKNOWN_FALLBACK_S`, `abs(interval)` otherwise, 0.0 when no car ahead.
+Differences from CLI/Arcade: it returns 0.0 (instead of raising) on `our_pos is None`
+(264-265) — safe only because `_lap_skip_reason` (296-321) filters those laps first, as its
+own docstring admits at 257-259. Its docstring at 248-250 states the duplication is
+INTENTIONAL ("kept inline here because the two copies are short and intentionally
+decoupled") — that rationale is exactly what this design gate is deciding to overturn, so
+unification should absorb it (analysis in F9).
+
+### F8. The layering evidence: why the "independence" framing is load-bearing — VERIFIED (V10, V11 ✔)
+
+- **Backend → parent is the ONLY existing direction.** Bare-metal: `mcp_tools.py:33`,
+  `simulator.py:45`, `endpoints/strategy.py:33` all `sys.path.insert(0, get_repo_root())`,
+  and `backend/core/paths.py:27-41` walks up for a `.git` DIRECTORY (skipping the submodule
+  gitlink file — the #27 fix), landing on the parent root. Docker:
+  `src/telemetry/docker-compose.yml:16` mounts `../../src:/app/src:ro` and paths.py falls
+  back to `/app` (:24, :41) — so `src.agents.*` resolves inside the container too. The
+  backend depends on the parent's `src/` tree in BOTH deployment modes, today, by design.
+- **Parent → backend does not exist anywhere.** Grep over `scripts/`, `src/agents/`,
+  `src/arcade/`, `src/simulation/`, `src/strategy/`, `src/f1_strat_manager/`, `tests/` for
+  `from backend.` / `import backend` / `telemetry.backend`: **zero matches**.
+- **The install contract makes that a feature, not an accident.** `INSTALL.md:37-59`
+  installs CLI and Arcade via `uv tool install git+...` or `uv sync` on a source checkout,
+  with NO submodule step; `--recurse-submodules` is documented as required ONLY for the
+  webapp flow (`INSTALL.md:89-95`). There is no `src/telemetry/__init__.py` and no
+  `src/__init__.py` (checked on disk), so nothing guarantees the backend package chain is
+  even importable from the parent side without a NEW mirrored sys.path shim onto
+  `src/telemetry` (backend modules import each other as top-level `backend.*`, e.g.
+  `endpoints/strategy.py:1323`). The arcade docstring's rejection of that shim
+  (`src/arcade/strategy.py:600-606`) reflects this real invariant.
+- Parent CI checks out submodules (`.github/workflows/ci.yml:52-54`), so parent-side tests
+  CAN see backend files — relevant to option (c) — but a user checkout is not CI.
+
+### F9. `_compute_gap_ahead` absorption — YES, with one behavioral note
+
+Deleting it and letting the canonical builder compute the gap internally is safe IF the
+canonical API treats "caller did not supply a gap" as "compute from rivals":
+- `simulator.py:877-879` calls `_local_build_race_state` only after `_lap_skip_reason`
+  (:870-873) has excluded `position is None` laps (:315-316), so `_compute_gap_ahead`'s
+  lenient `return 0.0` on None position (:264-265) is unreachable on the live path — the
+  canonical builder's fail-loud ValueError is behavior-identical where it matters.
+- Only one caller exists (`simulator.py:402`); no test or other module references it.
+- NOT the same thing: `endpoints/strategy.py:472-476` computes a gap from cumulative
+  session times over the DataFrame — that is a lap_state PRODUCER computation (different
+  inputs, before rivals exist as dicts), a cousin, not a fifth copy. Leave it out of scope,
+  but note it in the issue so nobody "unifies" it into the wrong layer later.
+
+### F10. Executed evidence for the literal recommendations
+
+Measured directly on the shipped parquets (2026-08-02):
+
+```
+TyreLife  2023 min 2.0 · 2024 min 2.0 · 2025 min 1.0 · rows with TyreLife==0: ZERO in all seasons
+Compound  values found: HARD/MEDIUM/SOFT/INTERMEDIATE/WET + the STRINGS 'None' (2023, 2025)
+          and 'nan' (2025); 'UNKNOWN': ZERO rows in all three seasons
+TrackTemp (2023+2024; the 2025 featured parquet carries no weather cols)
+          mean 35.3 · median 35.0 · p10 24.5 · p90 46.5
+AirTemp   mean 23.9 · median 24.1
+```
+
+Consequences:
+- `tyre_life=0` is a value the data can NEVER legitimately contain; `tyre_life=1` collides
+  with real fresh-tyre laps (2025 has them). Doctrine picks 0.
+- `compound="UNKNOWN"` collides with nothing in this corpus (0 rows; FastF1's API does
+  define UNKNOWN as a possible label, but the 2023-2025 data never emits it — flag, not
+  blocker). Meanwhile the REAL missing-compound strings that already flow out of
+  `race_state_manager.py:352` (`str()` of NaN/None) are `'nan'`/`'None'`/`''` — none of the
+  three builders normalises them, so today an incomplete row reaches the models as the
+  literal string `"nan"` regardless of which default was chosen.
+- `track_temp=35.0` IS the dataset median; the CLI's 40.0 corresponds to nothing measured.
+- `air_temp=25.0` ≈ median 24.1; all three already agree. Keep.
+
+### F11. Which defaults are actually live vs nearly dead (the honest stakes)
+
+> **CORRECTION (2026-08-02, from the follow-up gate in `GATE_weather_path_findings.md`).**
+> The claim below that the weather defaults are a "genuinely LIVE divergence" because they fire
+> "when `weather.parquet` is missing for a race" is **FALSE**. An executed scan found all 71 race
+> directories carry a readable `weather.parquet` with zero NaN `AirTemp`/`TrackTemp` rows, so on
+> the replay path (CLI and Arcade, both via `RaceReplayEngine`, which passes the frame at
+> `replay_engine.py:137`) that branch is unreachable with the shipped data. This is the same
+> mistake `CLAUDE.md` §11 records about the Arcade's temperatures on 2026-07-16.
+>
+> The **decision** (canonical 35.0) still stands, on the measured-median argument alone: 35.0 is
+> the dataset median and the CLI's 40.0 corresponds to nothing measured. Only this section's
+> justification was wrong.
+>
+> What the same gate found instead IS live, and is bigger: the backend's `lap_state` producer
+> emits `None` per weather key on 2025 laps (those parquets carry no weather columns), which the
+> old consumer passed to `float()` — a `TypeError` caught as a 422 on **every** 2025 lap of
+> `/recommend`. Filed as #788; fixed by this change's present-but-`None` handling.
+
+
+`dict.get(key, default)` fires only on a MISSING KEY (CLAUDE.md §11 2026-07-16 lesson).
+Checked against every producer:
+- `compound` / `tyre_life` / `position` / `driver` / `lap_number`: RSM ALWAYS emits the keys
+  (`race_state_manager.py:316-374, 596`), backend producers too (`endpoints/strategy.py:479,
+  588, 905-906, 945`). On RSM-fed paths the compound/tyre_life defaults are DEAD; the live
+  hazard is present-with-None / string-coerced NaN (F10). The defaults only breathe on
+  hand-built lap_states: HTTP clients of `/recommend` and test fixtures.
+- `total_laps`: same, except the /recommend client-JSON hole is real (F6).
+- **weather is the exception — genuinely LIVE divergence:** `get_weather_state` with no
+  `weather_df` returns ONLY `{"track_status": ...}` (`race_state_manager.py:470-472`), so
+  when `weather.parquet` is missing for a race, the KEYS are absent and every default
+  fires. On that same race the CLI feeds N14 `track_temp=40.0` and Arcade/backend feed
+  `35.0` — a real, reachable, surface-dependent model-input divergence today.
+- Present-with-None weather values (NaN row → None at :478-479) crash all three builders
+  (Pydantic float rejects None; arcade/backend `float(None)` TypeError) — caught by per-lap
+  try/except on CLI/arcade, a 422/500 on the backend. The canonical builder should treat
+  None-as-missing for weather (an `x if x is not None else DEFAULT` read), a strict
+  robustness gain, behavior-identical on every lap that works today.
+
+### F12. Option (a) — resolve the shim downward: REJECTED
+
+Three independent kills, each sufficient:
+1. **It breaks a documented install contract.** f1-sim/f1-arcade run today from a checkout
+   with `src/telemetry` EMPTY (INSTALL.md:37-59 vs :89-95; zero parent→backend imports,
+   F8). Under (a) the PMV would ImportError on every clone made without
+   `--recurse-submodules` and every `uv tool install` where the submodule content is
+   absent or unpackaged (no `__init__.py` chain, F8).
+2. **Layering inversion.** The parent's UNTOUCHABLE PMV would depend on a submodule pointer
+   versioned in another repo; a backend refactor could break the CLI, and fixing it would
+   require the commit-then-bump dance for what is today a parent-only file.
+3. **Import-name schizophrenia.** Backend code is imported as top-level `backend.*` (its
+   internal absolute imports demand it). The parent would need a mirrored
+   `sys.path.insert(src/telemetry)`; the same file could then be materialised twice under
+   two module names in one process — double side effects, the exact hazard class the
+   arcade docstring rejected (`src/arcade/strategy.py:600-606`).
+
+### F13. Option (c) — accept the copies + parity test: REJECTED (fallback only)
+
+- A parity test in the parent can only run when the submodule is checked out; on a
+  contributor clone without it, it silently skips — and in the SUBMODULE's own repo/CI
+  (where backend edits actually happen, per the commit-first rule) the parent-side test
+  does not exist at all. The guard is absent precisely where the drift originates.
+- Literal parity is the WEAK half of the problem. The drift that actually bit (#750
+  pace_delta axis, #465 dead position default, #633 gap zero-conflation) was LOGIC drift;
+  a field-by-field literal diff would have caught none of those bugs' next instances. To
+  assert logic parity the test must call all three builders — which needs the submodule
+  present AND importable, i.e. the same machinery (c) exists to avoid.
+- Precedent says convergence is the direction already chosen: the shared
+  `GAP_UNKNOWN_FALLBACK_S` import and `_shared_defaults.DEFAULT_TOTAL_LAPS` are both
+  fragments of (b) that already shipped.
+
+### F14. Option (b) — canonical module in `src/agents/`: RECOMMENDED, with the exact shape
+
+**Location:** `src/agents/race_state_builder.py` (new module — ADDITIVE, which even the
+strict CLAUDE.md §0.2 reading permits). Rationale: the output type `RaceState` is owned by
+`src/agents/strategy_orchestrator.py`; the two constants the builder needs already live in
+`src/agents` (`position_projection.GAP_UNKNOWN_FALLBACK_S`,
+`_shared_defaults.DEFAULT_TOTAL_LAPS`); and the backend's reverse shim + Docker mount
+already deliver exactly this path (F8). `src/simulation/` was considered and rejected: it
+would create a simulation→agents dependency that does not exist today.
+**Leaf-module constraint (hard):** import `RaceState` LAZILY inside the function, exactly
+as `backend/utils/race_state_builder.py:75` and the arcade (:616) do —
+`strategy_orchestrator` drags LangChain/LangGraph, and the builder must stay importable
+without paying that (mirror the discipline documented in `_shared_defaults.py:3-4`).
+
+**Canonical API (design, not code):**
+```
+build_race_state(
+    lap_state, *,
+    driver=None,            # CLI's explicit driver_code override; None → driver dict → "UNK"
+    gap_ahead_s=None,       # None → compute positional-car-ahead gap (absorbs _compute_gap_ahead)
+    pace_delta_s=None,      # None → compute vs car ahead per the #750 contract
+    risk_tolerance=0.5,
+    radio_msgs=None, rcm_events=None,   # None → []
+    rival=None,             # #431 targeting — _targeting_against_rival moves here verbatim
+) -> RaceState
+```
+`None`-means-compute keeps every existing caller byte-compatible: the /recommend endpoint
+keeps passing `request.gap_ahead_s` (client-override semantics unchanged), mcp_tools keeps
+its `or GAP_UNKNOWN_FALLBACK_S`, the simulator passes nothing and drops
+`_compute_gap_ahead`, CLI/Arcade pass nothing and lose their inline copies.
+
+**#431 stays clean (V13):** `_targeting_against_rival` (`race_state_builder.py:7-50`) is a
+pure `(lap_state, rival, fallbacks) → (gap, pace)` function with zero webapp imports;
+`rival: Optional[str] = None` on the canonical API leaks nothing — CLI/Arcade simply never
+pass it (the CLI's `--rival` is display-only today, `run_simulation_cli.py:1694-1700`, and
+wiring it later becomes a feature (b) enables for free, not a cost).
+
+**radio_msgs / rcm_events: PARAMETERS, not built internally.** Decision + justification:
+- The three surfaces have three different SOURCES (F3): CLI corpus+synthetic with a
+  precedence rule, Arcade instance state, backend caller params. Only the parameter shape
+  expresses all three without importing any surface's machinery into the shared module.
+- The CLI keeps its post-construction `.extend()/.append()` block UNCHANGED (RaceState list
+  fields are mutable; `scripts/run_simulation_cli.py:1744-1762` works identically on a
+  canonically-built object). The `--radio-every` synthetic generator, the corpus-suppresses-
+  synthetic rule and the SC tracker stay in the main loop where they live: zero PMV rewrite.
+- Arcade's builder becomes a thin wrapper: compute `radio_msgs`/`rcm_events` from
+  `self._radio_runner`/`self._sc_tracker` exactly as today (:678-697), then pass them as
+  params. The SC-injection LOGIC stays arcade-side (stateful, per-surface).
+- Building them INSIDE the canonical function would require it to hold a
+  RadioPipelineRunner and an SC tracker — instance state, Whisper deps, per-surface policy.
+  Rejected.
+
+**CLI surgical-edit test (the PMV constraint): PASSES.** The entire CLI change is (1) one
+import, (2) replace the BODY of `_build_race_state` (:1338-1373) with a delegation
+`return build_race_state(lap_state, driver=driver_code)` keeping the local function and its
+call site (:1711) untouched, (3) lines 1710-1764 stay byte-identical. The behavioral deltas
+are exactly the approved canonical literals, each validated with a real `f1-sim` run per
+the PMV rule — the same class of edit as the already-landed #750 fix to this function.
+
+**Submodule sequence (the commit-first rule):**
+1. **Parent PR** — add `src/agents/race_state_builder.py`; switch CLI + Arcade to it; unit
+   tests for the canonical builder land in parent `tests/` (they run WITHOUT the
+   submodule); real `f1-sim` run. Backend untouched and unbroken (its copy still works).
+2. **Submodule commit** (F1_Telemetry_Manager) — `backend/utils/race_state_builder.py`
+   becomes a re-export (`from src.agents.race_state_builder import build_race_state`,
+   preserving the public name so `simulator.py:400`, `endpoints/strategy.py:1349`,
+   `mcp_tools.py:595` need ZERO changes); delete `_compute_gap_ahead` (:245-279) and stop
+   passing `gap_ahead_s` from `_local_build_race_state` (:402). Note: the module ALREADY
+   imports `src.agents.*` at module top (:3), so the re-export adds no failure mode that
+   does not exist today.
+3. **Parent PR** — bump the submodule pointer. Until 3 lands the backend runs its old copy:
+   the drift window stays open between 1 and 3, so keep all three in one sprint.
+
+**Residual risks accepted (stated, not hidden):**
+- Between steps 1 and 3 the twin exists again, briefly and knowingly.
+- A future editor may top-level-import RaceState in the canonical module and slow every
+  surface's boot — guard with the module docstring + a cheap test asserting the module
+  imports without `langchain` appearing in `sys.modules`.
+- The canonical literals CHANGE observable CLI behavior on the weather-missing path
+  (40.0 → 35.0) — that is the point, but it must be named in the PR body.
+
+## Recommended canonical literals — one decision per row, each overridable
+
+| Field | Recommend | Grounds | Trade-off if overridden |
+|---|---|---|---|
+| `total_laps` | `session_meta.get("total_laps")`; missing → `DEFAULT_TOTAL_LAPS` (import from `_shared_defaults`, never restate 57) + `logger.warning` | Every internal producer supplies it (F6); the only reachable miss is client JSON at /recommend, and downstream agents ALREADY fall back to the same 57 — a builder stricter than its consumers buys a crash, not correctness. The warning keeps it loud. | Fail-loud (CLI today) is doctrine-purer; costs turning working (if sloppy) API calls into 422s. Defensible if the human prefers it. |
+| `compound` | `"UNKNOWN"`, PLUS normalise `""`/`"nan"`/`"None"`/absent → `"UNKNOWN"` | Never crashes (F5: pace encodes id-1 silently, tire warns + C3, N15 maps to its own trained −1 bucket, LLM prompt sees the truth); zero collisions in 71 races (F10); "MEDIUM" is a findable value = the sentinel-collision doctrine violation, and it lies to the prompt. The normalisation is what makes the choice REAL — today `"nan"` flows through regardless (F10). | "MEDIUM" yields near-identical model encodings and never prints an odd word in the UI. If "UNKNOWN" on screen is unacceptable, fix the DISPLAY, not the state. |
+| `tyre_life` | `0` | TyreLife==0 occurs ZERO times in 2023-2025 (executed, F10) → non-colliding sentinel; 1 collides with real fresh-tyre laps. Fires only on hand-built states (key missing), so the slightly out-of-distribution input is a corner, not a path. | `1` keeps the model strictly in-distribution at the cost of being indistinguishable from a real fresh tyre — the #428/#465 bug shape. |
+| `track_temp` | `35.0`; also treat present-but-None as missing | Measured dataset median is exactly 35.0 (F10); the divergence is LIVE today (fires whenever weather.parquet is absent, F11); 40.0 matches nothing measured. | Any float here is fabricated (schema forces float; `Optional[float]` is the honest long-term fix but a RaceState contract change, same as gap_ahead_s per the arcade's own comment :646-651). Choosing 40.0 needs a reason nobody has produced. |
+| `air_temp` | `25.0` (keep) | All three agree; ≈ dataset median 24.1. | — |
+| `lap` | top-level `lap_state["lap_number"]`, fallback driver dict, then default 1 + warning | RSM emits both (:596, :319); behavior-identical on all real paths; CLI's driver-dict direct index crashes on a hand-built state the other two accept. | Fail-loud purism, same argument as total_laps. |
+| `position` | keep fail-loud ValueError (all three agree); unify the message, cite #628+#465 | Already converged; the guard is load-bearing (#428 shape). | none |
+
+## What I tried to break and could not (option b)
+
+1. **"src/agents is untouchable, so (b) is forbidden."** Fails: the constraint is "additive
+   entry points only" (CLAUDE.md §0.2), and a NEW leaf module is the additive case —
+   `_shared_defaults.py` is the exact shipped precedent, created for the same
+   consolidate-the-restated-constant reason.
+2. **"The backend can't import it in Docker."** Fails: `docker-compose.yml:16` mounts
+   `../../src:/app/src:ro` and `paths.py` resolves `/app` — the canonical module ships into
+   the container by the SAME mechanism `position_projection` already does. The backend
+   image copies only `backend/` (Dockerfile:17); `src/` is a mount, so no rebuild semantics
+   change.
+3. **"It forces a CLI rewrite via the radio/RCM block."** Fails — but ONLY because of the
+   parameters-not-internal decision plus RaceState's mutable list fields. If a future
+   refactor freezes RaceState, the CLI's post-construction mutation breaks — record this in
+   the canonical module's docstring.
+4. **"A circular import: agents ↔ builder."** Fails: the builder imports
+   `strategy_orchestrator` lazily; nothing in `src/agents` imports the builder; Arcade and
+   CLI already import `src.agents.*` today (:615-616, :158).
+5. **"The submodule's standalone context breaks on `src.agents`."** Fails to be NEW:
+   `backend/utils/race_state_builder.py:3` already imports `src.agents.position_projection`
+   at module import time. Whatever handles that today handles the re-export identically —
+   a pre-existing property of the submodule, not a cost introduced by (b).
+6. **Could NOT fully close:** (i) whether every `uv` version users run fetches submodules
+   on `uv tool install git+...` — irrelevant to (b) (nothing parent-side will import
+   backend), decisive only against (a), which has two other independent kills; (ii) whether
+   any consumer outside this repo pair imports `backend.utils.race_state_builder` (MCP
+   clients call tools, not modules — none found); (iii) the hypothetical frozen-RaceState
+   future (risk recorded in 3).
+
+## Bottom line
+
+**Option (b).** One canonical `build_race_state` in `src/agents/race_state_builder.py`
+(leaf module, lazy RaceState import), radio/rcm/risk/rival as optional parameters,
+gap/pace computed internally when not supplied (absorbing `_compute_gap_ahead`),
+`_targeting_against_rival` moved verbatim, the backend file kept as a thin re-export so its
+three call sites do not change, the CLI edit strictly surgical (delegate the body, main
+loop untouched), landed as parent-PR → submodule-commit → pointer-bump in one sprint.
+Every literal above is a separate human decision — approve or override per row.

--- a/documents/audits/GATE_710_pace_envelope.md
+++ b/documents/audits/GATE_710_pace_envelope.md
@@ -1,0 +1,328 @@
+# GATE — #710 pace envelope (branch `fix/recalibrate-pit-bounds` vs `dev`)
+
+**Gate opened:** 2026-08-03 · adversarial gate, findings appended as confirmed.
+**Merge base:** `fc73c53` (dev == merge base; all changes are uncommitted worktree edits).
+
+## Scope observed
+
+Diff vs dev touches MORE than the pace half:
+- `src/agents/pace_agent.py` (+79) — the nominal change (`_N06_TRAINED_BOUNDS`, `_N06_ENVELOPE`, `_label_against_envelope`).
+- `tests/agents/test_n06_envelope.py` (new, untracked).
+- `src/strategy/inference/guard_rails.py` (+65/-x) — NOT named in the task.
+- `src/strategy/eval/decision_modes.py`, `src/strategy/eval/stint_lengths.py`, `tests/eval/*`, `documents/eval_reports/stint_lengths.*` — NOT named in the task.
+
+## Checklist (claims A–I) — final verdicts
+
+- [x] A. **CONFIRMED** — byte-identical frames dev-vs-branch (executed A/B) + strategy goldens
+  PASS + pace-MAE golden reproduces (`test_pace_mae_reproduces_from_featured_laps` PASSED).
+- [x] B. **CONFIRMED** — all 12 bounds re-derived, exact match, n=42957.
+- [x] C. **CONFIRMED** — train frame contains Years {2023, 2024} only.
+- [x] D. **CONFIRMED** — 42.6% / 41.9% / 46.7% exact; 0 inside all three ranges.
+- [x] E. **PARTIAL — see F5**: identifiers/flags correctly excluded, but the comment's own
+  arithmetic covers 22 of 25 features; `LapsSincePitStop` (continuous, trained 3-77) is
+  unbounded with no stated reason and no test pinning the choice.
+- [x] F. **CONFIRMED mechanically** (NaN → `unknown`, never compared — executed), with two
+  residues: F6 (junk coerced to NaN is silently `unknown` on the `run()` path) and the fact
+  that `unknown` never occurred once in 284 real replayed laps (the cited producers currently
+  cannot fire on the RSM path).
+- [x] G. **CONFIRMED** — checks the exact post-coercion frame `_predict` receives, exactly once
+  per agent call (284 verdicts / 284 laps), every live caller routed through it; only the
+  offline eval harness (`pace_holdout`) bypasses, acceptably. Residue: F7 (bootstrap frames).
+- [x] H. **REFUTED AS PRESENTED — see F1/F2/F3**: the claimed per-feature rates reproduce only
+  on the no-dropna frame (not the recipe the bounds declare), and the real inference rate is
+  31.0% of laps (88/284 across five circuits; 83% at Monza), not the ~5%-per-feature story.
+  The `run_from_state` fabricated defaults are all envelope-invisible (F9).
+- [x] I. **CONFIRMED** — 14/14 pass including the data-tier re-measure (executed locally, not
+  skipped); firing tests assert the log EFFECT via caplog; the identity test asserts the frame.
+  One nuance: the data test re-runs the same `pace_holdout` recipe the bounds were measured
+  with (circular in isolation), anchored externally by the pace-MAE golden which pins that
+  recipe to the thesis headline 0.4104 — both passed in the same session, so the anchor holds.
+- [x] Traps: TyreLife/LapNumber lower bounds ARE dropna-frame artefacts that scream on ordinary
+  laps (F3, measured); no second N06 feature path exists (all callers routed, executed grep +
+  call-graph walk); sentinel-in-range trap found live (F9: 90.0/300.0/25.0/35.0/50.0 all
+  mid-envelope; `tyre_life or 1` masquerades as an outlap).
+
+## Test-suite evidence (executed this session, on the branch worktree)
+
+- `tests/agents/test_n06_envelope.py` — **14 passed** (data-tier included, ran, not skipped).
+- `tests/mc/test_strategy_goldens.py` + `test_guard_rails.py` + `tests/eval/test_stint_lengths.py`
+  + `test_decision_modes.py` + `tests/agents/test_n15_envelope.py` — **86 passed**.
+- Full targeted suite incl. `tests/eval/test_ml_recompute_golden.py` — **106 passed, 1 failed**:
+  `test_undercut_auc_pr_reproduces_exactly`. **Attributed OUTSIDE this diff**: the recompute
+  returns `pending` because `data/processed/undercut_labeled/undercut_clean.parquet` is absent
+  on this machine, and the test's skip-guard (`test_ml_recompute_golden.py:15`) checks only the
+  model pkl, not the holdout parquet — so it FAILS where it should SKIP. Nothing in the branch
+  diff touches eval/reproduce/calibration or data. Pre-existing test-guard gap, recorded for a
+  separate issue.
+
+## Evidence-integrity note
+
+The orchestrator stashed/popped the worktree mid-gate (~90 s on unmodified `dev`). Both of my
+parquet measurements imported `src.agents.pace_agent._N06_TRAINED_BOUNDS` successfully, which is
+impossible on `dev`, so neither ran inside the window. Tree re-verified after the pop:
+`_N06_ENVELOPE` present in `pace_agent.py`, `tests/agents/test_n06_envelope.py` present. No
+finding below predates a state I did not re-verify.
+
+## Verified (executed, not read)
+
+- **B — bounds are MEASURED: CONFIRMED exactly.** Rebuilt 2023+2024 through
+  `augment_featured_laps` → `_encode_categoricals` → `_add_lag_deg_features` → `dropna(_DROPNA)`.
+  All twelve declared (lower, upper) pairs match the measured min/max **exactly** (`==`, not
+  approx), including `mean_sector_speed`'s full-precision floats. FuelLoad's odd-looking 0.9615
+  is exact because the featured artefact stores FuelLoad rounded to 4 decimals.
+- **C — right seasons: CONFIRMED.** Rebuilt frame n=42957 (claimed 42957), `Year` values in the
+  frame = {2023, 2024} only.
+- **D — Prev_Deg* percentages: CONFIRMED.** Fraction of training rows strictly below 0.0:
+  Prev_DegradationRate 42.6%, Prev_CumulativeDeg 41.9%, Prev_DegAcceleration 46.7% (claimed
+  42.6/41.9/46.7). All three training ranges straddle 0.0, so a bound could indeed never fire on
+  the pinned 0.0. The exclusion reasoning holds for every live caller (both `run_from_state`
+  and the orchestrator dict path pin 0.0).
+
+- **A (first half) — labels and nothing else: CONFIRMED byte-for-byte.** Loaded `dev`'s
+  `pace_agent.py` via `git show dev:...` as a parallel module and compared
+  `_build_feature_row` output dev-vs-branch on three scenarios (ordinary lap, 4-feature
+  out-of-range stint opener, None-Position + absent-baseline NaN path):
+  `assert_frame_equal(check_exact=True)` passes, `to_numpy().tobytes()` equal, and
+  `_predict` returns the identical float to the last digit in all three
+  (83.269715090096 / 97.82824754714966 / 90.15864652395248 on both sides). Goldens run
+  separately (see below).
+- **G — placement: CONFIRMED.** The check runs on `numeric`, the exact frame `_predict`
+  receives, after `pd.to_numeric(errors='coerce')` (`src/agents/pace_agent.py:459-461`), and
+  exactly once per agent call: my replay recorder saw 57/53/78 verdicts for 57/53/78 laps at
+  Lusail/Monza/Monaco. Every live caller reaches it — `no_llm.py:264`, orchestrator dict path
+  `strategy_orchestrator.py:1866` (via `run_pace_agent` → `run`), backend
+  `strategy.py:632,698`, `mcp_tools.py:451`, `scripts/debug_agent.py:247` all route through
+  `PaceAgent.run` → `_build_feature_row`. The one N06 consumer that bypasses it is
+  `pace_holdout.load_pace_predictions` (`model.predict` directly), which is the offline eval
+  harness, not an inference surface — acceptable, noted so nobody "fixes" it.
+- **F (NaN mechanics) — CONFIRMED executed.** `np.nan` arriving through a pandas frame lands in
+  `unknown` (never compared: `_is_unknown` catches it because `np.float64` subclasses `float`),
+  while an out-of-range `np.float64` is a violation. Verified with a live
+  `OperatingEnvelope.check` call on a coerced frame.
+
+## Findings
+
+### F1 — HIGH · `mean_sector_speed` at inference is a SPEED-TRAP reading, and the envelope fires on 79% of Monza laps
+
+`run_from_state` never passes `mean_sector_speed`, so `_compute_derived`
+(`src/agents/pace_agent.py:381`) falls back to `prev_speed_st` — the speed-trap value — on
+**every** RSM-path call. Trained bound [196.63, 314.97] describes real mean sector speeds;
+speed traps at a fast circuit run 315-340. Measured by replaying real 2025 races through
+`RaceReplayEngine` → `run_pace_agent_from_state` with a verdict recorder:
+
+| race | laps | laps with ≥1 violation | mean_sector_speed violations |
+|---|---|---|---|
+| Lusail NOR | 57 | 14 (24.6%) | 10 |
+| **Monza NOR** | 53 | **44 (83.0%)** | **42** |
+| Monaco NOR | 78 | 7 (9.0%) | 0 |
+| Spa NOR | 44 | 14 (31.8%) | 12 |
+| Silverstone NOR | 52 | 9 (17.3%) | 3 |
+| **total** | **284** | **88 (31.0%)** | 67 |
+
+(The Lusail row independently reproduces the coordinator's `f1-sim --no-llm` run to the exact
+per-feature counts: mean_sector_speed 10 / TyreLife 6 / Prev_TyreLife 6 / FuelEffect 3 /
+LapNumber 2 / FuelLoad 2 over 14 of 57 laps.) Spa and Silverstone additionally fire
+`Prev_SpeedST` itself (2 and 3 laps: 2025 slipstream trap readings above the trained max of
+362 km/h) — those ones are honest circuit-drift labels, unlike the fallback-quantity fires.
+
+Concrete failing scenario: Monza lap 3, green flag, nothing unusual — trap 329 km/h → warning.
+Every subsequent representative lap warns again; the log is a siren, not a label. Two distinct
+defects compound here: (a) the claimed 3.93% rate (design doc M4) was measured on the holdout
+frame where the feature IS a real mean sector speed, so it measures circuit drift, not the
+fallback; (b) the fallback itself is the same defect class M4 explicitly excluded Prev_Deg* for
+("feeding the model a different quantity than it trained on needs its own instrument") — the
+Prev_Deg* copy got the analysis, its `mean_sector_speed` twin did not. Lusail outlaps also fire
+the LOWER bound (trap 180-181 km/h under pit-limiter vs lower bound 196.6).
+
+### F2 — HIGH · the claimed M4 "2025 out-of-range rates" do not come from the recipe the change itself declares
+
+Executed both ways over `laps_featured_2025` + `augment_featured_laps`:
+
+| feature | claimed (M4) | measured WITH `_DROPNA` (the declared bound recipe) | measured WITHOUT `_DROPNA` |
+|---|---|---|---|
+| FuelEffect | 4.96% | **0.00%** | 4.96% |
+| TyreLife | 2.87% | **0.03%** | 2.87% |
+| LapNumber | 1.17% | **0.00%** | 1.17% |
+| FuelLoad | 1.17% | **0.00%** | 1.17% |
+| mean_sector_speed | 3.93% | 4.04% | 3.93% |
+| AirTemp | 1.96% | 1.96% | 1.96% |
+
+The M4 numbers reproduce only on the frame **without** the dropna step, i.e. a different
+denominator (n=22760) than the one the bounds are defined on (n=21247 for 2025). The rates
+happen to be MORE realistic that way (the dropped rows are exactly where inference goes out of
+range), but the doc presents one recipe and quotes rates from another, and neither matches what
+the agent actually does at inference (24.6% of Lusail laps, 83% of Monza laps — see F1/F3).
+
+### F3 — MEDIUM · six of the twelve bounds are artefacts of the training frame's structural exclusions, and they fire deterministically on ordinary laps
+
+`TyreLife ≥ 3`, `Prev_TyreLife ≥ 2`, `LapNumber ≥ 3`, `FuelEffect ≥ 0.055`,
+`FuelLoad ≤ 0.9615`, `laps_remaining ≤ 75` all exist because the featured artefact drops
+pit-in/out and inaccurate laps and `_DROPNA` then drops each stint's first surviving row — so
+the training frame **cannot contain** a race start or a stint opener. At inference the sim runs
+from lap 1 and calls the agent on every outlap. Measured: lap 1 fires 5 features at once
+(6 at Monaco, where `laps_remaining` 77 > 75 joins in), lap 2 fires 4-5, every stint opener
+fires 3-4 (`TyreLife`, `Prev_TyreLife`, `FuelEffect`, often `mean_sector_speed` via the
+pit-limiter trap). Judgement, since the coordinator asked for it: these ARE genuine
+training-range facts — N06 truly never saw such a lap, the prediction there truly is an
+extrapolation, and surfacing that standing train/serve mismatch is the envelope doing its job.
+What fails is the CLAIM AROUND IT: the change's own test rationale says "a normal lap must be
+silent, or the signal is worth nothing on a 57-lap race"
+(`tests/agents/test_n06_envelope.py:88`), and a warning on every stint opener of every race
+forever — plus F1's trap substitution — is not a quiet log. The bound is right; the noise
+budget and the call-site decision (#710's remit) are unresolved, and the M4 "quiet enough"
+evidence did not measure the distribution that matters.
+
+### F4 — MEDIUM · FuelLoad false positive: bound measured on a 4-decimal-ROUNDED artefact, checked against an UNROUNDED computation
+
+Training FuelLoad is stored rounded (max stored value exactly 0.9615). `run_from_state`
+computes `fuel_load = laps_remaining / max(total_laps, 1)` unrounded
+(`src/agents/pace_agent.py:749`). Monaco lap 3: 75/78 = 0.9615384… > 0.9615 → **violation
+fired on a lap class the model trained on** (training's own Monaco lap-3 rows store 0.9615 and
+sit inside the bound). Concrete: any 78-lap race warns `FuelLoad` on lap 3 while the identical
+physical situation was in-distribution at training time. One-ULP-class mismatches between an
+artefact-derived bound and a live computation are exactly the kind of edge `pytest.approx`
+would not have saved either, because the declared value matches the artefact, not the formula.
+
+### F5 — MEDIUM · claim E is incomplete: the comment's arithmetic does not reach 25, and `LapsSincePitStop` is a continuous count left unbounded with no stated reason
+
+The model consumes 25 features (`xgb_laptime_delta_feature_names.json`, executed read). The
+comment (`src/agents/pace_agent.py:105-116`) justifies 12 bounded + 5 identifiers + 2 flags +
+3 Prev_Deg* = **22**. Unaccounted: `Stint` (trained range 1-8), `Position` (1-20), and
+`LapsSincePitStop` (trained range **3-77**, 75 distinct values — the same lap-count nature as
+TyreLife, which IS bounded). On the RSM path `laps_since_pit = tyre_life` so violations would
+co-fire with TyreLife, but the orchestrator dict path (`strategy_orchestrator.py:1876`) takes
+`laps_since_pit` from `lap_state` and `run()` is public. `test_no_bound_is_declared_over_an_identifier`
+covers only the 5 identifiers, so nothing pins whether these three are excluded on purpose.
+Position/Stint are defensible as rank/ordinal codes; LapsSincePitStop is not, and no text says why.
+
+### F6 — LOW · the `unknown` path is real but currently unreachable on the replay path, and `to_numeric(coerce)` can silently convert junk into `unknown`
+
+Across all 188 replayed laps, `EnvelopeVerdict.unknown` was empty on every call (executed:
+recorder counted zero) — RSM always supplies Position and the stint baseline, so the NaN
+producers the docstring cites never fired. The NaN path itself does reach `unknown` correctly
+(`envelope._is_unknown` catches float NaN; verified by the unit test run). The residual hole:
+in the `run()` direct path a non-numeric value (e.g. a string) survives to
+`pd.to_numeric(errors='coerce')`, becomes NaN, lands in `unknown`, and is never reported by
+`_label_against_envelope` — an INVALID value silently downgraded to "no value", with no
+producer warning covering it. Cannot happen via `run_from_state` (its `float(...)` casts raise
+first). Note, not a blocker.
+
+### F8 — MEDIUM-LOW · the two lap-based veto shares point at an artefact that does not contain them (pit half; numbers themselves independently confirmed)
+
+`src/strategy/inference/guard_rails.py:56-58`: "Measured shares are quoted per bound below and
+are reproducible from `documents/eval_reports/stint_lengths.md`". Executed check of the
+regenerated artefact (md, 42 lines, plus a full JSON key walk): it carries ONLY the four
+minimum-stint rows. The `_NO_PIT_BEFORE_LAP` (42/1900 = 2.21%) and `_NO_PIT_LAST_N_LAPS`
+(26/1900 = 1.37%) shares — and the 1900 denominator itself (the report says 1895 counted + 5
+dropped) — appear in no shipped artefact, and `tests/eval/test_stint_lengths.py` asserts the
+ceiling for the four min-stint bounds only. The values are CORRECT (the parallel
+`GATE_716_calibration.md` reproduced both by independent reimplementation), so this is not a
+wrong number — it is a comment restating a session measurement while claiming artefact
+backing, the exact pattern the same commit's docstrings warn about. If the raw laps are
+regenerated and either share drifts past the ceiling, nothing that runs re-measures it.
+
+### F9 — LOW · every fabricated default in `run_from_state` is envelope-invisible by construction, and the one that is not tells the wrong story
+
+The trap hunt asked for sentinels that are also real values. All of them are here, deliberately
+mid-range: `MISSING_PREV_LAP_TIME_S` 90.0 ∈ [67.7, 149.0], `speed_st or 300.0` ∈ [156, 362],
+air 25.0 ∈ [14.5, 33.7], track 35.0 ∈ [16.7, 50.7], humidity 50.0 ∈ [18, 92]. So the envelope
+gives ZERO protection against the fabricated-input bug class on the RSM path — a lap running
+entirely on defaults labels as fully in-range. The exception: `tyre_life or 1` on a
+present-but-None tyre_life produces TyreLife=1 → a violation — but one indistinguishable from
+a genuine stint opener, so the log would say "outlap extrapolation" when the truth is "telemetry
+lost tyre_life". Not a defect of this change (labelling cannot fix fabrication), but the
+docstring's implied coverage should not be read as covering it, and a reader of the warning
+stream will misattribute that case.
+
+### F7 — LOW · the 200 bootstrap frames per lap are never checked
+
+`_bootstrap_ci` (`src/agents/pace_agent.py:507`) perturbs the six noisiest features ±2% and
+calls the model 200 more times per lap on frames built directly (`pd.DataFrame(row, ...)`),
+bypassing `_build_feature_row` and therefore the envelope. A base value just inside a bound is
+pushed outside in a fraction of the 200 draws. By design (noise model), and labelling 200
+sub-calls would be absurd — but "the check sees the same values the model is about to receive"
+(claim G) is true for 1 of the 201 model calls per lap. Recorded for precision, not as a defect.
+
+## What I tried to break and could NOT
+
+1. **The byte-identity claim.** Dev's `pace_agent.py` loaded as a parallel module, three
+   scenarios including out-of-range and the None/NaN path: frames byte-equal
+   (`to_numpy().tobytes()`), predictions equal to the last digit. The labelling really is
+   read-only — `check` builds new objects and never touches the frame.
+2. **The twelve bound VALUES.** Re-derived independently from the parquets through the declared
+   recipe: every declared number matches the measured min/max exactly, n=42957, seasons
+   2023+2024 only. They are measured, not chosen — including the full-precision
+   `mean_sector_speed` pair. (The rounding hazard I went hunting for in `pytest.approx` does
+   not exist here because the artefact itself stores FuelLoad rounded; the hazard shows up at
+   INFERENCE instead — F4.)
+3. **The Prev_Deg* exclusion.** Percentages exact; 0.0 comfortably inside all three trained
+   ranges; both live entry paths pin 0.0, so a declared bound could truly never fire. The
+   exclusion argument survives attack.
+4. **A second, unlabelled N06 path.** Walked every consumer of `run_pace_agent`,
+   `run_pace_agent_from_state` and the model file: orchestrator (both paths), no_llm engine,
+   backend endpoints, MCP tools, debug script — all route through `PaceAgent.run` →
+   `_build_feature_row`. Only the offline eval harness bypasses, and it should.
+5. **Double-checking per lap.** Recorder counted exactly one verdict per agent call on 284 real
+   laps; the bootstrap loop does not re-trigger it.
+6. **The NaN → `unknown` mechanics.** np.float64 NaN from a coerced frame lands in `unknown`,
+   never compared (executed micro-test); the unit test asserting silence on a NaN feature
+   passes for the right reason.
+7. **The envelope class itself.** Inverted-bounds rejection, ignore-undeclared-keys, and
+   frozen/immutability behaviour all held under direct probing.
+8. **The pit half's recalibrated values** (context for this branch): the regenerated report and
+   the shipped constants agree, the ceiling test passes, and the parallel GATE_716_calibration
+   reproduced every share independently — I did not find a number in `guard_rails.py` that is
+   wrong; F8 is about a false provenance pointer, not a false value.
+9. **The stash window.** Both of my parquet measurements imported branch-only symbols, so
+   neither ran against the temporarily-reverted tree; the tree was re-verified afterwards.
+
+## Fix list (by value, then risk)
+
+1. **F1 — decide what `mean_sector_speed` means at inference before the envelope ships its
+   warning.** Options in rising cost: (a) exclude it from `_N06_TRAINED_BOUNDS` with a comment
+   naming the fallback-quantity defect (mirror of the Prev_Deg* paragraph — smallest change,
+   honest); (b) declare the bound against the distribution the feature ACTUALLY receives at
+   inference (the speed-trap range), which is a different envelope for a different pipeline;
+   (c) fix the fallback itself (feed a real mean sector speed or NaN) — that is a model-input
+   change with golden impact, its own issue. Shipping as-is means 42 warnings per driver-race
+   at Monza and a log nobody will read by lap 10.
+2. **F3/F2 — restate the noise budget honestly at the call site and in M4.** The warning fires
+   on every race start and every stint opener by construction (measured 9-31% of laps on
+   normal circuits). Either downgrade those structural fires to DEBUG (they are true but
+   carry no news) while keeping WARNING for the non-structural ones, or document that the
+   consumer of this log must expect them. Update AUDIT_716_710_design M4 to name the frame its
+   rates were measured on (no-dropna, n=22760) — as written it implies the bound recipe's frame
+   and understates inference reality by ~6x.
+3. **F4 — kill the FuelLoad rounding false-positive**: either round the inference computation
+   to 4 decimals to match the artefact (`round(laps_remaining / total_laps, 4)` — matches
+   training semantics exactly), or widen the declared upper bound to the unrounded formula
+   value. One line either way; without it every 78-lap race warns on a trained lap class.
+4. **F5 — account for the last three features.** One comment line each for Stint/Position
+   (rank/ordinal, excluded on the same "no range" argument) and a real decision for
+   `LapsSincePitStop` (bound it, or say why not); extend the two exclusion tests to pin all
+   thirteen unbounded names so the enumeration cannot drift silently.
+5. **F8 — either add the two lap-based veto shares to the stint-lengths artefact (they already
+   have a home: the report), or soften the guard_rails comment to say where they actually came
+   from.**
+6. **F6 — decide whether `run()`-path junk-to-NaN deserves a log line** (a one-line `elif
+   verdict.unknown:` DEBUG would do), or document that `unknown` is intentionally silent
+   everywhere, not just for the two named producers.
+7. **Pre-existing, separate issue: `test_ml_recompute_golden.py:15` skip-guard** should also
+   require `data/processed/undercut_labeled/undercut_clean.parquet`, so the data tier skips
+   instead of failing on checkouts without the labeled holdout (it failed exactly that way in
+   this session, on a change that touches nothing near it).
+
+## Coordinator's direct question, answered
+
+**"Is TyreLife ≥ 3 a genuine training-range fact or a dropna artefact?"** Both, and the
+distinction decides the fix: the featured artefact + `_DROPNA` structurally exclude race
+starts and stint openers, so N06 has genuinely never seen such a lap — the prediction there
+IS an extrapolation and the label is TRUE. But because the exclusion is structural, the
+warning is guaranteed on laps that occur in every race forever; it separates "laps the
+pipeline can't train on" from "laps the sim must serve", which is a standing train/serve gap,
+not an anomaly. A quarter of laps warning (my 5-circuit measurement: 9-83%, mean 31%) fails
+the change's own silence criterion — the bound should stay DECLARED (it is a fact) but the
+structural fires need a different volume than the genuinely anomalous ones (fix 2), and
+`mean_sector_speed` should not be in the declared set at all until its fallback is fixed
+(fix 1). The orchestrator's Lusail run is confirmed exactly; its ~5% holdout-based estimate
+was the wrong distribution, as suspected, and the right one is worse.

--- a/documents/audits/GATE_716_calibration.md
+++ b/documents/audits/GATE_716_calibration.md
@@ -1,0 +1,441 @@
+# GATE — #716 pit-bound recalibration (branch `fix/recalibrate-pit-bounds` vs `dev`)
+
+Adversarial gate, 2026-08-03. Read-only except this report; findings appended as
+confirmed, never buffered. Success condition: find what is STILL broken.
+
+Diff under audit (8 files): `guard_rails.py`, `stint_lengths.py`,
+`decision_modes.py`, `pace_agent.py`, `tests/eval/test_stint_lengths.py`,
+`tests/eval/test_decision_modes.py`, `documents/eval_reports/stint_lengths.{md,json}`.
+
+## Checklist
+
+- [ ] Claim A — recalibrated, not deleted; proscriptive shape kept
+- [ ] Claim B — criterion (largest integer with veto share <= 5%) applied consistently
+- [ ] Claim C — values re-derived independently from data/raw (2023-2025)
+- [ ] Claim D — lap-based bounds: 2.21% / 1.37%, correctly unchanged
+- [ ] Claim E — all prose copies derive from constants; hunt for a FOURTH copy
+- [ ] Claim F — the wet-fallback false-comment story checks out
+- [ ] Claim G — the new ceiling test asserts the EFFECT, cannot pass vacuously
+- [ ] Claim H — nothing else breaks (stale reports, goldens, old-threshold tests)
+- [ ] Trap: `guard_rail_block` probe change correct, no real-stop bucket moved by the probe itself
+- [ ] Trap: `decision_modes.md` staleness
+- [ ] Trap: `_CALIBRATION_CEILING` single-sourcing vs dead weight
+- [ ] Trap: arithmetic of every %/count comment in `guard_rails.py`
+- [ ] What I tried to break and could not
+
+## Findings log (chronological)
+
+### V1 — Claims C and D VERIFIED by independent re-derivation (executed, not read back)
+
+Independent script (own reimplementation of the population rule — `PitInTime`
+notna, lap or lap+1 not neutralised by TrackStatus 4/5/6, TyreLife/Compound read
+off the stop row — no import of `src.strategy.eval`), run against
+`data/raw/{2023,2024,2025}`:
+
+- races=71, counted=1895 by bucket (341/896/548/110), +5 missing = 1900 total. Matches.
+- SOFT: bound 2 vetoes 11/341 = 3.226%; bound 3 = 5.279% > 5%. **2 is the largest
+  integer under the ceiling.** Matches shipped and comment "3.2%".
+- MEDIUM: 7 → 41/896 = 4.576% ("4.6%" OK); 8 → 5.80%. **7 maximal.**
+- HARD: 8 → 26/548 = 4.745% ("4.7%" OK); 9 → 5.47%. **8 maximal.**
+- WET fallback: 6 → 5/110 = 4.545% ("4.55%" OK); 7 → 7.27%. **6 maximal.**
+- Old bounds re-measured: SOFT 8 → 15.54%, MEDIUM 12 → 16.96%, HARD 15 → 12.23%,
+  wet 10 → 20.00%. Every "was" percentage in `guard_rails.py` is correct.
+- "11 SOFT stints ran exactly one lap" — counted 11. Correct.
+- `_NO_PIT_BEFORE_LAP=5` → 42/1900 = 2.211% ("2.21%" OK).
+- `_NO_PIT_LAST_N_LAPS=3` (rail inequality `remaining <= 3`, total_laps = max
+  LapNumber per race) → 26/1900 = 1.368% ("1.37%" OK).
+- "overshot the ceiling by between two and four times": 12.2/5 = 2.4x to 20/5 =
+  4.0x. Correct.
+
+### F1 (MEDIUM-LOW) — Claim B is FALSE as stated: the "largest integer under the ceiling" criterion was NOT applied to the two lap-based bounds
+
+Measured on the same 1900 stops: `_NO_PIT_BEFORE_LAP` could be **8** under the
+stated criterion (lap < 8 vetoes 92/1900 = 4.84% <= 5%; lap < 9 = 6.47%), and
+`_NO_PIT_LAST_N_LAPS` could be **at least 8** (remaining <= 8 vetoes 56/1900 =
+2.95%). Shipped values 5 and 3 are inside the ceiling but nowhere near maximal.
+
+Two different criteria are actually in play: "largest integer under the ceiling"
+for the four minimum-stint bounds, "leave untouched if under the ceiling" for the
+lap-based two. The code comments state the narrow versions accurately
+(`guard_rails.py:56` "Unchanged by #716: it already cleared the ceiling";
+`guard_rails.py:72` scopes "largest integer" to `_MIN_STINT_LAPS` only), so the
+SHIPPED ARTIFACT is internally consistent — treating the ceiling as a maximum-harm
+constraint rather than a target is also the defensible engineering choice for a
+proscriptive bound. What is false is the headline claim that ONE criterion was
+applied consistently to every bound. Anyone later "finishing the job" by raising
+the lap bounds to their ceiling-maximal values (8 and 8) would triple/sextuple the
+real stops those rails veto while every test stays green (see F-pending on the
+one-sided test). No file change needed; the claim needs restating wherever it is
+made outside the code.
+
+### Note — evidence integrity re-check after the orchestrator's stash warning
+
+The orchestrator reported a temporary `git stash`/pop window during my run.
+Re-verified immediately after the warning: `guard_rails.py` shows
+`_MIN_STINT_LAPS = {"SOFT": 2, "MEDIUM": 7, "HARD": 8}`, `_DEFAULT_MIN_STINT = 6`,
+`_CALIBRATION_CEILING = 0.05` (lines 54-90), and
+`tests/agents/test_n06_envelope.py` exists on disk. Every finding above matches
+the post-warning re-read. V1's measurements are additionally immune: they came
+from my own script over gitignored `data/raw/` (a stash never touches it), and
+the bound values V1 grades against were re-confirmed post-warning. No finding
+struck.
+
+### F2 (HIGH) — the branch silently DELETES `data/mc_measured_v1.json`'s entire `undercut_band` block, and the filtered diff hid it
+
+`rtk git diff dev --stat` showed 8 files; the raw diff shows **9**:
+`data/mc_measured_v1.json | 88 +----` — the whole `undercut_band` measurement
+(attempts_matched 716/1032, per-gap-bin success rates with CIs) is REMOVED from a
+TRACKED data file, in a branch whose subject is recalibrating pit bounds. Neither
+`AUDIT_716_710_design.md` nor any comment in the diff mentions it. This is
+exactly the class the repo added a guard for five commits ago (fc73c53, "fail the
+build when a tracked data file vanishes from the worktree") — here the file
+survives but a measured block inside it vanishes. Concrete failing scenario:
+whatever consumes `undercut_band` (MC undercut scoring / measured tables) silently
+falls back to its no-data path on every lap after this merges, and no pit-bounds
+test would ever notice. Needs: either an explanation + regeneration in the PR
+body, or `git checkout dev -- data/mc_measured_v1.json` before committing.
+(Follow-up below on consumers.)
+
+### F3 (MEDIUM, process) — the branch is three concerns in one uncommitted worktree, and the one NEW test file is untracked
+
+`fix/recalibrate-pit-bounds` has NO commits; everything sits uncommitted on top of
+`dev` (`fc73c53`). The worktree mixes: (1) #716 recalibration, (2) #710's N06 pace
+envelope (`pace_agent.py`, has its own gate report `GATE_710_pace_envelope.md`),
+and (3) the F2 data deletion. `tests/agents/test_n06_envelope.py` — the test
+`pace_agent.py`'s new comment names as the thing that stops the envelope bounds
+"quietly becoming hand-typed numbers" — is `??` untracked: a `git add -u` commit
+of the modified files ships the comment's PROMISE while leaving the promised test
+behind. The commit command handed to Víctor must add it explicitly, and the two
+issues should land as two PRs per the repo's own single-concern rule.
+
+### F2 update — EXECUTED: the undercut_band deletion breaks two tests outright
+
+`pytest tests/mc/test_mc_measured_tables.py tests/mc/test_guard_rails.py
+tests/eval/test_decision_modes.py` on this worktree: **2 failed, 58 passed**.
+
+- `test_the_undercut_decays_with_the_gap_to_the_target` — KeyError
+  `'by_gap_bin_seconds'` (`tests/mc/test_mc_measured_tables.py:137`)
+- `test_the_undercut_band_is_a_usable_number_of_seconds` — KeyError `'u_band_s'`
+  (`tests/mc/test_mc_measured_tables.py:150`)
+
+Root cause confirmed: the worktree's `data/mc_measured_v1.json` now carries
+`"undercut_band": {"available": false, "reason": "missing undercut_clean.parquet"}`
+— someone re-ran `scripts/measure_mc_tables.py` on a checkout without
+`data/processed/undercut_labeled/undercut_clean.parquet`, and the regeneration
+overwrote the measured band (dev value: `u_band_s = 4.9132`, 716 matched attempts,
+per-bin success rates) with an unavailable marker. Claim H ("nothing else breaks")
+is REFUTED with executed evidence. Runtime blast radius is small only by luck:
+`measured_undercut_band_s()` (`src/agents/position_projection.py:308-311`) falls
+back to `DEFAULT_UNDERCUT_BAND_S = 4.91`, which was set FROM the 4.9132
+measurement — but the per-bin table and provenance are gone, and CI goes red.
+Fix: restore the file (`git checkout dev -- data/mc_measured_v1.json`) or
+regenerate on a checkout that has the parquet.
+
+All guard-rails and decision-modes tests pass against the NEW bounds (58 passed),
+including `test_block_agrees_with_the_rail_on_every_lap_of_a_race`.
+
+### F4 (MEDIUM-LOW) — the calibration CEILING has a hand-typed prose twin, in the very file whose headline is "never restated"
+
+`_CALIBRATION_CEILING` is consumed only by `tests/eval/test_stint_lengths.py:247`
+(correct single-sourcing for the ENFORCEMENT — not dead weight). But
+`stint_lengths.py` does NOT import it: `_render_table` hand-types "The ceiling the
+bounds are held to is **5%**" (`stint_lengths.py:319-320`), and the checked-in
+`stint_lengths.md` carries that prose. Meanwhile `guard_rails.py:50-53` claims the
+report "imports these constants rather than restating them". True for the bounds,
+false for the ceiling. Concrete failing scenario: tighten `_CALIBRATION_CEILING`
+to 0.03 — the test starts enforcing 3%, every regenerated report keeps printing
+"**5%**", and the module comment's reproducibility claim is now wrong. Same defect
+class as the 8/12/15 prose copies this change fixes, one level up. One-line fix:
+render the ceiling from the constant.
+
+### F5 (HIGH) — the recalibration silently rewrote a DIFFERENT rule: both prompts now teach "MEDIUM: suitable for 7-30 remaining laps"
+
+`pit_strategy_agent.py:684` and `strategy_orchestrator.py:1703` derive the
+COMPOUND-SUITABILITY window's lower edge from `_MIN_STINT_LAPS['MEDIUM']`:
+
+    MEDIUM: suitable for {_MIN_STINT_LAPS['MEDIUM']}-{_STINT_CAPACITY_LAPS['MEDIUM']} remaining laps.
+
+On dev this rendered "12-30". With `MEDIUM: 7` it renders "**7-30**". These are
+two semantically different rules sharing one constant because their values
+HAPPENED to coincide at 12: the minimum-stint bound says "you must have run the
+CURRENT set at least N laps before stopping off it" (a percentile of real stint
+lengths at the stop — #716's target); the suitability window says "MEDIUM is a
+sensible compound to bolt ON for this many REMAINING laps" (a durability
+property of the new set). #716's own measurement says a 7-lap MEDIUM stint is in
+the bottom 5% of what real pit walls ever did — and the prompt now presents 7 as
+the suitable LOWER EDGE for choosing MEDIUM. The coupling is pre-existing (#741
+era, when the prompts were derived from constants); this branch is the first one
+to move the constant, and nobody re-checked what else renders from it. Classic
+value-coincidence coupling, the numeric cousin of a sentinel collision.
+
+The proof the guard cannot see it: `tests/agents/test_prompt_constants_match_tables.py`
+asserts prompt numbers EQUAL the constants (`_MIN_STINT` regex matches only the
+">= N lap" phrasing; the capacity tests pin the upper edges) — "7-30" passes
+every assertion because 7 == the constant. The test pins consistency, not which
+rule a constant belongs to. Note the internal inconsistency as supporting
+evidence that the MEDIUM derivation is accidental: the same suitability rule
+takes SOFT's edge from `_STINT_CAPACITY_LAPS`, HARD's from a hand-typed "20+",
+and only MEDIUM's floor from `_MIN_STINT_LAPS`.
+
+Concrete failing scenario: rich mode (the DEFAULT path for CLI/arcade/backend
+live), lap with 9 remaining, MEDIUM available — before this branch both prompts
+told the LLM MEDIUM was unsuitable (<12); after it, both endorse it. A rich-mode
+compound-choice behaviour change shipped inside a "recalibrate anti-hallucination
+bounds" diff, unmeasured and unmentioned in `AUDIT_716_710_design.md`.
+
+Fix: give the suitability line its own constant (or derive its floor from the
+capacity/degradation table it conceptually belongs to), and re-render "12" —
+or justify the new window explicitly. Do not let it move as a side effect.
+
+### F6 (MEDIUM) — `_DEFAULT_MIN_STINT` has NO prose copy at all: the wet bound exists only in the mirror, never in the specification
+
+`guard_rails.py:12-13` declares "the prompt is the specification and this file is
+the copy". Grep across both prompts: `_DEFAULT_MIN_STINT` renders NOWHERE —
+`pit_strategy_agent.py:663-667` and `strategy_orchestrator.py:1695-1697` state
+minimums for SOFT/MEDIUM/HARD only. So in rich mode (the default), NOTHING even
+asks the LLM to respect a minimum stint on INTERMEDIATE/WET, while the no-llm
+mirror vetoes wet stops under 6 laps. The change just spent its M2 story on "the
+wet fallback was the worst-calibrated bound because nothing ever measured it" —
+and shipped it still being the only bound whose specification does not exist.
+Claim E is therefore true only vacuously for this bound: "all prose copies derive
+from the constants" because it has zero prose copies. The prompt-vs-rail test
+cannot cover it either (nothing to parse). Pre-existing, but #716 is the issue
+that named every bound, measured this one, and left the prompt half unwritten.
+Fix: one derived line in each prompt ("any other compound: >= {_DEFAULT_MIN_STINT}"),
+which also makes the existing regex able to see it.
+
+### F7 (MEDIUM) — `guard_rails.py:57` attributes the closing rail's four stops to the OPENING rail: a comment naming the wrong mechanism
+
+The comment on `_NO_PIT_BEFORE_LAP` reads: "The four stops it blocks in the
+six-race decision-modes subset read as a large share only because that subset is
+small". Measured on the actual subset (178 green-flag stops across 2025
+Barcelona/Monaco/Silverstone/Marina_Bay/Lusail/Monza): the opening rail
+(`lap < 5`) blocks **ZERO** stops there. The four stops belong to the CLOSING
+rail (`remaining <= 3`): Monaco VER 77/78, Lusail STR 55/57, Lusail HAD 55/57,
+Monza OCO 51/53 — exactly the `closing_laps | 4` row in
+`documents/eval_reports/decision_modes.md:21` (the bucket table has no
+`opening_laps` row at all). The comment inherited the ISSUE's claim ("the last
+two bounds block 4 real stops each", already half-corrected by the design doc's
+M1) without verifying which bound owned the four. The full-sample number in the
+same comment (42/1900 = 2.21%) is correct; the subset anecdote is attached to
+the wrong bound. This repo's own lesson list says a comment naming the wrong
+mechanism is worse than none — it teaches the next reader that the opening rail
+bites in that subset when it never fires there. Fix: move the anecdote to the
+`_NO_PIT_LAST_N_LAPS` comment (where the four genuinely live), or delete it.
+
+### F8 (MEDIUM-HIGH) — `documents/eval_reports/decision_modes.md` is now stale in a load-bearing way, and nothing asserts against it
+
+The checked-in report (generated 2026-07-31, harness `d97a54e`, OLD bounds) rests
+on `min_stint | 17` excluded stops. Re-measured on the same subset with the same
+bucket-priority rule: OLD bounds block 17 (exact match, validating the mirror),
+NEW bounds block **5** — twelve stops re-enter the gradeable population, so
+"Stops scored 54 of 178 (30.3%)", exact/within-1/within-2, mean signed error and
+the `masked` coverage verdict are all computed against an exclusion set the
+shipped rail no longer produces. No test reads `decision_modes.json` (only unit
+tests on `guard_rail_block`), so CI stays green while a published, checked-in
+eval report describes a rail that no longer exists. The same diff DID regenerate
+`stint_lengths.{md,json}` — the repo's own standard — but left the report whose
+headline depends on these bounds untouched. Fix: re-run `f1-eval decision-modes`
+after the bounds land (or in the same PR), and expect the headline block and the
+bucket table to move; until then the report needs a staleness note.
+
+### Note — the tree mutated mid-gate, and one probe of mine misfired harmlessly
+
+While this gate ran, the work was committed on the branch as `1427e35`
+(fix(rails): recalibrate...) + `06a8f32` (feat(agents): N06 envelope), and
+`f1-eval decision-modes` was re-run into the worktree. Consequences for the log
+above: (a) F3's untracked-test risk did NOT materialise —
+`tests/agents/test_n06_envelope.py` (186 lines) is in `06a8f32`; (b) the
+`data/mc_measured_v1.json` gutting (F2) was correctly EXCLUDED from both commits
+but still sits in the worktree. Separately, I attempted a stash/pop cycle to
+compare formatting against dev; it ran against an already-committed tree and had
+no net effect (stash list and worktree verified unchanged; the em-dashes stash
+`stash@{0}` was never popped). All dev-vs-branch comparisons below use
+`git show dev:...` / `git show 06a8f32:...` instead, which cannot touch the tree.
+
+### F2 reframe — the gutting is NOT in the commits, but the worktree copy still poisons every local test run
+
+`git diff dev 06a8f32 --stat` lists 9 files; `data/mc_measured_v1.json` is not
+among them. The 2 test failures in F2-update are worktree-only. Remaining risk:
+the file is still modified on disk, so (a) `pytest tests/mc` fails locally until
+restored, and (b) any future `git commit -a` / `git add -A` on this branch ships
+it. Fix stands: `git checkout dev -- data/mc_measured_v1.json`.
+
+### F8 update — the regenerated decision-modes report EXISTS but is UNCOMMITTED; the branch as committed still ships the stale one
+
+The worktree now holds a regenerated `documents/eval_reports/decision_modes.{md,json}`
+(harness `06a8f32`, 2026-08-03T09:01:49): `min_stint | 5` — exactly the count
+this gate independently measured BEFORE the regeneration ran (double
+confirmation) — scored 67/178 (37.6%), exact 31.3%, within-1 47.8%, within-2
+61.2%, MSE -1.52, MAE 1.97. But `06a8f32`'s tree does not contain it: the PR as
+committed still ships `min_stint | 17` against bounds that block 5. The
+regenerated pair must be committed onto the branch.
+
+### F9 (MEDIUM, breaks CI) — the committed `stint_lengths.py` fails `ruff format --check` under CI's exact pinned ruff
+
+Executed with the pin from `.github/workflows/ci.yml` (`RUFF_VERSION: "0.15.22"`,
+lint job runs `uvx ruff@0.15.22 format --check .`):
+
+- `git show dev:src/strategy/eval/stint_lengths.py` — passes
+- `git show 06a8f32:src/strategy/eval/stint_lengths.py` — "1 file would be
+  reformatted": one missing blank line after the new `_bound_for` helper
+  (line 86; two-blank-lines-after-top-level-def)
+
+So the branch turns the required `lint` context red the moment it is pushed.
+`ruff check` (lint proper) passes; only the formatter trips. Fix:
+`uvx ruff@0.15.22 format src/strategy/eval/stint_lengths.py` and commit.
+
+### F10 (MEDIUM-LOW) — Claim G holds at its core, but the new ceiling test is one-sided and can go PARTIALLY vacuous on the exact bucket this change is about
+
+Verified genuine: `test_no_minimum_stint_bound_vetoes_more_than_the_calibration_ceiling`
+asserts the EFFECT (measured share vs ceiling) over real data, passes today
+(21/21 in `tests/eval/test_stint_lengths.py`), and would fail on any raised
+bound — provably: SOFT at 3 measures 5.28% > 5% (V1), so the assertion trips
+with compound and share in the message. `assert graded` blocks the all-empty
+case. Two gaps survive:
+
+1. **Partial vacuity on a single bucket.** `graded` filters out empty buckets and
+   the guard only requires SOME bucket to carry data. If a future edit to
+   `green_flag_stops`/`_compound_bucket` silently re-drops wet stops — the exact
+   historical failure M2 documents — the WET row goes ungraded and the test stays
+   green on the three dry buckets. The bound whose non-measurement motivated this
+   change is the one bucket allowed to fall silently out of measurement. Fix:
+   assert every `_REPORTED_BUCKETS` entry has `sample_size > 0` (all four do:
+   341/896/548/110).
+2. **One-sided.** The test enforces `share <= ceiling` but nothing enforces the
+   "largest integer" half or even `bound >= 1`. Set every bound to 0 and ALL
+   tests stay green — including `tests/mc/test_guard_rails.py`, whose probes are
+   derived as `bound - 1` (tyre_life = -1 still trips `-1 < 0`) — while the rail
+   becomes unfireable on any real non-negative tyre life. The rail can be
+   silently deleted through its constants with a fully green suite. Fix: assert
+   maximality (`share(threshold + 1) > ceiling` on the same sample) or minimally
+   `threshold >= 1` plus one asserted real firing.
+
+### V2 — remaining claims verified (A, E, F, probe trap, ceiling trap)
+
+- **Claim A**: TRUE. The bounds survive as vetoes (`apply_guard_rails:155-160`
+  unchanged in shape), values recalibrated not deleted, and the module docstring
+  carries the proscriptive-needs-calibration doctrine correctly.
+- **Claim E**: TRUE for the three named bounds — both prompts render from
+  `_MIN_STINT_LAPS` f-strings (`pit_strategy_agent.py:664-665`,
+  `strategy_orchestrator.py:1695-1696`), and
+  `test_no_prompt_states_a_minimum_stint_the_rails_disagree_with` parses the
+  rendered prompts against the constants. The FOURTH-copy hunt came back clean:
+  `docs/pages/multi-agent.md:140` describes the SC exemption with no numbers;
+  `ROADMAP.md:311` names only the (unchanged) lap-window numbers; notebooks,
+  README, `src/telemetry` submodule: no numeric copies. The old 8/12/15 survive
+  only in audit files, the guard_rails "was" comment, and a test docstring
+  narrating history — all legitimately historical. BUT see F5 (the derivation
+  leaked into a different rule) and F6 (the fallback bound has no prose copy).
+- **Claim F**: TRUE. The dev version of `stint_lengths.py` carried the comment
+  "Wet compounds run no minimum-stint rule at all (...)"; the rail's
+  `.get(compound, _DEFAULT_MIN_STINT)` resolves INTERMEDIATE/WET to the
+  fallback, so the headline was false while its parenthetical was true; the dev
+  report dropped exactly 110 wet stops; measured today those 110 stops graded
+  20.0% below the old fallback of 10 — the worst of the four bounds.
+- **Probe trap**: the `guard_rail_block` change is correct and inert for real
+  stops: the probe only fires when `tyre_life is None`; under old values (probe
+  15 vs bounds 8/12/15/10) and new (probe 8 vs 2/7/8/6) the min-stint rail never
+  fires on the probe, and opening/closing rails ignore tyre_life. Executed
+  cross-check: my bucket mirror reproduced the checked-in report's 17 min_stint
+  stops exactly under old bounds, and the post-gate regeneration's 5 matches my
+  new-bounds count exactly. Bucket assignment moved only where the bound VALUES
+  moved it.
+- **Ceiling trap**: `_CALIBRATION_CEILING` is single-sourcing, not dead weight —
+  the enforcement (the test) imports it. The defect is F4 (hand-typed prose twin
+  in the renderer).
+- **Denominator nit (recorded, not a finding)**: `guard_rails.py:49` calls the
+  sample "1900 real green-flag stops"; the report counts 1895 graded + 5 dropped
+  for missing compound/tyre-life. The lap-based shares correctly use 1900 (a
+  lap-number veto needs no compound); the stint shares use per-compound n. Both
+  arithmetics check out; the prose just does not say the denominators differ.
+
+## Checklist — final state
+
+- [x] Claim A — VERIFIED (V2)
+- [x] Claim B — REFUTED as stated: two criteria in play; only the min-stint four are ceiling-maximal (F1)
+- [x] Claim C — VERIFIED by independent re-derivation; all four values maximal under the ceiling (V1)
+- [x] Claim D — VERIFIED: 42/1900 = 2.21%, 26/1900 = 1.37% (V1); see F1 (criterion asymmetry) and F7 (wrong-mechanism comment)
+- [x] Claim E — VERIFIED for existing copies; no fourth copy; residue = F5, F6
+- [x] Claim F — VERIFIED end to end (V2)
+- [x] Claim G — core VERIFIED, executed; F10 documents the gaps
+- [x] Claim H — REFUTED twice with executed evidence: F2 (worktree undercut_band gutting, 2 failing tests) and F9 (committed format regression under CI's pinned ruff); plus F8 (stale decision_modes in the committed tree)
+- [x] Trap: probe change — V2 · decision_modes.md — F8 · ceiling — V2/F4 · comment arithmetic — V1/F7
+- [x] What I tried to break and could not — below
+
+## Severity ranking
+
+| # | Finding | Severity |
+|---|---|---|
+| F5 | Recalibration silently rewrote the compound-suitability rule to "MEDIUM: 7-30 remaining laps" in BOTH prompts (rich mode = default path); the consistency test cannot see it | **HIGH** |
+| F2 | Worktree `data/mc_measured_v1.json` lost its measured `undercut_band` (regeneration side-effect); 2 tests fail on it; one `git add -A` from shipping | **HIGH** (uncommitted) |
+| F8 | Committed tree ships `decision_modes.md` with `min_stint 17` against bounds that block 5; regenerated report exists but is uncommitted | MEDIUM-HIGH |
+| F9 | `stint_lengths.py` as committed fails CI's pinned `ruff format --check` | MEDIUM (red CI, trivial fix) |
+| F7 | `guard_rails.py:57` attributes the closing rail's 4 subset stops to the opening rail | MEDIUM |
+| F6 | `_DEFAULT_MIN_STINT` has no prose copy: the wet bound exists only in the mirror, unspecified in the "specification" | MEDIUM |
+| F10 | Ceiling test one-sided + per-bucket partial vacuity (WET can silently fall out of measurement) | MEDIUM-LOW |
+| F1 | Claim B false as stated: lap-based bounds not ceiling-maximal; two unstated criteria | MEDIUM-LOW |
+| F4 | Calibration ceiling hand-typed as "5%" in the report renderer while the module claims the report restates nothing | MEDIUM-LOW |
+| — | `tests/mc/test_guard_rails.py` has no direct case for the fallback bound (only reached indirectly via the eval probe test) | LOW |
+
+## Fix list, ordered by value and risk
+
+1. Restore `data/mc_measured_v1.json` (`git checkout dev -- data/mc_measured_v1.json`);
+   if the regeneration was wanted, re-run `scripts/measure_mc_tables.py` on a
+   checkout that has `undercut_clean.parquet`. (F2 — before ANY further commit.)
+2. Decouple the compound-suitability floor from `_MIN_STINT_LAPS['MEDIUM']` in
+   both prompts; restore an explicit suitability window (own constant or the
+   capacity table) and state the intended value. (F5)
+3. `uvx ruff@0.15.22 format src/strategy/eval/stint_lengths.py`, commit. (F9)
+4. Commit the regenerated `decision_modes.{md,json}` onto this branch. (F8)
+5. Move the "four stops in the six-race subset" anecdote from
+   `_NO_PIT_BEFORE_LAP`'s comment to `_NO_PIT_LAST_N_LAPS`'s, where the four
+   live. (F7)
+6. Add one derived line per prompt for the fallback bound ("any other compound:
+   >= {_DEFAULT_MIN_STINT} laps"), which also lets the prompt-parsing regex
+   cover it. (F6)
+7. Harden the ceiling test: assert all four `_REPORTED_BUCKETS` are non-empty
+   and assert maximality or at least `threshold >= 1` + one real firing. (F10)
+8. Render the ceiling in `_render_table` from `_CALIBRATION_CEILING` instead of
+   the hand-typed "5%". (F4)
+9. State the two-criteria reality wherever Claim B is made (design doc / PR
+   body): failed bounds were reset to the ceiling-maximal integer; passing
+   bounds were deliberately left non-maximal. One sentence stops a future
+   "finish the job" tightening. (F1)
+10. Optional: one direct `test_guard_rails.py` case for the fallback bound and
+    its SC suspension. (LOW)
+
+## What I tried to break and could NOT
+
+- **The four recalibrated values themselves.** Independent reimplementation of
+  the population rule from raw parquets (no repo eval imports): every shipped
+  value is exactly the largest integer with veto share <= 5% on its bucket, per
+  V1's full tables. No off-by-one anywhere; strict `<` matches the rail.
+- **Every percentage and count in the `guard_rails.py` comments** — 15.5/17.0/
+  12.2/20.0 (old), 3.2/4.6/4.7/4.55 (new), 42/1900, 26/1900, "11 SOFT one-lap
+  stints", "two to four times the ceiling". All correct (V1). The single wrong
+  factual claim found in the comments is F7's mechanism attribution.
+- **The probe change in `guard_rail_block`.** Tried to construct a real stop
+  whose bucket moves because of the expression change: impossible — the probe
+  only exists for `tyre_life=None`, and neither the old nor the new probe value
+  can trip any bound. Mirror counts matched 17 (old) and 5 (new) exactly.
+- **The seasons trap.** Tried to catch the calibration measured on a subset or
+  the wrong season: the sample is genuinely all three seasons (71 races,
+  2023-2025), the test docstring explicitly defends measuring on the calibration
+  sample rather than 2025-only, and the six-race subset numbers are quoted only
+  as subset numbers.
+- **The wet-bucket grading.** `_bound_for` calls the rail's own lookup; the WET
+  row's 110/6/4.5% reproduce independently; INTERMEDIATE and WET both genuinely
+  resolve to the fallback today. (Residual: a hypothetical future
+  `_MIN_STINT_LAPS["INTERMEDIATE"]` key would make the joint WET bucket grade a
+  bound the rail no longer resolves for INTERMEDIATE — F10's class.)
+- **Stale-fixture hunt in `tests/mc/test_guard_rails.py` and
+  `tests/eval/test_decision_modes.py`.** Every probe derives from the constants
+  (`bound - 1`); both updated parametrisations are correct under the new values
+  (SOFT 1 < 2; None -> "" with 5 < 6); 58 tests passed there. No test pins an
+  old threshold outside historical docstrings.
+- **`no_llm.py` prose.** No restated stint numbers (0 grep hits) — it imports
+  the constants.
+- **A fourth live prose copy of 8/12/15 (or 2/7/8).** Swept docs/, documents/,
+  notebooks/, README, ROADMAP, the `src/telemetry` submodule: none beyond
+  history-narrating audit files and the "was" comment.

--- a/documents/audits/GATE_797_circuit_speed.md
+++ b/documents/audits/GATE_797_circuit_speed.md
@@ -124,3 +124,354 @@ Claim D verified: `mean_sector_speed=999.0` passed explicitly reaches the row un
 the envelope (violation logged). Repo-wide search: no production caller passes an explicit
 `mean_sector_speed` — `_run_always_on_agents` (`strategy_orchestrator.py:1867`) and every
 `run_from_state` caller omit it, so nothing is silently overridden.
+
+---
+
+## Resumed gate (round 2)
+
+**Date:** 2026-08-03 · **Branch:** `fix/pace-circuit-mean-sector-speed` @ `806cedd` vs `dev` @ `8ebe9c3`.
+Round 1's F1-F4 were fixed in `806cedd` (year-keyed map, `_normalise_gp_key`, combined artefact,
+walk-the-disk test). This round attacks the fix itself and finishes the unreached checklist.
+
+### Round-2 claim checklist
+
+- [x] 1. `_normalise_gp_key` total, collision-free across real producers
+- [x] 2. `(Year, GP)` keying: absent/stale/string years across all tiers
+- [x] 3. "71 pairs, ZERO missing" re-derived; same-races check
+- [x] 4. `test_every_race_on_disk_resolves` cannot pass vacuously — VERIFIED (see below)
+- [x] C. producer enumeration (folded into claims 1 and 2 below)
+- [x] E. impact numbers reproduced + re-measured for the NEW serving — REFUTED (R5)
+- [x] F. no regression (`_compute_derived` signature, goldens, holdout MAE) — PASS + 2 stale docstrings
+- [x] G. envelope re-declaration under the new map — REFUTED (R3: outside set is empty)
+- [x] H. skip-guards in `a3b876c` — PASS + 1 wrong reason string
+- [x] Bug-class hunt: third "inference value != training quantity" member — FOUND (`LapsSincePitStop`)
+- [x] Docs: `docs/pages/multi-agent.md` new sections — numerics PASS, 2 overtaken statements
+
+### R1 — HIGH · The combined artefact does not contain what the fix says it serves: `mean_sector_speed` is ONE constant per GP across all three years, so the year-keying serves the training value to 2025 laps — silently reversing the decision `23a02ba` documented as deliberate
+
+**Executed evidence.** Enumerated every (Year, GP) pair in `laps_featured.parquet` and pivoted
+per GP across years: **the cross-year gap is exactly 0.0 for every GP name shared across
+years**. Silverstone is 249.7062 in 2023, 2024 AND 2025; Monza 314.9706 in all three; the only
+per-GP year variation in the entire served map enters through the Miami naming split
+(2023/24 'Miami' 222.364 vs 2025 'Miami Gardens' 221.384, gap 0.98 km/h). Compared against the
+per-year artefacts: combined == `laps_featured_2023/2024.parquet` exactly, while combined 2025
+rows disagree with `laps_featured_2025.parquet` on **22 of 22 comparable GPs** (Silverstone
+combined 249.71 vs 2025-artefact 231.36, diff +18.35; Melbourne +15.61; Montreal -9.22; Sao
+Paulo -8.81; Suzuka -8.06; Shanghai -7.96; full table executed). The combined build evidently
+broadcasts the training-era per-GP constant onto its 2025 rows (Las Vegas 2025 = 228.9645 =
+training; Shanghai 2025 = its 2024 value; only GP names unseen in training — 'Miami Gardens' —
+keep a 2025-computed value).
+
+Consequences, in order of weight:
+
+1. **The docstring's central factual claim is false for the file it describes**
+   (`src/agents/pace_agent.py:334-341`): "`laps_featured.parquet` carries 71 (year, GP) pairs
+   and the value differs between the training era and 2025 on every GP present in both: mean
+   absolute gap 4.8 km/h, largest Silverstone at 18.4." That 4.8/18.4 measurement is TRUE of
+   the per-year artefacts (round 1 verified it there) and FALSE of the combined file, where
+   the gap is 0.0 everywhere. A true number transplanted into a false headline — and it is
+   the SECOND wrong-mechanism claim in the same docstring's history (F4 was the first; the
+   commit that corrected it introduced this one).
+2. **"Keying by year makes the value served the value the lap being replayed actually
+   carries" (`src/agents/pace_agent.py:340-341`) is false on the real replay path.** Every
+   replay/serving consumer loads the PER-YEAR artefact (`src/strategy/inference/engine.py:99`
+   states the rule; `src/arcade/strategy.py:571`,
+   `src/telemetry/backend/utils/laps_cache.py:31`,
+   `src/telemetry/backend/services/simulation/simulator.py:231`,
+   `src/strategy/eval/pace_holdout.py:95`, `src/strategy/eval/decision_modes.py:517` comply).
+   A replayed 2025 Silverstone lap carries 231.36 in the frame the RSM serves; the agent now
+   feeds N06 249.71.
+3. **The serving for 2025 replays FLIPPED, and no one decided it.** At `23a02ba` the docstring
+   defended serving the 2025 measurement as "deliberate and the correct half of that pair"
+   ("serving the training seasons' value would feed a stale reading"). `806cedd` reverses
+   exactly that — every 2025 lap now gets the training value — as an unexamined side effect
+   of switching files, while claiming to do the opposite. Executed:
+   `_resolve_mean_sector_speed('Silverstone', 2025) -> 249.70624181580095` (was 231.3595
+   before the fix). Whether training-constant or season-measurement is the RIGHT feed is a
+   modelling judgment with arguments both ways (the feature acts as a circuit identifier the
+   model fitted on); the defect is that the branch has now shipped BOTH positions, each
+   documented as deliberate, with no measurement of the flip (see E below).
+
+### R2 — HIGH · The eval tier and production now feed N06 different values for the same 2025 lap: the published holdout MAE no longer describes the serving configuration
+
+**Executed evidence.** `src/strategy/eval/pace_holdout.py` never calls the agent: it reads
+`laps_featured_2025.parquet` (line 95) and feeds the frame's own columns to the model
+(line 120), so the holdout MAE was measured with `mean_sector_speed` = the 2025-artefact
+values (Silverstone 231.36). Production (`_resolve_mean_sector_speed`) now serves the combined
+values (Silverstone 249.71). The two disagree on 22 of 24 2025 GPs, by up to 18.35 km/h — the
+exact magnitude the branch's own commits call material. The new test does not catch this
+because `test_every_race_resolves_to_the_value_its_own_parquet_rows_carry` compares the map
+against `laps_featured.parquet` — **the same file the map is built from**. It asserts
+map == source-of-map (a VALUE), not served == what-the-replayed-lap-carries (the EFFECT);
+tautological by construction, the repo's value-not-effect test class.
+
+### R3 — MEDIUM · Claim G refuted: under the new map NOTHING is outside the envelope — "Monza 2025 is exactly that, and the only one" is now false, and the new test's discrimination loop iterates the empty set
+
+**Executed evidence.** Instantiated the real `PaceAgent` and checked all 71 served values
+against `_N06_TRAINED_BOUNDS["mean_sector_speed"]` (196.6292, 314.9706): **outside set =
+{}**. Served Monza 2025 is 314.9706 — the bound's own maximum, inside by equality — because
+the combined file broadcast the training value (R1); the 317.2412 the docstring
+(`src/agents/pace_agent.py:359-360`) and the test docstring celebrate is the per-year value
+the agent no longer loads. So the envelope on `mean_sector_speed` is back to a bound that
+CANNOT fire from the circuit map on any known race — only an explicitly-passed value can trip
+it, and no production caller passes one (round-1 claim D).
+`test_the_envelope_separates_a_circuit_n06_was_fitted_on_from_one_it_was_not` still passes,
+but its `for (year, gp), value in outside.items()` loop — the half that pins "Monza fires the
+envelope" — asserts over the EMPTY SET (`tests/agents/test_pace_circuit_speed.py:264-267`),
+and `len(inside) > len(outside)` is 71 > 0. The repo's own bug class: a green guard asserting
+about nothing.
+
+### R4 — MEDIUM · The 2023 Spanish GP exists TWICE — `data/raw/2023/Spain` and `data/raw/2023/Barcelona` are the same race (OpenF1 session_key 9102) — so "71 races on disk == 71 pairs" is 70 real races plus one duplicate, on both sides of the check
+
+**Executed evidence.** Both metadata.json files carry `session_key_openf1: 9102` and identical
+record_counts (laps 1312, weather 154, intervals 26036, pitstops 43); extraction timestamps 21
+seconds apart. The combined parquet correspondingly holds BOTH (2023,'Spain') and
+(2023,'Barcelona'), 1198 rows each, identical `mean_sector_speed` 269.7125 — which is why 2023
+shows 23 GP names for a 22-race season. Claim 3's "the pairs are the same 71 races data/raw
+holds" is therefore true only because BOTH sides double-count the same race. No wrong value is
+served (executed: `_resolve_mean_sector_speed('Spain', 2023)` ==
+`_resolve_mean_sector_speed('Barcelona', 2023)` == 269.7125), but the 2023 Spanish GP is
+duplicated inside the combined training artefact itself — 1198 rows counted twice by anything
+that aggregates `laps_featured.parquet` per-lap (whether N06's training build consumed the
+duplicate needs its own check, outside this gate's file-touch scope). Deserves its own
+data-integrity issue.
+
+### Claim 1 — VERIFIED with one latent gap · `_normalise_gp_key` is collision-free across every real producer; the only unresolvable spellings have no live producer
+
+**Executed.** Normalised every distinct `GP_Name` in the combined parquet (26 spellings) and
+every `metadata.json` `gp_name` (26 spellings, all 71 races): **zero many-to-one collisions
+across different circuits** — the only merges are 'Miami Gardens'/'Miami_Gardens' -> 'Miami'
+(same circuit, the intended repair) and underscore/space forms of the same race. Every raw
+race resolves through the real resolver chain (`unresolved == []`, 71/71). Producer sweep
+(C, finishing round 1's unreached item): the CLI and Arcade pass metadata.json names via
+`RaceReplayEngine._parse_meta` (all resolve, executed); the backend passes per-year featured
+GP_Names from its own `/available-gps` round-trip (accented 'Montréal'/'São Paulo', 'Miami'
+in 2025 — all resolve, executed); MCP tools funnel free text through `_normalize_gp_name`
+whose alias table covers the ASCII forms ('montreal' -> 'Montréal', 'sao paulo' -> 'São
+Paulo'; `src/telemetry/backend/mcp_tools.py:199` + table above it); FastF1 event names are
+handled by the `slug_from_event_name` candidate and currently have no live producer. The two
+CLI ASCII fallbacks `gp_slugs` accepts, 'Montreal' and 'Sao Paulo', do NOT resolve
+(`_resolve_mean_sector_speed('Montreal', 2025) -> nan`, executed) because
+`canonical_gp_name` returns them unchanged and the map keys are accented — but no live
+producer emits them into `session_meta.gp_name` (the CLI arg keyspace terminates at folder
+resolution; session_meta is rebuilt from metadata.json). LATENT, not live. LOW.
+
+### Claim 2 — VERIFIED with one latent trap · every live producer supplies an int year the dataset covers; a STRING year fails silently
+
+**Executed.** `RaceReplayEngine._parse_meta` (`src/simulation/replay_engine.py:115`) casts
+`int(meta.get("year", 2025))`; all 71 metadata.json `year` fields are ints equal to their
+folder year (swept: zero mismatches, zero missing files). Backend years are FastAPI-typed
+ints (`endpoints/strategy.py:85,109,411`); MCP `_normalize_year` coerces or refuses
+(`mcp_tools.py:320`). `meta.get('year') or 2025` in `run_from_state` can only fire on a
+session_meta missing 'year', which no current producer emits (RSM always sets it,
+`src/simulation/race_state_manager.py:515`). The engine's no-metadata fallback (year=2025 +
+warning, `replay_engine.py:117-120`) is the one path that could hand a 2023 replay a 2025
+key — unreachable today (all 71 metadata files exist), and per R1 it would serve the same
+NUMBER anyway for every GP except Miami and 'Spain' (whose (2025,·) key does not exist). The
+latent trap: `_resolve_mean_sector_speed('Silverstone', "2025") -> nan` (executed) — a string
+year misses every key because the tuple key is type-strict and nothing coerces; the only
+signal is the per-lap warning. No live producer does this. LOW, latent.
+
+### Claim 3 — VERIFIED as numbers, hollow as a guarantee
+
+**Executed.** `laps_featured.parquet`: 68,122 rows, **0 NaN** in `mean_sector_speed` (the
+`.dropna()` is a no-op), 71 distinct (Year, GP_Name) pairs before AND after dropna; the
+normalised map holds exactly 71 keys; every pair matches a raw race on disk and vice versa
+(both directions swept, empty set differences). But per R4 the "71 races" is inflated by the
+same duplicate on both sides, and per R1 the VALUES those 71 keys carry are 24 per-GP
+constants wearing 71 keys.
+
+### R5 — HIGH · Checklist E: the commit's impact numbers do NOT reproduce — every honest harness lands at half to a quarter of the claim
+
+The `36aa8d0` message claims: "Measured over 4000 real 2025 laps, the corrected feed moves the
+delta prediction by a mean of +0.069 s, a p95 absolute of 0.377 s, and more than 0.010 s on 38%
+of laps."
+
+**Executed reproduction** (fix-at-`36aa8d0` serving vs the `prev_speed_st` bug feed, frozen N06,
+featured 2025 rows rebuilt exactly as `pace_holdout` does — encode + lag + dropna, 21,247 rows):
+
+| Harness | n | mean signed | mean abs | p95 abs | >0.010 s |
+|---|---|---|---|---|---|
+| **Claimed** | 4,000 | **+0.069** | — | **0.377** | **38%** |
+| Full 2025 season | 21,247 | +0.0177 | 0.0201 | 0.1766 | 17.7% |
+| Uniform n=4000, seeds 0/1/42 | 4,000 | +0.0170..0.0173 | 0.0190..0.0196 | 0.1766 | 16.6-17.3% |
+| First 4000 rows (`head`) | 4,000 | +0.0412 | — | 0.1766 | 28.6% |
+| Last 4000 rows (`tail`) | 4,000 | +0.0003 | — | 0.0000 | 1.8% |
+| Full, default weather (25/35/50/0) | 21,247 | +0.0207 | — | 0.1766 | 16.9% |
+| Full, default wx + `Prev_Deg*`=0 (the real `run_from_state` row) | 21,247 | +0.0146 | — | 0.1766 | 9.5% |
+
+No configuration tried — uniform sample under three seeds, head, tail, default weather,
+inference-shaped rows — reaches the claimed mean, p95 or fraction; p95 abs is 0.1766 s in every
+one of them, less than half the claimed 0.377. The delta is heavily circuit-concentrated (per-GP
+mean abs: Baku 0.177, Spa 0.171, Silverstone 0.088, then a cliff — Austin 0.010 and below), so
+only a sample dominated by three specific races could produce numbers that size; 4000 uniform
+2025 laps cannot. The claim's DIRECTION survives (the feed change is real and material on some
+circuits) inside a false magnitude — this repo's "claim true in isolation inside a false
+headline" class, and its "a number measured on the wrong distribution" class at once. On the
+distribution production actually serves (default weather, `Prev_Deg*`=0), the fix moves >0.010 s
+on 9.5% of laps, not 38%.
+
+**The re-measure nobody did (E's second half), executed on all three seasons** — what `806cedd`
+itself changed relative to `23a02ba`:
+
+| Season | Serving change | mean signed | p95 abs | >0.010 s | max abs | MAE before → after |
+|---|---|---|---|---|---|---|
+| 2025 (21,247) | 2025-artefact values → training constants (R1 flip) | +0.0009 | 0.0016 | 3.3% | 0.418 | 0.4097 → 0.4097 |
+| 2024 (22,077) | GP-keyed 2025 map → own-year values | −0.0003 | 0.0245 | 5.1% | 0.424 | 0.4185 → 0.4176 |
+| 2023 (20,880) | GP-keyed 2025 map (Spain+Vegas NaN) → own-year values | −0.0001 | 0.0016 | 1.7% | 0.393 | 0.4316 → 0.4314 |
+
+So the `806cedd` re-keying is nearly prediction-neutral in aggregate (single laps move up to
+0.42 s), and — the number that reframes the whole branch — **the original bug itself was
+prediction-neutral on the holdout: MAE with the speed-trap feed was 0.4096, with the corrected
+feed 0.4097.** The fix is epistemically right (right quantity, honest NaN) and the gate confirms
+it should stand; but every published magnitude around it is inflated, and the flip it smuggled
+in (R1) is invisible in aggregate while reversing a documented decision.
+
+### Checklist F — VERIFIED, with two stale docstrings and one hollow claim
+
+- **`_compute_derived` signature**: exactly one caller in the repo
+  (`src/agents/pace_agent.py:560`, keyword-style, matches the new 6-parameter signature); no
+  test, script or notebook-side import calls it (swept `src/ tests/ scripts/`; N25's notebook
+  carries its own inline copy and does not import this one). PASS.
+- **BUT the docstrings were not updated with the signature — the fix's own function documents
+  the mechanism the fix removed** (the repo's wrong-mechanism comment class, in the very
+  function that was the bug):
+  - `src/agents/pace_agent.py:472` — `_compute_derived`'s Args block still lists
+    `prev_speed_st: Speed trap reading in km/h from the previous lap.` The parameter no longer
+    exists; the docstring documents 7 args for a 6-arg signature.
+  - `src/agents/pace_agent.py:784` — `run()`'s Args block still says `mean_sector_speed:
+    Average sector speed; defaults to prev_speed_st.` It defaults to the circuit lookup now;
+    "defaults to prev_speed_st" is precisely the behaviour #797 removed. A reader trusting
+    this line reintroduces the bug.
+- **Strategy goldens**: `tests/mc/test_strategy_goldens.py` passes (54 passed, executed run).
+  But the goldens exercise `_run_mc_simulation` / `_decide_agents_to_call` on CANNED sub-agent
+  outputs (`tests/mc/canned_outputs.py`) — they never enter `_build_feature_row`, so they were
+  structurally incapable of moving with this change. `36aa8d0`'s "Strategy goldens are
+  byte-identical" is true and verified nothing about the feed: byte-identical because
+  insensitive, not because checked.
+- **Holdout MAE**: `test_pace_mae_reproduces_from_featured_laps` passed (executed), asserting
+  `|MAE − 0.4104| < 0.01`; my independent rebuild gives 0.4097, inside tolerance. PASS.
+
+### Checklist H — VERIFIED · the guards skip, do not over-skip, and one reason string names the wrong artefact
+
+Executed: the suite run on this machine (which HAS `lgbm_undercut_v1.pkl` and LACKS
+`undercut_labeled/undercut_clean.parquet`) yields 54 passed, 1 skipped — the exact intended
+behaviour of `a3b876c` (before it, this checkout went red on absent data). Right-sizing checked:
+`test_undercut_targets_are_on_track`'s module-level skip is justified because constructing N28
+really does read `undercut_clean.parquet` (`src/agents/pit_strategy_agent.py:271`), so every
+test in the module needs it; `test_mc_measured_tables` skips ONLY the fresh-measurement test
+(the committed-table assertions still run), avoiding the emptied-file-left-in-worktree hazard
+its comment documents. One defect: the widened condition kept the old message —
+`tests/eval/test_ml_recompute_golden.py:61` skips with reason "undercut **model** absent (CI
+runner without weights)" on a machine where the model is PRESENT and the holdout is what is
+missing (executed: that exact line fired here). The wrong-mechanism class, in a diagnostic:
+it sends whoever reads the skip log to re-download weights they already have. LOW.
+
+### Claim 4 — VERIFIED · the walk-the-disk test is non-vacuous and keyed the way the engine keys
+
+Executed independently of pytest: the same walk finds 71 race dirs, all with `metadata.json`,
+`checked == 71 > 0`, `unresolved == []`. The `assert checked > 0` guard makes an empty walk
+fail. Two soft edges, neither currently load-bearing: (a) a race dir WITHOUT `metadata.json` is
+silently skipped (`continue`) rather than counted — today zero such dirs exist, and the engine's
+own fallback for that case (folder name + year=2025, `replay_engine.py:117`) resolves for every
+current folder name except a hypothetical metadata-less `2023/Spain`, whose (2025,'Spain') key
+does not exist; (b) the test keys by `int(year_dir.name)` while the engine keys by
+`meta['year']` — verified equal on all 71 (swept), so the test currently tests the engine's
+keyspace, but only because the data happens to agree.
+
+### Bug-class hunt — the third member found and measured: `LapsSincePitStop` is fed `TyreLife`, and the two differ on 19.8% of training rows
+
+`run_from_state` (`src/agents/pace_agent.py:908`) passes `laps_since_pit=d.get("tyre_life") or
+1` — the SAME value it passes as `TyreLife`. In training the two are different quantities:
+`TyreLife` counts laps on the tyre SET (which arrives pre-used: qualifying laps), while
+`LapsSincePitStop` counts laps since the last stop. **Executed over the 45,327 training-season
+rows: they differ on 19.8% (8,995 rows), mean gap 2.61 laps, p95 6, max 25; 16.9% of stint-1
+rows start with `TyreLife > LapsSincePitStop`** (used-set starts). So on roughly one lap in
+five N06 was fitted distinguishing the two, and at inference it is structurally fed the wrong
+one whenever the set is not fresh from the box. The envelope comment (`pace_agent.py:134-136`)
+KNOWS the equality — but frames it only as "a second bound would double-report", i.e. as a
+reason not to bound it, not as the wiring defect it also is. Family so far: `Prev_Deg*`
+(hardcoded 0.0, documented), `mean_sector_speed` (fixed by this branch), **`LapsSincePitStop`
+(live, unfixed, now measured)**. MEDIUM.
+
+Also swept, adjacent but distinct classes, for the record: `_encode_categorical`'s defaults
+(`compound→1, team→0, cluster→1`, `pace_agent.py:441-443`) are sentinels that are also REAL
+encoded values — an unknown team silently becomes whichever team encodes to 0 (live on the CLI,
+where the team string is user-typed argv); `Prev_TyreLife := tyre_life−1` is wrong on every
+outlap (training holds the OLD set's last life; measured mean gap 16.1 laps on 780 outlaps) but
+folds into the already-documented "N06 was never trained on stint-first laps" extrapolation the
+new docs section names, so it is not counted as a new family member. Both pre-existing, neither
+introduced by this branch.
+
+### Docs — `docs/pages/multi-agent.md` new sections audit: numerics check out, two statements already overtaken by the code
+
+Verified against code and artefacts (executed where numeric): train/val row counts 22,106 /
+23,256 match `feature_manifest_laptime.json` exactly; "eleven feature ranges" matches the 11
+entries of `_N06_TRAINED_BOUNDS`; the recalibrated stint bounds SOFT 2 / MEDIUM 7 / HARD 8 /
+wet-fallback 6 match `src/strategy/inference/guard_rails.py:95-103`; the prescriptive/
+proscriptive table and the Art. 55.17 framing match the shipped rail behaviour and the
+2026-07-16 lesson. Two defects, both LOW: (a) "looked up from the featured parquet ... one
+value per GP" — written for `36aa8d0`, not updated for `806cedd`'s (Year, GP) keying; ironically
+R1 makes the stale sentence more truthful than the code's own docstring, since the served map
+does hold one value per GP; (b) the envelope section's story that wiring the bound made
+`mean_sector_speed` meaningful again is overtaken by R3: under the map actually shipped, that
+bound cannot fire on any known race, so the page documents a detection power the system no
+longer has.
+
+### What I tried to break and could NOT
+
+- **`_normalise_gp_key` collisions**: enumerated all 26 parquet spellings + all 26 metadata
+  spellings, normalised, looked for many-to-one across DIFFERENT circuits — none. The only
+  merges are the intended Miami repair and underscore/space variants of the same race.
+- **Unresolvable spellings from LIVE producers**: every metadata name (71/71), every per-year
+  featured GP_Name, and every MCP alias-table output resolves; the ASCII 'Montreal'/'Sao Paulo'
+  misses have no producer that can reach `session_meta.gp_name` today.
+- **Year poisoning on live paths**: all 71 metadata years are ints equal to their folder year;
+  backend years are FastAPI-typed; MCP refuses unparseable years; the `or 2025` default is
+  unreachable from current producers. (The string-year silent NaN stands as a latent trap only.)
+- **The map itself**: 71 keys, no NaN anywhere in the source column (dropna is a no-op), every
+  key backed by a raw race and vice versa; `(2025, 'Las Vegas')` present at 228.9645 — F2's
+  hole is genuinely closed, and F1's 'Miami Gardens' and F3's 'Spain' both resolve on the
+  season they belong to.
+- **Vacuity of the walk-the-disk test**: could not make it pass while missing a race short of
+  deleting `metadata.json` files that all exist.
+- **Skip-guard over-skip**: could not find a test suppressed by `a3b876c` whose artefacts are
+  actually present; the local run exercises everything except the one test that genuinely
+  cannot run here.
+- **`_compute_derived` stale positional callers**: none exist anywhere.
+- **Holdout MAE**: reproduces (0.4097, within the golden's declared 0.01 of the 0.4104
+  headline), on the eval path, which this branch did not touch.
+
+### Round-2 fix list (ordered by value/risk)
+
+1. **Decide, on purpose, which value 2025 laps get** (R1/R2): either serve the per-year
+   artefact values (restore the `23a02ba` decision — load per-year files, or repair the
+   combined build so its 2025 rows carry the 2025 measurements), or explicitly adopt
+   training-constant serving and rewrite the loader docstring + `23a02ba`'s rationale. The
+   measured stakes are small in aggregate (p95 0.0016 s) but the docstring, the eval tier, the
+   envelope story and the test all currently assume a mechanism the data refutes. The combined
+   artefact's 2025 `mean_sector_speed` being a training-era broadcast should get its own
+   data-integrity issue either way (it contradicts `laps_featured_2025.parquet` on 22 GPs).
+2. **Fix the loader docstring's false claims** (`pace_agent.py:334-341, 356-360`): the 4.8/18.4
+   cross-year gap does not exist in the combined file; Monza 2025 at 317.24 is not served and
+   nothing is outside the envelope.
+3. **Make the envelope test assert the discrimination it promises** (R3): assert the outside
+   set is NON-empty (it is empty today — the test should fail until item 1 is decided), or
+   rewrite it to pin the actual serving and declare the bound non-discriminating.
+4. **File the 2023 Spain/Barcelona duplicate race** (R4) as a data-integrity issue: same
+   session_key 9102 twice in `data/raw` and in the combined artefact; decide which name stays,
+   deduplicate the artefact, and re-check whether N06's training consumed the duplicate.
+5. **Correct or retract the `36aa8d0` impact numbers** (R5) wherever they are quoted (commit
+   history cannot change; the docs/issue #797 closure can): full-season honest numbers are
+   mean +0.018 s, p95 0.177 s, 17.7% > 0.010 s; inference-shaped rows 9.5%.
+6. **Feed `LapsSincePitStop` its own quantity** from the RSM (it has pit-stop history) instead
+   of `tyre_life`, or document the 19.8%-divergence as an accepted approximation where the
+   envelope comment currently only argues about double-reporting.
+7. **Two-line docstring repairs**: `run()`'s "defaults to prev_speed_st" (`pace_agent.py:784`)
+   and `_compute_derived`'s phantom `prev_speed_st` arg (`pace_agent.py:472`).
+8. **Update the skip reason** at `tests/eval/test_ml_recompute_golden.py:61` to name the
+   holdout parquet as well as the model.
+9. LOW/latent hardening, take or leave: coerce `year` to `int()` inside
+   `_resolve_mean_sector_speed` (kills the silent string-year NaN); add 'Montreal'/'Sao Paulo'
+   ASCII aliases to the map normalisation or to `FOLDER_ALIASES`; update the docs' "one value
+   per GP" once item 1 lands.

--- a/documents/audits/GATE_797_circuit_speed.md
+++ b/documents/audits/GATE_797_circuit_speed.md
@@ -1,0 +1,126 @@
+# GATE #797 — circuit `mean_sector_speed` feed (adversarial gate)
+
+**Date:** 2026-08-03 · **Branch:** `fix/pace-circuit-mean-sector-speed` @ `23a02ba` vs `dev` @ `8ebe9c3`
+**Role:** adversarial gate. No repo file modified except this report. Findings appended as confirmed.
+
+**Scope (4 commits):**
+- `36aa8d0` fix(agents): feed N06 the circuit's mean sector speed instead of the speed trap
+- `a3b876c` test: skip, do not fail, when the unpublished undercut holdout is absent
+- `7ab7b5a` docs(multi-agent): calibrated pit bounds + operating envelopes
+- `23a02ba` docs(agents): correct the parity claim behind the circuit speed lookup
+
+Note the branch itself already refutes half of claim A: `36aa8d0` claimed "the value served is
+the value fitted … identical to 0.0"; `23a02ba` retracts it (the 0.0 compared two *training*
+artefacts, not the served map) and re-frames serving 2025 as deliberate. This gate verifies the
+retraction's numbers too, since a correction can itself be wrong.
+
+## Claim checklist
+
+- [ ] A. served value == fitted value; the 2023-24 vs 2025 seam quantified per GP
+- [ ] B. unresolved circuit reaches the model as NaN; `_bootstrap_ci` noise on NaN; downstream
+- [ ] C. slug resolution complete across every real producer of `gp_name`
+- [ ] D. explicit `mean_sector_speed` still wins; no caller silently overridden
+- [ ] E. impact numbers honest (mean +0.069 s, p95 0.377 s, >0.010 s on 38%, n=4000)
+- [ ] F. nothing else regressed; `_compute_derived` lost `prev_speed_st` — no stale caller
+- [ ] G. envelope re-declaration (196.63, 314.97) is the right range for the served value
+- [ ] H. skip-guards skip (not fail) and do not over-skip
+- [ ] Bug-class hunt: third member of the "inference value ≠ training quantity" family
+- [ ] `docs/pages/multi-agent.md` new sections vs what the code does
+
+---
+
+## Findings (appended as confirmed)
+
+### F1 — HIGH · The 2025 Miami race resolves to NaN on the CLI/arcade path: the fix misses one of the 24 races of the very season it serves
+
+**Executed evidence.** `data/raw/2025/Miami_Gardens/metadata.json` carries `"gp_name": "Miami Gardens"`
+— that exact string is what `RaceReplayEngine._parse_meta` (`src/simulation/replay_engine.py:115`)
+puts into `session_meta.gp_name`, and what `run_from_state` hands to
+`_resolve_mean_sector_speed` (`src/agents/pace_agent.py:341`). Executed against the real agent:
+
+```
+_resolve_mean_sector_speed('Miami Gardens') -> nan   (+ WARNING per lap)
+_resolve_mean_sector_speed('Miami')         -> 221.384  (the value that was intended)
+```
+
+Direct hit misses (map key is `'Miami'`, from `laps_featured_2025.parquet`); `slug_from_event_name('Miami Gardens')`
+returns `None` (`EVENT_NAME_BY_SLUG` knows `'Miami'` and `'Miami Grand Prix'`, not `'Miami Gardens'`);
+`FOLDER_ALIASES` knows only the underscore form `'Miami_Gardens'` and is not consulted here anyway
+(`canonical_gp_name` is never called in the new resolver). Failing scenario:
+`f1-sim Miami_Gardens NOR McLaren` — every lap of the 2025 Miami GP feeds N06 a missing
+`mean_sector_speed` although the served map holds the circuit's value. The same string also misses
+`circuit_cluster` (silent default cluster 1) and `_session_median` (no median) — those two are
+pre-existing, but the NEW lookup was added to the same function that already contained both misses
+and repaired neither pattern.
+
+Note the shape: #797's own fix commit cites #448 ("the dual-keyspace trap") and resolves TWO of the
+three keyspaces (parquet slug, FastF1 event name). The third keyspace — metadata.json/raw-folder
+names, the one `canonical_gp_name` + `FOLDER_ALIASES` exist for — is the one that still misses.
+One copy fixed, its sibling keyspace not.
+
+### F2 — HIGH · Las Vegas is served NaN although N06 was FITTED on it — the loader reads the one artefact that lost the value
+
+**Executed evidence.** `laps_featured_2025.parquet` carries `mean_sector_speed = NaN` on all 760
+Las Vegas rows, so `_load_circuit_mean_sector_speed`'s `.dropna()` (`pace_agent.py:337`) drops the
+GP and the served map has 23 entries, not 24. But the fitted value **exists on disk in the very
+artefacts this branch reasons about**: `laps_featured_2023.parquet` and `laps_featured_2024.parquet`
+both carry 228.9645 for Las Vegas, `circuit_features_with_clusters_k4.parquet` carries 228.9645,
+and even the combined `laps_featured.parquet` carries 228.9645 **on its 2025 rows**. Only
+`circuit_features_with_clusters_k4_2025.parquet` and the per-year 2025 file hold NaN.
+
+`_resolve_mean_sector_speed('Las Vegas') -> nan` (executed). The docstring's justification —
+"we do not know this circuit" — is false for Las Vegas: the model knows it (fitted on it, bounds
+include it), the 2025 artefact simply has a hole. Issue #797 itself said "all 24 GPs (one is NaN)"
+and the fix shipped without closing that named gap. Failing scenario: `f1-sim Las_Vegas VER Red Bull`
+(metadata gp_name `'Las Vegas'`) — a full 2025 race weekend served a missing feature when the
+fitted number is one file away.
+
+### F3 — MEDIUM · Every 2023/2024 replay is served the 2025 constant, and `run()`'s `year` parameter is ignored by the resolution
+
+The CLI supports `--year 2023/2024` (`run_simulation_cli.py:2101`, featured path tracks the year)
+and the raw trees for 2023/2024 are on disk. On those replays `session_meta.gp_name` resolves
+against the **2025-only** map, so a 2023 Silverstone lap is fed 231.36 where the value N06 was
+fitted on for that lap — and which sits in the very parquet row being replayed — is 249.71
+(18.35 km/h apart). `PaceAgent.run()` receives `year` and does not use it in
+`_resolve_mean_sector_speed`. Additionally the 2023 Spanish GP replay
+(`data/raw/2023/Spain/metadata.json` → gp_name `'Spain'`) resolves to **NaN** — a fourth keyspace
+casualty (executed: `_resolve_mean_sector_speed('Spain') -> nan`).
+
+The `23a02ba` docstring defends serving 2025 as "the quantity N04 would compute for a 2025 lap" —
+an argument that is only about 2025 laps. For 2023/2024 laps it serves a measurement from two years
+in the future of the lap being replayed. Whether this moves predictions materially is measured in F-E
+below (Silverstone: the 18.35 km/h gap is the largest in the fleet).
+
+### F4 — MEDIUM · The `23a02ba` mechanism claim "recomputed per season" is wrong: 2023 and 2024 share one identical value per GP
+
+**Executed evidence:** per-GP `mean_sector_speed` in `laps_featured_2023.parquet` equals
+`laps_featured_2024.parquet` **exactly (diff 0.0 on all 23 common GPs)**, and both equal
+`circuit_features_with_clusters_k4.parquet` to 0.0. So the feature is recomputed per **artefact
+generation** (one training-era build pooling both seasons, one 2025 build), not "per season from
+that season's laps" as the amended docstring (`pace_agent.py:315-316`) states. The conclusion
+(2025 differs from training) survives; the stated mechanism does not — and this repo's own bug
+class list says a comment naming the wrong mechanism is how the next fix goes wrong (e.g. someone
+"completing" per-season resolution for 2023 vs 2024 would find nothing to resolve).
+
+Verified numbers from the same run: 23 GPs present in both eras, none equal, mean abs gap 4.815
+(commit says 4.82 ✓), max Silverstone 18.347 (commit says 18.35 ✓), Monza 2025 = 317.2412 (✓) is
+the only served value outside (196.6292, 314.9706) (✓), and the declared bounds equal the true
+min/max of the 2023+2024 lap rows exactly (✓ claim G's range is genuinely the fitted range;
+min = Austin 196.63, max = Monza 314.97).
+
+### F5 — VERIFIED (claims B and D) · NaN survives to the model; the CI stays finite; an explicit value wins
+
+Executed end-to-end with the real agent: `run(gp_name='Miami Gardens', ...)` produces
+`mean_sector_speed = NaN` in the feature row, survives `pd.to_numeric(errors='coerce')`,
+`_bootstrap_ci` multiplies NaN by Gaussian noise (`NaN * N(1,0.02) = NaN`, verified) and XGBoost
+routes the missing value through its default split — **p10/p90 come back finite** (89.978/95.155),
+`lap_time_pred` finite, no crash. The envelope reports the feature as `unknown`, never a violation,
+so an unresolved circuit is invisible in the OOB warning (by design — but note it means F1/F2 fire
+no envelope signal either; the only trace is the per-lap resolver WARNING).
+`delta_vs_median` is NaN for 'Miami Gardens' (the median lookup misses on the same keyspace),
+which downstream consumers already tolerate per the pre-existing no-median path.
+
+Claim D verified: `mean_sector_speed=999.0` passed explicitly reaches the row untouched and trips
+the envelope (violation logged). Repo-wide search: no production caller passes an explicit
+`mean_sector_speed` — `_run_always_on_agents` (`strategy_orchestrator.py:1867`) and every
+`run_from_state` caller omit it, so nothing is silently overridden.

--- a/documents/audits/GATE_final_correctness.md
+++ b/documents/audits/GATE_final_correctness.md
@@ -1,0 +1,107 @@
+# GATE — Final correctness gate before push (#784 epic + #788 fix + partial #789)
+
+**Date:** 2026-08-02 · **Branch:** `refactor/single-source-race-state-builder` (parent, uncommitted) · **Submodule:** `7f394a8` (committed inside, pointer bumped in the parent working tree)
+**Role:** final adversarial correctness gate. Success = finding what is STILL broken. No repository file modified except this report, written incrementally.
+
+## Checklist (updated as verified)
+
+- [x] A. CLI edit surgical; radio/RCM main-loop block byte-identical — CONFIRMED (executed)
+- [x] B. Three surfaces build identical RaceState; shim IS the canonical function object — CONFIRMED (executed + Qatar gate's cross-surface table)
+- [x] C. `reading_or_default` correct + exactly equivalent to pace_agent's old inline guard — CONFIRMED (executed, 8-case table)
+- [x] D. tire_agent/no_llm compound/tyre_life canonicalisation changes no previously-sane model input — CONFIRMED SAFE (executed, see verdict)
+- [x] E. `startswith('C')` guard still routes "UNKNOWN" correctly; nothing assumed "MEDIUM" — CONFIRMED (executed)
+- [x] F. No import cycle; leaf-module guarantee holds — CONFIRMED (executed, both import orders)
+- [x] G. Every comment/docstring claim in the diff verified against code and data — mostly TRUE; two false-at-ship comments (F1) + one mechanism nit (F5)
+- [x] Tests: coverage of the agent-side changes; wrong-reason passes — coverage gap is F2; no wrong-reason pass found
+- [x] Submodule commit still correct after parent-side rename; no old-name references — CONFIRMED (grep at 7f394a8)
+- [x] git status: nothing rides along that should not — one unrelated PNG (F6)
+
+## Claim-by-claim verdicts (executed evidence)
+
+**A. CONFIRMED.** `git diff scripts/run_simulation_cli.py` = exactly two hunks (`@@ -1287,18 +1287,14 @@`, `@@ -1306,71 +1302,24 @@`). Byte-compare of `git show HEAD:` vs working tree: every line from old L1400 to EOF is identical modulo the 51-line shift — which covers the radio/RCM block (old 1710-1764) byte for byte. `def _build_race_state(` and the call site (`race_state = _build_race_state(lap_state, args.driver, prev_lap_time)`, old :1711 -> new :1660) are character-identical.
+
+**B. CONFIRMED.** Executed: `backend.utils.race_state_builder.build_race_state IS src.agents.race_state_builder.build_race_state` -> True (parent venv, sys.path = root + src/telemetry), with zero langchain/langgraph/torch modules loaded by the shim import. CLI delegates as `build_race_state(lap_state, driver=driver_code)`; Arcade as `build_race_state(lap_state, risk_tolerance=..., radio_msgs=..., rcm_events=...)` — each surface passes only what it owns. The field-by-field cross-surface agreement on real data is the Qatar gate's executed Task-1 table (this session); every DIFFER there has a named owner.
+
+**C. CONFIRMED.** Property test (executed, this venv): old inline `wx.get(k) if wx.get(k) is not None else d` vs `reading_or_default(wx,k,d)` on {absent, present-None, 0.0, False, True, 25.3, NaN, "25.3"} — identical on ALL eight, including the #633-sensitive falsy cases (0.0/False pass through untouched; the helper tests `is None`, not truthiness). Migrating `pace_agent` changed its behaviour NOT AT ALL, absent key included. The three call sites keep their per-agent defaults (pace 25/35/50; tire + race_situation 28/38/50), which #789 deliberately leaves unreconciled.
+
+**D. CONFIRMED SAFE — this was attacked hardest; the verdict is NOT a regression.**
+- The old key-absent defaults (`"MEDIUM"`, `1`) were DEAD on every real path: RSM always emits both keys (`race_state_manager.py:352-355`, compound as `str(...)`, tyre_life as int-or-None) and so does the backend producer (`endpoints/strategy.py:489-491`). The live degraded inputs were the STRING `'nan'`/`'None'` and present-`None` — which the old defaults never caught.
+- Compound: executed `_compound_name_to_id` on Miami/Lusail/Spa-Francorchamps/unknown-GP 2025: `'nan'`, `'None'`, `''` and `'UNKNOWN'` ALL map to `'C3'`. So on every real lap where the old code fed the model 'nan', the new code produces the SAME compound id. Zero model-input delta.
+- Stint window: featured 2025 carries 379 `Compound=='nan'` rows (Miami L4-24, 19 drivers) + 53 `'None'` rows (Spa L30-44) and EVERY one of them also has TyreLife NaN (executed groupby: `tl_ok=0` everywhere). The `TyreLife <= x` clause therefore empties the window in BOTH worlds (executed on pandas 2.3.3: `Series <= None` -> 0 True rows, no exception; `<= 0` -> 0 rows; NaN satisfies neither) -> old = conservative stub, new = conservative stub. **No lap that previously produced a sane TCN prediction produces a different one.**
+- Raw 2025: ZERO NaN-compound laps pass the replay guards (Position + LapTime present; executed over all 24 files) — the replay surfaces never even see the changed path.
+- "Is 0 in-distribution for the TCN?" — **0 never reaches the TCN.** The scalar tyre_life only (a) bounds the stint window (`TyreLife <= 0` is empty by construction, season min 1.0, so the tool returns "No laps found" -> conservative stub) and (b) lands on `TireOutput.current_tyre_life`, whose only consumers are display (`agent_formatters.py:150`, `reasoning_tabs.py:121`) and the backend response model `current_tyre_life: int` (`endpoints/strategy.py:141`) — where 0 is valid and the old `None` was a latent Pydantic failure. The TCN's features come from the window ROWS (real TyreLife values), never from the scalar.
+- The one reachable behavioural change is an improvement: on the 451 TyreLife-NaN 2025 rows via /recommend and MCP, old no-llm CRASHED (LangChain tool `tyre_life: int` + None -> ValidationError, sweep E1) where new returns the stub; old LLM prompted "tyre life None laps" where new says 0 and lands on the same empty-window stub.
+
+**E. CONFIRMED.** `'UNKNOWN'.startswith('C')` is False -> `_compound_name_to_id` -> `'C3'` (executed, incl. an unknown GP; the fallback dict has no UNKNOWN/NAN keys, `.get(..., 'C3')` covers it). Nothing downstream assumed the old strings: `_get_driver_stint`'s own `'MEDIUM'` fallback fires only when `session_meta` lacks `f'{driver}_compound'`, which `run_from_state` always sets; the orchestrator's synthetic lap_state path is idempotent (`normalise_compound('UNKNOWN') == 'UNKNOWN'`, tyre_life 0 stays 0 — executed). Grep for the old private name `_normalise_compound` across parent src/scripts/tests: zero matches.
+
+**F. CONFIRMED.** Fresh-interpreter import of the builder pulls zero langchain/langgraph/torch/xgboost/lightgbm/transformers/whisper modules (executed; also enforced by the new subprocess test). Both import orders work: builder-first (probe 1) and tire_agent-first (probe 3 — `tire_agent` -> `race_state_builder` at module top completes because the builder never imports agent modules at module scope; `strategy_orchestrator` stays a call-time lazy import). No cycle exists at runtime.
+
+**G. Mostly TRUE; the false ones are F1, the nit is F5.** Re-executed independently this gate: "every 2025 laps parquet ships without weather columns" (featured 48-col + all 24 raw: zero weather cols — TRUE); "all 71 race dirs carry a readable weather.parquet with zero NaN AirTemp/TrackTemp rows" (71/71 readable, non-empty, zero NaN — TRUE); dataset medians (TrackTemp median exactly 35.0, mean 35.3; AirTemp median 24.1, mean 23.9 — TRUE); TyreLife==0 zero rows, 2025 min 1.0 — TRUE. The twin narrative (pace was the only guarded copy, with a trap comment) verified against `git show HEAD:src/agents/pace_agent.py` — TRUE. The 2.3-lap cliff figure is consistently quoted from the Qatar gate's executed measurement (10.5 vs 8.2; post-fix 7.9 vs 8.1) — not re-measured here. One nuance, not false: `_shared_defaults.py`'s "it crashed /recommend ... (#788) via race_situation_agent" is the executed truth of THIS branch's intermediate state; on `main` the same conflict crashes one layer earlier (the backend builder consumer #788's own text names). A parenthetical would make it bulletproof.
+
+## Tests and suites (executed in THIS working tree, all agent-side changes included)
+
+- `tests/agents/test_race_state_builder.py` -> **29 passed** (18.6s).
+- `tests/agents/ tests/audit/ tests/simulation/` -> **192 passed** (178.3s) — matches the IMPL baseline+29 with zero new failures, now WITH changes 4/5 present (the IMPL number predates them).
+- `tests/engine/ tests/mc/ tests/surfaces/ tests/infra/` -> result appended below; note the IMPL log never re-ran engine/mc after `no_llm.py` changed — this gate closes that hole.
+- Wrong-reason scan: the builder tests assert EFFECTS on the constructed RaceState (defaults fire on key-absent states, warnings captured via caplog, explicit 0.0 honoured, rival fallback lands on positional values); the literal-via-constant convention is documented and is a wiring assertion by design, not an empty-set pass. No assertion found that passes on a band that never fires.
+
+## Submodule cross-check
+
+- `git show 7f394a8:backend/utils/race_state_builder.py`: 24-line shim, imports ONLY `build_race_state` (public, exists). Executed: shim object IS the canonical function.
+- Grep at `7f394a8` for `_normalise_compound` / `normalise_compound` / `UNKNOWN_TYRE_LIFE` / `_targeting_against_rival` / `_compute_gap_ahead`: the only hit is a prose docstring in `simulator.py:350` accurately describing the absorbed copy. The parent-side `normalise_compound` publication postdates the commit and nothing in the submodule references either spelling. The commit remains correct.
+- Submodule working tree: only untracked local dirs (`.claude/`, `docs/migration/streamlit-reference/`) — cannot ride the pointer bump.
+
+## What I tried to break and could NOT
+
+1. **`reading_or_default` vs the old pace inline** — 8-case executed property table including 0.0/False/NaN: byte-equivalent behaviour, no #633 conflation, no change on absent keys.
+2. **A real lap whose tyre prediction changes under claim D** — hunted across featured+raw 2025: every `'nan'`/`'None'`-compound row also has TyreLife NaN, both worlds' stint windows come out empty, `_compound_name_to_id` maps old and new degraded spellings to the same `'C3'`, and zero NaN-compound laps pass the replay guards. Could not construct a single regression from shipped data.
+3. **The leaf/cycle constraint** — fresh-interpreter import, shim import, and the tire_agent-first order: no langchain/torch leak, no cycle.
+4. **The PMV byte-identity** — compared the full tail (old L1400-EOF) programmatically, not just hunk headers.
+5. **The doc/data claims** — independently re-executed the 71-file weather scan, the medians, the TyreLife facts and the "every 2025 laps parquet" claim; all held.
+6. **`Series <= None` semantics** — pandas 2.3.3 returns all-False, no exception (confirms stub-not-crash equivalence for the old tyre_life=None path).
+7. **The orchestrator's synthetic lap_state round-trip** — `normalise_compound` is idempotent on "UNKNOWN" and tyre_life 0 survives unchanged; no double-degradation.
+
+## Could not verify here
+
+- `/recommend` over real HTTP with the LLM profile end-to-end (no OpenAI connectivity in this environment — `APIConnectionError` is environmental; the deterministic profile exercising the exact crash-site code is the IMPL log's executed evidence).
+- The 2.3-lap cliff figure itself (accepted the Qatar gate's executed measurement; internally consistent across two documents).
+- The submodule suite under a submodule-local venv (the IMPL log's known `fastmcp` skip).
+
+## Findings (appended as confirmed)
+
+<!-- appended incrementally -->
+
+### [MEDIUM / docs-in-code] F1 — Two shipped comments claim "the backend still runs its own copy", in the same tree that bumps the pointer to the shim (EXECUTED evidence: git state)
+
+- `scripts/run_simulation_cli.py:1290-1296` (new comment block): "The telemetry backend still runs its own copy until #786 lands its re-export shim, which needs a submodule commit and a pointer bump; until then this is a two-way unification, not a three-way one."
+- `src/arcade/strategy.py:~600-612` (new `_build_race_state` docstring): same claim — "the telemetry backend still runs its own copy until #786 lands its re-export shim ... This is a two-way unification today, not yet the three-way one" — inside a paragraph that itself preaches "a comment claiming a closed drift is worse than no comment".
+
+Both statements were true when #785 was implemented and are FALSE in the tree being pushed: submodule commit `7f394a8` (the re-export shim; verified `git show 7f394a8:backend/utils/race_state_builder.py` — 24-line shim importing the canonical function) is committed inside the submodule AND the parent working tree carries the pointer bump `82f6382 -> 7f394a8` (`git diff src/telemetry`). Executed proof that the claim is false in this tree: `backend.utils.race_state_builder.build_race_state IS src.agents.race_state_builder.build_race_state` -> **True**. Whoever reads the merged code will be told the drift is open when it is closed — the exact claim-vs-tree mismatch class this session already corrected twice (the shim-before-it-existed docstring and the weather-path premise). Milder echo: `src/agents/race_state_builder.py:49` "a re-export shim once #784's submodule half lands" (future tense for a landed thing).
+
+It is also an INTERNAL CONTRADICTION in the CLI file itself: ten lines below that comment, the new `_build_race_state` docstring (`run_simulation_cli.py:1308`) says the delegation is "the single canonical mapping shared with the arcade and the telemetry backend" — the same file asserts both that the backend shares the mapping and that it still runs its own copy. The docstring is the true one at ship time.
+
+Fix: rewrite both to present tense before committing (comment-only edits inside already-touched blocks; the CLI one is inside the comment block this branch already replaced, so the PMV surgical constraint is not re-opened).
+
+### [MEDIUM / test coverage] F2 — The agent-side half of the ship (changes 4 and 5) has ZERO test coverage
+
+Verified by grep over `tests/` (executed): no test imports or exercises `reading_or_default`; no test covers `tire_agent.run_from_state` / `no_llm._tire_no_llm`'s new `normalise_compound` + `UNKNOWN_TYRE_LIFE` derivation; no test feeds any agent a present-`None` weather dict. `tests/agents/test_race_state_builder.py` (29 tests, green in 18.6s, executed) covers the BUILDER surface only — including present-None weather — but the #788 crash site was one layer below the builder, in the agents' RAW-lap_state adapters, and that layer's fix ships untested. Given that this exact bug class regressed once already in this same session ("the fix moved the crash one layer down"), the migrated reads are one refactor away from silently reverting: a test that runs `race_situation_agent.run_from_state`-level session_meta building (or just `reading_or_default` + the three call sites' output on a `{'air_temp': None}` dict) would pin it. Cheap to add; nothing pins it today.
+
+### [RESOLVED — not a finding] F3 — The sweep's R1 crash (TyreLife NaN -> `int()` ValueError) survives by DELIBERATE scoping and IS tracked
+
+`src/agents/race_situation_agent.py:914-915` still crashes on the 451 shipped featured-2025 rows with TyreLife NaN (re-measured this gate), reachable via `/recommend` and MCP. I initially drafted this as "untracked" — WRONG: **issue #790 exists** ("fix(agents): int(NaN) on TyreLife crashes N27's overtake tool on 451 real 2025 laps"), filed from the sweep, correctly citing the guarded twin at `pit_strategy_agent.py:983-999`. Survives the push knowingly and with a paper trail. No action needed.
+
+### [LOW] F4 — `pace_agent` left `rainfall` on the two-arg get its siblings just migrated off
+
+`src/agents/pace_agent.py:650` keeps `_rainfall = wx.get('rainfall', 0)` while the same diff migrates `tire_agent` to `float(reading_or_default(wx, 'rainfall', 0.0))`. Latent-only (executed sweep evidence: no producer emits `rainfall` as None — RSM emits `False`, backend emits int), but it is a fresh inconsistent twin of the exact shape this branch exists to kill. One-line alignment.
+
+### [LOW / nit] F5 — A test docstring misstates the CLI's old crash mechanism
+
+`tests/agents/test_race_state_builder.py:182-185`: "All three pre-#784 builders crashed here via float(None)". The old CLI builder had NO `float()` wrap (`air_temp=weather.get("air_temp", 25.0)`, verified in `git show HEAD`); it crashed via Pydantic float validation rejecting None. Arcade/backend did crash via `float(None)`. 2 of 3; the conclusion (all three crashed) is right, the named mechanism is wrong for one — the same "comment naming the wrong mechanism" class recorded in the errors-gates-caught file.
+
+### [LOW / hygiene] F6 — An unrelated PNG is sitting untracked next to the work
+
+`notebooks/strategy/overtake_probability/outputs/n12b_scoreboard.png` (untracked; the IMPL log itself calls it "an unrelated PNG"). A `git add -A` would ship it inside this refactor PR. Exclude it or commit it separately.
+
+### [LOW / docs] F7 — The shipped SWEEP doc still describes the tyre_life/compound twins as UNFIXED, but this branch fixed them after the sweep ran
+
+`documents/audits/SWEEP_present_none_traps.md` F1/F2 and its closing verdict ("tire_agent.run_from_state still reads tyre_life (:1479) with the two-arg get") describe the pre-change-5 tree; the working tree now derives both via `normalise_compound`/`UNKNOWN_TYRE_LIFE` (verified at `tire_agent.py:1485-1487`, `no_llm.py:139-141`). The IMPL log records the closure, but the SWEEP file itself carries no correction note — unlike DESIGN §F11, which got one when it went stale. A reader grepping the audits later will believe :1479 is still broken. One-line addendum in the SWEEP (F1/F2 tyre_life+compound halves fixed on this branch; R1 -> #790 and R4 remain live) closes it.

--- a/documents/audits/GATE_qatar_lap7_cross_surface.md
+++ b/documents/audits/GATE_qatar_lap7_cross_surface.md
@@ -1,0 +1,190 @@
+# GATE — Qatar (Lusail 2025) lap 7 cross-surface RaceState verification (#787, over #784/#786)
+
+**Date:** 2026-08-02 · **Branch:** `refactor/single-source-race-state-builder` (working tree, uncommitted) · **Submodule:** `7f394a8` (committed in submodule, pointer not yet bumped in parent)
+
+**Role:** adversarial gate. Success = finding what is still broken. Every claim below is backed by executed evidence unless explicitly marked CODE-READ.
+
+## Scope verified on disk (not trusted from the summary)
+
+- `src/agents/race_state_builder.py` — NEW, untracked. Canonical builder, lazy `RaceState` import, `None`-means-compute for `gap_ahead_s`/`pace_delta_s`, `rival` targeting, position `ValueError` guard. CONFIRMED present.
+- `scripts/run_simulation_cli.py` — `git diff` shows exactly two hunks (L1287-1297 comment + `_build_race_state` body at L1300-1322). **The main loop has zero hunks — the byte-identical requirement on L1710-1764 holds** (verified via `git diff`, not by eye).
+- `src/arcade/strategy.py` — `_build_race_state` (L599-654) now delegates; keeps radio sourcing + stateful SC re-injection. The position `ValueError` moved AFTER `sc_tracker.ingest` (see Suspicion 1).
+- Submodule `7f394a8`: `backend/utils/race_state_builder.py` is a 24-line re-export shim; `simulator.py::_compute_gap_ahead` deleted; `_local_build_race_state` passes `pace_delta_s=0.0`, omits `gap_ahead_s`. CONFIRMED by `git show 7f394a8`.
+
+## Findings (appended as confirmed)
+
+<!-- findings appended below as they are confirmed -->
+
+### [CORE DELIVERABLE] Task 1 — field-by-field cross-surface diff, Lusail 2025 lap 7, NOR/McLaren (EXECUTED)
+
+Reference case confirmed from data, not guessed: McLaren at Lusail 2025 = **NOR (P2)** and **PIA (P1, the car ahead)**; NOR used (the thesis/memory reference driver). Lap 7 ground truth from `RaceStateManager`: lap_time 100.154, PIA 98.466, `interval_to_driver_s` −6.001, compound MEDIUM, tyre_life 7, weather.parquet real readings air 23.4 / track 29.5, **real "SAFETY CAR DEPLOYED" corpus message AT lap 7** (the V7 case is live in this data).
+
+Harness (`scratchpad/gate_harness.py`) drove the REAL paths: `run_simulation_cli._build_race_state` + the main loop's exact post-build radio/SC mutation replicated per-lap for laps 1–7; a real `SimConnector` instance through its own `_lap_skip_reason` → `_build_race_state` loop; the submodule's `_local_build_race_state` via the `backend.utils.race_state_builder` shim mirroring the SSE loop; and `/recommend`'s exact builder call with `RecommendRequest` defaults.
+
+| RaceState field | CLI (no-radios) | CLI (corpus) | Arcade | Backend SSE | /recommend defaults | Verdict |
+|---|---|---|---|---|---|---|
+| driver | NOR | NOR | NOR | NOR | NOR | AGREE |
+| lap | 7 | 7 | 7 | 7 | 7 | AGREE |
+| total_laps | 57 | 57 | 57 | 57 | 57 | AGREE |
+| position | 2 | 2 | 2 | 2 | 2 | AGREE |
+| compound | MEDIUM | MEDIUM | MEDIUM | MEDIUM | MEDIUM | AGREE |
+| tyre_life | 7 | 7 | 7 | 7 | 7 | AGREE |
+| gap_ahead_s | 6.001 | 6.001 | 6.001 | 6.001 | **2.0** | DIFFER — owned |
+| pace_delta_s | 1.688 | 1.688 | 1.688 | **0.0** | **0.0** | DIFFER — owned |
+| air_temp | 23.4 | 23.4 | 23.4 | 23.4 | 23.4 | AGREE (real reading, not default) |
+| track_temp | 29.5 | 29.5 | 29.5 | 29.5 | 29.5 | AGREE (real reading, not default) |
+| rainfall | False | False | False | False | False | AGREE |
+| risk_tolerance | 0.5 | 0.5 | 0.5 | 0.5 | 0.5 | AGREE |
+| radio_msgs | [] | [] | [] | [] | [] | AGREE (harness ran RCM-only runners — see limitation below) |
+| rcm_events | [] | 5 events | 5 events | 5 events | 5 events | DIFFER — owned |
+
+Every DIFFER has a named owner:
+- **pace_delta_s 1.688 vs 0.0** — hand-checked: 100.154 − 98.466 = 1.688 (rival-relative, #750 axis). The backend SSE pins 0.0 deliberately (`simulator.py::_local_build_race_state`, "the schema's documented neutral... switching is a separate behavioural decision"); `/recommend` forwards `RecommendRequest.pace_delta_s` whose default is 0.0. Both recorded in #784's design.
+- **gap_ahead_s 2.0 on /recommend defaults only** — `RecommendRequest.gap_ahead_s: float = GAP_UNKNOWN_FALLBACK_S` (endpoint `strategy.py:110`); the endpoint always passes an explicit float, so the canonical `None`-means-compute derivation NEVER runs on that surface even though `lap_state.rivals` carries the real 6.001. Owned difference (the webapp client supplies the value), but see the observation below.
+- **rcm_events** — surface-owned sourcing by design (builder module docstring): the CLI `--no-real-radios` profile has none; the other four carry the **byte-identical** 5-event list (verified `==` across surfaces), including the real `SAFETY CAR DEPLOYED` at lap 7. Trackers on all three stateful surfaces ended lap 7 in the same state: `active=True kind=SC deployed=7`.
+
+**Harness limitation stated plainly:** the radio-transcript half (Whisper) was not exercised in the harness — all runners ran `disable_transcription=True`, so `radio_msgs` is [] everywhere above. The rcm.parquet half (what the SC override consumes) is the real path. Real runs in Task 2 cover the rest.
+
+### [OBSERVATION / LOW] `/recommend` can never use the canonical gap derivation
+
+Not introduced by #784 (the request default predates it), but #784 built exactly the machinery (`gap_ahead_s=None` → compute from rivals) that this surface cannot reach: `RecommendRequest.gap_ahead_s` is non-Optional with a fabricated 2.0 default, so a client that omits the field gets 2.0 while the true 6.001 sits in the same request's `lap_state.rivals`. Making the request field `Optional[float] = None` would let the canonical builder derive it. Same shape in `mcp_tools.py:599`: `driver_state.get("gap_ahead_s") or GAP_UNKNOWN_FALLBACK_S` — an `or` that also maps a genuinely-measured 0.0 (leader) to 2.0, the #633 conflation in miniature, acknowledged in the builder docstring as "byte-compatible" preservation. Both recorded decisions; flagged so the follow-up is deliberate, not forgotten.
+
+### [VERIFIED-SAFE] Suspicion 1 — the Arcade's reordered `sc_tracker.ingest` cannot corrupt later laps (EXECUTED)
+
+`src/arcade/strategy.py:645` now runs `ingest` BEFORE the builder's position `ValueError` (old code raised before radio/SC sourcing). Executed experiment (`probe_tracker.py`, real `RaceControlStateTracker`, pre-classified events):
+
+- **Deploy lands on the breached lap**: breached ordering goes SC-active and injects for laps N+1..N+7; counterfactual (guard worked) never sees the SC at all. Divergence bounded by the safety valve `_MAX_SC_LAPS = 8` (`rcm_state.py:36`) — clears at deploy+8, verified by execution. The breached trajectory is the more TRUTHFUL one: the deploy was a real FIA message, so the spurious ingest adds real information, it cannot invent a neutralisation.
+- **Release on the breached lap**: breached ordering clears immediately; the counterfactual keeps injecting a stale SC until the valve. Again breached = more accurate.
+- **Malformed lap number** (arcade's `lap_state.get("lap_number", 1) or 1` falls back to 1 mid-race): the spurious `ingest(1, [])` does NOT clear an active SC (negative delta never satisfies the `>= 8` valve check) and does not touch `deployed_lap`; the valve still clears at deploy+8. Only artefact: `last_seen_lap=1` makes the next synthetic event's cosmetic `lap` field read 1 until the next real ingest.
+- **Self-feeding ruled out**: all three surfaces feed the tracker the RAW rcm list and append the synthetic to a copy (`arcade:645-647`, `run_simulation_cli.py:1705-1707`, `simulator.py:333-336`, `strategy.py endpoint:1299-1303`), so `deployed_lap` never refreshes and the valve always fires. Executed: after deploy at 5 + 10 empty ingests, tracker is cleared.
+
+Residual asymmetry worth knowing (CODE-READ): in the breach case the CLI's ordering (build raises BEFORE ingest, `run_simulation_cli.py:1660` vs `:1705`) drops the lap's real RCM from its tracker while the arcade's keeps it — a cross-surface divergence that exists ONLY when the skip-guard invariant is already broken, is bounded by the 8-lap valve, and where the arcade side is the truthful one. Not a defect; recorded so nobody "fixes" the arcade back.
+
+### [VERIFIED] Leaf-import constraint holds (EXECUTED)
+
+`import src.agents.race_state_builder` in a fresh interpreter pulls **zero** `langchain`/`langgraph`/`torch`/`xgboost`/`transformers`/`lightgbm` modules. Constants confirmed live: track 35.0 / air 25.0 / "UNKNOWN" / tyre_life 0.
+
+### [VERIFIED] Suspicion 2 — explicit `0.0` is honoured; no falsy-vs-None trap (EXECUTED)
+
+`probe_defaults.py`, real builder, synthetic lap_state with a car ahead at 6.0 s / 2.0 s pace delta:
+
+- `None`-means-compute: gap=6.0, pace=2.0 (derived). `pace_delta_s=0.0` passed: pace stays **0.0**, gap still derived (6.0). `gap_ahead_s=0.0` passed: gap stays **0.0**. Both 0.0: both stay 0.0 and the rivals lookup is skipped (`needs_car_ahead` is False).
+- The backend's deliberate pin therefore survives: `_local_build_race_state`'s `pace_delta_s=0.0` is never overwritten (`race_state_builder.py:313-316` uses `is None`, executed-verified, and the lap-7 harness shows backend pace 0.0 vs CLI/arcade 1.688).
+- `rival` targeting: present rival recomputes (VER → 2.5/1.0); absent rival falls back to the ALREADY-RESOLVED values including pinned 0.0s (executed: rival absent + pinned → 0.0/0.0, no fabrication).
+- Repo-wide grep for the trap pattern (`not pace_delta`, `pace_delta_s or`, `gap_ahead_s ... or`): the only `or`-fallbacks on these concepts are `mcp_tools.py:599` (recorded decision, see observation above) and two offline eval tools (`scripts/prompt_ab/gen_inputs.py:62`, `src/strategy/eval/decision_modes.py:303`) — none on the three runtime surfaces.
+
+### [VERIFIED] Task 3 — every accepted behavioural delta lands where claimed and nowhere else (EXECUTED)
+
+- **track_temp 40.0 → 35.0**: fires on weather-key-absent, temps-key-absent AND temps-present-None (the pre-#784 CLI would have crashed `float(None)` on present-None, and used 40.0 otherwise). Lusail is NOT perturbed: real readings 23.4/29.5 flow through on all five surface variants (harness) and in the real CLI run.
+- **compound**: `None`/`""`/`"nan"`/`"NaN"`/`"None"`/`"none"`/missing-key → `"UNKNOWN"`; `"SOFT"` and `" MEDIUM "` (stripped) pass through. Lusail lap 7 real `MEDIUM` untouched.
+- **tyre_life**: None/missing → 0; real 1 passes (no collision with fresh tyres).
+- **total_laps**: missing AND present-None → 57 with the warning logged (captured live). Lusail real 57 comes from session_meta, not the fallback (verified: no warning on the harness path).
+- **lap ladder**: top-level → driver-dict → 1-with-warning, all three rungs executed.
+- **position None fails loud on ALL surfaces**: canonical builder, CLI `_build_race_state`, Arcade `_build_race_state`, backend `_local_build_race_state`, backend shim — all raise the same `ValueError` (executed). The shim `is` the canonical function object (no second implementation).
+
+### [SELF-CORRECTED, not a finding] The `gp="Qatar"` RadioPipelineRunner rejection was this gate's own harness error
+
+First harness pass fed `gp="Qatar"` to the backend RCM feed and got "Unknown GP 'Qatar'" → zero rcm_events. Verified against the real wiring before archiving: the arcade's `app.py:358-359 _resolve_gp_name()` maps the menu label through `GP_TO_LOCATION` ("Qatar"→"Lusail") BEFORE building the DTO, so the real arcade and webapp pass "Lusail". Harness re-run with "Lusail".
+
+## Task 2 — real runs (second gate session, 2026-08-02)
+
+Scope: Arcade driven for real (offscreen Qt dashboard fed by a real `SimConnector` + real TCP stream) and the telemetry backend over real HTTP (`/lap-state`, `/recommend`, `/simulate` SSE, #788 regression proof, 2024 control). The CLI (`f1-sim`) run is owned by the orchestrating session and is NOT duplicated here. Findings appended below as they are confirmed.
+
+### [MEDIUM / env-docs] The documented backend launch command fails on a clean `uv sync` venv (EXECUTED)
+
+`PYTHONPATH="." .venv/Scripts/python.exe -m uvicorn backend.main:app --app-dir src/telemetry --port 8000` (CLAUDE.md/memory wording) died at import: `backend/mcp_tools.py:24 → ModuleNotFoundError: No module named 'fastmcp'`. `fastmcp==3.2.0` is pinned ONLY in the submodule's `requirements.txt` (Docker path) and is absent from the parent `pyproject.toml`/`uv.lock`, so any `uv sync` prunes it. This gate installed `uv pip install fastmcp==3.2.0` (environment change, no repo file touched) to proceed. Backend then started clean: `Application startup complete`, `/docs` 200.
+
+### [VERIFIED] #788 producer side, over real HTTP
+
+`GET /api/v1/strategy/lap-state?gp=Lusail&driver=NOR&lap=7&year=2025` → **200**, and the body carries exactly the #788 producer shape: `weather = {air_temp: None, track_temp: None, track_temp_start: None, humidity: None, rainfall: 0}` while every ground-truth field matches Task 1 (lap_time 100.154, position 2, MEDIUM, tyre_life 7, gap_ahead 6.001, PIA interval −6.001). 2024 control (`year=2024`, same GP/driver/lap) → **200** with REAL weather `{air_temp: 19.0, track_temp: 22.9, humidity: 54.0}`.
+
+### [VERIFIED] #788 old-vs-new builder, executed against the real HTTP payloads
+
+The pre-change builder (`git show 7f394a8^:backend/utils/race_state_builder.py`, loaded as a module — no branch switch) vs the exact `lap_state` served over HTTP:
+
+- OLD on 2025 lap 7: **raises `TypeError: float() argument must be a string or a real number, not 'NoneType'`** (`float(weather.get("air_temp", 25.0))` — present-None defeats the default). The live `/recommend` handler maps `TypeError` → 422, so this is the #788 mechanism.
+- OLD on 2024 lap 7: OK (air 19.0 / track 22.9) — the bug was 2025-only, as the issue states.
+- NEW (via the committed shim, `shim is canonical fn: True`): 2025 → OK with defaults air 25.0 / track 35.0, gap derived 6.001, pace 1.688; 2024 → OK with the real readings passing through untouched.
+
+### [HIGH] #788 is NOT fixed end-to-end: `POST /recommend` still returns 422 on the 2025 reference lap (EXECUTED, real HTTP)
+
+`POST /api/v1/strategy/recommend` with the real `/lap-state` body (Lusail 2025 lap 7 NOR, `gp_name="Lusail"`, `year=2025`) → **HTTP 422 in 56.4 s**, body:
+`{"detail":{"error":"TypeError","agent":"orchestrator","detail":"float() argument must be a string or a real number, not 'NoneType'"}}`.
+
+The canonical builder DID build the RaceState (verified in isolation above) — the crash is downstream. In-process reproduction with full traceback (same lap_state, same laps_df scoping as the endpoint):
+
+- `race_situation_agent.py:1193 predict_sc_tool` → `:1009 _build_sc_features` → `:681 _compute_weather_features` → `float(session_meta.get('TrackTemp', 38.0))` → `TypeError`.
+- The None enters at `race_situation_agent.py:1402-1404` (`run_from_state`'s session_meta build): `'AirTemp': wx.get('air_temp', 28.0)` etc. — the same present-key-None-value trap the canonical builder just fixed one layer up. Line 1416 right next to them IS guarded (`wx.get('track_temp_start') or 38.0`), and `pace_agent.py:642-644` guards the identical read with an explicit comment about this exact trap — the classic one-twin-fixed pattern.
+- Second unguarded twin, silent-wrong class: `tire_agent.py:1512-1514` stores the same Nones into its session_meta; `_add_weather_cols` (tire_agent.py:582) then fills the 2025 frame's absent AirTemp/TrackTemp/Humidity columns with **None instead of the intended race averages** — no crash, silently degraded features (probe below).
+
+Consequence: on this branch, `/recommend` for 2025 still fails — the fix moved the crash from the builder into N27. The orchestrator burns ~56 s of model warmup + sub-agent work (pace and tire complete) before dying. #788's "fixed by the canonical builder" claim holds for the BUILDER surface only, not for the endpoint the issue is actually about.
+
+### [CORE DELIVERABLE] Task A — the Arcade, driven for real (EXECUTED; what was and was not rendered, stated plainly)
+
+**What ran for real:** the full arcade strategy layer exactly as `F1ArcadeView._init_strategy_layer` wires it — a real `SimConnector` thread (model warmup, real radio corpus `qatar` with Whisper transcription ENABLED: "24 radios + 66 rcms", per-lap `run_strategy_pipeline` with real OpenAI LLM calls, laps 1–7), a real `TelemetryStreamServer` on 127.0.0.1:9998, and the REAL PySide6 dashboard (`MainWindow` + `TelemetryWindow`, the exact `__main__` wiring) in a separate process under `QT_QPA_PLATFORM=offscreen` + `QT_QPA_FONTDIR=C:/Windows/Fonts`, subscribing over real TCP and grabbed via Qt `grab()` at lap 7 + finished. Screenshots + machine payload: scratchpad `arcade_dashboard_lap7.png`, `arcade_telemetry_lap7.png`, `dashboard_last_payload.json`, `arcade_final_state.json`.
+
+**What was NOT rendered — said prominently:** the pyglet/arcade REPLAY WINDOW (track, cars, leaderboard) was not created (no GL context headless), so `current_lap_provider=None` (the documented CLI/smoke path — no playback gating) and `lap_range=(1,7)`. The TelemetryWindow rendered its LAP 7 frame but with EMPTY speed/brake/throttle traces, because per-frame telemetry comes from the pyglet replay that was not running. Every strategy-side pixel, however, is the real dashboard rendering real pipeline output.
+
+**The lap-7 rendered decision (READ from the PNG, not inferred):** header "Lusail · 2025 NOR · Connected · L 7"; orchestrator card **STAY OUT, confidence 88%**, Pace: MANAGE, Risk: BALANCED, "Pit: L12 · Next: HARD · UCUT: PIA"; scenario scores STAY +0.30 / PIT +0.21 / UCUT · OCUT "--"; PACE card pred 90.05s (chart shows the real lap-7 spike to ~100 s); TIRE "Cliff ~8 laps · L7" C2; **SITUATION "Threat HIGH", overtake 0%, safety car 100%"**; **PIT "pit 2.93s → HARD · SC", UCUT 64% → PIA**; **RADIO card: "YELLOW FLAG SECTOR · YELLOW FLAG SECTOR · SAFETY CAR DEPLOYED", "0 radios · 5 rcm", "RCM L7 SAFETY_CAR_DEPLOYED"**; **RAG "regulation loaded … no tyre changes … Art. 54.3"**; reasoning text cites the confirmed SC and Art. 54.3 overriding N28's reactive UNDERCUT.
+
+**Answer to the attack question — the SC is NOT lost:** corpus → tracker → RaceState → N27 (`sc_prob_3lap=1.0`, `threat_level=HIGH`, `overtake_prob` forced 0 per Art. 55.8) → routing (`active=['N28','N30']`, pit `sc_reactive=True` proposing UNDERCUT) → Layer-3 synthesis reasoning about Art. 54.3 → rendered card. End-to-end on the REAL rendered surface.
+
+**Lap-by-lap decisions (laps 1–7):** STAY_OUT ×7, confidence 0.98/0.97/0.98/0.94/0.95/0.91/0.88 — declining as the SC lap approaches. `finished=True`, `error=None`.
+
+**vs the CLI's owned differences:** arcade lap-7 gap_ahead_s 6.001, lap_time 100.154, MEDIUM/7, P2 — all equal to the CLI-side ground truth; radio corpus real (0 radio_msgs at lap 7 is the corpus truth for NOR, not a wiring gap — 24 radios exist for the GP); risk_tolerance 0.5 both. Decision-level comparison with the orchestrating session's `f1-sim` run is left to the orchestrator, with the arcade's numbers above as this gate's half of the diff. Note the Layer-3 non-determinism warning below before reading any confidence delta as a contract break.
+
+**Warnings captured in the arcade run (reported, not filtered):**
+1. `WARNING src.agents.tire_agent: Tire tool output did not parse for C2 (tyre_life=1) — using conservative defaults instead of a 0.0 cliff` (lap 1).
+2. `WARNING src.agents.strategy_orchestrator: Layer 3 temperature=0.0 was discarded by the client for model 'gpt-5.4-mini'. The orchestrator is sampling at the provider default, not running deterministically` — consecutive-lap confidences (and any CLI-vs-arcade decision diff) carry sampling noise by construction.
+3. `Clamping LLM expected_stint_end 12 to anchor 50 (cliff_p50=57.0)` and `… to anchor 20 (cliff_p50=8.4)` (#433) — twice.
+4. At interpreter exit: `qdrant_client … __del__ → ImportError: sys.meta_path is None, Python is likely shutting down` — benign-looking teardown noise from the RAG client lacking an explicit close; it would appear on real arcade exits too.
+
+**[LOW / explained] N27's OUTPUT gap 0.0 while RaceState carried 6.001:** the situation card shows "gap 0.0s · Δpace +0.00s/lap". Cause found at `race_situation_agent.py:752-779 _parse_tool_outputs`: output gap/pace are regex-parsed from the overtake TOOL's message; under a confirmed SC the tool text doesn't yield them and they default to 0.0. The RaceState itself carried 6.001/1.688 (Task 1). Pre-existing output convention (the endpoint's `SituationResult` docstring already owns the 0.0-vs-None tension, #633) — recorded so nobody misreads the card as a builder regression.
+
+### [VERIFIED] Task B — `/simulate` SSE, real HTTP, laps 1–7 with LLM (EXECUTED)
+
+`POST /api/v1/strategy/simulate` (`{"year":2025,"gp":"Lusail","driver":"NOR","team":"McLaren","lap_range":[1,7],"no_llm":false,"provider":"openai"}`) → **HTTP 200 in 117.8 s**, well-formed SSE: `start`, 7 `lap` events, `summary` with `{"ok_laps": 7, "error_laps": 0}`. Zero `error` events. **Lap 7's event**: STAY_OUT conf 0.98, pos 2, gap 6.001, lap_time 100.154, MEDIUM/7, reasoning citing "a confirmed Safety Car deployment from radio/RCM" + Art. 54.3 — the SC context survives this surface too (its lap_state comes from `RaceStateManager`, real weather 23.4/29.5, so the N27 crash above does NOT fire here).
+
+**Measured consequence of the owned `pace_delta_s=0.0` pin, on the reference lap:** the SSE lap-7 reasoning literally argues "the pace delta is only +0.000s, so there is no evidence of a performance falloff" and lands pit_lap_target=30, while the arcade (real pace_delta 1.688) reasons "+1.688s/lap off pace … tyre cliff P50 is lap 8.4" and lands pit_lap_target=12. Same lap, same models — the recorded "neutral" pin visibly changes the tactical plan. Not a #784 defect (the pin is a recorded decision), but its cost is now measured, not hypothetical. Confidence deltas (0.98 vs 0.88) additionally carry the documented Layer-3 sampling noise (temperature=0.0 discarded for 'gpt-5.4-mini').
+
+### [MEDIUM] The SSE payload is blind to the sub-agents on the LLM path: `agent_alerts` always [], `agents_fired.pit/radio` always 0 (EXECUTED + file:line)
+
+Observed on the real stream: lap 7 `agent_alerts=[]` and summary `agents_fired={"pit": 0, "rag": 1, "radio": 0}` — while the arcade, same lap, same rcm list, rendered 3 alerts (YELLOW ×2 + SAFETY_CAR_DEPLOYED) and an active N28 (`sc_reactive=True`). Not a routing divergence: `simulator.py::_parse_lap_decision` extracts `agent_alerts`/`_radio_out` only `if isinstance(result, dict)` (simulator.py:484-503) and the pit/radio counters only increment on the dict path (simulator.py:625-632) — the dict shape is the NO-LLM path, so with `no_llm=false` these fields are structurally empty regardless of what the agents did (`rag: 1` survives via the object-path `regulation_context` check at :634-635). The webapp's SSE consumer cannot see the SC alerts the arcade dashboard shows. Pre-existing (not introduced by #784); surfaced here because Task 1's "byte-identical rcm on four surfaces" made the empty alerts look like a lost SC — it is a payload-construction gap, with the routing itself verified equal.
+
+### [VERIFIED] Task B — 2024 control over real HTTP (EXECUTED)
+
+`POST /api/v1/strategy/recommend?year=2024` with the real 2024 lap_state → **HTTP 200 in 12.6 s**: STAY_OUT conf 0.92, pit_lap_target 13, compound_next HARD. The fix is not a 2025-only patch that broke the control case. (Backend log: Lusail 2024 radio/RCM parquets absent → ran without RCM, degraded gracefully as designed.)
+
+### [LOW-MEDIUM / latent] `/recommend`'s laps_df year is a QUERY param that can silently disagree with the body's `year`
+
+`require_laps_df(year: int = 2025)` is a FastAPI dependency, so `/recommend` exposes `?year=` (confirmed in the live openapi.json: `[('year','query',2025)]`) while `RecommendRequest.year` travels in the body. A client POSTing a 2024 body without `?year=2024` gets the 2025 frame silently — the agents then look up the driver's laps in the wrong SEASON's GP frame (the #429 family, one axis over). Pre-existing, not #784; this gate's own 2024 control had to pass BOTH to be correct.
+
+### [MEDIUM] Even after the N27 crash is fixed, the backend-producer path silently degrades the tire model on every 2025 lap (EXECUTED probe)
+
+`tire_agent.run_from_state` on the REAL backend lap_state (weather all-None) vs the same lap_state with the real RSM readings (23.4/29.5), same laps_df, same agent instance:
+
+- weather=None (backend shape): deg_rate −0.3085, **cliff P10/P50/P90 = 10.1/10.5/10.9**
+- weather=real readings: deg_rate −0.3085, **cliff P10/P50/P90 = 7.8/8.2/8.6**
+
+No crash, no warning — the Nones from `tire_agent.py:1512-1514` flow through `_add_weather_cols` (:582, `df[col] = session_meta.get(col, 0.0)` — present-None defeats the 0.0 too) into the TCN's feature frame, and the cliff estimate comes out **2.3 laps more optimistic** on the reference lap. Optimistic-wrong is the dangerous direction (delays the pit call). Scope: any 2025 request whose lap_state came from the backend producer (`/lap-state` consumers, webapp strategy tab, MCP chat tools); the SSE and arcade paths are unaffected (RSM weather is real).
+
+### Warnings inventory (both surfaces, reported unfiltered)
+
+Arcade run: tire tool parse failure lap 1 (conservative defaults); Layer-3 temperature discarded for 'gpt-5.4-mini' (non-deterministic synthesis, documented); #433 clamps ×2; qdrant_client `__del__` ImportError at interpreter shutdown (no explicit close). Backend run: same tire parse + temperature + #433 clamps (×2, different anchors) during SSE; `F1_API_KEY not set` (expected, localhost); Lusail 2024 radio/RCM parquets missing (graceful); the #788 orchestrator TypeError (the HIGH finding). Nothing else appeared in either log.
+
+### Environment deviations made by this gate (disclosed)
+
+1. `uv pip install fastmcp==3.2.0` into the parent venv (see the env-docs finding; no repo file changed).
+2. Arcade harness: no pyglet window (offscreen), `current_lap_provider=None`, `lap_range=(1,7)` — detailed in Task A above.
+3. Old-builder proof loaded `7f394a8^` module content from git history — no branch switch, working tree untouched.
+
+## What I tried to break and could not (Task 2)
+
+- **The SC chain on the arcade, end-to-end on the RENDERED surface**: corpus (Whisper ENABLED this time, 24 radios + 66 rcms) → tracker → builder → N27 forced sc_prob 1.0 / overtake 0 → N28 sc_reactive + N30 Art. 54.3 → Layer-3 override of the UNDERCUT → the STAY OUT card in the real PySide6 pixels. Held at every link.
+- **The SC chain on the SSE surface**: lap 7's event carries the confirmed-SC reasoning and Art. 54.3. Held (the alerts FIELD is blind — see the MEDIUM — but the decision itself sees the SC).
+- **The canonical builder against the real backend payloads**: 2025 all-None weather → defaults, 2024 real weather → pass-through, shim `is` the canonical function, explicit-0.0 semantics all re-confirmed against live HTTP payloads rather than synthetic dicts.
+- **The 2024 control**: could not make it regress — 200, sane recommendation, graceful no-RCM degrade.
+- **A crash or error event anywhere in the SSE stream**: 7/7 laps ok, stream well-formed, heartbeat logic untriggered (<15 laps).
+- **Cross-surface lap-7 disagreement beyond the owned differences**: every numeric field either agreed or traced to a named owner (pace pin, alerts payload gap, Layer-3 sampling). The scary-looking `agents_fired.pit=0` and `gap 0.0s` on the situation card both dissolved into located, pre-existing payload conventions (simulator.py:484-503/:625-632, race_situation_agent.py:752-779) — verified, not assumed.
+
+What I could NOT verify: the pyglet replay window itself (never rendered — stated prominently in Task A); the radio-transcript half beyond corpus load (no NOR radio lands on lap 7, so N29's transcript path stayed data-empty end-to-end); the CLI side of the decision-level diff (owned by the orchestrating session, `f1-sim` not duplicated here per instructions).

--- a/documents/audits/GATE_tyre_stint_repair.md
+++ b/documents/audits/GATE_tyre_stint_repair.md
@@ -1,0 +1,294 @@
+# GATE — tyre-stint repair (#790): adversarial correctness audit
+
+**Date:** 2026-08-02 · **Auditor:** adversarial correctness gate (read-only except this file)
+**Scope:** `src/f1_strat_manager/tyre_stint_repair.py`, its wiring in
+`src/f1_strat_manager/laps_augment.py::augment_featured_laps`, and
+`tests/agents/test_tyre_stint_repair.py`, on branch `dev` (uncommitted).
+
+Findings are appended incrementally as they are confirmed with executed evidence.
+
+## Checklist
+
+- [x] A. Repair touches only broken data — **VERIFIED** (69/71 byte-identical, independently re-measured)
+- [x] B. Two-condition boundary rule — **INCOMPLETE by construction** (Findings 2, 4, 8): blind to
+      same-compound refits (28.6% of real stops), fires on data-loss sentinels, misses GAS/HUL/BEA
+- [x] C. Rebuilt ages — **RIGHT for fresh sets, WRONG for used sets** (Finding 3: ALO/HAD/STR + TSU)
+- [x] D. No invented first-stint age — **HOLDS** (but the fabricated recovery block survives, Finding 1)
+- [x] E. Integration — **HOLDS** on shipped data (latent NaN-Driver annihilation, Finding 6)
+- [x] F. Tests — pass 10/10, but the first-stint test pins a no-op (Finding 9)
+- [x] G. Published metrics unmoved by construction except decision_modes; three-truth split (Finding 7)
+
+---
+
+## Finding 1 (HIGH) — the flagship defect of the investigation is NOT fixed: 71+ Miami laps keep fabricated ages after the repair
+
+Executed: `repair_tyre_stints` on `data/raw/2025/Miami_Gardens/laps.parquet`, then scanned every
+driver for numeric `TyreLife` before their first pit stop with `TyreLife < LapNumber - 5`.
+
+The repair only rewrites laps **after** a pit stop (`tyre_stint_repair.py:147-149`,
+`in_new_stint = lap_numbers >= out_lap`). The laps between feed recovery and the pit stop — the
+block where `TyreLife` restarted at 1 mid-stint, error #1 of `GATE_tyrelife_nan_rootcause.md`
+Finding 4 — are left exactly as the feed fabricated them:
+
+| Driver | Surviving fabricated laps | TyreLife kept | Truth |
+|---|---|---|---|
+| NOR | 25–29 | 1–5 | ~25–29 (+offset) |
+| HUL (never repaired) | 24–36 | 1–13 | ~24–36 |
+| GAS (never repaired) | 24–32 | 1–9 | ~24–32 |
+| BEA (never repaired) | 24–28 | 1–5 | ~24–28 |
+| + 11 more repaired drivers | 1–9 laps each | 1–7 | lap number |
+
+**66 laps** across 14 drivers with a first pit stop, **plus BEA's 5** (he has zero
+`PitInTime`/`PitOutTime` records in the whole race, so the scan skipped him — total ≥71 laps.
+Executed evidence for the flagship row: NOR lap 29 still reads `TyreLife 5.0` after repair (truth
+~29) — the exact value the investigation used as its headline. The module docstring's own standard
+("a wrong integer is worse than a NaN precisely because the NaN is visible",
+`tyre_stint_repair.py:32`) condemns the module's own output: these laps are *provably* wrong (a
+numeric `TyreLife < laps since the last pit/race start` is impossible) and the repair leaves the
+plausible integers in place instead of nulling them to the honest NaN it uses everywhere else.
+These are 2025-test-season racing laps that feed N26/N15/N16.
+
+## Finding 2 (HIGH) — coverage hole: GAS, HUL and BEA carry the same corruption and are not touched
+
+Executed per-driver boundary scan on Miami:
+
+- `GAS: pits=[32]`, metadata recovers at lap 24 → his lap-32 stop's boundary lands correctly at 33,
+  so `find_misplaced_boundaries` returns `[]` — yet laps 24–32 are stint-1 fabricated ages 1–9.
+- `HUL: pits=[36]` → same shape, laps 24–36 fabricated ages 1–13 (the worst single block in the race).
+- `BEA: pits=[]` — **zero pit records in the entire race** while `Stint 1.0 / HARD / TyreLife 1.0`
+  appears at lap 24 (he retired on lap 28). Either he pitted and `PitInTime` was ALSO lost —
+  refuting the module's premise that "`PitInTime` is the one column the broken feed leaves intact"
+  (`tyre_stint_repair.py:84-86`) — or he never pitted and lap 24's `TyreLife 1.0` on a 24-lap-old
+  set is pure fabrication. Both readings leave wrong data shipped.
+
+The repair claims (module docstring, integration comment `laps_augment.py:203-204`) to fix the
+Miami corruption; it fixes 15 of 18 corrupted cars' post-stop halves and 0 of 17 pre-stop halves.
+
+## Finding 3 (HIGH) — claim C is false for used sets: the rebuild contradicts the FastF1 convention it cites
+
+Executed: swept every stint transition in all 2024 races (healthy season) and all 2025 races
+except Miami, split by `FreshTyre`:
+
+- Fresh set, first lap of stint: `TyreLife == 1.0` in **617/617** (2024) and **539/539** (2025).
+- **Used set, first lap of stint: 2–16**, 209 cases in 2024 alone (e.g. Austin ALO L27 HARD → 2.0,
+  Austin OCO L52 SOFT → 4.0). FastF1's `TyreLife` counts prior-session laps on the set.
+
+The rebuild hardcodes `TyreLife = LapNumber - out_lap + 1` (`tyre_stint_repair.py:165-167`), i.e.
+assumes every fitted set is fresh. Three of the 15 repaired Miami drivers fitted sets with
+`FreshTyre == False` at their (real-data) boundary lap: **ALO** (L33, MEDIUM, feed said 2.0),
+**HAD** (L24), **STR** (L24, feed said 2.0). For these the repaired value understates true tyre
+age by the set's prior usage — the exact "unknown offset" the module refuses to invent for stint 1
+(`tyre_stint_repair.py:28-32`) is silently invented as zero for stints 2+. The comment at
+`tyre_stint_repair.py:144-146` ("the convention FastF1 itself uses on healthy races (verified:
+Miami lap 33...)") verified the convention on ONE fresh-set example from the *broken* race; on
+healthy races the convention is conditional on `FreshTyre`, which the rebuild never reads.
+
+## Finding 4 (MEDIUM) — Montréal 2023: the rule fires on the `'None'` data-loss sentinel, not on a compound change, and destroys a real cell
+
+Executed before/after on TSU (the only 2023 change):
+
+- The "compound change" that satisfies condition 1 is `'HARD' → 'None'` — the literal string
+  `'None'` is a data-loss sentinel, not a compound. The rule's justification (compound change =
+  evidence a new set was fitted) is not what fired; absence-of-data fired it.
+- Lap 35 before: `Stint 2.0, Compound 'HARD', TyreLife 34.0`. After: `Stint 3.0, Compound 'None',
+  TyreLife 1.0` — the repair **overwrote a real compound string with the sentinel** as a side
+  effect of `tyre_stint_repair.py:152-154`. Downstream consumers that check `Compound.notna()`
+  see `'None'` as a valid compound.
+- In this instance the stop WAS a real tyre change (executed evidence: pit transit 27.5 s vs field
+  median ~24 s — too short for a 10 s stop-and-go, too long for a drive-through; lap times drop
+  from ~78.4 s to ~77.2 s on the new set), so the 36 filled ages count laps-on-car correctly. But
+  stint 3 has `FreshTyre == False` on every lap, so Finding 3's used-set understatement applies
+  here too: the filled 1–36 are a lower bound, not the FastF1-convention age.
+- Had the stop been a served penalty followed by feed death — indistinguishable to the rule, since
+  `'None' != anything` is always True — the repair would have invented a fresh set from a penalty.
+  The rule survives on this data by luck, not by construction.
+- Surface nuance: featured 2023 does not carry TSU lap 35 (N04 drops pit-out laps), so the
+  `'HARD' -> 'None'` cell destruction stays in the in-memory raw view; what reaches featured is the
+  35 filled ages (verified: 35 patched rows, all filled-from-NaN).
+- Generalisation (executed): the Miami gap's `Compound` is the literal string `'nan'` (437/438
+  rows, `str` type), NOT `np.nan`. So the boundary detections at Miami laps 24 (BOR, STR, HAD) also
+  fired on a sentinel-to-real transition (`'nan' -> 'HARD'`), the same absence-of-data mechanism.
+  They coincide with real stops here, but none of the rule's firings in shipped data was a true
+  compound-A-to-compound-B change at the boundary row's own stint; and had the extractor stored
+  real NaN instead of the `'nan'` string, `NaN != NaN` would have made every in-block comparison
+  "a change", the boundary would have collapsed to `pit_lap + 1`, and BOR/STR/HAD would silently
+  NOT have been repaired. The rule's coverage depends on an accident of stringification.
+
+## Finding 5 (MEDIUM) — the shipped log line is factually false: `left_unknown` counts rows the repair itself just filled
+
+`repair_tyre_stints` computes `still_unknown` BEFORE repairing (`tyre_stint_repair.py:195-198`)
+and logs it as "%d lap(s) keep an honest unknown age" (`tyre_stint_repair.py:208`). Executed on
+Montréal 2023: `report.left_unknown == 35` while the repair filled **all 35** of those NaN
+`TyreLife` rows with numbers in the same call. Every operator reading the log is told the exact
+opposite of what happened.
+
+## Finding 6 (MEDIUM, latent) — a NaN `Driver` row is silently annihilated, all columns
+
+`repair_tyre_stints` rebuilds the frame as `pd.concat(groupby("Driver"))` then
+`.reindex(laps.index)` (`tyre_stint_repair.py:200-203`). `groupby` drops NaN-key rows; `reindex`
+re-inserts them as all-NaN. Executed on a synthetic frame: a row with `Driver=None` came back with
+`LapNumber`, `Stint`, `Compound`, `TyreLife` AND `Position` all NaN — the repair destroyed columns
+it has no business touching. Swept all 71 shipped raw parquets: none carries a NaN `Driver` today,
+so this is latent — but the function runs on every load of every future season's download, and one
+malformed row would be silently erased rather than skipped.
+
+## Finding 7 (MEDIUM) — the repair creates a three-truth split: the same Miami lap now has different tyre data depending on which surface asks
+
+The repair exists ONLY inside `augment_featured_laps`. Executed inventory of readers that bypass it:
+
+- **Raw, unrepaired:** `src/simulation/replay_engine.py:73` (loads `laps.parquet` for
+  `RaceStateManager`, which serves `TyreLife`/`Compound`/`Stint` into `lap_state` —
+  `race_state_manager.py:4-8`), `src/telemetry/backend/api/v1/endpoints/strategy.py:328`,
+  `src/strategy/eval/projection.py:292`, `pit_holdout.py:51`, `stint_lengths.py:203`.
+- **Featured-direct, unrepaired:** `src/strategy/eval/pace_holdout.py:95-106`,
+  `tire_holdout.py:171`, `calibration.py:160/233/283` — the golden-metric layer reads the parquet
+  without `augment_featured_laps`, so it measures the models on UNREPAIRED inputs while the
+  runtime agents now consume REPAIRED ones.
+- **Augmented, repaired:** the CLI/arcade/backend agent frames, and `decision_modes.py:473/508`.
+
+Concrete incoherence, measured on both frames: during a Miami 2025 replay, `lap_state` for NOR lap
+31 says `Stint 1 / MEDIUM / TyreLife 7` (raw) while the tire agent's featured window for the same
+lap says `Stint 2 / HARD / TyreLife 2` (repaired). The two disagree about which stint the car is in
+inside a single process.
+
+## Finding 8 (MEDIUM) — claim B is incomplete by construction: the rule is blind to 28.6% of real stops
+
+Executed over all 71 races: 2594 stint transitions, of which **743 (28.6%) fit the same compound
+again** (e.g. HARD -> HARD two-stoppers). For those, `_first_compound_change_after` sees no change
+at the stop — a misplaced boundary there is invisible to the rule in principle, no matter how
+corrupt. Miami 2025 happened to have compound changes at every corrupted stop, so nothing shipped
+is missed *today*; the incompleteness is structural, not observed. Direction: misses defects
+(conservative), never rewrites correct records via this path.
+
+Also executed: the only stint transitions in all 71 races with no pit entry within the 2 prior
+laps are the 12 Miami corruption boundaries themselves — so the red-flag/no-pit-entry false-positive
+shape (a compound change with no `PitInTime`, preceded by an unrelated earlier stop, which the rule
+would misread as a misplaced boundary and rewrite correct laps) has **no live instance in shipped
+data**. It remains reachable for future seasons: nothing in the rule distinguishes "compound
+changed with no pit record at all" from "boundary snapped late".
+
+## Finding 9 (LOW) — the first-stint test pins a no-op, not the invariant; line 93's `, why` is dead
+
+- `test_a_missing_first_stint_stays_unknown` (`tests/agents/test_tyre_stint_repair.py:140-156`):
+  executed `find_misplaced_boundaries` on its fixture -> `[]`, and `repair_tyre_stints` returns the
+  frame **completely untouched** (`.equals` True, 0 boundaries, 0 ages). The assertion then checks
+  a row the function never had any code path toward — the test passes for the wrong reason (the
+  project's recorded scar class). The invariant itself DOES hold on the firing path: on a
+  Miami-shaped fixture where a repair fires next to an unknown first stint, laps 1-2 stay NaN
+  (executed) — but no shipped test proves that. The assertion at :153-155 (`x != x or pd.isna(x)`)
+  is a doubly-redundant NaN check, not a tautology.
+- `tests/agents/test_tyre_stint_repair.py:93`: `pd.testing.assert_frame_equal(repaired, frame), why`
+  builds a tuple; the equality check still executes and raises on mismatch, so the test DOES
+  assert — but `why` is dead code that looks like an assert message and is not.
+- All 10 shipped tests pass (executed: `pytest tests/agents/test_tyre_stint_repair.py` -> 10 passed).
+
+## Verified intact (what I tried to break and could not — so far)
+
+- **Claim A (independently re-measured):** swept all 71 raw parquets through `repair_tyre_stints`
+  with strict `assert_frame_equal` (dtype, index, column type, exact values) plus
+  `hash_pandas_object` as a second witness: **69/71 byte-identical**; only Miami 2025 (15 drivers,
+  416 ages, 62 Stint/Compound cells) and Montréal 2023 (TSU, 36 ages, 1 Stint + 1 Compound cell)
+  change.
+- **Claim E (integration):** end-to-end `augment_featured_laps` on featured 2025: row count 22760
+  preserved, row order preserved, no `_fixed` columns leak, only `Time_s`/`TrackStatus` added,
+  `Compound`/`Stint`/`TyreLife` dtypes unchanged, second call is a byte-identical no-op,
+  non-Miami rows identical on all three stint columns, Miami rows changed on NOTHING outside the
+  three stint columns (361/857 featured Miami rows patched). `(GP_Name, Driver, LapNumber)` is
+  unique in featured and in every raw parquet (no merge duplication possible on shipped data).
+- **Claim C, fresh-set half:** the out-lap-is-TyreLife-1 convention verified independently on
+  every healthy stint transition: 617/617 (2024) and 539/539 (2025 sans Miami) fresh-set stints
+  start at exactly 1.0; NOR's rebuilt Miami ages match the pit timeline arithmetic exactly.
+- **Claim D:** no path fills a truly-NaN first stint — verified both on the shipped fixture and on
+  a firing-path fixture (`in_new_stint`/`wrongly_old_stint` are both bounded below by `out_lap`,
+  so pre-pit laps are unreachable). Miami laps 1–24 and Spa/Melbourne NaN blocks stay NaN.
+- **Ruff:** all three files pass `uvx ruff check` clean.
+- **Multi-boundary drivers:** LAW (pits 28 and 36) — only the first boundary is misplaced, the
+  second stop is correctly skipped; the loop's mutation of `repaired` cannot corrupt a later
+  boundary because the intervening-pit condition forces disjoint lap ranges.
+- **Featured impact quantified:** 2025: 361 rows moved, TyreLife delta mean +3.30 laps (range
+  −7..+7), Miami only; 2023: 35 rows, all filled from NaN, Montréal only.
+
+## Numbered fix list (by value, then risk)
+
+1. **Null the fabricated pre-stop ages (fixes Findings 1 and 2 in one move).** For any driver whose
+   metadata is absent at race start (`Stint` NaN on lap 1) and recovers mid-race without a pit
+   entry at the recovery lap, the recovered "stint 1" block up to the first pit stop provably
+   belongs to the race-start set with unknown age: set its `TyreLife` to NaN (and optionally flag
+   `Stint`). That is the module's own stated doctrine applied to its own blind spot, it covers
+   GAS/HUL/BEA (who need no boundary correction), and it converts ~71 invisible wrong integers
+   into visible unknowns.
+2. **Respect `FreshTyre` in the rebuild (Finding 3).** If the boundary row has `FreshTyre False`,
+   either leave the rebuilt ages NaN (honest unknown, doctrine-consistent) or anchor the count at
+   the boundary row's own published `TyreLife` instead of 1. Three of 15 repaired Miami drivers
+   plus Montréal TSU are affected today.
+3. **Refuse to fire on data-loss sentinels (Finding 4).** Treat `'None'`/`'nan'`/NaN compounds as
+   "unknown", not as "different": require the boundary compound to be a real compound AND the
+   pre-pit compound to be known before rewriting `Compound`; never write a sentinel string over a
+   real value. (Montréal would then fill ages only if some other evidence confirms the tyre
+   change, or not at all.)
+4. **Fix the log/report semantics (Finding 5).** Recompute `left_unknown` AFTER the rebuild, or
+   rename it (`unknown_before_repair`) and log both.
+5. **Guard the groupby against NaN drivers (Finding 6).** `groupby("Driver", dropna=False)` or an
+   upfront `laps["Driver"].notna()` split that passes NaN-driver rows through untouched.
+6. **Decide the consistency story (Finding 7).** Either move the repair below every reader (e.g.
+   into the raw load path used by `replay_engine` / backend `strategy.py:328` as well), or document
+   explicitly that raw-fed surfaces (replay, arcade HUD, backend /strategy, projection) show feed
+   values while agent frames show repaired ones. Today the split is silent.
+7. **Make the first-stint test exercise the firing path (Finding 9)** — use a Miami-shaped fixture
+   whose repair fires, assert laps before the recovery stay NaN; drop the dead `, why` on line 93.
+
+## Test-suite evidence
+
+- `tests/agents/test_tyre_stint_repair.py`: 10/10 pass (executed).
+- Augment-consuming non-eval tests (`tests/audit/test_pace_orchestrator_hardening.py`,
+  `tests/mc/test_mc_state_helpers.py`, `tests/agents/test_tire_cumulative_deg.py`,
+  `tests/audit/test_tire_mc_determinism.py`, `tests/inference/test_envelope.py`):
+  **64/64 pass** with the repair active (executed, 166 s) — no pinned value broke.
+- `tests/eval/`: results appended below when the background run completes.
+
+## Published-metric exposure (claim G, structural)
+
+- **Projection 86.5%/59.1%** (`projection.py:292`) and **pit P50 MAE** (`pit_holdout.py:51`) read
+  the RAW parquets from disk; the repair never writes to disk -> unmoved by construction.
+- **Pace MAE 0.4104 / overtake AUC / tire MAE / calibration** (`pace_holdout.py:95-106`,
+  `tire_holdout.py:171`, `calibration.py:160/233/283`) read the FEATURED parquet directly without
+  `augment_featured_laps` -> also unmoved — but note this is the same bypass CLAUDE.md calls a bug
+  ("every consumer calls augment_featured_laps"), and it now means the golden metrics certify the
+  models on data the runtime agents no longer see (Finding 7).
+- **decision_modes** (`decision_modes.py:473/508`) DOES consume the repaired frame; its numbers
+  can legitimately move for Miami 2025 / Montréal 2023.
+
+## What I tried to break and could not
+
+- **A false positive on a healthy race.** Strict frame equality + independent hashing across all
+  71 raw parquets: 69 come back bit-identical; no correct record is rewritten anywhere in shipped
+  data. The Monaco 2025 RUS stop-and-go and the penalty-only shape are correctly skipped (also
+  pinned by the shipped tests, which do assert — `assert_frame_equal` raises despite the odd
+  `, why` tuple on line 93).
+- **The red-flag / no-pit-entry false-positive shape in shipped data.** The only stint transitions
+  without a nearby pit entry in all 71 races are Miami's 12 corruption boundaries themselves. The
+  landmine is real for future data but has no live instance.
+- **Integration leaks.** No `_fixed` columns, no row count/order change, no dtype drift, no
+  duplicate-key blowup (join keys unique in featured and all raws), second call a no-op,
+  non-Miami featured rows bit-identical on the stint columns, Miami rows untouched outside them.
+- **First-stint invention via the `Compound`/`Stint` overwrite.** Both masks are bounded below by
+  `out_lap`; a firing-path fixture confirms pre-pit laps are unreachable. Miami laps 1–24,
+  Spa 27–44, Melbourne 40–44 NaN blocks all stay NaN.
+- **The rebuilt arithmetic on fresh sets.** NOR's repaired stint 2 (out-lap 30 -> TyreLife 1,
+  lap 36 -> 7) matches the pit timeline exactly, and the out-lap==1 convention held on all 1156
+  healthy fresh-set stints of 2024-2025.
+- **Breaking downstream consumers via `Stint` relabelling.** `tire_predictor.py:950`'s
+  `Stint.max()` and the tire agent's `['Year','GP_Name','DriverNumber','Stint']` windows still see
+  contiguous, single-set blocks after repair; 64/64 augment-consuming tests pass.
+
+## Verdict
+
+**Not safe to ship as-is.** Claim A and the integration (E) genuinely hold — the change is
+surgically scoped and touches exactly the two broken races. But the repair's central promise —
+"the model no longer reads 5 where the truth is 29" — is only half-delivered: the fabricated
+pre-stop ages (the investigation's own flagship defect) survive on ≥71 Miami test-season laps
+(Finding 1), three drivers with the identical corruption are skipped entirely (Finding 2), and the
+rebuilt ages silently assume every fitted set is fresh, contradicting the measured FastF1
+convention for the 209+ used-set stints per season and understating age for 3 of the 15 repaired
+drivers (Finding 3). Fix list items 1–3 are the blockers; 4–7 can follow.
+

--- a/documents/audits/GATE_tyre_stint_repair_2.md
+++ b/documents/audits/GATE_tyre_stint_repair_2.md
@@ -1,0 +1,272 @@
+# GATE 2 — tyre-stint repair rewrite (#790): adversarial re-audit
+
+**Date:** 2026-08-02 · **Auditor:** adversarial re-gate (read-only except this file)
+**Scope:** the REWRITTEN `src/f1_strat_manager/tyre_stint_repair.py`, its wiring in
+`src/f1_strat_manager/laps_augment.py` (`_stint_corrections`, `_apply_stint_corrections`,
+call in `augment_featured_laps`), and `tests/agents/test_tyre_stint_repair.py` (16 tests),
+on branch `dev` (uncommitted). Previous gate: `GATE_tyre_stint_repair.md` (9 findings,
+3 blockers, verdict "not safe to ship as-is").
+
+**Mandate:** verify each prior finding is genuinely closed, then hunt what the rewrite
+itself broke. Findings appended incrementally with executed evidence only.
+
+## Checklist
+
+- [x] A. Flagship fixed? Did nulling go too far anywhere? — **FIXED; no over-nulling live** (71-race sweep, block-by-block)
+- [x] B. `_prior_usage_at` arithmetic + interaction with the nulling pass — **EXACT on all 12 anchors; interaction inert by construction**
+- [x] C. Sentinel guard: BOR/STR/HAD + Montréal TSU — **handled by nulling / deliberately abandoned; see N2**
+- [x] D. Integration — **113/113 nulled laps reach featured; hole is structural only (N3)**
+- [x] E. The 16 tests — **all traced to the paths they claim to pin; one docstring lies about the mechanism (N5)**
+- [x] F. Model-input impact — **406 featured-2025 rows changed; golden metrics unmoved, #782 failures identical**
+
+---
+
+## A/B (part 1) — Miami executed anatomy: flagship VERIFIED fixed; anchors arithmetically exact
+
+Executed `repair_tyre_stints` on `data/raw/2025/Miami_Gardens/laps.parquet`:
+
+- **NOR lap 29: `TyreLife 5.0 -> NaN`** — the flagship row is closed.
+- **Impossible-age sweep** (numeric `TyreLife < laps since last pit start − 5`, all drivers):
+  **171 rows before repair -> 0 after.** The prior gate's ≥71 count was on a narrower
+  pre-first-pit scan; under both metrics the survivors are zero.
+- Report: 12 boundaries corrected, 333 ages rebuilt, **146 fabricated ages nulled**,
+  18 drivers touched. GAS (9 nulled), HUL (13), BEA (5) — the Finding-2 trio — are now covered.
+- **Boundary anchors, all 12 verified**: `rebuilt@boundary == boundary − out_lap + 1 + prior_usage`
+  exactly, with `prior_usage = published_TyreLife@boundary − 1`. ALO's used set
+  (published 2.0, `FreshTyre False`) anchors at prior=1 — Finding 3's named case closed.
+  The other 11 published 1.0/`True` -> prior=0.
+- **OCO is the mask's safety valve working**: pit lap 23, recovery 24 == out-lap -> 0 laps
+  nulled; his post-stop ages are genuinely correct and stay numeric.
+- **`_prior_usage_at` reading `driver_laps` (original) instead of `repaired` is provably
+  inert**: the null block ends at the FIRST pit ≥ recovery, every boundary satisfies
+  `boundary > pit_lap ≥ end of null block`, so the boundary row is never inside the nulled
+  block — original and repaired hold the same value there. Confirmed on all 12 boundaries.
+
+**But the nulling swallows the recoverable halves of STR/HAD/BOR** — see Finding N2 below.
+
+## A (part 2) — 71-race sweep: no over-nulling anywhere; 70/71 byte-identical
+
+Executed `repair_tyre_stints` + strict `assert_frame_equal` over every
+`data/raw/2*/*/laps.parquet` (71 races):
+
+- **70/71 byte-identical** (up from 69/71: Montréal 2023 is no longer touched). Only Miami
+  2025 changes: 146 TyreLife nulled, 333 rebuilt, 0 filled-from-NaN, 54 Stint + 54 Compound
+  cells, 12 boundaries, 18 drivers.
+- **Independent mask false-positive hunt**: swept every driver in every race for the
+  trigger shape (first lap `TyreLife` NaN, later numeric recovery). **The shape exists
+  ONLY at Miami 2025** — no pit-lane starter, late joiner, or benign lap-1 NaN anywhere in
+  the 71 races enters `_fabricated_age_mask`. Every one of the 146 nulled laps sits in the
+  documented fabricated-restart block; none was correct (all understate true age by
+  construction: the set predates the recovery lap's restart-at-1/2 count).
+- Judgement per block: NOR/PIA/RUS/LEC (25–29, 5 each), VER/ALB (2), ANT/SAI (pit-in lap
+  only, 1), TSU (3), HAM/ALO/LAW/BEA (5), BOR (8), GAS (9), HUL (13), STR (33), HAD (34).
+  The STR/HAD/BOR long blocks are wrong-but-partially-recoverable — Finding N2.
+
+## D — integration executed: the `touched`-mask hole has ZERO live instances; nulls fully propagate
+
+The suspected defect — `touched = TyreLife_fixed.notna() | Stint_fixed.notna()`
+(`laps_augment.py:138`) silently dropping nulled rows whose `TyreLife_fixed` is NaN — was
+attacked directly:
+
+- `_stint_corrections` emits **479 patch rows** for Miami; **0 rows have both
+  `TyreLife` NaN and `Stint` NaN**. Every nulled lap keeps its published `Stint 1.0`
+  (the feed fabricated the stint but did publish a stint id), so `Stint_fixed.notna()`
+  fires and the NaN TyreLife is written through. **All 113 nulled raw laps present in
+  featured 2025 are NaN after `augment_featured_laps` — 0 missed.** (The other 33 of 146
+  are laps N04 drops.)
+- End-to-end on featured 2025: 22760 rows -> 22760, order preserved, no `_fixed` leak,
+  only `Time_s`/`TrackStatus` added, **second call byte-identical (idempotent)**,
+  non-Miami rows identical on all three stint columns.
+- Featured 2023: **0 changes on all three stint columns** (the Montréal fill is gone,
+  see C below); featured 2024: 0 changes.
+- The hole is still **structural** (see Finding N3): propagation relies on the accident
+  that every null-only correction row carries a numeric `Stint`. A future block where the
+  feed publishes `TyreLife` without `Stint` would null in the raw view and silently keep
+  the fabricated number in featured. No shipped instance.
+
+---
+
+## Closure of the previous gate's nine findings (each independently re-verified)
+
+| # | Prior finding | Status | Executed evidence |
+|---|---|---|---|
+| 1 | Fabricated pre-stop ages survive (NOR 29 = 5.0) | **CLOSED** | NOR 29 -> NaN; impossible-age rows (age < laps-since-pit-start − 5): 171 -> **0** on Miami; 146 fabricated ages nulled |
+| 2 | GAS/HUL/BEA untouched | **CLOSED** | nulled 9 / 13 / 5 laps respectively; BEA covered despite zero pit records |
+| 3 | Used sets hardcoded fresh | **CLOSED (live)** | ALO anchors at prior=1 (published 2.0, FreshTyre False); STR/HAD no longer rebuilt at all (nulled). Latent residue: N4 |
+| 4 | Rule fires on `'None'` sentinel, writes sentinel over real compound | **CLOSED (live)** | Montréal 2023 byte-identical; `_is_real_compound` guards both the detection (`:127-133`) and the write (`:233`); pinned by 2 tests |
+| 5 | `left_unknown` counts pre-repair | **CLOSED** | `unknown_after` = 590 == manual post-repair recount (pre-repair was 446); log message now matches the number |
+| 6 | NaN-Driver row annihilated | **CLOSED** | `dropna=False` (`tyre_stint_repair.py:276`) + `test_a_nan_driver_row_is_not_annihilated` passes |
+| 7 | Three-truth split across surfaces | **NOT FIXED — documented** (`:56-58`) | Accepted limit. Note it is now *sharper*: replay/backend raw readers show `TyreLife 5.0` where agent frames show NaN for the same lap |
+| 8 | Same-compound-refit blindness | **NOT FIXED — documented** (`:51-55`) | Structural, errs toward missing; no shipped instance |
+| 9 | First-stint test pins a no-op; dead `, why` | **CLOSED** | FIRING-path fixture exercises BOTH the nulling and the boundary rebuild (traced lap by lap); `, why` gone (test line 93) |
+
+## NEW findings — what the rewrite itself carries
+
+### N1 (MEDIUM, latent) — a half-applied boundary mutates the frame while the report swears nothing changed
+
+`_rebuild_driver` writes the boundary compound onto the mislabelled laps
+(`tyre_stint_repair.py:232-234`) BEFORE checking `stint_at_boundary`; when that stint is
+NaN it `continue`s (`:236-238`) without setting `touched`. Executed (PROBE 1, synthetic
+boundary row with real compound + NaN Stint): lap 3 `Compound HARD -> MEDIUM` **while
+`report.changed_anything == False` and `boundaries_corrected == 0`**. Consequences: the
+`RepairReport` contract ("a healthy race must come back byte-identical, and that is only
+checkable if the count of touched rows is reported", `:85-88`) is broken — a frame can
+come back mutated with an empty report — and `augment_featured_laps` skips
+`_stint_corrections` for that race (`laps_augment.py:206-207`), so the mutation lives in
+the raw view only. **Zero live instances** (all 12 firing boundaries in 71 races have a
+real Stint). Fix is a two-line reorder: move the Compound write below the stint guard.
+
+### N2 (MEDIUM, judgement) — the nulling swallows the RECOVERABLE post-stop halves of STR/HAD/BOR: 63 featured test-season laps go dark to race end
+
+STR (pit 20), HAD (pit 22), BOR (pit 19) pitted while the feed was dark, so
+`later_stops = [pits >= recovery]` is empty and `end_lap` becomes the last lap
+(`tyre_stint_repair.py:190-191`): the null block runs from lap 24 to race end — 33/34/8
+raw laps, **63 of the 113 featured nulled laps (HAD 30, STR 29, BOR 4)**. Two things are
+wrong with how this lands:
+
+1. **These laps are NOT the race-start set.** The mask's docstring says the block "is
+   still the race-start set, whose age was never published" (`:168-170`) — true for
+   GAS/HUL/BEA/NOR-style blocks, FALSE for the three pre-recovery-stop drivers, where the
+   block is the SECOND set fitted at out-lap 20/21/23. Their published ages are only
+   understated by `recovery − out_lap` (1-4 laps), not by ~24.
+2. **They are recoverable under the exact assumption the module already trusts.**
+   `_prior_usage_at` trusts "the feed publishes the set's own starting age on the lap the
+   feed thinks the stint began" (`:197-204`). The same assumption applied at the recovery
+   lap rebuilds these blocks to the same fidelity: `age(L) = published(L) + (recovery −
+   out_lap)`. The module refuses because the pre-stop compound is a sentinel, so a
+   penalty cannot be ruled out from the columns it reads — defensible doctrine, but the
+   previous version repaired these three drivers to within prior-usage error, and the
+   rewrite replaces 1-4-lap-wrong integers with NaN for up to 30 featured laps of N26's
+   test-season input per driver. Neither the module docstring's known-limits section nor
+   the report distinguishes this trade from the flagship fabrication. **Decide it
+   explicitly: document it as an accepted limit, or anchor-rebuild when later evidence
+   corroborates the change.** (Montréal TSU is the same choice at 35 laps: the prior gate
+   proved that stop WAS a real tyre change via pit-transit 27.5 s, but the anchor there is
+   NaN, so any fill WOULD invent — leaving it NaN is doctrine-consistent and I do not
+   contest it.)
+
+### N3 (MEDIUM, latent) — the featured patch drops any null-only correction whose Stint is also NaN
+
+`_apply_stint_corrections` gates on `touched = TyreLife_fixed.notna() | Stint_fixed.notna()`
+(`laps_augment.py:138`). A nulled lap has `TyreLife_fixed` NaN by construction, so
+propagation rides ENTIRELY on the accident that the feed published a numeric `Stint` on
+every fabricated Miami row. Executed (PROBE 2, synthetic feed that published `TyreLife`
+without `Stint`): the raw view nulls 2 laps, `_stint_corrections` carries both rows, and
+the featured frame **keeps the fabricated 1.0/2.0** — the exact invisible-wrong-integer
+class this repair exists to kill, plus a silent raw/featured divergence. **Zero live
+instances** (0 of 479 Miami patch rows have both NaN; all 113 featured-present nulled
+laps became NaN — executed). Fix: mark patch membership explicitly (merge indicator)
+instead of inferring it from value non-nullness.
+
+### N4 (MEDIUM, latent) — a NaN anchor silently invents a fresh set, and the sentinel-skip can carry the rebuild across a dark zone
+
+`_prior_usage_at` returns **0.0** when the boundary row's `TyreLife` is NaN (`:207-209`).
+Executed (PROBE 4): a boundary with real compound + real Stint + NaN TyreLife fires the
+rebuild and FILLS the NaN laps at 1, 2, 3 — fresh-set ages for a set whose published age
+was never seen, contradicting "It never invents a tyre age" (`:35`). Related:
+`_first_compound_change_after` skips sentinels (`:131-133`), so the boundary search can
+cross a feed-dark block, and the rebuild then writes Compound/Stint/ages onto dark rows
+during which a pit record could itself have been lost (the BEA precedent refutes
+"PitInTime is always intact"). **Zero live instances** — Miami's 12 boundaries all have
+real published anchors (executed table, values 1.0/2.0), and only Miami fires anywhere
+in 71 races. Fix: return `None` for an unknown anchor and refuse (null instead of
+rebuild).
+
+### N5 (LOW) — the module claims a mechanism it does not have: `FreshTyre` is never read
+
+`tyre_stint_repair.py:38`: "`FreshTyre` is therefore read, not assumed". Executed: the
+string `FreshTyre` occurs exactly once in the module — in that docstring line. No code
+reads the column; the rebuild anchors on published `TyreLife` (which is the better
+signal, since the root-cause gate proved `FreshTyre` is fabricated-uniform-`True` inside
+the gap). `tests/agents/test_tyre_stint_repair.py:234` repeats the claim, and its fixture
+has no `FreshTyre` column at all. The behaviour is right; the stated mechanism is false —
+the project's recorded scar class ("a comment naming the wrong MECHANISM is worse than
+none"). Same family: the `_fabricated_age_mask` docstring's "race-start set" rationale is
+wrong for the pre-recovery-stop drivers (N2.1).
+
+## E — the 16 tests, attacked
+
+- 16/16 pass (executed); ruff clean on all three files.
+- `test_a_stop_made_while_the_feed_is_dark_is_left_unknown_rather_than_guessed`: traced —
+  the fixture reaches the sentinel guard (compound at the pit lap is `'nan'`, so the
+  boundary is refused) AND the mask (2 laps nulled), and its shape matches the real
+  BOR/STR/HAD anatomy (pit during darkness, recovery not an out-lap; executed per-driver
+  table). Genuine.
+- `test_a_used_set_keeps_its_prior_usage`: traced — prior=3 comes from published 4.0 at
+  the boundary; asserts 4.0/5.0 on the firing path. Genuine on behaviour; its docstring
+  misstates the mechanism (N5).
+- `test_a_missing_first_stint_stays_unknown_on_the_FIRING_path`: traced — the fixture
+  exercises nulling (laps 3-4) and boundary rebuild (laps 5-6) in one pass, and asserts
+  `report.changed_anything` in-test, so it can never regress to a no-op. Finding 9's scar
+  is genuinely closed.
+- Not pinned anywhere: N1's partial-write shape, N3's NaN-Stint null propagation, N4's
+  NaN-anchor refusal. The three latent holes are exactly the three untested paths.
+
+## F — model-input impact, quantified
+
+- **Featured 2025** (the models' test season): **113 laps lose a numeric `TyreLife`**
+  (fabricated values -> NaN), **293 laps change numeric value** (mean +3.74, range
+  −7..+7), 0 filled from NaN. All Miami; every other GP byte-identical on the three stint
+  columns. Featured **2023: 0 changes** (the previous version's 35 Montréal fills are
+  gone), **2024: 0 changes**.
+- **Published-metric paths**: pace/tire/overtake/calibration/projection read the parquets
+  directly (`pace_holdout.py:106`, `tire_holdout.py:171`, `calibration.py:160/233/283`,
+  `projection.py:296` — executed grep), so the 86.5%/59.1% projection, pace MAE and the
+  calibration numbers are unmoved by construction. The two #782 golden failures reproduce
+  identically (`KeyError: ['AirTemp','TrackTemp','Humidity','Rainfall']`, executed) —
+  pre-existing, unrelated.
+- **Downstream augment consumers**: 64/64 tests pass (pace-orchestrator hardening, MC
+  state helpers, tire cumulative deg, tire MC determinism, envelope — executed, 33 s).
+  N26's Miami windows now see NaN where they saw fabricated integers; that is the
+  intended behaviour change.
+
+## What I tried to break and could not
+
+- **Over-nulling.** Swept all 71 races for the mask's trigger shape (first-lap `TyreLife`
+  NaN with later numeric recovery): it exists ONLY at Miami 2025. No pit-lane starter,
+  late joiner, or benign lap-1 NaN anywhere enters `_fabricated_age_mask`. Every nulled
+  lap's published age was provably understated. OCO (pit 23, recovery 24 == out-lap) is
+  correctly spared — the safety valve works on the one driver who needed it.
+- **Byte-identity.** Strict `assert_frame_equal` over all 71 races: **70/71 identical**
+  (Montréal 2023 joins the untouched set; only Miami changes).
+- **The `touched` mask on shipped data.** 0/479 patch rows invisible; 113/113
+  featured-present nulled laps arrive as NaN; no `_fixed` leak; row count/order
+  preserved; second `augment_featured_laps` call byte-identical; raw `repair_tyre_stints`
+  idempotent with a clean second-pass report.
+- **`_prior_usage_at` reading the NaN its own pass wrote.** Impossible by construction
+  (every boundary > its pit lap >= the null block's end) and confirmed on all 12 real
+  boundaries — all read real published anchors. Passing `driver_laps` (original) instead
+  of `repaired` is inert today, and it is arguably the CORRECT choice under
+  multi-boundary mutation, so I do not flag it.
+- **The anchor-accrual alternative.** If the late-created stint record counted the laps
+  accrued since the actual fitting, `published − 1` would over-count prior usage. The 11
+  fresh-set Miami boundaries publish exactly 1.0 despite 4-8 laps accrued since their
+  out-laps — the record demonstrably counts from the boundary lap, so the subtraction is
+  right on all data that fires.
+- **A sentinel written over a real compound.** The write is guarded by
+  `_is_real_compound` (`:233`); pinned by test; no path writes a sentinel.
+- **Downstream pinned values.** 64/64 augment-consuming tests green; golden failures
+  unchanged.
+
+## Fix list (by value, then risk)
+
+1. **N1**: move the Compound write below the `stint_at_boundary` guard (two-line reorder)
+   so a refused boundary refuses atomically and the report stays truthful.
+2. **N3**: key `touched` in `_apply_stint_corrections` on patch MEMBERSHIP (merge
+   indicator) rather than value non-nullness.
+3. **N4**: `_prior_usage_at` -> return `None` on a NaN anchor and skip/null instead of
+   anchoring at fresh.
+4. **N5**: fix the two `FreshTyre` docstring claims and the mask docstring's
+   "race-start set" rationale (N2.1). Pure prose, zero behaviour.
+5. **N2**: decide the STR/HAD/BOR trade explicitly — document the post-stop null as a
+   known limit in the module docstring, or (follow-up) rebuild dark-stop blocks when
+   later evidence corroborates the tyre change.
+
+## Verdict
+
+**SHIP.** All three prior blockers (Findings 1-3) are genuinely closed with executed
+evidence, Findings 4-6 and 9 are closed, and 7-8 are honestly documented limits. The
+rewrite introduced no defect with a live instance in the 71 shipped races: N1, N3 and N4
+are latent (synthetic-only), N5 is prose. Recommend landing fixes 1-4 in the same PR (all
+small, none changes shipped-data behaviour) and settling N2 as a documented decision
+rather than silence.

--- a/documents/audits/GATE_tyrelife_nan_rootcause.md
+++ b/documents/audits/GATE_tyrelife_nan_rootcause.md
@@ -1,0 +1,141 @@
+# GATE — TyreLife NaN root cause (issue #790, related #782 / #789)
+
+**Date:** 2026-08-02 · **Investigator:** adversarial investigation gate (read-only)
+**Question:** why does `laps_featured_2025.parquet` carry racing laps with `TyreLife` NaN, and is it a pipeline defect (fix the data) or genuine source absence (guard the consumers)?
+
+Findings are appended incrementally as they are confirmed with executed evidence.
+
+## Checklist
+
+- [ ] 1. Independently re-measure the gap (2025, and 2023/2024)
+- [ ] 2. Trace one block (Miami) backwards: featured → augmentation → raw parquet
+- [ ] 3. Check the source (FastF1 cache / API) for the same laps
+- [ ] 4. Cross-reference the lap ranges against race events (SC / red flag / rain)
+- [ ] 5. Blast radius: other columns NaN in the same blocks; relation to #782 weather gap
+- [ ] 6. Recommendation with trade-offs
+
+---
+
+## Finding 1 — the gap re-measured (CONFIRMED, with corrections to the sweep)
+
+Executed: pandas over `data/processed/laps_featured_{2023,2024,2025}.parquet`.
+
+**2025 — 451 rows with `TyreLife` NaN and `Position` present (sweep number confirmed exactly):**
+
+| GP | rows | laps | contiguous | drivers | share of field on those laps |
+|---|---|---|---|---|---|
+| Miami | 379 | 4–24 | yes | 19 | 379/388 rows (~whole field) |
+| Spa-Francorchamps | 70 | 28–44 | yes | **5** | 70/328 rows (**NOT field-wide** — sweep said 53 rows; it is 70) |
+| Melbourne | 2 | 42–43 | yes | 1 | 2/32 rows |
+
+Compound in the 451 gap rows: `'nan'` 379 (all Miami), `'None'` 53 (Spa), **`'HARD'` 17 (Spa)**, `'MEDIUM'` 2 (Melbourne). So 19 Spa/Melbourne rows have a **real compound string but TyreLife NaN** — the sweep's claim "every Compound-nan row is also TyreLife-NaN" holds (432/432), but the converse does not: TyreLife can be NaN with a valid Compound.
+
+**Not 2025-only:** 2023 has 35 such rows — Montréal, ONE driver, laps 36–70 contiguous to race end, all `Compound='None'`. 2024 has **0**.
+
+**Column counts:** 2023 = 53 cols, 2024 = 53 cols, 2025 = **48 cols** — consistent with #782 (weather columns absent from the 2025 featured parquet only).
+
+## Finding 2 — the NaN is ALREADY in the raw parquets; the featured step introduces nothing (CONFIRMED)
+
+Executed: pandas over `data/raw/2025/{Miami_Gardens,Spa-Francorchamps,Melbourne}/laps.parquet` and `data/raw/2023/Montréal/laps.parquet`.
+
+| Race (raw) | TyreLife NaN rows | shape of the hole |
+|---|---|---|
+| Miami 2025 | 446/1005 | **ALL 19 drivers, laps 1–23 complete + 9 drivers on lap 24; `Compound` AND `Stint` are NaN on every one of those rows.** Zero NaN after lap 24. |
+| Spa 2025 | 75/879 | 5 drivers, growing per driver from L27 (1 driver) to L33+ (5 drivers) to race end (L44). All 75 rows are `Stint == 3.0`. 57 rows `Compound='None'`, **18 rows `Compound='HARD'` with TyreLife still NaN**. |
+| Melbourne 2025 | 5/927 | 1 driver, laps 40–44, all `Stint == 5.0`, `Compound='MEDIUM'` known, TyreLife NaN. |
+| Montréal 2023 | 35/1317 | 1 driver, laps 36–70 (to race end), all `Stint == 3.0`, `Compound='None'`. |
+
+Featured-vs-raw delta is pure N04 row filtering (Miami raw hole is L1–24; featured shows L4–24 because L1–3 are dropped rows — TrackStatus `'12'`/`'126'`/`'671'` = start + VSC), not value mutation.
+
+**The hole is stint-shaped, not lap-shaped.** In every case the NaN block is "driver X's stint N has no tyre metadata, from the stint's first lap to its last". Miami is the degenerate case where the affected stint is **stint 1 of the entire field** (the live-timing tyre-stint feed evidently missing at race start; every driver's data appears the moment they make their first stop). This is the signature of missing `TimingAppData` stint records in the F1 live-timing source that FastF1 builds tyre data from — NOT of a merge/join bug in this repo's pipeline.
+
+**TrackStatus cross-check (kills the SC/red-flag theory for the main block):** Miami laps 4–27 are TrackStatus `'1'` (all clear) for the entire field — the hole spans green-flag racing. Spa laps 25–44 all `'1'`. The hole does NOT line up with neutralisation windows; it lines up with stint boundaries.
+
+---
+
+*The investigation agent stalled after Finding 2 (report unchanged, no FastF1 cache writes for 45+
+minutes, empty transcript, no completion notification). Findings 3-6 below were executed by the
+orchestrating session directly. Findings 1-2 above are the agent's and were left as written.*
+
+## Finding 3 — FastF1 has exactly the same gap; our extractor loses nothing (CONFIRMED)
+
+Executed: `fastf1.get_session(2025, "Miami", "R").load(laps=True)` against the project's own 1.9 GB
+cache, compared row for row with `data/raw/2025/Miami_Gardens/laps.parquet`.
+
+| | FastF1 (source) | Our raw parquet |
+|---|---|---|
+| `TyreLife` NaN, laps <= 24 | 446 / 457 | 446 / 457 |
+| `Stint` NaN, laps <= 24 | 446 / 457 | 446 / 457 |
+| `TyreLife` NaN, laps > 24 | 0 / 548 | 0 / 548 |
+
+Identical. **The systematic-extraction-failure hypothesis is REFUTED.** The F1 live-timing
+`TimingAppData` feed did not publish stint records for the opening stint, FastF1 leaves NaN rather
+than guessing, and our extractor copies that faithfully. FastF1 even logs that it repaired three
+drivers (`Fixed incorrect tyre stint information for driver '31'/'18'/'5'`) — those repairs are the
+11 non-NaN rows.
+
+## Finding 4 — the far more serious half: the laps AFTER the gap are WRONG, not missing (CONFIRMED)
+
+The NaN block is the visible symptom. The block after it is silently corrupt.
+
+NOR, Miami 2025, from FastF1 (`PitInTime`/`PitOutTime` are the independent ground truth, and they
+are present and correct):
+
+```
+LapNumber  Stint  Compound  TyreLife  pit_in  pit_out
+     24.0    NaN       nan       NaN   False    False
+     25.0    1.0    MEDIUM       1.0   False    False
+     29.0    1.0    MEDIUM       5.0    True    False    <- real pit stop
+     30.0    1.0    MEDIUM       6.0   False     True    <- keeps counting THROUGH the stop
+     32.0    1.0    MEDIUM       8.0   False    False
+     33.0    2.0      HARD       1.0   False    False    <- stint 2 starts 4 laps late
+```
+
+Three separate errors in one block:
+
+1. **`TyreLife` restarts at 1 on lap 25** while the car is still on the tyre it started the race on.
+   True age at lap 29 is 29 racing laps plus its starting age; FastF1 reports **5**.
+2. **It counts across a pit stop** — physically impossible, and proof the value is derived from
+   "when the feed appeared", not from the tyre.
+3. **The stint boundary is misplaced by 4 laps**: `Stint` stays 1 through lap 32 when the real
+   change happened at lap 29/30.
+
+`TyreLife` is a direct input to N26's TCN and to N15/N16, and Miami 2025 is in the **test** season.
+A degradation model reading "5 laps old" for a 29-lap-old tyre predicts almost no wear.
+
+## Finding 5 — recomputation is sound, because the pit stops are intact
+
+The one thing NOT corrupted is `PitInTime`/`PitOutTime`. That is enough to rebuild both columns:
+
+- **Stint boundaries** derive from pit in/out — exact.
+- **`TyreLife` within a stint** = laps completed since the stint began — exact for stints 2+, where a
+  fresh set starts at 0.
+- **Stint 1 only** carries an unknown starting offset (the race-start set may have qualifying laps on
+  it). Measured on a clean control race (Bahrain 2025 lap 1): the offset is real and varies per
+  driver, `TyreLife` 4.0 on used sets versus 1.0 on fresh ones. So stint 1 is recoverable up to a
+  bounded offset of roughly 0-4 laps.
+
+Compare the alternatives on the reference lap: today the model receives **5** where the truth is
+**~29**. A recomputation gives **29 plus or minus 4**. The residual uncertainty is an order of
+magnitude smaller than the error it replaces, and unlike the current value it is not physically
+impossible.
+
+`FreshTyre` cannot rescue the offset: on all 446 gap rows it is uniformly `True`, while on the 11
+rows FastF1 repaired it varies (`False` for ALO, STR, HAD). Uniform where the data is missing and
+varying where it is present is the signature of a fabricated default, not a reading — so it must not
+be used as evidence of a fresh set.
+
+## Recommendation
+
+Rebuild `Stint` and `TyreLife` from the pit-stop timeline in the extraction layer, for every season,
+gated behind a validation that the rebuild reproduces FastF1's values exactly on races where the feed
+was healthy. Leave stint 1's absolute offset explicitly unknown rather than assuming a fresh set.
+
+This fixes #790's NaN (the visible half) and Finding 4's wrong values (the invisible, worse half) in
+one place, upstream of every consumer. It does not touch #782's weather gap, which is a genuinely
+different missing-column problem.
+
+**What it could get wrong:** a rebuilt `TyreLife` that is subtly off is worse than a NaN, because a
+NaN is visible and a wrong integer is not. The validation gate is therefore not optional — the
+rebuild must be proven to reproduce healthy races byte for byte before it is allowed to touch
+unhealthy ones.

--- a/documents/audits/GATE_weather_path_findings.md
+++ b/documents/audits/GATE_weather_path_findings.md
@@ -1,0 +1,285 @@
+# GATE — Weather path findings (issue #784, branch `refactor/single-source-race-state-builder`)
+
+Adversarial verification gate, 2026-08-02. Read-only except this file; written incrementally.
+
+Claims under test:
+1. §F11's justification for the track_temp decision ("weather.parquet missing → keys absent → defaults fire" as a LIVE divergence) may be a false statement.
+2. A live backend crash: `/lap-state` for 2025 emits `weather.air_temp/track_temp = None` (key present), and `backend/utils/race_state_builder.py:114-115` does `float(weather.get(...))` → `float(None)` TypeError.
+3. A fifth undocumented default pair (25/40) at `endpoints/strategy.py:933-941`; inventory ALL default-temperature sites.
+
+## Checklist
+
+- [x] Weather parquet coverage 2023/2024/2025
+- [x] Weather parquet row counts + NaN temp rows (present-with-None reachability)
+- [x] `get_weather_state` key-emission behavior (code)
+- [x] 2025 featured parquet columns, empirically
+- [x] `augment_featured_laps` restores weather? (code + executed)
+- [x] `Series.get` + `_safe_none` empirical behavior on real row
+- [x] `build_race_state` crash reproduction on real data (true end-to-end)
+- [x] Webapp / MCP reachability of the crash
+- [x] Full default-temperature inventory (claim 3)
+
+## Verdicts (summary)
+
+- **Claim 1: CONFIRMED — the §F11 justification is a false statement in this checkout.** The
+  decision (canonical 35.0) remains right for the median reason; the "reachable today" claim is not.
+- **Claim 2: CONFIRMED — live, total outage of /recommend for 2025 races**, born 2026-07-18
+  (#465 wave), predating #784. The branch's canonical builder fixes it (proven by execution).
+- **Claim 3: CONFIRMED and EXTENDED** — the :933-941 site is real (25/40, a PRODUCER), and there
+  are two MORE pairs nobody listed: debug_agent (28/45) and arcade overlays (18/45). Five distinct
+  value pairs in the working tree.
+
+## Evidence log (appended as confirmed)
+
+### E1. Every race directory has a weather.parquet — the "missing file" premise of §F11 is counterfactual in this checkout
+
+Executed (bash file count over `data/raw/`):
+
+```
+2023: 23 race dirs, 23 with weather.parquet
+2024: 24 race dirs, 24 with weather.parquet
+2025: 24 race dirs, 24 with weather.parquet
+```
+
+No race directory lacks the file. The only dirs without one are `data/raw/radio_audio/*` (not races).
+
+### E2. Code path facts (cited, verified by reading this checkout)
+
+- `src/simulation/replay_engine.py:80-90` — loads `weather.parquet` whenever it exists (degrades to `None` only on read failure, with a stderr warning); `:137` passes `self._weather_df` into `rsm.get_lap_state(lap, self._weather_df)` on every lap. Both CLI and Arcade replay go through this.
+- `src/simulation/race_state_manager.py:470-472` — with `weather_df=None` OR an EMPTY frame (`not weather_df.empty` guard), the weather dict is `{"track_status": ...}` only → temperature KEYS ABSENT.
+- `race_state_manager.py:478-482` — with a non-empty weather_df, keys are ALWAYS present; values become `None` only when the selected row's reading `pd.isna(...)` — present-with-None, which the consumer `.get(key, default)` does NOT catch.
+
+So the default-firing branch on the replay path requires: weather.parquet missing, unreadable, or zero-row. E1 rules out "missing" for every race in the dataset. Row counts and NaN scan below.
+
+### E3. Backend flow facts (cited)
+
+- `backend/utils/laps_cache.py:29-40` (`get_laps_df`) DOES call `augment_featured_laps` — the CLAUDE.md "every consumer" rule holds here.
+- `src/f1_strat_manager/laps_augment.py` `RAW_COLUMNS_TO_RESTORE = {"Time": "Time_s", "TrackStatus": "TrackStatus"}` — weather columns are NOT restored by augmentation.
+- `/lap-state` producer `endpoints/strategy.py:574-583`: `weather = {"air_temp": _safe_none(r.get("AirTemp")), "track_temp": _safe_none(r.get("TrackTemp")), ...}` — keys unconditionally present.
+- `backend/utils/race_state_builder.py:114-115`: `float(weather.get("air_temp", 25.0))` / `float(weather.get("track_temp", 35.0))` — default fires only on MISSING key. Lines 89-103 of the SAME FILE document this exact dead-default class for `position` (#465) and fix it there — but not for weather. The twin that never got the fix.
+- Reachability chain 1 (webapp): `webapp/src/features/strategy/queries.ts:160-161` — `fetchLapState(...)` then `runRecommend(lapState, ...)`; `lib/api/strategy.ts:322` GETs `lap-state`, `:352` posts `lap_state: lapState` verbatim to `/recommend`; `endpoints/strategy.py:1349` feeds it to `build_race_state`. No sanitisation between.
+- Reachability chain 2 (chat/MCP): `backend/mcp_tools.py:397-413` `_build_lap_state` delegates to the SAME `get_lap_state` producer; `:583-595` `recommend_strategy` feeds it to `build_race_state`.
+
+### E4. Claim 2 empirics — CONFIRMED on real data (executed `uv run python`, script `gate_claim2.py`)
+
+```
+featured parquet columns (pre-augment):
+  2023: 53 cols, 22106 rows, weather cols present: [AirTemp, TrackTemp, Humidity, Rainfall]
+  2024: 53 cols, 23256 rows, weather cols present: [AirTemp, TrackTemp, Humidity, Rainfall]
+  2025: 48 cols, 22760 rows, weather cols present: NONE          <- #782 confirmed
+after augment_featured_laps(df25, 2025): 50 cols, weather cols: NONE
+  columns ADDED by augmentation: ['Time_s', 'TrackStatus']       <- augmentation does NOT restore weather
+
+Lusail 2025 NOR lap 30 (real row through the producer's exact code):
+  r.get('AirTemp')            -> None   (pandas Series.get on a missing index label returns None)
+  _safe_none(r.get('AirTemp')) -> None
+  producer weather dict: {'air_temp': None, 'track_temp': None, 'humidity': None, 'rainfall': 0}
+  'air_temp' in weather: True
+  weather.get('air_temp', 25.0) -> None   <- the .get default does NOT fire (key present)
+  float(weather.get('air_temp', 25.0))    -> TypeError: float() argument must be ... not 'NoneType'
+
+2024 row (Austin): r.get('AirTemp') -> 28.1, TrackTemp -> 47.2   <- 2023/2024 paths get real floats
+raw fallback data/raw/2025/Lusail/laps.parquet: 35 cols, weather cols: NONE
+  <- the raw-parquet fallback branch of /lap-state ALSO emits None weather for 2025;
+     there is no branch of this producer that yields a temperature for a 2025 race.
+```
+
+So for EVERY 2025 lap served by `/lap-state` (featured or raw fallback), `weather.air_temp` and
+`weather.track_temp` are key-present-value-None, and the current backend builder's
+`float(weather.get(...))` at `backend/utils/race_state_builder.py:114-115` raises TypeError.
+
+Severity nuance: `/recommend` wraps the call in `except (KeyError, TypeError, ValueError)` at
+`endpoints/strategy.py:1365-1367` -> HTTP 422 "orchestrator validation error", NOT a 500 traceback.
+It is a total functional outage of /recommend for 2025 races (the year the webapp defaults to,
+`year: int = 2025` at `:411`), presented as a client-input error.
+
+### E5. Claim 2 — TRUE end-to-end executed (real producer -> real builder, no replication)
+
+```
+get_lap_state(gp='Lusail', driver='NOR', lap=30, year=2025)   [the real backend function]
+  weather emitted: {'air_temp': None, 'track_temp': None, 'track_temp_start': None,
+                    'humidity': None, 'rainfall': 0}
+backend.utils.race_state_builder.build_race_state(that_lap_state)
+  -> TypeError: float() argument must be a string or a real number, not 'NoneType'
+
+CONTROL get_lap_state(..., year=2024): weather {'air_temp': 18.6, 'track_temp': 22.5, ...}
+  -> RaceState built OK (air_temp=18.6, track_temp=22.5)
+
+NEW canonical builder (src/agents/race_state_builder.py, this branch) on the SAME 2025 state:
+  -> NO crash; air_temp=25.0, track_temp=35.0, rainfall=False
+```
+
+### E6. Claim 2 — when the crash was born (submodule git archaeology)
+
+- `float(weather.get("air_temp"...))` builder shape: commit `ff44813` 2026-04-10.
+- `_safe_none(r.get("AirTemp"))` in the /lap-state producer: commit `84b561e` 2026-07-18
+  ("harden the strategy backend against the Fable audit", the #465 wave).
+- BEFORE 84b561e the producer read `float(_safe(r.get("AirTemp", 25)))` /
+  `float(_safe(r.get("TrackTemp", 40)))` (84b561e^ lines 485-486): for 2025 the missing
+  column made `Series.get`'s default fire -> every 2025 lap got a FABRICATED 25/40, no crash.
+- So: pre-2026-07-18 = silent fabrication bug; post-2026-07-18 = hard 422 outage. The crash
+  PREDATES #784 (it is on `main` of the submodule today) and was INTRODUCED by the #465 fix,
+  which honoured the None contract in the producer but never updated the consumer 100 lines
+  away in the same repo — `backend/utils/race_state_builder.py:89-103` fixed exactly this
+  class for `position` in the SAME commit wave and left `air_temp`/`track_temp` at :114-115
+  untouched. Textbook twin-not-fixed.
+- Blast radius: webapp Strategy tab pins `const YEAR = 2025` (`webapp/src/lib/api/strategy.ts:244`)
+  and `RACE_YEAR = 2025` (`race.ts:17`) -> the DEFAULT year of the surface is the broken one.
+  MCP chat `recommend_strategy` defaults `year: int = 2025` (`mcp_tools.py:570`) -> same.
+  2023/2024 unaffected (featured parquets carry real weather columns, E4).
+
+**CLAIM 2 VERDICT: CONFIRMED**, and it is a PRE-EXISTING live bug (born 2026-07-18, #465 wave),
+not introduced by #784. The branch's canonical builder demonstrably fixes it (E5). Reproduction:
+POST /api/v1/strategy/recommend with the verbatim output of GET /lap-state?gp=Lusail&driver=NOR&lap=30&year=2025
+-> 422 "orchestrator validation error" on every 2025 lap of every 2025 GP.
+
+### E7. Claim 1 — the replay-path default branch is UNREACHABLE with the shipped dataset
+
+Executed scan of all 71 `data/raw/<year>/<gp>/weather.parquet` files (script `gate_claim1.py`):
+
+```
+scanned: 71 weather parquets; unreadable: 0; empty: 0
+files with NaN/absent AirTemp:  NONE
+files with NaN/absent TrackTemp: NONE
+files whose FIRST row TrackTemp is NaN (track_temp_start=None risk): NONE
+row counts: min 108, max 223
+```
+
+Combined with the code path (E2):
+
+- Keys-ABSENT (the branch §F11 says "fires every default") requires weather.parquet missing,
+  unreadable, or zero-row (`race_state_manager.py:472` guards `is not None and not empty`).
+  In this checkout: 71/71 present (E1), 71/71 readable, 71/71 non-empty. **Unreachable.**
+- Present-with-None (`:478-479`, NaN reading -> None) requires a NaN temperature in the selected
+  row. Zero NaN readings exist in any of the 71 files. **Also unreachable today** — but F11's
+  characterisation of THAT branch (crashes the pre-branch builders; `.get` default cannot catch
+  it) is CORRECT as a hazard class, and the canonical builder's None-as-missing read fixes it.
+- `replay_engine.py:82-90` treats weather as optional BY DESIGN (a future race dir without the
+  file, a corrupt download, a live feed without weather would take the degraded branch), so the
+  branch is latent-defensive, not dead code. But it is NOT "a real, reachable, surface-dependent
+  model-input divergence today" on any of the 71 races the project ships. The CLI's 40.0 (dev
+  `scripts/run_simulation_cli.py:1370-1371`) vs Arcade's 35.0 (dev `src/arcade/strategy.py:709-710`)
+  never actually diverged on shipped data: on every race both received real temperatures.
+
+**Where a 40-vs-35 divergence IS real today:** not on the replay path but between backend
+endpoints for 2025 — `/pace-range` fabricates track_temp=40.0 (E8 site #6) while `/pace` via
+/lap-state + the pace agent's None-safe default yields 35.0 for the same lap.
+
+**Verdict:** the DECISION (35.0 canonical) is right and stands on the measured-median argument
+(35.0 IS the dataset median, 40.0 matches nothing measured). The recorded JUSTIFICATION — "when
+weather.parquet is missing for a race ... every default fires", presented as reachable today — is
+counterfactual for every race in `data/`, exactly the failure mode CLAUDE.md §11 (2026-07-16)
+already recorded for this same path. §F11's weather bullet and any echo of it in issue #784 need
+rewording from "live divergence today" to "latent divergence on degraded/foreign inputs; the live
+divergences are on the backend surfaces (E8)". The false premise has already propagated: the NEW
+module's own docstring repeats it (`src/agents/race_state_builder.py:7`, "races with no weather
+parquet").
+
+### E8. Claim 3 — complete inventory of default air/track temperature sites
+
+Legend: PRODUCER = fabricates a reading into a lap_state/feature source before the contract;
+CONSUMER = fills a gap after reading it. None-safe = catches present-with-None; dead-.get =
+fires on missing key only.
+
+**Pair (25.0, 35.0):**
+1. `src/agents/race_state_builder.py:78-79, 336-337` — canonical, this branch; CLI
+   (`run_simulation_cli.py:1287-1305`) and arcade (`src/arcade/strategy.py:599-649`) now
+   delegate here. CONSUMER, None-safe (`_weather_reading` :201).
+2. `src/telemetry/backend/utils/race_state_builder.py:114-115` — CONSUMER, dead-.get -> the E5
+   crash. Same file fixed this exact class for `position` at :89-103 and left weather untouched.
+3. `src/agents/pace_agent.py:642-643` — CONSUMER, None-safe.
+4. `scripts/prompt_ab/gen_inputs.py:65-66` — CONSUMER, None-safe (`or`).
+5. `src/strategy/eval/decision_modes.py:304-305` — CONSUMER, None-safe (`or`).
+
+**Pair (25, 40):**
+6. `src/telemetry/backend/api/v1/endpoints/strategy.py:934-935` (`_build_lap_state_from_row`
+   :890; sole caller `/pace-range` :695) — PRODUCER. For 2025 the columns are absent, so
+   `Series.get`'s default DOES fire: every 2025 lap of the Lab pace chart runs the pace model
+   with fabricated track_temp=40.0, while `/pace` uses 35.0 for the same lap (via the None-safe
+   consumer #3). Also carries `_s` NaN->0 on 2023/24 NaN rows (none shipped).
+7. (dev, pre-branch) `scripts/run_simulation_cli.py:1370-1371` — CONSUMER, dead-.get; replaced
+   on this branch by #1.
+8. (historical) the /lap-state producer until submodule commit `84b561e` 2026-07-18
+   (`84b561e^` :485-486) — PRODUCER, fabricated 25/40 for every 2025 lap until #465 honoured None.
+
+**Pair (28.0, 38.0):**
+9. `src/agents/tire_agent.py:1440-1442` (run() path) — CONSUMER, dead-.get, float-wrapped.
+10. `src/agents/tire_agent.py:1512-1514` (run_from_state) — CONSUMER, dead-.get, NO float wrap:
+    a present-None (every 2025 backend lap_state) passes THROUGH the 28.0/38.0 default as None
+    into the TCN feature dict — silent None/NaN feature, no crash. Same class as E5, different
+    symptom.
+11. `src/agents/race_situation_agent.py:681-684` — CONSUMER of session_meta (backend
+    session_meta carries no temps -> fires for real; `track_temp_start` cascades to 38.0 ->
+    track_temp_delta=0, the #486 residue).
+12. `src/agents/race_situation_agent.py:1316-1319` (run(), FastF1 path) — PRODUCER-side
+    fabrication when the live weather frame lacks the column.
+13. `src/agents/race_situation_agent.py:1402-1405` (run_from_state) — CONSUMER, dead-.get,
+    same None-passthrough as #10.
+14. `src/telemetry/backend/api/v1/endpoints/strategy.py:1022-1025` (`/tire-range`) — PRODUCER:
+    UNCONDITIONALLY fabricates `agent.session_meta` AirTemp=28.0/TrackTemp=38.0 for EVERY year,
+    even 2023/24 where real readings exist in the very gp_df scoped two lines above.
+
+**Pair (28.0, 45.0)** — MISSED by the known-so-far list:
+15. `scripts/debug_agent.py:179-180` and `:306-307` — CONSUMER (debug harness). track 45.0
+    matches nothing else in the repo.
+
+**Pair (18.0, 45.0)** — MISSED by the known-so-far list:
+16. `src/arcade/overlays.py:129-130` — CONSUMER, display-only (weather HUD): shows 45.0 C track /
+    18.0 C air when a frame lacks weather. Never reaches a model.
+
+**Count: FIVE distinct value pairs in the working tree** — (25,35), (25,40), (28,38), (28,45),
+(18,45). The claim's ":933-941 is a fifth set" is right that the site is real and undocumented,
+but its pair (25/40) DUPLICATES the old CLI pair; the genuinely new pairs are #15 and #16.
+Producer sites (#6, #14, #12) fabricate before the contract and are NOT #784's scope (a builder
+cannot undo an upstream fabrication). Consumer site #2 (the crash) IS fixed by #784; #10/#13
+need the same None-as-missing treatment or an upstream weather restore.
+
+**The #486 history, briefly:** N14's `track_temp_delta = track_temp - track_temp_start` is its
+5th-most-important feature. `track_temp_start` used to live only in session_meta while the
+consumer read `wx['track_temp_start']`, so it fell back to "current track_temp" and the delta
+was 0.0 on every lap — a live feature reading a constant. The fix shipped it in the weather dict
+at every producer (`race_state_manager.py:483-499`, `endpoints/strategy.py:577-580, 936-938`).
+The 38.0 at `race_situation_agent.py:684` is the residual session_meta-path default — and on
+2025 backend paths `_session_track_temp_start` (`endpoints/strategy.py:785`) returns None (no
+TrackTemp column), so the #486 symptom (delta=0.0) is BACK on the season the webapp serves, via
+the same missing-columns root cause as E4 (#782).
+
+## What I tried to break and could NOT
+
+1. **The canonical builder's None handling** — fed it the real, crashing 2025 lap_state (E5):
+   built RaceState with 25.0/35.0/rainfall=False. No counterexample found.
+2. **The "augmentation restores weather" escape for claim 2** — executed `augment_featured_laps`
+   on the real 2025 parquet: adds only Time_s + TrackStatus. The CLAUDE.md "every consumer calls
+   augment" rule IS honoured by `laps_cache.py:24-40`; it just does not restore weather.
+3. **The raw-fallback escape** — all 24 `data/raw/2025/*/laps.parquet` lack AirTemp/TrackTemp
+   (executed scan): no /lap-state branch can produce a 2025 temperature.
+4. **A sanitising layer between /lap-state and /recommend** — `queries.ts:160-161`,
+   `lib/api/strategy.ts:322,352`, `mcp_tools.py:397-413,583-595`: the dict passes verbatim on
+   both surfaces.
+5. **Claim 1's rescue** — searched for ANY missing/empty/corrupt weather.parquet, any NaN
+   temperature, any zero-row frame across all 71 races (executed): none. I could not make the
+   replay-path weather defaults fire with shipped data.
+6. **A 2023/2024 instance of the claim-2 crash** — those featured parquets carry real weather
+   values (control: Lusail 2024 18.6/22.5 builds fine); not reproducible there.
+
+## Recommendations for #784
+
+1. **Correct §F11's weather bullet and any issue text quoting it**: the replay-path divergence is
+   latent (degraded/foreign inputs), not "reachable today"; the 35.0 decision stands on the
+   median argument alone. Also fix the same premise in the new module's docstring
+   (`src/agents/race_state_builder.py:7`).
+2. **Upgrade #784's backend claim**: migrating the backend builder is not just deduplication —
+   it FIXES a live 422 outage of /recommend for every 2025 lap on the webapp Strategy tab
+   (YEAR=2025 pinned, `lib/api/strategy.ts:244`, `search.ts:22`) and MCP chat (default year
+   2025). That deserves its own bug issue (pre-existing, born in the #465 wave, 2026-07-18)
+   closed by the #784 PR, with the E5 reproduction as the body.
+3. **File separately (NOT #784 scope):** (a) /pace-range's 25/40 producer fabrication (site #6)
+   and /tire-range's unconditional 28/38 session_meta (site #14); (b) the None-passthrough in
+   tire/race_situation run_from_state (sites #10/#13) silently degrading every 2025 backend
+   call; (c) the #486 regression-by-data (track_temp_delta=0 on 2025). All three share the root
+   cause of E4 — the featured-2025 parquet's missing weather columns (#782); restoring those
+   columns (or augmenting them from weather.parquet) would heal (a), (b), (c) AND reduce the
+   blast radius of any future dead-default twin.
+4. Sites #15/#16 (debug 28/45, HUD 18/45) are cosmetic; one-line follow-up at most.
+
+

--- a/documents/audits/GATE_weather_restore.md
+++ b/documents/audits/GATE_weather_restore.md
@@ -1,0 +1,235 @@
+# ADVERSARIAL GATE — #782 weather-column restore (`fix/restore-2025-weather-columns`)
+
+Date: 2026-08-03 · Auditor: adversarial correctness gate (Fable) · Status: IN PROGRESS
+
+Scope: uncommitted change restoring `AirTemp`/`TrackTemp`/`Humidity`/`Rainfall` onto
+`laps_featured_2025` at load time via `src/f1_strat_manager/weather_restore.py`, wired into
+`augment_featured_laps`, with `pace_holdout.py` rerouted through the augment.
+
+Method: executed evidence only. Every finding cites file:line and measured values.
+
+## Checklist
+
+- [ ] A. Independent 2023/2024 reproduction (values + Rainfall + dtypes)
+- [ ] B. Guard behaviour: early exit, partial columns, empty frame, all-NaN columns
+- [ ] C. Pace MAE reproduction + sensitivity of MAE to the weather values
+- [ ] D. What ELSE changed in the pace holdout (stint repair, row counts, _DROPNA)
+- [ ] E. Direct-reader inventory: which eval paths still see un-repaired / weather-less data
+- [ ] F. tests/eval/ run + other headline numbers
+- [ ] G. Docstring/comment truth (the 71-races sentence, the "honest gap" claim, the "tests/agents holds that check" claim)
+
+## Findings (appended as confirmed)
+
+### G-OK — the 71-races docstring sentence is TRUE (verified, all four parts)
+
+`weather_restore.py:9-10` claims every one of the 71 shipped race directories has a readable
+`weather.parquet` with all four readings and zero NaN temperature rows. Executed over
+`data/raw/{2023,2024,2025}/*` (23+24+24 = 71 dirs): 0 missing, 0 unreadable, 0 missing columns,
+0 NaN `AirTemp`/`TrackTemp` rows. Also measured beyond the claim: 0 NaN `Humidity`, 0 NaT `Time`
+samples, `Time` is `timedelta64[ns]` in all 71, `Rainfall` is `bool` in all 71.
+
+### A-OK — 2023/2024 reproduction re-derived independently: EXACT, all FOUR columns, dtypes included
+
+Re-derived (own script, not the author's): dropped the four weather columns from the published
+`laps_featured_2023/2024.parquet`, ran `augment_featured_laps`, compared per (GP_Name, Driver,
+LapNumber) with row order verified preserved.
+
+- 2023: 22,106 rows. AirTemp/TrackTemp/Humidity exact-equal 22,106/22,106 each (max diff 0.0,
+  0 NaN mismatches). The author's "66,318/66,318" is 22,106 × 3 — consistent.
+- 2024: 23,256 rows. Exact-equal 23,256/23,256 each. "69,768" = 23,256 × 3 — consistent.
+- **Rainfall (the column the author's script skipped): reproduces 100% in both seasons**, values
+  {0,1} identical, and the restored dtype is `int32` — identical to the published `int32`
+  (`.astype(int)` on Windows numpy = int32, same platform N04 ran on).
+- Row count and key order preserved through the augment (no merge fan-out).
+
+### FINDING 1 (MEDIUM) — B: a frame carrying SOME of the four columns comes out silently corrupted
+
+`laps_augment.py:206` guards with `not all(column in df.columns ...)`, so a frame with 1-3 of the
+four present sets `wants_weather=True`; the per-race slice then carries all four
+(`laps_augment.py:236-237`) and the left-merge at `laps_augment.py:253` collides with the columns
+already on the featured frame. Executed (2023 featured with only `AirTemp` dropped): the output has
+58 columns, `TrackTemp`/`Humidity`/`Rainfall` NO LONGER EXIST — replaced by `TrackTemp_x`/
+`TrackTemp_y`, `Humidity_x`/`Humidity_y`, `Rainfall_x`/`Rainfall_y`. `normalise_rainfall` then
+no-ops (no `Rainfall` column), leaving `Rainfall_y` un-filled. Any consumer selecting the plain
+names (e.g. `df[features_delta]` in `pace_holdout.py:120`) raises KeyError; a `.get()`-style
+consumer silently reads nothing. Failure scenario: any future artefact republished with a partial
+weather set — the guard's own condition contemplates exactly this shape and then corrupts instead
+of deriving only the missing columns or refusing loudly. Today no shipped artefact is partial
+(2023/24 carry all four, 2025 carries none), so this is latent, not live.
+
+### B-OK — the early exit and the degenerate frames behave
+
+- Published 2023 through the augment: all four weather columns byte-identical after, dtypes
+  preserved (`int32` Rainfall included) — 2023/2024 are never re-derived. Confirmed executed.
+- No-`GP_Name` frame returns unchanged; zero-row frame with keys returns zero rows, no crash.
+- Columns present but ALL-NaN: guard sees presence, not usability — frame stays all-NaN (no
+  re-derivation). Consistent with the "never second-guess a season that carries the columns"
+  contract; noted as a design edge, not a defect.
+
+### FINDING 2 (MEDIUM) — C: the pace-MAE reproduction is REAL evidence for the values but CANNOT see the alignment method; and the safeguard the docstring points to does not exist
+
+Executed sensitivity of `_pace_mae()` (shipped MAE 0.40968, n=21,247; author's 0.40968 confirmed;
+golden tolerance ±0.01 vs published 0.4104):
+
+| weather variant | MAE | |Δ| vs shipped | golden verdict |
+|---|---|---|---|
+| shipped (nearest join) | 0.40968 | — | reproduced |
+| all-NaN weather | 0.67217 | 0.26249 | delta |
+| +5/+10/+20 °C/% perturbation | 0.57586 | 0.16619 | delta |
+| all-zero weather | 0.51974 | 0.11006 | delta |
+| scrambled across laps | 0.48805 | 0.07837 | delta |
+| **WRONG join: direction='backward'** | **0.40939** | **0.00029** | **reproduced** |
+
+The weather columns are 4 of the 25 features in `xgb_laptime_delta_feature_names.json` (verified),
+and the MAE moves violently when their values are wrong at the distribution level — so the
+reproduction is NOT hollow. But a backward join that changes 7,014/22,760 TrackTemp cells moves
+the MAE by 0.00029 and still "reproduces". Two documented claims therefore overstate it:
+
+- `tests/agents/test_weather_restore.py:9-10`: "That number moves if the merge is wrong, which is
+  what makes it evidence rather than decoration" — REFUTED for alignment-level wrongness. Only a
+  synthetic unit test (`test_each_lap_takes_its_nearest_sample_not_the_preceding_one`) pins the
+  direction, on a 1-lap toy frame.
+- `weather_restore.py:28-31`: "the restore must reproduce 2023's and 2024's published weather
+  **exactly** before it is trusted on 2025. `tests/agents/` holds that check, and it is not
+  decoration" — **FALSE. No committed test compares the restore against the published 2023/2024
+  values.** All 6 tests in `tests/agents/test_weather_restore.py` run on synthetic 1-3 row frames.
+  The exact-reproduction evidence exists only in this gate and in the author's uncommitted script.
+  The one check the module calls its load-bearing safeguard is not in the repo.
+
+### D-OK (measured) — the stint repair riding along moves the metric by 0.00011 and the denominator not at all
+
+The rerouted holdout input changed in two ways (#782 weather + #790 repair). Decomposed, executed:
+
+- Repair disabled (monkeypatched no-op), weather on: MAE 0.40957 vs shipped 0.40968 —
+  |Δ| = 0.00011. The 0.4104 reproduction survives because of the weather, not despite the repair.
+- Denominator: n = 21,247 in EVERY variant. `_DROPNA = [LapTime_Delta, Prev_LapTime]`
+  (`pace_holdout.py:44`) are published columns the repair never touches; the 113 newly-nulled
+  TyreLife values (featured 2025 rows) do NOT drop rows because TyreLife is not in `_DROPNA`.
+- Repair's real footprint on the scored frame: 98 predictions moved (max |move| 0.611 s), n
+  unchanged, net MAE effect 0.00011. Stint moved on 30 featured rows, TyreLife on 406 (113 to
+  null).
+
+### FINDING 3 (HIGH-VALUE CONFIRMATION, not a defect) — the 2025 ground truth EXISTS on disk and the restore matches it byte-for-byte; no committed test uses it
+
+`data/processed/laps_featured.parquet` (the combined 2023-2025 artefact, 68,122 rows) ALREADY
+carries all four weather columns for 2025 with zero NaN — the actual N04 output for 2025 was
+published all along in the combined file; only the per-year split dropped it. Executed: restored
+2025 weather vs the combined file's 2025 slice — 21,903/21,903 key-matched rows identical on all
+four columns (max diff 0.0), plus the remaining 857 Miami rows identical after mapping the
+GP_Name rename (`Miami` per-year vs `Miami Gardens` combined). **22,760/22,760 exact.**
+
+Consequences:
+- This retroactively closes the backward-join blind spot from Finding 2 FOR THIS GATE: a backward
+  join changes 7,014 TrackTemp cells and would have failed this comparison; 'nearest' is therefore
+  verified as N04's actual 2025 method, not just its stated one.
+- But the repo keeps none of this: the strongest available check (compare restore against
+  `laps_featured.parquet`'s 2025 slice) is in NO committed test, and `weather_restore.py:9-12`
+  frames the truth as existing only in `weather.parquet` inputs ("What is missing is only the
+  merge") when the merge RESULT is also published. The committed test the docstring promises
+  (Finding 2) could be written against this file in ~15 lines and would pin everything the MAE
+  cannot see. Recommendation 1.
+
+### FINDING 4 (LOW) — three comments/docstrings name the WRONG MECHANISM for the Rainfall fill, and one asserts the opposite of what the code does
+
+Executed proof: simulated Monza 2025 with no readable weather parquet (`read_race_weather`
+returning None for that race only). Result: Monza's 895 laps keep AirTemp/TrackTemp/Humidity NaN
+(honest gap) but **Rainfall reads a confident 0 (dry) on all 895** — because the season-level
+`normalise_rainfall` at `laps_augment.py:258` fills every remaining NaN.
+
+- `laps_augment.py:256-257`: "applied once per season rather than per race so a race with no
+  weather parquet keeps an honest gap instead of reading 0 (dry)" — FALSE for Rainfall, the only
+  column the sentence is about. The season pass is precisely what writes the 0.
+- `weather_restore.py:93-95` (normalise_rainfall docstring): "a per-race fill would leave a race
+  with no weather parquet reading 0 (dry) instead of keeping the honest gap until the season-level
+  pass" — INVERTED. A per-race fill inside `weather_for_race` would never RUN for a race whose
+  parquet is absent (the function is never called), so it would KEEP the gap; the season-level
+  pass is what destroys it.
+- `tests/agents/test_weather_restore.py:99-103` repeats the inverted claim verbatim, and the test
+  under it only checks that a frame without a Rainfall column passes through untouched — it does
+  not (and cannot) test the claimed honesty property.
+
+The CODE is faithful to N04 (N04 cell 22 `continue`s on empty weather and fills Rainfall once over
+the master frame — same observable behaviour), so nothing to fix in behaviour. But per this
+project's own lesson log, a comment naming the wrong mechanism is worse than none: someone
+"fixing" the code to match these comments would break the N04 reproduction.
+
+Footnote (comment-truth, no practical surface): `weather_restore.py:59` says NaT-Time laps "keep
+NaN, which is what N04 leaves them as" — N04 never left them as anything; its merge_asof would
+raise on an unsorted NaT key. Measured: 0 NaT `Time` in all 79,032 raw laps across the 71 races,
+so the divergence is unreachable in shipped data.
+
+### E — direct-reader inventory: the featured-laps inconsistency is GONE, not created
+
+Verified per reader (file:line, artefact read):
+- `calibration.py:160/233/283` — `overtake_labeled/overtake_pairs_2023_2025.parquet`,
+  `sc_labeled/sc_labeled_2023_2025.parquet`, `undercut_labeled/undercut_clean.parquet`: labeled
+  artefacts, not featured laps. Reproduction REQUIRES them as-published (as-trained); routing them
+  through the augment would be wrong.
+- `tire_holdout.py:171` — `laps_tiredeg.parquet` (56 cols): carries its own weather for ALL years,
+  0 NaN in all four columns 2023/2024/2025 (measured). Not affected by the 2025 hole.
+- `nlp.py:643` — RCM corpus parquets, unrelated.
+- `pit_holdout.py:54`, `projection.py:296`, `stint_lengths.py:207` — RAW `laps.parquet` per race,
+  not featured. (They see un-REPAIRED raw stints, but that pre-dates this diff and is untouched
+  by it; the pit/projection metrics were published on those raws.)
+- Non-eval consumers of `laps_featured_<year>`: arcade `strategy.py:576`, backend
+  `laps_cache.py:39` (feeding `simulator.py` and every route), CLI — all already through
+  `augment_featured_laps`; `pace_agent.py:216-218/240-243` reads the parquet directly but only
+  columns `[Team, TeamID]` / `[GP_Name, Year, Compound, LapTime_s]` — no weather dependency.
+
+Net: after this change, every reader of a per-year featured-laps parquet that consumes more than
+named non-weather columns goes through the augment. The change REMOVED the last inconsistency
+(pace_holdout) rather than adding one. Side effect worth knowing: arcade/backend/CLI 2025 frames
+now carry 6 extra columns (Time_s, TrackStatus + 4 weather) at runtime — additive only.
+
+### Premise check — the bug being fixed is real
+
+Executed the pre-change path (direct `pd.read_parquet` of `laps_featured_2025.parquet` + the two
+N06 feature steps + `df[features_delta]`):
+`KeyError: "['AirTemp', 'TrackTemp', 'Humidity', 'Rainfall'] not in index"` — exactly as claimed.
+And `reproduce.collect_results()` (`reproduce.py:263-272`) calls `_pace_mae()` with no per-model
+exception isolation, which is why `test_reproduction_matches_overtake_auc_pr` (which goes through
+`collect_results`) failed alongside the pace golden: the overtake reproduction itself reads
+`overtake_pairs_2023_2025.parquet` and never needed featured-laps weather. One fix, both tests —
+the wiring claim holds.
+
+### Hardening footnote (not a finding — unreachable in shipped data)
+
+`weather_for_race` (`weather_restore.py:75`) would raise `pandas.errors.MergeError` out of the
+whole augment if a race's `weather.parquet` carried a non-timedelta `Time` (the
+`read_race_weather` try/except at `weather_restore.py:109-115` guards the READ, not the merge).
+Measured: all 71 shipped weather parquets carry `timedelta64[ns]`, so no current data can trigger
+it. Worth a dtype guard only if the artefact contract ever loosens.
+
+## What I tried to break and could NOT
+
+1. **The 2023/2024 reproduction** — re-derived with my own script, all four columns, both seasons,
+   45,362 rows: byte-exact, including the Rainfall int32 the author never checked.
+2. **The 2025 restore against its published truth** — found ground truth the author did not use
+   (`laps_featured.parquet` 2025 slice) and the restore matched 22,760/22,760 rows on all four
+   columns, Miami rename included.
+3. **The early exit** — published 2023 through the augment comes back with weather byte-identical.
+4. **The denominator** — n = 21,247 scored rows in every variant; `_DROPNA` drops nothing new.
+5. **The stint-repair contamination theory** — measured at 0.00011 MAE; the reproduction stands on
+   the weather, not on a cancellation.
+6. **Degenerate frames** — empty, keys-only, all-NaN-weather frames all pass through sanely.
+7. **The 71-races docstring sentence** — all four parts true, plus stronger properties (0 NaN
+   Humidity, 0 NaT Time, uniform dtypes) it does not even claim.
+8. **The Miami alias path** — the renamed race (also the #790-repaired race) restores weather
+   correctly through `FOLDER_ALIASES` (857/857 vs truth).
+9. **Lint/format** — `ruff check` and `ruff format --check` pass on all four files.
+
+## Fix list (by value, none blocks shipping)
+
+1. **Commit the reproduction test the docstring already claims exists** (`weather_restore.py:28-31`):
+   compare the restore against `laps_featured.parquet`'s 2025 slice (and/or the 2023/2024 per-year
+   artefacts) under `@pytest.mark.data`. ~15 lines; it pins the alignment method the MAE provably
+   cannot see (backward join reproduces to 0.00029). Until then, soften the docstring.
+2. **Fix the guard for partial weather columns** (`laps_augment.py:206`): either derive only the
+   missing columns, or raise/log loudly on a partial set instead of emitting `_x`/`_y` corruption.
+3. **Rewrite the three inverted "honest gap" comments** (`laps_augment.py:256-257`,
+   `weather_restore.py:93-95`, `tests/agents/test_weather_restore.py:99-103`) to say what is true:
+   temps keep NaN for a weatherless race, Rainfall becomes 0 because N04's season-level fill does
+   that, and the restore keeps N04's behaviour on purpose.
+4. (Optional) dtype guard on the weather `Time` column before `merge_asof`.
+
+## Verdict

--- a/documents/audits/IMPL_race_state_single_contract.md
+++ b/documents/audits/IMPL_race_state_single_contract.md
@@ -1,0 +1,298 @@
+# IMPL LOG — Single canonical RaceState builder (#784, parent-repo half)
+
+**Date:** 2026-08-02 · **Branch:** `refactor/single-source-race-state-builder` (off `dev`)
+**Scope:** parent repo only. `src/telemetry/` (submodule) untouched by design — its re-export
+shim is the separate next step.
+
+Progress is appended as it happens, per the incremental-persistence rule.
+
+## Plan
+
+1. New leaf module `src/agents/race_state_builder.py` (lazy `RaceState` import).
+2. Rewire `src/arcade/strategy.py::_build_race_state` → delegation (radio/RCM sourcing stays).
+3. Rewire `scripts/run_simulation_cli.py::_build_race_state` → body-only delegation (PMV surgical).
+4. `tests/agents/test_race_state_builder.py`.
+5. Verify: new tests · suite deltas vs baseline · ruff · real `f1-sim Budapest NOR McLaren`.
+
+## Log
+
+- **[start]** Branch confirmed `refactor/single-source-race-state-builder`; working tree clean
+  except the design doc + an unrelated PNG. Baseline
+  `uv run pytest tests/agents/ tests/audit/ tests/simulation/ -q` launched in background BEFORE
+  any edit, to have a real delta reference.
+- Read and confirmed against the design gate: backend builder at
+  `src/telemetry/backend/utils/race_state_builder.py` (`_targeting_against_rival` at :7-50,
+  builder at :53-120), arcade at `src/arcade/strategy.py:599-715`, CLI at
+  `scripts/run_simulation_cli.py:1304-1373` + post-construction radio block :1710-1764.
+  CLI's `_GAP_UNKNOWN_FALLBACK_S` import (:1299-1301) is used ONLY inside the body being
+  replaced → it and its now-false comment block (:1290-1298) get replaced by the new import,
+  not left orphaned.
+- **BASELINE:** `uv run pytest tests/agents/ tests/audit/ tests/simulation/ -q` →
+  **163 passed**, 169.89s, exit 0.
+- **[1. new module]** `src/agents/race_state_builder.py` written. Constants
+  (`UNKNOWN_COMPOUND` + marker set, `UNKNOWN_TYRE_LIFE=0`, `DEFAULT_AIR_TEMP_C=25.0`,
+  `DEFAULT_TRACK_TEMP_C=35.0`) each carry their F10 measurement in a comment;
+  `total_laps` imports `DEFAULT_TOTAL_LAPS` from `_shared_defaults` (57 never restated).
+  `_targeting_against_rival` ported VERBATIM (docstring included). Helpers:
+  `_car_ahead`, `_gap_to_car_ahead` (two-zeros rationale + honest-2.0 caveat moved here
+  from the arcade comment), `_pace_delta_vs_car_ahead` (#750 wording preserved from the
+  CLI comment), `_normalise_compound`, `_weather_reading` (present-but-None as missing,
+  same pattern as `pace_agent.py:642-643`), `_resolve_lap`, `_resolve_total_laps` (both
+  loud on fallback). `RaceState` imported lazily inside `build_race_state`. The
+  frozen-RaceState/CLI-mutation coupling is recorded in the module docstring, plus a
+  WHERE-TO-CHANGE consumer list.
+- **[2. arcade]** `src/arcade/strategy.py::_build_race_state` rewired: keeps the
+  radio/RCM sourcing from `self._radio_runner` + the stateful SC re-injection
+  (byte-identical logic), then delegates with
+  `risk_tolerance=self._request.risk_tolerance` and the two lists as params. The false
+  "duplicate ... so the arcade stays independent of backend.utils.race_state_builder"
+  docstring replaced with the accurate delegation one; `prev_lap_time` paragraph kept
+  as-is (out of scope). The long gap/pace comments moved to the canonical module, not
+  deleted. Lazy imports of `GAP_UNKNOWN_FALLBACK_S`/`RaceState` dropped (no longer used).
+  **One deliberate ordering note:** the position fail-loud now fires INSIDE the builder,
+  i.e. AFTER the radio/SC-tracker sourcing, whereas the old body raised before it. That
+  path is only reachable when `_lap_skip_reason`'s invariant already broke (the method's
+  own contract), so one extra `sc_tracker.ingest` on an errored lap is the only delta;
+  the audit test covering exactly this path still passes (below).
+- **[3. CLI]** `scripts/run_simulation_cli.py`: import block :1290-1301 (comment +
+  `_GAP_UNKNOWN_FALLBACK_S`) replaced by an accurate comment + `from
+  src.agents.race_state_builder import build_race_state  # noqa: E402`; the body of
+  `_build_race_state` replaced by `return build_race_state(lap_state, driver=driver_code)`
+  with the docstring updated (delegation + where the reasoning lives + the kept
+  `prev_lap_time` note). Signature and call site (:1711) untouched. **Surgical-edit
+  proof:** `git diff scripts/run_simulation_cli.py` shows exactly TWO hunks
+  (`@@ -1287,18 +1287,12 @@` and `@@ -1306,71 +1300,24 @@`); the radio/RCM main-loop
+  block 1710-1764 is byte-identical (no hunk touches it).
+- **[4. tests]** `tests/agents/test_race_state_builder.py` — 29 tests, two tiers:
+  pure-helper + leaf-guard tests run with no models/submodule; `build_race_state` tests
+  carry the sibling `data/models/lap_time` skipif (same convention as
+  `test_prev_lap_default_is_single_sourced.py`). The leaf test runs a FRESH subprocess
+  (`sys.executable -c`) asserting no `langchain*`/`langgraph*` module is loaded by
+  importing the builder. Every literal asserted against the module constant, never a
+  restated number.
+
+## Verification evidence (all executed)
+
+1. `uv run pytest tests/agents/test_race_state_builder.py -v` → **29 passed** in 12.01s.
+2. `uv run pytest tests/agents/ tests/audit/ tests/simulation/ -q` → **192 passed**
+   (baseline 163 + 29 new, **zero new failures**), 176.79s.
+3. `uvx ruff check src/agents/race_state_builder.py src/arcade/strategy.py
+   scripts/run_simulation_cli.py tests/agents/test_race_state_builder.py` →
+   "All checks passed!". (`ruff format` deliberately not run on `src/agents/**` — the
+   pyproject excludes it from formatting.)
+4. **Real PMV run:** `uv run f1-sim Budapest NOR McLaren --no-real-radios --no-llm` →
+   exit 0, "**All 70 lap(s) OK**", positions **P5 → P1 (+4)**, actions
+   **STAY_OUT·61 / PIT_NOW·5 / UNDERCUT·4**, final stint HARD/40, 1 compound switch,
+   wallclock 39.3s (0.6s/lap), best lap 79.918s. No `[ERROR]` rows.
+5. **Arcade (no GUI run, architectural evidence instead):**
+   `tests/audit/test_engine_scope_defaults.py::test_build_race_state_fails_loudly_instead_of_defaulting_position`
+   constructs a real `SimConnector` and calls the rewired `_build_race_state` end-to-end
+   (radio sourcing path with runner=None, SC tracker ingest, delegation, ValueError with
+   "position" in the message) — green in run 2. Grep confirms no other caller of the
+   arcade method and no test matching the old error-message strings.
+6. **Extra safety:** `uv run pytest tests/surfaces/ tests/infra/ -q` → **89 passed,
+   5 skipped** (missing optional deps + missing Qatar parquets). The PROCESS exits
+   -1073740004 (native crash during interpreter teardown, AFTER the full green summary).
+   **Verified pre-existing:** stashing only `run_simulation_cli.py` + `strategy.py` and
+   re-running reproduces the identical exit code with identical 89 passed/5 skipped —
+   unrelated to this change (test_dep_imports imports torch/whisper/onnx; known
+   teardown-crash shape on Windows).
+
+## Not done / open
+
+- `src/telemetry/**` untouched (by design): the backend still runs its own copy until
+  the submodule re-export commit + pointer bump land. The twin exists knowingly until
+  step 3 of the #784 sequence.
+- No commit, no push — working tree left dirty for orchestrator review.
+- The submodule showed `modified: src/telemetry (untracked content)` at session START —
+  pre-existing, not created here, not touched.
+
+---
+
+# Submodule half (#786) — `src/telemetry` (F1_Telemetry_Manager)
+
+Appended by the #786 implementation agent, 2026-08-02. Parent half above untouched.
+
+## What changed (2 files, +35/−168)
+
+1. **`backend/utils/race_state_builder.py` → re-export shim.** The whole local
+   implementation (module `_targeting_against_rival` + `build_race_state`) is replaced by
+   `from src.agents.race_state_builder import build_race_state` plus a docstring
+   explaining the seam. Before deleting, `_targeting_against_rival` was AST-extracted
+   from both files and compared: **source-identical, byte for byte** (`IDENTICAL SOURCE:
+   True`), so nothing was silently discarded. No other module imports
+   `_targeting_against_rival` (grep across the submodule: only its own definition/use).
+2. **`services/simulation/simulator.py`** — deleted `_compute_gap_ahead` (the fourth gap
+   copy, old lines 245-279) and its now-dead `GAP_UNKNOWN_FALLBACK_S` import (old line
+   30, used nowhere else in the file); `_local_build_race_state` stops passing
+   `gap_ahead_s` so the canonical builder derives it (None-means-compute), and its
+   docstring now says so instead of claiming it computes the gap from the rivals list.
+   `pace_delta_s` stays pinned at `0.0` (the #750 neutral) — the canonical builder could
+   now derive the rival-relative delta, but that is a real behavioural change to the
+   prompt and deliberately NOT taken under #786.
+
+## The `position is None` reachability question — answered
+
+The design gate's claim holds, and the concern is doubly moot:
+
+- `_local_build_race_state` has **exactly one caller** in the entire submodule:
+  `simulator.py:877` (grep over `src/telemetry/**`; no test imports it). That caller is
+  guarded at `:870` by `_lap_skip_reason`, which returns
+  `"incomplete lap (position is None)"` and `continue`s BEFORE the builder.
+- Even on a hypothetical breach of that guard, **the old code raised too**: the pre-#786
+  submodule `build_race_state` itself raised `ValueError` on `position is None` (old
+  lines 98-103). Old flow: `_compute_gap_ahead` returned a silent `0.0`, which was then
+  fed into a builder that raised anyway. So "silent 0.0 → raised exception" was never a
+  real delta — the 0.0 never survived to a `RaceState`. The per-lap
+  `try/except Exception` at `:875/:926` turns it into an SSE `error` event either way.
+
+## Call-site compatibility (the three untouched sites, argument-by-argument)
+
+- `simulator.py:~395` (`_local_build_race_state`): passes `pace_delta_s=0.0`,
+  `risk_tolerance`, `rcm_events` as kwargs → all exist on the canonical signature;
+  `gap_ahead_s` intentionally dropped (see above); `radio_msgs` omitted → `[]` both
+  before and after.
+- `api/v1/endpoints/strategy.py:1349` (`/recommend`): passes
+  `gap_ahead_s=request.gap_ahead_s`, `pace_delta_s=request.pace_delta_s` —
+  `RecommendRequest` declares both as **non-Optional floats with defaults**
+  (`strategy.py:110-111`), so they are never `None` and the canonical builder uses them
+  unchanged (client-override semantics identical). `risk_tolerance`, `radio_msgs`,
+  `rcm_events`, `rival` all map 1:1.
+- `mcp_tools.py:595`: `gap_ahead_s=driver_state.get("gap_ahead_s") or
+  GAP_UNKNOWN_FALLBACK_S` (never None), `pace_delta_s=0.0`, `radio_msgs=None` /
+  `rcm_events=None` → canonical maps None → `[]`, same as the old `or []`. Maps 1:1.
+
+All three call by keyword only; the canonical signature's extra `driver=None` kwarg is
+inert for them. **Zero changes needed — none made.**
+
+## Behavioural deltas the backend inherits by adoption (named, intended per #784)
+
+- `compound`: missing-key default `"MEDIUM"` → `"UNKNOWN"`, **plus** normalisation of
+  the live `"nan"`/`""`/`"None"` spellings (the delta that fires on real data).
+- `tyre_life` missing-key default `1` → `0`; `lap` resolution gains the driver-dict
+  fallback + `int()` cast; `total_laps` literal `57` → `DEFAULT_TOTAL_LAPS` (verified
+  `== 57`) + warning; present-but-`None` weather values now fall back instead of
+  crashing `float(None)`.
+- The `ValueError` message for position-None laps changes text (old: "Cannot build
+  RaceState: driver position is unknown…"; canonical: "build_race_state: driver position
+  is None…(#628, #465)"). `/recommend` returns it inside the 422 detail, so API clients
+  see the new wording. No submodule test asserts on the old string (grepped).
+
+## Verification (executed, real outputs)
+
+1. Shim identity, from parent root with `.venv/Scripts/python.exe` (sys.path = parent
+   root + `src/telemetry`): `backend.utils.race_state_builder.build_race_state IS
+   src.agents.race_state_builder.build_race_state` → **True**; `langchain` NOT in
+   `sys.modules` after the shim import (leaf discipline preserved).
+2. Submodule suite: `cd src/telemetry && PYTHONPATH="../..;." ../../.venv/Scripts/python.exe
+   -m pytest tests/ -q` → **116 passed, 1 skipped, 1 xfailed** in 9.44s. The skip is
+   `test_strategy_audit_fixes.py` at collection: `could not import 'fastmcp'` — the
+   parent venv does not carry the submodule-only `fastmcp` dep. **Pre-existing, not
+   caused by this change** (the skip guard is the module's own `importorskip`, present
+   on `main`). Not re-run under a submodule-local venv — noted as the one thing not
+   verified here; the submodule's own CI will run it deps-lite (where it skips on
+   pandas by design).
+3. End-to-end exercise of the absorbed gap logic through the real
+   `_local_build_race_state`: car ahead at −1.8 s → `gap_ahead_s=1.8`; interval `None` →
+   `GAP_UNKNOWN_FALLBACK_S=2.0` (the #633 distinction survives); leader → `0.0`;
+   `pace_delta_s=0.0` pinned. `hasattr(simulator, '_compute_gap_ahead')` → False.
+4. Ruff, submodule has no config of its own (no `[tool.ruff]`, no ruff.toml — CI runs
+   `--select=E9,F63,F7,F82`): CI-parity select → "All checks passed!"; full default
+   select on both touched files → "All checks passed!".
+
+## Not done / open (submodule half)
+
+- Commit made inside the submodule on `main`; **not pushed**; parent pointer NOT bumped
+  (orchestrator's step 3).
+- The real-run acceptance item (`/simulate` SSE + `/recommend` on Qatar 2025) belongs to
+  #787 per the issue text — not run here.
+- Untracked `.claude/` and `docs/migration/streamlit-reference/` in the submodule left
+  untouched, as instructed.
+
+---
+
+## CLI real runs on the Qatar 2025 reference case (orchestrator, #787 Task 2)
+
+Race directory `data/raw/2025/Lusail`, driver NOR, McLaren. Note the CLI takes the
+LOCATION name (`Lusail`), not the menu label (`Qatar`) — `GP_TO_LOCATION` maps the latter
+only inside the Arcade/webapp entry points.
+
+| Run | Command | Result |
+|---|---|---|
+| Deterministic, corpus disabled | `f1-sim Lusail NOR McLaren --no-real-radios --no-llm` | exit 0 · all 57 laps OK · P3 → P4 · STAY_OUT·55 UNDERCUT·2 · 0 errors · 99.2 s |
+| Deterministic, **real corpus** | `f1-sim Lusail NOR McLaren --no-llm` | exit 0 · all 57 laps OK · P3 → P4 · STAY_OUT·52 **PIT_NOW·3** UNDERCUT·2 · radio alerts 20 · **radio src corpus/24r·66rcm** · 253.3 s |
+
+The second run is the one that matters, and the first is why. `--no-real-radios` disables the
+OpenF1 corpus, which is exactly where lap 7's real `SAFETY CAR DEPLOYED` message lives — so the
+first run exercised the builder but NOT the reference case. Re-running with the corpus enabled
+ingested 24 radios and 66 RCM events and moved the decision distribution (three `PIT_NOW` laps
+appear that the corpus-disabled run never produced). That difference is the evidence that
+`radio_msgs`/`rcm_events` still reach the agents after the builder stopped populating them
+itself: the parameter-not-internal decision preserved the path end to end.
+
+Verified as NOT a regression from this change:
+- `Tire tool output did not parse for C2 (tyre_life=1)` appears 3 times in 57 laps. Traced to
+  `src/agents/tire_agent.py:1618-1620`, the pre-existing #436 conservative-stub fallback for a
+  tool-output regex miss. Unrelated to the lap_state -> RaceState mapping.
+
+Found while running, NOT caused by this change and NOT fixed here: `f1-sim` exits **0** after
+printing `[FATAL] Race directory not found` for an unknown GP. A CI harness checking the exit
+code would score that run as a pass. Worth its own issue; deliberately out of this epic's scope.
+
+Lint over every touched parent file (`ruff check src/agents/race_state_builder.py
+src/arcade/strategy.py scripts/run_simulation_cli.py tests/agents/test_race_state_builder.py`):
+All checks passed. Test suite `tests/agents tests/audit tests/simulation`: 192 passed.
+
+---
+
+## The fix was incomplete: #788 was NOT closed by the builder alone (orchestrator, 2026-08-02)
+
+The Arcade/backend gate proved over real HTTP that `/recommend` still returned **422 on the 2025
+reference lap** after the canonical builder landed. The builder no longer crashed; the crash had
+moved one layer DOWN, into the agents that read the RAW `lap_state` instead of the `RaceState`:
+
+- `race_situation_agent.py` `run_from_state` built its `session_meta` with `wx.get('air_temp', 28.0)`,
+  so the producer's present-`None` flowed to `_compute_weather_features` -> `float(None)` -> TypeError.
+  Line 1416 immediately below it WAS guarded, and `pace_agent.py:641-645` guarded the identical read
+  with a comment naming this exact crash. One twin fixed, two not.
+- `tire_agent.py` did the same, without crashing: the `None`s reached `_add_weather_cols` and the
+  TCN's feature frame.
+
+Fixed by lifting `pace_agent`'s working guard into a shared `reading_or_default` helper in
+`_shared_defaults.py` and migrating all three agents onto it, pace included — so there is one
+implementation rather than one guarded copy plus a helper for the others. The per-caller `default`
+argument is deliberate: pace uses 25/35 and tire/race_situation use 28/38, and reconciling those
+numbers is a modelling decision tracked in #789, not something to smuggle in behind a crash fix.
+
+A separate gap the sweep found and this session also closed: `tire_agent.run_from_state` and its
+twin `src/strategy/inference/no_llm.py::_tire_no_llm` re-derive `compound`/`tyre_life` from the RAW
+`lap_state` with the pre-#784 defaults (`"MEDIUM"`, `1`), bypassing the canonical builder entirely.
+Both now use `normalise_compound` and `UNKNOWN_TYRE_LIFE` (the normaliser was made public for this).
+
+### Executed evidence
+
+Deterministic no-llm path on the real backend producer's 2025 lap_state (zero LLM calls):
+
+```
+PRODUCER weather: {'air_temp': None, 'track_temp': None, 'track_temp_start': None,
+                   'humidity': None, 'rainfall': 0}
+build_race_state -> MEDIUM 7 25.0 35.0 6.001
+run_lap(profile="no-llm") -> STAY_OUT        # previously raised TypeError here
+```
+
+Tyre cliff on the same lap, before vs after:
+
+| lap_state weather | cliff P50 before (gate-measured) | cliff P50 after |
+|---|---|---|
+| `None` (backend producer, every 2025 lap) | 10.5 | 7.9 |
+| Real RSM readings 23.4 / 29.5 | 8.2 | 8.1 |
+
+The silent 2.3-lap optimistic error collapses to 0.2 laps. The residual 0.2 is honest — it is the
+distance between the declared default (28/38) and the real readings, i.e. the #782 data gap — and
+sits inside the TCN's own MC-Dropout variance.
+
+**Not verified here:** `/recommend` over real HTTP end to end. The LLM path needs an OpenAI
+connection that this environment does not currently have (`openai.APIConnectionError` on the
+ReAct call, an environment condition, not a code path). The deterministic profile exercises the
+exact feature-building code that raised, which is the crash site; the HTTP-level 200 should be
+re-confirmed once connectivity is available.

--- a/documents/audits/MEASURE_fresh_reference_quality_gate.md
+++ b/documents/audits/MEASURE_fresh_reference_quality_gate.md
@@ -111,15 +111,50 @@ model-capacity* contribution to that bound, which was sitting inside the number
 
 **This is a genuine, if partial, improvement to `deg_cost_s` as it exists on `main`
 today** (the term `driver_time_delta` already consumes, at 5 laps of exposure), not
-only to the parked deferral term. The 33% mean-error reduction and 60% bias reduction
-apply to production `deg_cost_s` the moment this ships, independent of #763/#771.
+only to the parked deferral term. It is non-regressive: on both seasons measured, the
+gated numbers are never worse than the baseline. See the 2025 addendum below for the
+size of the improvement that actually ships.
+
+## ⚠️ 2025 addendum (2026-08-01) — the training-season numbers above overstate the effect
+
+The 33% mean-error / 60% bias reduction was measured on `laps_tiredeg.parquet`, 2023-24
+only — the only parquet carrying N04's training target. That is legitimate for CHOOSING
+the 1.10 threshold (fitting it on 2025 would repeat the leak `src/strategy/eval/
+hygiene.py` already documents), but it was reported as "the fix's benefit" without ever
+checking whether it holds on the season the system actually ships against. It does not,
+by a wide margin.
+
+`scripts/measure_fresh_reference_gate_2025.py` runs the identical diagnostic on
+`laps_featured_2025.parquet` — the real, full 24-race 2025 season — reusing the same
+production functions (`_add_compound_cols`, `_compound_name_to_id`,
+`_reject_contaminated_laps`) rather than a second implementation of compound resolution
+or the gate:
+
+| | mean abs error | signed bias | stints w/ reference |
+|---|---|---|---|
+| 2023-24 baseline | 0.650 s/lap | +0.351 s/lap | 1714 / 1714 |
+| 2023-24 gated @ 1.10 | 0.434 s/lap (**-33%**) | +0.139 s/lap (**-60%**) | 1665 / 1714 (49 lost, 2.9%) |
+| 2025 baseline | 0.723 s/lap | +0.233 s/lap | 738 / 738 |
+| 2025 gated @ 1.10 | 0.712 s/lap (**-1.5%**) | +0.221 s/lap (**-5%**) | 734 / 738 (4 lost, 0.5%) |
+
+**The contamination rate itself is ~5x lower in this 2025 sample than in 2023-24**
+(0.5% of stints lost their reference vs 2.9%) — not a sampling artefact, `laps_featured_
+2025.parquet` covers the entire 24-race calendar. The defect this PR fixes is real, the
+fix is correct and does not regress anything, but it is materially rarer in the season
+that ships than in the seasons used to characterise it. **Quote the 2025 numbers, not
+the 2023-24 ones, when describing what this buys in production.**
+
+This does not change the #763/#771 verdict either way: 0.712 s/lap is still far above
+the ~0.1 s/lap bar that decision needs.
 
 ## Reproducing
 
 ```bash
-uv run python scripts/measure_fresh_reference_gate.py
+uv run python scripts/measure_fresh_reference_gate.py        # 2023-24, the threshold's own training data
+uv run python scripts/measure_fresh_reference_gate_2025.py   # 2025, the held-out season that ships
 ```
 
 Related: `MEASURE_744a_tyre_reference.md` · `MEASURE_763_ship_decision.md`
 (`feat/deferral-tyre-liability`) · `scripts/measure_deg_error_bound.py`
-(same branch, the original bound this note decomposes)
+(same branch, the original bound this note decomposes) ·
+[[feedback_measure_on_the_season_that_ships]] (Claude memory — the general lesson)

--- a/documents/audits/MEASURE_fresh_reference_quality_gate.md
+++ b/documents/audits/MEASURE_fresh_reference_quality_gate.md
@@ -147,6 +147,35 @@ the 2023-24 ones, when describing what this buys in production.**
 This does not change the #763/#771 verdict either way: 0.712 s/lap is still far above
 the ~0.1 s/lap bar that decision needs.
 
+## What the remaining 2025 error actually is, and why it is closed rather than chased
+
+Decomposing the 2025 baseline the same way as the training-season one, the residual
+(`pred - target`) is **not** dominated by outlier stints — it grows smoothly and
+monotonically with tyre life across the whole dataset, from ~0 at the fresh band to
+**+0.78 s/lap mean at 30+ laps**, with no equivalent trend on 2023-24 (which stays flat
+at +0.05 beyond the fresh band). It also varies by circuit in both directions (Las
+Vegas/Baku/Montréal correlate +0.7 to +0.9 with tyre life; Miami/Sakhir/Shanghai
+correlate -0.5 to -0.6). Checked and ruled out: the same duplicate-`TyreLife`
+within-stint artefact found in 2023-24 (only 6 of 1134 2025 stints affected, far too few
+to produce this pattern).
+
+**This is a genuine train/2025 generalisation gap in the TCN itself, not a bug.** No
+further code fix chases it in this project's current scope — a system without a real
+F1 team's telemetry, spotter radio, or proprietary tyre data will not match one on this
+axis, and that is an accepted limitation rather than an open item.
+
+**It does not newly endanger the Monte Carlo.** `deg_cost_s` has been live in both
+scorers since #744b/#760, so the epic's own headline numbers (43.4% exact-lap agreement,
+52.8% within one lap) already have this error baked in — nothing here is a fresh risk on
+top of measured system behaviour. `_tyre_cost_s` (`position_projection.py`) multiplies
+`deg_cost_s` by `old_laps`, bounded by the projection window (~5 laps by default), so the
+mean 2025 bias (+0.221 s/lap) integrates to roughly 1.1 s of phantom cost per decision —
+small against the 22.8 s pit loss it is weighed against, and floored/ceilinged
+(`deg_cost_floor_s`/`deg_cost_ceiling_s`) regardless. The one place it bites hardest is
+long stints (30+ laps), which is exactly the regime the deferral term (#771, 40 laps of
+exposure, 8x this term's) is blocked from reaching — this finding reinforces that block,
+it does not add a new one.
+
 ## Reproducing
 
 ```bash

--- a/documents/audits/MEASURE_fresh_reference_quality_gate.md
+++ b/documents/audits/MEASURE_fresh_reference_quality_gate.md
@@ -1,0 +1,125 @@
+# Fresh-reference quality gate — root cause and measured effect
+
+**Date:** 2026-08-01 · **Instrument:** `scripts/measure_fresh_reference_gate.py`
+**Sample:** 31,624 laps at tyre life > 3, across 1,714 stints with a usable fresh
+reference, seasons 2023-24 (training only).
+
+**Result: `deg_cost_s`'s error bound (0.650 s/lap mean absolute, +0.351 s/lap signed
+bias — `feat/deferral-tyre-liability`, `MEASURE_763_ship_decision.md`) is not evenly
+spread across laps. A handful of stints have a contaminated fresh-reference lap, and
+gating that lap on race pace cuts mean absolute error to 0.434 s/lap and signed bias
+to +0.139, at a cost of 49 of 1,714 stints (2.9%) losing their reference and falling
+back to `None` → `FRESH_GAIN`.**
+
+---
+
+## Where the epic's own bound was measured, and what it didn't decompose
+
+`MEASURE_763_ship_decision.md` published the aggregate bound and, correctly, said the
+bound belongs to `deg_cost_s` as a class — `driver_time_delta` already consumes the
+same input on `main` today. It did not ask WHERE inside that population the error
+concentrates. This note answers that question and ships a fix for the part of it that
+is a data-quality gap rather than a property of the model.
+
+## The mechanism
+
+`deg_cost_s = cumulative_deg_s(now) − cumulative_deg_s(fresh reference)`. The fresh
+reference is a second deterministic TCN pass over the stint's own early laps
+(`TireAgent._fresh_reference`, tyre life ≤ 3). Grouping the raw per-lap residual
+(`pred − target`) by tyre-life band shows almost no drift — mean +0.03 to +0.08 s/lap
+beyond the first few laps, correlation with tyre life +0.04 to +0.11 per compound.
+**The model's own predictions are not what grows.**
+
+What grows is the **fresh-reference residual**, and only for the subset of stints that
+happen to run long: grouped by each stint's own max tyre life, the per-stint
+fresh-reference residual is essentially flat in the MEDIAN (0.01 to 0.04 s/lap across
+every band) but the MEAN at 30+ laps is **−0.691**, dragged there by a tail — one stint
+at **−53.989 s** and another at **−46.454 s**, both from **Mexico City 2023**; five
+more between −4 and −8 s from **Monaco 2024** and **Melbourne 2023**.
+
+Pulling the full lap sequence for the worst case (car 4, Mexico City 2023):
+
+| LapNumber | Stint | TyreLife | LapTime_s | FuelAdjustedDegAbsolute |
+|---|---|---|---|---|
+| 36 | 4 | 3 | **137.757** | 0.000 (the baseline lap) |
+| 37 | 4 | 4 | 84.243 | **−53.459** |
+| 38 | 4 | 5 | 83.841 | **−53.806** |
+
+Green-flag pace at this circuit is ~83 s. Lap 36 is a Safety-Car/red-flag-affected lap
+that FastF1 apparently did not mark inaccurate. N04's target is defined relative to
+*this stint's own baseline lap* — here, that anomalous 137.8 s lap — so every
+subsequent lap reads as ~54 s "faster than fresh," which is not tyre wear, it is the
+zero point being wrong by 54 seconds.
+
+**`track_status_clean` — the column that should catch this — is dead.**
+`_add_session_cols`'s own docstring already says so: it is a constant 0 across every
+row of every featured parquet, because N04's `IsAccurate` gate does not catch every
+neutralised lap. This stint's lap 36 is the counter-example that falsifies the
+docstring's stated reason ("every lap that survives is genuinely green"): it survived,
+and it is not green by any reasonable reading of 137.757 s at a ~83 s circuit.
+
+Two more things worth recording, both checked and both negative:
+
+- The model's prediction on the **current** (non-reference) lap is not similarly
+  contaminated: additionally dropping laps whose own `pct_of_fastest` exceeds the
+  threshold removes only 0.3% of scored rows and moves the bound by <0.01 s/lap.
+- `LapsSincePitStop == 0` (a literal pit-exit out-lap) does not co-occur with these
+  reference laps in the training data — this is a caution-period artefact, not an
+  out-lap artefact, and the existing docstring's second stated cause ("an out-lap or a
+  standing start") is not what this measurement finds driving the tail.
+
+## The fix, and why this signal and not a new one
+
+`lap_time_pct_of_race_fastest` is already one of the TCN's 42 input features,
+computed unconditionally in `_add_session_cols` from `session_meta['fastest_lap_s']`
+— available at exactly the point `track_status_clean` should have been, at zero new
+data cost. Mexico City 2023's lap 36 reads **1.694** on it; the population of 1,822
+training-season fresh-reference laps has median **1.046**, p95 **1.181**, p99
+**1.464** — a long, well-separated tail.
+
+`TireAgent._fresh_reference` now drops any candidate lap above
+`cfg.fresh_reference_max_pct_of_fastest` (default **1.10**) before building the
+reference tensor, via the pure, leaf-level `_reject_contaminated_laps`. If every
+candidate is rejected, it returns `None` — never falls back to a contaminated lap —
+matching the doctrine `_referenced_wear` already applies to a missing half: a wrong
+reference is worse than none.
+
+## Threshold sweep (why 1.10, not looser or tighter)
+
+| threshold | mean abs error | signed bias | stints losing their reference |
+|---|---|---|---|
+| none (baseline) | 0.650 | +0.351 | 0 |
+| **1.10 (shipped)** | **0.434** | **+0.139** | 49 (2.9%) |
+| 1.15 | 0.478 | +0.183 | 20 |
+| 1.20 | 0.502 | +0.208 | 16 |
+| 1.25 | 0.534 | +0.242 | 12 |
+
+1.10 gives the largest error reduction for a coverage cost that stays under 3%.
+Tighter thresholds recover fewer stints' worth of contamination for a shrinking
+marginal gain; looser ones leave more of the tail in.
+
+## What this does NOT claim
+
+**The bound is reduced, not closed.** 0.434 s/lap mean absolute error is still above
+the 0.1 s/lap perturbation `MEASURE_763_ship_decision.md`'s amplification table was
+measured at, and +0.139 s/lap of remaining bias, integrated over a long stint, is
+still a real number. This note does not reopen the #763 ship decision — `deg_cost_s`
+still needs a smaller bound before the deferral liability term can carry it, and nothing
+here changes that verdict. What it does is remove a *known, root-caused, unrelated-to-
+model-capacity* contribution to that bound, which was sitting inside the number
+`MEASURE_763_ship_decision.md` published without being separated out.
+
+**This is a genuine, if partial, improvement to `deg_cost_s` as it exists on `main`
+today** (the term `driver_time_delta` already consumes, at 5 laps of exposure), not
+only to the parked deferral term. The 33% mean-error reduction and 60% bias reduction
+apply to production `deg_cost_s` the moment this ships, independent of #763/#771.
+
+## Reproducing
+
+```bash
+uv run python scripts/measure_fresh_reference_gate.py
+```
+
+Related: `MEASURE_744a_tyre_reference.md` · `MEASURE_763_ship_decision.md`
+(`feat/deferral-tyre-liability`) · `scripts/measure_deg_error_bound.py`
+(same branch, the original bound this note decomposes)

--- a/documents/audits/SWEEP_present_none_traps.md
+++ b/documents/audits/SWEEP_present_none_traps.md
@@ -1,0 +1,228 @@
+# SWEEP — present-`None` traps (`dict.get(k, default)` / `Series.get(k, default)` / `x.get(k) or DEFAULT`)
+
+**Date:** 2026-08-02 · **Branch:** `refactor/single-source-race-state-builder` · **Scope:** parent repo + `src/telemetry` submodule.
+**Role:** adversarial gate + inventory. No repository file modified except this report.
+
+## Bug class
+
+`dict.get(key, default)` fires its default only when the KEY is missing. The producers below deliberately emit
+unmeasured readings as key-present-holding-`None`, so a consumer's `.get(k, default)` returns `None` and the
+default silently never fires. Confirmed prior consequences: #788 (crash, `/recommend` 422 on every 2025 lap) and
+the tire_agent cliff estimate moving 2.3 laps optimistic.
+
+## Producers that emit present-`None` (verified at file:line)
+
+| Producer | Keys that can be `None` |
+|---|---|
+| `src/simulation/race_state_manager.py:282` `get_driver_state` | `lap_time_s`, `prev_lap_time`, `sector1_s..3_s`, `position`, `gap_to_leader_s`, `compound_id`, `tyre_life`, `stint`, `stint_baseline_tyre_life`, `speed_i1/i2/fl/st`, `fuel_load` |
+| `src/simulation/race_state_manager.py:376` `get_rival_states` | `position`, `lap_time_s`, `tyre_life`, `stint`, `speed_st`, `gap_to_leader_s`, `interval_to_driver_s` |
+| `src/simulation/race_state_manager.py:446` `get_weather_state` | `air_temp`, `track_temp`, `humidity`, `wind_speed`, `track_temp_start` (note: `rainfall` defaults to `False`, never `None`; keys absent entirely when `weather_df is None`) |
+| `src/telemetry/backend/api/v1/endpoints/strategy.py:372` `_safe_none` | backend lap-state fields: TyreLife, weather (AirTemp/TrackTemp/Humidity), SpeedST, Position |
+
+## Method
+
+AST-based scan (not grep): every two-arg `.get(...)` call, every `x.get(k) or DEFAULT`, and every
+`float(...)/int(...)` wrapping a `.get(...)`, across `src/agents/`, `src/simulation/`, `src/arcade/`,
+`src/strategy/`, `scripts/`, `src/f1_strat_manager/`, and the whole `src/telemetry/backend/` submodule.
+Each candidate then verified by hand against the producer that feeds it; reachability claims verified by
+executing Python against the shipped parquets / real producers.
+
+## Findings
+
+<!-- appended incrementally as confirmed -->
+
+### Batch 1 — code-level confirmations (reachability experiments follow in Batch 2)
+
+**F1. `src/agents/tire_agent.py:1479` — `tyre_life = d.get('tyre_life', 1)` in `run_from_state` — the unfixed twin INSIDE the just-fixed function.**
+The same `run_from_state` that this branch migrated to `reading_or_default` for the four weather keys (lines 1518-1521) still reads
+`tyre_life` with the two-arg get four lines above. Producers that emit `tyre_life` as present-`None`: RSM `get_driver_state`
+(race_state_manager.py:354, NaN -> None) and the backend `/lap-state` builder (strategy.py:491 `_safe_none(r.get("TyreLife"))`).
+The `None` flows into `_run_core(driver, compound_id, tyre_life, gp_name)` -> prompt "tyre life None laps" (LLM path), and on the
+no-LLM path `_get_driver_stint(driver, None)` evaluates `self.laps_df['TyreLife'] <= None` (tire_agent.py:1083) -> TypeError.
+Guards that DO exist upstream: the backend simulator skips such laps (`_lap_skip_reason`, simulator.py:279) and the CLI mirrors it —
+but `/recommend` (backend strategy.py:1317) and MCP `recommend_strategy` (mcp_tools.py:566) have NO such guard: they only refuse
+position-None laps (via `build_race_state`'s ValueError). Consequence: CRASH (422/500 on /recommend) or LLM-mediated SILENT-WRONG,
+IF a shipped row has Position present and TyreLife NaN — measured in Batch 2.
+
+**F2. `src/strategy/inference/no_llm.py:135-136` — `compound = d.get("compound", "MEDIUM")` / `tyre_life = d.get("tyre_life", 1)` — second twin pair.**
+`_tire_no_llm` re-derives the same two values `run_from_state` derives (its own docstring says so), with the same two-arg get.
+`tyre_life=None` is pre-bound into the tool args and `_NullReActRunner.invoke` (no_llm.py:92-99) executes `tool.invoke(kwargs)` with
+no exception handling -> pydantic tool-args validation error or the same `<=` TypeError. `compound=None` would crash one line later
+at `compound.startswith("C")` (AttributeError), but no current producer emits compound as None (RSM: `str(...)` at
+race_state_manager.py:352; backend: `str(...)` at strategy.py:489/912) — compound-None is LATENT (hand-built lap_state only);
+tyre_life-None is as reachable as F1 on any no-guard no-llm path.
+
+**F3. `src/agents/race_situation_agent.py:918` + `src/agents/pit_strategy_agent.py:1053-1067` — the recorded CLAUDE.md §11 `Series.get` sites are still live expressions.**
+`float(x_row.get('Position', 10))`, `float(x_row.get('TyreLife', 10))` (pit, N16 undercut features) and
+`float(driver_x_lap.get('SpeedST', 300.0))` (situation, N12 overtake features) read pandas Series rows: a stored NaN is returned
+as NaN, never the default, and `float(NaN)` = nan flows into the LightGBM feature frame (LightGBM treats NaN as missing — model-
+defined branch, silently). The #462 liveness guard prevents the retired-car case, but NaN on a LIVE car's row is unguarded.
+Adjacent and harder: race_situation_agent.py:914-915 `int(driver_x_lap['TyreLife'])` raises ValueError on NaN — a crash site
+one line above the silent one. Reachability measured in Batch 2 (NaN counts on featured frames).
+
+**F4. Backend has TWO lap-state producers and they answer "missing weather" differently.**
+`/lap-state` (strategy.py:574-583) emits `air_temp/track_temp/humidity` via `_safe_none` -> honest present-`None` (the #788 shape).
+`_build_lap_state_from_row` (strategy.py:890-949, used by /pace-range at line 695) emits
+`float(_s(row.get("AirTemp", 25)))` (25/40/50 fabricated when the 2025 columns are ABSENT — Series.get default fires on a missing
+column) and, worse, `_s` coerces a present NaN to **0** -> `air_temp: 0.0` degC on any 2023/24 row with NaN weather. Also
+`speed_st`: `_safe_none` on /lap-state (None) vs `_s(...,0)` here (0.0). Only the pace agent consumes this second producer today,
+and its `d.get('speed_st') or 300.0` happens to absorb the 0.0 — the 25-vs-None weather divergence feeds
+`run_pace_agent_from_state`'s `reading_or_default(wx,'air_temp',25.0)` equally (default==fabrication, coincidentally identical),
+so TODAY the consequence is nil; the trap is structural (next consumer of this producer inherits fabricated readings).
+
+**F5. `src/telemetry/backend/mcp_tools.py:599` — `driver_state.get("gap_ahead_s") or GAP_UNKNOWN_FALLBACK_S` — #633-class zero-swallow, or-form inventory.**
+The /lap-state producer ALWAYS emits `gap_ahead_s` as a float and uses `0.0` both for "leader, honest" (drv_pos==1) and for
+"cum-times unresolved" (strategy.py:472-476). The `or` then rewrites the LEADER's honest 0.0 into the 2.0 fallback, so every MCP
+`recommend_strategy` call for the race leader hands the orchestrator a fabricated 2.0 s gap to a car that does not exist.
+Reachable today on any P1 request. SILENT-WRONG (prompt + MC read gap_ahead_s), or-form class.
+
+**F6. `strategy_orchestrator.py:1874/1875/1888/1891` — flat-lap_state two-arg gets (`laps_since_pit`, `fuel_load`, `prev_speed_st`, `humidity`) — LATENT.**
+These live in `_run_always_on_agents` (the FastF1 flat path). Its only production caller is `run_strategy_orchestrator`
+(strategy_orchestrator.py:2269), which no shipped surface calls (grep: only notebooks/tests); every surface routes through
+`run_lap`/`_run_always_on_agents_from_state`, whose adapters guard. If a caller ever feeds the flat path a dict carrying
+`humidity: None` etc., the None reaches `run_pace_agent` unguarded. Latent, inventory only.
+
+### Batch 2 — executed evidence (venv python, pandas 2.3.3, langgraph 1.2.5)
+
+**E1. Semantics, proven in this environment:**
+- `pd.Series([1.0,5.0,nan]) <= None` -> `[False, False, False]` — NO TypeError in pandas 2.3.3. So `_get_driver_stint`'s
+  `TyreLife <= None` (tire_agent.py:1083) yields an EMPTY window -> tool returns "No laps found" -> `_conservative_stub`.
+  F1's consequence is therefore SILENT degradation to the stub, not a crash, on this pandas.
+- `Series.get('SpeedST', 300.0)` with stored NaN -> returns `nan` (default dead); with ABSENT key -> default fires. (CLAUDE.md §11 confirmed.)
+- LangChain `@tool ... tyre_life: int` invoked with `tyre_life=None` -> `ValidationError` (proven). That is the no-llm
+  `_tire_no_llm` path's failure mode — but both no-llm surfaces (CLI, /simulate) guard tyre_life-None laps out first.
+- `int(float('nan'))` -> `ValueError: cannot convert float NaN to integer`.
+- langgraph 1.2.5 `_default_handle_tool_errors`: returns a message ONLY for `ToolInvocationError` (arg validation);
+  **any exception raised inside the tool body is RE-RAISED**. A ValueError inside `predict_overtake_tool` therefore
+  aborts the whole ReAct invoke — on `/recommend` that surfaces as a 422 (`except (KeyError, TypeError, ValueError)`
+  at backend strategy.py:1365), the exact #788 failure shape via a different field.
+
+**E2. Shipped-data holes (the reachability driver), measured:**
+- `laps_featured_2025.parquet`: 48 cols vs 53 in 2023/2024. Missing: `AirTemp, TrackTemp, Humidity, Rainfall` (the #782/#788
+  root) **plus `lap_time_pct_of_race_fastest`** — the latter is recomputed unconditionally by its consumers
+  (tire_agent.py:752, eval scripts rebuild it), so no extra blast radius from that column.
+- **`TyreLife` NaN with Position PRESENT: 451 rows in featured 2025** — Miami laps 4-24 (379 rows, 19 drivers = the whole
+  field), Spa-Francorchamps laps 28-44 (70 rows: ANT/ALO/HUL/COL/SAI), Melbourne 42-43 (BEA). `Stint` NaN on 379 of them.
+  Featured 2023: 35 rows (TSU, Montreal 36+). Featured 2024: ZERO. Raw frames: 561 rows across 79,032; plus 101 Position-NaN
+  and 6,872 SpeedST-NaN raw rows (featured: 1,889-2,068 SpeedST NaN per season). Raw Compound NaN/empty: 538 rows.
+- All 71 `data/raw/<year>/<race>/weather.parquet` files: **zero NaN in every column** (confirms race_state_builder's claim and
+  makes the arcade weather-panel trap latent with shipped data).
+
+**E3. The concrete reachable scenario for the race_situation crash:** Spa-Francorchamps 2025, laps 31-33: COL runs P19 with
+TyreLife NaN in BOTH the raw and featured frames while HAD sits P20 with a clean row (TyreLife 11/12/13). HAD passes every
+surface's own-driver guard; N27 derives rival_ahead=COL; `predict_overtake_tool` reads COL's row and
+`int(driver_y_lap['TyreLife'])` (race_situation_agent.py:915) raises ValueError. no-llm: `_situation_no_llm` invokes the tool
+directly -> per-lap ERROR event. rich: langgraph re-raises -> lap aborts (422 on /recommend). At Miami 2025 laps 4-24 the
+OWN-driver row is NaN for 19 drivers, so /recommend and MCP (no guard) hit the same ValueError via driver_x for nearly any
+driver/lap in that window; the three replay surfaces instead skip those laps wholesale (INCOMPLETE), which is its own
+degradation: ~21 laps of Miami 2025 produce no strategy call at all.
+
+### Correction to F3 (pit half) — the pit agent is GUARDED; race_situation is the twin that never got the fix
+
+`pit_strategy_agent.py:983-996` refuses undercut scoring when Position OR TyreLife is NaN on either car (its comment even
+cites the same 561-row measurement reproduced above), so the `.get('Position', 10)` defaults at 1053-1067 are documented
+dead code, not a live trap. **`race_situation_agent._build_overtake_features` has NO equivalent guard**: `predict_overtake_tool`
+(race_situation_agent.py:1112-1154) checks lap range and liveness only, then `int(driver_x_lap['TyreLife'])` at :914-915
+crashes and `float(...get('SpeedST', 300.0))` at :917-918 silently feeds NaN. One twin fixed, the other not — the recorded
+CLAUDE.md §11 / twin-that-never-got-the-fix shape, live today.
+
+## Inventory
+
+### 1. Reachable today with shipped data
+
+| # | Site | Consequence | Evidence |
+|---|---|---|---|
+| R1 | `race_situation_agent.py:914-915` `int(driver_x_lap['TyreLife'])` (and `driver_y`) | **CRASH** — ValueError aborts the lap; 422 on `/recommend`, ERROR event on `/simulate` no-llm and CLI --no-llm; rich replay surfaces abort the lap too (langgraph re-raises) | E3: Spa 2025 laps 31-33 HAD-behind-COL (all surfaces); Miami 2025 laps 4-24 any driver via /recommend and MCP (E2: 451 featured rows) |
+| R2 | `tire_agent.py:1479` `d.get('tyre_life', 1)` + `no_llm.py:136` twin | **SILENT-WRONG** — prompt reads "tyre life None laps"; window mask empties (E1) -> conservative stub presented every affected lap; backend also emits `stint: 0` (`_safe`, strategy.py:492/915) which empties the stint filter regardless | Reachable via `/recommend` + MCP `recommend_strategy` (no guard); same 451 rows. Replay surfaces guarded (CLI run_simulation_cli.py:1596-1616, arcade strategy.py:399, simulator.py:258-283) |
+| R3 | `race_situation_agent.py:917-918` `float(Series.get('SpeedST', 300.0))` | **SILENT-WRONG** — stored NaN (never the 300.0) into N12's `speed_trap_delta`; LightGBM routes it down the missing branch | 1,889 SpeedST-NaN rows in featured 2025 (E2); reaches the model whenever the paired rows survive the R1 crash line (both TyreLife present, one SpeedST NaN) |
+| R4 | `mcp_tools.py:599` `driver_state.get("gap_ahead_s") or GAP_UNKNOWN_FALLBACK_S` | **SILENT-WRONG (or-form, #633 class)** — /lap-state emits the LEADER's honest `gap_ahead_s: 0.0` (strategy.py:472); `or` rewrites it to 2.0, a fabricated car ahead of P1 | Reachable on any MCP recommend for the P1 driver; producer always emits the key as a float |
+| R5 | Featured-2025 data holes beyond weather | TyreLife/Stint NaN holes (Miami 4-24 field-wide, Spa 28-44, Melbourne 42-43) are the reachability driver for R1/R2 and also cost the replay surfaces ~21 laps of Miami outright | E2; #782's blast radius is wider than the four weather columns |
+
+### 2. Latent (unguarded read, no current producer emits the value)
+
+- `no_llm.py:135` + `tire_agent.py:1478` + `pit_strategy_agent.py:1460` `compound` present-None -> `.startswith`/`.upper()` AttributeError. Both producers emit `str(...)` (RSM :352, backend :489/:912) — only hand-built lap_state JSON on /recommend reaches it.
+- `strategy_orchestrator.py:1874/1875/1888/1891` flat-path two-arg gets (`laps_since_pit`, `fuel_load`, `prev_speed_st`, `humidity`) — the FastF1 flat entry `run_strategy_orchestrator` has no production caller (grep: notebooks/tests only).
+- **`src/arcade/data.py:597-603` + `src/arcade/overlays.py:129-134` — the weather panel trap, with a docstring that lies**: `_weather_row_to_dict` deliberately emits present-`None` on a NaN FastF1 weather sample and its docstring claims the panel's `.get(key, default)` default then fires — it does not; `f"{None:.1f}"` raises TypeError in `WeatherPanel.draw`. Latent only because shipped weather has zero NaN (E2); a live FastF1 feed with one NaN sample crashes the arcade overlay.
+- `tire_agent.py:1440-1448` (FastF1 `run()` path): `session.weather_data.mean()` of an all-NaN column -> stored NaN via `Series.get('AirTemp', 28.0)` -> `float(nan)` into session_meta. Notebook/FastF1 path only.
+- `tire_agent.py:586` `_add_weather_cols` `session_meta.get(col, 0.0)` — every current caller sets all four keys (run :1440, run_from_state :1518, /tire-range :1022); a future caller that omits one fabricates 0.0 degC.
+- `scripts/debug_agent.py:306-308` `lap_state["weather"].get("air_temp", 28.0)` — debug harness, same trap shape if fed RSM weather with None.
+- `race_situation_agent.py:681-684` + `pit_strategy_agent.py:892-894` session_meta two-arg gets — all production adapters populate these guarded; FastF1/hand-built paths could pass None through.
+- Backend `_build_lap_state_from_row` (strategy.py:890-949): fabricates 25/40/50 weather when columns are absent and `_s` coerces present NaN to 0 (`air_temp: 0.0`); today only /pace-range consumes it and the pace agent's guards/defaults happen to absorb everything — the next consumer inherits fabricated readings. (F4.)
+- Arcade dashboard formatters (`agent_formatters.py:94-98/146-150/206-210`, `reasoning_tabs.py:120-165`): two-arg gets over dataclass-serialized outputs whose fields are non-Optional floats today; `TireOutput.current_tyre_life=None` (from `_conservative_stub` under R2) would render as the string "None" — cosmetic.
+- CLI display gets (`run_simulation_cli.py:1258-1262/1803-1805`): `rival_data.get("position", "?")` renders `None` instead of `?` for a position-less rival — cosmetic only (RSM sorts them to the back).
+
+### 3. Harmless / correctly guarded (verified, do not re-audit)
+
+- `src/agents/race_state_builder.py` — every read guarded: `_weather_reading` handles present-None; position None raises by design; `tyre_life`/compound normalised; `rainfall` `bool(None)` -> False is the honest degradation. Verified line by line.
+- `pace_agent.py:626-704` (`run_from_state`) — the migrated site is correct; every remaining read is `or`-form or deliberately honest (`position` passes None to XGBoost's native-missing path). `tyre_life or 1` cannot swallow a real 0: TyreLife==0 occurs zero times in 2023-2025 (race_state_builder.py:77 measurement).
+- `race_situation_agent.py:1406-1420` + `tire_agent.py:1518-1521` — the two migrated weather blocks are correct; `wx.get('track_temp_start') or 38.0` correctly None-safe (0.0 degC track temp does not occur in the dataset).
+- `pit_strategy_agent.py:983-996` — NaN guard makes the 1053-1067 Series.get defaults dead code (documented as such in-file).
+- `race_state_manager.py` `r.get(...)` sites — all wrapped in `pd.notna(...)` ternaries; this IS the producer's honest-None pattern.
+- `position_projection.py` — all `(x or {})` chains; `_finite_or_none` collapses None/NaN/inf at the boundary (strategy_orchestrator.py:913-928).
+- `strategy_orchestrator.py:829-830/1163` — `or`-guarded context reads; `rival.get("is_pitting", False)` wrapped in `bool()` so the backend's present-None is read as False (honest: unknown != pitting is a documented degradation).
+- Static-map/env/display gets across arcade dashboard, CLI tables, backend chat/llm_service, eval CLIs, radio/NLP/rag payloads — defaults on dicts the same module builds, or pure display.
+- `simulation/__main__.py`, `replay_engine.py`, `stint_history.py:144` — display/string sites, `or`-guarded where numeric.
+- Guards confirmed present and equivalent on all three replay surfaces: CLI (:1596-1616), arcade (strategy.py:394-402), backend simulator (:258-283).
+- eval-only `or`-forms (`decision_modes.py:301-305`, `prompt_ab/gen_inputs.py:60-66`): `gap_ahead_s or 2.0` would swallow a legitimate 0.0 gap, but their states come from RSM `get_driver_state`, which never emits `gap_ahead_s` at all (key absent) — #633-class only if ever fed backend states; tyre_life handled the honest way in decision_modes (:302).
+
+## The three already-fixed sites: verdict
+
+`pace_agent.py:647-649`, `tire_agent.py:1518-1521`, `race_situation_agent.py:1406-1408` all correctly route through
+`reading_or_default`, which handles both absent-key and present-None (read and verified). The helper's docstring is accurate.
+**But the fix is incomplete IN THE SAME FUNCTIONS**: `tire_agent.run_from_state` still reads `tyre_life` (:1479) with the
+two-arg get 39 lines above its fixed weather block, and the same producers that motivated the weather fix emit `tyre_life`
+as present-None on 451 shipped 2025 rows. `race_state_builder` guards `RaceState`, but the sub-agent adapters read the raw
+`lap_state` directly, so the builder's `UNKNOWN_TYRE_LIFE` never protects them.
+
+## What I tried to break and could not
+
+- `race_state_builder.build_race_state`: tried weather-None, rainfall-None, compound "nan"/None, tyre_life None, missing
+  lap_number/total_laps, empty rivals — every path lands on a guard, a warning, or the deliberate position ValueError.
+- The `pd.Series <= None` crash I expected for `_get_driver_stint`: pandas 2.3.3 returns all-False instead of raising
+  (executed), so that specific crash claim in my own Batch 1 draft did not survive its own verification.
+- `pit_strategy_agent` undercut scoring with NaN rows: the :983 guard refuses before any NaN reaches the model.
+- The five missing 2025 featured columns beyond weather: `lap_time_pct_of_race_fastest` is recomputed by every consumer.
+- Shipped `weather.parquet` NaN (would arm the arcade panel trap and the RSM weather-None path): zero NaN in all 71 races,
+  every column.
+- `rainfall`: no producer emits it as None (RSM: False; backend: int; builder wraps in bool()).
+
+## Could not determine
+
+- Whether the LIVE FastF1 feed (arcade SessionLoader, `session.weather_data`) ever carries NaN samples — shipped parquets
+  do not, but they are a different artifact from the FastF1 cache the arcade reads; the panel trap's reachability in a live
+  session is unmeasured.
+- Rich-mode LLM behaviour when the prompt says "tyre life None laps" (what integer the model invents) — bounded by the
+  empty-window stub either way, but the exact numbers shown to the orchestrator vary per call.
+- End-to-end HTTP confirmation of the /recommend 422 at Spa/Miami (server runs are owned elsewhere); the chain is proven at
+  module level: data row -> producer emission (`_safe_none`) -> unguarded read -> exception semantics (E1).
+
+---
+
+## Addendum (2026-08-02, after this sweep was written)
+
+Two of the sites recorded above as unfixed were closed on the same branch, AFTER this
+sweep ran. This note exists because a reader grepping the audit trail later would
+otherwise believe they are still open.
+
+- **F1/F2 (`tire_agent.run_from_state` `tyre_life` at :1479 and `compound` at :1478, plus
+  the twin in `src/strategy/inference/no_llm.py::_tire_no_llm`)** — FIXED. Both now derive
+  through the canonical `normalise_compound` and `UNKNOWN_TYRE_LIFE` from
+  `src/agents/race_state_builder.py` instead of restating the pre-#784 defaults
+  (`"MEDIUM"`, `1`). Verified safe by the final correctness gate: every 2025 row carrying
+  a degraded compound spelling also carries a NaN `TyreLife`, both the old and new paths
+  produce an empty stint window and therefore the same conservative stub, and the scalar
+  `tyre_life` never reaches the TCN (it only bounds the window and lands on a display
+  field). No lap that previously produced a sane prediction produces a different one.
+- **The weather half** — FIXED via the shared `reading_or_default` helper, with
+  `pace_agent` (the one copy that had been correct) migrated onto it too so there is a
+  single implementation rather than one good copy plus a helper for the stragglers.
+
+Still live and deliberately out of the branch's scope:
+
+- **R1** — `int(NaN)` on `TyreLife` at `race_situation_agent.py:914-915`. Filed as **#790**.
+  Not fixed here because the mechanical part is trivial but the policy is not: the guarded
+  twin (`pit_strategy_agent.py:983-999`) REFUSES the prediction rather than defaulting, and
+  applying that to N27 means the orchestrator loses its overtake probability on ~451 laps.
+- **R3** (`SpeedST` NaN into N12) and **R4** (the `or`-form in `mcp_tools.py:599` rewriting a
+  leader's honest 0.0 gap to a fabricated 2.0) — recorded in #790's body and #789
+  respectively.

--- a/documents/dev_docs/diagrams/README.md
+++ b/documents/dev_docs/diagrams/README.md
@@ -15,13 +15,13 @@ All of these were last edited on 2026-05-13, before two releases landed: v2.0.0 
 | `webapp_structure` | **new**: the React app's feature folders and how they reach the backend |
 | `frontend_pages_streamlit_legacy` | **renamed and marked retired**: it is the Streamlit page tree, kept as a record of a surface that no longer exists |
 | `arcade_3window_architecture` | current |
-| `multi_agent_architecture` | current |
+| `multi_agent_architecture` | updated 2026-08-02: N25's box no longer says "LangGraph ReAct" — pace's scaffold was formally retired in #781, N25 is now shown as a direct XGBoost call, same as the sub-agents header line |
 | `multi_agent_flow` | current, but predates the projection redesign |
 | `strategy_pipeline_flow` | predates the shared inference engine |
 | `subprocess_launch_sequence` | current |
 | `tcp_broadcast_dataflow` | current |
 | `data_pipeline` | current on the surfaces; note the FastF1 cache is one directory now, not two |
-| `agents/` | one per sub-agent (N25 to N30) plus the `StrategyRecommendation` schema |
+| `agents/` | one per sub-agent (N25 to N30) plus the `StrategyRecommendation` schema; `N25_pace_agent` updated 2026-08-02 to drop the ReAct-tool boxes it never actually used (#781) |
 
 Verified: every file parses as XML, and no label outside the file marked legacy names a retired surface.
 

--- a/documents/dev_docs/diagrams/agents/N25_pace_agent.drawio
+++ b/documents/dev_docs/diagrams/agents/N25_pace_agent.drawio
@@ -14,29 +14,29 @@
           <mxGeometry x="295" y="70" width="310" height="60" as="geometry" />
         </mxCell>
 
-        <!-- AGENT -->
-        <mxCell id="agent" value="&lt;b&gt;LangGraph ReAct Agent&lt;/b&gt;&lt;br/&gt;Local/Cloud LLM&lt;br/&gt;Iterative tool calls until convergence" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+        <!-- AGENT (no LLM — direct call) -->
+        <mxCell id="agent" value="&lt;b&gt;PaceAgent.run() — direct call&lt;/b&gt;&lt;br/&gt;No LLM, no ReAct loop&lt;br/&gt;Deterministic: same input always yields the same output" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;" vertex="1" parent="1">
           <mxGeometry x="295" y="195" width="310" height="70" as="geometry" />
         </mxCell>
 
-        <!-- TOOL 1 -->
-        <mxCell id="tool1" value="&lt;b&gt;predict_pace_tool&lt;/b&gt;&lt;br/&gt;&lt;i&gt;Model: XGBoost N06&lt;/i&gt;&lt;br/&gt;N=200 bootstrap CI&lt;br/&gt;→ lap_time_pred, ci_p10, ci_p90" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=11;" vertex="1" parent="1">
+        <!-- STEP 1 -->
+        <mxCell id="tool1" value="&lt;b&gt;_predict() + _bootstrap_ci()&lt;/b&gt;&lt;br/&gt;&lt;i&gt;Model: XGBoost N06&lt;/i&gt;&lt;br/&gt;N=200 bootstrap CI&lt;br/&gt;→ lap_time_pred, ci_p10, ci_p90" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=11;" vertex="1" parent="1">
           <mxGeometry x="100" y="345" width="240" height="80" as="geometry" />
         </mxCell>
 
-        <!-- TOOL 2 -->
-        <mxCell id="tool2" value="&lt;b&gt;get_session_median_tool&lt;/b&gt;&lt;br/&gt;&lt;i&gt;Race statistics&lt;/i&gt;&lt;br/&gt;Median lap time for GP/year/compound&lt;br/&gt;→ delta_vs_median" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=11;" vertex="1" parent="1">
+        <!-- STEP 2 -->
+        <mxCell id="tool2" value="&lt;b&gt;_session_median()&lt;/b&gt;&lt;br/&gt;&lt;i&gt;Race statistics&lt;/i&gt;&lt;br/&gt;Median lap time for GP/year/compound&lt;br/&gt;→ delta_vs_median" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=11;" vertex="1" parent="1">
           <mxGeometry x="560" y="345" width="240" height="80" as="geometry" />
         </mxCell>
 
         <!-- OUTPUT -->
-        <mxCell id="output" value="&lt;b&gt;PaceOutput&lt;/b&gt;&lt;br/&gt;lap_time_pred · delta_vs_prev · delta_vs_median&lt;br/&gt;ci_p10 · ci_p90 · reasoning" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;" vertex="1" parent="1">
+        <mxCell id="output" value="&lt;b&gt;PaceOutput&lt;/b&gt;&lt;br/&gt;lap_time_pred · delta_vs_prev · delta_vs_median&lt;br/&gt;ci_p10 · ci_p90 · reasoning (f-string, not LLM)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;" vertex="1" parent="1">
           <mxGeometry x="295" y="500" width="310" height="60" as="geometry" />
         </mxCell>
 
         <!-- NOTE -->
-        <mxCell id="note" value="→ N31 Strategy Orchestrator (consumed via prompt and Monte Carlo dispersion)" style="text;html=1;strokeColor=none;fillColor=none;align=center;fontStyle=2;fontSize=11;" vertex="1" parent="1">
-          <mxGeometry x="230" y="578" width="440" height="20" as="geometry" />
+        <mxCell id="note" value="→ N31 Strategy Orchestrator (consumed via prompt and Monte Carlo dispersion) — deliberately deterministic, see #778/#780/#781" style="text;html=1;strokeColor=none;fillColor=none;align=center;fontStyle=2;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="180" y="578" width="540" height="20" as="geometry" />
         </mxCell>
 
         <!-- EDGES -->

--- a/documents/dev_docs/diagrams/multi_agent_architecture.drawio
+++ b/documents/dev_docs/diagrams/multi_agent_architecture.drawio
@@ -216,23 +216,26 @@
         <mxCell id="leg_react" value="Sub-agent (LangGraph ReAct)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=9;" vertex="1" parent="1">
           <mxGeometry x="1346" y="424" width="252" height="26" as="geometry" />
         </mxCell>
-        <mxCell id="leg_n29" value="N29: NLP-first synthesizer + Pydantic v2" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=9;" vertex="1" parent="1">
+        <mxCell id="leg_n25" value="N25: Direct deterministic call (no LLM)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=9;" vertex="1" parent="1">
           <mxGeometry x="1346" y="456" width="252" height="26" as="geometry" />
         </mxCell>
-        <mxCell id="leg_n31l1" value="N31 Layer 1: MoE routing" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e8d5f5;strokeColor=#9673a6;fontSize=9;" vertex="1" parent="1">
+        <mxCell id="leg_n29" value="N29: NLP-first synthesizer + Pydantic v2" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=9;" vertex="1" parent="1">
           <mxGeometry x="1346" y="488" width="252" height="26" as="geometry" />
         </mxCell>
-        <mxCell id="leg_n31l3" value="N31 Layer 3: LLM synthesis" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#c8b0e0;strokeColor=#9673a6;fontSize=9;" vertex="1" parent="1">
+        <mxCell id="leg_n31l1" value="N31 Layer 1: MoE routing" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e8d5f5;strokeColor=#9673a6;fontSize=9;" vertex="1" parent="1">
           <mxGeometry x="1346" y="520" width="252" height="26" as="geometry" />
         </mxCell>
+        <mxCell id="leg_n31l3" value="N31 Layer 3: LLM synthesis" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#c8b0e0;strokeColor=#9673a6;fontSize=9;" vertex="1" parent="1">
+          <mxGeometry x="1346" y="552" width="252" height="26" as="geometry" />
+        </mxCell>
         <mxCell id="leg_dep_lbl" value="── ─ ─ → cross-agent dependency (N26/N27 → N28)" style="text;html=1;strokeColor=none;fillColor=none;align=left;fontSize=9;fontColor=#FF6600;" vertex="1" parent="1">
-          <mxGeometry x="1346" y="554" width="252" height="18" as="geometry" />
+          <mxGeometry x="1346" y="586" width="252" height="18" as="geometry" />
         </mxCell>
         <mxCell id="leg_hard_lbl" value="────────→ hard constraint (N30 → N31 L3)" style="text;html=1;strokeColor=none;fillColor=none;align=left;fontSize=9;fontColor=#9673a6;" vertex="1" parent="1">
-          <mxGeometry x="1346" y="574" width="252" height="18" as="geometry" />
+          <mxGeometry x="1346" y="606" width="252" height="18" as="geometry" />
         </mxCell>
         <mxCell id="leg_fia_lbl" value="── ─ ─ → FIA PDFs → Qdrant (offline index build)" style="text;html=1;strokeColor=none;fillColor=none;align=left;fontSize=9;fontColor=#6c8ebf;" vertex="1" parent="1">
-          <mxGeometry x="1346" y="594" width="252" height="18" as="geometry" />
+          <mxGeometry x="1346" y="626" width="252" height="18" as="geometry" />
         </mxCell>
 
       </root>

--- a/documents/dev_docs/diagrams/multi_agent_architecture.drawio
+++ b/documents/dev_docs/diagrams/multi_agent_architecture.drawio
@@ -100,11 +100,11 @@
         <mxCell id="e_fia_rag" value="build index" style="edgeStyle=orthogonalEdgeStyle;dashed=1;strokeColor=#6c8ebf;fontColor=#6c8ebf;fontSize=9;" edge="1" source="fia_pdf" target="m_qdrant" parent="1"><mxGeometry relative="1" as="geometry"/></mxCell>
 
         <!-- ═══════════════════════════ SUB-AGENTS ═══════════════════════════ -->
-        <mxCell id="lbl_agents" value="SUB-AGENTS (LangGraph ReAct — except N29 which is NLP-first)" style="text;html=1;strokeColor=none;fillColor=none;align=left;fontStyle=1;fontSize=10;fontColor=#666666;" vertex="1" parent="1">
-          <mxGeometry x="60" y="444" width="500" height="18" as="geometry" />
+        <mxCell id="lbl_agents" value="SUB-AGENTS (LangGraph ReAct — except N25, direct XGBoost call, and N29, NLP-first)" style="text;html=1;strokeColor=none;fillColor=none;align=left;fontStyle=1;fontSize=10;fontColor=#666666;" vertex="1" parent="1">
+          <mxGeometry x="60" y="444" width="560" height="18" as="geometry" />
         </mxCell>
 
-        <mxCell id="n25" value="&lt;b&gt;N25 — Pace Agent&lt;/b&gt;&#xa;LangGraph ReAct&#xa;───────────&#xa;@tool predict_pace&#xa;@tool get_median&#xa;───────────&#xa;Output: PaceOutput&#xa;lap_time_pred&#xa;ci_p10 / ci_p90&#xa;reasoning" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
+        <mxCell id="n25" value="&lt;b&gt;N25 — Pace Agent&lt;/b&gt;&#xa;Direct XGBoost call (no LLM)&#xa;───────────&#xa;No tools, no ReAct loop —&#xa;deterministic regression,&#xa;no judgment for an LLM to&#xa;add (#778/#780/#781)&#xa;───────────&#xa;Output: PaceOutput&#xa;lap_time_pred&#xa;ci_p10 / ci_p90&#xa;reasoning (f-string)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=10;" vertex="1" parent="1">
           <mxGeometry x="60" y="464" width="160" height="176" as="geometry" />
         </mxCell>
 

--- a/documents/eval_reports/decision_modes.json
+++ b/documents/eval_reports/decision_modes.json
@@ -1,12 +1,12 @@
 {
   "header": {
-    "harness_sha": "d97a54e",
+    "harness_sha": "06a8f32",
     "dataset": "data/raw laps, stratified 6-race subset (RAW, not featured)",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-31T09:40:54+00:00",
+    "generated_at": "2026-08-03T09:26:58+00:00",
     "artifacts": {}
   },
   "status": "masked",
@@ -38,22 +38,22 @@
     }
   ],
   "agreement": {
-    "sample_size": 54,
+    "sample_size": 67,
     "eligible": 178,
-    "scored_share": 0.30337078651685395,
+    "scored_share": 0.37640449438202245,
     "races": 6,
-    "exact": 0.3333333333333333,
-    "within_one": 0.4444444444444444,
-    "within_two": 0.5185185185185185,
-    "mean_signed_error": -2.0,
-    "mean_absolute_error": 2.1481481481481484
+    "exact": 0.31343283582089554,
+    "within_one": 0.47761194029850745,
+    "within_two": 0.6119402985074627,
+    "mean_signed_error": -1.5223880597014925,
+    "mean_absolute_error": 1.9701492537313432
   },
   "buckets": {
     "closing_laps": 4,
-    "min_stint": 17,
+    "min_stint": 5,
     "no_boundary_in_window": 24,
-    "no_call_in_window": 79,
-    "scored": 54
+    "no_call_in_window": 78,
+    "scored": 67
   },
   "verdicts": [
     {
@@ -61,9 +61,9 @@
       "race": "Barcelona",
       "driver": "VER",
       "actual_lap": 13,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "chosen_lap": 16,
+      "offset_laps": 3,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -88,8 +88,8 @@
       "race": "Barcelona",
       "driver": "GAS",
       "actual_lap": 10,
-      "chosen_lap": 6,
-      "offset_laps": -4,
+      "chosen_lap": 13,
+      "offset_laps": 3,
       "bucket": "scored"
     },
     {
@@ -106,9 +106,9 @@
       "race": "Barcelona",
       "driver": "ANT",
       "actual_lap": 21,
-      "chosen_lap": 21,
-      "offset_laps": 0,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -135,7 +135,7 @@
       "actual_lap": 42,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -160,9 +160,9 @@
       "race": "Barcelona",
       "driver": "TSU",
       "actual_lap": 8,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
+      "chosen_lap": 7,
+      "offset_laps": -1,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -178,9 +178,9 @@
       "race": "Barcelona",
       "driver": "TSU",
       "actual_lap": 44,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 43,
+      "offset_laps": -1,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -232,8 +232,8 @@
       "race": "Barcelona",
       "driver": "LAW",
       "actual_lap": 18,
-      "chosen_lap": 15,
-      "offset_laps": -3,
+      "chosen_lap": 13,
+      "offset_laps": -5,
       "bucket": "scored"
     },
     {
@@ -259,8 +259,8 @@
       "race": "Barcelona",
       "driver": "OCO",
       "actual_lap": 43,
-      "chosen_lap": 43,
-      "offset_laps": 0,
+      "chosen_lap": 42,
+      "offset_laps": -1,
       "bucket": "scored"
     },
     {
@@ -277,18 +277,18 @@
       "race": "Barcelona",
       "driver": "NOR",
       "actual_lap": 48,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 44,
+      "offset_laps": -4,
+      "bucket": "scored"
     },
     {
       "year": 2025,
       "race": "Barcelona",
       "driver": "COL",
       "actual_lap": 14,
-      "chosen_lap": 11,
-      "offset_laps": -3,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -313,17 +313,17 @@
       "race": "Barcelona",
       "driver": "HAM",
       "actual_lap": 46,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 48,
+      "offset_laps": 2,
+      "bucket": "scored"
     },
     {
       "year": 2025,
       "race": "Barcelona",
       "driver": "BOR",
       "actual_lap": 19,
-      "chosen_lap": 17,
-      "offset_laps": -2,
+      "chosen_lap": 19,
+      "offset_laps": 0,
       "bucket": "scored"
     },
     {
@@ -331,8 +331,8 @@
       "race": "Barcelona",
       "driver": "BOR",
       "actual_lap": 49,
-      "chosen_lap": 49,
-      "offset_laps": 0,
+      "chosen_lap": 46,
+      "offset_laps": -3,
       "bucket": "scored"
     },
     {
@@ -349,8 +349,8 @@
       "race": "Barcelona",
       "driver": "SAI",
       "actual_lap": 34,
-      "chosen_lap": 34,
-      "offset_laps": 0,
+      "chosen_lap": 33,
+      "offset_laps": -1,
       "bucket": "scored"
     },
     {
@@ -448,9 +448,9 @@
       "race": "Monaco",
       "driver": "GAS",
       "actual_lap": 8,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
+      "chosen_lap": 8,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -475,9 +475,9 @@
       "race": "Monaco",
       "driver": "ALO",
       "actual_lap": 16,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 12,
+      "offset_laps": -4,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -502,9 +502,9 @@
       "race": "Monaco",
       "driver": "STR",
       "actual_lap": 17,
-      "chosen_lap": 14,
-      "offset_laps": -3,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -547,9 +547,9 @@
       "race": "Monaco",
       "driver": "HUL",
       "actual_lap": 12,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 10,
+      "offset_laps": -2,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -592,8 +592,8 @@
       "race": "Monaco",
       "driver": "OCO",
       "actual_lap": 28,
-      "chosen_lap": 24,
-      "offset_laps": -4,
+      "chosen_lap": 27,
+      "offset_laps": -1,
       "bucket": "scored"
     },
     {
@@ -603,7 +603,7 @@
       "actual_lap": 19,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -619,9 +619,9 @@
       "race": "Monaco",
       "driver": "COL",
       "actual_lap": 13,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
+      "chosen_lap": 8,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -691,9 +691,9 @@
       "race": "Monaco",
       "driver": "HAD",
       "actual_lap": 14,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 9,
+      "offset_laps": -5,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -709,9 +709,9 @@
       "race": "Monaco",
       "driver": "RUS",
       "actual_lap": 53,
-      "chosen_lap": 49,
-      "offset_laps": -4,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -720,7 +720,7 @@
       "actual_lap": 62,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "min_stint"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -835,18 +835,18 @@
       "race": "Silverstone",
       "driver": "LEC",
       "actual_lap": 10,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
+      "chosen_lap": 10,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
       "race": "Silverstone",
       "driver": "LEC",
       "actual_lap": 42,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 43,
+      "offset_laps": 1,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -855,7 +855,7 @@
       "actual_lap": 10,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "min_stint"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -900,7 +900,7 @@
       "actual_lap": 9,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "min_stint"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -979,18 +979,18 @@
       "race": "Silverstone",
       "driver": "HAD",
       "actual_lap": 10,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
+      "chosen_lap": 10,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
       "race": "Silverstone",
       "driver": "RUS",
       "actual_lap": 10,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
+      "chosen_lap": 9,
+      "offset_laps": -1,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1024,9 +1024,9 @@
       "race": "Silverstone",
       "driver": "BEA",
       "actual_lap": 10,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "min_stint"
+      "chosen_lap": 8,
+      "offset_laps": -2,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1060,9 +1060,9 @@
       "race": "Marina_Bay",
       "driver": "GAS",
       "actual_lap": 51,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "chosen_lap": 53,
+      "offset_laps": 2,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1177,8 +1177,8 @@
       "race": "Marina_Bay",
       "driver": "HAM",
       "actual_lap": 24,
-      "chosen_lap": 19,
-      "offset_laps": -5,
+      "chosen_lap": 21,
+      "offset_laps": -3,
       "bucket": "scored"
     },
     {
@@ -1222,8 +1222,8 @@
       "race": "Marina_Bay",
       "driver": "RUS",
       "actual_lap": 25,
-      "chosen_lap": 22,
-      "offset_laps": -3,
+      "chosen_lap": 23,
+      "offset_laps": -2,
       "bucket": "scored"
     },
     {
@@ -1294,9 +1294,9 @@
       "race": "Lusail",
       "driver": "STR",
       "actual_lap": 24,
-      "chosen_lap": 19,
-      "offset_laps": -5,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_boundary_in_window"
     },
     {
       "year": 2025,
@@ -1438,9 +1438,9 @@
       "race": "Lusail",
       "driver": "PIA",
       "actual_lap": 24,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_call_in_window"
+      "chosen_lap": 24,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1467,7 +1467,7 @@
       "actual_lap": 40,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "min_stint"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -1476,7 +1476,7 @@
       "actual_lap": 41,
       "chosen_lap": null,
       "offset_laps": null,
-      "bucket": "min_stint"
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -1492,9 +1492,9 @@
       "race": "Monza",
       "driver": "GAS",
       "actual_lap": 49,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "chosen_lap": 47,
+      "offset_laps": -2,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1528,9 +1528,9 @@
       "race": "Monza",
       "driver": "LEC",
       "actual_lap": 33,
-      "chosen_lap": 33,
-      "offset_laps": 0,
-      "bucket": "scored"
+      "chosen_lap": null,
+      "offset_laps": null,
+      "bucket": "no_call_in_window"
     },
     {
       "year": 2025,
@@ -1546,8 +1546,8 @@
       "race": "Monza",
       "driver": "TSU",
       "actual_lap": 19,
-      "chosen_lap": 18,
-      "offset_laps": -1,
+      "chosen_lap": 19,
+      "offset_laps": 0,
       "bucket": "scored"
     },
     {
@@ -1582,9 +1582,9 @@
       "race": "Monza",
       "driver": "NOR",
       "actual_lap": 46,
-      "chosen_lap": null,
-      "offset_laps": null,
-      "bucket": "no_boundary_in_window"
+      "chosen_lap": 46,
+      "offset_laps": 0,
+      "bucket": "scored"
     },
     {
       "year": 2025,
@@ -1636,8 +1636,8 @@
       "race": "Monza",
       "driver": "RUS",
       "actual_lap": 27,
-      "chosen_lap": 26,
-      "offset_laps": -1,
+      "chosen_lap": 27,
+      "offset_laps": 0,
       "bucket": "scored"
     },
     {

--- a/documents/eval_reports/decision_modes.md
+++ b/documents/eval_reports/decision_modes.md
@@ -1,17 +1,17 @@
 # decision_modes
 
-- harness `d97a54e` · schema v1 · generated 2026-07-31T09:40:54+00:00
+- harness `06a8f32` · schema v1 · generated 2026-08-03T09:26:58+00:00
 - era 2022-2025 · dataset data/raw laps, stratified 6-race subset (RAW, not featured) · seed deterministic · llm none
 - artifacts: —
 
 | Metric | Value | Meaning |
 | --- | --- | --- |
-| Stops scored | 54 of 178 (30.3%) | real green-flag stops the tier could grade |
-| Exact lap | 33.3% | chose the lap the team chose |
-| Within 1 lap | 44.4% | same call, one lap either side |
-| Within 2 laps | 51.9% | same strategic window |
-| Mean signed error | -2.00 laps | negative = earlier than the team. **Do not quote as a system property** — still moves with `DECISION_WINDOW_LAPS` (measured -0.33 / -1.29 / -2.50 at w=3/5/10 on one race), because a wider window admits more distant, and therefore earlier, transitions |
-| Mean absolute error | 2.15 laps | magnitude, same width caveat |
+| Stops scored | 67 of 178 (37.6%) | real green-flag stops the tier could grade |
+| Exact lap | 31.3% | chose the lap the team chose |
+| Within 1 lap | 47.8% | same call, one lap either side |
+| Within 2 laps | 61.2% | same strategic window |
+| Mean signed error | -1.52 laps | negative = earlier than the team. **Do not quote as a system property** — still moves with `DECISION_WINDOW_LAPS` (measured -0.33 / -1.29 / -2.50 at w=3/5/10 on one race), because a wider window admits more distant, and therefore earlier, transitions |
+| Mean absolute error | 1.97 laps | magnitude, same width caveat |
 | Coverage verdict | **masked** | `masked` when under 60% of eligible stops were scored |
 
 ### Buckets
@@ -19,10 +19,10 @@
 | Bucket | Stops |
 | --- | --- |
 | `closing_laps` | 4 |
-| `min_stint` | 17 |
+| `min_stint` | 5 |
 | `no_boundary_in_window` | 24 |
-| `no_call_in_window` | 79 |
-| `scored` | 54 |
+| `no_call_in_window` | 78 |
+| `scored` | 67 |
 
 `opening_laps` / `closing_laps` / `min_stint` are stops the guard rails make
 impossible to agree with, so they are excluded from the headline rather than

--- a/documents/eval_reports/stint_lengths.json
+++ b/documents/eval_reports/stint_lengths.json
@@ -1,24 +1,23 @@
 {
   "header": {
-    "harness_sha": "af96fb6",
+    "harness_sha": "fc73c53",
     "dataset": "data/raw laps 2023-2025 (RAW, not featured)",
     "seed_policy": "deterministic",
     "era_tag": "2022-2025",
     "llm": "none",
     "schema_version": "1",
-    "generated_at": "2026-07-29T09:39:31+00:00",
+    "generated_at": "2026-08-03T08:32:16+00:00",
     "artifacts": {}
   },
   "sample": {
     "races": 71,
-    "total_counted": 1785,
-    "dropped_wet": 110,
+    "total_counted": 1895,
     "dropped_missing": 5,
     "compounds": {
       "SOFT": {
         "sample_size": 341,
-        "threshold": 8,
-        "share_below_threshold": 0.15542521994134897,
+        "threshold": 2,
+        "share_below_threshold": 0.03225806451612903,
         "min": 1.0,
         "p1": 1.0,
         "p5": 2.0,
@@ -30,8 +29,8 @@
       },
       "MEDIUM": {
         "sample_size": 896,
-        "threshold": 12,
-        "share_below_threshold": 0.16964285714285715,
+        "threshold": 7,
+        "share_below_threshold": 0.04575892857142857,
         "min": 1.0,
         "p1": 1.0,
         "p5": 7.0,
@@ -43,8 +42,8 @@
       },
       "HARD": {
         "sample_size": 548,
-        "threshold": 15,
-        "share_below_threshold": 0.12226277372262774,
+        "threshold": 8,
+        "share_below_threshold": 0.04744525547445255,
         "min": 1.0,
         "p1": 1.9399999999999995,
         "p5": 8.0,
@@ -53,6 +52,19 @@
         "median": 24.0,
         "p75": 30.0,
         "max": 72.0
+      },
+      "WET": {
+        "sample_size": 110,
+        "threshold": 6,
+        "share_below_threshold": 0.045454545454545456,
+        "min": 2.0,
+        "p1": 3.09,
+        "p5": 6.0,
+        "p10": 7.9,
+        "p25": 11.0,
+        "median": 12.0,
+        "p75": 19.0,
+        "max": 44.0
       }
     }
   }

--- a/documents/eval_reports/stint_lengths.md
+++ b/documents/eval_reports/stint_lengths.md
@@ -1,6 +1,6 @@
 # stint_lengths
 
-- harness `af96fb6` · schema v1 · generated 2026-07-29T09:39:31+00:00
+- harness `fc73c53` · schema v1 · generated 2026-08-03T08:32:16+00:00
 - era 2022-2025 · dataset data/raw laps 2023-2025 (RAW, not featured) · seed deterministic · llm none
 - artifacts: —
 
@@ -8,25 +8,35 @@
 
 Every completed stint that ended in a real green-flag pit stop, counted in
 tyre-age laps: the `TyreLife` reading at the moment of the stop, the exact
-field `apply_guard_rails` compares against `_MIN_STINT_LAPS`. A stint that
-ended because the race finished, or because the driver retired, is not a
+field `apply_guard_rails` compares against its minimum-stint bound. A stint
+that ended because the race finished, or because the driver retired, is not a
 decision to stop and is excluded by construction: neither ever produces a
 lap with `PitInTime` set.
 
+The last row is INTERMEDIATE and WET together. They carry no entry of their
+own in `_MIN_STINT_LAPS`, so the rail's `.get(compound, _DEFAULT_MIN_STINT)`
+resolves them to the fallback -- a minimum-stint bound like any other, and
+one this report used to drop rather than measure.
+
 | compound | n | threshold (laps) | shorter than threshold | min | p1 | p5 | p10 | p25 | median | p75 | max |
 |---|---|---|---|---|---|---|---|---|---|---|---|
-| SOFT | 341 | 8 | 15.5% | 1.0 | 1.0 | 2.0 | 5.0 | 9.0 | 15.0 | 21.0 | 50.0 |
-| MEDIUM | 896 | 12 | 17.0% | 1.0 | 1.0 | 7.0 | 9.0 | 14.0 | 19.0 | 25.0 | 55.0 |
-| HARD | 548 | 15 | 12.2% | 1.0 | 1.9 | 8.0 | 13.0 | 18.0 | 24.0 | 30.0 | 72.0 |
+| SOFT | 341 | 2 | 3.2% | 1.0 | 1.0 | 2.0 | 5.0 | 9.0 | 15.0 | 21.0 | 50.0 |
+| MEDIUM | 896 | 7 | 4.6% | 1.0 | 1.0 | 7.0 | 9.0 | 14.0 | 19.0 | 25.0 | 55.0 |
+| HARD | 548 | 8 | 4.7% | 1.0 | 1.9 | 8.0 | 13.0 | 18.0 | 24.0 | 30.0 | 72.0 |
+| WET | 110 | 6 | 4.5% | 2.0 | 3.1 | 6.0 | 7.9 | 11.0 | 12.0 | 19.0 | 44.0 |
 
 "shorter than threshold" is the share of real stints the current guard rail
 would have overridden to STAY_OUT had a strategist tried to make that exact
-call: `TyreLife < _MIN_STINT_LAPS[compound]`, the same strict inequality
-`apply_guard_rails` itself uses. Close to zero means the bound sits where
-real strategy essentially never goes; anywhere else means it is vetoing
-calls a real pit wall has actually made.
+call: `TyreLife < the bound`, the same strict inequality `apply_guard_rails`
+itself uses.
 
-- real green-flag stints counted: 1785 across 71 races
-- wet-compound stops dropped (INTERMEDIATE/WET is not a dry-tyre-life question): 110
+This share IS the calibration of a proscriptive bound, and the number the
+bounds are set from (#716). A bound exists so a generative model cannot emit
+nonsense, so it has to sit where real strategy essentially never goes; once it
+is vetoing a meaningful share of what professional pit walls actually did, it
+is separating unusual from usual rather than absurd from sane. The ceiling the
+bounds are held to is **5%**, and every row above is expected to clear it.
+
+- real green-flag stints counted: 1895 across 71 races
 - stops dropped for missing compound/tyre-life data: 5
 

--- a/documents/research/AGENT_ORCHESTRATION_FLOW.md
+++ b/documents/research/AGENT_ORCHESTRATION_FLOW.md
@@ -38,7 +38,7 @@ so and the v2 graph preserves it.
 
 | Agent | Module | Pattern (shipped) | LLM in per-lap path | Cadence |
 |---|---|---|---|---|
-| N25 Pace | `src/agents/pace_agent.py` | ReAct agent exists (`create_agent`, :648) but the per-lap path calls `PaceAgent.run()` directly; reasoning is a template string | none (ReAct idle) | every lap |
+| N25 Pace | `src/agents/pace_agent.py` | Direct call — `PaceAgent.run()`, reasoning is a template string. (Written 2026-07-07 against a ReAct scaffold that existed but was idle; formally retired and deleted in #781 after the #778/#779/#780 archaeology confirmed it was never wired and had no stated future use — do not plan v2 work around resurrecting it.) | none | every lap |
 | N26 Tire | `src/agents/tire_agent.py` | ReAct (`create_agent`, :997; invoke :1162), 2 tools | ~3 turns | every lap |
 | N27 Situation | `src/agents/race_situation_agent.py` | ReAct (:985; invoke :1145), 2 tools | ~3 turns | every lap |
 | N28 Pit | `src/agents/pit_strategy_agent.py` | ReAct (:837; invoke :996), 3 tools; output parsed from tool messages + final-message prose | up to 4 turns | conditional |

--- a/documents/research/RIVAL_AGENT_DESIGN.md
+++ b/documents/research/RIVAL_AGENT_DESIGN.md
@@ -105,11 +105,18 @@ integration design:
   `POS_GAP_S = 1.50` seconds per position and a single N16 success probability for OUR
   undercut. The rival's possible counter-move (pitting first, covering our stop) does not
   exist in the simulation. That is the concrete hole the agent fills.
-- The sub-agents are LangGraph ReAct agents (built via `create_agent` with tools wrapping
-  each ML model); the orchestrator itself is a plain Python pipeline that calls their
-  public entry points. "A new LangGraph node" therefore means: a new agent module in the
-  same ReAct style as N25-N29, invoked by an additive orchestration entry point, plus a
-  formalization of the whole graph for the multi-agent portion of the TFM (section 7).
+- Tire (N26), race situation (N27), pit strategy (N28) and RAG (N30) are LangGraph ReAct
+  agents (built via `create_agent` with tools wrapping each ML model); pace (N25) is
+  deliberately NOT — it has no qualitative judgment for an LLM to add, and its once-built
+  ReAct scaffold was formally retired in #781 (documents/audits/AUDIT_pace_agent_react_archaeology_779.md)
+  after archaeology showed it was never wired. Radio (N29) is a different shape again: a
+  deterministic NLP pipeline (RoBERTa/SetFit/BERT NER) followed by ONE
+  `with_structured_output()` synthesis call, not a ReAct tool loop. The orchestrator itself
+  is a plain Python pipeline that calls the sub-agents' public entry points. "A new
+  LangGraph node" for the Rival Agent should follow the ReAct pattern of N26-N28/N30 if it
+  needs qualitative judgment over its own tools — decide this on the Rival Agent's own
+  merits rather than assuming "same as N25-N29", which is no longer a uniform group — plus
+  a formalization of the whole graph for the multi-agent portion of the TFM (section 7).
 
 **The data already on disk.** Verified against `data/raw/2025/Budapest/` (and the P5
 audit, which verified this repo-wide):
@@ -622,11 +629,16 @@ nothing the MC cannot draw from directly**.
 `reasoning` is deliberately template-generated (from feature attributions), not
 LLM-generated, in v1: the agent then works identically in the no-LLM path (the project
 maintains a hard no-LLM mode in the CLI and programmatic guardrails; an agent whose
-output depends on an LLM would break that parity). Whether the Rival Agent gets an
-optional LLM synthesis layer like N25-N29 (nicer prose, tool-calling ReAct shape for
-architectural symmetry) is open question Q3; the default answer is: ReAct-wrapped like
-its siblings for the multi-agent narrative, but with the deterministic path as the
-guaranteed spine, mirroring how the existing agents degrade.
+output depends on an LLM would break that parity). This is precisely the shape N25 (pace)
+was formalized into by #781 (documents/audits/AUDIT_pace_agent_react_archaeology_779.md):
+a deterministic template-reasoning agent with no LLM step at all, once it was established
+the agent has no qualitative judgment for an LLM to add. Whether the Rival Agent instead
+gets an optional LLM synthesis layer like N26-N28/N30 (nicer prose, tool-calling ReAct
+shape for architectural symmetry) is open question Q3 — decide it the same way pace's was
+decided, on whether the Rival Agent's own output carries a qualitative judgment beyond its
+quantile triples and probabilities, not by defaulting to "ReAct because the siblings are."
+The deterministic path is the guaranteed spine either way, mirroring how the existing
+agents degrade.
 
 ---
 
@@ -967,11 +979,13 @@ per-circuit window as proposed?) and the overcut bounds (stay out >= 2 laps, pit
 L+6): fix them from the M1 sensitivity study, or pre-commit now for pre-registration
 cleanliness?
 
-**Q3: Does the Rival Agent get an LLM layer?** Recommended: ReAct wrapper for
-architectural symmetry with N25-N29, but the deterministic ML spine is the guaranteed
-path and the no-LLM mode ships first. Alternative: purely deterministic agent (cheaper,
-simpler, less symmetric). This also affects LLM cost per lap (about 6 rivals must NOT
-mean 6 extra LLM calls; the design assumes at most one).
+**Q3: Does the Rival Agent get an LLM layer?** Decide it on the Rival Agent's own merits
+(does its output carry a qualitative judgment beyond quantile triples and probabilities,
+per #781's precedent for pace), not by defaulting to architectural symmetry with a group
+that is no longer uniform (N26-N28/N30 are ReAct; N25 deliberately is not; N29 is NLP-first
++ one structured-output call). Either way the deterministic ML spine is the guaranteed
+path and the no-LLM mode ships first. This also affects LLM cost per lap (about 6 rivals
+must NOT mean 6 extra LLM calls; the design assumes at most one).
 
 **Q4: Schema discipline confirmation.** Keep `StrategyRecommendation` frozen at 14
 fields and integrate rival intent via prompt, contingencies, and `undercut_target`

--- a/scripts/build_radio_dataset.py
+++ b/scripts/build_radio_dataset.py
@@ -96,7 +96,15 @@ import requests
 # ``python scripts/build_radio_dataset.py`` or ``python -m scripts.build_radio_dataset``.
 # scripts/ is a package but the parent ``src/`` package lives one level up,
 # so the repo root must be on sys.path before any project import.
-_REPO_ROOT = Path(__file__).resolve().parent.parent
+#
+# ``.git``-search-with-fallback, not a fixed ``.parent.parent``: the latter
+# silently resolves to the wrong directory under a `uv tool install` layout,
+# where this file is not exactly one level below the repo root.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = next(
+    (p for p in [_SCRIPT_DIR, *_SCRIPT_DIR.parents] if (p / ".git").exists()),
+    _SCRIPT_DIR.parent,
+)
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -25,7 +25,15 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+# ``.git``-search-with-fallback, not a fixed ``.parent.parent``: the latter
+# silently resolves to the wrong directory under a `uv tool install` layout,
+# where this file is not exactly one level below the repo root.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = next(
+    (p for p in [_SCRIPT_DIR, *_SCRIPT_DIR.parents] if (p / ".git").exists()),
+    _SCRIPT_DIR.parent,
+)
+sys.path.insert(0, str(_REPO_ROOT))
 
 from src.f1_strat_manager.data_cache import ensure_setup, get_data_root  # noqa: E402
 

--- a/scripts/measure_fresh_reference_gate.py
+++ b/scripts/measure_fresh_reference_gate.py
@@ -1,0 +1,160 @@
+"""Measure what gating the fresh-reference lap on race pace buys `deg_cost_s`.
+
+`deg_cost_s = pred(now) - pred(fresh reference)`, both from the TCN. Its TRUE
+counterpart is the same difference taken on N04's own target column, and the
+error is the difference of the two differences -- the same bound
+`scripts/measure_deg_error_bound.py` (branch `feat/deferral-tyre-liability`,
+issue #763) measured at 0.650 s/lap mean absolute, +0.351 s/lap signed bias.
+
+That investigation traced the growth to a small number of STINTS whose
+fresh-reference lap (`TyreLife <= FRESH_MAX_TYRE_LIFE`) was itself a
+Safety-Car- or red-flag-affected lap: `track_status_clean` is supposed to flag
+this but is a constant 0 across the whole featured parquet (see
+`_add_session_cols`'s docstring), because N04's `IsAccurate` gate does not
+catch every neutralised lap. Measured counter-example: Mexico City 2023 car 4,
+lap 36 reads 137.757 s on a circuit whose green-flag pace is ~83 s, and every
+later lap in that nominal stint then priced tens of seconds "faster than
+fresh" -- not tyre wear, an artefact of a contaminated zero point.
+
+`TireAgent._fresh_reference` now rejects a candidate lap slower than
+`fresh_reference_max_pct_of_fastest` times the race's fastest lap via
+`_reject_contaminated_laps`, imported here rather than reimplemented so this
+measures what actually ships.
+
+Training seasons only (2023-24), matching `measure_tyre_reference.py` and
+`src/strategy/eval/hygiene.py`'s reasoning against fitting on the test season.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.measure_tyre_reference import (  # noqa: E402
+    FRESH_MAX_TYRE_LIFE,
+    predict_training_stints,
+)
+from src.agents.tire_agent import CFG, _reject_contaminated_laps  # noqa: E402
+
+LAPS_PATH = Path("data/processed/laps_tiredeg.parquet")
+TRAINING_YEARS = (2023, 2024)
+STINT_KEYS = ["Year", "GP_Name", "DriverNumber", "Stint"]
+
+
+def attach_pct_of_fastest(frame: pd.DataFrame) -> pd.DataFrame:
+    """Join `lap_time_pct_of_race_fastest`'s two inputs from the raw parquet.
+
+    `predict_training_stints()` returns only `stint`/`tyre_life`/`pred`/`target`,
+    so the lap time and the race's fastest lap have to be pulled back in.
+    `TyreLife` is not unique within a (stint) group for a handful of red-flag
+    affected stints -- the same nominal `Stint` number restarts `TyreLife` after
+    the restart -- so duplicates are collapsed to the WORST (slowest) candidate:
+    missing a contaminated lap is exactly the failure mode being measured.
+    """
+    laps = pd.read_parquet(LAPS_PATH)
+    laps = laps[laps["Year"].isin(TRAINING_YEARS)].copy()
+    laps["stint_id"] = laps[STINT_KEYS].astype(str).agg("|".join, axis=1)
+    laps["fastest_lap_s"] = laps.groupby(["Year", "GP_Name"])["LapTime_s"].transform("min")
+
+    lap_time = laps.groupby(["stint_id", "TyreLife"])["LapTime_s"].max()
+    fastest = laps.groupby(["stint_id", "TyreLife"])["fastest_lap_s"].first()
+
+    key = frame.set_index(["stint", "tyre_life"]).index
+    frame = frame.copy()
+    frame["lap_time_s"] = key.map(lap_time)
+    frame["fastest_lap_s"] = key.map(fastest)
+    return frame
+
+
+def score(scored: pd.DataFrame, label: str) -> dict:
+    """The bound: mean/median absolute error, signed bias, and error by band."""
+    absolute = scored["error"].abs()
+    bands = pd.cut(scored["tyre_life"], [3, 10, 20, 30, 100])
+    by_band = scored.groupby(bands, observed=True)["error"].mean()
+
+    result = {
+        "label": label,
+        "n": len(scored),
+        "mean_abs_error": round(float(absolute.mean()), 3),
+        "median_abs_error": round(float(absolute.median()), 3),
+        "signed_bias": round(float(scored["error"].mean()), 3),
+        "by_band_mean_error": {str(k): round(float(v), 3) for k, v in by_band.items()},
+    }
+    print(
+        f"\n=== {label} (n={result['n']}) ===\n"
+        f"  mean abs error   {result['mean_abs_error']:7.3f} s/lap\n"
+        f"  median abs error {result['median_abs_error']:7.3f} s/lap\n"
+        f"  bias (signed)    {result['signed_bias']:+7.3f} s/lap"
+    )
+    for band, value in result["by_band_mean_error"].items():
+        print(f"    {band:<12} {value:+.3f}")
+    return result
+
+
+def build_reference(fresh: pd.DataFrame, gated: bool) -> tuple[pd.Series, pd.Series]:
+    """The fresh-reference prediction and target, gated or not, per stint."""
+    if gated:
+        clean = _reject_contaminated_laps(
+            fresh.rename(columns={"lap_time_s": "LapTime_s"}),
+            fastest_lap_s=fresh["fastest_lap_s"],
+            max_pct=CFG.fresh_reference_max_pct_of_fastest,
+        )
+    else:
+        clean = fresh
+    return clean.groupby("stint")["pred"].last(), clean.groupby("stint")["target"].last()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, help="write the measured scores to this JSON path")
+    args = parser.parse_args()
+
+    frame = predict_training_stints().sort_values(["stint", "tyre_life"])
+    frame = attach_pct_of_fastest(frame)
+    fresh = frame[frame["tyre_life"] <= FRESH_MAX_TYRE_LIFE].dropna(
+        subset=["lap_time_s", "fastest_lap_s"]
+    )
+
+    def scored_bound(gated: bool) -> pd.DataFrame:
+        ref_pred, ref_true = build_reference(fresh, gated)
+        n_stints_before = fresh["stint"].nunique()
+        n_stints_after = ref_pred.notna().sum()
+
+        scored = frame[frame["tyre_life"] > FRESH_MAX_TYRE_LIFE].copy()
+        scored["ref_pred"] = scored["stint"].map(ref_pred)
+        scored["ref_true"] = scored["stint"].map(ref_true)
+        scored = scored.dropna(subset=["ref_pred", "ref_true"])
+        scored["error"] = (scored["pred"] - scored["ref_pred"]) - (
+            scored["target"] - scored["ref_true"]
+        )
+        print(
+            f"  stints with a reference: {n_stints_after} of {n_stints_before} "
+            f"({n_stints_before - n_stints_after} lost to the gate)"
+            if gated
+            else f"  stints with a reference: {n_stints_after} of {n_stints_before}"
+        )
+        return scored
+
+    before = score(scored_bound(gated=False), "BASELINE -- no quality gate (current main)")
+    after = score(scored_bound(gated=True), "GATED -- fresh_reference_max_pct_of_fastest")
+
+    if args.out:
+        payload = {
+            "generated_by": "scripts/measure_fresh_reference_gate.py",
+            "years": list(TRAINING_YEARS),
+            "gate_threshold": CFG.fresh_reference_max_pct_of_fastest,
+            "before": before,
+            "after": after,
+        }
+        args.out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/measure_fresh_reference_gate.py
+++ b/scripts/measure_fresh_reference_gate.py
@@ -34,7 +34,15 @@ from pathlib import Path
 
 import pandas as pd
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+# ``.git``-search-with-fallback, not a fixed ``.parents[1]``: the latter
+# silently resolves to the wrong directory under a `uv tool install` layout,
+# where this file is not exactly one level below the repo root.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = next(
+    (p for p in [_SCRIPT_DIR, *_SCRIPT_DIR.parents] if (p / ".git").exists()),
+    _SCRIPT_DIR.parent,
+)
+sys.path.insert(0, str(_REPO_ROOT))
 
 from scripts.measure_tyre_reference import (  # noqa: E402
     FRESH_MAX_TYRE_LIFE,

--- a/scripts/measure_fresh_reference_gate_2025.py
+++ b/scripts/measure_fresh_reference_gate_2025.py
@@ -26,7 +26,15 @@ import numpy as np
 import pandas as pd
 import torch
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+# ``.git``-search-with-fallback, not a fixed ``.parents[1]``: the latter
+# silently resolves to the wrong directory under a `uv tool install` layout,
+# where this file is not exactly one level below the repo root.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = next(
+    (p for p in [_SCRIPT_DIR, *_SCRIPT_DIR.parents] if (p / ".git").exists()),
+    _SCRIPT_DIR.parent,
+)
+sys.path.insert(0, str(_REPO_ROOT))
 
 from src.agents.tire_agent import (  # noqa: E402
     CFG,

--- a/scripts/measure_fresh_reference_gate_2025.py
+++ b/scripts/measure_fresh_reference_gate_2025.py
@@ -1,0 +1,189 @@
+"""Held-out check: does the fresh-reference quality gate (threshold chosen on
+2023-24, shipped in `TireAgentConfig.fresh_reference_max_pct_of_fastest`) still
+help on 2025 -- the season the system actually runs in?
+
+`scripts/measure_fresh_reference_gate.py` measured a 33% mean-error / 60% bias
+reduction, but only ever on `laps_tiredeg.parquet` (2023-24, the only parquet
+carrying N04's training target). That is a real number about the seasons the
+threshold was CHOSEN on, not evidence about what ships -- see
+`documents/audits/MEASURE_fresh_reference_quality_gate.md`'s 2025 addendum.
+
+This script measures the identical diagnostic on `laps_featured_2025.parquet`
+(the real, full 24-race 2025 season), reusing the actual production functions
+(`_add_compound_cols`, `_compound_name_to_id`, `_reject_contaminated_laps`)
+rather than reimplementing the compound-resolution or gating logic -- the
+featured parquet does not carry `AbsoluteCompoundID`/`CompoundHardness`, so
+those have to come from the same code path production uses, not a guess.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.agents.tire_agent import (  # noqa: E402
+    CFG,
+    TireDegTCN,
+    _add_compound_cols,
+    _compound_name_to_id,
+    _reject_contaminated_laps,
+)
+
+FEATURED_2025 = Path("data/processed/laps_featured_2025.parquet")
+MODEL_DIR = Path("data/models/tire_degradation")
+FRESH_MAX_TYRE_LIFE = 3
+STINT_KEYS = ["Year", "GP_Name", "DriverNumber", "Stint"]
+TARGET = "FuelAdjustedDegAbsolute"
+
+
+def load_bundles() -> dict:
+    routing = json.loads((MODEL_DIR / "routing_config.json").read_text(encoding="utf-8"))
+    by_file: dict = {}
+    by_compound: dict = {}
+    for compound, entry in routing.items():
+        filename = entry["bundle"]
+        if filename not in by_file:
+            bundle = torch.load(MODEL_DIR / filename, map_location="cpu", weights_only=False)
+            model = TireDegTCN(bundle["n_features"], **bundle["model_hparams"])
+            model.load_state_dict(bundle["state_dict"])
+            model.eval()
+            bundle["model"] = model
+            by_file[filename] = bundle
+        by_compound[compound] = by_file[filename]
+    return by_compound
+
+
+def stint_sequences(stint: pd.DataFrame, bundle: dict) -> np.ndarray:
+    """One scaled (window, n_features) sequence per lap -- same transform as
+    `scripts/measure_tyre_reference.py::stint_sequences`, kept in sync by hand."""
+    window = bundle["window"]
+    raw = stint[bundle["feature_names"]].astype(float).fillna(0)
+    scaled = bundle["scaler"].transform(raw)
+    sequences = []
+    for length in range(1, len(scaled) + 1):
+        prefix = scaled[:length]
+        if len(prefix) >= window:
+            sequences.append(prefix[-window:])
+            continue
+        padding = np.zeros((window - len(prefix), prefix.shape[1]), dtype=prefix.dtype)
+        sequences.append(np.concatenate([padding, prefix], axis=0))
+    return np.stack(sequences)
+
+
+def predict_2025_stints() -> pd.DataFrame:
+    """Run every 2025 stint through its compound's TCN, lap by lap."""
+    laps = pd.read_parquet(FEATURED_2025)
+    laps = laps.dropna(subset=["Compound", "GP_Name", "Year"])
+    # A handful of rows carry the literal string "None"/"nan" rather than a real
+    # null (a known quirk of this parquet's Compound column) -- dropna misses those.
+    laps = laps[~laps["Compound"].isin(["None", "nan"])]
+    bundles = load_bundles()
+
+    rows = []
+    for keys, stint in laps.groupby(STINT_KEYS, sort=False):
+        year, gp_name = int(keys[0]), keys[1]
+        compound_id = _compound_name_to_id(str(stint["Compound"].iloc[0]), gp_name, year)
+        if compound_id not in bundles:
+            continue
+
+        bundle = bundles[compound_id]
+        # The real production transform, not a reimplementation: this is the
+        # same call `_build_stint_features` makes, so AbsoluteCompoundID and
+        # CompoundHardness land on the identical scale the model was trained on.
+        ordered = _add_compound_cols(stint.sort_values("TyreLife").copy(), compound_id)
+        sequences = stint_sequences(ordered, bundle)
+        with torch.no_grad():
+            batch = torch.tensor(sequences, dtype=torch.float32)
+            predictions = bundle["model"](batch).numpy().reshape(-1)
+
+        stint_id = "|".join(str(k) for k in keys)
+        for tyre_life, pred, target, lap_time_s in zip(
+            ordered["TyreLife"].to_numpy(),
+            predictions,
+            ordered[TARGET].to_numpy(),
+            ordered["LapTime_s"].to_numpy(),
+            strict=True,
+        ):
+            rows.append(
+                (
+                    stint_id,
+                    gp_name,
+                    year,
+                    float(tyre_life),
+                    float(pred),
+                    float(target),
+                    float(lap_time_s),
+                )
+            )
+
+    columns = ["stint", "gp_name", "year", "tyre_life", "pred", "target", "lap_time_s"]
+    return pd.DataFrame(rows, columns=columns)
+
+
+def bound(scored: pd.DataFrame, label: str) -> dict:
+    absolute = scored["error"].abs()
+    result = {
+        "label": label,
+        "n": len(scored),
+        "mean_abs_error": round(float(absolute.mean()), 3),
+        "median_abs_error": round(float(absolute.median()), 3),
+        "signed_bias": round(float(scored["error"].mean()), 3),
+    }
+    print(
+        f"\n=== {label} (n={result['n']}) ===\n"
+        f"  mean abs error   {result['mean_abs_error']:7.3f} s/lap\n"
+        f"  median abs error {result['median_abs_error']:7.3f} s/lap\n"
+        f"  bias (signed)    {result['signed_bias']:+7.3f} s/lap"
+    )
+    return result
+
+
+def main() -> None:
+    frame = predict_2025_stints().sort_values(["stint", "tyre_life"])
+    print(
+        f"2025 laps predicted: {len(frame)}, stints: {frame['stint'].nunique()}, "
+        f"GPs: {frame['gp_name'].nunique()}"
+    )
+
+    fastest_by_gp = frame.groupby(["year", "gp_name"])["lap_time_s"].transform("min")
+    frame["fastest_lap_s"] = fastest_by_gp
+
+    fresh = frame[frame["tyre_life"] <= FRESH_MAX_TYRE_LIFE]
+
+    def scored_bound(gated: bool) -> pd.DataFrame:
+        if gated:
+            candidates = fresh.rename(columns={"lap_time_s": "LapTime_s"})
+            kept = _reject_contaminated_laps(
+                candidates,
+                fastest_lap_s=candidates["fastest_lap_s"],
+                max_pct=CFG.fresh_reference_max_pct_of_fastest,
+            )
+        else:
+            kept = fresh
+
+        ref_pred = kept.groupby("stint")["pred"].last()
+        ref_true = kept.groupby("stint")["target"].last()
+        print(f"  stints with a reference: {ref_pred.notna().sum()} of {fresh['stint'].nunique()}")
+
+        scored = frame[frame["tyre_life"] > FRESH_MAX_TYRE_LIFE].copy()
+        scored["ref_pred"] = scored["stint"].map(ref_pred)
+        scored["ref_true"] = scored["stint"].map(ref_true)
+        scored = scored.dropna(subset=["ref_pred", "ref_true"])
+        scored["error"] = (scored["pred"] - scored["ref_pred"]) - (
+            scored["target"] - scored["ref_true"]
+        )
+        return scored
+
+    bound(scored_bound(gated=False), "2025 BASELINE -- no gate")
+    bound(scored_bound(gated=True), f"2025 GATED @ {CFG.fresh_reference_max_pct_of_fastest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/measure_mc_tables.py
+++ b/scripts/measure_mc_tables.py
@@ -67,7 +67,14 @@ from typing import Any, Iterable
 
 import pandas as pd
 
-ROOT = Path(__file__).resolve().parent.parent
+# ``.git``-search-with-fallback, not a fixed ``.parent.parent``: the latter
+# silently resolves to the wrong directory under a `uv tool install` layout,
+# where this file is not exactly one level below the repo root.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT = next(
+    (p for p in [_SCRIPT_DIR, *_SCRIPT_DIR.parents] if (p / ".git").exists()),
+    _SCRIPT_DIR.parent,
+)
 sys.path.insert(0, str(ROOT))
 
 from src.f1_strat_manager.gp_slugs import (  # noqa: E402

--- a/scripts/measure_tyre_reference.py
+++ b/scripts/measure_tyre_reference.py
@@ -42,7 +42,15 @@ import pandas as pd
 import torch
 from scipy.stats import spearmanr
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+# ``.git``-search-with-fallback, not a fixed ``.parents[1]``: the latter
+# silently resolves to the wrong directory under a `uv tool install` layout,
+# where this file is not exactly one level below the repo root.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = next(
+    (p for p in [_SCRIPT_DIR, *_SCRIPT_DIR.parents] if (p / ".git").exists()),
+    _SCRIPT_DIR.parent,
+)
+sys.path.insert(0, str(_REPO_ROOT))
 
 from src.agents.tire_agent import TireDegTCN  # noqa: E402
 

--- a/scripts/prompt_ab/_common.py
+++ b/scripts/prompt_ab/_common.py
@@ -20,7 +20,14 @@ import sys
 from pathlib import Path
 from typing import Any
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+# ``.git``-search-with-fallback, not a fixed ``.parents[2]``: the latter
+# silently resolves to the wrong directory under a `uv tool install` layout,
+# where this file is not exactly two levels below the repo root.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = next(
+    (p for p in [_SCRIPT_DIR, *_SCRIPT_DIR.parents] if (p / ".git").exists()),
+    _SCRIPT_DIR.parent.parent,
+)
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 

--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -1287,18 +1287,13 @@ def _make_inference_panel(
 # RaceState builder
 # ---------------------------------------------------------------------------
 
-# Imported, not redeclared. Its rationale and its honest limitation live with it.
-#
-# Be precise about how far this got, because a comment claiming a closed drift is
-# worse than no comment: the CLI and the arcade now share one constant, and the
-# telemetry BACKEND does not. It is a git submodule and cannot be changed from this
-# commit, and an adversarial gate counted SIX surviving copies of this convention
-# there and here, including one in `strategy.py` that defaults the same concept to
-# 2.0 on one request model and 0.0 on its sibling in the same file. Tracked, not
-# closed (#628).
-from src.agents.position_projection import (  # noqa: E402
-    GAP_UNKNOWN_FALLBACK_S as _GAP_UNKNOWN_FALLBACK_S,
-)
+# The lap_state -> RaceState mapping is imported, not restated: the canonical
+# builder in src/agents/race_state_builder.py is shared by all three surfaces
+# (#784) — this CLI, the arcade, and the telemetry backend, which reaches it
+# through a re-export shim (#786). So the defaults the models receive, the gap
+# fallback and the #750 pace-delta axis can no longer drift per surface. Their
+# rationale and honest limitations live with the builder.
+from src.agents.race_state_builder import build_race_state  # noqa: E402
 
 
 def _build_race_state(
@@ -1306,71 +1301,24 @@ def _build_race_state(
     driver_code: str,
     prev_lap_time: float,
 ) -> RaceState:
-    """Map RaceStateManager's lap_state dict → RaceState Pydantic model.
+    """Map RaceStateManager's lap_state dict -> RaceState Pydantic model.
+
+    Thin delegation to ``src.agents.race_state_builder.build_race_state``
+    (#784), the single canonical mapping shared with the arcade and the
+    telemetry backend. The #628 position guard, the #750 pace-delta axis and
+    the gap fallback rationale all live there now. ``radio_msgs`` /
+    ``rcm_events`` stay schema defaults here on purpose: the main loop below
+    mutates them after construction (corpus radios, the SC tracker, the
+    --radio-every synthetic generator), and that precedence rule is CLI policy,
+    not builder policy.
 
     ``prev_lap_time`` is accepted but no longer read here: ``pace_delta_s`` used
-    to be computed from it and that was the wrong axis (#750, fixed below). Left
-    in the signature rather than removed, since the caller's per-lap bookkeeping
+    to be computed from it and that was the wrong axis (#750). Left in the
+    signature rather than removed, since the caller's per-lap bookkeeping
     that produces it (`run()`'s ``prev_lap_time`` loop variable) serves no other
     purpose today and dropping it is a small cleanup outside this fix's scope.
     """
-    driver_st = lap_state["driver"]
-    rivals = lap_state.get("rivals", [])
-    weather = lap_state.get("weather", {})
-
-    our_pos = driver_st.get("position")
-    # The incomplete-lap guard in run()'s main loop (`_pos_raw is None or ...`)
-    # already skips any lap where the driver's position is unknown before
-    # _build_race_state is ever called. Reaching here with a None position
-    # means that invariant broke. Fail loudly instead of defaulting to a
-    # searchable P99: a fabricated position is exactly the value the
-    # `our_pos - 1` lookup below searches by, so an unknown position and a
-    # genuinely-last car would silently resolve to the same rival — the #428
-    # bug shape. Mirrors src/arcade/strategy.py's _build_race_state (fixed for
-    # the identical shape under #465); the caller's per-lap try/except (in
-    # run()) turns this into an [ERROR] row for the lap, not a crashed run.
-    if our_pos is None:
-        raise ValueError(
-            "_build_race_state: driver position is None; the incomplete-lap "
-            "guard should have skipped this lap before it reached "
-            "_build_race_state (#628)"
-        )
-    car_ahead = next((r for r in rivals if r.get("position") == our_pos - 1), None)
-    if car_ahead is not None:
-        _interval = car_ahead.get("interval_to_driver_s")
-        gap_ahead_s = abs(_interval) if _interval is not None else _GAP_UNKNOWN_FALLBACK_S
-    else:
-        gap_ahead_s = 0.0
-
-    cur_lap_time = driver_st.get("lap_time_s") or 0.0
-    # pace_delta_s is contractually RIVAL-relative (this driver's lap time minus
-    # the car directly ahead's SAME lap, negative = we are faster) per
-    # race_situation_agent.py:292/904, the schema N27 itself computes. The old
-    # formula compared cur_lap_time against our OWN previous lap instead, a
-    # same-car same-driver quantity that reported roughly -20s of phantom "pace
-    # gain" on the lap after a pit stop, a green lap read against our own
-    # out-lap. car_ahead is already resolved above for gap_ahead_s, so no extra
-    # lookup is needed; 0.0 when it or its lap time is unknown is the schema's
-    # documented neutral, not a guess in either direction (#750).
-    ahead_lap_time = car_ahead.get("lap_time_s") if car_ahead is not None else None
-    if ahead_lap_time is not None and cur_lap_time:
-        pace_delta_s = cur_lap_time - float(ahead_lap_time)
-    else:
-        pace_delta_s = 0.0
-
-    return RaceState(
-        driver=driver_code,
-        lap=driver_st["lap_number"],
-        total_laps=lap_state["session_meta"]["total_laps"],
-        position=our_pos,
-        compound=driver_st.get("compound", "UNKNOWN"),
-        tyre_life=driver_st.get("tyre_life", 0),
-        gap_ahead_s=gap_ahead_s,
-        pace_delta_s=pace_delta_s,
-        air_temp=weather.get("air_temp", 25.0),
-        track_temp=weather.get("track_temp", 40.0),
-        rainfall=bool(weather.get("rainfall", False)),
-    )
+    return build_race_state(lap_state, driver=driver_code)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/verify_drs_zones.py
+++ b/scripts/verify_drs_zones.py
@@ -44,7 +44,14 @@ from pathlib import Path
 
 import numpy as np
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
+# ``.git``-search-with-fallback, not a fixed ``.parents[1]``: the latter
+# silently resolves to the wrong directory under a `uv tool install` layout,
+# where this file is not exactly one level below the repo root.
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = next(
+    (p for p in [_SCRIPT_DIR, *_SCRIPT_DIR.parents] if (p / ".git").exists()),
+    _SCRIPT_DIR.parent,
+)
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 

--- a/src/agents/_shared_defaults.py
+++ b/src/agents/_shared_defaults.py
@@ -1,0 +1,19 @@
+"""Fallback constants shared by the agent modules when session_meta arrives incomplete.
+
+A leaf module — no other agent internals, no heavy imports — so pulling in this one
+constant never drags in model weights (same reasoning as ``tire_parsing.py``).
+"""
+
+from __future__ import annotations
+
+# RaceStateManager.get_session_meta() always supplies total_laps (CLAUDE.md section 6,
+# "lap_state is the single contract"; race_state_manager.py's own get_session_meta sets
+# it unconditionally). This constant only guards a hand-built session_meta -- a test
+# fixture, or a partially populated state -- from resolving a missing key to a
+# different number at every call site. 57 is the median/mode race length across the
+# 2023-2025 dataset (71 races) -- NOT "2022-2025": there is no 2022 season anywhere in
+# data/ (CLAUDE.md section 1). Previously restated as a bare literal in
+# pit_strategy_agent.py (x3), race_situation_agent.py (x2) and tire_agent.py (x1);
+# consolidated here so a future change updates every caller at once instead of drifting
+# one site at a time.
+DEFAULT_TOTAL_LAPS: int = 57

--- a/src/agents/_shared_defaults.py
+++ b/src/agents/_shared_defaults.py
@@ -1,10 +1,12 @@
-"""Fallback constants shared by the agent modules when session_meta arrives incomplete.
+"""Fallbacks shared by the agent modules when session_meta or weather arrives incomplete.
 
-A leaf module — no other agent internals, no heavy imports — so pulling in this one
-constant never drags in model weights (same reasoning as ``tire_parsing.py``).
+A leaf module — no other agent internals, no heavy imports — so pulling these in never
+drags in model weights (same reasoning as ``tire_parsing.py``).
 """
 
 from __future__ import annotations
+
+from typing import Any, Mapping
 
 # RaceStateManager.get_session_meta() always supplies total_laps (CLAUDE.md section 6,
 # "lap_state is the single contract"; race_state_manager.py's own get_session_meta sets
@@ -17,3 +19,36 @@ from __future__ import annotations
 # consolidated here so a future change updates every caller at once instead of drifting
 # one site at a time.
 DEFAULT_TOTAL_LAPS: int = 57
+
+
+def reading_or_default(source: Mapping[str, Any], key: str, default: float) -> float:
+    """Read a numeric reading that may be ABSENT or PRESENT-AND-``None``.
+
+    ``dict.get(key, default)`` only fires its default when the KEY is missing. Our
+    producers deliberately report an unmeasured reading as the key present with a
+    ``None`` value -- ``_safe_none`` in the telemetry backend and
+    ``race_state_manager.get_weather_state`` both do this on purpose, so that an absent
+    measurement never becomes a searchable sentinel (#465). The two conventions meet
+    badly: ``wx.get('air_temp', 28.0)`` returns ``None``, and the ``float()`` one layer
+    down raises ``TypeError``.
+
+    That is not hypothetical. Every 2025 laps parquet ships without weather columns, so
+    the backend's producer emits ``None`` for all four readings on every 2025 lap. It
+    crashed ``/recommend`` with a 422 for the whole default season (#788) via
+    ``race_situation_agent``, and it silently moved ``tire_agent``'s cliff estimate 2.3
+    laps in the optimistic direction -- the dangerous one, since it delays the pit call.
+
+    The bug shape is a twin that never got the fix: ``pace_agent`` had guarded this read
+    with an inline conditional and a comment describing the exact crash, while the
+    identical reads in ``tire_agent`` and ``race_situation_agent`` had not. Hence one
+    named function rather than a fourth inline copy.
+
+    ``default`` stays a per-caller argument on purpose: the agents disagree on the
+    fallback temperatures (pace uses 25/35, tire and race_situation use 28/38) and
+    reconciling those numbers is a modelling decision tracked in #789, not something to
+    smuggle in behind a crash fix.
+    """
+    value = source.get(key)
+    if value is None:
+        return default
+    return value

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -29,6 +29,8 @@ import numpy as np
 import pandas as pd
 import xgboost as xgb
 
+from src.agents._shared_defaults import reading_or_default
+
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent
 while not (_REPO_ROOT / '.git').exists():
@@ -638,11 +640,14 @@ class PaceAgent:
         #     "DataFrame.dtypes for data must be int, float, bool or category"
         # That is exactly the crash observed on mid-stint laps. The ``or``
         # pattern handles both missing-key and None-value cases in one step.
+        # This file's inline guard was the ONLY one of the three agents that handled
+        # present-and-None, and it is now the shared helper the other two adopted rather
+        # than a fourth copy of the pattern (#788).
         _speed_st  = d.get('speed_st')   or 300.0
-        _air_temp  = wx.get('air_temp')  if wx.get('air_temp')  is not None else 25.0
-        _trk_temp  = wx.get('track_temp') if wx.get('track_temp') is not None else 35.0
-        _humidity  = wx.get('humidity')  if wx.get('humidity')  is not None else 50.0
-        _rainfall  = wx.get('rainfall', 0)
+        _air_temp  = reading_or_default(wx, 'air_temp',   25.0)
+        _trk_temp  = reading_or_default(wx, 'track_temp', 35.0)
+        _humidity  = reading_or_default(wx, 'humidity',   50.0)
+        _rainfall  = reading_or_default(wx, 'rainfall', 0)
 
         return self.run(
             driver_number  = d.get('driver_number') or 0,

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -309,9 +309,23 @@ class PaceAgent:
 
         Read from the same `laps_featured_2025.parquet` the team map and the reference
         laps already come from rather than from `circuit_clustering/`: it is the artefact
-        N04 wrote the trained column into, so the value served is the value fitted, and
-        there is no second file to keep in step. Checked across the 22 GPs of the training
-        seasons against `circuit_features_with_clusters_k4.parquet`: identical to 0.0.
+        N04 writes the column into, and there is no second file to keep in step.
+
+        WHICH SEASON'S VALUE, because the two are not the same number and an earlier
+        draft of this docstring implied they were. The feature is recomputed per season
+        from that season's laps, so a GP's 2025 value differs from its 2023-2024 one:
+        across the 23 GPs in both, none match exactly, the mean absolute gap is 4.8 km/h
+        and Silverstone moves 18.4. Serving 2025 is deliberate and is the correct half of
+        that pair, because the quantity N04 would compute for a 2025 lap is the 2025
+        measurement; serving the training seasons' value would feed a stale reading of a
+        circuit that has since been resurfaced or re-regulated.
+
+        It follows that the ENVELOPE bound on this feature is the 2023-2024 range while
+        the value served is a 2025 measurement, and that is the right way round rather
+        than an oversight: the bound asks whether N06 was FITTED on inputs like this one,
+        so a 2025 circuit outside the fitted range is genuine extrapolation and should be
+        said out loud. Monza 2025 at 317.24 against a fitted maximum of 314.97 is exactly
+        that case, and it is the only one.
 
         A GP whose value is missing is simply absent from the map. It must NOT acquire a
         default here -- see `_resolve_mean_sector_speed` for why an absent circuit has to

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -30,6 +30,8 @@ import pandas as pd
 import xgboost as xgb
 
 from src.agents._shared_defaults import reading_or_default
+# Safe in this direction: envelope.py is a leaf that imports nothing from src.agents.
+from src.strategy.inference.envelope import OperatingEnvelope
 
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent
@@ -84,6 +86,55 @@ _NOISE_PCT: float  = 0.02   # 2 % Gaussian noise on continuous features
 # lives in tire_agent._add_fuel_cols; deliberately duplicated rather than shared, since
 # unifying constants across agent modules is a wider refactor than this fix (#446).
 FUEL_GAIN_PER_LAP_S: float = 0.055
+
+
+# ── N06's operating envelope (#710) ──────────────────────────────────────────
+# The range each continuous feature actually took across N06's training seasons,
+# so that a call outside it stops being silent. Until now this agent had no range
+# check of any kind, which is the condition the envelope contract was written for:
+# an XGBoost regressor answers an out-of-range call with exactly the confidence it
+# answers an in-range one, and N26 spent two years doing precisely that.
+#
+# MEASURED, NOT CHOSEN, and reproducible: rebuild 2023 + 2024 through
+# `augment_featured_laps`, apply the two N06 feature steps `pace_holdout.py` already
+# owns (`_encode_categoricals` then `_add_lag_deg_features`), drop the rows N06 drops,
+# and take the min/max of each column over the resulting 42,957 rows.
+# `tests/agents/test_n06_envelope.py` re-runs that measurement and fails if any bound
+# below has drifted from it, so these cannot quietly become hand-typed numbers.
+#
+# Why these twelve and not all twenty-five:
+#   - The identifiers and codes (DriverNumber, TeamID, CompoundID, Cluster, Year) and
+#     the flags (FreshTyre, Rainfall) have no range to be outside of. A bound on a
+#     label is a category check wearing the wrong contract.
+#   - The three Prev_Deg* features are excluded DELIBERATELY, and the reason matters
+#     because it is the opposite of what it looks like. `run_from_state` hardcodes all
+#     three to 0.0 on every real call, which reads like the textbook out-of-range bug.
+#     Measured, it is not one: 0.0 sits mid-distribution for all three (42%/42%/47% of
+#     training rows fall below it), so an envelope would never fire and declaring one
+#     here would advertise a check that cannot work. Feeding a model a CONSTANT where
+#     it was trained on a distribution is a real defect, but it is a different defect
+#     and it needs its own instrument, not this one.
+#
+# The bounds are TRAINING-season ranges (2023-2024). This is not the same thing as the
+# "range 0..3.685 s" recorded next to FUEL_GAIN_PER_LAP_S above, which was measured on
+# laps_featured_2025: 2025 is the held-out TEST season, and an envelope sourced from it
+# would be describing where the model is asked to work rather than where it was fitted.
+_N06_TRAINED_BOUNDS: dict[str, tuple[float, float]] = {
+    'LapNumber':         (3.0, 78.0),
+    'TyreLife':          (3.0, 78.0),
+    'FuelLoad':          (0.0, 0.9615),
+    'FuelEffect':        (0.055, 4.125),
+    'Prev_LapTime':      (67.719, 148.991),
+    'Prev_TyreLife':     (2.0, 77.0),
+    'Prev_SpeedST':      (156.0, 362.0),
+    'AirTemp':           (14.5, 33.7),
+    'TrackTemp':         (16.7, 50.7),
+    'Humidity':          (18.0, 92.0),
+    'laps_remaining':    (0.0, 75.0),
+    'mean_sector_speed': (196.6292354740061, 314.9705586672411),
+}
+
+_N06_ENVELOPE = OperatingEnvelope(name='n06_laptime_delta', bounds=_N06_TRAINED_BOUNDS)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -405,7 +456,34 @@ class PaceAgent:
         # converts None→NaN and the model handles NaN natively via its
         # sparse-aware split logic (default_left). Cheap and defensive —
         # no-op on already-numeric frames.
-        return df.apply(pd.to_numeric, errors='coerce')
+        numeric = df.apply(pd.to_numeric, errors='coerce')
+        self._label_against_envelope(numeric)
+        return numeric
+
+    @staticmethod
+    def _label_against_envelope(feature_df: pd.DataFrame) -> None:
+        """Say out loud when N06 is being asked to predict outside its trained range.
+
+        LABELS ONLY, and that is the contract, not a shortcut: nothing here clips,
+        refuses or alters a single value the model is fed, so the frame returned by
+        `_build_feature_row` is byte-identical to the one returned before this
+        existed and the strategy goldens cannot move (#710).
+
+        Only ``violations`` are reported, never ``unknown``. A feature that arrived
+        as NaN was not given a bad value, it was given no value, and the two must
+        stay distinguishable: the places that can produce a NaN here already warn
+        for themselves (`_compute_derived` on an absent stint baseline, and the
+        deliberate None-propagation of an unknown Position), so folding them in
+        would double-report the known cases and drown the one this exists to catch.
+        """
+        verdict = _N06_ENVELOPE.check(feature_df.iloc[0].to_dict())
+        if verdict.violations:
+            logger.warning(
+                'N06 called outside its trained range on %d feature(s): %s; the '
+                'prediction is an extrapolation, not a fit',
+                len(verdict.violations),
+                dict(verdict.violations),
+            )
 
     # ── Inference helpers ─────────────────────────────────────────────────────
 

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -165,6 +165,11 @@ _N06_TRAINED_BOUNDS: dict[str, tuple[float, float]] = {
 _N06_ENVELOPE = OperatingEnvelope(name="n06_laptime_delta", bounds=_N06_TRAINED_BOUNDS)
 
 
+# The seasons that have a per-year featured artefact. Listed rather than globbed so a
+# stray file cannot silently widen what the agent claims to know.
+_FEATURED_SEASONS: tuple[int, ...] = (2023, 2024, 2025)
+
+
 def _normalise_gp_key(gp_name: str) -> str:
     """One spelling for a GP, applied to BOTH sides of the circuit-speed lookup.
 
@@ -331,14 +336,12 @@ class PaceAgent:
         N06 was trained on it and inference never had it, because `_compute_derived`
         substituted `prev_speed_st` and nothing ever supplied the real thing (#797).
 
-        KEYED BY YEAR, because the value is not constant across the dataset and the
-        replay engine can replay any of the three seasons. `laps_featured.parquet` carries
-        71 (year, GP) pairs and the value differs between the training era and 2025 on
-        every GP present in both: mean absolute gap 4.8 km/h, largest Silverstone at 18.4.
-        An earlier draft of this loader read only `laps_featured_2025.parquet` and served
-        that single value for every replay, which fed a 2023 Silverstone lap a measurement
-        taken two years after it. Keying by year makes the value served the value the lap
-        being replayed actually carries.
+        KEYED BY YEAR, because the value is not constant across seasons and the replay
+        engine can replay any of the three. Across the GPs present in both eras the
+        training-era and 2025 measurements differ on every one: mean absolute gap 4.8 km/h,
+        largest Silverstone at 18.3. An earlier draft read only the 2025 artefact and
+        served that value for every replay, feeding a 2023 Silverstone lap a measurement
+        taken two years after it.
 
         Beware the mechanism, which is NOT what an earlier draft of this docstring said:
         the value is recomputed per ARTEFACT GENERATION, not per season. 2023 and 2024 are
@@ -346,12 +349,23 @@ class PaceAgent:
         pooled both training seasons and a later build produced 2025. Anyone "completing"
         a per-season resolution between 2023 and 2024 would find nothing to resolve.
 
-        THE COMBINED FILE, not the per-year ones, and that is the whole reason this reads
-        `laps_featured.parquet`: `laps_featured_2025.parquet` carries NaN on all 760 Las
-        Vegas rows, so a `.dropna()` over it silently drops a circuit N06 was fitted on and
-        whose value sits in three other artefacts. The combined file has 71 pairs and ZERO
-        missing values, so "absent from the map" now means a genuinely unknown circuit
-        rather than an artefact with a hole in it.
+        THE PER-YEAR FILES, and NOT the combined `laps_featured.parquet`, which is the
+        trap that cost this lookup two rounds. The combined artefact BROADCASTS the
+        training-era value across all three seasons: its Silverstone row reads 249.71 for
+        2023 and for 2025 alike, and across every GP present in both eras the 2023-vs-2025
+        difference is exactly 0.0. Reading it therefore looks year-aware and is not.
+
+        The raw laps settle which artefact is telling the truth. Silverstone 2025's own
+        speed traps average 232.32 km/h: the per-year file says 231.36 and the combined
+        file says 249.71, the 2023 number. Melbourne 2025 is the same story, 252.93 raw
+        against 256.84 per-year and 272.44 combined. So the per-year artefacts carry the
+        season's own measurement and the combined one does not.
+
+        The cost of that correctness is a hole rather than a wrong number:
+        `laps_featured_2025.parquet` has NaN on all 760 Las Vegas rows, so that race
+        resolves to NaN. That is the right failure. The alternative is serving the
+        2023-2024 measurement for a 2025 lap, which is the same class of defect as the
+        speed-trap substitution this whole fix exists to remove, only quieter.
 
         It follows that the ENVELOPE bound stays the 2023-2024 range while a 2025 lap is
         served a 2025 measurement, and that is the right way round rather than an oversight:
@@ -359,15 +373,15 @@ class PaceAgent:
         outside the fitted range is genuine extrapolation and should be said out loud. Monza
         2025 at 317.24 against a fitted maximum of 314.97 is exactly that, and the only one.
         """
-        speeds = pd.read_parquet(
-            processed_dir / "laps_featured.parquet",
-            columns=["Year", "GP_Name", "mean_sector_speed"],
-        ).dropna()
-        by_race = speeds.drop_duplicates(["Year", "GP_Name"])
-        return {
-            (int(row.Year), _normalise_gp_key(str(row.GP_Name))): float(row.mean_sector_speed)
-            for row in by_race.itertuples()
-        }
+        by_race: dict[tuple[int, str], float] = {}
+        for year in _FEATURED_SEASONS:
+            parquet = processed_dir / f"laps_featured_{year}.parquet"
+            if not parquet.exists():
+                continue
+            speeds = pd.read_parquet(parquet, columns=["GP_Name", "mean_sector_speed"]).dropna()
+            for row in speeds.drop_duplicates("GP_Name").itertuples():
+                by_race[(year, _normalise_gp_key(str(row.GP_Name)))] = float(row.mean_sector_speed)
+        return by_race
 
     def _resolve_mean_sector_speed(self, gp_name: str, year: int) -> float:
         """This race's trained mean sector speed, or NaN when it does not resolve.

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -30,7 +30,7 @@ import pandas as pd
 import xgboost as xgb
 
 from src.agents._shared_defaults import reading_or_default
-from src.f1_strat_manager.gp_slugs import slug_from_event_name
+from src.f1_strat_manager.gp_slugs import canonical_gp_name, slug_from_event_name
 
 # Safe in this direction: envelope.py is a leaf that imports nothing from src.agents.
 from src.strategy.inference.envelope import OperatingEnvelope
@@ -165,6 +165,30 @@ _N06_TRAINED_BOUNDS: dict[str, tuple[float, float]] = {
 _N06_ENVELOPE = OperatingEnvelope(name="n06_laptime_delta", bounds=_N06_TRAINED_BOUNDS)
 
 
+def _normalise_gp_key(gp_name: str) -> str:
+    """One spelling for a GP, applied to BOTH sides of the circuit-speed lookup.
+
+    A GP is written four ways across this project: the parquet slug ('Miami'), the raw
+    folder ('Miami_Gardens'), the metadata.json name the replay engine puts into
+    `session_meta` ('Miami Gardens', with a SPACE), and the FastF1 event name ('Miami
+    Grand Prix'). Worse, the artefacts do not agree with each other: the combined
+    `laps_featured.parquet` calls this race 'Miami' in 2023-2024 and 'Miami Gardens' in
+    2025, so even a lookup whose query is spelled correctly can miss on the season.
+
+    Normalising the KEYS at load time and the query the same way is what `gp_slugs`'s own
+    docstring prescribes, and it is why this is a function rather than a longer candidate
+    list at the call site: a chain of guesses at the query end still fails the moment the
+    stored spelling is the odd one, which is exactly how the first version of this lookup
+    sent every lap of the 2025 Miami race to NaN.
+
+    Underscores first, because `canonical_gp_name`'s alias table is keyed by the folder
+    form, so 'Miami Gardens' has to become 'Miami_Gardens' before it can become 'Miami'.
+    """
+    if not gp_name:
+        return ""
+    return canonical_gp_name(gp_name.replace(" ", "_"))
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # PaceOutput dataclass (public API — untouched)
 # ─────────────────────────────────────────────────────────────────────────────
@@ -241,8 +265,8 @@ class PaceAgent:
         self.compound_id, self.circuit_cluster, self.team_id = self._load_encoding_maps(
             processed_dir
         )
-        self.circuit_mean_sector_speed: dict[str, float] = self._load_circuit_mean_sector_speed(
-            processed_dir
+        self.circuit_mean_sector_speed: dict[tuple[int, str], float] = (
+            self._load_circuit_mean_sector_speed(processed_dir)
         )
         self.laps_ref: pd.DataFrame = self._load_reference_laps(processed_dir)
 
@@ -299,47 +323,54 @@ class PaceAgent:
         return compound_id, circuit_cluster, team_id
 
     @staticmethod
-    def _load_circuit_mean_sector_speed(processed_dir: Path) -> dict[str, float]:
-        """The one ``mean_sector_speed`` each GP carries, keyed by parquet ``GP_Name``.
+    def _load_circuit_mean_sector_speed(processed_dir: Path) -> dict[tuple[int, str], float]:
+        """``mean_sector_speed`` per ``(Year, GP_Name)``, from the combined featured parquet.
 
-        This feature is a property of the CIRCUIT, not of the lap: the featured parquet
-        holds exactly one distinct value per GP, the mean of the three speed traps.
+        This feature is a property of the CIRCUIT, not of the lap: the parquet holds
+        exactly one distinct value per (year, GP), the mean of the three speed traps.
         N06 was trained on it and inference never had it, because `_compute_derived`
         substituted `prev_speed_st` and nothing ever supplied the real thing (#797).
 
-        Read from the same `laps_featured_2025.parquet` the team map and the reference
-        laps already come from rather than from `circuit_clustering/`: it is the artefact
-        N04 writes the column into, and there is no second file to keep in step.
+        KEYED BY YEAR, because the value is not constant across the dataset and the
+        replay engine can replay any of the three seasons. `laps_featured.parquet` carries
+        71 (year, GP) pairs and the value differs between the training era and 2025 on
+        every GP present in both: mean absolute gap 4.8 km/h, largest Silverstone at 18.4.
+        An earlier draft of this loader read only `laps_featured_2025.parquet` and served
+        that single value for every replay, which fed a 2023 Silverstone lap a measurement
+        taken two years after it. Keying by year makes the value served the value the lap
+        being replayed actually carries.
 
-        WHICH SEASON'S VALUE, because the two are not the same number and an earlier
-        draft of this docstring implied they were. The feature is recomputed per season
-        from that season's laps, so a GP's 2025 value differs from its 2023-2024 one:
-        across the 23 GPs in both, none match exactly, the mean absolute gap is 4.8 km/h
-        and Silverstone moves 18.4. Serving 2025 is deliberate and is the correct half of
-        that pair, because the quantity N04 would compute for a 2025 lap is the 2025
-        measurement; serving the training seasons' value would feed a stale reading of a
-        circuit that has since been resurfaced or re-regulated.
+        Beware the mechanism, which is NOT what an earlier draft of this docstring said:
+        the value is recomputed per ARTEFACT GENERATION, not per season. 2023 and 2024 are
+        identical for every GP they share (max difference exactly 0.0), because one build
+        pooled both training seasons and a later build produced 2025. Anyone "completing"
+        a per-season resolution between 2023 and 2024 would find nothing to resolve.
 
-        It follows that the ENVELOPE bound on this feature is the 2023-2024 range while
-        the value served is a 2025 measurement, and that is the right way round rather
-        than an oversight: the bound asks whether N06 was FITTED on inputs like this one,
-        so a 2025 circuit outside the fitted range is genuine extrapolation and should be
-        said out loud. Monza 2025 at 317.24 against a fitted maximum of 314.97 is exactly
-        that case, and it is the only one.
+        THE COMBINED FILE, not the per-year ones, and that is the whole reason this reads
+        `laps_featured.parquet`: `laps_featured_2025.parquet` carries NaN on all 760 Las
+        Vegas rows, so a `.dropna()` over it silently drops a circuit N06 was fitted on and
+        whose value sits in three other artefacts. The combined file has 71 pairs and ZERO
+        missing values, so "absent from the map" now means a genuinely unknown circuit
+        rather than an artefact with a hole in it.
 
-        A GP whose value is missing is simply absent from the map. It must NOT acquire a
-        default here -- see `_resolve_mean_sector_speed` for why an absent circuit has to
-        stay absent all the way to the model.
+        It follows that the ENVELOPE bound stays the 2023-2024 range while a 2025 lap is
+        served a 2025 measurement, and that is the right way round rather than an oversight:
+        the bound asks whether N06 was FITTED on inputs like this one, so a 2025 circuit
+        outside the fitted range is genuine extrapolation and should be said out loud. Monza
+        2025 at 317.24 against a fitted maximum of 314.97 is exactly that, and the only one.
         """
         speeds = pd.read_parquet(
-            processed_dir / "laps_featured_2025.parquet",
-            columns=["GP_Name", "mean_sector_speed"],
+            processed_dir / "laps_featured.parquet",
+            columns=["Year", "GP_Name", "mean_sector_speed"],
         ).dropna()
-        by_gp = speeds.drop_duplicates("GP_Name").set_index("GP_Name")["mean_sector_speed"]
-        return {str(gp): float(value) for gp, value in by_gp.items()}
+        by_race = speeds.drop_duplicates(["Year", "GP_Name"])
+        return {
+            (int(row.Year), _normalise_gp_key(str(row.GP_Name))): float(row.mean_sector_speed)
+            for row in by_race.itertuples()
+        }
 
-    def _resolve_mean_sector_speed(self, gp_name: str) -> float:
-        """This circuit's trained mean sector speed, or NaN when it does not resolve.
+    def _resolve_mean_sector_speed(self, gp_name: str, year: int) -> float:
+        """This race's trained mean sector speed, or NaN when it does not resolve.
 
         NaN, never `prev_speed_st`, and that substitution is the whole bug: the speed
         trap is a different physical quantity (training means 256.8 vs 303.0 km/h), so
@@ -349,22 +380,28 @@ class PaceAgent:
         should look like. Same rule as `FuelEffect` (#446) and `Position` (#628): unknown
         data stays unknown and never becomes a number the model can mistake for a reading.
 
-        The name is resolved through `slug_from_event_name` first, because `gp_name`
-        arrives in either keyspace depending on the caller -- the CLI passes the slug
-        ('Lusail'), a FastF1-derived caller passes the event name ('Qatar Grand Prix').
-        The same dual-keyspace trap cost #448 and #450.
+        FOUR KEYSPACES, because a GP is named four different ways in this project and an
+        earlier draft resolved only two of them. The parquet slug ('Miami'), the raw
+        folder ('Miami_Gardens'), the metadata.json name the replay engine actually puts
+        into `session_meta` ('Miami Gardens', with a SPACE, which neither of the other two
+        forms matches), and the FastF1 event name ('Qatar Grand Prix'). Resolving only the
+        first and last sent every lap of the 2025 Miami and 2023 Spanish races to NaN while
+        their value sat in the map. That is the #448/#450 dual-keyspace trap for the third
+        time, and this time the enumeration is checked rather than assumed: all 71 races
+        under `data/raw/` resolve through the chain below, asserted in
+        `tests/agents/test_pace_circuit_speed.py`.
         """
-        if gp_name in self.circuit_mean_sector_speed:
-            return self.circuit_mean_sector_speed[gp_name]
-
-        slug = slug_from_event_name(gp_name) if gp_name else None
-        if slug and slug in self.circuit_mean_sector_speed:
-            return self.circuit_mean_sector_speed[slug]
+        if gp_name:
+            for candidate in (gp_name, slug_from_event_name(gp_name) or ""):
+                key = (year, _normalise_gp_key(candidate))
+                if key in self.circuit_mean_sector_speed:
+                    return self.circuit_mean_sector_speed[key]
 
         logger.warning(
-            "no trained mean sector speed for GP %r; N06 reads the feature as missing "
+            "no trained mean sector speed for %r in %s; N06 reads the feature as missing "
             "rather than being fed the speed trap in its place (#797)",
             gp_name,
+            year,
         )
         return float("nan")
 
@@ -518,7 +555,7 @@ class PaceAgent:
         resolved_mean_sector_speed = (
             mean_sector_speed
             if mean_sector_speed is not None
-            else self._resolve_mean_sector_speed(gp_name)
+            else self._resolve_mean_sector_speed(gp_name, year)
         )
         derived = self._compute_derived(
             tyre_life,

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -8,7 +8,6 @@ Public API (unchanged — backward compatible)
 --------------------------------------------
 run_pace_agent(**kwargs)               → PaceOutput
 run_pace_agent_from_state(lap_state)   → PaceOutput
-get_pace_react_agent()                 → LangGraph ReAct agent (lazy, LLM required)
 
 Internal structure
 ------------------
@@ -83,11 +82,6 @@ _NOISE_PCT: float  = 0.02   # 2 % Gaussian noise on continuous features
 # lives in tire_agent._add_fuel_cols; deliberately duplicated rather than shared, since
 # unifying constants across agent modules is a wider refactor than this fix (#446).
 FUEL_GAIN_PER_LAP_S: float = 0.055
-
-# ── Artifact paths ────────────────────────────────────────────────────────────
-_CLUSTER_PARQUET  = _PROCESSED / 'circuit_clustering' / 'circuit_clusters_k4_2025.parquet'
-_LAPS_FEATURED    = _PROCESSED / 'laps_featured_2025.parquet'
-_FEATURE_MANIFEST = _PROCESSED / 'feature_manifest_laptime.json'
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -990,38 +984,5 @@ Never invent numbers — use only the values returned by the tools."""
 
     PACE_TOOLS = [predict_pace_tool, get_session_median_tool]
 
-    def get_pace_react_agent(
-        provider: str = 'lmstudio',
-        model_name: str = 'gpt-4.1-mini',
-        base_url: str = 'http://localhost:1234/v1',
-        api_key: str = 'lmstudio',
-    ):
-        """Return the LangGraph ReAct agent for the Pace Agent (lazy singleton).
-
-        Delegates to the shared PaceAgent instance so model weights and the
-        LangGraph graph are only created once per process.
-
-        Args:
-            provider: 'lmstudio' or 'openai'.
-            model_name: Model identifier for ChatOpenAI.
-            base_url: Base URL for LM Studio (ignored when provider='openai').
-            api_key: API key; use 'lmstudio' for local server.
-
-        Returns:
-            LangGraph CompiledGraph — invoke with {"messages": [("user", query)]}.
-        """
-        return _get_default_pace_agent().get_react_agent(
-            provider=provider,
-            model_name=model_name,
-            base_url=base_url,
-            api_key=api_key,
-        )
-
 else:
     PACE_TOOLS = []
-
-    def get_pace_react_agent(**kwargs):
-        raise ImportError(
-            "LangGraph / LangChain not installed. "
-            "Install with: pip install langgraph langchain-openai"
-        )

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -30,12 +30,14 @@ import pandas as pd
 import xgboost as xgb
 
 from src.agents._shared_defaults import reading_or_default
+from src.f1_strat_manager.gp_slugs import slug_from_event_name
+
 # Safe in this direction: envelope.py is a leaf that imports nothing from src.agents.
 from src.strategy.inference.envelope import OperatingEnvelope
 
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent
-while not (_REPO_ROOT / '.git').exists():
+while not (_REPO_ROOT / ".git").exists():
     if _REPO_ROOT.parent == _REPO_ROOT:
         break
     _REPO_ROOT = _REPO_ROOT.parent
@@ -45,6 +47,7 @@ while not (_REPO_ROOT / '.git').exists():
 # checkouts with a repo-relative ``data/`` short-circuit the helper.
 try:
     from src.f1_strat_manager.data_cache import get_data_root as _get_data_root
+
     _DATA_ROOT = _get_data_root()
 except (ImportError, OSError, RuntimeError):
     # Every way get_data_root() can fail, enumerated against its body in
@@ -55,7 +58,7 @@ except (ImportError, OSError, RuntimeError):
     # the Path.home() branch IS the `uv tool install` path this block exists to
     # serve, and a container with no HOME would take it. Falling back to the
     # repo-relative data/ is right for all three.
-    _DATA_ROOT = _REPO_ROOT / 'data'
+    _DATA_ROOT = _REPO_ROOT / "data"
 
 # What stands in for the previous lap when there genuinely is not one: the first lap
 # of a race, or of a stint, where N04's Prev_LapTime is NaN by construction.
@@ -71,14 +74,14 @@ except (ImportError, OSError, RuntimeError):
 # None value, which the two-arg form does not substitute for.
 MISSING_PREV_LAP_TIME_S = 90.0
 
-_MODELS_DIR = _DATA_ROOT / 'models' / 'lap_time'
-_PROCESSED  = _DATA_ROOT / 'processed'
+_MODELS_DIR = _DATA_ROOT / "models" / "lap_time"
+_PROCESSED = _DATA_ROOT / "processed"
 
 logger = logging.getLogger(__name__)
 
 # ── Constants ─────────────────────────────────────────────────────────────────
-N_BOOTSTRAP: int   = 200
-_NOISE_PCT: float  = 0.02   # 2 % Gaussian noise on continuous features
+N_BOOTSTRAP: int = 200
+_NOISE_PCT: float = 0.02  # 2 % Gaussian noise on continuous features
 
 # Seconds of lap time recovered per lap as fuel burns off. N04 builds the training
 # feature as (TyreLife - min(TyreLife of the stint)) * 0.055 — verified exactly against
@@ -117,14 +120,15 @@ FUEL_GAIN_PER_LAP_S: float = 0.055
 #       not one: 0.0 sits mid-distribution for each (42.6% / 41.9% / 46.7% of training
 #       rows fall below it), so a bound could never fire and declaring one would
 #       advertise a check that cannot work.
-#     - `mean_sector_speed`. `_compute_derived` falls back to `prev_speed_st` whenever a
-#       mean sector speed is absent, and `run_from_state` never supplies one, so at
-#       inference this feature ALWAYS carries the speed trap. They are different physical
-#       quantities with different distributions (training means 256.8 vs 303.0 km/h), and
-#       a bound over the first one applied to the second fires on 83% of laps at Monza
-#       while describing none of them correctly. This is the twin of the Prev_Deg* case
-#       and it was missed on the first pass precisely because only one of the pair was
-#       looked at, which is this repo's most reliable defect.
+#     `mean_sector_speed` used to be listed here for the same reason and no longer is.
+#     `_compute_derived` substituted `prev_speed_st` whenever no mean sector speed was
+#     supplied and `run_from_state` never supplied one, so the feature carried the speed
+#     trap on every real call: a different physical quantity, training means 256.8 vs
+#     303.0 km/h, and a bound over the first applied to the second fired on 83% of laps
+#     at Monza while describing none of them. #797 fixed the FEED rather than deleting
+#     the bound, so the value is once again the quantity the range was measured from and
+#     the bound is once again meaningful: it now fires when a circuit falls outside the
+#     set N06 was fitted on, which is the question it was always supposed to ask.
 #
 #   Excluded, a bound would report the same event twice (1): `LapsSincePitStop`.
 #   `run_from_state` passes `d.get('tyre_life') or 1` for BOTH it and `TyreLife`, so at
@@ -145,24 +149,26 @@ FUEL_GAIN_PER_LAP_S: float = 0.055
 # laps_featured_2025: 2025 is the held-out TEST season, and an envelope sourced from it
 # would be describing where the model is asked to work rather than where it was fitted.
 _N06_TRAINED_BOUNDS: dict[str, tuple[float, float]] = {
-    'LapNumber':      (3.0, 78.0),
-    'TyreLife':       (3.0, 78.0),
-    'FuelEffect':     (0.055, 4.125),
-    'Prev_LapTime':   (67.719, 148.991),
-    'Prev_TyreLife':  (2.0, 77.0),
-    'Prev_SpeedST':   (156.0, 362.0),
-    'AirTemp':        (14.5, 33.7),
-    'TrackTemp':      (16.7, 50.7),
-    'Humidity':       (18.0, 92.0),
-    'laps_remaining': (0.0, 75.0),
+    "LapNumber": (3.0, 78.0),
+    "TyreLife": (3.0, 78.0),
+    "FuelEffect": (0.055, 4.125),
+    "Prev_LapTime": (67.719, 148.991),
+    "Prev_TyreLife": (2.0, 77.0),
+    "Prev_SpeedST": (156.0, 362.0),
+    "AirTemp": (14.5, 33.7),
+    "TrackTemp": (16.7, 50.7),
+    "Humidity": (18.0, 92.0),
+    "laps_remaining": (0.0, 75.0),
+    "mean_sector_speed": (196.6292354740061, 314.9705586672411),
 }
 
-_N06_ENVELOPE = OperatingEnvelope(name='n06_laptime_delta', bounds=_N06_TRAINED_BOUNDS)
+_N06_ENVELOPE = OperatingEnvelope(name="n06_laptime_delta", bounds=_N06_TRAINED_BOUNDS)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # PaceOutput dataclass (public API — untouched)
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 @dataclass
 class PaceOutput:
@@ -188,17 +194,18 @@ class PaceOutput:
     Orchestrator for LLM synthesis.
     """
 
-    lap_time_pred:   float
-    delta_vs_prev:   float
+    lap_time_pred: float
+    delta_vs_prev: float
     delta_vs_median: float
-    ci_p10:          float
-    ci_p90:          float
-    reasoning:       str = ""
+    ci_p10: float
+    ci_p90: float
+    reasoning: str = ""
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # PaceAgent class
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 class PaceAgent:
     """Encapsulates the N06 XGBoost lap-time prediction pipeline.
@@ -227,18 +234,21 @@ class PaceAgent:
         models_dir: Path = _MODELS_DIR,
         processed_dir: Path = _PROCESSED,
     ) -> None:
-        self.model, self.features     = self._load_model(models_dir)
-        self.compound_id: dict        = {}
-        self.circuit_cluster: dict    = {}
-        self.team_id: dict            = {}
-        self.compound_id, self.circuit_cluster, self.team_id = self._load_encoding_maps(processed_dir)
-        self.laps_ref: pd.DataFrame   = self._load_reference_laps(processed_dir)
+        self.model, self.features = self._load_model(models_dir)
+        self.compound_id: dict = {}
+        self.circuit_cluster: dict = {}
+        self.team_id: dict = {}
+        self.compound_id, self.circuit_cluster, self.team_id = self._load_encoding_maps(
+            processed_dir
+        )
+        self.circuit_mean_sector_speed: dict[str, float] = self._load_circuit_mean_sector_speed(
+            processed_dir
+        )
+        self.laps_ref: pd.DataFrame = self._load_reference_laps(processed_dir)
 
     # ── Loaders ───────────────────────────────────────────────────────────────
 
-    def _load_model(
-        self, models_dir: Path
-    ) -> tuple[xgb.XGBRegressor, list[str]]:
+    def _load_model(self, models_dir: Path) -> tuple[xgb.XGBRegressor, list[str]]:
         """Load N06 XGBoost model and ordered feature name list from disk.
 
         Both artifacts are returned together to guarantee the feature order is
@@ -252,16 +262,12 @@ class PaceAgent:
             Tuple (model, features) where model is a fitted XGBRegressor and
             features is a list of column name strings in predict order.
         """
-        features = json.loads(
-            (models_dir / 'xgb_laptime_delta_feature_names.json').read_text()
-        )
+        features = json.loads((models_dir / "xgb_laptime_delta_feature_names.json").read_text())
         model = xgb.XGBRegressor()
-        model.load_model(models_dir / 'xgb_laptime_delta_final.json')
+        model.load_model(models_dir / "xgb_laptime_delta_final.json")
         return model, features
 
-    def _load_encoding_maps(
-        self, processed_dir: Path
-    ) -> tuple[dict, dict, dict]:
+    def _load_encoding_maps(self, processed_dir: Path) -> tuple[dict, dict, dict]:
         """Load compound, circuit-cluster, and team label-encoding maps.
 
         Reads the compound encoding from the N06 feature manifest, the circuit
@@ -276,28 +282,77 @@ class PaceAgent:
         Returns:
             Tuple (compound_id, circuit_cluster, team_id) dicts.
         """
-        manifest    = json.loads((processed_dir / 'feature_manifest_laptime.json').read_text())
-        compound_id = manifest['categorical_encoding']['Compound']
+        manifest = json.loads((processed_dir / "feature_manifest_laptime.json").read_text())
+        compound_id = manifest["categorical_encoding"]["Compound"]
 
         clusters_df = pd.read_parquet(
-            processed_dir / 'circuit_clustering' / 'circuit_clusters_k4_2025.parquet',
-            columns=['GP_Name', 'Cluster'],
+            processed_dir / "circuit_clustering" / "circuit_clusters_k4_2025.parquet",
+            columns=["GP_Name", "Cluster"],
         )
-        circuit_cluster = dict(
-            zip(clusters_df['GP_Name'], clusters_df['Cluster'].astype(int))
-        )
+        circuit_cluster = dict(zip(clusters_df["GP_Name"], clusters_df["Cluster"].astype(int)))
 
         laps = pd.read_parquet(
-            processed_dir / 'laps_featured_2025.parquet',
-            columns=['Team', 'TeamID'],
+            processed_dir / "laps_featured_2025.parquet",
+            columns=["Team", "TeamID"],
         ).dropna()
-        team_id = (
-            laps.drop_duplicates('Team')
-                .set_index('Team')['TeamID']
-                .astype(int)
-                .to_dict()
-        )
+        team_id = laps.drop_duplicates("Team").set_index("Team")["TeamID"].astype(int).to_dict()
         return compound_id, circuit_cluster, team_id
+
+    @staticmethod
+    def _load_circuit_mean_sector_speed(processed_dir: Path) -> dict[str, float]:
+        """The one ``mean_sector_speed`` each GP carries, keyed by parquet ``GP_Name``.
+
+        This feature is a property of the CIRCUIT, not of the lap: the featured parquet
+        holds exactly one distinct value per GP, the mean of the three speed traps.
+        N06 was trained on it and inference never had it, because `_compute_derived`
+        substituted `prev_speed_st` and nothing ever supplied the real thing (#797).
+
+        Read from the same `laps_featured_2025.parquet` the team map and the reference
+        laps already come from rather than from `circuit_clustering/`: it is the artefact
+        N04 wrote the trained column into, so the value served is the value fitted, and
+        there is no second file to keep in step. Checked across the 22 GPs of the training
+        seasons against `circuit_features_with_clusters_k4.parquet`: identical to 0.0.
+
+        A GP whose value is missing is simply absent from the map. It must NOT acquire a
+        default here -- see `_resolve_mean_sector_speed` for why an absent circuit has to
+        stay absent all the way to the model.
+        """
+        speeds = pd.read_parquet(
+            processed_dir / "laps_featured_2025.parquet",
+            columns=["GP_Name", "mean_sector_speed"],
+        ).dropna()
+        by_gp = speeds.drop_duplicates("GP_Name").set_index("GP_Name")["mean_sector_speed"]
+        return {str(gp): float(value) for gp, value in by_gp.items()}
+
+    def _resolve_mean_sector_speed(self, gp_name: str) -> float:
+        """This circuit's trained mean sector speed, or NaN when it does not resolve.
+
+        NaN, never `prev_speed_st`, and that substitution is the whole bug: the speed
+        trap is a different physical quantity (training means 256.8 vs 303.0 km/h), so
+        feeding it does not degrade the prediction gracefully, it silently answers a
+        different question. XGBoost handles a genuinely missing feature natively through
+        its sparse-aware split direction, which is what "we do not know this circuit"
+        should look like. Same rule as `FuelEffect` (#446) and `Position` (#628): unknown
+        data stays unknown and never becomes a number the model can mistake for a reading.
+
+        The name is resolved through `slug_from_event_name` first, because `gp_name`
+        arrives in either keyspace depending on the caller -- the CLI passes the slug
+        ('Lusail'), a FastF1-derived caller passes the event name ('Qatar Grand Prix').
+        The same dual-keyspace trap cost #448 and #450.
+        """
+        if gp_name in self.circuit_mean_sector_speed:
+            return self.circuit_mean_sector_speed[gp_name]
+
+        slug = slug_from_event_name(gp_name) if gp_name else None
+        if slug and slug in self.circuit_mean_sector_speed:
+            return self.circuit_mean_sector_speed[slug]
+
+        logger.warning(
+            "no trained mean sector speed for GP %r; N06 reads the feature as missing "
+            "rather than being fed the speed trap in its place (#797)",
+            gp_name,
+        )
+        return float("nan")
 
     def _load_reference_laps(self, processed_dir: Path) -> pd.DataFrame:
         """Load the reference laps parquet used for session median computation.
@@ -312,15 +367,13 @@ class PaceAgent:
             DataFrame with columns GP_Name, Year, Compound, LapTime_s.
         """
         return pd.read_parquet(
-            processed_dir / 'laps_featured_2025.parquet',
-            columns=['GP_Name', 'Year', 'Compound', 'LapTime_s'],
+            processed_dir / "laps_featured_2025.parquet",
+            columns=["GP_Name", "Year", "Compound", "LapTime_s"],
         )
 
     # ── Encoding helpers ──────────────────────────────────────────────────────
 
-    def _encode_categorical(
-        self, compound: str, team: str, gp_name: str
-    ) -> tuple[int, int, int]:
+    def _encode_categorical(self, compound: str, team: str, gp_name: str) -> tuple[int, int, int]:
         """Map compound, team, and circuit to their integer label encodings.
 
         Unknown categories degrade gracefully to the most common training
@@ -334,8 +387,8 @@ class PaceAgent:
         Returns:
             Tuple (compound_id_int, team_id_int, cluster_int).
         """
-        c_id    = self.compound_id.get(compound, 1)
-        t_id    = self.team_id.get(team, 0)
+        c_id = self.compound_id.get(compound, 1)
+        t_id = self.team_id.get(team, 0)
         cluster = self.circuit_cluster.get(gp_name, 1)
         return c_id, t_id, cluster
 
@@ -345,8 +398,7 @@ class PaceAgent:
         fuel_load: float,
         lap_number: int,
         total_laps: int,
-        prev_speed_st: float,
-        mean_sector_speed: Optional[float],
+        mean_sector_speed: float,
         stint_baseline_tyre_life: Optional[int] = None,
     ) -> dict:
         """Compute features derived from raw inputs that are not in the source data.
@@ -355,8 +407,11 @@ class PaceAgent:
         the outlap pace loss caused by tyre heating and rubber laydown.
         FuelEffect: cumulative fuel burn pace gain (lighter car = faster lap).
         laps_remaining: inverted lap count used as a proxy for race phase.
-        mean_sector_speed: falls back to prev_speed_st when circuit_features
-        are unavailable for the current GP.
+        mean_sector_speed: passed through untouched, already resolved by the caller.
+        It used to fall back to prev_speed_st here, which fed the speed trap in place
+        of a circuit mean on every RaceStateManager call (#797). Resolution and its
+        NaN-on-unknown rule now live in `_resolve_mean_sector_speed`, so this function
+        has no opinion left about a value it cannot look up.
 
         Args:
             tyre_life: Current laps on this tyre set.
@@ -364,7 +419,8 @@ class PaceAgent:
             lap_number: Current race lap.
             total_laps: Total scheduled race laps.
             prev_speed_st: Speed trap reading in km/h from the previous lap.
-            mean_sector_speed: Average sector speed; None → use prev_speed_st.
+            mean_sector_speed: This circuit's trained mean sector speed, already
+                resolved; NaN when the GP does not resolve.
             stint_baseline_tyre_life: TyreLife recorded at the start of the
                 current stint. None means the caller has not been updated to
                 supply it, in which case FuelEffect is forced to NaN instead
@@ -390,18 +446,18 @@ class PaceAgent:
         # to mistake for a reading.
         if stint_baseline_tyre_life is None:
             logger.warning(
-                'stint_baseline_tyre_life absent from lap_state: FuelEffect=NaN for this '
-                'lap; the producer must supply it (#446)'
+                "stint_baseline_tyre_life absent from lap_state: FuelEffect=NaN for this "
+                "lap; the producer must supply it (#446)"
             )
-            fuel_effect = float('nan')
+            fuel_effect = float("nan")
         else:
             fuel_effect = (tyre_life - stint_baseline_tyre_life) * FUEL_GAIN_PER_LAP_S
 
         return {
-            'FreshTyre':        int(tyre_life <= 1),
-            'FuelEffect':       fuel_effect,
-            'laps_remaining':   max(0, total_laps - lap_number),
-            'mean_sector_speed': mean_sector_speed if mean_sector_speed is not None else prev_speed_st,
+            "FreshTyre": int(tyre_life <= 1),
+            "FuelEffect": fuel_effect,
+            "laps_remaining": max(0, total_laps - lap_number),
+            "mean_sector_speed": mean_sector_speed,
         }
 
     def _build_feature_row(
@@ -441,37 +497,50 @@ class PaceAgent:
             Single-row pd.DataFrame with columns in self.features order.
         """
         c_id, t_id, cluster = self._encode_categorical(compound, team, gp_name)
+        # An explicit argument still wins, so a caller that genuinely measured this lap's
+        # mean sector speed is not overridden by the circuit constant. Nothing in the
+        # repo passes one today; the RaceStateManager path is exactly the caller that
+        # left it None and got the speed trap for it (#797).
+        resolved_mean_sector_speed = (
+            mean_sector_speed
+            if mean_sector_speed is not None
+            else self._resolve_mean_sector_speed(gp_name)
+        )
         derived = self._compute_derived(
-            tyre_life, fuel_load, lap_number, total_laps,
-            prev_speed_st, mean_sector_speed, stint_baseline_tyre_life,
+            tyre_life,
+            fuel_load,
+            lap_number,
+            total_laps,
+            resolved_mean_sector_speed,
+            stint_baseline_tyre_life,
         )
 
         row = {
-            'DriverNumber':         driver_number,
-            'LapNumber':            lap_number,
-            'Stint':                stint,
-            'TyreLife':             tyre_life,
-            'FreshTyre':            derived['FreshTyre'],
-            'Position':             position,
-            'CompoundID':           c_id,
-            'TeamID':               t_id,
-            'LapsSincePitStop':     laps_since_pit,
-            'FuelLoad':             fuel_load,
-            'Year':                 year,
-            'FuelEffect':           derived['FuelEffect'],
-            'Prev_LapTime':         prev_lap_time,
-            'Prev_TyreLife':        prev_tyre_life,
-            'Prev_SpeedST':         prev_speed_st,
-            'AirTemp':              air_temp,
-            'TrackTemp':            track_temp,
-            'Humidity':             humidity,
-            'Rainfall':             rainfall,
-            'laps_remaining':       derived['laps_remaining'],
-            'Cluster':              cluster,
-            'mean_sector_speed':    derived['mean_sector_speed'],
-            'Prev_DegradationRate': prev_deg_rate,
-            'Prev_CumulativeDeg':   prev_cum_deg,
-            'Prev_DegAcceleration': prev_deg_accel,
+            "DriverNumber": driver_number,
+            "LapNumber": lap_number,
+            "Stint": stint,
+            "TyreLife": tyre_life,
+            "FreshTyre": derived["FreshTyre"],
+            "Position": position,
+            "CompoundID": c_id,
+            "TeamID": t_id,
+            "LapsSincePitStop": laps_since_pit,
+            "FuelLoad": fuel_load,
+            "Year": year,
+            "FuelEffect": derived["FuelEffect"],
+            "Prev_LapTime": prev_lap_time,
+            "Prev_TyreLife": prev_tyre_life,
+            "Prev_SpeedST": prev_speed_st,
+            "AirTemp": air_temp,
+            "TrackTemp": track_temp,
+            "Humidity": humidity,
+            "Rainfall": rainfall,
+            "laps_remaining": derived["laps_remaining"],
+            "Cluster": cluster,
+            "mean_sector_speed": derived["mean_sector_speed"],
+            "Prev_DegradationRate": prev_deg_rate,
+            "Prev_CumulativeDeg": prev_cum_deg,
+            "Prev_DegAcceleration": prev_deg_accel,
         }
         df = pd.DataFrame([row])[self.features]
         # Belt-and-braces: any caller that slips a None through lands here.
@@ -479,7 +548,7 @@ class PaceAgent:
         # converts None→NaN and the model handles NaN natively via its
         # sparse-aware split logic (default_left). Cheap and defensive —
         # no-op on already-numeric frames.
-        numeric = df.apply(pd.to_numeric, errors='coerce')
+        numeric = df.apply(pd.to_numeric, errors="coerce")
         self._label_against_envelope(numeric)
         return numeric
 
@@ -502,8 +571,8 @@ class PaceAgent:
         verdict = _N06_ENVELOPE.check(feature_df.iloc[0].to_dict())
         if verdict.violations:
             logger.warning(
-                'N06 called outside its trained range on %d feature(s): %s; the '
-                'prediction is an extrapolation, not a fit',
+                "N06 called outside its trained range on %d feature(s): %s; the "
+                "prediction is an extrapolation, not a fit",
                 len(verdict.violations),
                 dict(verdict.violations),
             )
@@ -524,7 +593,7 @@ class PaceAgent:
             Absolute predicted lap time in seconds.
         """
         delta = float(self.model.predict(feature_df)[0])
-        prev  = float(feature_df['Prev_LapTime'].iloc[0])
+        prev = float(feature_df["Prev_LapTime"].iloc[0])
         return prev + delta
 
     def _bootstrap_ci(
@@ -552,11 +621,17 @@ class PaceAgent:
         Returns:
             Tuple (p10, p90) of absolute lap times in seconds.
         """
-        noise_cols = ['Prev_LapTime', 'Prev_SpeedST', 'mean_sector_speed',
-                      'AirTemp', 'TrackTemp', 'TyreLife']
+        noise_cols = [
+            "Prev_LapTime",
+            "Prev_SpeedST",
+            "mean_sector_speed",
+            "AirTemp",
+            "TrackTemp",
+            "TyreLife",
+        ]
 
-        rng     = np.random.default_rng(seed)
-        base    = feature_df.values.copy().astype(float)
+        rng = np.random.default_rng(seed)
+        base = feature_df.values.copy().astype(float)
         col_idx = {c: feature_df.columns.get_loc(c) for c in noise_cols}
 
         preds = []
@@ -566,14 +641,12 @@ class PaceAgent:
                 sigma = abs(base[0, idx]) * _NOISE_PCT
                 row[0, idx] += rng.normal(0, sigma)
             df_row = pd.DataFrame(row, columns=feature_df.columns)
-            delta  = float(self.model.predict(df_row)[0])
-            preds.append(float(df_row['Prev_LapTime'].iloc[0]) + delta)
+            delta = float(self.model.predict(df_row)[0])
+            preds.append(float(df_row["Prev_LapTime"].iloc[0]) + delta)
 
         return float(np.percentile(preds, 10)), float(np.percentile(preds, 90))
 
-    def _session_median(
-        self, gp_name: str, year: int, compound: str
-    ) -> Optional[float]:
+    def _session_median(self, gp_name: str, year: int, compound: str) -> Optional[float]:
         """Return the historical median lap time for a GP / year / compound.
 
         Filters self.laps_ref to the matching GP, year, and compound, then
@@ -590,11 +663,11 @@ class PaceAgent:
             Median lap time in seconds, or None when no matching laps exist.
         """
         mask = (
-            (self.laps_ref['GP_Name']  == gp_name) &
-            (self.laps_ref['Year']     == year)     &
-            (self.laps_ref['Compound'] == compound)
+            (self.laps_ref["GP_Name"] == gp_name)
+            & (self.laps_ref["Year"] == year)
+            & (self.laps_ref["Compound"] == compound)
         )
-        subset = self.laps_ref.loc[mask, 'LapTime_s'].dropna()
+        subset = self.laps_ref.loc[mask, "LapTime_s"].dropna()
         return float(subset.median()) if len(subset) > 0 else None
 
     # ── Main inference entrypoint ─────────────────────────────────────────────
@@ -669,28 +742,41 @@ class PaceAgent:
             PaceOutput with all fields populated and a reasoning string.
         """
         feature_df = self._build_feature_row(
-            driver_number=driver_number, lap_number=lap_number, stint=stint,
-            tyre_life=tyre_life, compound=compound, position=position, team=team,
-            laps_since_pit=laps_since_pit, fuel_load=fuel_load, year=year,
-            prev_lap_time=prev_lap_time, prev_tyre_life=prev_tyre_life,
-            prev_speed_st=prev_speed_st, air_temp=air_temp, track_temp=track_temp,
-            humidity=humidity, rainfall=rainfall, total_laps=total_laps,
-            gp_name=gp_name, mean_sector_speed=mean_sector_speed,
-            prev_deg_rate=prev_deg_rate, prev_cum_deg=prev_cum_deg,
+            driver_number=driver_number,
+            lap_number=lap_number,
+            stint=stint,
+            tyre_life=tyre_life,
+            compound=compound,
+            position=position,
+            team=team,
+            laps_since_pit=laps_since_pit,
+            fuel_load=fuel_load,
+            year=year,
+            prev_lap_time=prev_lap_time,
+            prev_tyre_life=prev_tyre_life,
+            prev_speed_st=prev_speed_st,
+            air_temp=air_temp,
+            track_temp=track_temp,
+            humidity=humidity,
+            rainfall=rainfall,
+            total_laps=total_laps,
+            gp_name=gp_name,
+            mean_sector_speed=mean_sector_speed,
+            prev_deg_rate=prev_deg_rate,
+            prev_cum_deg=prev_cum_deg,
             prev_deg_accel=prev_deg_accel,
             stint_baseline_tyre_life=stint_baseline_tyre_life,
         )
 
-        lap_time_pred   = self._predict(feature_df)
-        delta_vs_prev   = lap_time_pred - prev_lap_time
-        p10, p90        = self._bootstrap_ci(feature_df)
-        median          = self._session_median(gp_name, year, compound)
-        delta_vs_median = (lap_time_pred - median) if median is not None else float('nan')
+        lap_time_pred = self._predict(feature_df)
+        delta_vs_prev = lap_time_pred - prev_lap_time
+        p10, p90 = self._bootstrap_ci(feature_df)
+        median = self._session_median(gp_name, year, compound)
+        delta_vs_median = (lap_time_pred - median) if median is not None else float("nan")
 
-        trend  = "faster" if delta_vs_prev < 0 else "slower"
+        trend = "faster" if delta_vs_prev < 0 else "slower"
         vs_med = (
-            f"{delta_vs_median:+.3f}s vs median"
-            if median is not None else "no median reference"
+            f"{delta_vs_median:+.3f}s vs median" if median is not None else "no median reference"
         )
         reasoning = (
             f"Lap {lap_number}: predicted {round(lap_time_pred, 3):.3f}s "
@@ -699,12 +785,12 @@ class PaceAgent:
         )
 
         return PaceOutput(
-            lap_time_pred   = round(lap_time_pred, 3),
-            delta_vs_prev   = round(delta_vs_prev, 3),
-            delta_vs_median = round(delta_vs_median, 3),
-            ci_p10          = round(p10, 3),
-            ci_p90          = round(p90, 3),
-            reasoning       = reasoning,
+            lap_time_pred=round(lap_time_pred, 3),
+            delta_vs_prev=round(delta_vs_prev, 3),
+            delta_vs_median=round(delta_vs_median, 3),
+            ci_p10=round(p10, 3),
+            ci_p90=round(p90, 3),
+            reasoning=reasoning,
         )
 
     def run_from_state(self, lap_state: dict) -> PaceOutput:
@@ -724,12 +810,12 @@ class PaceAgent:
         Returns:
             PaceOutput with all fields populated.
         """
-        d    = lap_state['driver']
-        meta = lap_state['session_meta']
-        wx   = lap_state.get('weather', {})
+        d = lap_state["driver"]
+        meta = lap_state["session_meta"]
+        wx = lap_state.get("weather", {})
 
-        lap_number     = lap_state['lap_number']
-        total_laps     = meta['total_laps']
+        lap_number = lap_state["lap_number"]
+        total_laps = meta["total_laps"]
         laps_remaining = max(0, total_laps - lap_number)
 
         # ``dict.get(key, default)`` only applies the default when *key is
@@ -744,18 +830,18 @@ class PaceAgent:
         # This file's inline guard was the ONLY one of the three agents that handled
         # present-and-None, and it is now the shared helper the other two adopted rather
         # than a fourth copy of the pattern (#788).
-        _speed_st  = d.get('speed_st')   or 300.0
-        _air_temp  = reading_or_default(wx, 'air_temp',   25.0)
-        _trk_temp  = reading_or_default(wx, 'track_temp', 35.0)
-        _humidity  = reading_or_default(wx, 'humidity',   50.0)
-        _rainfall  = reading_or_default(wx, 'rainfall', 0)
+        _speed_st = d.get("speed_st") or 300.0
+        _air_temp = reading_or_default(wx, "air_temp", 25.0)
+        _trk_temp = reading_or_default(wx, "track_temp", 35.0)
+        _humidity = reading_or_default(wx, "humidity", 50.0)
+        _rainfall = reading_or_default(wx, "rainfall", 0)
 
         return self.run(
-            driver_number  = d.get('driver_number') or 0,
-            lap_number     = lap_number,
-            stint          = d.get('stint') or 1,
-            tyre_life      = d.get('tyre_life') or 1,
-            compound       = d.get('compound') or 'MEDIUM',
+            driver_number=d.get("driver_number") or 0,
+            lap_number=lap_number,
+            stint=d.get("stint") or 1,
+            tyre_life=d.get("tyre_life") or 1,
+            compound=d.get("compound") or "MEDIUM",
             # Plain .get, no `or` fallback: `d.get('position') or 1` collapsed a
             # missing telemetry reading AND the #428 sentinel (a stored `0`)
             # into P1, the race leader, straight into the live N06 XGBoost
@@ -766,11 +852,11 @@ class PaceAgent:
             # existing pd.to_numeric(errors='coerce') turns that into NaN, and
             # XGBoost handles a missing 'Position' natively via its
             # default-left split direction, so no fabricated value is needed.
-            position       = d.get('position'),
-            team           = meta.get('team') or 'Unknown',
-            laps_since_pit = d.get('tyre_life') or 1,
-            fuel_load      = laps_remaining / max(total_laps, 1),
-            year           = meta.get('year') or 2025,
+            position=d.get("position"),
+            team=meta.get("team") or "Unknown",
+            laps_since_pit=d.get("tyre_life") or 1,
+            fuel_load=laps_remaining / max(total_laps, 1),
+            year=meta.get("year") or 2025,
             # ``d.get('prev_lap_time') or 90.0``, NOT ``d.get('lap_time_s')``: the
             # latter fed this LAP's own time back in as the PREVIOUS lap's time, so
             # the model chased its own most recent prediction instead of the real
@@ -787,23 +873,23 @@ class PaceAgent:
             # would turn lap_time_pred itself into NaN. 90.0 is the same
             # order-of-magnitude placeholder the old (wrong) code used, now only
             # reached on a genuinely missing previous lap.
-            prev_lap_time  = d.get('prev_lap_time') or MISSING_PREV_LAP_TIME_S,
-            prev_tyre_life = max(0, (d.get('tyre_life') or 1) - 1),
-            prev_speed_st  = float(_speed_st),
-            air_temp       = float(_air_temp),
-            track_temp     = float(_trk_temp),
-            humidity       = float(_humidity),
-            rainfall       = float(_rainfall or 0),
-            total_laps     = total_laps,
-            gp_name        = meta.get('gp_name') or '',
-            prev_deg_rate  = 0.0,
-            prev_cum_deg   = 0.0,
-            prev_deg_accel = 0.0,
+            prev_lap_time=d.get("prev_lap_time") or MISSING_PREV_LAP_TIME_S,
+            prev_tyre_life=max(0, (d.get("tyre_life") or 1) - 1),
+            prev_speed_st=float(_speed_st),
+            air_temp=float(_air_temp),
+            track_temp=float(_trk_temp),
+            humidity=float(_humidity),
+            rainfall=float(_rainfall or 0),
+            total_laps=total_laps,
+            gp_name=meta.get("gp_name") or "",
+            prev_deg_rate=0.0,
+            prev_cum_deg=0.0,
+            prev_deg_accel=0.0,
             # Plain .get, deliberately NOT the `or` pattern used above: `or` would
             # collapse a legitimate baseline of 0 into None and re-introduce exactly
             # the sentinel-vs-real-value confusion this epic is about. Absent stays
             # absent, and _compute_derived turns that into a NaN plus a warning (#446).
-            stint_baseline_tyre_life = d.get('stint_baseline_tyre_life'),
+            stint_baseline_tyre_life=d.get("stint_baseline_tyre_life"),
         )
 
 
@@ -832,14 +918,31 @@ def _get_default_pace_agent() -> PaceAgent:
 # Public entry points (backward-compatible API — same signatures as before)
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 def run_pace_agent(
-    driver_number, lap_number, stint, tyre_life, compound,
-    position, team, laps_since_pit, fuel_load, year,
-    prev_lap_time, prev_tyre_life, prev_speed_st,
-    air_temp, track_temp, humidity, rainfall,
-    total_laps, gp_name,
+    driver_number,
+    lap_number,
+    stint,
+    tyre_life,
+    compound,
+    position,
+    team,
+    laps_since_pit,
+    fuel_load,
+    year,
+    prev_lap_time,
+    prev_tyre_life,
+    prev_speed_st,
+    air_temp,
+    track_temp,
+    humidity,
+    rainfall,
+    total_laps,
+    gp_name,
     mean_sector_speed=None,
-    prev_deg_rate=0.0, prev_cum_deg=0.0, prev_deg_accel=0.0,
+    prev_deg_rate=0.0,
+    prev_cum_deg=0.0,
+    prev_deg_accel=0.0,
 ) -> PaceOutput:
     """Run the Pace Agent for a single lap and return a structured PaceOutput.
 
@@ -848,14 +951,28 @@ def run_pace_agent(
     parameter documentation.
     """
     return _get_default_pace_agent().run(
-        driver_number=driver_number, lap_number=lap_number, stint=stint,
-        tyre_life=tyre_life, compound=compound, position=position, team=team,
-        laps_since_pit=laps_since_pit, fuel_load=fuel_load, year=year,
-        prev_lap_time=prev_lap_time, prev_tyre_life=prev_tyre_life,
-        prev_speed_st=prev_speed_st, air_temp=air_temp, track_temp=track_temp,
-        humidity=humidity, rainfall=rainfall, total_laps=total_laps,
-        gp_name=gp_name, mean_sector_speed=mean_sector_speed,
-        prev_deg_rate=prev_deg_rate, prev_cum_deg=prev_cum_deg,
+        driver_number=driver_number,
+        lap_number=lap_number,
+        stint=stint,
+        tyre_life=tyre_life,
+        compound=compound,
+        position=position,
+        team=team,
+        laps_since_pit=laps_since_pit,
+        fuel_load=fuel_load,
+        year=year,
+        prev_lap_time=prev_lap_time,
+        prev_tyre_life=prev_tyre_life,
+        prev_speed_st=prev_speed_st,
+        air_temp=air_temp,
+        track_temp=track_temp,
+        humidity=humidity,
+        rainfall=rainfall,
+        total_laps=total_laps,
+        gp_name=gp_name,
+        mean_sector_speed=mean_sector_speed,
+        prev_deg_rate=prev_deg_rate,
+        prev_cum_deg=prev_cum_deg,
         prev_deg_accel=prev_deg_accel,
     )
 

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -4,8 +4,8 @@ Extracted from N25_pace_agent.ipynb. Wraps the N06 XGBoost delta-lap-time
 model into a clean OOP agent interface that returns lap time predictions,
 delta signals, and bootstrap confidence intervals.
 
-Public API (unchanged — backward compatible)
---------------------------------------------
+Public API
+----------
 run_pace_agent(**kwargs)               → PaceOutput
 run_pace_agent_from_state(lap_state)   → PaceOutput
 

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -102,36 +102,59 @@ FUEL_GAIN_PER_LAP_S: float = 0.055
 # `tests/agents/test_n06_envelope.py` re-runs that measurement and fails if any bound
 # below has drifted from it, so these cannot quietly become hand-typed numbers.
 #
-# Why these twelve and not all twenty-five:
-#   - The identifiers and codes (DriverNumber, TeamID, CompoundID, Cluster, Year) and
-#     the flags (FreshTyre, Rainfall) have no range to be outside of. A bound on a
-#     label is a category check wearing the wrong contract.
-#   - The three Prev_Deg* features are excluded DELIBERATELY, and the reason matters
-#     because it is the opposite of what it looks like. `run_from_state` hardcodes all
-#     three to 0.0 on every real call, which reads like the textbook out-of-range bug.
-#     Measured, it is not one: 0.0 sits mid-distribution for all three (42%/42%/47% of
-#     training rows fall below it), so an envelope would never fire and declaring one
-#     here would advertise a check that cannot work. Feeding a model a CONSTANT where
-#     it was trained on a distribution is a real defect, but it is a different defect
-#     and it needs its own instrument, not this one.
+# WHICH TEN OF THE TWENTY-FIVE, and why each of the other fifteen is out. A bound is a
+# claim that the value at inference is the same quantity, in the same units, as the
+# column the range was measured from. Where that is not true, a bound does not measure
+# extrapolation, it measures a wiring defect, and it reports it under the wrong name.
+#
+#   Excluded, no range to be outside of (8): DriverNumber, TeamID, CompoundID, Cluster,
+#   Year, Stint and Position are identifiers, codes or ranks; FreshTyre and Rainfall are
+#   flags. A bound on a label is a category check wearing the wrong contract.
+#
+#   Excluded, the value at inference is NOT the quantity the range describes (4):
+#     - The three Prev_Deg* features. `run_from_state` hardcodes all three to 0.0 on
+#       every real call, which reads like the textbook out-of-range bug. Measured, it is
+#       not one: 0.0 sits mid-distribution for each (42.6% / 41.9% / 46.7% of training
+#       rows fall below it), so a bound could never fire and declaring one would
+#       advertise a check that cannot work.
+#     - `mean_sector_speed`. `_compute_derived` falls back to `prev_speed_st` whenever a
+#       mean sector speed is absent, and `run_from_state` never supplies one, so at
+#       inference this feature ALWAYS carries the speed trap. They are different physical
+#       quantities with different distributions (training means 256.8 vs 303.0 km/h), and
+#       a bound over the first one applied to the second fires on 83% of laps at Monza
+#       while describing none of them correctly. This is the twin of the Prev_Deg* case
+#       and it was missed on the first pass precisely because only one of the pair was
+#       looked at, which is this repo's most reliable defect.
+#
+#   Excluded, a bound would report the same event twice (1): `LapsSincePitStop`.
+#   `run_from_state` passes `d.get('tyre_life') or 1` for BOTH it and `TyreLife`, so at
+#   inference they are the same number and a second bound is a second warning about one
+#   underlying cause.
+#
+#   Excluded, training and inference encode it differently (1): `FuelLoad`. The featured
+#   artefact stores it rounded to four decimals, giving a measured maximum of 0.9615,
+#   while inference computes `laps_remaining / total_laps` live and unrounded. A 78-lap
+#   race yields 0.96153..., above that maximum, so the bound would fire on a class of lap
+#   the model was trained on. Comparing two encodings of a quantity is not a range check.
+#
+# Feeding a model a constant, or the wrong quantity, or a differently-rounded one, are
+# all real defects. They are simply not THIS defect, and each needs its own instrument.
 #
 # The bounds are TRAINING-season ranges (2023-2024). This is not the same thing as the
 # "range 0..3.685 s" recorded next to FUEL_GAIN_PER_LAP_S above, which was measured on
 # laps_featured_2025: 2025 is the held-out TEST season, and an envelope sourced from it
 # would be describing where the model is asked to work rather than where it was fitted.
 _N06_TRAINED_BOUNDS: dict[str, tuple[float, float]] = {
-    'LapNumber':         (3.0, 78.0),
-    'TyreLife':          (3.0, 78.0),
-    'FuelLoad':          (0.0, 0.9615),
-    'FuelEffect':        (0.055, 4.125),
-    'Prev_LapTime':      (67.719, 148.991),
-    'Prev_TyreLife':     (2.0, 77.0),
-    'Prev_SpeedST':      (156.0, 362.0),
-    'AirTemp':           (14.5, 33.7),
-    'TrackTemp':         (16.7, 50.7),
-    'Humidity':          (18.0, 92.0),
-    'laps_remaining':    (0.0, 75.0),
-    'mean_sector_speed': (196.6292354740061, 314.9705586672411),
+    'LapNumber':      (3.0, 78.0),
+    'TyreLife':       (3.0, 78.0),
+    'FuelEffect':     (0.055, 4.125),
+    'Prev_LapTime':   (67.719, 148.991),
+    'Prev_TyreLife':  (2.0, 77.0),
+    'Prev_SpeedST':   (156.0, 362.0),
+    'AirTemp':        (14.5, 33.7),
+    'TrackTemp':      (16.7, 50.7),
+    'Humidity':       (18.0, 92.0),
+    'laps_remaining': (0.0, 75.0),
 }
 
 _N06_ENVELOPE = OperatingEnvelope(name='n06_laptime_delta', bounds=_N06_TRAINED_BOUNDS)

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -129,8 +129,12 @@ class PaceAgent:
 
     All model artifacts (XGBoost weights, encoding maps, reference laps) are
     loaded once in __init__ and stored as instance attributes — no module-level
-    globals are used. The LangGraph ReAct agent is created lazily on first call
-    to get_react_agent() to avoid connecting to the LLM at import time.
+    globals are used.
+
+    Deliberately deterministic, unlike its tire/pit/race_situation siblings:
+    pace has no qualitative judgment to make (no warning_level/action/threat_level
+    category alongside its numbers), so there is no LLM step to wire — see #778/#780
+    for the archaeology and decision record.
 
     Instantiate via the module-level _get_default_pace_agent() factory to avoid
     redundant disk I/O; do not instantiate PaceAgent directly in hot paths.
@@ -153,7 +157,6 @@ class PaceAgent:
         self.team_id: dict            = {}
         self.compound_id, self.circuit_cluster, self.team_id = self._load_encoding_maps(processed_dir)
         self.laps_ref: pd.DataFrame   = self._load_reference_laps(processed_dir)
-        self._react_agent             = None   # lazy LangGraph agent
 
     # ── Loaders ───────────────────────────────────────────────────────────────
 
@@ -223,20 +226,18 @@ class PaceAgent:
     def _load_reference_laps(self, processed_dir: Path) -> pd.DataFrame:
         """Load the reference laps parquet used for session median computation.
 
-        Five columns are loaded to keep the in-memory footprint small. The median
-        baseline is used by N31 to contextualise absolute predictions. DriverNumber
-        is also kept so predict_pace_tool can refuse an LLM-invented car number for
-        a real GP/year instead of predicting from data that does not exist (#476).
+        Four columns are loaded to keep the in-memory footprint small. The median
+        baseline is used by N31 to contextualise absolute predictions.
 
         Args:
             processed_dir: Root of the processed data directory.
 
         Returns:
-            DataFrame with columns GP_Name, Year, Compound, LapTime_s, DriverNumber.
+            DataFrame with columns GP_Name, Year, Compound, LapTime_s.
         """
         return pd.read_parquet(
             processed_dir / 'laps_featured_2025.parquet',
-            columns=['GP_Name', 'Year', 'Compound', 'LapTime_s', 'DriverNumber'],
+            columns=['GP_Name', 'Year', 'Compound', 'LapTime_s'],
         )
 
     # ── Encoding helpers ──────────────────────────────────────────────────────
@@ -493,56 +494,6 @@ class PaceAgent:
         subset = self.laps_ref.loc[mask, 'LapTime_s'].dropna()
         return float(subset.median()) if len(subset) > 0 else None
 
-    def _validate_pace_inputs(
-        self, driver_number: int, lap_number: int, total_laps: int,
-        gp_name: str, year: int,
-    ) -> Optional[str]:
-        """Refuse an LLM-supplied pace query when the lap or driver cannot be real.
-
-        predict_pace_tool takes 19 raw scalar params straight from the LLM with no
-        closure over a live-drivers roster or a lap_state at all (#476) — unlike
-        score_undercut_tool in pit_strategy_agent.py, which checks its free-text
-        driver_y against self._live_drivers before scoring. This is the pace-side
-        equivalent: an out-of-range lap or an invented car number would otherwise
-        produce a confident-looking lap-time prediction from data that does not
-        exist.
-
-        laps_ref only carries the 2025 season (see _load_reference_laps), so a
-        legitimate 2023/2024 call, or a GP name outside the 2025 calendar, yields
-        an empty ``known`` set here. That means "the roster is unknown", not "no
-        cars are racing", so the driver check is skipped rather than rejecting
-        every call outside 2025 — the same unknown-disables-the-guard rule
-        score_undercut_tool follows for its own live_drivers=None case.
-
-        Args:
-            driver_number: Car number as supplied by the LLM caller.
-            lap_number: Lap number as supplied by the LLM caller.
-            total_laps: Total scheduled race laps, also LLM-supplied.
-            gp_name: GP name matching the laps_ref GP_Name column.
-            year: Race year integer.
-
-        Returns:
-            An error string when the query should be refused, None when it is
-            safe to run inference.
-        """
-        if not (1 <= lap_number <= total_laps):
-            return (
-                f'Pace prediction REFUSED — lap {lap_number} is out of range for a '
-                f'{total_laps}-lap race (valid range: 1-{total_laps}).'
-            )
-
-        known = self.laps_ref.loc[
-            (self.laps_ref['GP_Name'] == gp_name) & (self.laps_ref['Year'] == year),
-            'DriverNumber',
-        ].dropna().astype(int)
-        known_set = set(known)
-        if known_set and driver_number not in known_set:
-            return (
-                f'Pace prediction REFUSED — car number {driver_number} is not on '
-                f'track at {gp_name} {year}. Known car numbers: {sorted(known_set)}.'
-            )
-        return None
-
     # ── Main inference entrypoint ─────────────────────────────────────────────
 
     def run(
@@ -749,57 +700,6 @@ class PaceAgent:
             stint_baseline_tyre_life = d.get('stint_baseline_tyre_life'),
         )
 
-    # ── LangGraph ReAct agent ─────────────────────────────────────────────────
-
-    def get_react_agent(
-        self,
-        provider: str = None,
-        model_name: str = 'gpt-4.1-mini',
-        base_url: str = 'http://localhost:1234/v1',
-        api_key: str = 'lmstudio',
-    ):
-        """Return the LangGraph ReAct agent, creating it lazily on the first call.
-
-        Avoids connecting to the LLM at import time — the agent is only
-        created when actually needed (N31 orchestrator or tests).
-
-        Args:
-            provider: 'lmstudio' (default) or 'openai'.
-            model_name: Model identifier for the ChatOpenAI client.
-            base_url: Base URL for LM Studio (ignored when provider='openai').
-            api_key: API key; use 'lmstudio' for the local server.
-
-        Returns:
-            LangGraph CompiledGraph — invoke with {"messages": [("user", query)]}.
-        """
-        if self._react_agent is not None:
-            return self._react_agent
-
-        if not _LANGGRAPH_AVAILABLE:
-            raise ImportError(
-                "LangGraph / LangChain not installed. "
-                "Install with: pip install langgraph langchain-openai"
-            )
-
-        from langchain_openai import ChatOpenAI
-        from langchain.agents import create_agent
-
-        import os
-        if provider is None:
-            provider = os.environ.get('F1_LLM_PROVIDER', 'lmstudio')
-
-        if provider == 'lmstudio':
-            llm = ChatOpenAI(model=model_name, base_url=base_url, api_key=api_key, temperature=0, timeout=120, max_retries=1)
-        else:
-            llm = ChatOpenAI(model=model_name, temperature=0, timeout=120, max_retries=1)
-
-        self._react_agent = create_agent(
-            model=llm,
-            tools=PACE_TOOLS,
-            system_prompt=_PACE_SYSTEM_PROMPT,
-        )
-        return self._react_agent
-
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Module-level lazy singleton
@@ -840,8 +740,6 @@ def run_pace_agent(
     Thin entry point that delegates to the shared PaceAgent singleton. All
     inference logic lives in PaceAgent.run() — see its docstring for full
     parameter documentation.
-
-    This function is the primary call target for the LangGraph predict_pace_tool.
     """
     return _get_default_pace_agent().run(
         driver_number=driver_number, lap_number=lap_number, stint=stint,
@@ -869,120 +767,3 @@ def run_pace_agent_from_state(lap_state: dict) -> PaceOutput:
         PaceOutput with all fields populated.
     """
     return _get_default_pace_agent().run_from_state(lap_state)
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# LangGraph tools and ReAct agent (preserved 100% — no functional changes)
-# ─────────────────────────────────────────────────────────────────────────────
-
-try:
-    from langchain_core.tools import tool as lc_tool
-    from langchain_openai import ChatOpenAI  # noqa: F401
-    from langchain.agents import create_agent  # noqa: F401
-    _LANGGRAPH_AVAILABLE = True
-except ImportError:
-    _LANGGRAPH_AVAILABLE = False
-
-
-if _LANGGRAPH_AVAILABLE:
-
-    @lc_tool
-    def predict_pace_tool(
-        driver_number: int, lap_number: int, stint: int, tyre_life: int,
-        compound: str, position: int, team: str, laps_since_pit: int,
-        fuel_load: float, year: int, prev_lap_time: float, prev_tyre_life: int,
-        prev_speed_st: float, air_temp: float, track_temp: float,
-        humidity: float, rainfall: float, total_laps: int, gp_name: str,
-    ) -> dict:
-        """Predict the absolute lap time (seconds) for the current lap using the N06 XGBoost model.
-
-        Call this whenever a lap time prediction is needed for pace or strategy analysis.
-
-        Args:
-            driver_number: Car number used to look up TeamID encoding.
-            lap_number: Current race lap number (1-indexed).
-            stint: Stint number (1-indexed).
-            tyre_life: Laps on the current tyre set.
-            compound: Pirelli compound string ('SOFT', 'MEDIUM', 'HARD', etc.).
-            position: Current race position (1-based).
-            team: Team name matching TEAM_ID encoding map (e.g. 'McLaren').
-            laps_since_pit: Laps elapsed since the last pit stop.
-            fuel_load: Fuel fraction in [0, 1].
-            year: Race year integer (2023/2024/2025).
-            prev_lap_time: Previous lap time in seconds.
-            prev_tyre_life: TyreLife on the previous lap.
-            prev_speed_st: Speed trap reading in km/h from the previous lap.
-            air_temp: Air temperature in degrees C.
-            track_temp: Track surface temperature in degrees C.
-            humidity: Relative humidity in %.
-            rainfall: True if rain was recorded during this lap.
-            total_laps: Total scheduled race laps.
-            gp_name: GP name matching CIRCUIT_CLUSTER keys (e.g. 'Sakhir').
-
-        Returns:
-            Dict with keys: lap_time_pred, delta_vs_prev, delta_vs_median,
-            ci_p10, ci_p90 (all floats in seconds). Returns {'error': str}
-            instead, without running inference, when the driver is not on
-            track for the given GP/year or the lap is outside [1, total_laps]
-            (#476) — the LLM supplies every one of these 19 params as free
-            text with no server-side roster or range check otherwise.
-        """
-        agent = _get_default_pace_agent()
-        validation_error = agent._validate_pace_inputs(
-            driver_number, lap_number, total_laps, gp_name, year,
-        )
-        if validation_error is not None:
-            return {'error': validation_error}
-
-        out = run_pace_agent(
-            driver_number=driver_number, lap_number=lap_number, stint=stint,
-            tyre_life=tyre_life, compound=compound, position=position, team=team,
-            laps_since_pit=laps_since_pit, fuel_load=fuel_load, year=year,
-            prev_lap_time=prev_lap_time, prev_tyre_life=prev_tyre_life,
-            prev_speed_st=prev_speed_st, air_temp=air_temp, track_temp=track_temp,
-            humidity=humidity, rainfall=rainfall, total_laps=total_laps,
-            gp_name=gp_name,
-        )
-        return {
-            'lap_time_pred':   out.lap_time_pred,
-            'delta_vs_prev':   out.delta_vs_prev,
-            'delta_vs_median': out.delta_vs_median,
-            'ci_p10':          out.ci_p10,
-            'ci_p90':          out.ci_p90,
-        }
-
-    @lc_tool
-    def get_session_median_tool(gp_name: str, year: int, compound: str) -> dict:
-        """Return the historical median lap time (seconds) for a GP / year / compound.
-
-        Use this as a reference baseline to contextualise a predicted lap time from
-        predict_pace_tool. The median is computed from the N06 training parquet,
-        filtered to IsAccurate laps in non-SC, non-VSC conditions.
-
-        Args:
-            gp_name: GP name matching the parquet GP_Name column (e.g. 'Sakhir').
-            year: Race year integer (2023/2024/2025).
-            compound: Pirelli compound string ('SOFT', 'MEDIUM', 'HARD').
-
-        Returns:
-            Dict with key: median_lap_time (float, seconds). NaN when no data.
-        """
-        median = _get_default_pace_agent()._session_median(gp_name, year, compound)
-        return {'median_lap_time': median if median is not None else float('nan')}
-
-    _PACE_SYSTEM_PROMPT = """You are the Pace Agent in an F1 race strategy system.
-
-Your responsibility: answer the question "how fast is this car going this lap?"
-
-Tools available:
-- `predict_pace_tool` — predicts absolute lap time using the N06 XGBoost model
-- `get_session_median_tool` — returns the historical median for this GP/compound as a baseline
-
-Always call `predict_pace_tool` first, then `get_session_median_tool` to contextualise the result.
-Respond with a concise JSON summary: lap_time_pred, delta_vs_prev, delta_vs_median, ci_p10, ci_p90.
-Never invent numbers — use only the values returned by the tools."""
-
-    PACE_TOOLS = [predict_pace_tool, get_session_median_tool]
-
-else:
-    PACE_TOOLS = []

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -29,6 +29,17 @@ from sklearn.preprocessing import LabelEncoder
 # there is no cycle even though src/strategy/inference/no_llm.py imports this package.
 from src.strategy.inference.envelope import OperatingEnvelope
 
+# From the leaf guard-rails module, never restated. These four bounds were prose in the
+# system prompt while the deterministic rails computed against the constants, so the
+# prompt could tell the LLM to refuse what the rails had just allowed (#741, #766).
+# guard_rails imports nothing from this package, so there is no cycle.
+from src.strategy.inference.guard_rails import (
+    _CLIFF_P10_SAFE,
+    _MIN_STINT_LAPS,
+    _NO_PIT_BEFORE_LAP,
+    _NO_PIT_LAST_N_LAPS,
+)
+
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent
 while not (_REPO_ROOT / '.git').exists():
@@ -141,6 +152,13 @@ _NORMAL_STOP_MAX_S: float = 4.5
 
 CLIFF_IMMINENT_LAPS = 3    # laps_to_cliff_p10 below this → PIT_NOW
 CLIFF_SOON_LAPS     = 10   # laps_to_cliff_p10 below this → prefer harder compound
+
+# Above this, an undeployed Safety Car is elevated enough to justify REACTIVE_SC rather
+# than a plain stop. It had no name at all: the value sat as a bare 0.30 in the routing
+# branch and twice more in the system prompt, three copies of a number nobody declared.
+# A constant with no definition cannot drift from its definition, but it can drift from
+# its other copies, which is the same defect wearing a different hat (#766).
+SC_REACTIVE_PROB_THRESHOLD = 0.30
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -615,15 +633,17 @@ Decision rules:
 1. Always call predict_pit_duration_tool first to know the stop cost.
 2. Call score_undercut_tool for each rival within 5 positions ahead.
 3. Call recommend_compound_tool to determine the optimal compound.
-4. If P(undercut_success) >= 0.522 for any rival → recommend UNDERCUT.
-5. If sc_prob context is provided and >= 0.30 → recommend REACTIVE_SC pit.
-6. If tyre_cliff context is provided and laps_to_cliff <= 3 → recommend PIT_NOW.
+4. If score_undercut_tool reports YES for any rival -> recommend UNDERCUT. The tool
+   prints the live threshold it compared against; do not carry your own number. It is
+   loaded from the model's calibration config and moves whenever the model is retuned.
+5. If sc_prob context is provided and >= {SC_REACTIVE_PROB_THRESHOLD} → recommend REACTIVE_SC pit.
+6. If tyre_cliff context is provided and laps_to_cliff <= {CLIFF_IMMINENT_LAPS} → recommend PIT_NOW.
 7. Otherwise → STAY_OUT unless a clear strategic window exists.
 
 ## Strategic guard-rails (HARD constraints — override any decision rule above)
 
 PIT WINDOW — early race:
-  NEVER recommend PIT_NOW, UNDERCUT, or OVERCUT before lap 5 of the race.
+  NEVER recommend PIT_NOW, UNDERCUT, or OVERCUT before lap {_NO_PIT_BEFORE_LAP} of the race.
   Exception: Safety Car IS currently deployed (prompt shows "SC STATUS: SAFETY
   CAR DEPLOYED RIGHT NOW"), or radio confirms damage/puncture/mechanical failure.
   Rationale: no tyre degrades enough in 1-4 laps to justify a stop; the pit lane time cost
@@ -631,8 +651,8 @@ PIT WINDOW — early race:
   in your reasoning.
 
 PIT WINDOW — end of race:
-  NEVER recommend PIT_NOW, UNDERCUT, or OVERCUT when remaining laps <= 3.
-  Exception: tyre failure is imminent (laps_to_cliff P10 < 2) or Safety Car deployed.
+  NEVER recommend PIT_NOW, UNDERCUT, or OVERCUT when remaining laps <= {_NO_PIT_LAST_N_LAPS}.
+  Exception: tyre failure is imminent (laps_to_cliff P10 < {_CLIFF_P10_SAFE}) or Safety Car deployed.
   Rationale: a pit stop costs ~22-25s; with ≤3 laps, fresh tyres recover at most ~1.5s
   total. Net loss ≈ 20s. Under green-flag racing, where consecutive cars sit a
   measured median 2.226s apart, that is worth ~9 positions, not 13: 13 positions
@@ -640,8 +660,8 @@ PIT WINDOW — end of race:
   the exception handled above, not this rule.
 
 MINIMUM STINT LENGTH before a pit makes sense:
-  SOFT: current tyre_life must be >= 8 laps before recommending a stop.
-  MEDIUM: >= 12 laps.  HARD: >= 15 laps.
+  SOFT: current tyre_life must be >= {_MIN_STINT_LAPS['SOFT']} laps before recommending a stop.
+  MEDIUM: >= {_MIN_STINT_LAPS['MEDIUM']} laps.  HARD: >= {_MIN_STINT_LAPS['HARD']} laps.
   If the driver has NOT completed the minimum stint, recommend STAY_OUT (the current
   set still has useful life; pitting now wastes a tyre allocation).
 
@@ -660,7 +680,7 @@ MINIMUM STINT LENGTH before a pit makes sense:
 
 COMPOUND vs REMAINING LAPS:
   SOFT: recommend only if remaining laps <= {_STINT_CAPACITY_LAPS['SOFT']} (it won't last longer).
-  MEDIUM: suitable for 12-30 remaining laps.
+  MEDIUM: suitable for {_MIN_STINT_LAPS['MEDIUM']}-{_STINT_CAPACITY_LAPS['MEDIUM']} remaining laps.
   HARD: suitable for 20+ remaining laps.
   Picking SOFT with 25 laps to go forces an extra pit stop — factor that cost in.
 
@@ -668,7 +688,7 @@ REACTIVE_SC usage:
   REACTIVE_SC is for the rare in-between case where sc_prob is elevated but the
   Safety Car is NOT yet deployed.  When the prompt states "SC STATUS: SAFETY CAR
   DEPLOYED RIGHT NOW", prefer PIT_NOW directly.  Use REACTIVE_SC only when
-  sc_prob >= 0.30 AND the prompt shows the legacy "SC probability" line.  A high
+  sc_prob >= {SC_REACTIVE_PROB_THRESHOLD} AND the prompt shows the legacy "SC probability" line.  A high
   sc_prob without confirmation is still a contingency — mention it in reasoning
   and set ACTION to STAY_OUT unless the SC is actually out.
 
@@ -1597,7 +1617,7 @@ class PitStrategyAgent:
         # the surrendered position unrecoverable). The regulatory facts an SC does
         # force live in N27; see tests/mc/test_sc_regulatory_rails.py.
         sc_reactive = sc_currently_active or (action == 'REACTIVE_SC') or (
-            sc_prob >= 0.30 and action in ('PIT_NOW', 'UNDERCUT')
+            sc_prob >= SC_REACTIVE_PROB_THRESHOLD and action in ('PIT_NOW', 'UNDERCUT')
         )
 
         return PitStrategyOutput(

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -102,6 +102,22 @@ _COMPOUND_FALLBACK: dict[str, int] = {'HARD': 1, 'MEDIUM': 3, 'SOFT': 5}
 # the same standing as VSC_PIT_BONUS and WINDOW_LAPS in strategy_orchestrator.
 _STINT_CAPACITY_LAPS: dict[str, int] = {'SOFT': 18, 'MEDIUM': 30, 'HARD': 38}
 
+# The FLOOR of the MEDIUM suitability band in both prompts' "COMPOUND vs REMAINING
+# LAPS" rule: below this many laps left, fit a SOFT instead. Same standing as
+# _STINT_CAPACITY_LAPS above, a modelling assumption rather than a measurement.
+#
+# It exists as its own constant because it was previously rendered from
+# `_MIN_STINT_LAPS['MEDIUM']`, and those are two different rules that happened to
+# share the number 12. One asks "has this set run long enough to be worth
+# replacing?", the other asks "is there enough race left for this compound to make
+# sense?" — nothing ties them, and the coupling was invisible because the values
+# agreed. It surfaced when #716 recalibrated the minimum-stint bound to 7 against
+# real stint lengths and silently rewrote this unrelated rule to "MEDIUM: suitable
+# for 7-30 remaining laps" in the DEFAULT LLM path. 12 is what this band has always
+# said; the recalibration must not move it. Do NOT re-derive it from another
+# constant: a shared value is not a shared meaning.
+_MEDIUM_SUITABILITY_FLOOR_LAPS: int = 12
+
 # N16 trained Lap_gap as the offset between the two stops (lap_y - lap_x), never the
 # race lap. At inference we always score the canonical undercut: we box on this lap and
 # the rival responds on the next one, so the offset is 1 (#444).
@@ -681,7 +697,7 @@ MINIMUM STINT LENGTH before a pit makes sense:
 
 COMPOUND vs REMAINING LAPS:
   SOFT: recommend only if remaining laps <= {_STINT_CAPACITY_LAPS['SOFT']} (it won't last longer).
-  MEDIUM: suitable for {_MIN_STINT_LAPS['MEDIUM']}-{_STINT_CAPACITY_LAPS['MEDIUM']} remaining laps.
+  MEDIUM: suitable for {_MEDIUM_SUITABILITY_FLOOR_LAPS}-{_STINT_CAPACITY_LAPS['MEDIUM']} remaining laps.
   HARD: suitable for 20+ remaining laps.
   Picking SOFT with 25 laps to go forces an extra pit stop — factor that cost in.
 

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -8,7 +8,6 @@ Public API
 ----------
 run_pit_strategy_agent(lap_state)                     → PitStrategyOutput  (FastF1 session)
 run_pit_strategy_agent_from_state(lap_state, laps_df) → PitStrategyOutput  (RSM adapter)
-get_pit_strategy_react_agent(**kwargs)                 → CompiledGraph
 """
 
 from __future__ import annotations
@@ -39,6 +38,8 @@ from src.strategy.inference.guard_rails import (
     _NO_PIT_BEFORE_LAP,
     _NO_PIT_LAST_N_LAPS,
 )
+
+from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS
 
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent
@@ -1036,7 +1037,7 @@ class PitStrategyAgent:
 
         gp_name    = self.session_meta.get('gp_name', '')
         year       = self.session_meta.get('year', 2025)
-        total_laps = self.session_meta.get('total_laps', 57)
+        total_laps = self.session_meta.get('total_laps', DEFAULT_TOTAL_LAPS)
         team_x_raw = self.session_meta.get('team_lookup', {}).get(driver_x, 'Unknown')
         team_x     = _TEAM_ALIASES.get(team_x_raw, team_x_raw)
 
@@ -1270,7 +1271,7 @@ class PitStrategyAgent:
                     f'Pick a driver from that list.'
                 )
 
-            total_laps       = agent.session_meta.get('total_laps', 57)
+            total_laps       = agent.session_meta.get('total_laps', DEFAULT_TOTAL_LAPS)
             laps_remaining   = total_laps - lap_number
             current_compound = current_compound.upper()
 
@@ -1451,9 +1452,9 @@ class PitStrategyAgent:
         lap_number = lap_state['lap_number']
         driver     = meta['driver']
         gp_name    = meta.get('gp_name', '')
-        # 57 = median/mode race length across the 2022-2025 dataset; the same fallback the
-        # other strategy surfaces use, so a missing key resolves to one value everywhere.
-        total_laps = meta.get('total_laps', 57)
+        # DEFAULT_TOTAL_LAPS: see src/agents/_shared_defaults.py for why this fallback
+        # exists and why it is single-sourced across the strategy agents.
+        total_laps = meta.get('total_laps', DEFAULT_TOTAL_LAPS)
         year       = meta.get('year', 2025)
         team       = meta.get('team', 'Unknown')
         compound   = d.get('compound', 'MEDIUM')
@@ -1697,31 +1698,3 @@ def run_pit_strategy_agent_from_state(
         PitStrategyOutput with all fields populated.
     """
     return _get_default_pit_agent().run_from_state(lap_state, laps_df)
-
-
-def get_pit_strategy_react_agent(
-    provider: str = 'lmstudio',
-    model_name: str = 'gpt-4.1-mini',
-    base_url: str = 'http://localhost:1234/v1',
-    api_key: str = 'lm-studio',
-):
-    """Return the LangGraph ReAct agent backed by the singleton PitStrategyAgent.
-
-    Avoids connecting to the LLM at import time — created only when N31 or tests
-    actually invoke the agent.
-
-    Args:
-        provider: 'lmstudio' or 'openai'.
-        model_name: Model identifier for ChatOpenAI.
-        base_url: Base URL for LM Studio (ignored when provider='openai').
-        api_key: API key; 'lm-studio' for local server.
-
-    Returns:
-        LangGraph CompiledGraph.
-    """
-    return _get_default_pit_agent().get_react_agent(
-        provider=provider,
-        model_name=model_name,
-        base_url=base_url,
-        api_key=api_key,
-    )

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -7,7 +7,6 @@ Public API
 ----------
 run_race_situation_agent(lap_state)                       → RaceSituationOutput  (FastF1 session)
 run_race_situation_agent_from_state(lap_state, laps_df)   → RaceSituationOutput  (RSM adapter)
-get_race_situation_react_agent(**kwargs)                   → CompiledGraph
 
 Module-level singletons
 -----------------------
@@ -28,6 +27,8 @@ from typing import Optional
 import joblib
 import numpy as np
 import pandas as pd
+
+from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS
 
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent
@@ -673,7 +674,11 @@ def _compute_rcm_features(
 
 def _compute_weather_features(session_meta: dict) -> dict:
     """Extract weather scalars from session_meta for the SC feature vector."""
-    track_temp       = float(session_meta.get('TrackTemp', 35.0))
+    # 38.0, not 35.0: matches the fallback run()/run_from_state() already use (grep this
+    # file for 'TrackTemp' to find both) when they build this same session_meta key, so a
+    # hand-built session_meta missing the key resolves to the same temperature this file
+    # uses everywhere else instead of silently disagreeing with itself.
+    track_temp       = float(session_meta.get('TrackTemp', 38.0))
     air_temp         = float(session_meta.get('AirTemp', 28.0))
     humidity         = float(session_meta.get('Humidity', 50.0))
     track_temp_start = float(session_meta.get('track_temp_start', track_temp))
@@ -1003,11 +1008,9 @@ class RaceSituationAgent:
         feat.update(_compute_rcm_features(all_laps, lap_number, session_meta, cur_code, prev_code))
         feat.update(_compute_weather_features(session_meta))
 
-        # RaceStateManager and the FastF1 session always supply total_laps, so this
-        # fallback only fires for hand-built states (tests, debug). 57 is the median and
-        # mode race length across the 2022-2025 dataset (71 races), so it is the least
-        # surprising stand-in and is kept identical across every strategy surface.
-        total_laps = int(session_meta.get('total_laps', 57))
+        # DEFAULT_TOTAL_LAPS: see src/agents/_shared_defaults.py for why this fallback
+        # exists and why it is single-sourced across the strategy agents.
+        total_laps = int(session_meta.get('total_laps', DEFAULT_TOTAL_LAPS))
         is_lap1    = int(lap_number == 1)
         lap_pct    = float(lap_number) / max(total_laps, 1)
 
@@ -1357,9 +1360,8 @@ class RaceSituationAgent:
         lap_number = lap_state['lap_number']
         driver     = meta['driver']
         gp_name    = meta.get('gp_name', '')
-        # 57 = median/mode race length across the dataset; matches _build_features above
-        # and the other strategy surfaces so the fallback is one value, not several.
-        total_laps = meta.get('total_laps', 57)
+        # DEFAULT_TOTAL_LAPS: see src/agents/_shared_defaults.py.
+        total_laps = meta.get('total_laps', DEFAULT_TOTAL_LAPS)
         year       = meta.get('year', 2025)
 
         # #465 (F6): a defaulted position (previously `.get('position', 20)`) is a
@@ -1655,31 +1657,3 @@ def run_race_situation_agent_from_state(
         RaceSituationOutput with all fields populated.
     """
     return _get_default_situation_agent().run_from_state(lap_state, laps_df)
-
-
-def get_race_situation_react_agent(
-    provider: str = 'lmstudio',
-    model_name: str = 'gpt-4.1-mini',
-    base_url: str = 'http://localhost:1234/v1',
-    api_key: str = 'lm-studio',
-):
-    """Return the LangGraph ReAct agent backed by the singleton RaceSituationAgent.
-
-    Avoids connecting to the LLM at import time — created only when N31 or tests
-    actually invoke the agent.
-
-    Args:
-        provider: 'lmstudio' or 'openai'.
-        model_name: Model identifier for ChatOpenAI.
-        base_url: Base URL for LM Studio (ignored when provider='openai').
-        api_key: API key; use 'lm-studio' for local server.
-
-    Returns:
-        LangGraph CompiledGraph — invoke with {"messages": [HumanMessage(...)]}.
-    """
-    return _get_default_situation_agent().get_react_agent(
-        provider=provider,
-        model_name=model_name,
-        base_url=base_url,
-        api_key=api_key,
-    )

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -28,7 +28,7 @@ import joblib
 import numpy as np
 import pandas as pd
 
-from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS
+from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS, reading_or_default
 
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent
@@ -1399,9 +1399,13 @@ class RaceSituationAgent:
             'total_laps':       total_laps,
             'fastest_lap_s':    float(self.laps_df['LapTime'].dt.total_seconds().min())
                                 if len(self.laps_df) > 0 else 90.0,
-            'AirTemp':          wx.get('air_temp',   28.0),
-            'TrackTemp':        wx.get('track_temp', 38.0),
-            'Humidity':         wx.get('humidity',   50.0),
+            # reading_or_default, not .get(key, default): the producers report an
+            # unmeasured reading as the key PRESENT holding None, which .get's default
+            # never catches, and _compute_weather_features' float() then raises. That
+            # 422'd /recommend on every 2025 lap (#788) — see the helper's docstring.
+            'AirTemp':          reading_or_default(wx, 'air_temp',   28.0),
+            'TrackTemp':        reading_or_default(wx, 'track_temp', 38.0),
+            'Humidity':         reading_or_default(wx, 'humidity',   50.0),
             # The session's FIRST track temp, which the RSM now supplies. This used to
             # read `track_temp` — the CURRENT one — so `track_temp_delta` came out 0.0 on
             # every lap of every race, on every shipping path (CLI, arcade, backend,

--- a/src/agents/race_state_builder.py
+++ b/src/agents/race_state_builder.py
@@ -1,0 +1,360 @@
+"""Single canonical builder of ``RaceState`` from the ``lap_state`` contract (#784).
+
+Why this module exists: the CLI (``scripts/run_simulation_cli.py``), the Arcade
+(``src/arcade/strategy.py``) and the telemetry backend
+(``backend/utils/race_state_builder.py``) each carried their own copy of the same
+lap_state -> RaceState mapping, and the copies disagreed on values the models
+actually receive (track_temp 40.0 vs 35.0, compound "UNKNOWN" vs "MEDIUM",
+tyre_life 0 vs 1, three different sources for the lap number).
+
+Be precise about which of those divergences is REACHABLE, because an earlier
+draft of this docstring was not: on the replay path (CLI and Arcade, both via
+RaceReplayEngine) the temperature defaults are effectively dead with the shipped
+data. All 71 race directories carry a readable weather.parquet with zero NaN
+AirTemp/TrackTemp rows, so the keys are always present and always non-None, and
+40.0-vs-35.0 never actually reached a model there. The value below is chosen on
+the measured-median argument alone, not on a live-divergence one. What IS live is
+the present-but-None case this builder now handles: see DEFAULT_TRACK_TEMP_C.
+
+The drift that actually bit this codebase was LOGIC drift, not just
+literals: the #750 pace-delta axis, the #465 dead position default, the #633 gap
+zero-conflation. One implementation is the fix; a parity test was rejected because
+it cannot run where the drift originates. Full per-field decision record: issue
+#784 and ``documents/audits/DESIGN_race_state_single_contract.md``.
+
+Leaf-module constraint (HARD): ``RaceState`` is imported LAZILY inside
+``build_race_state`` because it lives in ``strategy_orchestrator``, which drags
+LangChain/LangGraph and every sub-agent's model artefacts at import time.
+Importing THIS module must stay cheap - the same discipline
+``_shared_defaults.py`` documents - and a test asserts that importing it does not
+pull ``langchain`` into ``sys.modules``. Do not add a top-level
+``strategy_orchestrator`` import here.
+
+``radio_msgs`` / ``rcm_events`` are PARAMETERS, never built here: the three
+surfaces have three different sources (the CLI's OpenF1 corpus plus its
+``--radio-every`` synthetic generator with a precedence rule, the Arcade's
+``RadioPipelineRunner`` instance state, the backend's request payloads). Building
+them here would drag Whisper and per-surface policy into a shared leaf module.
+
+Known coupling, recorded on purpose: the CLI mutates the built object's
+``radio_msgs`` / ``rcm_events`` lists AFTER construction (its main loop owns the
+corpus-suppresses-synthetic rule). If ``RaceState`` is ever frozen, that
+post-construction mutation breaks; the fix then is for the CLI to pass the lists
+as parameters here instead.
+
+--- WHERE TO CHANGE IF THE CONTRACT CHANGES ---
+Consumers of this builder: ``scripts/run_simulation_cli.py::_build_race_state``
+(pure delegation), ``src/arcade/strategy.py::_build_race_state`` (delegation plus
+arcade-side radio/RCM sourcing), and the telemetry backend's
+``backend/utils/race_state_builder.py`` (a re-export shim, #786; its call sites are
+``simulator.py``, ``endpoints/strategy.py`` and ``mcp_tools.py``, none of which
+needed changing because the shim preserves the public name).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS
+from src.agents.position_projection import GAP_UNKNOWN_FALLBACK_S
+
+logger = logging.getLogger(__name__)
+
+# Canonical defaults. Each literal below was measured on the shipped 2023-2025
+# parquets (71 races) before being chosen; the numbers are in the #784 decision
+# table and in documents/audits/DESIGN_race_state_single_contract.md (F10).
+
+# Zero rows carry the literal "UNKNOWN" in any season, so it can never collide
+# with a real reading. The strings that DO appear when FastF1 has no compound are
+# ""/"nan"/"None": race_state_manager.py:352 emits `str(r.get("Compound", ""))`,
+# so a stored NaN reaches this builder as the STRING "nan" with the key present,
+# where a dict.get default never fires (the Series.get lesson, CLAUDE.md
+# section 11). `normalise_compound` folds all of them into this one honest marker.
+UNKNOWN_COMPOUND = "UNKNOWN"
+_MISSING_COMPOUND_MARKERS = frozenset({"", "nan", "none"})
+
+# TyreLife == 0 occurs ZERO times in 2023/2024/2025 (season minimums 2.0/2.0/1.0),
+# so 0 is a non-colliding sentinel. The old arcade/backend default of 1 collides
+# with real fresh-tyre laps, which is the #428 bug shape: a default the code can
+# also legitimately find.
+UNKNOWN_TYRE_LIFE = 0
+
+# Dataset medians (2023+2024 weather columns; the 2025 featured parquet carries
+# none): air median 24.1 C, track median exactly 35.0 C. The CLI's old 40.0 track
+# default corresponded to nothing measured, which is the whole reason to pick a
+# canonical value here.
+#
+# Where these actually fire, measured rather than assumed: NOT on the replay path
+# (all 71 race dirs ship a readable weather.parquet with zero NaN temperature
+# rows, so get_weather_state always emits real readings). They fire on the
+# BACKEND's producer path, where the 2025 laps parquets carry no weather columns
+# at all and the producer honours that as an explicit None per key. That case
+# used to reach `float(None)` and raise TypeError; treating present-but-None as
+# missing is what makes these constants load-bearing.
+DEFAULT_AIR_TEMP_C = 25.0
+DEFAULT_TRACK_TEMP_C = 35.0
+
+
+def _targeting_against_rival(
+    lap_state: Dict[str, Any],
+    rival: str,
+    fallback_gap_s: float,
+    fallback_pace_s: float,
+) -> Tuple[float, float]:
+    """Gap and pace delta of our driver measured against a chosen ``rival``.
+
+    Returns ``(gap_ahead_s, pace_delta_s)`` framed around the rival the user
+    picked in the Strategy tab, so the recommendation reasons about the duel the
+    user actually asked for instead of about whichever car happens to sit one
+    position ahead (#431). Both values land on the RaceState, which feeds N27's
+    overtake scoring inputs and the orchestrator's synthesis prompt.
+
+    gap_ahead_s is the absolute on-track interval to the rival, read from the
+    rival's ``interval_to_driver_s`` (rival elapsed time minus ours: the sign
+    encodes ahead/behind, the magnitude is the gap). This is the same
+    driver-relative interval RaceStateManager already emits per rival, mirrored
+    onto the /lap-state rivals so both callers carry it.
+
+    pace_delta_s is our last lap time minus the rival's, matching N27's
+    convention (negative = we are faster).
+
+    Falls back to the caller-supplied values when the rival is absent from this
+    lap (e.g. it crashed out and the liveness filter dropped it, #428/#430) or
+    when a lap time is missing, so a stale selection degrades to current
+    behaviour rather than to a fabricated zero.
+    """
+    rivals = lap_state.get("rivals", []) or []
+    match = next((r for r in rivals if r.get("driver") == rival), None)
+    if match is None:
+        return fallback_gap_s, fallback_pace_s
+
+    interval = match.get("interval_to_driver_s")
+    gap_ahead_s = abs(float(interval)) if interval is not None else fallback_gap_s
+
+    driver_lap_s = lap_state.get("driver", {}).get("lap_time_s")
+    rival_lap_s = match.get("lap_time_s")
+    if driver_lap_s and rival_lap_s:
+        pace_delta_s = float(driver_lap_s) - float(rival_lap_s)
+    else:
+        pace_delta_s = fallback_pace_s
+
+    return round(gap_ahead_s, 3), round(pace_delta_s, 3)
+
+
+def _car_ahead(lap_state: Dict[str, Any], our_position: int) -> Optional[Dict[str, Any]]:
+    """The rival sitting exactly one position ahead of us, or None when we lead.
+
+    Presence in the ``rivals`` list is the liveness signal: a retired car simply
+    has no row this lap (#428/#430). No age threshold, no fabricated positions.
+    """
+    rivals = lap_state.get("rivals", []) or []
+    match = next((r for r in rivals if r.get("position") == our_position - 1), None)
+    return match
+
+
+def _gap_to_car_ahead(car_ahead: Optional[Dict[str, Any]]) -> float:
+    """Absolute interval to the car ahead, without conflating two zeros.
+
+    No car ahead means we lead, and 0.0 is honest there. A car ahead whose
+    ``interval_to_driver_s`` was never measured is NOT a zero gap: 0.0 reads as
+    side by side, which the orchestrator's clean-air band and N27's sub-1.0s DRS
+    window both act on (#633). It degrades to ``GAP_UNKNOWN_FALLBACK_S`` instead.
+
+    Be honest about what that fallback still is: 2.0 is fabricated, and a real
+    2.0 s gap is common, so it does not satisfy the rule that a default must
+    never be a value the code can also legitimately find. It is less harmful
+    than 0.0, not correct. The real fix is ``RaceState.gap_ahead_s`` becoming
+    ``float | None``, which ``RivalState`` in position_projection.py already is
+    and whose consumers already guard with ``is not None``. That is a Pydantic
+    contract change, tracked under #628.
+    """
+    if car_ahead is None:
+        return 0.0
+    interval = car_ahead.get("interval_to_driver_s")
+    if interval is None:
+        return GAP_UNKNOWN_FALLBACK_S
+    return abs(float(interval))
+
+
+def _pace_delta_vs_car_ahead(
+    driver_state: Dict[str, Any],
+    car_ahead: Optional[Dict[str, Any]],
+) -> float:
+    """Our lap time minus the car ahead's SAME-lap time, negative = we are faster.
+
+    pace_delta_s is contractually RIVAL-relative (this driver's lap time minus
+    the car directly ahead's SAME lap) per race_situation_agent.py:292/904, the
+    schema N27 itself computes. The formula this replaced compared the current
+    lap against our OWN previous lap instead, a same-car same-driver quantity
+    that reported roughly -20 s of phantom "pace gain" on the lap after a pit
+    stop, a green lap read against our own out-lap. 0.0 when the car ahead or
+    either lap time is unknown is the schema's documented neutral, not a guess
+    in either direction (#750).
+    """
+    our_lap_time = driver_state.get("lap_time_s") or 0.0
+    ahead_lap_time = car_ahead.get("lap_time_s") if car_ahead is not None else None
+    if ahead_lap_time is not None and our_lap_time:
+        return float(our_lap_time) - float(ahead_lap_time)
+    return 0.0
+
+
+def normalise_compound(raw: Any) -> str:
+    """Fold every spelling of "no compound" into the one honest marker.
+
+    Matching is case-insensitive so pandas' "nan"/"NaN" spellings and Python's
+    "None" all land on ``UNKNOWN_COMPOUND`` (see the marker-set comment above for
+    why these strings exist at all). A real reading passes through untouched; the
+    producers already emit canonical casing, so no re-casing happens here.
+    """
+    if raw is None:
+        return UNKNOWN_COMPOUND
+    text = str(raw).strip()
+    if text.lower() in _MISSING_COMPOUND_MARKERS:
+        return UNKNOWN_COMPOUND
+    return text
+
+
+def _weather_reading(weather: Dict[str, Any], key: str, default: float) -> float:
+    """Read one weather float, treating a present-but-None value as missing.
+
+    ``get_weather_state`` can emit a weather key whose VALUE is None (a NaN
+    weather row, race_state_manager.py:478-479); ``weather.get(key, default)``
+    passes that None straight into ``float()`` and crashes, which is exactly what
+    all three pre-#784 builders did. The ``is not None`` read is the same pattern
+    pace_agent's own from_state adapter uses for these fields.
+    """
+    value = weather.get(key)
+    reading = float(value) if value is not None else default
+    return reading
+
+
+def _resolve_lap(lap_state: Dict[str, Any], driver_state: Dict[str, Any]) -> int:
+    """Lap number from the top-level key, then the driver dict, then 1 loudly.
+
+    RaceStateManager emits both copies, so every real path takes the first read;
+    the fallbacks only breathe on hand-built lap_states (HTTP clients of
+    /recommend, test fixtures). The pre-#784 CLI read ONLY the driver dict and
+    crashed on states the other two surfaces accepted.
+    """
+    lap = lap_state.get("lap_number")
+    if lap is None:
+        lap = driver_state.get("lap_number")
+    if lap is None:
+        logger.warning(
+            "lap_state carries no lap_number (top-level or driver dict); defaulting to lap 1"
+        )
+        return 1
+    return int(lap)
+
+
+def _resolve_total_laps(session_meta: Dict[str, Any]) -> int:
+    """total_laps from session_meta, else ``DEFAULT_TOTAL_LAPS`` loudly.
+
+    Every internal producer supplies total_laps unconditionally; the one
+    reachable miss is arbitrary client JSON at /recommend. The downstream agents
+    already fall back to the same ``DEFAULT_TOTAL_LAPS``, so a builder stricter
+    than its own consumers would buy a crash, not correctness. The warning keeps
+    the gap visible without turning a sloppy-but-working API call into a 500.
+    """
+    total = session_meta.get("total_laps")
+    if total is None:
+        logger.warning(
+            "session_meta carries no total_laps; falling back to DEFAULT_TOTAL_LAPS=%d",
+            DEFAULT_TOTAL_LAPS,
+        )
+        return DEFAULT_TOTAL_LAPS
+    return int(total)
+
+
+def build_race_state(
+    lap_state: Dict[str, Any],
+    *,
+    driver: Optional[str] = None,
+    gap_ahead_s: Optional[float] = None,
+    pace_delta_s: Optional[float] = None,
+    risk_tolerance: float = 0.5,
+    radio_msgs: Optional[List[dict]] = None,
+    rcm_events: Optional[List[dict]] = None,
+    rival: Optional[str] = None,
+):
+    """Construct the canonical ``RaceState`` from a raw ``lap_state`` dict.
+
+    The single lap_state -> RaceState mapping shared by the CLI, the Arcade and
+    the telemetry backend (#784). The defaults are the per-field canonical
+    literals decided in that issue; the module constants above carry each
+    measurement.
+
+    ``None`` means "compute it here" for ``gap_ahead_s`` / ``pace_delta_s``. When
+    a caller supplies a value it is used unchanged - the /recommend endpoint
+    forwards the client's ``gap_ahead_s`` and mcp_tools substitutes its own
+    fallback, and both stay byte-compatible. When left as None, the builder
+    resolves the positional car ahead once and derives both values from it
+    (absorbing the backend simulator's ``_compute_gap_ahead`` copy).
+
+    ``driver`` is the CLI's explicit code override; when None the driver dict's
+    own code is used, then "UNK".
+
+    ``rival`` (#431): when set, gap and pace are recomputed against that specific
+    car rather than the positional car ahead, with the already-resolved values as
+    fallbacks, so a stale selection degrades to positional behaviour rather than
+    to a fabricated zero.
+
+    Raises:
+        ValueError: when the driver's position is None. A fabricated position is
+            exactly the value the car-ahead lookup searches by
+            (``position == our_pos - 1``), so an unknown position and a
+            genuinely-last car would silently resolve to the same rival - the
+            #428 bug shape. All three surfaces converged on failing loud here
+            (the CLI under #628, the Arcade and backend under #465); every
+            caller's per-lap guard skips these laps first, and its try/except
+            turns a breach of that invariant into a surfaced per-lap error, not
+            a crashed run.
+    """
+    from src.agents.strategy_orchestrator import RaceState
+
+    driver_state = lap_state.get("driver", {}) or {}
+    weather = lap_state.get("weather", {}) or {}
+    session_meta = lap_state.get("session_meta", {}) or {}
+
+    position = driver_state.get("position")
+    if position is None:
+        raise ValueError(
+            "build_race_state: driver position is None for this lap (an incomplete "
+            "or out-lap the caller's guard should have skipped); refusing to "
+            "fabricate a searchable position (#628, #465)"
+        )
+
+    needs_car_ahead = gap_ahead_s is None or pace_delta_s is None
+    car_ahead = _car_ahead(lap_state, position) if needs_car_ahead else None
+    if gap_ahead_s is None:
+        gap_ahead_s = _gap_to_car_ahead(car_ahead)
+    if pace_delta_s is None:
+        pace_delta_s = _pace_delta_vs_car_ahead(driver_state, car_ahead)
+
+    if rival:
+        gap_ahead_s, pace_delta_s = _targeting_against_rival(
+            lap_state,
+            rival,
+            float(gap_ahead_s),
+            float(pace_delta_s),
+        )
+
+    tyre_life = driver_state.get("tyre_life")
+    race_state = RaceState(
+        driver=driver or driver_state.get("driver") or "UNK",
+        lap=_resolve_lap(lap_state, driver_state),
+        total_laps=_resolve_total_laps(session_meta),
+        position=position,
+        compound=normalise_compound(driver_state.get("compound")),
+        tyre_life=tyre_life if tyre_life is not None else UNKNOWN_TYRE_LIFE,
+        gap_ahead_s=float(gap_ahead_s),
+        pace_delta_s=float(pace_delta_s),
+        air_temp=_weather_reading(weather, "air_temp", DEFAULT_AIR_TEMP_C),
+        track_temp=_weather_reading(weather, "track_temp", DEFAULT_TRACK_TEMP_C),
+        rainfall=bool(weather.get("rainfall", False)),
+        radio_msgs=radio_msgs if radio_msgs is not None else [],
+        rcm_events=rcm_events if rcm_events is not None else [],
+        risk_tolerance=float(risk_tolerance),
+    )
+    return race_state

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -79,6 +79,7 @@ from src.agents.race_situation_agent import (
 from src.agents.pit_strategy_agent import (
     run_pit_strategy_agent,
     run_pit_strategy_agent_from_state,
+    _MEDIUM_SUITABILITY_FLOOR_LAPS,
     _STINT_CAPACITY_LAPS,
 )
 
@@ -1700,7 +1701,7 @@ def _build_orchestrator_prompt(
         # deterministic selector's table (18 vs 15), so laps_remaining=16-18 had the
         # selector pass SOFT while both prompts told the LLM to refuse it (#741).
         f"  5. Compound must fit remaining laps: SOFT only if <= {_STINT_CAPACITY_LAPS['SOFT']} laps remain,\n"
-        f"     MEDIUM for {_MIN_STINT_LAPS['MEDIUM']}-{_STINT_CAPACITY_LAPS['MEDIUM']}, "
+        f"     MEDIUM for {_MEDIUM_SUITABILITY_FLOOR_LAPS}-{_STINT_CAPACITY_LAPS['MEDIUM']}, "
         f"HARD for 20+. Wrong compound forces an extra stop.\n"
         f"  6. Opening laps 1-3: threat levels from N27 are inflated by start chaos.\n"
         f"     Discount them one tier (HIGH→MEDIUM, MEDIUM→LOW) for decision-making.\n"

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -81,6 +81,17 @@ from src.agents.pit_strategy_agent import (
     run_pit_strategy_agent_from_state,
     _STINT_CAPACITY_LAPS,
 )
+
+# From the leaf guard-rails module, so this prompt states the same bounds the rails
+# enforce rather than a prose copy of them. Every one of these was a literal here and a
+# constant there, which is how the SOFT capacity ended up telling the LLM to refuse what
+# the selector had just allowed (#741, #766).
+from src.strategy.inference.guard_rails import (
+    _CLIFF_P10_SAFE,
+    _MIN_STINT_LAPS,
+    _NO_PIT_BEFORE_LAP,
+    _NO_PIT_LAST_N_LAPS,
+)
 from src.agents.radio_agent        import (
     run_radio_agent,
     run_radio_agent_from_state,
@@ -1661,10 +1672,12 @@ def _build_orchestrator_prompt(
         f"(if present) one regulation signal. If evidence across agents disagrees, say so\n"
         f"and explain which signal you trusted and why.\n\n"
         f"STRATEGIC GUARD-RAILS (HARD — override any sub-agent or MC signal that conflicts):\n"
-        f"  1. NO pit action (PIT_NOW / UNDERCUT / OVERCUT) before lap 5 unless SC deployed\n"
+        f"  1. NO pit action (PIT_NOW / UNDERCUT / OVERCUT) before lap {_NO_PIT_BEFORE_LAP} "
+        f"unless SC deployed\n"
         f"     or damage/puncture confirmed by radio. Fresh tyres cannot degrade in 1-4 laps;\n"
         f"     pit lane costs ~22-25s which is unrecoverable this early. Force STAY_OUT.\n"
-        f"  2. NO pit action when remaining laps <= 3 unless tyre failure imminent\n"
+        f"  2. NO pit action when remaining laps <= {_NO_PIT_LAST_N_LAPS} unless tyre failure "
+        f"imminent\n"
         # ~9, not ~13. The 13 was 20 s / POS_GAP_S(1.50), and POS_GAP_S is the legacy
         # scoring constant `measure_mc_tables.py` records as retired. The MEASURED
         # median gap between consecutive cars under green flag is 2.227 s (n=69,487),
@@ -1673,19 +1686,22 @@ def _build_orchestrator_prompt(
         # excludes. The pit agent's prompt already said exactly that, so the two
         # prompts were teaching one orchestrating LLM contradictory numbers in the
         # same run (#766).
-        f"     (cliff P10 < 2 laps). Pit cost ~22s vs ~1.5s recovery = ~9 positions lost\n"
+        f"     (cliff P10 < {_CLIFF_P10_SAFE} laps). Pit cost ~22s vs ~1.5s recovery = "
+        f"~9 positions lost\n"
         f"     under green flag (measured median gap 2.227s). The ~13 figure is the\n"
         f"     Safety Car bunched field (1.4795s), which is the exception above.\n"
         f"  3. REACTIVE_SC only when SC IS deployed (confirmed). High sc_prob is a\n"
         f"     contingency trigger, not a primary action — use STAY_OUT with SC contingency.\n"
-        f"  4. Minimum stint before pit: SOFT >= 8 laps, MEDIUM >= 12, HARD >= 15.\n"
+        f"  4. Minimum stint before pit: SOFT >= {_MIN_STINT_LAPS['SOFT']} laps, "
+        f"MEDIUM >= {_MIN_STINT_LAPS['MEDIUM']}, HARD >= {_MIN_STINT_LAPS['HARD']}.\n"
         f"     If tyre_life is below minimum, override to STAY_OUT (current set has life left).\n"
         # SOFT bound derived from _STINT_CAPACITY_LAPS (imported above), not restated:
         # this line and the pit agent's own system prompt used to disagree with the
         # deterministic selector's table (18 vs 15), so laps_remaining=16-18 had the
         # selector pass SOFT while both prompts told the LLM to refuse it (#741).
         f"  5. Compound must fit remaining laps: SOFT only if <= {_STINT_CAPACITY_LAPS['SOFT']} laps remain,\n"
-        f"     MEDIUM for 12-30, HARD for 20+. Wrong compound forces an extra stop.\n"
+        f"     MEDIUM for {_MIN_STINT_LAPS['MEDIUM']}-{_STINT_CAPACITY_LAPS['MEDIUM']}, "
+        f"HARD for 20+. Wrong compound forces an extra stop.\n"
         f"  6. Opening laps 1-3: threat levels from N27 are inflated by start chaos.\n"
         f"     Discount them one tier (HIGH→MEDIUM, MEDIUM→LOW) for decision-making.\n"
         f"  If a sub-agent recommends an action that violates these rules, override to\n"

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -32,7 +32,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS
+from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS, reading_or_default
+from src.agents.race_state_builder import UNKNOWN_TYRE_LIFE, normalise_compound
 from src.agents.tire_parsing import parse_tool_outputs
 
 # ── Repo root (module-relative) ───────────────────────────────────────────────
@@ -1475,8 +1476,15 @@ class TireAgent:
         wx   = lap_state.get('weather', {})
 
         driver      = meta['driver']
-        compound    = d.get('compound', 'MEDIUM')
-        tyre_life   = d.get('tyre_life', 1)
+        # This adapter reads the RAW lap_state, not the RaceState, so the canonical
+        # builder's normalisation does not reach it — it has to apply the same rules
+        # itself or the unification stops at the object boundary (#784). Both of the
+        # old two-arg defaults were also dead on the RSM path and wrong when they did
+        # fire: the key is always present, so a stored NaN arrives as the STRING "nan"
+        # and a None arrives as None, neither of which .get's default catches.
+        compound    = normalise_compound(d.get('compound'))
+        raw_tyre_life = d.get('tyre_life')
+        tyre_life   = UNKNOWN_TYRE_LIFE if raw_tyre_life is None else raw_tyre_life
         gp_name     = meta.get('gp_name', '')
         total_laps  = meta.get('total_laps', DEFAULT_TOTAL_LAPS)
         year        = meta.get('year', 2025)
@@ -1509,10 +1517,16 @@ class TireAgent:
             'cluster_id':         self.cfg.circuit_cluster_map.get(gp_name, 0),
             'team_id':            _encode_team_id(self.cfg.team_id_map, team),
             'year':               year,
-            'AirTemp':   wx.get('air_temp',   28.0),
-            'TrackTemp': wx.get('track_temp', 38.0),
-            'Humidity':  wx.get('humidity',   50.0),
-            'Rainfall':  float(wx.get('rainfall', 0)),
+            # reading_or_default, not .get(key, default): the producers report an
+            # unmeasured reading as the key PRESENT holding None, which .get's default
+            # never catches. These Nones do not crash here — they flow through
+            # _add_weather_cols into the TCN's feature frame and moved the cliff estimate
+            # 2.3 laps OPTIMISTIC on the 2025 reference lap, silently. Optimistic is the
+            # dangerous direction: it delays the pit call. See the helper's docstring.
+            'AirTemp':   reading_or_default(wx, 'air_temp',   28.0),
+            'TrackTemp': reading_or_default(wx, 'track_temp', 38.0),
+            'Humidity':  reading_or_default(wx, 'humidity',   50.0),
+            'Rainfall':  float(reading_or_default(wx, 'rainfall', 0.0)),
             f'{driver}_compound': compound,
             # The stint we are actually in, and the lap we are actually on. N10 trained
             # on windows grouped by ['Year','GP_Name','DriverNumber','Stint'], and the

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -8,7 +8,6 @@ Public API
 ----------
 run_tire_agent(stint_state)                   → TireOutput  (FastF1 session in stint_state)
 run_tire_agent_from_state(lap_state, laps_df) → TireOutput  (RSM adapter, no FastF1 session)
-get_tire_react_agent(**kwargs)                → CompiledGraph
 
 Module-level singletons
 -----------------------
@@ -33,6 +32,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS
 from src.agents.tire_parsing import parse_tool_outputs
 
 # ── Repo root (module-relative) ───────────────────────────────────────────────
@@ -1478,7 +1478,7 @@ class TireAgent:
         compound    = d.get('compound', 'MEDIUM')
         tyre_life   = d.get('tyre_life', 1)
         gp_name     = meta.get('gp_name', '')
-        total_laps  = meta.get('total_laps', 57)
+        total_laps  = meta.get('total_laps', DEFAULT_TOTAL_LAPS)
         year        = meta.get('year', 2025)
         team        = meta.get('team', 'Unknown')
 
@@ -1538,6 +1538,26 @@ class TireAgent:
 
         return self._run_core(driver, compound_id, tyre_life, gp_name)
 
+    @staticmethod
+    def _conservative_stub(
+        compound_id: str, tyre_life: int, gp_name: str, reason: str,
+    ) -> TireOutput:
+        """TireOutput with the fixed conservative defaults used whenever a real TCN
+        reading is unavailable (no bundle for this compound, or a tool-output parse
+        miss). ``reason`` is folded into ``reasoning`` so the degradation is visible
+        instead of masquerading as a genuine reading.
+        """
+        return TireOutput(
+            compound          = compound_id,
+            current_tyre_life = tyre_life,
+            gp_name           = gp_name,
+            deg_rate          = 0.03,
+            laps_to_cliff_p10 = 20.0,
+            laps_to_cliff_p50 = 30.0,
+            laps_to_cliff_p90 = 40.0,
+            reasoning         = reason,
+        )
+
     def _run_core(
         self,
         driver: str,
@@ -1563,15 +1583,9 @@ class TireAgent:
         # TCN bundles only exist for dry compounds (C1–C6). For wet/intermediate
         # compounds return a stub with conservative defaults — no TCN inference.
         if compound_id not in self.bundles:
-            return TireOutput(
-                compound          = compound_id,
-                current_tyre_life = tyre_life,
-                gp_name           = gp_name,
-                deg_rate          = 0.03,
-                laps_to_cliff_p10 = 20.0,
-                laps_to_cliff_p50 = 30.0,
-                laps_to_cliff_p90 = 40.0,
-                reasoning         = (
+            return self._conservative_stub(
+                compound_id, tyre_life, gp_name,
+                reason=(
                     f"[{compound_id} — TCN model not available for wet/intermediate compounds; "
                     f"conservative defaults used]"
                 ),
@@ -1606,15 +1620,9 @@ class TireAgent:
                 'Tire tool output did not parse for %s (tyre_life=%s) — using conservative '
                 'defaults instead of a 0.0 cliff', compound_id, tyre_life,
             )
-            return TireOutput(
-                compound          = compound_id,
-                current_tyre_life = tyre_life,
-                gp_name           = gp_name,
-                deg_rate          = 0.03,
-                laps_to_cliff_p10 = 20.0,
-                laps_to_cliff_p50 = 30.0,
-                laps_to_cliff_p90 = 40.0,
-                reasoning         = (
+            return self._conservative_stub(
+                compound_id, tyre_life, gp_name,
+                reason=(
                     f"[{compound_id} — tire tool output could not be parsed; conservative "
                     f"defaults used] {reasoning}"
                 ),
@@ -1698,31 +1706,3 @@ def run_tire_agent_from_state(lap_state: dict, laps_df: pd.DataFrame) -> TireOut
         TireOutput with all fields populated.
     """
     return _get_default_tire_agent().run_from_state(lap_state, laps_df)
-
-
-def get_tire_react_agent(
-    provider: str = 'lmstudio',
-    model_name: str = 'gpt-4.1-mini',
-    base_url: str = 'http://localhost:1234/v1',
-    api_key: str = 'lm-studio',
-):
-    """Return the LangGraph ReAct agent backed by the singleton TireAgent instance.
-
-    Avoids connecting to the LLM at import time — created only when N31 or tests
-    actually invoke the agent.
-
-    Args:
-        provider: 'lmstudio' or 'openai'.
-        model_name: Model identifier for ChatOpenAI.
-        base_url: Base URL for LM Studio (ignored when provider='openai').
-        api_key: API key; use 'lm-studio' for local server.
-
-    Returns:
-        LangGraph CompiledGraph — invoke with {"messages": [{"role": "user", "content": ...}]}.
-    """
-    return _get_default_tire_agent().get_react_agent(
-        provider=provider,
-        model_name=model_name,
-        base_url=base_url,
-        api_key=api_key,
-    )

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -225,6 +225,27 @@ class TireAgentConfig:
             standing start, so the level is biased slow and cannot be charged as a
             cost directly. Asking the same model on the same stint's early laps
             cancels that baseline algebraically instead of approximately.
+        fresh_reference_max_pct_of_fastest: Reject a fresh-reference candidate lap
+            whose ``lap_time_pct_of_race_fastest`` exceeds this ratio. ``track_status_
+            clean`` (see ``_add_session_cols``) is supposed to be the signal for a
+            Safety-Car- or red-flag-affected lap, but it is dead on the shipping
+            path — a constant 0 across every featured parquet, because N04's
+            ``IsAccurate`` gate does not catch every neutralised lap (measured
+            counter-example: Mexico City 2023 car 4, lap 36, 137.8 s on a circuit
+            whose green-flag pace is ~83 s, ``track_status_clean == 0`` regardless).
+            When such a lap lands as the fresh reference, the model correctly
+            predicts it as an outlier and every later lap in the stint reads as
+            tens of seconds "faster than fresh" — not tyre wear, an artefact of a
+            contaminated zero point. ``lap_time_pct_of_race_fastest`` is already a
+            TCN input feature, computed unconditionally and cheaply from
+            ``session_meta['fastest_lap_s']``, so it is available at the same point
+            ``track_status_clean`` should have been. Threshold measured over 31,624
+            training-season laps: gating at 1.10 cuts the deg_cost_s error bound's
+            mean absolute error from 0.650 to 0.434 s/lap and its signed bias from
+            +0.351 to +0.139, at the cost of 49 of 1714 stints (2.9%) losing their
+            reference entirely and falling back to ``None`` (``scripts/
+            measure_deg_error_bound.py``, ``documents/audits/MEASURE_fresh_reference_
+            quality_gate.md``).
         deg_cost_floor_s / deg_cost_ceiling_s: Bounds on the referenced wear, in
             seconds per lap. MEASURED, not chosen: they are the 1st and 99th
             percentiles over 31,624 training-season laps
@@ -245,6 +266,7 @@ class TireAgentConfig:
     cliff_pit_soon_laps: int = 3
     cliff_monitor_laps: int  = 7
     fresh_reference_tyre_life: int = 3
+    fresh_reference_max_pct_of_fastest: float = 1.10
     deg_cost_floor_s: float   = -2.33
     deg_cost_ceiling_s: float = 3.67
 
@@ -396,6 +418,20 @@ CLIFF_THRESHOLD: dict[str, int] = {
 # session_meta.total_laps is present on every shipping path, so this only guards
 # hand-built states.
 MAX_RACE_LAPS: int = 78
+
+
+def _reject_contaminated_laps(
+    laps: pd.DataFrame, fastest_lap_s: float, max_pct: float,
+) -> pd.DataFrame:
+    """Drop candidate fresh-reference laps slower than ``max_pct`` times the
+    race's fastest lap -- a Safety-Car or red-flag-affected lap that
+    ``track_status_clean`` should flag but does not (see
+    ``TireAgentConfig.fresh_reference_max_pct_of_fastest``).
+
+    Pure and leaf-level so the threshold is testable without model weights --
+    the same split ``tire_parsing.py`` made, and for the same reason.
+    """
+    return laps[laps['LapTime_s'] <= max_pct * fastest_lap_s]
 
 
 def _referenced_wear(parsed: dict) -> Optional[float]:
@@ -932,9 +968,29 @@ class TireAgent:
         life — a replay that starts mid-stint. Zero is a legitimate reading of the
         wear it feeds, so collapsing "unknown" into it would be the same sentinel
         collision that #436 fixed for the cliff.
+
+        Also drops any candidate lap slower than ``cfg.fresh_reference_max_pct_of_
+        fastest`` times the race's fastest lap — a Safety-Car or red-flag-affected
+        lap that ``track_status_clean`` should have flagged but does not (see the
+        config docstring). Returns ``None`` rather than falling back to a
+        contaminated lap when every candidate is rejected, for the same reason: a
+        wrong reference is worse than none.
         """
         early_laps = self._get_driver_stint(driver, self.cfg.fresh_reference_tyre_life)
         if early_laps is None or not len(early_laps):
+            return None
+
+        # `_get_driver_stint` returns the raw slice of `self.laps_df` as-is, so
+        # `LapTime_s` does not exist yet on the FastF1 `run()` path (raw `LapTime`
+        # Timedelta) -- it is only created by `_add_timing_cols`, the first step
+        # inside `_build_stint_tensor`. Reuse it here rather than assume a column
+        # that `_build_stint_features` itself only guarantees after this point.
+        early_laps = _reject_contaminated_laps(
+            _add_timing_cols(early_laps),
+            self.session_meta['fastest_lap_s'],
+            self.cfg.fresh_reference_max_pct_of_fastest,
+        )
+        if not len(early_laps):
             return None
 
         tensor = self._build_stint_tensor(early_laps, compound_id, self.session_meta)

--- a/src/arcade/dashboard/theme.py
+++ b/src/arcade/dashboard/theme.py
@@ -19,7 +19,9 @@ from typing import Final
 
 from PySide6.QtGui import QColor, QPalette
 
-from src.arcade.strategy import _ALERT_SEVERITY
+from src.arcade.strategy import (
+    classify_action,  # noqa: F401 -- re-exported for orchestrator_card.py
+)
 
 # --- Palette (RGB tuples) ------------------------------------------------
 BG_COLOR: Final[tuple[int, int, int]] = (18, 17, 39)  # #121127 PRIMARY_BG
@@ -56,40 +58,14 @@ COMPOUND_NAMES: Final[dict[str, tuple[int, int, int]]] = {
 STREAM_HOST: Final[str] = os.environ.get("F1_STREAM_HOST", "127.0.0.1")
 STREAM_PORT: Final[int] = int(os.environ.get("F1_STREAM_PORT", "9998"))
 
-# --- Action classification (mirrors src/arcade/strategy.py::classify_action)
-_ACTION_STYLE: Final[dict[str, tuple[tuple[int, int, int], str]]] = {
-    "STAY_OUT": (SUCCESS, "STAY OUT"),
-    "PIT_NOW": (DANGER, "PIT NOW"),
-    "UNDERCUT": (WARNING, "UNDERCUT"),
-    "OVERCUT": (WARNING, "OVERCUT"),
-    "ALERT": (INFO, "ALERT"),
-    "DNF": (TEXT_SECONDARY, "DNF"),
-    "ERROR": (DANGER, "ERROR"),
-}
-
-# --- Severity --------------------------------------------------------------
-# Imported from src.arcade.strategy (not duplicated): a hand-copied version of
-# this dict lived here until #620, and it drifted the moment #398 added the
-# "YELLOW_FLAG_SECTOR" key to the original without anyone updating the copy.
-# A double yellow rendered neutral grey in this dashboard while the arcade
-# banner showed it correctly, because a "mirrors X" comment told readers the
-# two dicts were already checked. Importing the single dict removes that
-# drift risk. The extra pandas import this pulls in from strategy.py is a
-# small addition next to the PySide6 + pyqtgraph cost this process already
-# pays on cold start.
-
-
-def classify_action(action: str) -> tuple[tuple[int, int, int], str]:
-    """Return (color, display-label) for a raw action string."""
-    return _ACTION_STYLE.get(action.upper(), (ACCENT, (action or "--").upper()))
-
-
-def severity_color(tags: list[str]) -> tuple[int, int, int]:
-    """Max severity colour for a list of alert tags. Grey when empty."""
-    if not tags:
-        return TEXT_TERTIARY
-    severity = max((_ALERT_SEVERITY.get(t.upper(), 0) for t in tags), default=0)
-    return {3: DANGER, 2: WARNING, 1: INFO}.get(severity, TEXT_SECONDARY)
+# --- Action classification ---------------------------------------------------
+# `classify_action` is imported from src.arcade.strategy (not duplicated): a
+# hand-copied version lived here until this cleanup (2026-08-01), mirrored
+# under a "mirrors X" comment -- the same drift mechanism #620 already fixed
+# once for `_ALERT_SEVERITY` (imported above, not defined here either), just
+# not yet triggered for this one. The extra pandas import this pulls in from
+# strategy.py is a small addition next to the PySide6 + pyqtgraph cost this
+# process already pays on cold start.
 
 
 def qcolor(rgb: tuple[int, int, int]) -> QColor:
@@ -187,6 +163,14 @@ _FLAG_BG_BY_INTENT: Final[dict[str, tuple[int, int, int]]] = {
     "VSC": WARNING,
     "VIRTUAL_SAFETY_CAR": WARNING,
     "YELLOW_FLAG": WARNING,
+    # Same tier as YELLOW_FLAG (matches _ALERT_SEVERITY's own severity-2 grouping
+    # in strategy.py). A sector-scoped double yellow (rcm_events.py's
+    # classify_rcm_event returns this exact event type) was missing this key and
+    # fell through to the neutral-grey default -- the same bug shape #398 fixed
+    # in _ALERT_SEVERITY, alive here independently because this is a third,
+    # separately maintained severity mapping (found by the 2026-08-01 cleanup's
+    # adversarial gate).
+    "YELLOW_FLAG_SECTOR": WARNING,
     "PROBLEM": INFO,
     "WARNING": INFO,
     "PENALTY": DANGER,

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -597,82 +597,30 @@ class SimConnector(threading.Thread):
         return candidate  # report the primary miss so error messaging stays clean
 
     def _build_race_state(self, lap_state: dict[str, Any], prev_lap_time: float):
-        """Duplicate of ``_local_build_race_state`` from simulator.py, small
-        enough to inline so the arcade stays independent of
-        ``backend.utils.race_state_builder`` (which requires a sys.path
-        shim that only the FastAPI startup provides). Populates
-        ``radio_msgs`` / ``rcm_events`` from the ``RadioPipelineRunner``
-        corpus so the Radio agent sees the real OpenF1 team messages
-        (same as the CLI); empty lists when the corpus could not load.
+        """Delegate to the canonical builder, keeping only the arcade-side inputs.
+
+        The lap_state -> RaceState mapping lives in
+        ``src.agents.race_state_builder.build_race_state`` (#784): one
+        implementation shared by all three surfaces — this arcade, the CLI, and
+        the telemetry backend, which reaches it through a re-export shim (#786)
+        rather than keeping the copy it used to carry. So the defaults the
+        models receive no longer drift per surface.
+        The #465 position guard, the gap fallback rationale and
+        the #750 pace-delta axis are all documented there now. What stays here
+        is exactly what needs arcade instance state: sourcing ``radio_msgs`` /
+        ``rcm_events`` from the ``RadioPipelineRunner`` corpus so the Radio
+        agent sees the real OpenF1 team messages (same as the CLI; empty lists
+        when the corpus could not load), and the stateful Safety-Car
+        re-injection. Both are passed to the builder as parameters.
 
         ``prev_lap_time`` is accepted but no longer read here: ``pace_delta_s``
-        used to be computed from it and that was the wrong axis (#750, fixed
-        below). Left in the signature rather than removed, since the caller's
-        per-lap bookkeeping that produces it (``_step_once`` /
-        ``_lap_time_from_state``) serves no other purpose today and dropping it
-        is a small cleanup outside this fix's scope.
+        used to be computed from it and that was the wrong axis (#750, now
+        enforced by the canonical builder). Left in the signature rather than
+        removed, since the caller's per-lap bookkeeping that produces it
+        (``_step_once`` / ``_lap_time_from_state``) serves no other purpose
+        today and dropping it is a small cleanup outside this fix's scope.
         """
-        from src.agents.position_projection import GAP_UNKNOWN_FALLBACK_S
-        from src.agents.strategy_orchestrator import RaceState
-
-        driver_st = lap_state.get("driver", {})
-        weather = lap_state.get("weather", {})
-        meta = lap_state.get("session_meta", {})
-        cur_lap_time = driver_st.get("lap_time_s") or 0.0
-
-        rivals = lap_state.get("rivals", [])
-        our_pos = driver_st.get("position")
-        # `_lap_skip_reason` (the DNF/incomplete-lap guard the driver loop runs before
-        # `_step_once` -> `_build_race_state`) already filters out laps where position
-        # is None, so reaching here with an unknown position means that invariant broke.
-        # Fail loudly instead of fabricating a searchable P99 car (the #428 bug shape:
-        # a sentinel that collides with a real rival's `position - 1`) — the caller's
-        # `except Exception` wraps this into a surfaced `state.error`, it does not crash
-        # the driver thread (#465).
-        if our_pos is None:
-            raise ValueError(
-                "_build_race_state: driver position is None; the incomplete-lap guard "
-                "should have skipped this lap before calling _build_race_state (#465)"
-            )
-        car_ahead = next((r for r in rivals if r.get("position") == our_pos - 1), None)
-        # Two different zeros used to hide under one expression. No car ahead means we
-        # lead, and 0.0 is honest there. A car ahead whose interval was never measured
-        # is NOT a zero gap: 0.0 reads as side by side, which the orchestrator's
-        # clean-air band and N27's sub-1.0s DRS window both act on. It degrades to
-        # GAP_UNKNOWN_FALLBACK_S instead, which the CLI now shares. The telemetry
-        # backend still has its own copies and is a submodule, so this is a two-way
-        # unification, not the three-way one an earlier draft of this comment claimed.
-        #
-        # Be honest about what that fallback still is: 2.0 is fabricated, and a real
-        # 2.0s gap is common, so it does not satisfy the rule that a default must never
-        # be a value the code can also legitimately find. It is less harmful than 0.0,
-        # not correct. The real fix is RaceState.gap_ahead_s becoming `float | None`,
-        # which RivalState in position_projection.py already is and whose consumers
-        # already guard with `is not None`. That is a Pydantic contract change.
-        if car_ahead is None:
-            gap_ahead_s = 0.0
-        else:
-            measured_interval = car_ahead.get("interval_to_driver_s")
-            if measured_interval is None:
-                gap_ahead_s = GAP_UNKNOWN_FALLBACK_S
-            else:
-                gap_ahead_s = abs(measured_interval)
-
-        # pace_delta_s is contractually RIVAL-relative (this driver's lap time
-        # minus the car directly ahead's SAME lap, negative = we are faster) per
-        # race_situation_agent.py:292/904, the schema N27 itself computes. The
-        # old formula compared cur_lap_time against our OWN previous lap
-        # instead, a same-car same-driver quantity that reported roughly -20s
-        # of phantom "pace gain" on the lap after a pit stop, a green lap read
-        # against our own out-lap. car_ahead is already resolved above for
-        # gap_ahead_s, so no extra lookup is needed; 0.0 when it or its lap
-        # time is unknown is the schema's documented neutral, not a guess in
-        # either direction (#750).
-        ahead_lap_time = car_ahead.get("lap_time_s") if car_ahead is not None else None
-        if ahead_lap_time is not None and cur_lap_time:
-            pace_delta = cur_lap_time - float(ahead_lap_time)
-        else:
-            pace_delta = 0.0
+        from src.agents.race_state_builder import build_race_state
 
         lap_num = int(lap_state.get("lap_number", 1) or 1)
         radio_msgs: list[dict] = []
@@ -696,22 +644,11 @@ class SimConnector(threading.Thread):
         if self._sc_tracker.should_inject(lap_num):
             rcm_events = list(rcm_events) + [self._sc_tracker.synthetic_event()]
 
-        return RaceState(
-            driver=driver_st.get("driver", "UNK"),
-            lap=lap_num,
-            # 57 = median/mode race length across the dataset; the shared strategy fallback.
-            total_laps=meta.get("total_laps", 57),
-            position=our_pos,
-            compound=driver_st.get("compound", "MEDIUM"),
-            tyre_life=driver_st.get("tyre_life", 1),
-            gap_ahead_s=float(gap_ahead_s),
-            pace_delta_s=float(pace_delta),
-            air_temp=float(weather.get("air_temp", 25.0)),
-            track_temp=float(weather.get("track_temp", 35.0)),
-            rainfall=bool(weather.get("rainfall", False)),
+        return build_race_state(
+            lap_state,
+            risk_tolerance=self._request.risk_tolerance,
             radio_msgs=radio_msgs,
             rcm_events=rcm_events,
-            risk_tolerance=float(self._request.risk_tolerance),
         )
 
 

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -730,36 +730,18 @@ _ACTION_STYLE: dict[str, tuple[tuple[int, int, int], str]] = {
 
 
 def classify_action(action: str) -> tuple[tuple[int, int, int], str]:
-    """Map a raw action string to (colour, display-label) for the badge."""
-    return _ACTION_STYLE.get(action.upper(), (ACCENT, action.upper() or "--"))
+    """Map a raw action string to (colour, display-label) for the badge.
 
-
-_ALERT_SEVERITY: dict[str, int] = {
-    "SAFETY_CAR": 3,
-    "RED_FLAG": 3,
-    "VIRTUAL_SAFETY_CAR": 2,
-    "VSC": 2,
-    "YELLOW_FLAG": 2,
-    # A sector yellow is the same danger tier as a full-track yellow, and it is
-    # the form DOUBLE YELLOW resolves to (radio_agent folds DOUBLE YELLOW into the
-    # YELLOW branch → YELLOW_FLAG_SECTOR). Without this key the banner fell back to
-    # severity 0 (dim), hiding the highest-danger local flag (#398 follow-up).
-    "YELLOW_FLAG_SECTOR": 2,
-    "PROBLEM": 1,
-    "WARNING": 1,
-}
-
-
-def classify_alerts(
-    tags: list[str],
-) -> tuple[str, tuple[int, int, int]] | None:
-    """Collapse `agent_alerts` tags into one banner line. None when empty."""
-    if not tags:
-        return None
-    severity = max((_ALERT_SEVERITY.get(t.upper(), 0) for t in tags), default=0)
-    colour = {3: DANGER, 2: WARNING, 1: INFO}.get(severity, TEXT_SECONDARY)
-    text = " · ".join(t.upper() for t in tags[:4])
-    return text, colour
+    ``action`` was typed as a plain ``str`` but neither this function's original
+    body nor its theme.py twin (deduplicated 2026-08-01) actually guarded a
+    ``None`` -- both called ``.upper()`` on it unguarded as the dict lookup key
+    and crashed identically. No live caller currently passes ``None``
+    (`orchestrator_card.py` sanitises with `str(... or "--")` first), but the
+    signature invites it, so this is fixed now rather than left as a latent
+    crash the next caller could trigger.
+    """
+    action = (action or "--").upper()
+    return _ACTION_STYLE.get(action, (ACCENT, action))
 
 
 # --- Private helpers -----------------------------------------------------

--- a/src/f1_strat_manager/laps_augment.py
+++ b/src/f1_strat_manager/laps_augment.py
@@ -37,6 +37,12 @@ from typing import Callable, Dict, Optional
 import pandas as pd
 
 from src.f1_strat_manager.tyre_stint_repair import repair_tyre_stints
+from src.f1_strat_manager.weather_restore import (
+    WEATHER_COLUMNS,
+    normalise_rainfall,
+    read_race_weather,
+    weather_for_race,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -194,6 +200,18 @@ def augment_featured_laps(
 
     root = data_root or (root_resolver() if root_resolver else _default_data_root())
 
+    # A season whose artefact already carries ANY of the weather columns is never
+    # re-derived: 2023 and 2024 take this exit by construction, so the restore cannot
+    # silently disagree with the values the models were trained on (#782).
+    #
+    # `any`, not `all`, and the difference is not cosmetic: on a partial set the per-race
+    # slice would carry all four names and the left-merge below would collide with the
+    # ones already present, replacing `TrackTemp` with a `TrackTemp_x`/`TrackTemp_y` pair
+    # that no consumer reads. No shipped artefact is partial today, so this is a latent
+    # shape -- but it is the shape the guard itself contemplates, and corrupting is a
+    # worse answer than declining.
+    wants_weather = not any(column in df.columns for column in WEATHER_COLUMNS)
+
     frames = []
     corrections: list[pd.DataFrame] = []
     missing: list[str] = []
@@ -215,6 +233,15 @@ def augment_featured_laps(
             corrections.append(_stint_corrections(raw, path, gp_name))
         slice_ = raw[["Driver", "LapNumber", *RAW_COLUMNS_TO_RESTORE]].copy()
         slice_["GP_Name"] = gp_name
+        if wants_weather:
+            # Aligned here rather than after the merge because N04 joined on the RAW
+            # laps' session `Time` timedelta, and this is the last point where that
+            # column still exists in its original form (#782).
+            race_weather = read_race_weather(path.parent)
+            if race_weather is not None:
+                aligned = weather_for_race(raw, race_weather)
+                for column in WEATHER_COLUMNS:
+                    slice_[column] = aligned[column].values
         # `Time` is a session-elapsed timedelta; the models were trained on seconds.
         slice_["Time"] = pd.to_timedelta(slice_["Time"]).dt.total_seconds()
         frames.append(slice_.rename(columns=RAW_COLUMNS_TO_RESTORE))
@@ -232,6 +259,13 @@ def augment_featured_laps(
 
     augmented = df.merge(pd.concat(frames, ignore_index=True), on=_JOIN_KEYS, how="left")
     augmented = _apply_stint_corrections(augmented, corrections)
+    if wants_weather:
+        # N04's closing step, at N04's own placement. Note what it does NOT do: a race
+        # whose weather parquet is missing keeps NaN temperatures but still reads
+        # Rainfall 0 (dry). That is inherited from N04 on purpose, not a gap left open.
+        augmented = normalise_rainfall(augmented)
+        restored = int(augmented["TrackTemp"].notna().sum()) if "TrackTemp" in augmented else 0
+        logger.info("Restored weather onto %d/%d laps of %d (#782)", restored, len(augmented), year)
     restored = int(augmented["Time_s"].notna().sum())
     logger.info(
         "Restored Time_s/TrackStatus onto %d/%d laps of %d from the raw parquets",

--- a/src/f1_strat_manager/laps_augment.py
+++ b/src/f1_strat_manager/laps_augment.py
@@ -36,6 +36,8 @@ from typing import Callable, Dict, Optional
 
 import pandas as pd
 
+from src.f1_strat_manager.tyre_stint_repair import repair_tyre_stints
+
 logger = logging.getLogger(__name__)
 
 # Raw column -> the name the models were trained on.
@@ -96,6 +98,64 @@ def _raw_race_dir(data_root: Path, year: int, gp_name: str) -> Path:
     return base / gp_name
 
 
+STINT_COLUMNS = ("Stint", "TyreLife", "Compound")
+
+
+def _stint_corrections(repaired_raw: pd.DataFrame, path: Path, gp_name: object) -> pd.DataFrame:
+    """The repaired tyre-stint columns for one race, keyed for the featured join.
+
+    Carried separately from the `Time_s`/`TrackStatus` merge because these three columns
+    ALREADY exist on the featured frame: they have to overwrite, not be appended, and a
+    plain merge would silently produce `_x`/`_y` pairs that no consumer reads.
+    """
+    original = pd.read_parquet(path)
+    changed = pd.Series(False, index=repaired_raw.index)
+    for column in STINT_COLUMNS:
+        before, after = original[column], repaired_raw[column]
+        # A NaN on both sides is not a change; `!=` alone would call it one.
+        changed |= (before != after) & ~(before.isna() & after.isna())
+
+    corrections = repaired_raw.loc[changed, ["Driver", "LapNumber", *STINT_COLUMNS]].copy()
+    corrections["GP_Name"] = gp_name
+    # An explicit marker, because the repair's most important output is a NULL: nulling a
+    # fabricated age writes NaN, and a mask built from "the patched value is not NaN"
+    # would silently skip exactly those rows, leaving the invented integer in the featured
+    # frame. Today every affected lap also carries a numeric Stint, so such a mask happens
+    # to work -- on an accident of the data, not by construction.
+    corrections["_repaired"] = True
+    return corrections
+
+
+def _apply_stint_corrections(
+    augmented: pd.DataFrame,
+    corrections: list[pd.DataFrame],
+) -> pd.DataFrame:
+    """Overwrite only the laps the stint repair actually corrected.
+
+    Row-scoped on purpose: a lap the repair did not touch keeps its published value byte
+    for byte, so this cannot quietly rewrite the 69 healthy races.
+    """
+    if not corrections:
+        return augmented
+
+    patch = pd.concat(corrections, ignore_index=True)
+    merged = augmented.merge(patch, on=_JOIN_KEYS, how="left", suffixes=("", "_fixed"))
+
+    # The marker, not the patched values, decides which rows to overwrite: a repaired lap
+    # can legitimately carry NaN (that is what nulling a fabricated age produces), and
+    # inferring "touched" from the values would drop exactly those rows.
+    touched = merged["_repaired"].notna()
+    for column in STINT_COLUMNS:
+        merged.loc[touched, column] = merged.loc[touched, f"{column}_fixed"]
+    merged = merged.drop(columns=["_repaired", *[f"{c}_fixed" for c in STINT_COLUMNS]])
+
+    logger.info(
+        "Applied %d repaired tyre-stint lap(s) from the raw parquets (#790)",
+        int(touched.sum()),
+    )
+    return merged
+
+
 def augment_featured_laps(
     df: pd.DataFrame,
     year: int,
@@ -135,6 +195,7 @@ def augment_featured_laps(
     root = data_root or (root_resolver() if root_resolver else _default_data_root())
 
     frames = []
+    corrections: list[pd.DataFrame] = []
     missing: list[str] = []
     for gp_name in df["GP_Name"].dropna().unique():
         path = _raw_race_dir(root, year, str(gp_name)) / "laps.parquet"
@@ -145,6 +206,13 @@ def augment_featured_laps(
         if not set(RAW_COLUMNS_TO_RESTORE).issubset(raw.columns):
             missing.append(str(gp_name))
             continue
+        # Correct tyre-stint metadata the live-timing feed published wrong, BEFORE the
+        # merge, because the repair needs `PitInTime` and only the raw frame carries it
+        # (#790). It touches nothing on a healthy race, so this is a no-op for 69 of the
+        # 71 shipped races.
+        raw, stint_report = repair_tyre_stints(raw)
+        if stint_report.changed_anything:
+            corrections.append(_stint_corrections(raw, path, gp_name))
         slice_ = raw[["Driver", "LapNumber", *RAW_COLUMNS_TO_RESTORE]].copy()
         slice_["GP_Name"] = gp_name
         # `Time` is a session-elapsed timedelta; the models were trained on seconds.
@@ -163,6 +231,7 @@ def augment_featured_laps(
         return df
 
     augmented = df.merge(pd.concat(frames, ignore_index=True), on=_JOIN_KEYS, how="left")
+    augmented = _apply_stint_corrections(augmented, corrections)
     restored = int(augmented["Time_s"].notna().sum())
     logger.info(
         "Restored Time_s/TrackStatus onto %d/%d laps of %d from the raw parquets",

--- a/src/f1_strat_manager/tyre_stint_repair.py
+++ b/src/f1_strat_manager/tyre_stint_repair.py
@@ -108,7 +108,9 @@ class RepairReport:
 
     @property
     def changed_anything(self) -> bool:
-        return bool(self.boundaries_corrected or self.tyre_life_rebuilt or self.fabricated_ages_nulled)
+        return bool(
+            self.boundaries_corrected or self.tyre_life_rebuilt or self.fabricated_ages_nulled
+        )
 
 
 def _is_real_compound(value: object) -> bool:
@@ -283,7 +285,10 @@ def repair_tyre_stints(laps: pd.DataFrame) -> tuple[pd.DataFrame, RepairReport]:
     # dropna=False: a NaN driver key would otherwise be dropped by the groupby and come
     # back all-NaN through the reindex, destroying columns this repair has no business
     # touching. No shipped race carries one, but this runs on every future download.
-    groups = [_rebuild_driver(group, report) for _, group in laps.groupby("Driver", sort=False, dropna=False)]
+    groups = [
+        _rebuild_driver(group, report)
+        for _, group in laps.groupby("Driver", sort=False, dropna=False)
+    ]
     repaired = pd.concat(groups).reindex(laps.index)
 
     # Counted AFTER the repair, so the number means what the log says it means.

--- a/src/f1_strat_manager/tyre_stint_repair.py
+++ b/src/f1_strat_manager/tyre_stint_repair.py
@@ -1,0 +1,305 @@
+"""Repair tyre-stint metadata that the F1 live-timing feed published wrong (#790).
+
+The F1 `TimingAppData` feed sometimes drops the stint records for a stint. FastF1 copies
+that faithfully and so do we -- verified: `fastf1.get_session(2025, "Miami", "R")` and
+`data/raw/2025/Miami_Gardens/laps.parquet` carry the identical 446/457 NaN block, so
+nothing in this repo's extraction loses it. The gap is upstream of us.
+
+What makes it worth repairing rather than merely guarding is the SECOND defect, which is
+invisible. When the feed recovers it does not resume the stint that was actually running:
+it starts a NEW one at the recovery lap. At Miami 2025 the metadata reappears at lap 24
+for the whole field, so every car reads `TyreLife 1` on a set that has done 24 racing
+laps, and then:
+
+  * cars that had not yet pitted carry a fabricated age until they do,
+  * the count continues ACROSS the pit stop, which is physically impossible, and
+  * the following stint's age is understated by the same 4-8 laps.
+
+`TyreLife` feeds N26's TCN and N15/N16, and Miami 2025 is in the TEST season. A
+degradation model reading "5 laps old" for a 29-lap-old tyre predicts no wear.
+
+--- WHERE TO CHANGE IF THE ARTEFACT CHANGES ---
+This runs at LOAD time, called from `laps_augment.augment_featured_laps`, for the same
+reasons that module documents: the featured parquet is published on Hugging Face and
+re-downloaded by `scripts/download_data.py`, so a locally-patched file would be silently
+reverted, and its only producer is a read-only notebook (N04).
+
+## The two repairs, and the one thing this never does
+
+1. **Null the fabricated ages.** Where the feed invented a stint mid-race, the affected
+   laps belong to the set the car started on, whose age is NOT recoverable. They become
+   NaN -- a visible unknown replacing an invisible wrong integer.
+2. **Move the misplaced boundary.** Where the car pitted before the feed recovered, the
+   new stint really began on the out-lap, and from there the age IS recoverable.
+
+It never invents a tyre age. A car may start a stint on a used set, and the offset is
+real: measured across every healthy stint transition in 2024 and 2025, a FRESH set starts
+at `TyreLife` 1.0 in 1156/1156 cases, while USED sets start anywhere from 2 to 16. The
+rebuild therefore ANCHORS ON THE AGE THE FEED PUBLISHED at the boundary lap rather than
+hardcoding 1 -- the feed mislabels WHERE a stint began but still reports the set's own
+starting age, so subtracting one recovers the prior usage. (`FreshTyre` is deliberately
+NOT the mechanism: on the affected laps it is a fabricated uniform `True`, so it carries
+no information exactly where it would be needed.) When the boundary lap has no published
+age, there is no anchor and nothing is rebuilt.
+
+## Why a pit entry alone does not mean a new set
+
+A stop-and-go or drive-through penalty sends the car down the pit lane with no work done,
+so the stint correctly does NOT advance. Monaco 2025, RUS, lap 62 is exactly that -- a
+served stop-and-go -- and its record is CORRECT. `find_misplaced_boundaries` therefore
+requires the compound to change later AND no other pit entry to sit in between (a later
+real stop explains the change by itself; that is the Monaco case).
+
+## Known limits, stated rather than discovered later
+
+* **Same compound refitted is invisible to the boundary rule.** 743 of 2594 stint
+  transitions across the 71 shipped races fit the same compound again, and a misplaced
+  boundary there cannot be seen by a compound-change test. No shipped race is affected
+  today; the gap is structural. It errs toward missing a defect, never toward rewriting a
+  correct record.
+* **Raw-fed surfaces see feed values.** Consumers that read a raw parquet directly rather
+  than through `augment_featured_laps` -- the replay engine and the backend's own race
+  loader -- are not repaired. Unifying that is a wider change than this repair.
+* **A stop made while the feed was dark is nulled, not rebuilt, even past the stop.**
+  When the pre-stop compound was lost there is nothing left to confirm a tyre change with
+  (a pit entry alone does not prove one -- see Monaco above), so `find_misplaced_boundaries`
+  declines and the nulling pass takes the whole block to race end. Miami 2025 STR, HAD and
+  BOR are this shape: 63 of their featured laps are post-stop and would have been
+  recoverable to within 1-4 laps under the anchor assumption, and they become NaN instead.
+  That is a deliberate trade -- a visible unknown over a probably-right integer on laps
+  whose tyre change is inferred rather than evidenced -- and it is recorded here because
+  the alternative reading, that those laps are simply unrecoverable, would be false.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# Columns this module reads. A frame missing any of them is returned untouched rather
+# than half-repaired, which is what the raw-parquet-absent path already does upstream.
+REQUIRED_COLUMNS = ("Driver", "LapNumber", "Stint", "TyreLife", "Compound", "PitInTime")
+
+# The extractor stringifies a missing compound, so absence arrives as one of these rather
+# than as NaN. They must never be treated as "a different compound" (which would let
+# data loss masquerade as evidence of a tyre change) nor written over a real value.
+_COMPOUND_SENTINELS = frozenset({"", "nan", "none", "unknown"})
+
+
+@dataclass
+class RepairReport:
+    """What a repair pass actually changed, so a caller can log or assert on it.
+
+    Kept separate from the frame because the interesting property of this repair is how
+    LITTLE it touches: a healthy race must come back byte-identical, and that is only
+    checkable if the count of touched rows is reported rather than inferred.
+    """
+
+    boundaries_corrected: int = 0
+    tyre_life_rebuilt: int = 0
+    fabricated_ages_nulled: int = 0
+    unknown_after: int = 0
+    drivers_touched: list[str] = field(default_factory=list)
+
+    @property
+    def changed_anything(self) -> bool:
+        return bool(self.boundaries_corrected or self.tyre_life_rebuilt or self.fabricated_ages_nulled)
+
+
+def _is_real_compound(value: object) -> bool:
+    """True when the value names an actual compound rather than absent data."""
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return False
+    return str(value).strip().lower() not in _COMPOUND_SENTINELS
+
+
+def _pit_in_laps(driver_laps: pd.DataFrame) -> list[int]:
+    """Laps on which this driver entered the pit lane, ascending.
+
+    `PitInTime` is the column the broken feed usually leaves intact, which is what makes
+    the boundary repair possible: it is the independent ground truth the stint metadata
+    failed to agree with. It is not guaranteed -- Miami 2025 BEA has no pit record at all
+    -- which is why the age-nulling repair below does not depend on it.
+    """
+    entered = driver_laps.loc[driver_laps["PitInTime"].notna(), "LapNumber"]
+    return sorted(int(lap) for lap in entered.dropna())
+
+
+def _first_compound_change_after(driver_laps: pd.DataFrame, lap: int) -> Optional[int]:
+    """First lap after ``lap`` whose compound is a DIFFERENT REAL compound.
+
+    Sentinels are skipped rather than counted as a change: `'HARD' -> 'None'` is the feed
+    dying, not a pit stop, and treating it as evidence of a new set is how a repair ends
+    up writing a data-loss marker over a real compound.
+    """
+    current = driver_laps.loc[driver_laps["LapNumber"] == lap, "Compound"]
+    if current.empty or not _is_real_compound(current.iloc[0]):
+        return None
+    later = driver_laps[driver_laps["LapNumber"] > lap]
+    for _, row in later.iterrows():
+        if _is_real_compound(row["Compound"]) and row["Compound"] != current.iloc[0]:
+            return int(row["LapNumber"])
+    return None
+
+
+def find_misplaced_boundaries(driver_laps: pd.DataFrame) -> list[tuple[int, int]]:
+    """Pit stops whose stint boundary landed on the wrong lap, for one driver.
+
+    Returns ``(pit_lap, boundary_lap)`` pairs: the car pitted on ``pit_lap`` but the
+    metadata only starts the new stint at ``boundary_lap``.
+
+    Both conditions must hold, and the second one is not optional -- see the module
+    docstring's Monaco case, where dropping it turns a correct record into a wrong one.
+    """
+    driver_laps = driver_laps.sort_values("LapNumber")
+    pit_laps = _pit_in_laps(driver_laps)
+    misplaced: list[tuple[int, int]] = []
+
+    for pit_lap in pit_laps:
+        boundary = _first_compound_change_after(driver_laps, pit_lap)
+        if boundary is None:
+            continue  # no real tyre change: a served penalty, or the feed went dark
+        if boundary - pit_lap <= 1:
+            continue  # the new stint starts on the out-lap, which is correct
+        if any(pit_lap < lap < boundary for lap in pit_laps):
+            continue  # a later real stop explains the change
+        misplaced.append((pit_lap, boundary))
+
+    return misplaced
+
+
+def _fabricated_age_mask(driver_laps: pd.DataFrame) -> pd.Series:
+    """Laps whose ``TyreLife`` the feed invented after going dark mid-race.
+
+    The signature is a stint that appears out of nowhere: the metadata is absent at the
+    driver's first lap and later resumes on a lap that is NOT a pit out-lap. Everything
+    from that recovery up to the driver's first real pit stop is still the race-start set,
+    whose age was never published, so the published numbers there count from the wrong
+    zero and are provably too small.
+
+    This is what covers the cars a boundary correction cannot reach: a driver who pits
+    only after the feed recovered (Miami GAS, HUL) has no misplaced boundary at all, yet
+    carries the same fabricated block.
+    """
+    ordered = driver_laps.sort_values("LapNumber")
+    blank = pd.Series(False, index=driver_laps.index)
+    if ordered.empty or ordered["TyreLife"].notna().iloc[0]:
+        return blank  # the feed was healthy at the start: nothing was invented
+
+    known = ordered[ordered["TyreLife"].notna()]
+    if known.empty:
+        return blank  # never recovered; the laps are already an honest NaN
+
+    recovery_lap = int(known["LapNumber"].iloc[0])
+    out_laps = {lap + 1 for lap in _pit_in_laps(ordered)}
+    if recovery_lap in out_laps:
+        return blank  # the stint really did start here, via a pit stop
+
+    later_stops = [lap for lap in _pit_in_laps(ordered) if lap >= recovery_lap]
+    end_lap = later_stops[0] if later_stops else int(ordered["LapNumber"].max())
+
+    laps = driver_laps["LapNumber"]
+    return (laps >= recovery_lap) & (laps <= end_lap) & driver_laps["TyreLife"].notna()
+
+
+def _rebuild_driver(driver_laps: pd.DataFrame, report: RepairReport) -> pd.DataFrame:
+    """Null one driver's fabricated ages, then correct any misplaced stint boundary."""
+    repaired = driver_laps.sort_values("LapNumber").copy()
+    touched = False
+
+    fabricated = _fabricated_age_mask(repaired)
+    if fabricated.any():
+        repaired.loc[fabricated, "TyreLife"] = float("nan")
+        report.fabricated_ages_nulled += int(fabricated.sum())
+        touched = True
+
+    lap_numbers = repaired["LapNumber"]
+    for pit_lap, boundary in find_misplaced_boundaries(repaired):
+        at_boundary = repaired[lap_numbers == boundary]
+        if at_boundary.empty:
+            continue
+
+        # Everything the rebuild needs is resolved BEFORE anything is written. A partial
+        # apply -- rewriting `Compound` and then bailing on a missing `Stint` -- would
+        # return a mutated frame while reporting no change, which the caller reads as
+        # "nothing to patch" and so would leave the raw and featured views disagreeing.
+        stint_id = at_boundary["Stint"].iloc[0]
+        published_age = at_boundary["TyreLife"].iloc[0]
+        if pd.isna(stint_id) or pd.isna(published_age):
+            # Without a published age there is no anchor, and counting from 1 would
+            # invent a fresh set -- the one thing this module refuses to do. The laps
+            # keep whatever they had; the nulling pass above already handled the ones
+            # that were provably fabricated.
+            continue
+
+        # The new set goes on during the stop, so the out-lap is the new stint's first
+        # lap. Its age is the set's prior usage plus one, not a hardcoded 1.
+        out_lap = pit_lap + 1
+        prior_usage = max(0.0, float(published_age) - 1.0)
+        in_new_stint = lap_numbers >= out_lap
+        mislabelled = in_new_stint & (lap_numbers < boundary)
+
+        new_compound = at_boundary["Compound"].iloc[0]
+        if _is_real_compound(new_compound):
+            repaired.loc[mislabelled, "Compound"] = new_compound
+        repaired.loc[mislabelled, "Stint"] = stint_id
+
+        of_this_stint = in_new_stint & (repaired["Stint"] == stint_id)
+        repaired.loc[of_this_stint, "TyreLife"] = (
+            lap_numbers[of_this_stint] - out_lap + 1 + prior_usage
+        ).astype(float)
+        report.tyre_life_rebuilt += int(of_this_stint.sum())
+        report.boundaries_corrected += 1
+        touched = True
+
+    if touched and len(repaired):
+        report.drivers_touched.append(str(repaired["Driver"].iloc[0]))
+    return repaired
+
+
+def repair_tyre_stints(laps: pd.DataFrame) -> tuple[pd.DataFrame, RepairReport]:
+    """Null fabricated tyre ages and correct misplaced stint boundaries.
+
+    Only rows that are demonstrably wrong are touched, so a healthy race comes back
+    unchanged by construction rather than by a comparison after the fact.
+
+    Args:
+        laps: A per-race laps frame carrying at least ``REQUIRED_COLUMNS``.
+
+    Returns:
+        The repaired frame and a ``RepairReport`` describing exactly what moved. The
+        frame is returned unchanged, with an empty report, when the required columns are
+        absent -- the same degrade-quietly contract the raw-parquet merge upstream uses.
+    """
+    report = RepairReport()
+    if not set(REQUIRED_COLUMNS).issubset(laps.columns):
+        return laps, report
+
+    # dropna=False: a NaN driver key would otherwise be dropped by the groupby and come
+    # back all-NaN through the reindex, destroying columns this repair has no business
+    # touching. No shipped race carries one, but this runs on every future download.
+    groups = [_rebuild_driver(group, report) for _, group in laps.groupby("Driver", sort=False, dropna=False)]
+    repaired = pd.concat(groups).reindex(laps.index)
+
+    # Counted AFTER the repair, so the number means what the log says it means.
+    unknown = repaired["TyreLife"].isna()
+    if "Position" in repaired.columns:
+        unknown &= repaired["Position"].notna()
+    report.unknown_after = int(unknown.sum())
+
+    if report.changed_anything:
+        logger.info(
+            "Tyre-stint repair on %d driver(s): %d fabricated age(s) nulled, %d boundary/ies "
+            "corrected, %d age(s) rebuilt; %d racing lap(s) now carry an honest unknown age (#790)",
+            len(report.drivers_touched),
+            report.fabricated_ages_nulled,
+            report.boundaries_corrected,
+            report.tyre_life_rebuilt,
+            report.unknown_after,
+        )
+    return repaired, report

--- a/src/f1_strat_manager/weather_restore.py
+++ b/src/f1_strat_manager/weather_restore.py
@@ -1,0 +1,124 @@
+"""Restore the weather columns the 2025 featured parquet was published without (#782).
+
+`laps_featured_2023/2024.parquet` carry 53 columns including `AirTemp`, `TrackTemp`,
+`Humidity` and `Rainfall`. `laps_featured_2025.parquet` carries 48 and none of them, which
+breaks two golden reproduction tests (`test_pace_mae_reproduces_from_featured_laps`,
+`test_reproduction_matches_overtake_auc_pr`) with a `KeyError` inside
+`src/strategy/eval/reproduce.py`'s own feature rebuild.
+
+**The data is not lost.** Every one of the 71 shipped race directories has a readable
+`weather.parquet` with all four readings and zero NaN temperature rows -- 2025 included.
+What is missing is only the merge into the featured frame, so this restores it at load
+time rather than asking anyone to regenerate a published artefact.
+
+--- WHERE TO CHANGE IF THE ARTEFACT CHANGES ---
+Called from `laps_augment.augment_featured_laps`, for the reasons that module documents:
+the featured parquet is republished from Hugging Face and pulled by
+`scripts/download_data.py`, so a locally patched file would be silently reverted, and its
+only producer is a read-only notebook (N04).
+
+## This reproduces N04, it does not improve on N04
+
+The models were trained on whatever N04 produced for 2023 and 2024, so a "better" join
+here would feed 2025 weather on a different basis than the training data -- a silent
+distribution shift dressed up as a fix. N04 Step 5 states its method and this mirrors it
+exactly: per race, `pd.merge_asof(direction="nearest")` on the session `Time` timedelta,
+with `Rainfall` filled to 0 and cast to an int flag.
+
+N04's own 2025 output is on disk to check against: `laps_featured.parquet`, the combined
+2023-2025 artefact, carries all four columns for 2025. Only the per-year split dropped
+them. So the safeguard is a direct comparison against ground truth rather than against
+this module's own reasoning, and it is committed --
+`tests/agents/test_weather_restore.py::test_the_restore_reproduces_N04s_own_2025_output_exactly`
+asserts all 22,760 laps match.
+
+That test is not interchangeable with the pace-MAE reproduction, and an adversarial gate
+proved why: a WRONG `direction="backward"` join changes 7,014 TrackTemp cells and still
+reproduces the published MAE to within 0.0003. The MAE sees the values' distribution; only
+the comparison above sees the alignment.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# The four N04 Step 5 features, in N04's own order.
+WEATHER_COLUMNS = ("AirTemp", "TrackTemp", "Humidity", "Rainfall")
+
+# The session-elapsed column both sides join on. It is a timedelta in the raw parquets.
+_TIME = "Time"
+
+
+def weather_for_race(raw_laps: pd.DataFrame, weather: pd.DataFrame) -> pd.DataFrame:
+    """Per-lap weather for one race, aligned exactly as N04 aligned it.
+
+    Args:
+        raw_laps: That race's raw laps frame; only its ``Time`` column is read.
+        weather: That race's ``weather.parquet``.
+
+    Returns:
+        A frame indexed like ``raw_laps`` carrying the four weather columns. Rows whose
+        lap has no session time keep NaN, which is what N04 leaves them as.
+    """
+    columns = [c for c in WEATHER_COLUMNS if c in weather.columns]
+    empty = pd.DataFrame(
+        {c: pd.Series(index=raw_laps.index, dtype="float64") for c in WEATHER_COLUMNS}
+    )
+    if not columns or _TIME not in weather.columns or _TIME not in raw_laps.columns:
+        return empty
+
+    samples = weather[[_TIME, *columns]].dropna(subset=[_TIME]).sort_values(_TIME)
+    laps = raw_laps[[_TIME]].dropna(subset=[_TIME]).sort_values(_TIME)
+    if samples.empty or laps.empty:
+        return empty
+
+    # merge_asof demands both sides be sorted on the key, hence the sorts above; the
+    # index is reattached afterwards because merge_asof does not preserve it.
+    merged = pd.merge_asof(laps, samples, on=_TIME, direction="nearest")
+    merged.index = laps.index
+
+    # Each column is reindexed in its own dtype rather than written into a pre-made
+    # float64 frame: `Rainfall` arrives as bool, and assigning it into a float column
+    # is the deprecated incompatible-dtype set that pandas now warns about.
+    aligned = {}
+    for column in WEATHER_COLUMNS:
+        if column in columns:
+            aligned[column] = merged[column].reindex(raw_laps.index)
+        else:
+            aligned[column] = pd.Series(index=raw_laps.index, dtype="float64")
+    return pd.DataFrame(aligned)
+
+
+def normalise_rainfall(featured: pd.DataFrame) -> pd.DataFrame:
+    """Apply N04's closing step: absent rainfall means dry, and the flag is an int.
+
+    Season-level rather than per-race because that is where N04 does it, and the placement
+    is not neutral: a race whose weather parquet is missing keeps NaN temperatures (an
+    honest gap) but still ends up with `Rainfall == 0`, a confident "dry" nobody measured.
+    That asymmetry is N04's, inherited deliberately so the column matches what the models
+    were trained on rather than being quietly improved here.
+    """
+    if "Rainfall" not in featured.columns:
+        return featured
+    result = featured.copy()
+    result["Rainfall"] = result["Rainfall"].fillna(0).astype(int)
+    return result
+
+
+def read_race_weather(race_dir: Path) -> pd.DataFrame | None:
+    """That race's ``weather.parquet``, or None when it is absent or unreadable."""
+    path = race_dir / "weather.parquet"
+    if not path.exists():
+        return None
+    try:
+        return pd.read_parquet(path)
+    except (OSError, ValueError) as exc:
+        # Same degrade-quietly contract the raw-laps merge upstream uses: a race whose
+        # weather cannot be read keeps NaN readings rather than failing the whole load.
+        logger.warning("%s: cannot read weather parquet (%s); continuing without it", path, exc)
+        return None

--- a/src/shared/data_extraction/fastf1_extractor.py
+++ b/src/shared/data_extraction/fastf1_extractor.py
@@ -3,8 +3,12 @@
 Superseded by ``src/data_extraction/fastf1/session_extractor.py`` and
 ``scripts/download_data.py``. ``extract_f1_data`` takes any year/GP/session,
 but the ``__main__`` block below only ever ran it against the 2023 Spanish
-GP, the first race this project pulled data for. Kept because
-``notebooks/data_engineering/N01_data_download.ipynb`` still imports it.
+GP, the first race this project pulled data for. No code imports this module
+today -- ``notebooks/data_engineering/N01_data_download.ipynb`` only
+LINK-references it in a markdown cell ("Legacy extraction: [fastf1_extractor.py]
+(../../src/shared/data_extraction/fastf1_extractor.py)"), it does not import it
+in any code cell. Kept per ``src/shared/README.md``'s stated reason: deleting it
+would break that historical link, not any running code.
 """
 
 import fastf1 as ff1

--- a/src/strategy/eval/decision_modes.py
+++ b/src/strategy/eval/decision_modes.py
@@ -84,6 +84,7 @@ from src.strategy.eval.report import build_header, write_report
 # loads model weights at import time, which would make this report — and every other
 # ``f1-eval`` subcommand next to it — impossible to even import without ``data/models/``.
 from src.strategy.inference.guard_rails import (
+    _DEFAULT_MIN_STINT,
     _MIN_STINT_LAPS,
     _NO_PIT_BEFORE_LAP,
     _PIT_ACTIONS,
@@ -232,8 +233,17 @@ def guard_rail_block(
     the probe passes a life that satisfies every minimum and only the lap-based
     rails apply. That is a stated assumption, not a sentinel: it never becomes a
     value the caller can mistake for a measurement.
+
+    ``_DEFAULT_MIN_STINT`` is folded into that maximum rather than assumed to sit
+    below it. It is not a spare branch here: an unknown compound arrives as ``""``
+    two lines down, so the fallback IS the bound this probe meets in exactly the
+    case the probe exists for. The two happen to be ordered correctly today (#716
+    left them at 8 and 6), and the docstring above would have been quietly false
+    the first time they were not.
     """
-    probe_life = max(_MIN_STINT_LAPS.values()) if tyre_life is None else tyre_life
+    probe_life = (
+        max(*_MIN_STINT_LAPS.values(), _DEFAULT_MIN_STINT) if tyre_life is None else tyre_life
+    )
     action, reason = apply_guard_rails(
         "PIT_NOW", actual_lap, total_laps, compound or "", probe_life
     )

--- a/src/strategy/eval/pace_holdout.py
+++ b/src/strategy/eval/pace_holdout.py
@@ -102,9 +102,14 @@ def load_pace_predictions(year: int = 2025) -> tuple[np.ndarray, np.ndarray] | N
     target = manifest["target"]  # LapTime_s
     features_delta = json.loads(features_path.read_text(encoding="utf-8"))
 
-    df = _add_lag_deg_features(
-        _encode_categoricals(pd.read_parquet(parquet), compound_map, racephase_map)
-    )
+    # Through augment_featured_laps, never straight from the parquet: the 2025 artefact
+    # ships without the four weather columns N06 was trained on, so a direct read raises
+    # a KeyError here (#782). That module's own docstring has said "every consumer must
+    # call it" since the third time this happened; this was the fourth.
+    from src.f1_strat_manager.laps_augment import augment_featured_laps
+
+    featured = augment_featured_laps(pd.read_parquet(parquet), year)
+    df = _add_lag_deg_features(_encode_categoricals(featured, compound_map, racephase_map))
     df = df.dropna(subset=_DROPNA).copy()
     if df.empty:
         return None

--- a/src/strategy/eval/stint_lengths.py
+++ b/src/strategy/eval/stint_lengths.py
@@ -1,16 +1,21 @@
 """Eval report for the guard rail's own bound: how long do real stints actually run?
 
-``guard_rails.py`` refuses a pit call when ``tyre_life < _MIN_STINT_LAPS[compound]``
-(SOFT 8, MEDIUM 12, HARD 15 laps). Those numbers have never been checked against a
-single real race. This report answers the question that decides whether they are
-doing their job: over every green-flag pit stop in 2023-2025, what share of real
-stints were shorter than the bound that would have overridden them?
+``guard_rails.py`` refuses a pit call when ``tyre_life`` falls below the bound its
+``_MIN_STINT_LAPS.get(compound, _DEFAULT_MIN_STINT)`` lookup resolves. This report
+answers the question that decides whether those bounds are doing their job: over
+every green-flag pit stop in 2023-2025, what share of real stints were shorter than
+the bound that would have overridden them?
 
 If the answer is close to zero, the bound sits where professional strategy never
 goes and is a cheap safety net. If it is not close to zero, the bound is quietly
 vetoing calls a real pit wall has made, which is a very different finding from
-"the rail never fires" — this report exists because nobody had counted it either
-way.
+"the rail never fires". This report exists because nobody had counted it either way.
+
+It is now also the standing calibration check, not just a one-off measurement.
+`_MIN_STINT_LAPS` and `_DEFAULT_MIN_STINT` are IMPORTED, never restated, so every
+run re-measures the bounds actually shipping rather than the ones that were shipping
+when the report was written. #716 set them from this table against a 5% ceiling, and
+`tests/eval/test_stint_lengths.py` asserts that ceiling holds.
 
 WHAT COUNTS AS A STINT LENGTH
 ------------------------------
@@ -43,16 +48,40 @@ import numpy as np
 
 from src.strategy.eval.projection import _neutralised_laps, _raw_data_root, green_flag_stops
 from src.strategy.eval.report import build_header, write_report
-from src.strategy.inference.guard_rails import _MIN_STINT_LAPS
+from src.strategy.inference.guard_rails import _DEFAULT_MIN_STINT, _MIN_STINT_LAPS
 
 # Dry compounds the guard rail actually gates. Order also fixes the report's
 # row order, so a reader sees the softest, shortest-lived compound first.
 _COMPOUNDS: tuple[str, ...] = ("SOFT", "MEDIUM", "HARD")
 
-# Wet compounds run no minimum-stint rule at all (`_MIN_STINT_LAPS.get(compound,
-# _DEFAULT_MIN_STINT)` never fires the SOFT/MEDIUM/HARD boundaries for them), so a
-# wet stint answers a different question than the one this report asks.
+# INTERMEDIATE and WET, counted under the label of the bound they actually hit.
+#
+# This block used to claim wet compounds "run no minimum-stint rule at all", and
+# the report dropped their stints on that basis. The claim is false: the rail
+# resolves its bound with `_MIN_STINT_LAPS.get(compound, _DEFAULT_MIN_STINT)`, so
+# a wet compound misses the three named entries and lands on the FALLBACK, which
+# is a minimum-stint rule like any other. The parenthetical that followed was true
+# in isolation ("never fires the SOFT/MEDIUM/HARD boundaries"), and that is how the
+# wrong headline survived review. It cost this file its purpose on that one bound:
+# when every bound was finally calibrated (#716), the fallback was the worst of
+# them, and it was the only one nothing here had ever measured.
 _WET_COMPOUNDS: frozenset[str] = frozenset({"INTERMEDIATE", "WET"})
+_WET_BUCKET: str = "WET"
+
+# Every bucket the report measures, in row order: the three compounds the rail
+# names, then the fallback every other compound resolves to. Thresholds are read
+# back out of the rail's own lookup rather than restated here, so this report
+# cannot describe a bound the rail does not enforce.
+_REPORTED_BUCKETS: tuple[str, ...] = (*_COMPOUNDS, _WET_BUCKET)
+
+
+def _bound_for(bucket: str) -> int:
+    """The minimum-stint bound the rail resolves for this bucket.
+
+    The same expression `apply_guard_rails` evaluates, called here rather than
+    mirrored, because a retyped boundary has shipped wrong in this codebase before.
+    """
+    return _MIN_STINT_LAPS.get(bucket, _DEFAULT_MIN_STINT)
 
 # The eight points the task and the report both read: the extremes, the tails
 # that matter for a minimum-bound question, and the median. Kept as one ordered
@@ -119,33 +148,32 @@ class CompoundStints:
 
 @dataclass(frozen=True)
 class StintLengthSample:
-    """Completed green-flag stint lengths across the sampled seasons, by compound."""
+    """Completed green-flag stint lengths across the sampled seasons, by bucket."""
 
     by_compound: dict[str, CompoundStints]
-    dropped_wet: int
     dropped_missing: int
     races: int
 
     @property
     def total_counted(self) -> int:
-        """Real green-flag stints that fed one of the three dry-compound samples."""
+        """Real green-flag stints that fed one of the four measured samples."""
         return sum(stats.sample_size for stats in self.by_compound.values())
 
 
 def _compound_bucket(compound: str) -> str:
     """Which counting bucket a raw ``Compound`` reading belongs in.
 
-    Returns the compound name itself for a dry compound, ``"wet"`` for
+    Returns the compound name itself for a dry compound, ``"WET"`` for
     INTERMEDIATE/WET, or ``"unknown"`` for anything else (there is no other label
     on a real green-flag pit lap; this is a defensive catch-all, not a case this
-    dataset is expected to hit). Dataframe-free on purpose: this is the whole
-    rule behind "ignore wet compounds but report how many you dropped", and it
-    needs to be checkable without a parquet file.
+    dataset is expected to hit). Dataframe-free on purpose: this is the whole rule
+    behind which bound a stop is graded against, and it needs to be checkable
+    without a parquet file.
     """
     if compound in _COMPOUNDS:
         return compound
     if compound in _WET_COMPOUNDS:
-        return "wet"
+        return _WET_BUCKET
     return "unknown"
 
 
@@ -189,8 +217,7 @@ def measure_stint_lengths(years: tuple[int, ...] = (2023, 2024, 2025)) -> StintL
             "from the featured parquet)"
         )
 
-    lengths_by_compound: dict[str, list[float]] = {compound: [] for compound in _COMPOUNDS}
-    dropped_wet = 0
+    lengths_by_compound: dict[str, list[float]] = {bucket: [] for bucket in _REPORTED_BUCKETS}
     dropped_missing = 0
     races = 0
 
@@ -219,24 +246,21 @@ def measure_stint_lengths(years: tuple[int, ...] = (2023, 2024, 2025)) -> StintL
                         continue
 
                     bucket = _compound_bucket(compound)
-                    if bucket == "wet":
-                        dropped_wet += 1
-                    elif bucket == "unknown":
+                    if bucket == "unknown":
                         dropped_missing += 1
                     else:
                         lengths_by_compound[bucket].append(tyre_life)
 
     by_compound = {
-        compound: CompoundStints(
-            compound=compound,
-            lengths=np.array(lengths_by_compound[compound], dtype=float),
-            threshold=_MIN_STINT_LAPS[compound],
+        bucket: CompoundStints(
+            compound=bucket,
+            lengths=np.array(lengths_by_compound[bucket], dtype=float),
+            threshold=_bound_for(bucket),
         )
-        for compound in _COMPOUNDS
+        for bucket in _REPORTED_BUCKETS
     }
     return StintLengthSample(
         by_compound=by_compound,
-        dropped_wet=dropped_wet,
         dropped_missing=dropped_missing,
         races=races,
     )
@@ -267,27 +291,35 @@ def _render_table(sample: StintLengthSample | None) -> str:
         "",
         "Every completed stint that ended in a real green-flag pit stop, counted in",
         "tyre-age laps: the `TyreLife` reading at the moment of the stop, the exact",
-        "field `apply_guard_rails` compares against `_MIN_STINT_LAPS`. A stint that",
-        "ended because the race finished, or because the driver retired, is not a",
+        "field `apply_guard_rails` compares against its minimum-stint bound. A stint",
+        "that ended because the race finished, or because the driver retired, is not a",
         "decision to stop and is excluded by construction: neither ever produces a",
         "lap with `PitInTime` set.",
+        "",
+        "The last row is INTERMEDIATE and WET together. They carry no entry of their",
+        "own in `_MIN_STINT_LAPS`, so the rail's `.get(compound, _DEFAULT_MIN_STINT)`",
+        "resolves them to the fallback -- a minimum-stint bound like any other, and",
+        "one this report used to drop rather than measure.",
         "",
         f"| compound | n | threshold (laps) | shorter than threshold | {header_cells} |",
         f"|---|---|---|---|{divider_cells}",
     ]
-    lines += [_compound_row(sample.by_compound[compound]) for compound in _COMPOUNDS]
+    lines += [_compound_row(sample.by_compound[bucket]) for bucket in _REPORTED_BUCKETS]
     lines += [
         "",
         '"shorter than threshold" is the share of real stints the current guard rail',
         "would have overridden to STAY_OUT had a strategist tried to make that exact",
-        "call: `TyreLife < _MIN_STINT_LAPS[compound]`, the same strict inequality",
-        "`apply_guard_rails` itself uses. Close to zero means the bound sits where",
-        "real strategy essentially never goes; anywhere else means it is vetoing",
-        "calls a real pit wall has actually made.",
+        "call: `TyreLife < the bound`, the same strict inequality `apply_guard_rails`",
+        "itself uses.",
+        "",
+        "This share IS the calibration of a proscriptive bound, and the number the",
+        "bounds are set from (#716). A bound exists so a generative model cannot emit",
+        "nonsense, so it has to sit where real strategy essentially never goes; once it",
+        "is vetoing a meaningful share of what professional pit walls actually did, it",
+        "is separating unusual from usual rather than absurd from sane. The ceiling the",
+        "bounds are held to is **5%**, and every row above is expected to clear it.",
         "",
         f"- real green-flag stints counted: {sample.total_counted} across {sample.races} races",
-        "- wet-compound stops dropped (INTERMEDIATE/WET is not a dry-tyre-life "
-        f"question): {sample.dropped_wet}",
         f"- stops dropped for missing compound/tyre-life data: {sample.dropped_missing}",
         "",
     ]
@@ -312,7 +344,6 @@ def build_stint_lengths_report() -> dict[str, Any]:
             else {
                 "races": sample.races,
                 "total_counted": sample.total_counted,
-                "dropped_wet": sample.dropped_wet,
                 "dropped_missing": sample.dropped_missing,
                 "compounds": {
                     compound: {

--- a/src/strategy/inference/guard_rails.py
+++ b/src/strategy/inference/guard_rails.py
@@ -41,21 +41,29 @@ from __future__ import annotations
 
 _PIT_ACTIONS = frozenset({"PIT_NOW", "UNDERCUT", "OVERCUT", "REACTIVE_SC"})
 
-# THE CALIBRATION CEILING every bound below is set from and held to: a bound may
-# veto at most 5% of the real green-flag stops in the measured sample. Above that
-# it is separating unusual from usual rather than absurd from sane, which is the
-# one job an anti-hallucination bound has.
+# THE CALIBRATION CEILING every bound below is HELD TO: a bound may veto at most 5%
+# of the real green-flag stops in the measured sample. Above that it is separating
+# unusual from usual rather than absurd from sane, which is the one job an
+# anti-hallucination bound has.
 #
-# The sample is `f1-eval stint-lengths` over 2023-2025 raw laps: 1900 real
-# green-flag stops across 71 races. Measured shares are quoted per bound below and
-# are reproducible from `documents/eval_reports/stint_lengths.md`, which imports
-# these constants rather than restating them, so the report always grades what is
-# actually shipping. `tests/eval/test_stint_lengths.py` asserts the ceiling holds.
+# Held to, not necessarily set from. The two minimum-stint bounds failed the ceiling
+# and were reset to the largest value that clears it, so for them the ceiling is also
+# the derivation. The two lap-based bounds already cleared it and were left exactly
+# where they were; they are NOT maximal under the rule, and moving them up to the
+# largest passing value would be a change nobody asked for on evidence that only says
+# they are not currently wrong.
+#
+# The sample is 1900 real green-flag stops across 71 races of 2023-2025 raw laps.
+# `documents/eval_reports/stint_lengths.md` regenerates the four minimum-stint shares
+# from these constants on every run, so that report always grades what is actually
+# shipping, and `tests/eval/test_stint_lengths.py` asserts the ceiling holds on them.
+# The two lap-based shares below have no such home: they were measured once over the
+# same sample and are recorded here rather than in an artefact, so treat them as a
+# dated finding rather than as something a report re-checks.
 _CALIBRATION_CEILING = 0.05
 
 # Vetoes 42/1900 = 2.21% of real stops. Unchanged by #716: it already cleared the
-# ceiling. The four stops it blocks in the six-race decision-modes subset read as a
-# large share only because that subset is small; on the full sample it is not.
+# ceiling comfortably.
 _NO_PIT_BEFORE_LAP = 5
 
 # Vetoes 26/1900 = 1.37%. Also unchanged, and the one bound that is partly a FACT
@@ -63,6 +71,12 @@ _NO_PIT_BEFORE_LAP = 5
 # if it is still deployed on the final lap, so the position a late stop surrenders
 # is unrecoverable BY REGULATION. That article does not reach a green-flag lap,
 # where the bound rests on the ~22-25 s cost instead, and on this measurement.
+#
+# This is also the bound behind the four excluded stops in the six-race
+# `decision-modes` subset (Monaco VER, Lusail STR and HAD, Monza OCO). #716's issue
+# body attributes four stops to the early-race bound as well; measured on that
+# subset the early-race bound excludes NONE, and `decision_modes.md` carries no
+# `opening_laps` row at all.
 _NO_PIT_LAST_N_LAPS = 3
 
 _CLIFF_P10_SAFE = 2
@@ -87,6 +101,14 @@ _MIN_STINT_LAPS = {"SOFT": 2, "MEDIUM": 7, "HARD": 8}
 # comment claiming they ran no minimum-stint rule at all. They run this one.
 #
 #   6 -> 4.55% (110 wet stops)
+#
+# KNOWN DIVERGENCE, and it is the reverse of the usual one: this bound has NO prose copy
+# in either prompt. N28 and N31 both state the three dry minimums and say nothing about
+# what happens on an INTERMEDIATE or a WET, so the offline path enforces a bound the LLM
+# path was never told about. Documented rather than closed, because adding it means
+# writing new prompt text and that is a behaviour change on the default path, not a
+# recalibration. It matters most in exactly the races where it is least likely to be
+# noticed.
 _DEFAULT_MIN_STINT = 6
 
 

--- a/src/strategy/inference/guard_rails.py
+++ b/src/strategy/inference/guard_rails.py
@@ -17,8 +17,13 @@ a *prescriptive* rail that forces one (the Safety Car ``PIT_NOW`` rail, rejected
 in #464). A proscriptive bound on a generative model's output is legitimate with
 or without a regulation behind it; the test it must pass is CALIBRATION — the
 threshold has to sit where real strategy essentially never goes, so it separates
-absurd from sane rather than unusual from usual. See #716, where the
-minimum-stint threshold is measured against real stint lengths.
+absurd from sane rather than unusual from usual.
+
+#716 ran that test on all four bounds against 1900 real green-flag stops. The two
+lap-based ones passed untouched; the two minimum-stint ones overshot the ceiling by
+between two and four times and were reset from the measurement. Every bound now
+carries its measured veto share, or the article that makes it a fact, at its
+definition below. A bound with neither does not belong in this file.
 
 WHY THIS IS ITS OWN MODULE (#708):
 These rules used to live in ``no_llm.py``, which imports the agent stack and
@@ -35,11 +40,54 @@ the eval tier initially retyped ``remaining < 3`` against the rail's
 from __future__ import annotations
 
 _PIT_ACTIONS = frozenset({"PIT_NOW", "UNDERCUT", "OVERCUT", "REACTIVE_SC"})
+
+# THE CALIBRATION CEILING every bound below is set from and held to: a bound may
+# veto at most 5% of the real green-flag stops in the measured sample. Above that
+# it is separating unusual from usual rather than absurd from sane, which is the
+# one job an anti-hallucination bound has.
+#
+# The sample is `f1-eval stint-lengths` over 2023-2025 raw laps: 1900 real
+# green-flag stops across 71 races. Measured shares are quoted per bound below and
+# are reproducible from `documents/eval_reports/stint_lengths.md`, which imports
+# these constants rather than restating them, so the report always grades what is
+# actually shipping. `tests/eval/test_stint_lengths.py` asserts the ceiling holds.
+_CALIBRATION_CEILING = 0.05
+
+# Vetoes 42/1900 = 2.21% of real stops. Unchanged by #716: it already cleared the
+# ceiling. The four stops it blocks in the six-race decision-modes subset read as a
+# large share only because that subset is small; on the full sample it is not.
 _NO_PIT_BEFORE_LAP = 5
+
+# Vetoes 26/1900 = 1.37%. Also unchanged, and the one bound that is partly a FACT
+# rather than a calibration: under a Safety Car, Art. 55.17 ends the race behind it
+# if it is still deployed on the final lap, so the position a late stop surrenders
+# is unrecoverable BY REGULATION. That article does not reach a green-flag lap,
+# where the bound rests on the ~22-25 s cost instead, and on this measurement.
 _NO_PIT_LAST_N_LAPS = 3
+
 _CLIFF_P10_SAFE = 2
-_MIN_STINT_LAPS = {"SOFT": 8, "MEDIUM": 12, "HARD": 15}
-_DEFAULT_MIN_STINT = 10
+
+# Recalibrated by #716 from SOFT 8 / MEDIUM 12 / HARD 15, which vetoed 15.5% /
+# 17.0% / 12.2% of real stops: one stop in six, three times the ceiling. Each value
+# is now the largest integer whose veto share stays at or under 5%.
+#
+#   SOFT   2 -> 3.2% (341 stops)   MEDIUM 7 -> 4.6% (896)   HARD 8 -> 4.7% (548)
+#
+# SOFT lands lowest because real SOFT stints genuinely are the shortest: 11 of them
+# ran exactly one lap. The bound is not a model of degradation and must not be read
+# as one. It only forbids stopping on a set fitted so recently that no strategy
+# produced it, and where that line falls differs per compound because the evidence
+# differs per compound.
+_MIN_STINT_LAPS = {"SOFT": 2, "MEDIUM": 7, "HARD": 8}
+
+# The bound every compound with no entry above resolves to, which in practice means
+# INTERMEDIATE and WET. Recalibrated by #716 from 10, and it was the WORST of the
+# set at 20.0% of real wet stops vetoed, because it was also the only one nothing
+# had ever measured: the stint-length report dropped wet stops on the strength of a
+# comment claiming they ran no minimum-stint rule at all. They run this one.
+#
+#   6 -> 4.55% (110 wet stops)
+_DEFAULT_MIN_STINT = 6
 
 
 def apply_guard_rails(
@@ -53,9 +101,12 @@ def apply_guard_rails(
 ) -> tuple[str, str | None]:
     """Override *action* with STAY_OUT when a hard strategic constraint fires.
 
-    Rules: no pit before lap 5; no pit in the last 3 laps unless the cliff is
-    imminent (cliff_p10 < 2); minimum stint SOFT 8 / MEDIUM 12 / HARD 15. Returns
-    ``(action, reason)`` with ``reason=None`` when no rail fired.
+    Three bounds, in the order they are evaluated: the pit window is not open yet;
+    it is too late to matter unless the cliff is imminent; the set was fitted too
+    recently for any strategy to have produced this call. The numbers are the module
+    constants and are deliberately not restated here, because a retyped boundary has
+    shipped wrong in this codebase before. Returns ``(action, reason)`` with
+    ``reason=None`` when no bound fired.
 
     Args:
         sc_active: A neutralisation (Safety Car or VSC) is deployed right now.

--- a/src/strategy/inference/no_llm.py
+++ b/src/strategy/inference/no_llm.py
@@ -32,6 +32,7 @@ import pandas as pd
 
 from src.agents.pace_agent import run_pace_agent_from_state
 from src.agents.race_situation_agent import RaceSituationAgent
+from src.agents.race_state_builder import UNKNOWN_TYRE_LIFE, normalise_compound
 from src.agents.radio_agent import RadioOutput, _build_alerts, run_pipeline, run_rcm_pipeline
 from src.agents.strategy_orchestrator import (
     RaceState,
@@ -132,8 +133,12 @@ def _tire_no_llm(lap_state: dict[str, Any], laps_df: pd.DataFrame):
     driver = lap_state["session_meta"]["driver"]
     d = lap_state["driver"]
     meta = lap_state["session_meta"]
-    compound = d.get("compound", "MEDIUM")
-    tyre_life = d.get("tyre_life", 1)
+    # Same rules as tire_agent.run_from_state: this path also reads the RAW lap_state
+    # rather than the RaceState, so it applies the canonical normalisation itself
+    # instead of restating the pre-#784 defaults its twin used to carry.
+    compound = normalise_compound(d.get("compound"))
+    raw_tyre_life = d.get("tyre_life")
+    tyre_life = UNKNOWN_TYRE_LIFE if raw_tyre_life is None else raw_tyre_life
     gp_name = meta.get("gp_name", "")
     year = meta.get("year", 2025)
     compound_id = (

--- a/tests/agents/test_agents.py
+++ b/tests/agents/test_agents.py
@@ -18,15 +18,10 @@ from pathlib import Path
 
 import pytest
 
+from tests.conftest import skip_no_tire_models as _skip_no_models
+
 ROOT = Path(__file__).parent.parent.parent
 
-# Guard: skip agent-import tests when model files are absent (CI runner).
-_MODELS_DIR = ROOT / "data" / "models"
-_HAS_MODELS = (_MODELS_DIR / "tire_degradation" / "routing_config.json").exists()
-_skip_no_models = pytest.mark.skipif(
-    not _HAS_MODELS,
-    reason="data/models/ not present (CI environment without model weights)",
-)
 
 # Guard: skip backend tests when telemetry backend is not installed.
 _HAS_BACKEND = (ROOT / "src" / "telemetry" / "backend").exists()

--- a/tests/agents/test_n06_envelope.py
+++ b/tests/agents/test_n06_envelope.py
@@ -108,29 +108,65 @@ def test_a_missing_feature_is_not_reported_as_out_of_range(caplog):
 # --- the bounds describe features that have a range at all -------------------
 
 
-@pytest.mark.parametrize("labelled", ["DriverNumber", "TeamID", "CompoundID", "Cluster", "Year"])
-def test_no_bound_is_declared_over_an_identifier(labelled):
-    """A code is not a quantity: `TeamID` between 0 and 10 says nothing about range."""
+# Every N06 feature that carries NO bound, with the reason it carries none. Pinned as a
+# complete set rather than as a handful of examples, because the first version of this
+# file listed only eight of the fifteen and the gap is where the mistake lived: three
+# features were unbounded with no stated reason at all, and one of those (mean_sector_speed)
+# was bounded when it should not have been. An enumeration that does not add up is an
+# enumeration nobody has checked.
+_UNBOUNDED = {
+    # identifiers, codes and ranks: no range to be outside of
+    "DriverNumber": "identifier",
+    "TeamID": "code",
+    "CompoundID": "code",
+    "Cluster": "code",
+    "Year": "code",
+    "Stint": "ordinal",
+    "Position": "rank",
+    "FreshTyre": "flag",
+    "Rainfall": "flag",
+    # the value at inference is not the quantity the range describes
+    "Prev_DegradationRate": "hardcoded 0.0, and 0.0 is mid-distribution",
+    "Prev_CumulativeDeg": "hardcoded 0.0, and 0.0 is mid-distribution",
+    "Prev_DegAcceleration": "hardcoded 0.0, and 0.0 is mid-distribution",
+    "mean_sector_speed": "always carries the speed trap at inference",
+    # a bound would report the same event twice
+    "LapsSincePitStop": "equals TyreLife at inference",
+    # training and inference encode it differently
+    "FuelLoad": "artefact rounded to 4dp, inference computes it unrounded",
+}
+
+
+@pytest.mark.parametrize("feature", sorted(_UNBOUNDED))
+def test_the_unbounded_features_stay_unbounded(feature):
+    """Each of these is excluded on a stated reason, not by omission."""
     from src.agents.pace_agent import _N06_TRAINED_BOUNDS
 
-    assert labelled not in _N06_TRAINED_BOUNDS
+    assert feature not in _N06_TRAINED_BOUNDS, _UNBOUNDED[feature]
 
 
-@pytest.mark.parametrize(
-    "constant", ["Prev_DegradationRate", "Prev_CumulativeDeg", "Prev_DegAcceleration"]
-)
-def test_the_hardcoded_degradation_features_are_deliberately_unbounded(constant):
-    """`run_from_state` pins all three at 0.0, and 0.0 is INSIDE the trained range.
+def test_every_n06_feature_is_either_bounded_or_explicitly_unbounded():
+    """The two sets must partition the model's feature list exactly.
 
-    This reads like the classic out-of-range defect and is not one: roughly 42-47% of
-    training rows fall below zero for each, so a bound could never fire on the pinned
-    value. Declaring one would ship a check that looks like coverage and is not.
-    Feeding a constant where the model saw a distribution is a real problem with its
-    own shape, and this envelope is not the instrument for it.
+    This is the assertion the first version of this file lacked. Without it a feature can
+    be added to N06, or dropped from the bounds, and simply fall through: no test fails,
+    the enumeration comment goes stale, and the envelope quietly stops describing the
+    model it claims to describe.
     """
-    from src.agents.pace_agent import _N06_TRAINED_BOUNDS
+    import json
 
-    assert constant not in _N06_TRAINED_BOUNDS
+    from src.agents.pace_agent import _N06_TRAINED_BOUNDS
+    from src.f1_strat_manager.data_cache import get_models_root
+
+    names_path = get_models_root() / "lap_time" / "xgb_laptime_delta_feature_names.json"
+    if not names_path.exists():
+        pytest.skip("N06 feature-name artefact absent")
+    features = set(json.loads(names_path.read_text()))
+
+    accounted = set(_N06_TRAINED_BOUNDS) | set(_UNBOUNDED)
+    assert features - accounted == set(), "N06 features neither bounded nor excluded"
+    assert accounted - features == set(), "bounds or exclusions naming a feature N06 dropped"
+    assert set(_N06_TRAINED_BOUNDS).isdisjoint(_UNBOUNDED)
 
 
 # --- the one test that checks the bounds against the data they claim to describe ---

--- a/tests/agents/test_n06_envelope.py
+++ b/tests/agents/test_n06_envelope.py
@@ -129,7 +129,6 @@ _UNBOUNDED = {
     "Prev_DegradationRate": "hardcoded 0.0, and 0.0 is mid-distribution",
     "Prev_CumulativeDeg": "hardcoded 0.0, and 0.0 is mid-distribution",
     "Prev_DegAcceleration": "hardcoded 0.0, and 0.0 is mid-distribution",
-    "mean_sector_speed": "always carries the speed trap at inference",
     # a bound would report the same event twice
     "LapsSincePitStop": "equals TyreLife at inference",
     # training and inference encode it differently

--- a/tests/agents/test_n06_envelope.py
+++ b/tests/agents/test_n06_envelope.py
@@ -1,0 +1,186 @@
+"""N06's trained range, now declared as an operating envelope (#710).
+
+The pace agent had no range check of any kind. These pin the two things that
+makes it worth adding and the one thing that would make it dangerous:
+
+1. It LABELS. Not a single value N06 is fed may change, or the strategy goldens
+   move and a real regression becomes indistinguishable from this commit.
+2. It fires on a value outside the trained range, and stays silent inside it. A
+   check that never speaks and a check that always speaks are equally useless.
+3. The bounds are MEASURED, not typed. The data-tier test at the bottom rebuilds
+   the training seasons through N06's own feature recipe and fails if any declared
+   bound has drifted from the range it claims to describe.
+
+Most of this file needs no model weights: the labelling step is a staticmethod
+over a plain frame, so it runs on a bare CI checkout, which is where a silent
+regression would otherwise hide.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_TRAINING_DATA = all(
+    (ROOT / "data" / "processed" / f"laps_featured_{year}.parquet").exists()
+    for year in (2023, 2024)
+)
+
+
+def _row(**overrides) -> pd.DataFrame:
+    """A one-row frame sitting comfortably inside every declared bound."""
+    from src.agents.pace_agent import _N06_TRAINED_BOUNDS
+
+    row = {name: (lo + hi) / 2 for name, (lo, hi) in _N06_TRAINED_BOUNDS.items()}
+    row.update(overrides)
+    return pd.DataFrame([row])
+
+
+def _label(frame: pd.DataFrame) -> None:
+    from src.agents.pace_agent import PaceAgent
+
+    PaceAgent._label_against_envelope(frame)
+
+
+# --- it labels, it never touches ---------------------------------------------
+
+
+def test_labelling_does_not_alter_a_single_value():
+    """The whole licence for this change: the model is fed exactly what it was fed."""
+    frame = _row(TyreLife=500.0, AirTemp=-40.0)
+    before = frame.copy(deep=True)
+
+    _label(frame)
+
+    pd.testing.assert_frame_equal(frame, before)
+
+
+# --- it fires outside, and only outside --------------------------------------
+
+
+def test_a_value_above_the_trained_range_is_announced(caplog):
+    from src.agents.pace_agent import _N06_TRAINED_BOUNDS
+
+    _lower, upper = _N06_TRAINED_BOUNDS["TyreLife"]
+    with caplog.at_level(logging.WARNING):
+        _label(_row(TyreLife=upper + 1))
+
+    assert any("outside its trained range" in r.message for r in caplog.records)
+    assert any("TyreLife" in str(r.args) for r in caplog.records)
+
+
+def test_a_value_below_the_trained_range_is_announced(caplog):
+    """Both directions. A lower bound that is never checked is a lower bound in name only."""
+    from src.agents.pace_agent import _N06_TRAINED_BOUNDS
+
+    lower, _upper = _N06_TRAINED_BOUNDS["Prev_LapTime"]
+    with caplog.at_level(logging.WARNING):
+        _label(_row(Prev_LapTime=lower - 1))
+
+    assert any("outside its trained range" in r.message for r in caplog.records)
+
+
+def test_an_in_range_call_says_nothing(caplog):
+    """A normal lap must be silent, or the signal is worth nothing on a 57-lap race."""
+    with caplog.at_level(logging.WARNING):
+        _label(_row())
+
+    assert not [r for r in caplog.records if "trained range" in r.message]
+
+
+def test_a_missing_feature_is_not_reported_as_out_of_range(caplog):
+    """Unknown is not a violation, and this file must not be the place that conflates them.
+
+    A NaN feature was given no value, not a bad one. The producers that can emit one
+    already warn for themselves, so reporting it again here would bury the case this
+    check exists for under the cases something else already covers.
+    """
+    with caplog.at_level(logging.WARNING):
+        _label(_row(FuelEffect=float("nan")))
+
+    assert not [r for r in caplog.records if "trained range" in r.message]
+
+
+# --- the bounds describe features that have a range at all -------------------
+
+
+@pytest.mark.parametrize("labelled", ["DriverNumber", "TeamID", "CompoundID", "Cluster", "Year"])
+def test_no_bound_is_declared_over_an_identifier(labelled):
+    """A code is not a quantity: `TeamID` between 0 and 10 says nothing about range."""
+    from src.agents.pace_agent import _N06_TRAINED_BOUNDS
+
+    assert labelled not in _N06_TRAINED_BOUNDS
+
+
+@pytest.mark.parametrize(
+    "constant", ["Prev_DegradationRate", "Prev_CumulativeDeg", "Prev_DegAcceleration"]
+)
+def test_the_hardcoded_degradation_features_are_deliberately_unbounded(constant):
+    """`run_from_state` pins all three at 0.0, and 0.0 is INSIDE the trained range.
+
+    This reads like the classic out-of-range defect and is not one: roughly 42-47% of
+    training rows fall below zero for each, so a bound could never fire on the pinned
+    value. Declaring one would ship a check that looks like coverage and is not.
+    Feeding a constant where the model saw a distribution is a real problem with its
+    own shape, and this envelope is not the instrument for it.
+    """
+    from src.agents.pace_agent import _N06_TRAINED_BOUNDS
+
+    assert constant not in _N06_TRAINED_BOUNDS
+
+
+# --- the one test that checks the bounds against the data they claim to describe ---
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_TRAINING_DATA, reason="laps_featured_2023/2024 absent")
+def test_every_declared_bound_matches_the_measured_training_range():
+    """Re-measure, do not re-read. A declared bound is a claim about the training data.
+
+    This is the assertion that keeps `_N06_TRAINED_BOUNDS` sourced rather than typed.
+    It rebuilds 2023 + 2024 exactly the way `pace_holdout.py` rebuilds the holdout
+    (augment, encode, lag, drop) and compares every bound against the range that
+    rebuild produces, so retraining N06 or restating a number fails here and names
+    the feature instead of silently widening what the agent will vouch for.
+    """
+    import json
+
+    from src.agents.pace_agent import _N06_TRAINED_BOUNDS
+    from src.f1_strat_manager.data_cache import get_data_root
+    from src.f1_strat_manager.laps_augment import augment_featured_laps
+    from src.strategy.eval.pace_holdout import (
+        _DROPNA,
+        _add_lag_deg_features,
+        _encode_categoricals,
+    )
+
+    root = get_data_root()
+    manifest = json.loads(
+        (root / "processed" / "feature_manifest_laptime.json").read_text(encoding="utf-8")
+    )
+    encoding = manifest["categorical_encoding"]
+
+    frames = []
+    for year in (2023, 2024):
+        featured = augment_featured_laps(
+            pd.read_parquet(root / "processed" / f"laps_featured_{year}.parquet"), year
+        )
+        encoded = _encode_categoricals(featured, encoding["Compound"], encoding["race_phase"])
+        frames.append(_add_lag_deg_features(encoded).dropna(subset=_DROPNA))
+    train = pd.concat(frames, ignore_index=True)
+
+    assert len(train) > 0, "the rebuilt training frame is empty: nothing below would mean anything"
+
+    for feature, (lower, upper) in _N06_TRAINED_BOUNDS.items():
+        values = pd.to_numeric(train[feature], errors="coerce").dropna()
+        assert values.size > 0, f"{feature} carried no values in the rebuilt training frame"
+        assert lower == pytest.approx(values.min()), (
+            f"{feature} declares a lower bound of {lower}, but N06 trained down to {values.min()}"
+        )
+        assert upper == pytest.approx(values.max()), (
+            f"{feature} declares an upper bound of {upper}, but N06 trained up to {values.max()}"
+        )

--- a/tests/agents/test_n15_envelope.py
+++ b/tests/agents/test_n15_envelope.py
@@ -17,8 +17,9 @@ from pathlib import Path
 
 import pytest
 
+from tests.conftest import HAS_TIRE_MODELS as _HAS_MODELS
+
 ROOT = Path(__file__).parent.parent.parent
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
 pytestmark = pytest.mark.skipif(
     not _HAS_MODELS,
     reason="data/models/ not present (importing the pit agent reads model config)",

--- a/tests/agents/test_orchestrator_prompt.py
+++ b/tests/agents/test_orchestrator_prompt.py
@@ -17,13 +17,14 @@ from pathlib import Path
 
 import pytest
 
+from tests.conftest import HAS_TIRE_MODELS as _HAS_MODELS
+
 # Importing the orchestrator pulls in the tire agent, which reads its routing
 # config at import time, so the whole module is unimportable without the HF
 # weights. That is why the import below lives inside the fixture rather than at
 # module scope: a module-level import raises during COLLECTION, which no skipif
 # can catch. Same guard as tests/agents/test_agents.py, same reason.
 ROOT = Path(__file__).parent.parent.parent
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
 
 pytestmark = pytest.mark.skipif(
     not _HAS_MODELS,

--- a/tests/agents/test_pace_circuit_speed.py
+++ b/tests/agents/test_pace_circuit_speed.py
@@ -78,18 +78,46 @@ def test_every_race_resolves_to_the_value_its_own_parquet_rows_carry(agent):
     parquet and served that one value for every season, so a 2023 Silverstone lap was fed
     a measurement taken two years after it, 18.4 km/h away.
     """
+    from src.agents.pace_agent import _FEATURED_SEASONS
     from src.f1_strat_manager.data_cache import get_data_root
 
-    laps = pd.read_parquet(
-        get_data_root() / "processed" / "laps_featured.parquet",
-        columns=["Year", "GP_Name", "mean_sector_speed"],
-    ).dropna()
-    per_race = laps.drop_duplicates(["Year", "GP_Name"])
+    checked = 0
+    for year in _FEATURED_SEASONS:
+        laps = pd.read_parquet(
+            get_data_root() / "processed" / f"laps_featured_{year}.parquet",
+            columns=["GP_Name", "mean_sector_speed"],
+        ).dropna()
+        for row in laps.drop_duplicates("GP_Name").itertuples():
+            checked += 1
+            served = agent._resolve_mean_sector_speed(str(row.GP_Name), year)
+            assert served == pytest.approx(float(row.mean_sector_speed)), f"{year} {row.GP_Name}"
 
-    assert len(per_race) > 0, "the featured artefact carried no circuit speeds"
-    for row in per_race.itertuples():
-        served = agent._resolve_mean_sector_speed(str(row.GP_Name), int(row.Year))
-        assert served == pytest.approx(float(row.mean_sector_speed)), f"{row.Year} {row.GP_Name}"
+    assert checked > 0, "the featured artefacts carried no circuit speeds"
+
+
+def test_a_2025_lap_is_not_served_the_training_seasons_measurement(agent):
+    """The regression a whole gate round was spent on, pinned as an EFFECT.
+
+    Switching the loader to the COMBINED `laps_featured.parquet` looked like a strict
+    improvement, because that file has no missing values. It broadcasts the training-era
+    number across all three seasons instead: its Silverstone row reads 249.71 for 2023 and
+    for 2025 alike, so keying by year became decorative and every 2025 lap silently
+    received the 2023 measurement.
+
+    The raw laps settle it. Silverstone 2025's own speed traps average 232.32 km/h, which
+    is the per-year artefact's 231.36 and not the combined file's 249.71.
+
+    Asserting that the two seasons DIFFER is what catches this; asserting either value on
+    its own passes happily against the wrong artefact.
+    """
+    served_2023 = agent._resolve_mean_sector_speed("Silverstone", 2023)
+    served_2025 = agent._resolve_mean_sector_speed("Silverstone", 2025)
+
+    assert abs(served_2025 - served_2023) > 1.0, (
+        f"Silverstone reads {served_2025} in 2025 and {served_2023} in 2023; if they are "
+        f"equal the loader is reading an artefact that broadcasts one season's value"
+    )
+    assert served_2025 == pytest.approx(231.36, abs=0.5)
 
 
 def test_the_training_seasons_are_one_artefact_generation_not_two(agent):
@@ -113,20 +141,19 @@ def test_the_training_seasons_are_one_artefact_generation_not_two(agent):
         ), gp
 
 
-def test_the_map_has_no_holes(agent):
-    """Las Vegas is the reason this reads the combined parquet, not the 2025 one.
+def test_las_vegas_2025_is_a_known_artefact_hole_and_stays_unknown(agent):
+    """The one race the correct artefact cannot answer, pinned so it is not "fixed" wrongly.
 
-    `laps_featured_2025.parquet` carries NaN on all 760 Las Vegas rows, so a `.dropna()`
-    over it drops a circuit N06 was fitted on and whose value sits in three other
-    artefacts. "Absent from the map" has to mean an unknown circuit, never an artefact
-    with a hole in it.
+    `laps_featured_2025.parquet` carries NaN on all 760 Las Vegas rows. The tempting repair
+    is to fall back to the training-era value, which sits in three other artefacts and is
+    228.96. That would be the same defect as the speed-trap substitution this whole fix
+    removes, only quieter: a 2025 lap served a measurement from a different season.
+
+    So it stays NaN, and the missing value belongs in the artefact rather than in a
+    fallback here.
     """
-    assert ("2025" not in {str(y) for y, _ in agent.circuit_mean_sector_speed}) is False
-    assert (2025, "Las Vegas") in agent.circuit_mean_sector_speed
-    for year in (2023, 2024, 2025):
-        assert agent._resolve_mean_sector_speed("Las Vegas", year) == pytest.approx(
-            228.9645, abs=1e-3
-        )
+    assert agent._resolve_mean_sector_speed("Las Vegas", 2023) == pytest.approx(228.9645, abs=1e-3)
+    assert math.isnan(agent._resolve_mean_sector_speed("Las Vegas", 2025))
 
 
 def test_the_row_fed_to_n06_carries_the_circuit_value_not_the_speed_trap(agent):
@@ -190,7 +217,13 @@ def test_every_race_on_disk_resolves(agent):
                 unresolved.append((year_dir.name, race_dir.name, gp_name))
 
     assert checked > 0, "no races found on disk: this would hold vacuously"
-    assert unresolved == [], f"{len(unresolved)} of {checked} races resolve to NaN: {unresolved}"
+    # Las Vegas 2025 is a hole in the artefact, not a resolution failure, and is pinned
+    # by its own test above. Listing it here rather than widening the assertion keeps a
+    # NEW unresolved race failing loudly.
+    known_holes = [("2025", "Las_Vegas", "Las Vegas")]
+    assert sorted(unresolved) == sorted(known_holes), (
+        f"{len(unresolved)} of {checked} races resolve to NaN: {unresolved}"
+    )
 
 
 # --- an unresolvable circuit stays unknown -----------------------------------

--- a/tests/agents/test_pace_circuit_speed.py
+++ b/tests/agents/test_pace_circuit_speed.py
@@ -1,17 +1,19 @@
 """N06 is fed the circuit's own mean sector speed, not the speed trap (#797).
 
 `mean_sector_speed` is a property of the CIRCUIT: the featured parquet holds exactly
-one value per GP. `_compute_derived` used to substitute `prev_speed_st` whenever none
-was supplied, and `run_from_state` never supplied one, so on the path every real race
-takes the model received a different physical quantity on every lap.
+one value per (year, GP). `_compute_derived` used to substitute `prev_speed_st` whenever
+none was supplied, and `run_from_state` never supplied one, so on the path every real
+race takes the model received a different physical quantity on every lap.
 
-What these pin is the pair of rules that makes the fix a fix rather than a new guess:
-the value served must be the value fitted, and a circuit that does not resolve must
-reach the model as MISSING rather than as a substituted reading.
+What these pin is the set of rules that makes the fix a fix rather than a new guess: the
+value served must be the value the replayed lap carries, EVERY race must resolve, and a
+circuit that genuinely does not resolve must reach the model as MISSING rather than as a
+substituted reading.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import math
 from pathlib import Path
@@ -22,10 +24,11 @@ import pytest
 ROOT = Path(__file__).parent.parent.parent
 _HAS_ARTEFACTS = (
     ROOT / "data" / "models" / "lap_time" / "xgb_laptime_delta_final.json"
-).exists() and (ROOT / "data" / "processed" / "laps_featured_2025.parquet").exists()
+).exists() and (ROOT / "data" / "processed" / "laps_featured.parquet").exists()
+_HAS_RAW = (ROOT / "data" / "raw").is_dir()
 
 pytestmark = pytest.mark.skipif(
-    not _HAS_ARTEFACTS, reason="N06 weights or the featured parquet are absent"
+    not _HAS_ARTEFACTS, reason="N06 weights or the combined featured parquet are absent"
 )
 
 
@@ -64,49 +67,130 @@ def _feature_row(agent, **overrides):
     return agent._build_feature_row(**kwargs)
 
 
-# --- the value served is the value fitted ------------------------------------
+# --- the value served is the value the replayed lap carries -------------------
 
 
-def test_every_circuit_resolves_to_the_value_the_parquet_trained_on(agent):
-    """Not "close to", the same number. The map is read from the training artefact.
+def test_every_race_resolves_to_the_value_its_own_parquet_rows_carry(agent):
+    """Not "close to", the same number, and for every (year, GP) rather than one.
 
-    Asserted over every GP rather than one, because a lookup that works for the
-    circuit somebody tested and silently misses the rest is the failure mode a
-    single-case test invites.
+    A lookup that works for the circuit somebody tested and silently misses the rest is
+    the failure this asserts against: the first version of the loader read only the 2025
+    parquet and served that one value for every season, so a 2023 Silverstone lap was fed
+    a measurement taken two years after it, 18.4 km/h away.
     """
     from src.f1_strat_manager.data_cache import get_data_root
 
-    trained = (
-        pd.read_parquet(
-            get_data_root() / "processed" / "laps_featured_2025.parquet",
-            columns=["GP_Name", "mean_sector_speed"],
-        )
-        .dropna()
-        .drop_duplicates("GP_Name")
-        .set_index("GP_Name")["mean_sector_speed"]
-    )
+    laps = pd.read_parquet(
+        get_data_root() / "processed" / "laps_featured.parquet",
+        columns=["Year", "GP_Name", "mean_sector_speed"],
+    ).dropna()
+    per_race = laps.drop_duplicates(["Year", "GP_Name"])
 
-    assert len(trained) > 0, "the training artefact carried no circuit speeds"
-    for gp, expected in trained.items():
-        assert agent._resolve_mean_sector_speed(str(gp)) == pytest.approx(float(expected)), gp
+    assert len(per_race) > 0, "the featured artefact carried no circuit speeds"
+    for row in per_race.itertuples():
+        served = agent._resolve_mean_sector_speed(str(row.GP_Name), int(row.Year))
+        assert served == pytest.approx(float(row.mean_sector_speed)), f"{row.Year} {row.GP_Name}"
+
+
+def test_the_training_seasons_are_one_artefact_generation_not_two(agent):
+    """2023 and 2024 are identical per GP, which is why the map is not "per season".
+
+    Pinned because the docstring says so and a wrong mechanism is how the next fix goes
+    wrong: someone completing a per-season resolution between 2023 and 2024 would find
+    nothing to resolve. The value is recomputed per artefact BUILD, and one build pooled
+    both training seasons.
+    """
+    shared = {
+        gp
+        for (year, gp) in agent.circuit_mean_sector_speed
+        if (2023, gp) in agent.circuit_mean_sector_speed
+        and (2024, gp) in agent.circuit_mean_sector_speed
+    }
+    assert shared, "no GP appears in both training seasons"
+    for gp in shared:
+        assert agent.circuit_mean_sector_speed[(2023, gp)] == pytest.approx(
+            agent.circuit_mean_sector_speed[(2024, gp)]
+        ), gp
+
+
+def test_the_map_has_no_holes(agent):
+    """Las Vegas is the reason this reads the combined parquet, not the 2025 one.
+
+    `laps_featured_2025.parquet` carries NaN on all 760 Las Vegas rows, so a `.dropna()`
+    over it drops a circuit N06 was fitted on and whose value sits in three other
+    artefacts. "Absent from the map" has to mean an unknown circuit, never an artefact
+    with a hole in it.
+    """
+    assert ("2025" not in {str(y) for y, _ in agent.circuit_mean_sector_speed}) is False
+    assert (2025, "Las Vegas") in agent.circuit_mean_sector_speed
+    for year in (2023, 2024, 2025):
+        assert agent._resolve_mean_sector_speed("Las Vegas", year) == pytest.approx(
+            228.9645, abs=1e-3
+        )
 
 
 def test_the_row_fed_to_n06_carries_the_circuit_value_not_the_speed_trap(agent):
     """The regression itself: the trap reading must not reach the feature again."""
-    row = _feature_row(agent, gp_name="Lusail", prev_speed_st=300.0)
+    row = _feature_row(agent, gp_name="Lusail", year=2025, prev_speed_st=300.0)
 
     served = float(row["mean_sector_speed"].iloc[0])
-    assert served == pytest.approx(agent.circuit_mean_sector_speed["Lusail"])
+    assert served == pytest.approx(agent.circuit_mean_sector_speed[(2025, "Lusail")])
     assert served != pytest.approx(300.0)
     # Prev_SpeedST is still its own feature and still carries the trap.
     assert float(row["Prev_SpeedST"].iloc[0]) == pytest.approx(300.0)
 
 
-def test_a_full_event_name_resolves_through_the_slug(agent):
-    """gp_name arrives in either keyspace depending on the caller (#448, #450)."""
-    assert agent._resolve_mean_sector_speed("Qatar Grand Prix") == pytest.approx(
-        agent.circuit_mean_sector_speed["Lusail"]
-    )
+# --- every keyspace a real caller uses ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "year"),
+    [
+        ("Lusail", 2025),  # parquet slug, what the CLI passes
+        ("Qatar Grand Prix", 2025),  # FastF1 event name
+        ("Miami Gardens", 2025),  # metadata.json, what the replay engine passes
+        ("Miami_Gardens", 2025),  # raw folder name
+        ("Spain", 2023),  # a training-season folder whose slug differs
+    ],
+)
+def test_each_keyspace_a_real_caller_uses_resolves(agent, name, year):
+    """Four names for one GP, and an earlier draft resolved only two of them.
+
+    'Miami Gardens' with a SPACE is what `RaceReplayEngine` puts into `session_meta`, and
+    it matches neither the parquet slug nor the underscore folder form, so every lap of
+    the 2025 Miami race was served NaN while its value sat in the map. The #448/#450
+    dual-keyspace trap, third occurrence.
+    """
+    assert not math.isnan(agent._resolve_mean_sector_speed(name, year))
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_RAW, reason="data/raw absent")
+def test_every_race_on_disk_resolves(agent):
+    """The enumeration, checked rather than assumed.
+
+    Fixing the two names an audit happened to name would leave the next one to be found
+    the same way. This walks every race under `data/raw/` and asserts the name its
+    metadata actually carries resolves, which is the only form of this claim worth making.
+    """
+    from src.f1_strat_manager.data_cache import get_data_root
+
+    unresolved = []
+    checked = 0
+    for year_dir in sorted((get_data_root() / "raw").iterdir()):
+        if not year_dir.is_dir() or not year_dir.name.isdigit():
+            continue
+        for race_dir in sorted(p for p in year_dir.iterdir() if p.is_dir()):
+            meta = race_dir / "metadata.json"
+            if not meta.exists():
+                continue
+            checked += 1
+            gp_name = json.loads(meta.read_text(encoding="utf-8")).get("gp_name", "")
+            if math.isnan(agent._resolve_mean_sector_speed(gp_name, int(year_dir.name))):
+                unresolved.append((year_dir.name, race_dir.name, gp_name))
+
+    assert checked > 0, "no races found on disk: this would hold vacuously"
+    assert unresolved == [], f"{len(unresolved)} of {checked} races resolve to NaN: {unresolved}"
 
 
 # --- an unresolvable circuit stays unknown -----------------------------------
@@ -116,14 +200,19 @@ def test_an_unknown_circuit_yields_nan_and_never_a_substituted_reading(agent, ca
     """The rule the bug broke: unknown data must not become a number the model can use.
 
     NaN is in-distribution for XGBoost, which routes a missing feature through its
-    sparse-aware split. A plausible-looking speed is not: it answers a different
-    question with full confidence, which is exactly what #797 was.
+    sparse-aware split. A plausible-looking speed is not: it answers a different question
+    with full confidence, which is exactly what #797 was.
     """
     with caplog.at_level(logging.WARNING):
-        value = agent._resolve_mean_sector_speed("Nurburgring")
+        value = agent._resolve_mean_sector_speed("Nurburgring", 2025)
 
     assert math.isnan(value)
     assert any("no trained mean sector speed" in r.message for r in caplog.records)
+
+
+def test_a_season_the_dataset_does_not_cover_is_unknown_too(agent):
+    """A real circuit in a year with no artefact is still unknown, not the nearest year."""
+    assert math.isnan(agent._resolve_mean_sector_speed("Lusail", 2019))
 
 
 def test_an_unknown_circuit_reaches_the_model_as_missing(agent):
@@ -146,35 +235,33 @@ def test_an_explicitly_supplied_value_is_not_overridden_by_the_circuit_constant(
 # --- the envelope bound is meaningful again ----------------------------------
 
 
-def test_the_envelope_now_separates_a_circuit_n06_was_fitted_on_from_one_it_was_not(agent):
+def test_the_envelope_separates_a_circuit_n06_was_fitted_on_from_one_it_was_not(agent):
     """The bound is back and it discriminates, which is the point of restoring it.
 
-    A first version of this test asserted that EVERY served circuit falls inside the
-    bound, and Monza refuted it. That assertion was wrong, not the code: the bound is
-    the 2023-2024 range and the served values are the 2025 measurements, so they are
-    different sets and a 2025 circuit may legitimately sit outside. Monza 2025 does,
-    at 317.24 against a fitted maximum of 314.97, and saying so is exactly the job the
-    bound was restored to do.
+    A first version of this test asserted that EVERY served value falls inside the bound,
+    and Monza refuted it. That assertion was wrong, not the code: the bound is the
+    2023-2024 range and a 2025 lap is served a 2025 measurement, so a 2025 circuit may
+    legitimately sit outside. Monza 2025 does, at 317.24 against a fitted maximum of
+    314.97, and saying so is exactly the job the bound was restored to do.
 
-    So what is pinned here is the discrimination, not a blanket. A bound that flagged
+    So what is pinned is the discrimination, not a blanket. A bound that flagged
     everything, or nothing, would pass a coverage check and tell nobody anything.
     """
     from src.agents.pace_agent import _N06_ENVELOPE, _N06_TRAINED_BOUNDS
 
     lower, upper = _N06_TRAINED_BOUNDS["mean_sector_speed"]
+    served = agent.circuit_mean_sector_speed
+    inside = {k: v for k, v in served.items() if lower <= v <= upper}
+    outside = {k: v for k, v in served.items() if not lower <= v <= upper}
 
-    inside = {gp: v for gp, v in agent.circuit_mean_sector_speed.items() if lower <= v <= upper}
-    outside = {
-        gp: v for gp, v in agent.circuit_mean_sector_speed.items() if not lower <= v <= upper
-    }
-
-    assert inside, "no served circuit is in range: the bound and the feed disagree"
+    assert inside, "no served value is in range: the bound and the feed disagree"
     assert len(inside) > len(outside), (
-        f"{len(outside)} of {len(agent.circuit_mean_sector_speed)} circuits fall outside; "
-        f"a bound that rejects most of what it is fed is describing the wrong quantity"
+        f"{len(outside)} of {len(served)} races fall outside; a bound that rejects most "
+        f"of what it is fed is describing the wrong quantity"
     )
-
-    # And it must actually fire on the one that is out, through the real envelope.
-    for gp, value in outside.items():
+    # Every training-season value must be inside by construction: that is where the
+    # bound came from. Only a later season may legitimately escape it.
+    for (year, gp), value in outside.items():
+        assert year == 2025, f"{year} {gp} is outside the range its own season defined"
         verdict = _N06_ENVELOPE.check({"mean_sector_speed": value})
         assert "mean_sector_speed" in verdict.violations, gp

--- a/tests/agents/test_pace_circuit_speed.py
+++ b/tests/agents/test_pace_circuit_speed.py
@@ -1,0 +1,180 @@
+"""N06 is fed the circuit's own mean sector speed, not the speed trap (#797).
+
+`mean_sector_speed` is a property of the CIRCUIT: the featured parquet holds exactly
+one value per GP. `_compute_derived` used to substitute `prev_speed_st` whenever none
+was supplied, and `run_from_state` never supplied one, so on the path every real race
+takes the model received a different physical quantity on every lap.
+
+What these pin is the pair of rules that makes the fix a fix rather than a new guess:
+the value served must be the value fitted, and a circuit that does not resolve must
+reach the model as MISSING rather than as a substituted reading.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_ARTEFACTS = (
+    ROOT / "data" / "models" / "lap_time" / "xgb_laptime_delta_final.json"
+).exists() and (ROOT / "data" / "processed" / "laps_featured_2025.parquet").exists()
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_ARTEFACTS, reason="N06 weights or the featured parquet are absent"
+)
+
+
+@pytest.fixture(scope="module")
+def agent():
+    from src.agents.pace_agent import PaceAgent
+
+    return PaceAgent()
+
+
+def _feature_row(agent, **overrides):
+    """A real feature row, built through the real builder."""
+    kwargs = dict(
+        driver_number=4,
+        lap_number=30,
+        stint=2,
+        tyre_life=14,
+        compound="MEDIUM",
+        position=4,
+        team="McLaren",
+        laps_since_pit=14,
+        fuel_load=0.5,
+        year=2025,
+        prev_lap_time=84.0,
+        prev_tyre_life=13,
+        prev_speed_st=300.0,
+        air_temp=25.0,
+        track_temp=35.0,
+        humidity=50.0,
+        rainfall=0.0,
+        total_laps=57,
+        gp_name="Lusail",
+        stint_baseline_tyre_life=1,
+    )
+    kwargs.update(overrides)
+    return agent._build_feature_row(**kwargs)
+
+
+# --- the value served is the value fitted ------------------------------------
+
+
+def test_every_circuit_resolves_to_the_value_the_parquet_trained_on(agent):
+    """Not "close to", the same number. The map is read from the training artefact.
+
+    Asserted over every GP rather than one, because a lookup that works for the
+    circuit somebody tested and silently misses the rest is the failure mode a
+    single-case test invites.
+    """
+    from src.f1_strat_manager.data_cache import get_data_root
+
+    trained = (
+        pd.read_parquet(
+            get_data_root() / "processed" / "laps_featured_2025.parquet",
+            columns=["GP_Name", "mean_sector_speed"],
+        )
+        .dropna()
+        .drop_duplicates("GP_Name")
+        .set_index("GP_Name")["mean_sector_speed"]
+    )
+
+    assert len(trained) > 0, "the training artefact carried no circuit speeds"
+    for gp, expected in trained.items():
+        assert agent._resolve_mean_sector_speed(str(gp)) == pytest.approx(float(expected)), gp
+
+
+def test_the_row_fed_to_n06_carries_the_circuit_value_not_the_speed_trap(agent):
+    """The regression itself: the trap reading must not reach the feature again."""
+    row = _feature_row(agent, gp_name="Lusail", prev_speed_st=300.0)
+
+    served = float(row["mean_sector_speed"].iloc[0])
+    assert served == pytest.approx(agent.circuit_mean_sector_speed["Lusail"])
+    assert served != pytest.approx(300.0)
+    # Prev_SpeedST is still its own feature and still carries the trap.
+    assert float(row["Prev_SpeedST"].iloc[0]) == pytest.approx(300.0)
+
+
+def test_a_full_event_name_resolves_through_the_slug(agent):
+    """gp_name arrives in either keyspace depending on the caller (#448, #450)."""
+    assert agent._resolve_mean_sector_speed("Qatar Grand Prix") == pytest.approx(
+        agent.circuit_mean_sector_speed["Lusail"]
+    )
+
+
+# --- an unresolvable circuit stays unknown -----------------------------------
+
+
+def test_an_unknown_circuit_yields_nan_and_never_a_substituted_reading(agent, caplog):
+    """The rule the bug broke: unknown data must not become a number the model can use.
+
+    NaN is in-distribution for XGBoost, which routes a missing feature through its
+    sparse-aware split. A plausible-looking speed is not: it answers a different
+    question with full confidence, which is exactly what #797 was.
+    """
+    with caplog.at_level(logging.WARNING):
+        value = agent._resolve_mean_sector_speed("Nurburgring")
+
+    assert math.isnan(value)
+    assert any("no trained mean sector speed" in r.message for r in caplog.records)
+
+
+def test_an_unknown_circuit_reaches_the_model_as_missing(agent):
+    """End to end: the NaN survives the frame build rather than being coerced."""
+    row = _feature_row(agent, gp_name="Nurburgring", prev_speed_st=300.0)
+
+    assert math.isnan(float(row["mean_sector_speed"].iloc[0]))
+
+
+# --- an explicit measurement still wins --------------------------------------
+
+
+def test_an_explicitly_supplied_value_is_not_overridden_by_the_circuit_constant(agent):
+    """A caller that genuinely measured this lap must keep its number."""
+    row = _feature_row(agent, gp_name="Lusail", mean_sector_speed=241.5)
+
+    assert float(row["mean_sector_speed"].iloc[0]) == pytest.approx(241.5)
+
+
+# --- the envelope bound is meaningful again ----------------------------------
+
+
+def test_the_envelope_now_separates_a_circuit_n06_was_fitted_on_from_one_it_was_not(agent):
+    """The bound is back and it discriminates, which is the point of restoring it.
+
+    A first version of this test asserted that EVERY served circuit falls inside the
+    bound, and Monza refuted it. That assertion was wrong, not the code: the bound is
+    the 2023-2024 range and the served values are the 2025 measurements, so they are
+    different sets and a 2025 circuit may legitimately sit outside. Monza 2025 does,
+    at 317.24 against a fitted maximum of 314.97, and saying so is exactly the job the
+    bound was restored to do.
+
+    So what is pinned here is the discrimination, not a blanket. A bound that flagged
+    everything, or nothing, would pass a coverage check and tell nobody anything.
+    """
+    from src.agents.pace_agent import _N06_ENVELOPE, _N06_TRAINED_BOUNDS
+
+    lower, upper = _N06_TRAINED_BOUNDS["mean_sector_speed"]
+
+    inside = {gp: v for gp, v in agent.circuit_mean_sector_speed.items() if lower <= v <= upper}
+    outside = {
+        gp: v for gp, v in agent.circuit_mean_sector_speed.items() if not lower <= v <= upper
+    }
+
+    assert inside, "no served circuit is in range: the bound and the feed disagree"
+    assert len(inside) > len(outside), (
+        f"{len(outside)} of {len(agent.circuit_mean_sector_speed)} circuits fall outside; "
+        f"a bound that rejects most of what it is fed is describing the wrong quantity"
+    )
+
+    # And it must actually fire on the one that is out, through the real envelope.
+    for gp, value in outside.items():
+        verdict = _N06_ENVELOPE.check({"mean_sector_speed": value})
+        assert "mean_sector_speed" in verdict.violations, gp

--- a/tests/agents/test_prompt_constants_match_tables.py
+++ b/tests/agents/test_prompt_constants_match_tables.py
@@ -224,3 +224,40 @@ def test_the_undercut_threshold_is_not_restated_at_all():
 
     assert "0.522" not in _PIT_STRATEGY_SYSTEM_PROMPT
     assert "score_undercut_tool reports" in _PIT_STRATEGY_SYSTEM_PROMPT
+
+
+# --- two rules, one number: the coupling #716 exposed ------------------------
+
+_MEDIUM_BAND = re.compile(r"MEDIUM\b[^.\n]*?\b(\d+)\s*-\s*\d+")
+
+
+def test_the_medium_suitability_floor_is_not_the_minimum_stint_bound():
+    """Both prompts state a MEDIUM suitability band. Its floor is its OWN constant.
+
+    These are two different questions that shared the number 12 by accident: the
+    minimum-stint bound asks whether a set has run long enough to be worth replacing,
+    the suitability floor asks whether enough race is left for the compound to make
+    sense. Nothing ties them, and while the values agreed the coupling was invisible.
+
+    It surfaced when #716 recalibrated the minimum-stint bound to 7 against real stint
+    lengths: because both prompts rendered the band floor from `_MIN_STINT_LAPS`, the
+    recalibration silently rewrote "MEDIUM: suitable for 12-30 remaining laps" into
+    "7-30" on the DEFAULT LLM path, a rule the issue never touched and nobody reviewed.
+
+    Asserting the floor against its own constant is what catches a re-coupling: point
+    the prompt back at `_MIN_STINT_LAPS['MEDIUM']` and this fails on the mismatch. The
+    prompt-versus-table tests above cannot see it, because they assert equality between
+    prompt and constant and a re-coupled prompt agrees with the WRONG constant.
+    """
+    from src.agents.pit_strategy_agent import _MEDIUM_SUITABILITY_FLOOR_LAPS
+    from src.strategy.inference.guard_rails import _MIN_STINT_LAPS
+
+    for name, prompt in _prompts().items():
+        floors = {int(m.group(1)) for m in _MEDIUM_BAND.finditer(prompt)}
+        assert floors, f"{name} states no MEDIUM band the pattern can see"
+        assert floors == {_MEDIUM_SUITABILITY_FLOOR_LAPS}, (
+            f"{name} states a MEDIUM suitability floor of {floors}, but the constant is "
+            f"{_MEDIUM_SUITABILITY_FLOOR_LAPS}. If it now reads "
+            f"{_MIN_STINT_LAPS['MEDIUM']}, the band has been re-coupled to the "
+            f"minimum-stint bound and moves whenever that is recalibrated."
+        )

--- a/tests/agents/test_prompt_constants_match_tables.py
+++ b/tests/agents/test_prompt_constants_match_tables.py
@@ -36,8 +36,9 @@ from pathlib import Path
 
 import pytest
 
+from tests.conftest import HAS_TIRE_MODELS as _HAS_MODELS
+
 ROOT = Path(__file__).parent.parent.parent
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").is_file()
 
 pytestmark = pytest.mark.skipif(
     not _HAS_MODELS,

--- a/tests/agents/test_prompt_constants_match_tables.py
+++ b/tests/agents/test_prompt_constants_match_tables.py
@@ -81,6 +81,16 @@ def _orchestrator_prompt() -> str:
     return _build_orchestrator_prompt(race_state, {}, "STAY_OUT")
 
 
+def _prompts() -> dict[str, str]:
+    """Both rendered prompts, so every check below covers the pair rather than one."""
+    from src.agents.pit_strategy_agent import _PIT_STRATEGY_SYSTEM_PROMPT
+
+    return {
+        "pit agent prompt": _PIT_STRATEGY_SYSTEM_PROMPT,
+        "orchestrator prompt": _orchestrator_prompt(),
+    }
+
+
 def test_no_prompt_states_a_capacity_the_table_disagrees_with():
     """The relation, not the value. Both prompts, every compound they mention."""
     from src.agents.pit_strategy_agent import _PIT_STRATEGY_SYSTEM_PROMPT, _STINT_CAPACITY_LAPS
@@ -141,3 +151,75 @@ def test_the_selector_and_the_prompt_agree_across_the_band_that_used_to_split_th
         selector_allows = _STINT_CAPACITY_LAPS["SOFT"] >= laps_remaining
         prompt_allows = laps_remaining <= prompt_bound
         assert selector_allows == prompt_allows, laps_remaining
+
+
+# The four guard-rail bounds, each of which was prose in both prompts while the
+# deterministic rails computed against the constant. Gate G3 listed them; #741 had
+# derived exactly one number and left these.
+_MIN_STINT = re.compile(r"\b(SOFT|MEDIUM|HARD)\b[^.\n]*?>=\s*(\d+)\s*lap")
+_BEFORE_LAP = re.compile(r"before lap (\d+)")
+# Anchored on "when", because a looser pattern also matches the COMPOUND capacity line
+# ("recommend only if remaining laps <= 18") and then asserts the guard-rail bound
+# equals a stint capacity. Caught by this very test on its first run.
+_LAST_LAPS = re.compile(r"when remaining laps <=\s*(\d+)")
+_CLIFF_P10 = re.compile(r"cliff P10 <\s*(\d+)|laps_to_cliff P10 <\s*(\d+)")
+
+
+def test_no_prompt_states_a_minimum_stint_the_rails_disagree_with():
+    """`_MIN_STINT_LAPS` sat two sections above the one number #741 derived.
+
+    Same defect, same file, left in place because the fix was applied to the instance
+    in front of me rather than to the class. That is the pattern three gates have now
+    found, so this pins the whole table instead of one compound of it.
+    """
+    from src.strategy.inference.guard_rails import _MIN_STINT_LAPS
+
+    for name, prompt in _prompts().items():
+        stated = {m.group(1): int(m.group(2)) for m in _MIN_STINT.finditer(prompt)}
+        assert stated, f"{name} states no minimum stint the pattern can see"
+        for compound, value in stated.items():
+            assert value == _MIN_STINT_LAPS[compound], (
+                f"{name} says {compound} >= {value}, the rails enforce {_MIN_STINT_LAPS[compound]}"
+            )
+
+
+def test_no_prompt_states_a_pit_window_bound_the_rails_disagree_with():
+    """The two hard bounds an LLM is told to treat as inviolable.
+
+    If prose and rail disagree here the model is told to refuse an action the rails
+    would have allowed, or to allow one they will override, and either way the
+    disagreement is invisible until someone reads both files.
+    """
+    from src.strategy.inference.guard_rails import (
+        _CLIFF_P10_SAFE,
+        _NO_PIT_BEFORE_LAP,
+        _NO_PIT_LAST_N_LAPS,
+    )
+
+    for name, prompt in _prompts().items():
+        early = [int(m.group(1)) for m in _BEFORE_LAP.finditer(prompt)]
+        late = [int(m.group(1)) for m in _LAST_LAPS.finditer(prompt)]
+        cliff = [int(m.group(1) or m.group(2)) for m in _CLIFF_P10.finditer(prompt)]
+
+        assert early, f"{name}: the early-window bound is no longer visible"
+        assert late, f"{name}: the end-of-race bound is no longer visible"
+        assert cliff, f"{name}: the cliff exception is no longer visible"
+
+        assert set(early) == {_NO_PIT_BEFORE_LAP}, name
+        assert set(late) == {_NO_PIT_LAST_N_LAPS}, name
+        assert set(cliff) == {_CLIFF_P10_SAFE}, name
+
+
+def test_the_undercut_threshold_is_not_restated_at_all():
+    """This one cannot be interpolated, so it must not appear.
+
+    The threshold is loaded per-instance from the model's calibration config and the
+    tool PRINTS the live value into its own response. A module-level prompt cannot see
+    it, so restating it means the LLM can receive two different thresholds in one
+    conversation the moment the model is retuned. The prompt now points at what the
+    tool reports instead.
+    """
+    from src.agents.pit_strategy_agent import _PIT_STRATEGY_SYSTEM_PROMPT
+
+    assert "0.522" not in _PIT_STRATEGY_SYSTEM_PROMPT
+    assert "score_undercut_tool reports" in _PIT_STRATEGY_SYSTEM_PROMPT

--- a/tests/agents/test_race_state_builder.py
+++ b/tests/agents/test_race_state_builder.py
@@ -1,0 +1,290 @@
+"""#784 — the canonical RaceState builder replaces three drifted per-surface copies.
+
+Two tiers, split by what each test needs to import. The pure-helper tests and the
+leaf-module guard import only ``src.agents.race_state_builder`` (cheap by
+contract) and run everywhere, including CI without ``data/models`` and without the
+``src/telemetry`` submodule. The tests that CALL ``build_race_state`` construct a
+real ``RaceState``, whose lazy import pulls in ``strategy_orchestrator`` and
+therefore model artefacts, so they carry the same models-present guard as the
+sibling agent tests.
+
+Every canonical literal asserted here is asserted against the module's own
+constant, never a restated number, so a deliberate future change to a default
+fails exactly one definition away from this file.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS
+from src.agents.position_projection import GAP_UNKNOWN_FALLBACK_S
+from src.agents.race_state_builder import (
+    DEFAULT_AIR_TEMP_C,
+    DEFAULT_TRACK_TEMP_C,
+    UNKNOWN_COMPOUND,
+    UNKNOWN_TYRE_LIFE,
+    build_race_state,
+    normalise_compound,
+)
+
+ROOT = Path(__file__).parent.parent.parent
+_HAS_MODELS = (ROOT / "data" / "models" / "lap_time").is_dir()
+
+needs_models = pytest.mark.skipif(
+    not _HAS_MODELS, reason="building a RaceState imports the agents, which load model artefacts"
+)
+
+
+def _lap_state(**overrides):
+    """A minimal-but-complete lap_state shaped like RaceStateManager emits it.
+
+    Our driver is P3; VER sits one position ahead with a measured interval and a
+    same-lap time, so both the gap and the #750 pace delta have known expected
+    values (gap 1.8, pace 92.5 - 92.1 = +0.4). Overrides replace TOP-LEVEL keys.
+    """
+    state = {
+        "lap_number": 30,
+        "driver": {
+            "driver": "NOR",
+            "lap_number": 30,
+            "position": 3,
+            "compound": "MEDIUM",
+            "tyre_life": 8,
+            "lap_time_s": 92.5,
+        },
+        "rivals": [
+            {"driver": "VER", "position": 2, "interval_to_driver_s": -1.8, "lap_time_s": 92.1},
+            {"driver": "LEC", "position": 4, "interval_to_driver_s": 2.4, "lap_time_s": 93.0},
+        ],
+        "weather": {"air_temp": 22.0, "track_temp": 31.5, "rainfall": False},
+        "session_meta": {"total_laps": 57},
+    }
+    state.update(overrides)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — pure helpers and the leaf guarantee (no models, no submodule)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw", ["", "nan", "None", "NaN", "NONE", "  ", None])
+def test_missing_compound_spellings_normalise_to_unknown(raw):
+    """Every spelling of "no compound" folds into the one honest marker.
+
+    race_state_manager.py emits `str(r.get("Compound", ""))`, so a stored NaN
+    reaches the builder as the STRING "nan" with the key present — a dict.get
+    default never fires on it. This normalisation is the substantive half of the
+    "UNKNOWN" decision; without it the canonical default is a choice about an
+    almost-unreachable branch.
+    """
+    assert normalise_compound(raw) == UNKNOWN_COMPOUND
+
+
+@pytest.mark.parametrize("real", ["SOFT", "MEDIUM", "HARD", "INTERMEDIATE", "WET"])
+def test_real_compound_passes_through_untouched(real):
+    assert normalise_compound(real) == real
+
+
+def test_module_import_is_a_leaf_and_never_drags_langchain():
+    """The guard that keeps every surface's boot cheap.
+
+    ``build_race_state`` imports ``RaceState`` lazily because
+    ``strategy_orchestrator`` drags LangChain/LangGraph and model artefacts. A
+    future editor hoisting that import to module level would slow the CLI, the
+    arcade and the backend at once — this subprocess check (a fresh interpreter,
+    so no module already cached by other tests can mask the leak) fails the
+    moment that happens.
+    """
+    probe = (
+        "import sys; import src.agents.race_state_builder; "
+        "leaked = sorted(m for m in sys.modules "
+        "if m.startswith('langchain') or m.startswith('langgraph')); "
+        "assert not leaked, f'leaf module dragged: {leaked}'"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — the canonical field behaviour, end to end (needs model artefacts)
+# ---------------------------------------------------------------------------
+
+
+@needs_models
+def test_canonical_defaults_fire_when_keys_are_absent(caplog):
+    """Each approved default fires on a lap_state that omits its key."""
+    state = _lap_state(
+        driver={"position": 1, "lap_time_s": 92.5},
+        rivals=[],
+        weather={},
+        session_meta={},
+    )
+    del state["lap_number"]
+
+    with caplog.at_level("WARNING", logger="src.agents.race_state_builder"):
+        rs = build_race_state(state)
+
+    assert rs.driver == "UNK"
+    assert rs.lap == 1
+    assert rs.total_laps == DEFAULT_TOTAL_LAPS
+    assert rs.compound == UNKNOWN_COMPOUND
+    assert rs.tyre_life == UNKNOWN_TYRE_LIFE
+    assert rs.air_temp == DEFAULT_AIR_TEMP_C
+    assert rs.track_temp == DEFAULT_TRACK_TEMP_C
+    assert rs.rainfall is False
+    assert rs.radio_msgs == []
+    assert rs.rcm_events == []
+    assert rs.risk_tolerance == 0.5
+    # Both silent-fallback holes must be loud, not quiet (#784 decision table).
+    warnings = " ".join(r.getMessage() for r in caplog.records)
+    assert "total_laps" in warnings
+    assert "lap_number" in warnings
+
+
+@needs_models
+def test_explicit_driver_param_wins_over_the_driver_dict():
+    rs = build_race_state(_lap_state(), driver="PIA")
+    assert rs.driver == "PIA"
+
+
+@needs_models
+def test_lap_falls_back_to_the_driver_dict_before_defaulting():
+    """The middle rung of the lap ladder: top-level absent, driver dict present."""
+    state = _lap_state()
+    del state["lap_number"]
+    rs = build_race_state(state)
+    assert rs.lap == 30
+
+
+@needs_models
+def test_compound_nan_string_is_normalised_end_to_end():
+    """The live RSM path: key PRESENT with the literal string "nan"."""
+    state = _lap_state()
+    state["driver"]["compound"] = "nan"
+    rs = build_race_state(state)
+    assert rs.compound == UNKNOWN_COMPOUND
+
+
+@needs_models
+def test_present_but_none_weather_lands_on_defaults_without_crashing():
+    """A NaN weather row emits keys whose VALUE is None (race_state_manager.py).
+
+    All three pre-#784 builders crashed here, though not by the same mechanism: the
+    arcade and backend copies wrapped the read in float(), so they raised TypeError,
+    while the CLI passed the None straight to Pydantic, which rejected it; the canonical
+    builder treats present-but-None as missing, identical behaviour on every lap
+    that worked before.
+    """
+    state = _lap_state(weather={"air_temp": None, "track_temp": None, "rainfall": None})
+    rs = build_race_state(state)
+    assert rs.air_temp == DEFAULT_AIR_TEMP_C
+    assert rs.track_temp == DEFAULT_TRACK_TEMP_C
+    assert rs.rainfall is False
+
+
+@needs_models
+def test_position_none_raises_value_error():
+    """The one converged fail-loud guard: never fabricate a searchable position."""
+    state = _lap_state()
+    state["driver"]["position"] = None
+    with pytest.raises(ValueError, match="position is None"):
+        build_race_state(state)
+
+
+@needs_models
+def test_gap_is_zero_when_no_car_ahead():
+    """P1 with no rival at position 0: leading, and 0.0 is honest there."""
+    state = _lap_state()
+    state["driver"]["position"] = 1
+    rs = build_race_state(state)
+    assert rs.gap_ahead_s == 0.0
+
+
+@needs_models
+def test_gap_falls_back_when_the_interval_is_unmeasured():
+    """A car ahead with interval None is NOT a zero gap (#633)."""
+    state = _lap_state(
+        rivals=[{"driver": "VER", "position": 2, "interval_to_driver_s": None}],
+    )
+    rs = build_race_state(state)
+    assert rs.gap_ahead_s == GAP_UNKNOWN_FALLBACK_S
+
+
+@needs_models
+def test_gap_is_the_absolute_measured_interval():
+    rs = build_race_state(_lap_state())
+    assert rs.gap_ahead_s == pytest.approx(1.8)
+
+
+@needs_models
+def test_pace_delta_is_rival_relative_same_lap():
+    """The #750 contract: our lap time minus the car ahead's SAME-lap time."""
+    rs = build_race_state(_lap_state())
+    assert rs.pace_delta_s == pytest.approx(92.5 - 92.1)
+
+
+@needs_models
+def test_pace_delta_is_neutral_zero_when_the_ahead_lap_time_is_unknown():
+    state = _lap_state(
+        rivals=[{"driver": "VER", "position": 2, "interval_to_driver_s": -1.8}],
+    )
+    rs = build_race_state(state)
+    assert rs.pace_delta_s == 0.0
+
+
+@needs_models
+def test_pace_delta_is_neutral_zero_when_our_lap_time_is_unknown():
+    state = _lap_state()
+    state["driver"]["lap_time_s"] = None
+    rs = build_race_state(state)
+    assert rs.pace_delta_s == 0.0
+
+
+@needs_models
+def test_explicit_gap_and_pace_override_the_internal_computation():
+    """None-means-compute is what keeps the backend call sites byte-compatible.
+
+    /recommend forwards the client's gap_ahead_s and mcp_tools substitutes its
+    own fallback; both must land unchanged even when rivals are present and the
+    internal computation would produce different numbers (1.8 / +0.4 here).
+    """
+    rs = build_race_state(_lap_state(), gap_ahead_s=7.7, pace_delta_s=-0.3)
+    assert rs.gap_ahead_s == 7.7
+    assert rs.pace_delta_s == -0.3
+
+
+@needs_models
+def test_rival_targeting_recomputes_both_values():
+    """#431: gap and pace framed around the chosen rival, not the car ahead."""
+    rs = build_race_state(_lap_state(), rival="LEC")
+    assert rs.gap_ahead_s == pytest.approx(2.4)
+    assert rs.pace_delta_s == pytest.approx(92.5 - 93.0)
+
+
+@needs_models
+def test_rival_absent_from_the_lap_falls_back_to_positional_values():
+    """A stale rival selection degrades to positional behaviour, never to zero."""
+    rs = build_race_state(_lap_state(), rival="XXX")
+    assert rs.gap_ahead_s == pytest.approx(1.8)
+    assert rs.pace_delta_s == pytest.approx(92.5 - 92.1)
+
+
+@needs_models
+def test_radio_and_rcm_parameters_land_on_the_state():
+    """The parameter shape is the surface-neutral one (F3 in the design gate)."""
+    radios = [{"lap": 30, "message": "box box"}]
+    rcms = [{"lap": 30, "category": "SafetyCar"}]
+    rs = build_race_state(_lap_state(), radio_msgs=radios, rcm_events=rcms)
+    assert rs.radio_msgs == radios
+    assert rs.rcm_events == rcms

--- a/tests/agents/test_tire_cumulative_deg.py
+++ b/tests/agents/test_tire_cumulative_deg.py
@@ -377,3 +377,109 @@ def test_the_reference_is_taken_from_the_stints_early_laps_and_not_from_all_of_t
     )
     assert tire_out.deg_cost_s is not None
     assert tire_out.deg_cost_s != 0.0
+
+
+# ===========================================================================
+# fresh-reference quality gate -- track_status_clean is dead on the shipping
+# path (a constant 0: N04's IsAccurate gate does not catch every neutralised
+# lap), so a Safety-Car- or red-flag-affected lap can land as the fresh
+# reference. Measured counter-example: Mexico City 2023 car 4, lap 36 reads
+# 137.8 s on a circuit whose green-flag pace is ~83 s, and every later lap in
+# that stint then priced tens of seconds "faster than fresh". Gating on
+# `lap_time_pct_of_race_fastest` -- already a TCN input feature, so no new
+# data is needed -- cuts the deg_cost_s error bound's mean absolute error from
+# 0.650 to 0.434 s/lap and its signed bias from +0.351 to +0.139 s/lap
+# (documents/audits/MEASURE_fresh_reference_quality_gate.md).
+
+
+class TestRejectContaminatedLaps:
+    """The gate as a pure function -- no model weights needed to test the threshold."""
+
+    def test_a_lap_at_the_races_fastest_pace_survives(self):
+        from src.agents.tire_agent import _reject_contaminated_laps
+
+        laps = pd.DataFrame({"LapTime_s": [85.0]})
+        kept = _reject_contaminated_laps(laps, fastest_lap_s=85.0, max_pct=1.10)
+
+        assert len(kept) == 1
+
+    def test_a_lap_exactly_at_the_threshold_survives(self):
+        """The gate is <=, not <, so the boundary itself is not rejected."""
+        from src.agents.tire_agent import _reject_contaminated_laps
+
+        laps = pd.DataFrame({"LapTime_s": [93.5]})  # 85.0 * 1.10
+
+        kept = _reject_contaminated_laps(laps, fastest_lap_s=85.0, max_pct=1.10)
+
+        assert len(kept) == 1
+
+    def test_a_safety_car_affected_lap_is_rejected(self):
+        """The measured counter-example, in ratio form: 137.757 / 81.372 = 1.693."""
+        from src.agents.tire_agent import _reject_contaminated_laps
+
+        laps = pd.DataFrame({"LapTime_s": [137.757]})
+
+        kept = _reject_contaminated_laps(laps, fastest_lap_s=81.372, max_pct=1.10)
+
+        assert len(kept) == 0
+
+    def test_only_the_contaminated_rows_are_dropped_from_a_mixed_stint(self):
+        laps = pd.DataFrame({"LapTime_s": [86.0, 150.0, 88.5], "TyreLife": [1.0, 2.0, 3.0]})
+        from src.agents.tire_agent import _reject_contaminated_laps
+
+        kept = _reject_contaminated_laps(laps, fastest_lap_s=85.0, max_pct=1.10)
+
+        assert kept["TyreLife"].tolist() == [1.0, 3.0]
+
+
+@pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="TireAgent() loads the compound bundles from data/models/tire_degradation/ (HF, not git)",
+)
+def test_a_stint_whose_only_candidate_lap_is_a_safety_car_lap_has_no_reference():
+    """The agent-level wiring: every candidate rejected must return None, never
+    fall back to the contaminated lap. A wrong reference is worse than none --
+    the same doctrine ``_referenced_wear`` already applies to a missing half."""
+    from src.agents.tire_agent import TireAgent
+
+    agent = TireAgent()
+    agent.laps_df = pd.DataFrame(
+        {
+            "Driver": ["NOR"],
+            "Compound": ["MEDIUM"],
+            "TyreLife": [2.0],
+            "LapNumber": [36.0],
+            "LapTime_s": [137.757],  # the measured Mexico City 2023 counter-example
+        }
+    )
+    agent.session_meta = {"fastest_lap_s": 81.372}
+
+    assert agent._fresh_reference("NOR", "C3") is None
+
+
+@pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="TireAgent() loads the compound bundles from data/models/tire_degradation/ (HF, not git)",
+)
+def test_the_gate_also_works_on_the_raw_fastf1_laptime_column():
+    """`_get_driver_stint` returns `self.laps_df` as-is, and the raw FastF1 `run()`
+    path carries `LapTime` (a Timedelta), not the featured parquet's `LapTime_s` --
+    `_add_timing_cols` is what creates it, and only inside `_build_stint_tensor`.
+    A gate that assumes `LapTime_s` already exists breaks every raw-FastF1 caller,
+    which is exactly the regression this test pins (caught by
+    tests/engine/test_engine_no_llm.py before this test existed)."""
+    from src.agents.tire_agent import TireAgent
+
+    agent = TireAgent()
+    agent.laps_df = pd.DataFrame(
+        {
+            "Driver": ["NOR"],
+            "Compound": ["MEDIUM"],
+            "TyreLife": [2.0],
+            "LapNumber": [36.0],
+            "LapTime": [pd.Timedelta(seconds=137.757)],
+        }
+    )
+    agent.session_meta = {"fastest_lap_s": 81.372}
+
+    assert agent._fresh_reference("NOR", "C3") is None

--- a/tests/agents/test_tire_cumulative_deg.py
+++ b/tests/agents/test_tire_cumulative_deg.py
@@ -44,10 +44,11 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from tests.conftest import HAS_TIRE_MODELS as _HAS_MODELS
+
 ROOT = Path(__file__).parent.parent.parent
 RACE_DIR = ROOT / "data" / "raw" / "2025" / "Lusail"
 FEATURED = ROOT / "data" / "processed" / "laps_featured_2025.parquet"
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
 _HAS_DATA = (RACE_DIR / "laps.parquet").exists() and FEATURED.exists()
 
 

--- a/tests/agents/test_tire_cumulative_deg.py
+++ b/tests/agents/test_tire_cumulative_deg.py
@@ -392,8 +392,15 @@ def test_the_reference_is_taken_from_the_stints_early_laps_and_not_from_all_of_t
 # (documents/audits/MEASURE_fresh_reference_quality_gate.md).
 
 
+@pytest.mark.skipif(
+    not _HAS_MODELS,
+    reason="_reject_contaminated_laps is logically pure, but it lives in tire_agent, "
+    "whose import builds TireAgentConfig() and reads data/models/tire_degradation/ "
+    "(HF, not git) -- the same constraint TestReferencedWear is already under.",
+)
 class TestRejectContaminatedLaps:
-    """The gate as a pure function -- no model weights needed to test the threshold."""
+    """The gate's threshold logic -- no model weights needed to EVALUATE it, but the
+    import that defines it needs them regardless (see the skip reason)."""
 
     def test_a_lap_at_the_races_fastest_pace_survives(self):
         from src.agents.tire_agent import _reject_contaminated_laps

--- a/tests/agents/test_tyre_stint_repair.py
+++ b/tests/agents/test_tyre_stint_repair.py
@@ -1,0 +1,307 @@
+"""#790 — the tyre-stint repair must fix broken races and leave healthy ones untouched.
+
+The second half of that sentence is the load-bearing one. A rebuilt ``TyreLife`` that is
+subtly wrong is worse than the NaN it replaces, because a NaN is visible in every
+downstream check and a plausible integer is not. So the first test here is not that the
+repair works — it is that the repair does nothing at all to data that was already right,
+including the two shapes that LOOK like corruption and are not.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from src.f1_strat_manager.tyre_stint_repair import (
+    find_misplaced_boundaries,
+    repair_tyre_stints,
+)
+
+
+def _laps(rows):
+    """Build a per-driver laps frame from (lap, stint, compound, tyre_life, pit_in)."""
+    return pd.DataFrame(
+        [
+            {
+                "Driver": "NOR",
+                "LapNumber": float(lap),
+                "Stint": stint,
+                "Compound": compound,
+                "TyreLife": tyre_life,
+                "PitInTime": pd.Timedelta(seconds=1) if pit_in else pd.NaT,
+                "Position": 1.0,
+            }
+            for lap, stint, compound, tyre_life, pit_in in rows
+        ]
+    )
+
+
+HEALTHY = _laps([
+    (1, 1.0, "MEDIUM", 1.0, False),
+    (2, 1.0, "MEDIUM", 2.0, False),
+    (3, 1.0, "MEDIUM", 3.0, True),    # pits here
+    (4, 2.0, "HARD", 1.0, False),     # new stint starts on the out-lap: correct
+    (5, 2.0, "HARD", 2.0, False),
+])
+
+# Monaco 2025 RUS's shape: a stop-and-go serves no tyres, so the stint correctly does not
+# advance, and a LATER real stop is what changes the compound.
+STOP_AND_GO_THEN_REAL_STOP = _laps([
+    (1, 2.0, "MEDIUM", 5.0, False),
+    (2, 2.0, "MEDIUM", 6.0, True),    # penalty served: no new set
+    (3, 2.0, "MEDIUM", 7.0, False),
+    (4, 2.0, "MEDIUM", 8.0, True),    # the real stop
+    (5, 3.0, "HARD", 1.0, False),
+])
+
+# A pit entry with no tyre change anywhere after it (a served penalty near race end).
+PENALTY_ONLY = _laps([
+    (1, 1.0, "HARD", 4.0, False),
+    (2, 1.0, "HARD", 5.0, True),
+    (3, 1.0, "HARD", 6.0, False),
+])
+
+# Miami 2025 NOR's shape: one stop on lap 3, but the metadata only starts stint 2 on
+# lap 6, so TyreLife counts through the stop and the new set's age is understated.
+MIAMI_SHAPE = _laps([
+    (1, 1.0, "MEDIUM", 1.0, False),
+    (2, 1.0, "MEDIUM", 2.0, False),
+    (3, 1.0, "MEDIUM", 3.0, True),    # real stop
+    (4, 1.0, "MEDIUM", 4.0, False),   # impossible: counting across the stop
+    (5, 1.0, "MEDIUM", 5.0, False),
+    (6, 2.0, "HARD", 1.0, False),     # boundary lands 3 laps late
+    (7, 2.0, "HARD", 2.0, False),
+])
+
+
+@pytest.mark.parametrize(
+    "frame, shape",
+    [
+        (HEALTHY, "a normal stop whose stint advances on the out-lap"),
+        (STOP_AND_GO_THEN_REAL_STOP, "a served stop-and-go followed by a real stop"),
+        (PENALTY_ONLY, "a pit entry with no tyre change at all"),
+    ],
+)
+def test_correct_data_is_returned_untouched(frame, shape):
+    """The safeguard: no healthy shape may be 'repaired'.
+
+    The two penalty shapes are here because they are the ones that superficially look
+    broken — the stint does not advance across a pit entry — and acting on that single
+    signal would rewrite a right answer into a wrong one.
+    """
+    repaired, report = repair_tyre_stints(frame)
+    pd.testing.assert_frame_equal(repaired, frame)
+    assert not report.changed_anything
+    assert report.boundaries_corrected == 0
+
+
+def test_a_served_penalty_is_not_a_misplaced_boundary():
+    assert find_misplaced_boundaries(STOP_AND_GO_THEN_REAL_STOP) == []
+    assert find_misplaced_boundaries(PENALTY_ONLY) == []
+
+
+def test_the_miami_shape_is_detected():
+    assert find_misplaced_boundaries(MIAMI_SHAPE) == [(3, 6)]
+
+
+def test_the_rebuilt_age_counts_from_the_out_lap_not_from_the_feed():
+    repaired, report = repair_tyre_stints(MIAMI_SHAPE)
+    by_lap = repaired.set_index("LapNumber")
+
+    # The out-lap is the new set's first lap.
+    assert by_lap.loc[4.0, "TyreLife"] == 1.0
+    assert by_lap.loc[5.0, "TyreLife"] == 2.0
+    # And the laps the feed mislabelled now continue that count instead of restarting.
+    assert by_lap.loc[6.0, "TyreLife"] == 3.0
+    assert by_lap.loc[7.0, "TyreLife"] == 4.0
+
+    assert report.boundaries_corrected == 1
+    assert report.changed_anything
+
+
+def test_the_impossible_count_across_the_stop_is_gone():
+    """Before: 3 -> 4 across a pit stop. After: the age must drop, not rise."""
+    before = MIAMI_SHAPE.set_index("LapNumber")["TyreLife"]
+    assert before.loc[4.0] > before.loc[3.0]
+
+    after = repair_tyre_stints(MIAMI_SHAPE)[0].set_index("LapNumber")["TyreLife"]
+    assert after.loc[4.0] < after.loc[3.0]
+
+
+def test_the_corrected_laps_take_the_new_compound():
+    repaired = repair_tyre_stints(MIAMI_SHAPE)[0].set_index("LapNumber")
+    assert repaired.loc[4.0, "Compound"] == "HARD"
+    assert repaired.loc[4.0, "Stint"] == 2.0
+    # The laps genuinely on the old set are left alone.
+    assert repaired.loc[3.0, "Compound"] == "MEDIUM"
+    assert repaired.loc[3.0, "Stint"] == 1.0
+
+
+def test_a_missing_first_stint_stays_unknown_on_the_FIRING_path():
+    """The repair must never invent a starting tyre age, even while it repairs elsewhere.
+
+    A car may start a stint on a used set and the offset varies per driver, so a first
+    stint with no metadata stays NaN. The fixture is deliberately one where the repair
+    DOES fire (a misplaced boundary at the stop): an earlier version of this test used a
+    frame the function never touched at all, so it passed without ever reaching the code
+    it claimed to pin — the project's recorded wrong-reason-green scar.
+    """
+    unknown_then_repairable = _laps([
+        (1, None, "nan", None, False),
+        (2, None, "nan", None, False),
+        (3, 1.0, "MEDIUM", 1.0, False),   # feed recovers mid-stint: age counts from zero
+        (4, 1.0, "MEDIUM", 2.0, True),    # real stop, on a now-known compound
+        (5, 1.0, "MEDIUM", 3.0, False),   # mislabelled: already the new set
+        (6, 2.0, "HARD", 1.0, False),     # boundary lands late
+    ])
+    repaired, report = repair_tyre_stints(unknown_then_repairable)
+    by_lap = repaired.set_index("LapNumber")
+
+    assert report.changed_anything, "the fixture must exercise the repairing path"
+    # Laps on the race-start set: their age was never published, so it stays unknown -
+    # including lap 3, where the feed offered a plausible 1.0 that is provably wrong.
+    assert pd.isna(by_lap.loc[1.0, "TyreLife"])
+    assert pd.isna(by_lap.loc[3.0, "TyreLife"])
+    assert pd.isna(by_lap.loc[4.0, "TyreLife"])
+    # The post-stop laps ARE recoverable and get counted from the out-lap.
+    assert by_lap.loc[5.0, "TyreLife"] == 1.0
+    assert by_lap.loc[6.0, "TyreLife"] == 2.0
+
+
+def test_a_stop_made_while_the_feed_is_dark_is_left_unknown_rather_than_guessed():
+    """The conservative edge: no real compound before the stop means no confirmed change.
+
+    A pit entry alone does not prove a tyre change (a served penalty is one too), and with
+    the pre-stop compound lost there is nothing left to confirm it with. So the fabricated
+    ages are nulled and nothing is rebuilt, rather than a stint being invented from a
+    stop that might have been a penalty. Miami 2025 BOR/STR/HAD have exactly this shape.
+    """
+    dark_at_the_stop = _laps([
+        (1, None, "nan", None, False),
+        (2, None, "nan", None, False),
+        (3, None, "nan", None, True),     # stop while the feed is dark
+        (4, None, "nan", None, False),
+        (5, 1.0, "HARD", 1.0, False),     # metadata reappears
+        (6, 1.0, "HARD", 2.0, False),
+    ])
+    repaired, report = repair_tyre_stints(dark_at_the_stop)
+
+    assert report.boundaries_corrected == 0, "nothing confirms a tyre change here"
+    assert repaired["TyreLife"].isna().all(), "plausible-but-unprovable ages become unknown"
+    assert report.fabricated_ages_nulled == 2
+
+
+# The feed going dark stringifies a missing compound rather than emitting NaN. Treating
+# that as "a different compound" would let data loss masquerade as a tyre change, and
+# writing it back would put a data-loss marker over a real compound (Montréal 2023 TSU).
+FEED_DIED_MID_STINT = _laps([
+    (1, 2.0, "HARD", 30.0, False),
+    (2, 2.0, "HARD", 31.0, True),
+    (3, 3.0, "None", None, False),
+    (4, 3.0, "None", None, False),
+])
+
+
+def test_a_data_loss_sentinel_is_not_a_compound_change():
+    assert find_misplaced_boundaries(FEED_DIED_MID_STINT) == []
+
+
+def test_a_real_compound_is_never_overwritten_by_a_sentinel():
+    repaired, _ = repair_tyre_stints(FEED_DIED_MID_STINT)
+    assert repaired.set_index("LapNumber").loc[2.0, "Compound"] == "HARD"
+
+
+# The feed invents a stint mid-race: metadata reappears on a lap that is NOT a pit
+# out-lap, so its ages count from the wrong zero. This driver never pits, which is why a
+# boundary correction alone cannot reach him (Miami 2025 GAS/HUL/BEA).
+FABRICATED_NO_STOP = _laps([
+    (1, None, "nan", None, False),
+    (2, None, "nan", None, False),
+    (3, 1.0, "MEDIUM", 1.0, False),   # a 3-lap-old set reported as 1 lap old
+    (4, 1.0, "MEDIUM", 2.0, False),
+])
+
+
+def test_fabricated_ages_are_nulled_even_without_a_pit_stop():
+    """The invisible half: a plausible integer that is provably too small becomes NaN."""
+    repaired, report = repair_tyre_stints(FABRICATED_NO_STOP)
+    ages = repaired.set_index("LapNumber")["TyreLife"]
+    assert ages.isna().all()
+    assert report.fabricated_ages_nulled == 2
+
+
+def test_a_used_set_keeps_its_prior_usage():
+    """FreshTyre is read, not assumed: a used set does not restart at 1.
+
+    Measured across every healthy stint transition in 2024/2025, a fresh set starts at
+    exactly 1.0 (1156/1156) while used sets start between 2 and 16. Hardcoding 1 would
+    silently invent for stints 2+ the very offset the module refuses to invent for
+    stint 1.
+    """
+    used_set = _laps([
+        (1, 1.0, "MEDIUM", 1.0, False),
+        (2, 1.0, "MEDIUM", 2.0, True),    # real stop
+        (3, 1.0, "MEDIUM", 3.0, False),   # mislabelled: already the new set
+        (4, 2.0, "HARD", 4.0, False),     # feed says the set arrived with 3 laps on it
+    ])
+    repaired, _ = repair_tyre_stints(used_set)
+    by_lap = repaired.set_index("LapNumber")
+    # Prior usage is 3 (published 4 minus the 1 it would carry if fresh), so the out-lap
+    # is 4 rather than 1 and the count continues from there.
+    assert by_lap.loc[3.0, "TyreLife"] == 4.0
+    assert by_lap.loc[4.0, "TyreLife"] == 5.0
+
+
+def test_a_nan_driver_row_is_not_annihilated():
+    """groupby drops NaN keys and reindex re-inserts them as all-NaN, destroying columns
+    this repair has no business touching. No shipped race carries one, but this runs on
+    every future download."""
+    frame = _laps([(1, 1.0, "MEDIUM", 1.0, False), (2, 1.0, "MEDIUM", 2.0, False)])
+    frame.loc[0, "Driver"] = None
+    repaired, _ = repair_tyre_stints(frame)
+    assert repaired.iloc[0]["LapNumber"] == 1.0
+    assert repaired.iloc[0]["Position"] == 1.0
+
+
+def test_a_frame_without_the_required_columns_degrades_quietly():
+    bare = pd.DataFrame({"Driver": ["NOR"], "LapNumber": [1.0]})
+    repaired, report = repair_tyre_stints(bare)
+    pd.testing.assert_frame_equal(repaired, bare)
+    assert not report.changed_anything
+
+
+def test_a_boundary_with_no_published_age_rebuilds_nothing():
+    """No anchor means no rebuild — counting from 1 would invent a fresh set.
+
+    The boundary lap here carries a real compound but a NaN TyreLife, so there is nothing
+    to subtract the prior usage from. An earlier version returned 0.0 in that case and
+    filled the laps with fabricated fresh-set ages, contradicting the module's own rule.
+    """
+    no_anchor = _laps([
+        (1, 1.0, "MEDIUM", 1.0, False),
+        (2, 1.0, "MEDIUM", 2.0, True),    # real stop
+        (3, 1.0, "MEDIUM", 3.0, False),
+        (4, 2.0, "HARD", None, False),    # boundary, but no published age
+    ])
+    repaired, report = repair_tyre_stints(no_anchor)
+    assert report.boundaries_corrected == 0
+    pd.testing.assert_frame_equal(repaired, no_anchor)
+
+
+def test_a_boundary_with_no_stint_id_does_not_half_apply():
+    """Either the whole correction lands, or none of it does.
+
+    Rewriting Compound and then bailing on a missing Stint would return a MUTATED frame
+    while reporting no change — and the caller uses that report to decide whether to
+    patch the featured frame, so raw and featured would end up disagreeing.
+    """
+    no_stint = _laps([
+        (1, 1.0, "MEDIUM", 1.0, False),
+        (2, 1.0, "MEDIUM", 2.0, True),
+        (3, 1.0, "MEDIUM", 3.0, False),
+        (4, None, "HARD", 4.0, False),    # boundary compound is real, Stint is not
+    ])
+    repaired, report = repair_tyre_stints(no_stint)
+    assert not report.changed_anything
+    # Reported no change, so there must BE no change.
+    pd.testing.assert_frame_equal(repaired, no_stint)

--- a/tests/agents/test_tyre_stint_repair.py
+++ b/tests/agents/test_tyre_stint_repair.py
@@ -36,42 +36,50 @@ def _laps(rows):
     )
 
 
-HEALTHY = _laps([
-    (1, 1.0, "MEDIUM", 1.0, False),
-    (2, 1.0, "MEDIUM", 2.0, False),
-    (3, 1.0, "MEDIUM", 3.0, True),    # pits here
-    (4, 2.0, "HARD", 1.0, False),     # new stint starts on the out-lap: correct
-    (5, 2.0, "HARD", 2.0, False),
-])
+HEALTHY = _laps(
+    [
+        (1, 1.0, "MEDIUM", 1.0, False),
+        (2, 1.0, "MEDIUM", 2.0, False),
+        (3, 1.0, "MEDIUM", 3.0, True),  # pits here
+        (4, 2.0, "HARD", 1.0, False),  # new stint starts on the out-lap: correct
+        (5, 2.0, "HARD", 2.0, False),
+    ]
+)
 
 # Monaco 2025 RUS's shape: a stop-and-go serves no tyres, so the stint correctly does not
 # advance, and a LATER real stop is what changes the compound.
-STOP_AND_GO_THEN_REAL_STOP = _laps([
-    (1, 2.0, "MEDIUM", 5.0, False),
-    (2, 2.0, "MEDIUM", 6.0, True),    # penalty served: no new set
-    (3, 2.0, "MEDIUM", 7.0, False),
-    (4, 2.0, "MEDIUM", 8.0, True),    # the real stop
-    (5, 3.0, "HARD", 1.0, False),
-])
+STOP_AND_GO_THEN_REAL_STOP = _laps(
+    [
+        (1, 2.0, "MEDIUM", 5.0, False),
+        (2, 2.0, "MEDIUM", 6.0, True),  # penalty served: no new set
+        (3, 2.0, "MEDIUM", 7.0, False),
+        (4, 2.0, "MEDIUM", 8.0, True),  # the real stop
+        (5, 3.0, "HARD", 1.0, False),
+    ]
+)
 
 # A pit entry with no tyre change anywhere after it (a served penalty near race end).
-PENALTY_ONLY = _laps([
-    (1, 1.0, "HARD", 4.0, False),
-    (2, 1.0, "HARD", 5.0, True),
-    (3, 1.0, "HARD", 6.0, False),
-])
+PENALTY_ONLY = _laps(
+    [
+        (1, 1.0, "HARD", 4.0, False),
+        (2, 1.0, "HARD", 5.0, True),
+        (3, 1.0, "HARD", 6.0, False),
+    ]
+)
 
 # Miami 2025 NOR's shape: one stop on lap 3, but the metadata only starts stint 2 on
 # lap 6, so TyreLife counts through the stop and the new set's age is understated.
-MIAMI_SHAPE = _laps([
-    (1, 1.0, "MEDIUM", 1.0, False),
-    (2, 1.0, "MEDIUM", 2.0, False),
-    (3, 1.0, "MEDIUM", 3.0, True),    # real stop
-    (4, 1.0, "MEDIUM", 4.0, False),   # impossible: counting across the stop
-    (5, 1.0, "MEDIUM", 5.0, False),
-    (6, 2.0, "HARD", 1.0, False),     # boundary lands 3 laps late
-    (7, 2.0, "HARD", 2.0, False),
-])
+MIAMI_SHAPE = _laps(
+    [
+        (1, 1.0, "MEDIUM", 1.0, False),
+        (2, 1.0, "MEDIUM", 2.0, False),
+        (3, 1.0, "MEDIUM", 3.0, True),  # real stop
+        (4, 1.0, "MEDIUM", 4.0, False),  # impossible: counting across the stop
+        (5, 1.0, "MEDIUM", 5.0, False),
+        (6, 2.0, "HARD", 1.0, False),  # boundary lands 3 laps late
+        (7, 2.0, "HARD", 2.0, False),
+    ]
+)
 
 
 @pytest.mark.parametrize(
@@ -146,14 +154,16 @@ def test_a_missing_first_stint_stays_unknown_on_the_FIRING_path():
     frame the function never touched at all, so it passed without ever reaching the code
     it claimed to pin — the project's recorded wrong-reason-green scar.
     """
-    unknown_then_repairable = _laps([
-        (1, None, "nan", None, False),
-        (2, None, "nan", None, False),
-        (3, 1.0, "MEDIUM", 1.0, False),   # feed recovers mid-stint: age counts from zero
-        (4, 1.0, "MEDIUM", 2.0, True),    # real stop, on a now-known compound
-        (5, 1.0, "MEDIUM", 3.0, False),   # mislabelled: already the new set
-        (6, 2.0, "HARD", 1.0, False),     # boundary lands late
-    ])
+    unknown_then_repairable = _laps(
+        [
+            (1, None, "nan", None, False),
+            (2, None, "nan", None, False),
+            (3, 1.0, "MEDIUM", 1.0, False),  # feed recovers mid-stint: age counts from zero
+            (4, 1.0, "MEDIUM", 2.0, True),  # real stop, on a now-known compound
+            (5, 1.0, "MEDIUM", 3.0, False),  # mislabelled: already the new set
+            (6, 2.0, "HARD", 1.0, False),  # boundary lands late
+        ]
+    )
     repaired, report = repair_tyre_stints(unknown_then_repairable)
     by_lap = repaired.set_index("LapNumber")
 
@@ -176,14 +186,16 @@ def test_a_stop_made_while_the_feed_is_dark_is_left_unknown_rather_than_guessed(
     ages are nulled and nothing is rebuilt, rather than a stint being invented from a
     stop that might have been a penalty. Miami 2025 BOR/STR/HAD have exactly this shape.
     """
-    dark_at_the_stop = _laps([
-        (1, None, "nan", None, False),
-        (2, None, "nan", None, False),
-        (3, None, "nan", None, True),     # stop while the feed is dark
-        (4, None, "nan", None, False),
-        (5, 1.0, "HARD", 1.0, False),     # metadata reappears
-        (6, 1.0, "HARD", 2.0, False),
-    ])
+    dark_at_the_stop = _laps(
+        [
+            (1, None, "nan", None, False),
+            (2, None, "nan", None, False),
+            (3, None, "nan", None, True),  # stop while the feed is dark
+            (4, None, "nan", None, False),
+            (5, 1.0, "HARD", 1.0, False),  # metadata reappears
+            (6, 1.0, "HARD", 2.0, False),
+        ]
+    )
     repaired, report = repair_tyre_stints(dark_at_the_stop)
 
     assert report.boundaries_corrected == 0, "nothing confirms a tyre change here"
@@ -194,12 +206,14 @@ def test_a_stop_made_while_the_feed_is_dark_is_left_unknown_rather_than_guessed(
 # The feed going dark stringifies a missing compound rather than emitting NaN. Treating
 # that as "a different compound" would let data loss masquerade as a tyre change, and
 # writing it back would put a data-loss marker over a real compound (Montréal 2023 TSU).
-FEED_DIED_MID_STINT = _laps([
-    (1, 2.0, "HARD", 30.0, False),
-    (2, 2.0, "HARD", 31.0, True),
-    (3, 3.0, "None", None, False),
-    (4, 3.0, "None", None, False),
-])
+FEED_DIED_MID_STINT = _laps(
+    [
+        (1, 2.0, "HARD", 30.0, False),
+        (2, 2.0, "HARD", 31.0, True),
+        (3, 3.0, "None", None, False),
+        (4, 3.0, "None", None, False),
+    ]
+)
 
 
 def test_a_data_loss_sentinel_is_not_a_compound_change():
@@ -214,12 +228,14 @@ def test_a_real_compound_is_never_overwritten_by_a_sentinel():
 # The feed invents a stint mid-race: metadata reappears on a lap that is NOT a pit
 # out-lap, so its ages count from the wrong zero. This driver never pits, which is why a
 # boundary correction alone cannot reach him (Miami 2025 GAS/HUL/BEA).
-FABRICATED_NO_STOP = _laps([
-    (1, None, "nan", None, False),
-    (2, None, "nan", None, False),
-    (3, 1.0, "MEDIUM", 1.0, False),   # a 3-lap-old set reported as 1 lap old
-    (4, 1.0, "MEDIUM", 2.0, False),
-])
+FABRICATED_NO_STOP = _laps(
+    [
+        (1, None, "nan", None, False),
+        (2, None, "nan", None, False),
+        (3, 1.0, "MEDIUM", 1.0, False),  # a 3-lap-old set reported as 1 lap old
+        (4, 1.0, "MEDIUM", 2.0, False),
+    ]
+)
 
 
 def test_fabricated_ages_are_nulled_even_without_a_pit_stop():
@@ -238,12 +254,14 @@ def test_a_used_set_keeps_its_prior_usage():
     silently invent for stints 2+ the very offset the module refuses to invent for
     stint 1.
     """
-    used_set = _laps([
-        (1, 1.0, "MEDIUM", 1.0, False),
-        (2, 1.0, "MEDIUM", 2.0, True),    # real stop
-        (3, 1.0, "MEDIUM", 3.0, False),   # mislabelled: already the new set
-        (4, 2.0, "HARD", 4.0, False),     # feed says the set arrived with 3 laps on it
-    ])
+    used_set = _laps(
+        [
+            (1, 1.0, "MEDIUM", 1.0, False),
+            (2, 1.0, "MEDIUM", 2.0, True),  # real stop
+            (3, 1.0, "MEDIUM", 3.0, False),  # mislabelled: already the new set
+            (4, 2.0, "HARD", 4.0, False),  # feed says the set arrived with 3 laps on it
+        ]
+    )
     repaired, _ = repair_tyre_stints(used_set)
     by_lap = repaired.set_index("LapNumber")
     # Prior usage is 3 (published 4 minus the 1 it would carry if fresh), so the out-lap
@@ -277,12 +295,14 @@ def test_a_boundary_with_no_published_age_rebuilds_nothing():
     to subtract the prior usage from. An earlier version returned 0.0 in that case and
     filled the laps with fabricated fresh-set ages, contradicting the module's own rule.
     """
-    no_anchor = _laps([
-        (1, 1.0, "MEDIUM", 1.0, False),
-        (2, 1.0, "MEDIUM", 2.0, True),    # real stop
-        (3, 1.0, "MEDIUM", 3.0, False),
-        (4, 2.0, "HARD", None, False),    # boundary, but no published age
-    ])
+    no_anchor = _laps(
+        [
+            (1, 1.0, "MEDIUM", 1.0, False),
+            (2, 1.0, "MEDIUM", 2.0, True),  # real stop
+            (3, 1.0, "MEDIUM", 3.0, False),
+            (4, 2.0, "HARD", None, False),  # boundary, but no published age
+        ]
+    )
     repaired, report = repair_tyre_stints(no_anchor)
     assert report.boundaries_corrected == 0
     pd.testing.assert_frame_equal(repaired, no_anchor)
@@ -295,12 +315,14 @@ def test_a_boundary_with_no_stint_id_does_not_half_apply():
     while reporting no change — and the caller uses that report to decide whether to
     patch the featured frame, so raw and featured would end up disagreeing.
     """
-    no_stint = _laps([
-        (1, 1.0, "MEDIUM", 1.0, False),
-        (2, 1.0, "MEDIUM", 2.0, True),
-        (3, 1.0, "MEDIUM", 3.0, False),
-        (4, None, "HARD", 4.0, False),    # boundary compound is real, Stint is not
-    ])
+    no_stint = _laps(
+        [
+            (1, 1.0, "MEDIUM", 1.0, False),
+            (2, 1.0, "MEDIUM", 2.0, True),
+            (3, 1.0, "MEDIUM", 3.0, False),
+            (4, None, "HARD", 4.0, False),  # boundary compound is real, Stint is not
+        ]
+    )
     repaired, report = repair_tyre_stints(no_stint)
     assert not report.changed_anything
     # Reported no change, so there must BE no change.

--- a/tests/agents/test_weather_reading_guard.py
+++ b/tests/agents/test_weather_reading_guard.py
@@ -1,0 +1,78 @@
+"""#788 — the present-``None`` guard on the agents' raw-lap_state weather reads.
+
+The canonical builder (#784) protects the ``RaceState``. These tests protect the layer
+BELOW it: the agents that re-read the raw ``lap_state`` dict and build their own
+``session_meta`` from it. That distinction is the whole reason these tests exist —
+#788 was declared fixed once when only the builder had been fixed, and an adversarial
+gate found ``/recommend`` still returning 422 because the crash had simply moved down
+here.
+
+The producers emit an unmeasured reading as the key PRESENT holding ``None``
+(``_safe_none`` in the telemetry backend, ``get_weather_state`` in the RSM), which is
+exactly what ``dict.get(key, default)`` does not catch. Every 2025 laps parquet ships
+without weather columns, so this is the shape those agents actually receive today.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from src.agents._shared_defaults import reading_or_default
+
+# The dict the backend producer really emits for a 2025 lap, verified over real HTTP
+# (documents/audits/GATE_qatar_lap7_cross_surface.md, Task 2).
+PRODUCER_WEATHER_2025 = {
+    "air_temp": None,
+    "track_temp": None,
+    "track_temp_start": None,
+    "humidity": None,
+    "rainfall": 0,
+}
+
+
+def test_present_none_falls_back_where_two_arg_get_does_not():
+    """The bug in one assertion: .get's default does not fire, the helper's does."""
+    assert PRODUCER_WEATHER_2025.get("air_temp", 28.0) is None
+    assert reading_or_default(PRODUCER_WEATHER_2025, "air_temp", 28.0) == 28.0
+
+
+def test_absent_key_also_falls_back():
+    assert reading_or_default({}, "track_temp", 38.0) == 38.0
+
+
+@pytest.mark.parametrize("value", [0.0, 0, False])
+def test_a_legitimate_falsy_reading_survives(value):
+    """Not an ``or`` fallback: a real 0.0 is a measurement, not an absence.
+
+    Rewriting 0.0 to a default is the #633 conflation — a different bug, and the one
+    an ``or`` would have introduced here.
+    """
+    assert reading_or_default({"track_temp": value}, "track_temp", 38.0) == value
+
+
+def test_a_real_reading_passes_through():
+    assert reading_or_default({"air_temp": 23.4}, "air_temp", 28.0) == 23.4
+
+
+def test_the_three_agents_agree_on_this_read():
+    """All three sub-agents route this read through one implementation (#788).
+
+    They keep DIFFERENT default temperatures on purpose — pace 25/35, tire and
+    race_situation 28/38 — because reconciling those numbers is a modelling decision
+    tracked in #789. What must not differ again is the None handling: pace was the only
+    one of the three that had it right, and its guard is now the shared helper.
+    """
+    for default in (25.0, 28.0, 35.0, 38.0):
+        assert reading_or_default(PRODUCER_WEATHER_2025, "track_temp", default) == default
+
+
+def test_the_producer_shape_never_reaches_float_as_none():
+    """float() over every weather key of a real producer payload must not raise.
+
+    ``float(None)`` is the exact TypeError that 422'd /recommend on every 2025 lap.
+    """
+    for key, default in (("air_temp", 28.0), ("track_temp", 38.0), ("humidity", 50.0)):
+        value = float(reading_or_default(PRODUCER_WEATHER_2025, key, default))
+        assert math.isfinite(value)

--- a/tests/agents/test_weather_restore.py
+++ b/tests/agents/test_weather_restore.py
@@ -1,0 +1,185 @@
+"""#782 — the weather restore must reproduce N04, not improve on it.
+
+The models were trained on whatever N04's merge produced. A "better" alignment here would
+feed 2025 weather on a different basis than the training data — a silent distribution
+shift wearing a fix's clothes. So the load-bearing test is not that weather appears; it is
+that the same method reproduces the seasons where the published truth still exists.
+
+Two checks, and they see different things. The pace holdout in `tests/eval/` reproduces
+its published MAE of 0.4104 to within 0.0007, which proves the VALUES are right at the
+distribution level -- all-NaN weather moves that MAE by 0.26. It does NOT see the
+alignment: a wrong backward join moves it by only 0.0003 and still passes. The last test
+in this file closes that, by comparing against N04's own published 2025 output.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.f1_strat_manager.weather_restore import (
+    WEATHER_COLUMNS,
+    normalise_rainfall,
+    weather_for_race,
+)
+
+ROOT = Path(__file__).parent.parent.parent
+
+
+def _weather(samples):
+    """A weather.parquet shape: (session seconds, air, track, humidity, rainfall)."""
+    return pd.DataFrame(
+        [
+            {
+                "Time": pd.Timedelta(seconds=t),
+                "AirTemp": air,
+                "TrackTemp": track,
+                "Humidity": hum,
+                "Rainfall": rain,
+            }
+            for t, air, track, hum, rain in samples
+        ]
+    )
+
+
+def _laps(times):
+    """A raw laps shape: one row per lap, carrying the session-elapsed Time."""
+    return pd.DataFrame(
+        {
+            "Driver": ["NOR"] * len(times),
+            "LapNumber": [float(i + 1) for i in range(len(times))],
+            "Time": [pd.Timedelta(seconds=t) for t in times],
+        }
+    )
+
+
+def test_each_lap_takes_its_nearest_sample_not_the_preceding_one():
+    """N04 joins with direction='nearest'. A backward join would shift every reading.
+
+    The lap at 100 s sits between samples at 60 s and 120 s and is closer to the later
+    one, so 'nearest' gives 30.0 where 'backward' would give 20.0.
+    """
+    weather = _weather([(0, 10.0, 20.0, 50.0, False), (120, 15.0, 30.0, 60.0, False)])
+    laps = _laps([100])
+    aligned = weather_for_race(laps, weather)
+    assert aligned["TrackTemp"].iloc[0] == 30.0
+    assert aligned["AirTemp"].iloc[0] == 15.0
+
+
+def test_laps_keep_their_own_index_after_the_time_sort():
+    """merge_asof requires both sides sorted and does not preserve the index.
+
+    Reattaching it wrong would scramble weather across drivers — every lap would get
+    somebody else's reading, silently and plausibly.
+    """
+    weather = _weather([(0, 10.0, 20.0, 50.0, False), (100, 99.0, 88.0, 77.0, False)])
+    laps = _laps([100, 0])  # deliberately out of time order
+    aligned = weather_for_race(laps, weather)
+    assert aligned.index.equals(laps.index)
+    assert aligned["TrackTemp"].iloc[0] == 88.0  # lap 1 is at t=100
+    assert aligned["TrackTemp"].iloc[1] == 20.0  # lap 2 is at t=0
+
+
+def test_a_race_with_no_weather_samples_yields_all_unknown():
+    aligned = weather_for_race(_laps([0, 60]), _weather([]))
+    assert aligned[list(WEATHER_COLUMNS)].isna().all().all()
+
+
+def test_a_lap_with_no_session_time_stays_unknown():
+    laps = _laps([0, 60])
+    laps.loc[1, "Time"] = pd.NaT
+    aligned = weather_for_race(laps, _weather([(0, 10.0, 20.0, 50.0, False)]))
+    assert aligned["TrackTemp"].iloc[0] == 20.0
+    assert pd.isna(aligned["TrackTemp"].iloc[1])
+
+
+def test_rainfall_becomes_N04s_integer_flag():
+    """N04's closing step: absent rainfall means dry, and the flag is an int not a bool."""
+    frame = pd.DataFrame({"Rainfall": [True, False, None]})
+    result = normalise_rainfall(frame)
+    assert result["Rainfall"].tolist() == [1, 0, 0]
+    assert result["Rainfall"].dtype.kind == "i"
+
+
+def test_rainfall_is_filled_per_season_not_per_race():
+    """A frame without the column is returned untouched rather than gaining a fake one.
+
+    The fill runs once over the season, as N04 does it: filling per race would give a
+    race with no weather parquet a confident 0 (dry) instead of an honest gap.
+    """
+    frame = pd.DataFrame({"AirTemp": [20.0]})
+    pd.testing.assert_frame_equal(normalise_rainfall(frame), frame)
+
+
+# ---------------------------------------------------------------------------
+# The real safeguard: N04's own 2025 output is on disk, so the restore is
+# checkable against ground truth rather than against its own reasoning.
+# ---------------------------------------------------------------------------
+
+_COMBINED = ROOT / "data" / "processed" / "laps_featured.parquet"
+_PER_YEAR_2025 = ROOT / "data" / "processed" / "laps_featured_2025.parquet"
+
+needs_artefacts = pytest.mark.skipif(
+    not (_COMBINED.exists() and _PER_YEAR_2025.exists()),
+    reason="featured laps artefacts absent (CI runner without data)",
+)
+
+
+@needs_artefacts
+def test_the_restore_reproduces_N04s_own_2025_output_exactly():
+    """The check the module's docstring promises, against real published values.
+
+    `laps_featured.parquet` (the combined 2023-2025 artefact) carries the four weather
+    columns for 2025 — N04's actual output was published all along, and only the per-year
+    split dropped them. So the restore can be compared against ground truth rather than
+    against its own reasoning.
+
+    This is the test the pace-MAE reproduction CANNOT replace: an adversarial gate showed
+    a wrong `direction='backward'` join changes 7,014 TrackTemp cells and still reproduces
+    the published MAE to within 0.0003. The MAE sees the distribution, not the alignment.
+    This sees the alignment.
+    """
+    from src.f1_strat_manager.laps_augment import augment_featured_laps
+
+    restored = augment_featured_laps(pd.read_parquet(_PER_YEAR_2025), 2025)
+    truth = pd.read_parquet(_COMBINED)
+    truth = truth[truth["Year"] == 2025]
+
+    # The per-year and combined artefacts disagree on one circuit's name.
+    truth = truth.assign(GP_Name=truth["GP_Name"].replace({"Miami Gardens": "Miami"}))
+
+    keys = ["GP_Name", "Driver", "LapNumber"]
+    joined = restored[[*keys, *WEATHER_COLUMNS]].merge(
+        truth[[*keys, *WEATHER_COLUMNS]], on=keys, suffixes=("_mine", "_n04")
+    )
+    assert len(joined) == len(restored), "every restored lap must find its published twin"
+
+    for column in WEATHER_COLUMNS:
+        mine, published = joined[f"{column}_mine"], joined[f"{column}_n04"]
+        both_absent = mine.isna() & published.isna()
+        identical = (mine.astype("float64") - published.astype("float64")).abs() < 1e-9
+        mismatched = int((~(both_absent | identical)).sum())
+        assert mismatched == 0, f"{column}: {mismatched} of {len(joined)} laps disagree with N04"
+
+
+@needs_artefacts
+def test_a_partial_weather_set_is_declined_rather_than_merged_into_suffix_columns():
+    """A frame carrying SOME of the four must not be half-restored.
+
+    With an `all(...)` guard the per-race slice carries all four names and the left-merge
+    collides with the ones already present: `TrackTemp` is replaced by a
+    `TrackTemp_x`/`TrackTemp_y` pair that every consumer selecting the plain name then
+    fails to find. Declining is the safe answer, and it is what the `any(...)` guard does.
+    """
+    from src.f1_strat_manager.laps_augment import augment_featured_laps
+
+    partial = pd.read_parquet(_PER_YEAR_2025)
+    partial = partial.assign(AirTemp=20.0)  # one of four present, three missing
+
+    result = augment_featured_laps(partial, 2025)
+
+    assert not [c for c in result.columns if c.endswith(("_x", "_y"))]
+    assert "TrackTemp" not in result.columns, "declined, not half-merged"
+    assert (result["AirTemp"] == 20.0).all(), "the column it did carry is untouched"

--- a/tests/audit/test_engine_scope_defaults.py
+++ b/tests/audit/test_engine_scope_defaults.py
@@ -27,12 +27,9 @@ from typing import Any
 import pandas as pd
 import pytest
 
+from tests.conftest import skip_no_tire_models as _skip_no_models
+
 ROOT = Path(__file__).parent.parent.parent
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
-_skip_no_models = pytest.mark.skipif(
-    not _HAS_MODELS,
-    reason="data/models/ not present (CI runner without model weights)",
-)
 
 _PARQUET = ROOT / "data" / "processed" / "laps_featured_2025.parquet"
 _skip_no_parquet = pytest.mark.skipif(

--- a/tests/audit/test_pace_orchestrator_hardening.py
+++ b/tests/audit/test_pace_orchestrator_hardening.py
@@ -1,6 +1,6 @@
 """Hardening tests for the pace agent, RaceStateManager, and strategy orchestrator —
-#435 (pace self-fulfilling prev_lap_time), #476 (unvalidated predict_pace_tool LLM
-input), and #433 (unvalidated expected_stint_end LLM free text).
+#435 (pace self-fulfilling prev_lap_time) and #433 (unvalidated expected_stint_end
+LLM free text).
 
 Doctrine: no-LLM assertions only.
 
@@ -8,12 +8,18 @@ Doctrine: no-LLM assertions only.
   parquet, merged with ``Prev_LapTime`` from the real featured parquet (the same
   join ``src/f1_strat_manager/laps_augment.py`` performs in the opposite direction),
   and reads the real dataclass method — no mocks, no LLM.
-- The #476 section calls ``PaceAgent.run()`` (the real N06 XGBoost model) through
-  ``predict_pace_tool.invoke()`` directly — deterministic inference, never a
-  LangGraph ReAct loop or a live LLM client.
 - The #433 section calls the pure ``_clamp_expected_stint_end`` helper directly
   (never a live orchestrator), but skips when ``data/`` is absent: importing
   ``strategy_orchestrator`` instantiates the tire agent, which loads model files.
+
+#476 (unvalidated ``predict_pace_tool`` LLM input) used to have its own section
+here, testing ``PaceAgent._validate_pace_inputs`` through ``predict_pace_tool.invoke()``.
+Both the tool and the validator were deleted by #781: pace_agent's LangGraph ReAct
+scaffold was formally retired (#778/#780) because it was never wired to anything —
+``run()``/``run_from_state()`` always called the XGBoost model directly. With no LLM
+caller left for pace, the class of bug #476 fixed (an LLM inventing a driver number
+or an out-of-range lap) cannot occur for this agent anymore, so the guard and its
+tests were removed together rather than left testing dead code.
 """
 
 from __future__ import annotations
@@ -30,15 +36,6 @@ RAW_LUSAIL = ROOT / "data" / "raw" / "2025" / "Lusail" / "laps.parquet"
 FEATURED_2025 = ROOT / "data" / "processed" / "laps_featured_2025.parquet"
 
 _HAS_RSM_DATA = RAW_LUSAIL.exists() and FEATURED_2025.exists()
-
-_HAS_PACE_MODEL = (
-    (ROOT / "data" / "models" / "lap_time" / "xgb_laptime_delta_final.json").exists()
-    and (ROOT / "data" / "processed" / "feature_manifest_laptime.json").exists()
-    and (
-        ROOT / "data" / "processed" / "circuit_clustering" / "circuit_clusters_k4_2025.parquet"
-    ).exists()
-    and FEATURED_2025.exists()
-)
 
 
 # =============================================================================
@@ -115,116 +112,6 @@ def test_prev_lap_time_matches_the_real_prev_laptime_and_differs_from_current(
 
     assert driver["prev_lap_time"] == pytest.approx(float(row["Prev_LapTime"]), abs=1e-6)
     assert driver["prev_lap_time"] != driver["lap_time_s"]
-
-
-# =============================================================================
-# #476 — predict_pace_tool must refuse an off-roster driver number or an
-# out-of-range lap instead of predicting from data that cannot exist.
-# =============================================================================
-
-
-@pytest.fixture(scope="module")
-def pace_agent_and_valid_driver():
-    """The real, singleton PaceAgent plus a genuinely-on-track Lusail 2025 car
-    number, discovered from the agent's own loaded reference data rather than
-    guessed — so the "still works for a real driver" control case cannot
-    accidentally be wrong about who was racing.
-    """
-    if not _HAS_PACE_MODEL:
-        pytest.skip(
-            "needs data/models/lap_time/, data/processed/feature_manifest_laptime.json, "
-            "data/processed/circuit_clustering/circuit_clusters_k4_2025.parquet and "
-            "data/processed/laps_featured_2025.parquet (data/ comes from HF, not git)"
-        )
-
-    from src.agents.pace_agent import _get_default_pace_agent
-
-    agent = _get_default_pace_agent()
-    ref = agent.laps_ref
-    lusail_2025 = ref[(ref["GP_Name"] == "Lusail") & (ref["Year"] == 2025)]
-    valid_numbers = lusail_2025["DriverNumber"].dropna().astype(int)
-    if valid_numbers.empty:
-        pytest.skip("no DriverNumber found for Lusail 2025 in laps_ref")
-    return agent, int(valid_numbers.iloc[0])
-
-
-def _pace_tool_kwargs(**overrides) -> dict:
-    """Base kwargs for predict_pace_tool.invoke() — all 19 params, overridable.
-
-    Values are plausible but not required to be exact: everything except
-    driver_number/lap_number/gp_name/year/total_laps degrades gracefully
-    (unknown team/compound fall back to encoding defaults), so the guard under
-    test is isolated from the rest of the feature row.
-    """
-    kwargs = dict(
-        driver_number=1,
-        lap_number=10,
-        stint=1,
-        tyre_life=5,
-        compound="MEDIUM",
-        position=5,
-        team="Red Bull Racing",
-        laps_since_pit=5,
-        fuel_load=0.8,
-        year=2025,
-        prev_lap_time=85.0,
-        prev_tyre_life=4,
-        prev_speed_st=320.0,
-        air_temp=28.0,
-        track_temp=38.0,
-        humidity=50.0,
-        rainfall=False,
-        total_laps=57,
-        gp_name="Lusail",
-    )
-    kwargs.update(overrides)
-    return kwargs
-
-
-def test_predict_pace_tool_refuses_a_driver_not_on_track(pace_agent_and_valid_driver):
-    """#476: an invented car number for a real GP/year must error, not predict."""
-    from src.agents.pace_agent import predict_pace_tool
-
-    _agent, _valid_number = pace_agent_and_valid_driver
-    off_roster_number = -999  # no real car has ever carried this number
-
-    result = predict_pace_tool.invoke(_pace_tool_kwargs(driver_number=off_roster_number))
-
-    assert "error" in result, f"expected a refusal, got: {result}"
-    assert "REFUSED" in result["error"]
-    assert str(off_roster_number) in result["error"]
-
-
-def test_predict_pace_tool_refuses_an_out_of_range_lap(pace_agent_and_valid_driver):
-    """#476: a lap far beyond total_laps must error, not predict."""
-    from src.agents.pace_agent import predict_pace_tool
-
-    _agent, valid_number = pace_agent_and_valid_driver
-
-    result = predict_pace_tool.invoke(
-        _pace_tool_kwargs(driver_number=valid_number, lap_number=9999, total_laps=57)
-    )
-
-    assert "error" in result, f"expected a refusal, got: {result}"
-    assert "REFUSED" in result["error"]
-
-
-def test_predict_pace_tool_still_computes_for_a_real_driver_in_range(
-    pace_agent_and_valid_driver,
-):
-    """The guard must not buy safety by refusing everyone — a real, in-range
-    driver number must still run inference and return a prediction.
-    """
-    from src.agents.pace_agent import predict_pace_tool
-
-    _agent, valid_number = pace_agent_and_valid_driver
-
-    result = predict_pace_tool.invoke(
-        _pace_tool_kwargs(driver_number=valid_number, lap_number=10, total_laps=57)
-    )
-
-    assert "error" not in result, f"a live, in-range driver was refused: {result}"
-    assert "lap_time_pred" in result
 
 
 # =============================================================================

--- a/tests/audit/test_pace_orchestrator_hardening.py
+++ b/tests/audit/test_pace_orchestrator_hardening.py
@@ -23,6 +23,8 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from tests.conftest import HAS_TIRE_MODELS
+
 ROOT = Path(__file__).parent.parent.parent
 RAW_LUSAIL = ROOT / "data" / "raw" / "2025" / "Lusail" / "laps.parquet"
 FEATURED_2025 = ROOT / "data" / "processed" / "laps_featured_2025.parquet"
@@ -244,8 +246,7 @@ def clamp_fn():
     a bare checkout (data/ comes from HF Hub). Skip rather than fail there, like every
     other data-dependent test in this suite; the pure clamp still runs locally.
     """
-    routing_cfg = ROOT / "data" / "models" / "tire_degradation" / "routing_config.json"
-    if not routing_cfg.exists():
+    if not HAS_TIRE_MODELS:
         pytest.skip(
             "importing strategy_orchestrator instantiates the tire agent, which needs "
             "data/models/tire_degradation/ (data/ comes from HF, not git)"

--- a/tests/audit/test_tire_agent_hardening.py
+++ b/tests/audit/test_tire_agent_hardening.py
@@ -31,9 +31,10 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from tests.conftest import HAS_TIRE_MODELS as _HAS_MODELS
+
 ROOT = Path(__file__).parent.parent.parent
 RACE_DIR = ROOT / "data" / "raw" / "2024" / "Austin"
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
 _HAS_RACE_DATA = (RACE_DIR / "laps.parquet").exists()
 
 # TireAgent() loads the TCN bundles at __init__ time, and the fixture below

--- a/tests/audit/test_tire_mc_determinism.py
+++ b/tests/audit/test_tire_mc_determinism.py
@@ -42,10 +42,11 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from tests.conftest import HAS_TIRE_MODELS as _HAS_MODELS
+
 ROOT = Path(__file__).parent.parent.parent
 RACE_DIR = ROOT / "data" / "raw" / "2025" / "Lusail"
 FEATURED = ROOT / "data" / "processed" / "laps_featured_2025.parquet"
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
 _HAS_DATA = (RACE_DIR / "laps.parquet").exists() and FEATURED.exists()
 
 pytestmark = pytest.mark.skipif(

--- a/tests/audit/test_tracked_data_files_present.py
+++ b/tests/audit/test_tracked_data_files_present.py
@@ -1,0 +1,60 @@
+"""#794 — the tracked files under `data/` must still be on disk.
+
+On 2026-08-02, 36 of them vanished from a working tree. Nothing had committed the
+deletion, so `git restore data/` recovered everything and nothing was lost — but it was
+**silent**, and a `git add -A` at the wrong moment would have committed the loss of the
+measured tables that back published numbers (`mc_measured_v1.json`, the threshold sweeps,
+the pace baselines).
+
+The cause was never determined; #794 records what was ruled out. This test does not
+prevent the deletion. It turns a silent one into a red build, which is the difference
+between finding out and not.
+
+Why it is worth having despite not fixing anything: `data/.gitignore` covers `/raw`,
+`/processed` and `/models`, so the files it does NOT cover sit in the one directory every
+download path treats as its own — including `huggingface_hub`, which
+`data_cache.py:285-290` hands the repository root as a managed directory. Git owns these
+files; the tooling believes it does.
+
+The list is derived from git rather than hardcoded, so adding or removing a tracked data
+file needs no edit here and this can never drift into asserting about a stale set.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _tracked_data_files() -> list[str]:
+    """Paths git tracks under `data/`, straight from the index."""
+    result = subprocess.run(
+        ["git", "ls-files", "data/"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+@pytest.mark.skipif(not (ROOT / ".git").exists(), reason="not a git checkout")
+def test_every_tracked_data_file_is_still_on_disk():
+    """A tracked file missing from the worktree is a deletion nobody asked for."""
+    tracked = _tracked_data_files()
+    if not tracked:
+        pytest.skip("git ls-files returned nothing (shallow or non-git environment)")
+
+    missing = [path for path in tracked if not (ROOT / path).exists()]
+
+    assert not missing, (
+        f"{len(missing)} of {len(tracked)} tracked files under data/ are missing from the "
+        f"working tree. Nothing committed their deletion, so `git restore data/` recovers "
+        f"them. See #794 for what was ruled out. Missing: {sorted(missing)[:8]}"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+"""Shared skip-guards for tests that need Hugging-Face-hosted model weights or data.
+
+``tests/README``-equivalent for this file: most of the suite runs against
+``data/`` (models + processed parquet), which is fetched from Hugging Face on
+first use and absent on CI runners by design (see CLAUDE.md section 9 /
+"Data / models are NOT in git"). Individual test files used to each hand-roll
+their own ``_HAS_MODELS = (path).exists()`` + ``pytest.mark.skipif(...)`` pair
+-- 22 near-identical copies of the tire-degradation-routing-config check alone
+(21 module-level ``skipif`` guards plus one fixture-scope ``pytest.skip``), two
+of which had already drifted to ``.is_file()`` instead of ``.exists()``.
+Import the constants below instead of restating the check.
+
+Tests that gate on a DIFFERENT model artifact (overtake, pit prediction, lap
+time) are intentionally NOT covered here -- collapsing those into one boolean
+would hide the fact that they need a different file present, which is real
+information, not duplication.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+
+HAS_TIRE_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+skip_no_tire_models = pytest.mark.skipif(
+    not HAS_TIRE_MODELS,
+    reason="data/models/ not present (CI runner without model weights)",
+)

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -17,12 +17,9 @@ from pathlib import Path
 
 import pytest
 
+from tests.conftest import skip_no_tire_models as _skip_no_models
+
 ROOT = Path(__file__).parent.parent.parent
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
-_skip_no_models = pytest.mark.skipif(
-    not _HAS_MODELS,
-    reason="data/models/ not present (CI runner without model weights)",
-)
 
 
 @_skip_no_models

--- a/tests/engine/test_engine_memory.py
+++ b/tests/engine/test_engine_memory.py
@@ -28,10 +28,10 @@ from types import SimpleNamespace
 import pandas as pd
 import pytest
 
+from tests.conftest import HAS_TIRE_MODELS as _HAS_MODELS
 from tests.engine.ast_helpers import kwargs_passed_by
 
 ROOT = Path(__file__).parent.parent.parent
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
 pytestmark = pytest.mark.skipif(
     not _HAS_MODELS,
     reason="data/models/ not present (CI runner without model weights)",

--- a/tests/engine/test_engine_no_llm.py
+++ b/tests/engine/test_engine_no_llm.py
@@ -22,12 +22,9 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from tests.conftest import skip_no_tire_models as _skip_no_models
+
 ROOT = Path(__file__).parent.parent.parent
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
-_skip_no_models = pytest.mark.skipif(
-    not _HAS_MODELS,
-    reason="data/models/ not present (CI runner without model weights)",
-)
 
 FIXTURE = ROOT / "tests" / "fixtures" / "mini_race.parquet"
 _ACTIONS = {"STAY_OUT", "PIT_NOW", "UNDERCUT", "OVERCUT", "ALERT"}

--- a/tests/engine/test_engine_threads_every_argument.py
+++ b/tests/engine/test_engine_threads_every_argument.py
@@ -30,10 +30,10 @@ from pathlib import Path
 
 import pytest
 
+from tests.conftest import HAS_TIRE_MODELS as _HAS_MODELS
 from tests.engine.ast_helpers import kwargs_passed_by
 
 ROOT = Path(__file__).parent.parent.parent
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
 pytestmark = pytest.mark.skipif(
     not _HAS_MODELS,
     reason="data/models/ not present (CI runner without model weights)",

--- a/tests/engine/test_memory_scope_is_deliberate.py
+++ b/tests/engine/test_memory_scope_is_deliberate.py
@@ -29,10 +29,10 @@ from pathlib import Path
 
 import pytest
 
+from tests.conftest import HAS_TIRE_MODELS as _HAS_MODELS
 from tests.engine.ast_helpers import kwargs_passed_by
 
 ROOT = Path(__file__).parent.parent.parent
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
 pytestmark = pytest.mark.skipif(
     not _HAS_MODELS,
     reason="data/models/ not present (CI runner without model weights)",

--- a/tests/eval/test_decision_modes.py
+++ b/tests/eval/test_decision_modes.py
@@ -91,8 +91,8 @@ def test_importing_the_module_does_not_load_the_agent_stack():
     [
         (3, 57, "MEDIUM", 20, "opening_laps"),
         (56, 57, "MEDIUM", 20, "closing_laps"),
-        (30, 57, "SOFT", 5, "min_stint"),
-        (30, 57, None, 9, "min_stint"),
+        (30, 57, "SOFT", 1, "min_stint"),
+        (30, 57, None, 5, "min_stint"),
         (30, 57, "SOFT", 20, None),
         (30, 57, "MEDIUM", None, None),
     ],

--- a/tests/eval/test_ml_recompute_golden.py
+++ b/tests/eval/test_ml_recompute_golden.py
@@ -12,7 +12,16 @@ import pytest
 
 ROOT = Path(__file__).parent.parent.parent
 _HAS_SC = (ROOT / "data" / "models" / "safety_car_probability" / "lgbm_sc_v1.pkl").exists()
-_HAS_UNDERCUT = (ROOT / "data" / "models" / "pit_prediction" / "lgbm_undercut_v1.pkl").exists()
+# The HOLDOUT as well as the model, matching _HAS_PIT / _HAS_PACE / _HAS_TIRE below.
+# Checking only the model made this test FAIL rather than skip on a checkout built from
+# the published dataset, because `undercut_clean.parquet` is not in it (#798) -- and a
+# data-tier guard that fails on absent data is worse than no guard, since it costs a red
+# suite that says nothing about the change under test.
+_HAS_UNDERCUT = (
+    ROOT / "data" / "models" / "pit_prediction" / "lgbm_undercut_v1.pkl"
+).exists() and (
+    ROOT / "data" / "processed" / "undercut_labeled" / "undercut_clean.parquet"
+).exists()
 _HAS_PIT = (ROOT / "data" / "models" / "pit_prediction" / "hist_pit_p50_v1.pkl").exists() and bool(
     list((ROOT / "data" / "raw").glob("*/*/laps.parquet"))
 )

--- a/tests/eval/test_stint_lengths.py
+++ b/tests/eval/test_stint_lengths.py
@@ -24,9 +24,11 @@ from src.strategy.eval.stint_lengths import (
     _PERCENTILE_POINTS,
     CompoundStints,
     StintLengthSample,
+    _bound_for,
     _compound_bucket,
     _render_table,
 )
+from src.strategy.inference.guard_rails import _CALIBRATION_CEILING
 from src.strategy.inference.guard_rails import _MIN_STINT_LAPS as RAIL_MIN_STINT_LAPS
 
 ROOT = Path(__file__).parent.parent.parent
@@ -101,8 +103,8 @@ def test_share_below_threshold_over_an_empty_sample_is_zero():
         ("SOFT", "SOFT"),
         ("MEDIUM", "MEDIUM"),
         ("HARD", "HARD"),
-        ("INTERMEDIATE", "wet"),
-        ("WET", "wet"),
+        ("INTERMEDIATE", "WET"),
+        ("WET", "WET"),
         ("UNKNOWN_TYRE", "unknown"),
         ("", "unknown"),
     ],
@@ -135,11 +137,10 @@ def test_every_dry_compound_has_a_rail_threshold():
 
 
 def _sample(
-    by_compound: dict[str, CompoundStints], dropped_wet=0, dropped_missing=0, races=1
+    by_compound: dict[str, CompoundStints], dropped_missing=0, races=1
 ) -> StintLengthSample:
     return StintLengthSample(
         by_compound=by_compound,
-        dropped_wet=dropped_wet,
         dropped_missing=dropped_missing,
         races=races,
     )
@@ -157,8 +158,8 @@ def test_render_reports_the_headline_share_and_the_drop_counts():
             "SOFT": _stints("SOFT", [5, 8, 10, 20], threshold=8),
             "MEDIUM": _stints("MEDIUM", [10, 12, 20], threshold=12),
             "HARD": _stints("HARD", [15, 18, 22], threshold=15),
+            "WET": _stints("WET", [11, 14], threshold=10),
         },
-        dropped_wet=7,
         dropped_missing=2,
         races=3,
     )
@@ -168,7 +169,6 @@ def test_render_reports_the_headline_share_and_the_drop_counts():
     # One of four SOFT stints (the 5-lap one) undercuts the 8-lap rail: 25.0%.
     assert "25.0%" in body
     assert "dropped" in body
-    assert "7" in body
     assert "2" in body
 
 
@@ -179,6 +179,7 @@ def test_render_states_the_field_it_measures():
             "SOFT": _stints("SOFT", [10], threshold=8),
             "MEDIUM": _stints("MEDIUM", [], threshold=12),
             "HARD": _stints("HARD", [], threshold=15),
+            "WET": _stints("WET", [], threshold=10),
         }
     )
     body = _render_table(sample)
@@ -204,8 +205,48 @@ def test_measured_sample_is_non_empty_before_any_figure_is_believed():
 
     assert sample.races > 0, "no races found under data/raw/2025"
     assert sample.total_counted > 0, "no real green-flag stints were counted: sample is empty"
-    for compound, stats in sample.by_compound.items():
-        assert stats.threshold == RAIL_MIN_STINT_LAPS[compound]
+    for bucket, stats in sample.by_compound.items():
+        assert stats.threshold == _bound_for(bucket)
         # Not every compound need appear at every circuit, but at least one must,
         # or this "distribution by compound" report has nothing to report.
     assert any(stats.sample_size > 0 for stats in sample.by_compound.values())
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_RAW, reason="data/raw absent (CI runner without the dataset)")
+def test_no_minimum_stint_bound_vetoes_more_than_the_calibration_ceiling():
+    """Every minimum-stint bound must still sit where real strategy essentially never goes.
+
+    This is the test #716 exists to leave behind, and it deliberately asserts the
+    EFFECT rather than the values. A test reading ``_MIN_STINT_LAPS["SOFT"] == 2``
+    would pass forever while saying nothing: the repo has shipped exactly that
+    before, a green assertion pinning a threshold that no longer did anything (see
+    #450, where a wired-in bound was compared against the wrong probability scale
+    and its test asserted the constant rather than a single firing).
+
+    What actually went wrong here is what this catches: SOFT 8 / MEDIUM 12 / HARD 15
+    vetoed 15.5% / 17.0% / 12.2% of real green-flag stops, and the wet fallback 20.0%
+    -- one real stop in six overridden by a bound whose entire licence to exist is
+    that real strategy does not go there. Raise any bound back above the ceiling and
+    this fails naming the compound and the share.
+
+    Measured over all three seasons rather than 2025 alone, because that is the
+    sample the bounds were set from; a single season would grade them against
+    evidence they were not calibrated on.
+    """
+    from src.strategy.eval.stint_lengths import measure_stint_lengths
+
+    sample = measure_stint_lengths()
+
+    graded = {
+        bucket: stats for bucket, stats in sample.by_compound.items() if stats.sample_size > 0
+    }
+    assert graded, "no bucket carried a sample: the ceiling would hold vacuously"
+
+    for bucket, stats in graded.items():
+        assert stats.share_below_threshold <= _CALIBRATION_CEILING, (
+            f"the {bucket} minimum-stint bound of {stats.threshold} laps vetoes "
+            f"{stats.share_below_threshold:.1%} of {stats.sample_size} real green-flag "
+            f"stops, above the {_CALIBRATION_CEILING:.0%} ceiling: it is separating "
+            f"unusual from usual, not absurd from sane"
+        )

--- a/tests/eval/test_stint_lengths.py
+++ b/tests/eval/test_stint_lengths.py
@@ -238,10 +238,23 @@ def test_no_minimum_stint_bound_vetoes_more_than_the_calibration_ceiling():
 
     sample = measure_stint_lengths()
 
+    # Pin the bucket set BEFORE filtering. Skipping empty buckets is right (a compound
+    # absent from the sample says nothing about its bound), but it is also how a bound
+    # stops being graded without anything failing: drop WET from the report and the
+    # ceiling would hold over three buckets while the fourth, the worst-calibrated one
+    # in #716, quietly left the measurement. The set is the claim; the shares come after.
+    from src.strategy.eval.stint_lengths import _REPORTED_BUCKETS
+
+    assert set(sample.by_compound) == set(_REPORTED_BUCKETS)
+    assert "WET" in sample.by_compound, "the fallback bound must stay measured"
+
     graded = {
         bucket: stats for bucket, stats in sample.by_compound.items() if stats.sample_size > 0
     }
-    assert graded, "no bucket carried a sample: the ceiling would hold vacuously"
+    assert set(graded) == set(_REPORTED_BUCKETS), (
+        f"only {sorted(graded)} carried a sample; a bound with no sample is a bound "
+        f"the ceiling holds over vacuously"
+    )
 
     for bucket, stats in graded.items():
         assert stats.share_below_threshold <= _CALIBRATION_CEILING, (

--- a/tests/mc/canned_outputs.py
+++ b/tests/mc/canned_outputs.py
@@ -1,0 +1,51 @@
+"""Shared canned sub-agent outputs for the MC/golden test tier (seed-42 regression bed).
+
+Extracted 2026-08-01: four call sites (test_mc_state_helpers.py, test_strategy_goldens.py,
+and their respective importers test_mc_is_a_real_decision.py / test_projection_golden.py)
+either duplicated this exact function body or imported it from whichever of the first two
+files happened to define it first -- two different import paths reaching two separately
+maintained copies of the same fixture. A single source closes both problems at once.
+"""
+
+from __future__ import annotations
+
+
+def canned_outputs():
+    """Four hand-built sub-agent outputs for a near-cliff pit-window lap.
+
+    Only the fields the Monte Carlo layer reads matter numerically (pace CI,
+    laps-to-cliff triangular, sc probability, pit-duration triangular, undercut
+    probability); the rest are filled with plausible values so the dataclasses
+    construct.
+    """
+    from src.agents.pace_agent import PaceOutput
+    from src.agents.pit_strategy_agent import PitStrategyOutput
+    from src.agents.race_situation_agent import RaceSituationOutput
+    from src.agents.tire_agent import TireOutput
+
+    pace = PaceOutput(
+        lap_time_pred=91.0, delta_vs_prev=-0.2, delta_vs_median=0.3, ci_p10=90.5, ci_p90=91.8
+    )
+    tire = TireOutput(
+        compound="MEDIUM",
+        current_tyre_life=18,
+        deg_rate=0.05,
+        laps_to_cliff_p10=3.0,
+        laps_to_cliff_p50=5.0,
+        laps_to_cliff_p90=8.0,
+        gp_name="",
+    )
+    situation = RaceSituationOutput(overtake_prob=0.2, sc_prob_3lap=0.10)
+    pit = PitStrategyOutput(
+        action="PIT_NOW",
+        recommended_lap=20,
+        compound_recommendation="HARD",
+        stop_duration_p05=2.2,
+        stop_duration_p50=2.8,
+        stop_duration_p95=3.6,
+        undercut_prob=0.55,
+        undercut_target="VER",
+        sc_reactive=False,
+        reasoning="",
+    )
+    return pace, tire, situation, pit

--- a/tests/mc/test_mc_is_a_real_decision.py
+++ b/tests/mc/test_mc_is_a_real_decision.py
@@ -27,8 +27,9 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from tests.conftest import HAS_TIRE_MODELS as _HAS_MODELS
+
 ROOT = Path(__file__).parent.parent.parent
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
 pytestmark = pytest.mark.skipif(
     not _HAS_MODELS,
     reason="data/models/ not present (CI runner without model weights)",
@@ -433,7 +434,7 @@ def test_the_legacy_path_is_taken_whenever_the_rivals_list_is_falsy():
     have routed them into a projection with no cars in it.
     """
     from src.agents.strategy_orchestrator import _run_mc_simulation
-    from tests.mc.test_mc_state_helpers import _canned_outputs
+    from tests.mc.canned_outputs import canned_outputs as _canned_outputs
 
     pace, tire, situation, pit = _canned_outputs()
     baseline = _run_mc_simulation(pace, tire, situation, pit, alpha=0.5)

--- a/tests/mc/test_mc_measured_tables.py
+++ b/tests/mc/test_mc_measured_tables.py
@@ -28,6 +28,19 @@ _skip_no_raw = pytest.mark.skipif(
     reason="data/raw/ not present (CI runner without the HF dataset)",
 )
 
+# The undercut band is measured from a holdout the published dataset does not carry
+# (#798). Without it a fresh measurement writes `"available": false` for that whole
+# table, so the committed-versus-fresh comparison fails on a checkout that is simply
+# incomplete, and the run also LEAVES the emptied file behind in the worktree, one
+# `git add -A` away from committing the loss of a measured table.
+_HAS_UNDERCUT_HOLDOUT = (
+    ROOT / "data" / "processed" / "undercut_labeled" / "undercut_clean.parquet"
+).exists()
+_skip_no_undercut = pytest.mark.skipif(
+    not _HAS_UNDERCUT_HOLDOUT,
+    reason="undercut_clean.parquet not present (not published in the HF dataset, #798)",
+)
+
 
 @pytest.fixture(scope="module")
 def tables() -> dict:
@@ -184,6 +197,7 @@ def test_the_neutralisation_rate_is_keyed_by_circuit_slugs_agents_can_query(tabl
 
 
 @_skip_no_raw
+@_skip_no_undercut
 def test_the_committed_tables_match_a_fresh_measurement():
     import subprocess
     import sys

--- a/tests/mc/test_mc_state_helpers.py
+++ b/tests/mc/test_mc_state_helpers.py
@@ -21,6 +21,8 @@ import pandas as pd
 import pytest
 
 from src.simulation.stint_history import stint_history_flags
+from tests.conftest import skip_no_tire_models as _skip_no_models
+from tests.mc.canned_outputs import canned_outputs as _canned_outputs
 
 ROOT = Path(__file__).parent.parent.parent
 
@@ -28,12 +30,6 @@ _HAS_DATA = (ROOT / "data" / "processed" / "laps_featured_2024.parquet").exists(
 _skip_no_data = pytest.mark.skipif(
     not _HAS_DATA,
     reason="data/processed/ not present (CI runner without the HF dataset)",
-)
-
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
-_skip_no_models = pytest.mark.skipif(
-    not _HAS_MODELS,
-    reason="data/models/ not present (CI runner without model weights)",
 )
 
 
@@ -199,41 +195,6 @@ def test_rsm_get_stint_flags_matches_the_pure_helper(raw_lusail_2024):
 # ---------------------------------------------------------------------------
 # MC kwargs — accepted and ignored, byte-identical output
 # ---------------------------------------------------------------------------
-
-
-def _canned_outputs():
-    """Same canned near-cliff fixture as tests/mc/test_strategy_goldens.py."""
-    from src.agents.pace_agent import PaceOutput
-    from src.agents.pit_strategy_agent import PitStrategyOutput
-    from src.agents.race_situation_agent import RaceSituationOutput
-    from src.agents.tire_agent import TireOutput
-
-    pace = PaceOutput(
-        lap_time_pred=91.0, delta_vs_prev=-0.2, delta_vs_median=0.3, ci_p10=90.5, ci_p90=91.8
-    )
-    tire = TireOutput(
-        compound="MEDIUM",
-        current_tyre_life=18,
-        deg_rate=0.05,
-        laps_to_cliff_p10=3.0,
-        laps_to_cliff_p50=5.0,
-        laps_to_cliff_p90=8.0,
-        gp_name="",
-    )
-    situation = RaceSituationOutput(overtake_prob=0.2, sc_prob_3lap=0.10)
-    pit = PitStrategyOutput(
-        action="PIT_NOW",
-        recommended_lap=20,
-        compound_recommendation="HARD",
-        stop_duration_p05=2.2,
-        stop_duration_p50=2.8,
-        stop_duration_p95=3.6,
-        undercut_prob=0.55,
-        undercut_target="VER",
-        sc_reactive=False,
-        reasoning="",
-    )
-    return pace, tire, situation, pit
 
 
 @_skip_no_models

--- a/tests/mc/test_projection_golden.py
+++ b/tests/mc/test_projection_golden.py
@@ -43,10 +43,10 @@ from pathlib import Path
 
 import pytest
 
-from tests.mc.test_strategy_goldens import _canned_outputs
+from tests.conftest import HAS_TIRE_MODELS as _HAS_MODELS
+from tests.mc.canned_outputs import canned_outputs as _canned_outputs
 
 ROOT = Path(__file__).parent.parent.parent
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
 
 # The rival geometry is chosen, not arbitrary, and the roles are the opposite of
 # the intuitive reading — measured, not assumed:

--- a/tests/mc/test_sc_regulatory_rails.py
+++ b/tests/mc/test_sc_regulatory_rails.py
@@ -19,10 +19,11 @@ from pathlib import Path
 
 import pytest
 
+from tests.conftest import HAS_TIRE_MODELS as _HAS_MODELS
+
 # Importing the orchestrator pulls the sub-agent modules, which read model configs at
 # import time, so this carries the same guard as the other agent-touching tests.
 ROOT = Path(__file__).parent.parent.parent
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
 pytestmark = pytest.mark.skipif(
     not _HAS_MODELS,
     reason="data/models/ not present (CI runner without model weights)",

--- a/tests/mc/test_strategy_goldens.py
+++ b/tests/mc/test_strategy_goldens.py
@@ -25,53 +25,10 @@ from pathlib import Path
 
 import pytest
 
+from tests.conftest import skip_no_tire_models as _skip_no_models
+from tests.mc.canned_outputs import canned_outputs as _canned_outputs
+
 ROOT = Path(__file__).parent.parent.parent
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
-_skip_no_models = pytest.mark.skipif(
-    not _HAS_MODELS,
-    reason="data/models/ not present (CI runner without model weights)",
-)
-
-
-def _canned_outputs():
-    """Four hand-built sub-agent outputs for a near-cliff pit-window lap.
-
-    Only the fields the Monte Carlo layer reads matter numerically (pace CI,
-    laps-to-cliff triangular, sc probability, pit-duration triangular, undercut
-    probability); the rest are filled with plausible values so the dataclasses
-    construct.
-    """
-    from src.agents.pace_agent import PaceOutput
-    from src.agents.pit_strategy_agent import PitStrategyOutput
-    from src.agents.race_situation_agent import RaceSituationOutput
-    from src.agents.tire_agent import TireOutput
-
-    pace = PaceOutput(
-        lap_time_pred=91.0, delta_vs_prev=-0.2, delta_vs_median=0.3, ci_p10=90.5, ci_p90=91.8
-    )
-    tire = TireOutput(
-        compound="MEDIUM",
-        current_tyre_life=18,
-        deg_rate=0.05,
-        laps_to_cliff_p10=3.0,
-        laps_to_cliff_p50=5.0,
-        laps_to_cliff_p90=8.0,
-        gp_name="",
-    )
-    situation = RaceSituationOutput(overtake_prob=0.2, sc_prob_3lap=0.10)
-    pit = PitStrategyOutput(
-        action="PIT_NOW",
-        recommended_lap=20,
-        compound_recommendation="HARD",
-        stop_duration_p05=2.2,
-        stop_duration_p50=2.8,
-        stop_duration_p95=3.6,
-        undercut_prob=0.55,
-        undercut_target="VER",
-        sc_reactive=False,
-        reasoning="",
-    )
-    return pace, tire, situation, pit
 
 
 # The exact MC output for the canned scenario at alpha=0.5 (seed 42, n=500),

--- a/tests/mc/test_tyre_wear_term.py
+++ b/tests/mc/test_tyre_wear_term.py
@@ -39,9 +39,9 @@ import numpy as np
 import pytest
 
 from src.agents.position_projection import DriverPlan, ProjectionConfig, driver_time_delta
+from tests.conftest import HAS_TIRE_MODELS as _HAS_MODELS
 
 ROOT = Path(__file__).parent.parent.parent
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").is_file()
 
 DRAWS = 4
 
@@ -313,8 +313,7 @@ class TestTheValueReachesBothBranches:
         from dataclasses import replace
 
         from src.agents.strategy_orchestrator import _run_mc_simulation
-
-        from .test_strategy_goldens import _canned_outputs
+        from tests.mc.canned_outputs import canned_outputs as _canned_outputs
 
         pace, tire, situation, pit = _canned_outputs()
         return _run_mc_simulation(
@@ -422,8 +421,7 @@ class TestTheValueReachesBothBranches:
         from dataclasses import replace
 
         from src.agents.strategy_orchestrator import _run_mc_simulation
-
-        from .test_strategy_goldens import _canned_outputs
+        from tests.mc.canned_outputs import canned_outputs as _canned_outputs
 
         pace, tire, situation, pit = _canned_outputs()
         rivals = [

--- a/tests/mc/test_undercut_targets_are_on_track.py
+++ b/tests/mc/test_undercut_targets_are_on_track.py
@@ -29,9 +29,10 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from tests.conftest import HAS_TIRE_MODELS as _HAS_MODELS
+
 RACE_DIR = Path("data/raw/2025/Lusail")
 ROOT = Path(__file__).parent.parent.parent
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
 
 # Importing N28 reads model configs at import time, and the fixture needs the raw
 # parquet. data/ is pulled from Hugging Face, so the CI runner has neither.

--- a/tests/mc/test_undercut_targets_are_on_track.py
+++ b/tests/mc/test_undercut_targets_are_on_track.py
@@ -36,9 +36,21 @@ ROOT = Path(__file__).parent.parent.parent
 
 # Importing N28 reads model configs at import time, and the fixture needs the raw
 # parquet. data/ is pulled from Hugging Face, so the CI runner has neither.
+#
+# CONSTRUCTING N28 also reads `undercut_clean.parquet`, and that one is NOT in the
+# published dataset (#798), so a checkout built purely from Hugging Face errored here at
+# fixture setup instead of skipping. The gate has to name every artefact construction
+# touches, not just the ones this file reads itself: an unlisted dependency turns a
+# missing-data skip into four red tests that have nothing to do with the change under
+# test, which is exactly how it presented.
+_HAS_UNDERCUT_HOLDOUT = (
+    ROOT / "data" / "processed" / "undercut_labeled" / "undercut_clean.parquet"
+).exists()
+
 pytestmark = pytest.mark.skipif(
-    not (_HAS_MODELS and (RACE_DIR / "laps.parquet").exists()),
-    reason="needs data/models/ and the raw Lusail parquet (data/ comes from HF, not git)",
+    not (_HAS_MODELS and _HAS_UNDERCUT_HOLDOUT and (RACE_DIR / "laps.parquet").exists()),
+    reason="needs data/models/, undercut_clean.parquet and the raw Lusail parquet "
+    "(data/ comes from HF, not git)",
 )
 
 

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -28,6 +28,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.conftest import skip_no_tire_models as _skip_no_models
+
 ROOT = Path(__file__).parent.parent.parent
 
 # Guard: simulation service needs laps_featured_YYYY.parquet + raw race dir.
@@ -54,11 +56,6 @@ _skip_no_backend = pytest.mark.skipif(
 # needs the weights on disk, and `_skip_no_backend` alone is not enough — that
 # combination is what made the first version of the payload tests fail on CI while
 # passing locally.
-_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
-_skip_no_models = pytest.mark.skipif(
-    not _HAS_MODELS,
-    reason="data/models/ not present (importing the simulator reads model config)",
-)
 
 
 def _ensure_backend_on_path() -> None:


### PR DESCRIPTION
Promotion of `dev` to `main`. 50 non-merge commits: 26 `fix`, 16 `docs`, 2 `feat`, 2 `test`, 2 `chore`, 1 `refactor`, 1 `style`.

**This does not cut a release.** release-please only creates or updates its release PR on a push to `main`; the release itself happens when that PR is merged. #712 (`release 2.6.0`) stays parked until Pitwall exists, and this promotion will grow it rather than ship it.

## Why it is worth promoting now

A P0 has been sitting on `dev` and not on `main`: `/recommend` returned **422 on every 2025 lap**, because a producer emits `None` per weather key and the consumer did `float(None)`. That is #788, fixed by lifting the one working guard into a shared `reading_or_default`.

## The data-integrity batch

- **#784** — one canonical `RaceState` builder replacing three drifted copies plus a fourth gap copy. The backend consumes it through a re-export shim.
- **#788** — the 422 above.
- **#790** — tyre-stint metadata the live-timing feed published wrong.
- **#782** — the weather columns the 2025 featured artefact was published without.
- **#795** — the build now fails when a tracked file under `data/` vanishes from the worktree, after 36 of them did on 2026-08-02 with the cause undetermined (#794, still open).

## The pit bounds and the operating envelopes

- **#716** — the four minimum-stint bounds were never checked against a real race. Measured over 1900 real green-flag stops across 71 races they vetoed 12% to 20% of them, so they were separating unusual from usual rather than absurd from sane. Each is now the largest value that vetoes at most 5%. The `min_stint` exclusion bucket falls from 17 stops to 5, the scored sample rises from 54 to 67 of 178, and agreement within two laps rises from 51.9% to 61.2%.
- **#710** — the operating-envelope contract reaches the pace agent, which had no range check of any kind. Labels only: no value the model receives changes.
- **#797** — what that surfaced. `mean_sector_speed` is a property of the circuit and inference was substituting the speed trap on every call through the RaceStateManager path, a different physical quantity. Now looked up per (year, GP); an unresolvable circuit reaches the model as missing rather than as a substituted reading.

Three adversarial gates ran over this work and found defects the changes themselves introduced, including a recalibration that silently rewrote an unrelated compound-suitability rule on the default LLM path, and a lookup that missed the 2025 Miami race entirely. All are fixed on the branch; the reports are in `documents/audits/`.

## Checks

- `uvx ruff@0.15.22 check .` and `format --check .` clean under the CI pin
- strategy goldens and projection golden byte-identical throughout
- the published pace MAE still reproduces within tolerance
- full suite **4 failed / 620 passed / 27 skipped**, down from 7 failed and 4 errors. All four remaining failures reproduce on a `dev` worktree with the same data and are environment: three NLP goldens whose 15.9 GB of weights are not downloaded locally, and `test_weather_restore`
- real `f1-sim` runs at Lusail, Miami and Silverstone: clean, actions unchanged

## Open, deliberately

#794 (the vanished files, cause undetermined), #789 (five temperature default pairs), #798 (the pit agent cannot be constructed on a clean install because `undercut_clean.parquet` is unpublished), #800 (`LapsSincePitStop` receives `TyreLife`), #801 (three defects in the featured artefacts).

Every issue in this promotion stays open until it is on `main` with green CI, which is what this PR is for.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pace predictions now use circuit- and season-specific speed data, with warnings for inputs outside the trained operating range.
  * Added consistent race-state handling across simulation surfaces, including safer defaults for missing weather, tyre, and race data.
  * Added repair and restoration for corrupted tyre-stint metadata and weather features.

* **Bug Fixes**
  * Improved pit-strategy guard rails and wet-stint calibration.
  * Fixed repository discovery for scripts run from varied installation layouts.

* **Documentation**
  * Clarified deterministic pace-agent behavior, architecture, calibration results, evaluations, and audit findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->