### PR TITLE
fix(agents): one measured air/track temperature pair, not five

### DIFF
--- a/src/agents/_shared_defaults.py
+++ b/src/agents/_shared_defaults.py
@@ -52,3 +52,31 @@ def reading_or_default(source: Mapping[str, Any], key: str, default: float) -> f
     if value is None:
         return default
     return value
+
+
+# The air and track temperature a consumer reads when the reading is genuinely absent.
+#
+# MEASURED, not chosen: the medians over the 68,122 laps of 2023-2025, taken through
+# ``augment_featured_laps`` so the weather columns the 2025 artefact ships without are
+# restored first (#782). AirTemp median 24.20, TrackTemp median 34.20.
+#
+# One pair, because there were FIVE for the same two quantities (#789), three of them
+# feeding models: pace read 25.0/35.0, tire and race_situation read 28.0/38.0, and the
+# backend producer read 25/40 in one route and 28/38 in another. The 28.0/38.0 pair sat
+# 3.8 degrees above the median in both quantities, and pace's 35.0 matches the TrackTemp
+# MEAN (35.22) rather than its median, which is how two plausible numbers for one
+# quantity survive next to each other.
+#
+# WHAT UNIFYING THEM DOES NOT DO is move any model input on a replay. Measured through
+# ``RaceReplayEngine.replay()`` over four races across three seasons, 229 lap states
+# carried a real air and track temperature on 100% of laps, so these defaults never
+# fire there. (Measured through ``rsm.get_lap_state(lap)`` WITHOUT the weather frame
+# they appear to fire on every lap, which is an artefact of calling the state manager
+# directly rather than through the engine that supplies it -- the same wrong-call
+# reading CLAUDE.md section 11 already records for the arcade temperatures.)
+#
+# So this is a dedup of a LATENT disagreement, and the paths where it does bite are the
+# ones with no weather frame at all: a hand-built session_meta, a test fixture, or the
+# backend producer that emits None per key (#788).
+DEFAULT_AIR_TEMP_C: float = 24.2
+DEFAULT_TRACK_TEMP_C: float = 34.2

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -29,7 +29,11 @@ import numpy as np
 import pandas as pd
 import xgboost as xgb
 
-from src.agents._shared_defaults import reading_or_default
+from src.agents._shared_defaults import (
+    DEFAULT_AIR_TEMP_C,
+    DEFAULT_TRACK_TEMP_C,
+    reading_or_default,
+)
 from src.f1_strat_manager.gp_slugs import canonical_gp_name, slug_from_event_name
 
 # Safe in this direction: envelope.py is a leaf that imports nothing from src.agents.
@@ -896,8 +900,8 @@ class PaceAgent:
         # present-and-None, and it is now the shared helper the other two adopted rather
         # than a fourth copy of the pattern (#788).
         _speed_st = d.get("speed_st") or 300.0
-        _air_temp = reading_or_default(wx, "air_temp", 25.0)
-        _trk_temp = reading_or_default(wx, "track_temp", 35.0)
+        _air_temp = reading_or_default(wx, "air_temp", DEFAULT_AIR_TEMP_C)
+        _trk_temp = reading_or_default(wx, "track_temp", DEFAULT_TRACK_TEMP_C)
         _humidity = reading_or_default(wx, "humidity", 50.0)
         _rainfall = reading_or_default(wx, "rainfall", 0)
 

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -28,11 +28,16 @@ import joblib
 import numpy as np
 import pandas as pd
 
-from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS, reading_or_default
+from src.agents._shared_defaults import (
+    DEFAULT_AIR_TEMP_C,
+    DEFAULT_TOTAL_LAPS,
+    DEFAULT_TRACK_TEMP_C,
+    reading_or_default,
+)
 
 # ── Repo root (with root-stop guard for uv tool install) ─────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent
-while not (_REPO_ROOT / '.git').exists():
+while not (_REPO_ROOT / ".git").exists():
     if _REPO_ROOT.parent == _REPO_ROOT:
         break
     _REPO_ROOT = _REPO_ROOT.parent
@@ -42,6 +47,7 @@ while not (_REPO_ROOT / '.git').exists():
 # ``uv tool install`` flow (``~/.f1-strat/data/``).
 try:
     from src.f1_strat_manager.data_cache import get_data_root as _get_data_root
+
     _DATA_ROOT = _get_data_root()
 except (ImportError, OSError, RuntimeError):
     # Every way get_data_root() can fail, enumerated against its body in
@@ -52,28 +58,27 @@ except (ImportError, OSError, RuntimeError):
     # the Path.home() branch IS the `uv tool install` path this block exists to
     # serve, and a container with no HOME would take it. Falling back to the
     # repo-relative data/ is right for all three.
-    _DATA_ROOT = _REPO_ROOT / 'data'
+    _DATA_ROOT = _REPO_ROOT / "data"
 
 from src.f1_strat_manager.gp_slugs import rekey_by_slug, slug_from_event_name  # noqa: E402
 
-_MODELS    = _DATA_ROOT / 'models'
-_PROCESSED = _DATA_ROOT / 'processed'
-_AGENTS    = _DATA_ROOT / 'models' / 'agents'
+_MODELS = _DATA_ROOT / "models"
+_PROCESSED = _DATA_ROOT / "processed"
+_AGENTS = _DATA_ROOT / "models" / "agents"
 
 
 # ── Authoritative compound allocation ─────────────────────────────────────────
-_compounds_path = _DATA_ROOT / 'tire_compounds_by_race.json'
+_compounds_path = _DATA_ROOT / "tire_compounds_by_race.json"
 TIRE_COMPOUNDS: dict = (
-    json.loads(_compounds_path.read_text(encoding='utf-8'))
-    if _compounds_path.exists() else {}
+    json.loads(_compounds_path.read_text(encoding="utf-8")) if _compounds_path.exists() else {}
 )
 
 # ── Feature engineering constants (matching N13/N14 training definitions) ─────
-CLIFF_THRESHOLDS = {'SOFT': 20, 'MEDIUM': 35, 'HARD': 50}
-STATUS_ENC       = {'1': 0, '2': 1, '5': 2, '7': 3, '6': 4, '4': 5}
-STATUS_SEVERITY  = {'1': 1, '2': 2, '5': 3, '7': 4, '6': 5, '4': 6}
-_INCIDENT_RE     = r'INCIDENT|COLLISION|CONTACT|SPIN|OFF TRACK|STOPPED CAR|DEBRIS|MARSHAL'
-_EXCLUDE_RE      = r'TRACK LIMITS|LAP TIME|PENALTY|PIT LANE|FORMATION|GRID|DRS|SAFETY CAR|VIRTUAL'
+CLIFF_THRESHOLDS = {"SOFT": 20, "MEDIUM": 35, "HARD": 50}
+STATUS_ENC = {"1": 0, "2": 1, "5": 2, "7": 3, "6": 4, "4": 5}
+STATUS_SEVERITY = {"1": 1, "2": 2, "5": 3, "7": 4, "6": 5, "4": 6}
+_INCIDENT_RE = r"INCIDENT|COLLISION|CONTACT|SPIN|OFF TRACK|STOPPED CAR|DEBRIS|MARSHAL"
+_EXCLUDE_RE = r"TRACK LIMITS|LAP TIME|PENALTY|PIT LANE|FORMATION|GRID|DRS|SAFETY CAR|VIRTUAL"
 
 
 # ── RCM context override (post-hoc fix for "SC active but model says low") ────
@@ -85,7 +90,7 @@ _EXCLUDE_RE      = r'TRACK LIMITS|LAP TIME|PENALTY|PIT LANE|FORMATION|GRID|DRS|S
 # under a VSC, so the two are tracked apart from here on. Strings match exactly what
 # radio_agent._classify_rcm_event() emits. (src/nlp/rcm_state.py mirrors these sets for
 # its cross-lap tracker; keep them in sync.)
-_SC_DEPLOY_EVENT_TYPES:  frozenset[str] = frozenset({"SAFETY_CAR_DEPLOYED"})
+_SC_DEPLOY_EVENT_TYPES: frozenset[str] = frozenset({"SAFETY_CAR_DEPLOYED"})
 _VSC_DEPLOY_EVENT_TYPES: frozenset[str] = frozenset({"VIRTUAL_SAFETY_CAR_DEPLOYED"})
 
 # SC release. Art. 55.15's "SAFETY CAR IN THIS LAP" (the real message, which classifies
@@ -95,10 +100,12 @@ _VSC_DEPLOY_EVENT_TYPES: frozenset[str] = frozenset({"VIRTUAL_SAFETY_CAR_DEPLOYE
 # neutralised: _neutralization_from_rcm keeps the flag active for it and it clears the
 # lap after. SAFETY_CAR_IN_PIT_LANE is the same case for the rarer "IN THE PIT LANE"
 # wording.
-_SC_RELEASE_EVENT_TYPES:  frozenset[str] = frozenset({
-    "SAFETY_CAR_ENDING",
-    "SAFETY_CAR_IN_PIT_LANE",
-})
+_SC_RELEASE_EVENT_TYPES: frozenset[str] = frozenset(
+    {
+        "SAFETY_CAR_ENDING",
+        "SAFETY_CAR_IN_PIT_LANE",
+    }
+)
 
 # VSC release. Art. 56.7's restart is near-instant (green ~10-15 s after "VSC ENDING"),
 # so at lap granularity the neutralisation is over on the announcement lap: this releases
@@ -122,6 +129,7 @@ class Neutralization(str, Enum):
 # ─────────────────────────────────────────────────────────────────────────────
 # RaceSituationConfig
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 @dataclass
 class RaceSituationConfig:
@@ -165,12 +173,12 @@ class RaceSituationConfig:
             fires on 13.59% of laps.
     """
 
-    model_name: str = 'gpt-4.1-mini'
+    model_name: str = "gpt-4.1-mini"
 
-    high_overtake:   float = 0.65
+    high_overtake: float = 0.65
     medium_overtake: float = 0.40
-    high_sc:         float = 0.0864
-    medium_sc:       float = 0.0432
+    high_sc: float = 0.0864
+    medium_sc: float = 0.0432
 
     def __post_init__(self) -> None:
         self.export_dir = _AGENTS
@@ -180,23 +188,23 @@ class RaceSituationConfig:
             pass  # read-only mount in Docker
 
         # Overtake model (N12)
-        _ov = _MODELS / 'overtake_probability'
-        self.overtake_model      = joblib.load(_ov / 'lgbm_overtake_v1.pkl')
-        self.overtake_calibrator = joblib.load(_ov / 'calibrator.pkl')
-        with open(_ov / 'model_config.json') as f:
+        _ov = _MODELS / "overtake_probability"
+        self.overtake_model = joblib.load(_ov / "lgbm_overtake_v1.pkl")
+        self.overtake_calibrator = joblib.load(_ov / "calibrator.pkl")
+        with open(_ov / "model_config.json") as f:
             ov_cfg = json.load(f)
-        self.overtake_features: list[str]     = ov_cfg['features']
-        self.overtake_cat_features: list[str] = ov_cfg['categorical_features']
-        self.overtake_threshold: float        = ov_cfg['optimal_threshold']
+        self.overtake_features: list[str] = ov_cfg["features"]
+        self.overtake_cat_features: list[str] = ov_cfg["categorical_features"]
+        self.overtake_threshold: float = ov_cfg["optimal_threshold"]
 
         # SC model (N14)
-        _sc = _MODELS / 'safety_car_probability'
-        self.sc_model      = joblib.load(_sc / 'lgbm_sc_v1.pkl')
-        self.sc_calibrator = joblib.load(_sc / 'calibrator_sc_v1.pkl')
-        with open(_sc / 'feature_list_v1.json') as f:
+        _sc = _MODELS / "safety_car_probability"
+        self.sc_model = joblib.load(_sc / "lgbm_sc_v1.pkl")
+        self.sc_calibrator = joblib.load(_sc / "calibrator_sc_v1.pkl")
+        with open(_sc / "feature_list_v1.json") as f:
             sc_cfg = json.load(f)
-        self.sc_features: list[str] = sc_cfg['features']
-        self.sc_threshold: float    = sc_cfg['best_threshold']
+        self.sc_features: list[str] = sc_cfg["features"]
+        self.sc_threshold: float = sc_cfg["best_threshold"]
 
         # DO NOT assign overtake_threshold/sc_threshold onto high_overtake/high_sc.
         # #450 did exactly that and it is a unit error: both tuned thresholds are
@@ -220,15 +228,13 @@ class RaceSituationConfig:
         # are pit-wall alert levels, set on the served calibrated scale (#665).
 
         # Circuit cluster map (k=4 parquet from N05)
-        _cl = pd.read_parquet(_PROCESSED / 'circuit_clustering' / 'circuit_clusters_k4.parquet')
-        self.circuit_cluster_map: dict = dict(
-            zip(_cl['GP_Name'], _cl['Cluster'].astype(int))
-        )
+        _cl = pd.read_parquet(_PROCESSED / "circuit_clustering" / "circuit_clusters_k4.parquet")
+        self.circuit_cluster_map: dict = dict(zip(_cl["GP_Name"], _cl["Cluster"].astype(int)))
 
         # Circuit SC base rates (from N13 labeled parquet)
         _sc_df = pd.read_parquet(
-            _PROCESSED / 'sc_labeled' / 'sc_labeled_2023_2025.parquet',
-            columns=['event_name', 'circuit_sc_rate'],
+            _PROCESSED / "sc_labeled" / "sc_labeled_2023_2025.parquet",
+            columns=["event_name", "circuit_sc_rate"],
         )
         # Re-key to the SLUG keyspace the replay path queries with. This table ships
         # keyed by FastF1 event names, which the FastF1 session path supplies but the
@@ -239,10 +245,10 @@ class RaceSituationConfig:
         # through `sc_rate_for`, which resolves EITHER keyspace, so the FastF1 path
         # keeps working too.
         self.circuit_sc_rate_map: dict = rekey_by_slug(
-            _sc_df.drop_duplicates('event_name')
-                  .set_index('event_name')['circuit_sc_rate']
-                  .to_dict(),
-            'circuit_sc_rate_map',
+            _sc_df.drop_duplicates("event_name")
+            .set_index("event_name")["circuit_sc_rate"]
+            .to_dict(),
+            "circuit_sc_rate_map",
         )
 
     def sc_rate_for(self, event_name: str) -> float:
@@ -267,6 +273,7 @@ CFG = RaceSituationConfig()
 # ─────────────────────────────────────────────────────────────────────────────
 # RaceSituationOutput
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 @dataclass
 class RaceSituationOutput:
@@ -308,19 +315,23 @@ class RaceSituationOutput:
     overtake_prob: float
     sc_prob_3lap: float
     threat_level: str = field(init=False)
-    gap_ahead_s: float  = 0.0
+    gap_ahead_s: float = 0.0
     pace_delta_s: float = 0.0
-    reasoning: str      = ''
+    reasoning: str = ""
     sc_currently_active: bool = False  # any neutralisation (SC OR VSC) confirmed by RCM this lap
-    vsc_active: bool          = False  # the active neutralisation is specifically a VSC (Art. 56)
+    vsc_active: bool = False  # the active neutralisation is specifically a VSC (Art. 56)
 
     def __post_init__(self) -> None:
-        if self.sc_currently_active or self.overtake_prob >= CFG.high_overtake or self.sc_prob_3lap >= CFG.high_sc:
-            self.threat_level = 'HIGH'
+        if (
+            self.sc_currently_active
+            or self.overtake_prob >= CFG.high_overtake
+            or self.sc_prob_3lap >= CFG.high_sc
+        ):
+            self.threat_level = "HIGH"
         elif self.overtake_prob >= CFG.medium_overtake or self.sc_prob_3lap >= CFG.medium_sc:
-            self.threat_level = 'MEDIUM'
+            self.threat_level = "MEDIUM"
         else:
-            self.threat_level = 'LOW'
+            self.threat_level = "LOW"
 
     @property
     def sc_active(self) -> bool:
@@ -336,6 +347,7 @@ class RaceSituationOutput:
 # Pure feature sub-helpers — accept all state as arguments, read no globals
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 def _abs_compound(relative: str, gp_name: str, year: int) -> str:
     """Map SOFT/MEDIUM/HARD → Cx string using TIRE_COMPOUNDS; fallback to input."""
     return TIRE_COMPOUNDS.get(str(year), {}).get(gp_name, {}).get(relative.upper(), relative)
@@ -343,17 +355,19 @@ def _abs_compound(relative: str, gp_name: str, year: int) -> str:
 
 def _agg(grp: pd.DataFrame) -> pd.Series:
     """Aggregate lap times for one lap group into mean, std, min scalars."""
-    lt = grp['LapTime'].dt.total_seconds().dropna()
-    return pd.Series({
-        'lt_mean': lt.mean() if not lt.empty else np.nan,
-        'lt_std':  lt.std(ddof=1) if len(lt) > 1 else 0.0,
-        'lt_min':  lt.min() if not lt.empty else np.nan,
-    })
+    lt = grp["LapTime"].dt.total_seconds().dropna()
+    return pd.Series(
+        {
+            "lt_mean": lt.mean() if not lt.empty else np.nan,
+            "lt_std": lt.std(ddof=1) if len(lt) > 1 else 0.0,
+            "lt_min": lt.min() if not lt.empty else np.nan,
+        }
+    )
 
 
 def _zscore(series: pd.DataFrame, col: str, lap_number: int) -> float:
     """Standardise the value at lap_number against the full causal history."""
-    mu  = series[col].mean()
+    mu = series[col].mean()
     sig = max(float(series[col].std(ddof=1)), 0.01)
     val = series.loc[series.index == lap_number, col]
     return float((val.iloc[0] - mu) / sig) if not val.empty else 0.0
@@ -374,7 +388,7 @@ def _is_neutralised(track_status: object) -> bool:
     if track_status is None or pd.isna(track_status):
         return False
     codes = str(track_status)
-    return '4' in codes or '6' in codes
+    return "4" in codes or "6" in codes
 
 
 def _dominant_status(grp: pd.DataFrame) -> str:
@@ -390,10 +404,10 @@ def _dominant_status(grp: pd.DataFrame) -> str:
 
     Mirrors N13's most_severe_status (notebook N13_sc_eda.ipynb, Step 2 loader cell).
     """
-    codes = grp['TrackStatus'].dropna().astype(str).tolist()
-    chars = [c for c in ''.join(codes) if c in STATUS_SEVERITY]
+    codes = grp["TrackStatus"].dropna().astype(str).tolist()
+    chars = [c for c in "".join(codes) if c in STATUS_SEVERITY]
     if not chars:
-        return '1'
+        return "1"
     return max(chars, key=lambda c: STATUS_SEVERITY[c])
 
 
@@ -417,41 +431,42 @@ def _compute_laptime_features(all_laps: pd.DataFrame, lap_number: int) -> dict:
         Dict with: lap_time_mean_z, lap_time_std_z, lap_time_min_z,
         lap_time_cv, lap_time_trend_5.
     """
-    causal = all_laps[all_laps['LapNumber'] <= lap_number]
+    causal = all_laps[all_laps["LapNumber"] <= lap_number]
     if causal.empty:
         # No prior lap data — return neutral defaults matching the N14 schema.
         # Happens on lap 1 of every replay (no lap has finished yet) and also
         # when the race has been neutralised (all LapTimes NaN under red flag).
         return {
-            'lap_time_mean_z':  0.0,
-            'lap_time_std_z':   0.0,
-            'lap_time_min_z':   0.0,
-            'lap_time_cv':      0.0,
-            'lap_time_trend_5': 1.0,
+            "lap_time_mean_z": 0.0,
+            "lap_time_std_z": 0.0,
+            "lap_time_min_z": 0.0,
+            "lap_time_cv": 0.0,
+            "lap_time_trend_5": 1.0,
         }
 
-    per_lap = causal.groupby('LapNumber').apply(_agg)
+    per_lap = causal.groupby("LapNumber").apply(_agg)
     # apply() on an empty-after-filter group can return a DataFrame with no
     # columns at all — guard before dropna so we don't KeyError on 'lt_mean'.
-    if 'lt_mean' not in per_lap.columns:
+    if "lt_mean" not in per_lap.columns:
         return {
-            'lap_time_mean_z':  0.0,
-            'lap_time_std_z':   0.0,
-            'lap_time_min_z':   0.0,
-            'lap_time_cv':      0.0,
-            'lap_time_trend_5': 1.0,
+            "lap_time_mean_z": 0.0,
+            "lap_time_std_z": 0.0,
+            "lap_time_min_z": 0.0,
+            "lap_time_cv": 0.0,
+            "lap_time_trend_5": 1.0,
         }
-    per_lap = per_lap.dropna(subset=['lt_mean'])
+    per_lap = per_lap.dropna(subset=["lt_mean"])
 
-    lt_mean_z = _zscore(per_lap, 'lt_mean', lap_number)
-    lt_std_z  = _zscore(per_lap, 'lt_std',  lap_number)
-    lt_min_z  = _zscore(per_lap, 'lt_min',  lap_number)
+    lt_mean_z = _zscore(per_lap, "lt_mean", lap_number)
+    lt_std_z = _zscore(per_lap, "lt_std", lap_number)
+    lt_min_z = _zscore(per_lap, "lt_min", lap_number)
     lt_cv = (
-        float(per_lap.loc[lap_number, 'lt_std'] / max(per_lap.loc[lap_number, 'lt_mean'], 1.0))
-        if lap_number in per_lap.index else 0.0
+        float(per_lap.loc[lap_number, "lt_std"] / max(per_lap.loc[lap_number, "lt_mean"], 1.0))
+        if lap_number in per_lap.index
+        else 0.0
     )
 
-    lt_means = per_lap['lt_mean'].values
+    lt_means = per_lap["lt_mean"].values
     n = len(lt_means)
     if n >= 5:
         last5 = lt_means[-5:].mean()
@@ -461,45 +476,45 @@ def _compute_laptime_features(all_laps: pd.DataFrame, lap_number: int) -> dict:
         lt_trend5 = 1.0
 
     return {
-        'lap_time_mean_z':  lt_mean_z,
-        'lap_time_std_z':   lt_std_z,
-        'lap_time_min_z':   lt_min_z,
-        'lap_time_cv':      lt_cv,
-        'lap_time_trend_5': lt_trend5,
+        "lap_time_mean_z": lt_mean_z,
+        "lap_time_std_z": lt_std_z,
+        "lap_time_min_z": lt_min_z,
+        "lap_time_cv": lt_cv,
+        "lap_time_trend_5": lt_trend5,
     }
 
 
 def _compute_driver_tyre_features(cur: pd.DataFrame, prev: pd.DataFrame) -> dict:
     """Compute driver count, tyre life, and pit-stop features for the current lap."""
-    n_drv       = int(cur['Driver'].nunique()) if not cur.empty else 0
-    n_drv_prev  = int(prev['Driver'].nunique()) if not prev.empty else n_drv
+    n_drv = int(cur["Driver"].nunique()) if not cur.empty else 0
+    n_drv_prev = int(prev["Driver"].nunique()) if not prev.empty else n_drv
     n_drv_delta = n_drv - n_drv_prev
 
-    tl      = cur['TyreLife'].dropna()
+    tl = cur["TyreLife"].dropna()
     tl_mean = float(tl.mean()) if not tl.empty else np.nan
-    tl_max  = float(tl.max())  if not tl.empty else np.nan
+    tl_max = float(tl.max()) if not tl.empty else np.nan
 
     high_risk = 0
     for _, r in cur.iterrows():
-        cmp = str(r.get('Compound', '')).upper()
+        cmp = str(r.get("Compound", "")).upper()
         thr = CLIFF_THRESHOLDS.get(cmp, 999)
         try:
-            if float(r['TyreLife']) > thr:
+            if float(r["TyreLife"]) > thr:
                 high_risk += 1
         except (TypeError, ValueError):
             pass
 
-    pit_count = int(cur['PitInTime'].notna().sum()) if 'PitInTime' in cur.columns else 0
-    outlap    = int((cur['TyreLife'] <= 2).sum()) if not cur.empty else 0
+    pit_count = int(cur["PitInTime"].notna().sum()) if "PitInTime" in cur.columns else 0
+    outlap = int((cur["TyreLife"] <= 2).sum()) if not cur.empty else 0
 
     return {
-        'n_drivers':                n_drv,
-        'n_drivers_delta':          n_drv_delta,
-        'tyre_life_mean':           tl_mean,
-        'tyre_life_max':            tl_max,
-        'tyre_age_high_risk_count': high_risk,
-        'active_pitstop_count':     pit_count,
-        'outlap_drivers':           outlap,
+        "n_drivers": n_drv,
+        "n_drivers_delta": n_drv_delta,
+        "tyre_life_mean": tl_mean,
+        "tyre_life_max": tl_max,
+        "tyre_age_high_risk_count": high_risk,
+        "active_pitstop_count": pit_count,
+        "outlap_drivers": outlap,
     }
 
 
@@ -516,19 +531,19 @@ def _compute_track_status_features(all_laps: pd.DataFrame, lap_number: int) -> d
     Returns:
         Dict with model features plus '_cur_code', '_prev_code', '_yel_esc' sentinels.
     """
-    causal_laps = all_laps[all_laps['LapNumber'] <= lap_number]
+    causal_laps = all_laps[all_laps["LapNumber"] <= lap_number]
     if causal_laps.empty:
         # No lap data yet — return green-flag defaults. Matches N14's behaviour
         # when the model receives a pre-race or post-red-flag blank state.
         return {
-            '_cur_code':               '1',
-            '_prev_code':              '1',
-            '_yel_esc':                0,
-            'track_status_enc':        STATUS_ENC.get('1', 0),
-            'status_changed':          0,
-            'status_change_direction': 0,
-            'yellow_escalation_count': 0,
-            'laps_since_last_yellow':  10,
+            "_cur_code": "1",
+            "_prev_code": "1",
+            "_yel_esc": 0,
+            "track_status_enc": STATUS_ENC.get("1", 0),
+            "status_changed": 0,
+            "status_change_direction": 0,
+            "yellow_escalation_count": 0,
+            "laps_since_last_yellow": 10,
         }
 
     # Grouped by lap NUMBER across every car, so a driver a lap down inherits the
@@ -538,32 +553,27 @@ def _compute_track_status_features(all_laps: pd.DataFrame, lap_number: int) -> d
     # `groupby("LapNumber")` union, so keying this on the clock would feed N14 a
     # distribution it never saw. Inference has to reproduce its notebook, and this
     # repo has already paid for three bugs that were exactly that divergence.
-    lap_status = (
-        causal_laps
-        .groupby('LapNumber')
-        .apply(_dominant_status)
-        .sort_index()
-    )
+    lap_status = causal_laps.groupby("LapNumber").apply(_dominant_status).sort_index()
     # Pandas quirk: when the grouped object is empty or apply() returns an
     # empty result, groupby().apply() can yield an empty DataFrame (with the
     # full column schema) instead of an empty Series. The early-return above
     # prevents that, but cheap belt-and-braces check in case of edge cases.
     if not isinstance(lap_status, pd.Series) or lap_status.empty:
         return {
-            '_cur_code':               '1',
-            '_prev_code':              '1',
-            '_yel_esc':                0,
-            'track_status_enc':        STATUS_ENC.get('1', 0),
-            'status_changed':          0,
-            'status_change_direction': 0,
-            'yellow_escalation_count': 0,
-            'laps_since_last_yellow':  10,
+            "_cur_code": "1",
+            "_prev_code": "1",
+            "_yel_esc": 0,
+            "track_status_enc": STATUS_ENC.get("1", 0),
+            "status_changed": 0,
+            "status_change_direction": 0,
+            "yellow_escalation_count": 0,
+            "laps_since_last_yellow": 10,
         }
 
-    cur_code  = str(lap_status.iloc[-1])
+    cur_code = str(lap_status.iloc[-1])
     prev_code = str(lap_status.iloc[-2]) if len(lap_status) > 1 else cur_code
 
-    cur_sev  = STATUS_SEVERITY.get(cur_code, 1)
+    cur_sev = STATUS_SEVERITY.get(cur_code, 1)
     prev_sev = STATUS_SEVERITY.get(prev_code, 1)
 
     # Force plain int dtype — FastF1 stores TrackStatus as a Categorical, and
@@ -575,24 +585,24 @@ def _compute_track_status_features(all_laps: pd.DataFrame, lap_number: int) -> d
         index=lap_status.index,
         dtype=int,
     )
-    escalated  = (sev_series > sev_series.shift(1).fillna(1)).astype(int)
-    yel_esc    = int(escalated.iloc[:-1].tail(3).sum())
+    escalated = (sev_series > sev_series.shift(1).fillna(1)).astype(int)
+    yel_esc = int(escalated.iloc[:-1].tail(3).sum())
 
     lsl, since = [], 10
     for code in lap_status:
-        since = 0 if str(code) != '1' else min(since + 1, 10)
+        since = 0 if str(code) != "1" else min(since + 1, 10)
         lsl.append(since)
     laps_since_yellow = int(lsl[-2]) if len(lsl) > 1 else 10
 
     return {
-        '_cur_code':               cur_code,
-        '_prev_code':              prev_code,
-        '_yel_esc':                yel_esc,
-        'track_status_enc':        STATUS_ENC.get(cur_code, 0),
-        'status_changed':          int(cur_code != prev_code),
-        'status_change_direction': int(cur_sev > prev_sev) - int(cur_sev < prev_sev),
-        'yellow_escalation_count': yel_esc,
-        'laps_since_last_yellow':  laps_since_yellow,
+        "_cur_code": cur_code,
+        "_prev_code": prev_code,
+        "_yel_esc": yel_esc,
+        "track_status_enc": STATUS_ENC.get(cur_code, 0),
+        "status_changed": int(cur_code != prev_code),
+        "status_change_direction": int(cur_sev > prev_sev) - int(cur_sev < prev_sev),
+        "yellow_escalation_count": yel_esc,
+        "laps_since_last_yellow": laps_since_yellow,
     }
 
 
@@ -621,54 +631,53 @@ def _compute_rcm_features(
         yellow_sectors_prev3, rcm_incident_count_prev3.
     """
     had_inc = inc_esc = ys_cur = ys_prev3 = rcm_prev3 = 0
-    _sess = session_meta.get('session')
-    if _sess is not None and hasattr(_sess, 'race_control_messages'):
+    _sess = session_meta.get("session")
+    if _sess is not None and hasattr(_sess, "race_control_messages"):
         rcm = _sess.race_control_messages.copy()
-        if 'Lap' not in rcm.columns:
-            rcm['Lap'] = np.nan
+        if "Lap" not in rcm.columns:
+            rcm["Lap"] = np.nan
 
-        _caution = rcm.get('Flag', pd.Series(dtype=str)).isin(['YELLOW', 'DOUBLE YELLOW', 'RED'])
-        _keyword = (
-            rcm.get('Message', pd.Series(dtype=str)).str.upper().str.contains(
-                _INCIDENT_RE, na=False, regex=True
-            ) &
-            ~rcm.get('Message', pd.Series(dtype=str)).str.upper().str.contains(
-                _EXCLUDE_RE, na=False, regex=True
-            )
+        _caution = rcm.get("Flag", pd.Series(dtype=str)).isin(["YELLOW", "DOUBLE YELLOW", "RED"])
+        _keyword = rcm.get("Message", pd.Series(dtype=str)).str.upper().str.contains(
+            _INCIDENT_RE, na=False, regex=True
+        ) & ~rcm.get("Message", pd.Series(dtype=str)).str.upper().str.contains(
+            _EXCLUDE_RE, na=False, regex=True
         )
         _scope = (
-            rcm['Scope'].str.upper().isin(['TRACK', 'SECTOR']) | rcm['Scope'].isna()
-        ) if 'Scope' in rcm.columns else pd.Series(True, index=rcm.index)
+            (rcm["Scope"].str.upper().isin(["TRACK", "SECTOR"]) | rcm["Scope"].isna())
+            if "Scope" in rcm.columns
+            else pd.Series(True, index=rcm.index)
+        )
         clean = (_caution | _keyword) & _scope
 
-        valid    = set(all_laps['LapNumber'].dropna().astype(int))
-        inc_raw  = set(rcm.loc[clean, 'Lap'].dropna().astype(int))
+        valid = set(all_laps["LapNumber"].dropna().astype(int))
+        inc_raw = set(rcm.loc[clean, "Lap"].dropna().astype(int))
         inc_laps = {l for r in inc_raw for l in (r - 1, r, r + 1)} & valid
 
-        had_inc  = int(lap_number in inc_laps)
+        had_inc = int(lap_number in inc_laps)
         inc_prev = int((lap_number - 1) in inc_laps)
-        inc_esc  = inc_prev * int(cur_code != prev_code)
+        inc_esc = inc_prev * int(cur_code != prev_code)
 
-        if 'Scope' in rcm.columns and 'Flag' in rcm.columns:
-            sect_y    = rcm[
-                rcm['Scope'].str.upper().str.contains('SECTOR', na=False) &
-                rcm['Flag'].str.upper().str.contains('YELLOW', na=False)
+        if "Scope" in rcm.columns and "Flag" in rcm.columns:
+            sect_y = rcm[
+                rcm["Scope"].str.upper().str.contains("SECTOR", na=False)
+                & rcm["Flag"].str.upper().str.contains("YELLOW", na=False)
             ]
-            sy_per_lap = sect_y.groupby('Lap').size()
+            sy_per_lap = sect_y.groupby("Lap").size()
         else:
             sy_per_lap = pd.Series(dtype=int)
 
-        ys_cur    = int(sy_per_lap.get(lap_number, 0))
-        ys_prev3  = sum(int(sy_per_lap.get(l, 0)) for l in range(max(1, lap_number - 3), lap_number))
-        inc_per   = rcm.loc[clean].groupby('Lap').size() if clean.any() else pd.Series(dtype=int)
+        ys_cur = int(sy_per_lap.get(lap_number, 0))
+        ys_prev3 = sum(int(sy_per_lap.get(l, 0)) for l in range(max(1, lap_number - 3), lap_number))
+        inc_per = rcm.loc[clean].groupby("Lap").size() if clean.any() else pd.Series(dtype=int)
         rcm_prev3 = sum(int(inc_per.get(l, 0)) for l in range(max(1, lap_number - 3), lap_number))
 
     return {
-        'had_incident_msg':         had_inc,
-        'incident_escalation':      inc_esc,
-        'yellow_sectors_this_lap':  ys_cur,
-        'yellow_sectors_prev3':     ys_prev3,
-        'rcm_incident_count_prev3': rcm_prev3,
+        "had_incident_msg": had_inc,
+        "incident_escalation": inc_esc,
+        "yellow_sectors_this_lap": ys_cur,
+        "yellow_sectors_prev3": ys_prev3,
+        "rcm_incident_count_prev3": rcm_prev3,
     }
 
 
@@ -678,15 +687,15 @@ def _compute_weather_features(session_meta: dict) -> dict:
     # file for 'TrackTemp' to find both) when they build this same session_meta key, so a
     # hand-built session_meta missing the key resolves to the same temperature this file
     # uses everywhere else instead of silently disagreeing with itself.
-    track_temp       = float(session_meta.get('TrackTemp', 38.0))
-    air_temp         = float(session_meta.get('AirTemp', 28.0))
-    humidity         = float(session_meta.get('Humidity', 50.0))
-    track_temp_start = float(session_meta.get('track_temp_start', track_temp))
+    track_temp = float(session_meta.get("TrackTemp", DEFAULT_TRACK_TEMP_C))
+    air_temp = float(session_meta.get("AirTemp", DEFAULT_AIR_TEMP_C))
+    humidity = float(session_meta.get("Humidity", 50.0))
+    track_temp_start = float(session_meta.get("track_temp_start", track_temp))
     return {
-        'track_temp':       track_temp,
-        'air_temp':         air_temp,
-        'humidity':         humidity,
-        'track_temp_delta': track_temp - track_temp_start,
+        "track_temp": track_temp,
+        "air_temp": air_temp,
+        "humidity": humidity,
+        "track_temp_delta": track_temp - track_temp_start,
     }
 
 
@@ -703,13 +712,13 @@ def _ensure_timedelta_laps(laps_df: pd.DataFrame) -> pd.DataFrame:
         Copy with LapTime as Timedelta and Sector*Time columns present (NaT if absent).
     """
     df = laps_df.copy()
-    if 'LapTime' not in df.columns:
-        if 'LapTime_s' in df.columns:
-            df['LapTime'] = pd.to_timedelta(df['LapTime_s'], unit='s')
+    if "LapTime" not in df.columns:
+        if "LapTime_s" in df.columns:
+            df["LapTime"] = pd.to_timedelta(df["LapTime_s"], unit="s")
         else:
-            df['LapTime'] = pd.to_timedelta(90.0, unit='s')
-    elif not hasattr(df['LapTime'].iloc[0], 'total_seconds'):
-        df['LapTime'] = pd.to_timedelta(pd.to_numeric(df['LapTime'], errors='coerce'), unit='s')
+            df["LapTime"] = pd.to_timedelta(90.0, unit="s")
+    elif not hasattr(df["LapTime"].iloc[0], "total_seconds"):
+        df["LapTime"] = pd.to_timedelta(pd.to_numeric(df["LapTime"], errors="coerce"), unit="s")
 
     # Same normalisation for the session elapsed time, and it is load-bearing:
     # _build_overtake_features reads `Time` to compute the gap the way N11 was
@@ -720,10 +729,10 @@ def _ensure_timedelta_laps(laps_df: pd.DataFrame) -> pd.DataFrame:
     # leader when the real gap was 33.950 s, which is the difference between "in the
     # DRS window" and "half a minute away". #447 restored the column; this is what
     # lets the agent actually see it.
-    if 'Time' not in df.columns and 'Time_s' in df.columns:
-        df['Time'] = pd.to_timedelta(df['Time_s'], unit='s')
+    if "Time" not in df.columns and "Time_s" in df.columns:
+        df["Time"] = pd.to_timedelta(df["Time_s"], unit="s")
 
-    for col in ('Sector1Time', 'Sector2Time', 'Sector3Time'):
+    for col in ("Sector1Time", "Sector2Time", "Sector3Time"):
         if col not in df.columns:
             df[col] = pd.NaT
 
@@ -740,8 +749,8 @@ def _ensure_timedelta_laps(laps_df: pd.DataFrame) -> pd.DataFrame:
     # it would advertise a 3-class reconstruction this frame cannot deliver. If a
     # lap's real track status is needed (yellow/VSC/SC), it has to come from
     # data/raw/, where the neutralised laps are still present.
-    if 'TrackStatus' not in df.columns:
-        df['TrackStatus'] = '1'
+    if "TrackStatus" not in df.columns:
+        df["TrackStatus"] = "1"
 
     return df
 
@@ -749,6 +758,7 @@ def _ensure_timedelta_laps(laps_df: pd.DataFrame) -> pd.DataFrame:
 # ─────────────────────────────────────────────────────────────────────────────
 # Stateless output parser
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 def _parse_tool_outputs(messages: list) -> dict:
     """Extract numeric probabilities from ToolMessage strings in the agent history.
@@ -763,16 +773,16 @@ def _parse_tool_outputs(messages: list) -> dict:
         Dict with: overtake_prob, sc_prob_3lap, gap_ahead_s, pace_delta_s.
         Missing fields default to 0.0.
     """
-    result = {'overtake_prob': 0.0, 'sc_prob_3lap': 0.0, 'gap_ahead_s': 0.0, 'pace_delta_s': 0.0}
+    result = {"overtake_prob": 0.0, "sc_prob_3lap": 0.0, "gap_ahead_s": 0.0, "pace_delta_s": 0.0}
     for msg in messages:
-        content = getattr(msg, 'content', '')
+        content = getattr(msg, "content", "")
         if not isinstance(content, str):
             continue
         for pattern, key in [
-            (r'P\(overtake\)\s*=\s*(\d+(?:\.\d+)?)', 'overtake_prob'),
-            (r'P\(SC 3-lap\)\s*=\s*(\d+(?:\.\d+)?)', 'sc_prob_3lap'),
-            (r'gap=([\d.]+)s',                        'gap_ahead_s'),
-            (r'pace_delta=([-\d.]+)s/lap',            'pace_delta_s'),
+            (r"P\(overtake\)\s*=\s*(\d+(?:\.\d+)?)", "overtake_prob"),
+            (r"P\(SC 3-lap\)\s*=\s*(\d+(?:\.\d+)?)", "sc_prob_3lap"),
+            (r"gap=([\d.]+)s", "gap_ahead_s"),
+            (r"pace_delta=([-\d.]+)s/lap", "pace_delta_s"),
         ]:
             m = re.search(pattern, content)
             if m and result[key] == 0.0:
@@ -789,6 +799,7 @@ try:
     from langchain_core.messages import HumanMessage
     from langchain_openai import ChatOpenAI
     from langchain.agents import create_agent
+
     _LANGGRAPH_AVAILABLE = True
 except ImportError:
     _LANGGRAPH_AVAILABLE = False
@@ -844,6 +855,7 @@ Your job is to assess two dimensions of strategic threat per lap:
 # RaceSituationAgent — encapsulated agent class
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 class RaceSituationAgent:
     """Encapsulated Race Situation Agent combining N12 overtake and N14 SC models.
 
@@ -862,10 +874,10 @@ class RaceSituationAgent:
 
     def __init__(self, cfg: RaceSituationConfig = CFG) -> None:
         self.cfg: RaceSituationConfig = cfg
-        self.laps_df: pd.DataFrame    = pd.DataFrame()
-        self.session_meta: dict       = {}
-        self._react_agent             = None
-        self._tools: list             = self._build_tools()
+        self.laps_df: pd.DataFrame = pd.DataFrame()
+        self.session_meta: dict = {}
+        self._react_agent = None
+        self._tools: list = self._build_tools()
 
     # ── Feature builders (instance methods: use self.cfg) ─────────────────────
 
@@ -875,7 +887,7 @@ class RaceSituationAgent:
         driver_y_lap: pd.Series,
         laps_recent: pd.DataFrame,
         circuit_cluster: int,
-        gp_name: str = '',
+        gp_name: str = "",
         year: int = 2025,
     ) -> pd.DataFrame:
         """Build the 15 N12 overtake model features from a driver pair at one lap.
@@ -902,71 +914,87 @@ class RaceSituationAgent:
             Single-row DataFrame with 15 columns in cfg.overtake_features order.
             compound_x/y cast to pandas category for LightGBM categorical encoding.
         """
-        t_x = driver_x_lap.get('Time')
-        t_y = driver_y_lap.get('Time')
+        t_x = driver_x_lap.get("Time")
+        t_y = driver_y_lap.get("Time")
         if pd.notna(t_x) and pd.notna(t_y):
             gap_ahead_s = float((t_x - t_y).total_seconds())
         else:
-            gap_ahead_s = float((driver_x_lap['LapTime'] - driver_y_lap['LapTime']).total_seconds())
+            gap_ahead_s = float((driver_x_lap["LapTime"] - driver_y_lap["LapTime"]).total_seconds())
         gap_ahead_s = max(0.0, gap_ahead_s)
 
-        pace_delta_s   = float((driver_x_lap['LapTime'] - driver_y_lap['LapTime']).total_seconds())
-        tyre_life_x    = int(driver_x_lap['TyreLife'])
-        tyre_life_y    = int(driver_y_lap['TyreLife'])
+        pace_delta_s = float((driver_x_lap["LapTime"] - driver_y_lap["LapTime"]).total_seconds())
+        tyre_life_x = int(driver_x_lap["TyreLife"])
+        tyre_life_y = int(driver_y_lap["TyreLife"])
         tyre_life_diff = tyre_life_x - tyre_life_y
-        speed_trap_delta = (
-            float(driver_x_lap.get('SpeedST', 300.0)) - float(driver_y_lap.get('SpeedST', 300.0))
+        speed_trap_delta = float(driver_x_lap.get("SpeedST", 300.0)) - float(
+            driver_y_lap.get("SpeedST", 300.0)
         )
-        lap_number      = int(driver_x_lap['LapNumber'])
+        lap_number = int(driver_x_lap["LapNumber"])
         # DRS is unavailable under SC/VSC (Art. 22.1(c): activation only resumes one lap
         # after a safety car period, two in the 2023 regulation). The gap-based rule
         # below cannot know that, so a neutralised lap used to report an open DRS window
         # purely because the field had bunched to under a second: the feature was live
         # and lying, on exactly the laps where it is regulated shut.
-        drs_allowed     = not _is_neutralised(driver_x_lap.get('TrackStatus'))
-        drs_window      = int(gap_ahead_s < 1.0) if drs_allowed else 0
-        drs_ready_gap   = gap_ahead_s * drs_window
+        drs_allowed = not _is_neutralised(driver_x_lap.get("TrackStatus"))
+        drs_window = int(gap_ahead_s < 1.0) if drs_allowed else 0
+        drs_ready_gap = gap_ahead_s * drs_window
 
-        compound_x = _abs_compound(str(driver_x_lap.get('Compound', 'MEDIUM')), gp_name, year)
-        compound_y = _abs_compound(str(driver_y_lap.get('Compound', 'MEDIUM')), gp_name, year)
+        compound_x = _abs_compound(str(driver_x_lap.get("Compound", "MEDIUM")), gp_name, year)
+        compound_y = _abs_compound(str(driver_y_lap.get("Compound", "MEDIUM")), gp_name, year)
         gap_pace_product = gap_ahead_s * pace_delta_s
 
-        _dx = laps_recent[laps_recent['Driver'] == driver_x_lap['Driver']].sort_values('LapNumber').tail(3)
-        _dy = laps_recent[laps_recent['Driver'] == driver_y_lap['Driver']].sort_values('LapNumber').tail(3)
+        _dx = (
+            laps_recent[laps_recent["Driver"] == driver_x_lap["Driver"]]
+            .sort_values("LapNumber")
+            .tail(3)
+        )
+        _dy = (
+            laps_recent[laps_recent["Driver"] == driver_y_lap["Driver"]]
+            .sort_values("LapNumber")
+            .tail(3)
+        )
 
         if len(_dx) >= 2 and len(_dy) >= 2:
-            _dx_t = _dx['LapTime'].dt.total_seconds().values
-            _dy_t = _dy['LapTime'].dt.total_seconds().values
+            _dx_t = _dx["LapTime"].dt.total_seconds().values
+            _dy_t = _dy["LapTime"].dt.total_seconds().values
             n_shared = min(len(_dx_t), len(_dy_t))
             pace_delta_rolling3 = float((_dx_t[:n_shared] - _dy_t[:n_shared]).mean())
 
-            _tx = _dx['Time'] if 'Time' in _dx.columns else None
-            if _tx is not None and pd.notna(_dx.iloc[-2]['Time']) and pd.notna(_dy.iloc[-2]['Time']):
-                prev_gap  = float((_dx.iloc[-2]['Time'] - _dy.iloc[-2]['Time']).total_seconds())
+            _tx = _dx["Time"] if "Time" in _dx.columns else None
+            if (
+                _tx is not None
+                and pd.notna(_dx.iloc[-2]["Time"])
+                and pd.notna(_dy.iloc[-2]["Time"])
+            ):
+                prev_gap = float((_dx.iloc[-2]["Time"] - _dy.iloc[-2]["Time"]).total_seconds())
                 gap_trend = gap_ahead_s - prev_gap
             else:
                 gap_trend = 0.0
         else:
             pace_delta_rolling3 = pace_delta_s
-            gap_trend           = 0.0
+            gap_trend = 0.0
 
-        return pd.DataFrame([{
-            'gap_ahead_s':         gap_ahead_s,
-            'pace_delta_s':        pace_delta_s,
-            'tyre_life_x':         tyre_life_x,
-            'tyre_life_y':         tyre_life_y,
-            'tyre_life_diff':      tyre_life_diff,
-            'speed_trap_delta':    speed_trap_delta,
-            'LapNumber':           lap_number,
-            'drs_window':          drs_window,
-            'compound_x':          compound_x,
-            'compound_y':          compound_y,
-            'circuit_cluster':     circuit_cluster,
-            'gap_pace_product':    gap_pace_product,
-            'drs_ready_gap':       drs_ready_gap,
-            'gap_trend':           gap_trend,
-            'pace_delta_rolling3': pace_delta_rolling3,
-        }])[self.cfg.overtake_features]
+        return pd.DataFrame(
+            [
+                {
+                    "gap_ahead_s": gap_ahead_s,
+                    "pace_delta_s": pace_delta_s,
+                    "tyre_life_x": tyre_life_x,
+                    "tyre_life_y": tyre_life_y,
+                    "tyre_life_diff": tyre_life_diff,
+                    "speed_trap_delta": speed_trap_delta,
+                    "LapNumber": lap_number,
+                    "drs_window": drs_window,
+                    "compound_x": compound_x,
+                    "compound_y": compound_y,
+                    "circuit_cluster": circuit_cluster,
+                    "gap_pace_product": gap_pace_product,
+                    "drs_ready_gap": drs_ready_gap,
+                    "gap_trend": gap_trend,
+                    "pace_delta_rolling3": pace_delta_rolling3,
+                }
+            ]
+        )[self.cfg.overtake_features]
 
     def _build_sc_features(
         self,
@@ -992,17 +1020,17 @@ class RaceSituationAgent:
         Returns:
             Single-row DataFrame with 32 columns in cfg.sc_features order.
         """
-        cur  = all_laps[all_laps['LapNumber'] == lap_number]
-        prev = all_laps[all_laps['LapNumber'] == lap_number - 1]
+        cur = all_laps[all_laps["LapNumber"] == lap_number]
+        prev = all_laps[all_laps["LapNumber"] == lap_number - 1]
 
         feat: dict = {}
         feat.update(_compute_laptime_features(all_laps, lap_number))
         feat.update(_compute_driver_tyre_features(cur, prev))
 
-        ts_feat   = _compute_track_status_features(all_laps, lap_number)
-        cur_code  = ts_feat.pop('_cur_code')
-        prev_code = ts_feat.pop('_prev_code')
-        ts_feat.pop('_yel_esc')
+        ts_feat = _compute_track_status_features(all_laps, lap_number)
+        cur_code = ts_feat.pop("_cur_code")
+        prev_code = ts_feat.pop("_prev_code")
+        ts_feat.pop("_yel_esc")
         feat.update(ts_feat)
 
         feat.update(_compute_rcm_features(all_laps, lap_number, session_meta, cur_code, prev_code))
@@ -1010,28 +1038,28 @@ class RaceSituationAgent:
 
         # DEFAULT_TOTAL_LAPS: see src/agents/_shared_defaults.py for why this fallback
         # exists and why it is single-sourced across the strategy agents.
-        total_laps = int(session_meta.get('total_laps', DEFAULT_TOTAL_LAPS))
-        is_lap1    = int(lap_number == 1)
-        lap_pct    = float(lap_number) / max(total_laps, 1)
+        total_laps = int(session_meta.get("total_laps", DEFAULT_TOTAL_LAPS))
+        is_lap1 = int(lap_number == 1)
+        lap_pct = float(lap_number) / max(total_laps, 1)
 
         anom_hard = 0
-        hist = all_laps[all_laps['LapNumber'] < lap_number]
+        hist = all_laps[all_laps["LapNumber"] < lap_number]
         if not cur.empty and not hist.empty:
-            for drv in cur['Driver'].unique():
-                h = hist[hist['Driver'] == drv]['LapTime'].dt.total_seconds().tail(5)
+            for drv in cur["Driver"].unique():
+                h = hist[hist["Driver"] == drv]["LapTime"].dt.total_seconds().tail(5)
                 if len(h) >= 2:
-                    med    = h.median()
-                    lt_cur = cur.loc[cur['Driver'] == drv, 'LapTime'].dt.total_seconds()
+                    med = h.median()
+                    lt_cur = cur.loc[cur["Driver"] == drv, "LapTime"].dt.total_seconds()
                     if not lt_cur.empty and med > 0 and float(lt_cur.iloc[0]) / med > 1.30:
                         anom_hard += 1
 
-        yel_esc = feat.get('yellow_escalation_count', 0)
-        feat['anomaly_and_yellow'] = int(anom_hard > 0 and yel_esc > 0)
-        feat['lap1_chaos']         = is_lap1 * abs(feat.get('n_drivers_delta', 0))
-        feat['circuit_cluster']    = int(session_meta.get('circuit_cluster', 0))
-        feat['circuit_sc_rate']    = float(session_meta.get('circuit_sc_rate', 0.10))
-        feat['lap_pct']            = lap_pct
-        feat['is_lap1']            = is_lap1
+        yel_esc = feat.get("yellow_escalation_count", 0)
+        feat["anomaly_and_yellow"] = int(anom_hard > 0 and yel_esc > 0)
+        feat["lap1_chaos"] = is_lap1 * abs(feat.get("n_drivers_delta", 0))
+        feat["circuit_cluster"] = int(session_meta.get("circuit_cluster", 0))
+        feat["circuit_sc_rate"] = float(session_meta.get("circuit_sc_rate", 0.10))
+        feat["lap_pct"] = lap_pct
+        feat["is_lap1"] = is_lap1
 
         return pd.DataFrame([feat])[self.cfg.sc_features]
 
@@ -1054,12 +1082,12 @@ class RaceSituationAgent:
             An error string naming the problem, or None when lap_number is valid.
         """
         if lap_number < 1:
-            return f'invalid lap_number {lap_number} — laps start at 1'
-        current = getattr(self, '_current_lap', None)
+            return f"invalid lap_number {lap_number} — laps start at 1"
+        current = getattr(self, "_current_lap", None)
         if current is not None and lap_number > current:
             return (
-                f'invalid lap_number {lap_number} — the race is currently at lap '
-                f'{current}; cannot query a future lap'
+                f"invalid lap_number {lap_number} — the race is currently at lap "
+                f"{current}; cannot query a future lap"
             )
         return None
 
@@ -1080,15 +1108,15 @@ class RaceSituationAgent:
             or None when every driver is live (or presence is unknown, in which
             case the guard disables rather than rejecting every target).
         """
-        live = getattr(self, '_live_drivers', None)
+        live = getattr(self, "_live_drivers", None)
         if live is None:
             return None
         unknown = [d for d in drivers if d not in live]
         if not unknown:
             return None
         return (
-            f'{" and ".join(unknown)} not on track at lap {lap_number}. '
-            f'Drivers racing this lap: {", ".join(sorted(live))}. Pick from that list.'
+            f"{' and '.join(unknown)} not on track at lap {lap_number}. "
+            f"Drivers racing this lap: {', '.join(sorted(live))}. Pick from that list."
         )
 
     # ── LangChain tool factory ────────────────────────────────────────────────
@@ -1125,50 +1153,54 @@ class RaceSituationAgent:
             """
             lap_err = agent._lap_range_error(lap_number)
             if lap_err:
-                return f'Overtake scoring REFUSED — {lap_err}'
+                return f"Overtake scoring REFUSED — {lap_err}"
             drv_err = agent._unknown_driver_error((driver_x, driver_y), lap_number)
             if drv_err:
-                return f'Overtake scoring REFUSED — {drv_err}'
+                return f"Overtake scoring REFUSED — {drv_err}"
 
             x_rows = agent.laps_df[
-                (agent.laps_df['Driver'] == driver_x) & (agent.laps_df['LapNumber'] == lap_number)
+                (agent.laps_df["Driver"] == driver_x) & (agent.laps_df["LapNumber"] == lap_number)
             ]
             y_rows = agent.laps_df[
-                (agent.laps_df['Driver'] == driver_y) & (agent.laps_df['LapNumber'] == lap_number)
+                (agent.laps_df["Driver"] == driver_y) & (agent.laps_df["LapNumber"] == lap_number)
             ]
 
             if x_rows.empty or y_rows.empty:
-                return f'No lap data for {driver_x} or {driver_y} at lap {lap_number}'
+                return f"No lap data for {driver_x} or {driver_y} at lap {lap_number}"
 
             laps_recent = agent.laps_df[
-                agent.laps_df['Driver'].isin([driver_x, driver_y]) &
-                (agent.laps_df['LapNumber'] >= lap_number - 3) &
-                (agent.laps_df['LapNumber'] <= lap_number)
+                agent.laps_df["Driver"].isin([driver_x, driver_y])
+                & (agent.laps_df["LapNumber"] >= lap_number - 3)
+                & (agent.laps_df["LapNumber"] <= lap_number)
             ]
 
             feat_df = agent._build_overtake_features(
-                x_rows.iloc[0], y_rows.iloc[0], laps_recent,
-                circuit_cluster = agent.session_meta.get('circuit_cluster', 0),
-                gp_name         = agent.session_meta.get('gp_name', ''),
-                year            = agent.session_meta.get('year', 2025),
+                x_rows.iloc[0],
+                y_rows.iloc[0],
+                laps_recent,
+                circuit_cluster=agent.session_meta.get("circuit_cluster", 0),
+                gp_name=agent.session_meta.get("gp_name", ""),
+                year=agent.session_meta.get("year", 2025),
             )
 
-            for i, col in enumerate(['compound_x', 'compound_y', 'circuit_cluster']):
+            for i, col in enumerate(["compound_x", "compound_y", "circuit_cluster"]):
                 training_cats = agent.cfg.overtake_model._Booster.pandas_categorical[i]
-                feat_df[col]  = pd.Categorical(feat_df[col], categories=training_cats)
+                feat_df[col] = pd.Categorical(feat_df[col], categories=training_cats)
 
-            raw_proba   = agent.cfg.overtake_model.predict_proba(feat_df)[:, 1]
-            calib_proba = agent.cfg.overtake_calibrator.predict_proba(raw_proba.reshape(-1, 1))[:, 1][0]
+            raw_proba = agent.cfg.overtake_model.predict_proba(feat_df)[:, 1]
+            calib_proba = agent.cfg.overtake_calibrator.predict_proba(raw_proba.reshape(-1, 1))[
+                :, 1
+            ][0]
 
-            gap  = feat_df['gap_ahead_s'].iloc[0]
-            pace = feat_df['pace_delta_s'].iloc[0]
-            drs  = 'active' if feat_df['drs_window'].iloc[0] else 'inactive'
+            gap = feat_df["gap_ahead_s"].iloc[0]
+            pace = feat_df["pace_delta_s"].iloc[0]
+            drs = "active" if feat_df["drs_window"].iloc[0] else "inactive"
 
             return (
-                f'P(overtake) = {calib_proba:.3f} | '
-                f'gap={gap:.2f}s | '
-                f'pace_delta={pace:.3f}s/lap | '
-                f'DRS: {drs}'
+                f"P(overtake) = {calib_proba:.3f} | "
+                f"gap={gap:.2f}s | "
+                f"pace_delta={pace:.3f}s/lap | "
+                f"DRS: {drs}"
             )
 
         @lc_tool
@@ -1186,27 +1218,34 @@ class RaceSituationAgent:
             """
             lap_err = agent._lap_range_error(lap_number)
             if lap_err:
-                return f'SC scoring REFUSED — {lap_err}'
+                return f"SC scoring REFUSED — {lap_err}"
             if len(agent.laps_df) < 10:
-                return f'Insufficient lap data at lap {lap_number}'
+                return f"Insufficient lap data at lap {lap_number}"
 
             feat_df = agent._build_sc_features(agent.laps_df, lap_number, agent.session_meta)
 
-            raw_proba   = agent.cfg.sc_model.predict_proba(feat_df)[:, 1]
+            raw_proba = agent.cfg.sc_model.predict_proba(feat_df)[:, 1]
             calib_proba = agent.cfg.sc_calibrator.predict_proba(raw_proba.reshape(-1, 1))[:, 1][0]
 
-            lt_std_z     = feat_df['lap_time_std_z'].iloc[0]
-            sc_rate      = feat_df['circuit_sc_rate'].iloc[0]
-            status_enc   = int(feat_df['track_status_enc'].iloc[0])
-            had_incident = int(feat_df['had_incident_msg'].iloc[0])
+            lt_std_z = feat_df["lap_time_std_z"].iloc[0]
+            sc_rate = feat_df["circuit_sc_rate"].iloc[0]
+            status_enc = int(feat_df["track_status_enc"].iloc[0])
+            had_incident = int(feat_df["had_incident_msg"].iloc[0])
 
-            _status_desc = {0: 'green', 1: 'yellow', 2: 'red flag', 3: 'VSC ending', 4: 'VSC', 5: 'SC'}
+            _status_desc = {
+                0: "green",
+                1: "yellow",
+                2: "red flag",
+                3: "VSC ending",
+                4: "VSC",
+                5: "SC",
+            }
             return (
-                f'P(SC 3-lap) = {calib_proba:.3f} | '
-                f'lap_time_std_z={lt_std_z:.2f} | '
-                f'circuit_sc_rate={sc_rate:.2f} | '
-                f'status: {_status_desc.get(status_enc, "unknown")} | '
-                f'{"incident flagged" if had_incident else "no incidents"}'
+                f"P(SC 3-lap) = {calib_proba:.3f} | "
+                f"lap_time_std_z={lt_std_z:.2f} | "
+                f"circuit_sc_rate={sc_rate:.2f} | "
+                f"status: {_status_desc.get(status_enc, 'unknown')} | "
+                f"{'incident flagged' if had_incident else 'no incidents'}"
             )
 
         return [predict_overtake_tool, predict_sc_tool]
@@ -1216,9 +1255,9 @@ class RaceSituationAgent:
     def get_react_agent(
         self,
         provider: str = None,
-        model_name: str = 'gpt-4.1-mini',
-        base_url: str = 'http://localhost:1234/v1',
-        api_key: str = 'lm-studio',
+        model_name: str = "gpt-4.1-mini",
+        base_url: str = "http://localhost:1234/v1",
+        api_key: str = "lm-studio",
     ):
         """Return the LangGraph ReAct agent, creating it on the first call (lazy).
 
@@ -1238,17 +1277,25 @@ class RaceSituationAgent:
             ImportError: When LangGraph / LangChain are not installed.
         """
         if not _LANGGRAPH_AVAILABLE:
-            raise ImportError('LangGraph / LangChain not installed.')
+            raise ImportError("LangGraph / LangChain not installed.")
 
         if self._react_agent is not None:
             return self._react_agent
 
         import os
-        if provider is None:
-            provider = os.environ.get('F1_LLM_PROVIDER', 'lmstudio')
 
-        if provider == 'lmstudio':
-            llm = ChatOpenAI(model=model_name, base_url=base_url, api_key=api_key, temperature=0, timeout=120, max_retries=1)
+        if provider is None:
+            provider = os.environ.get("F1_LLM_PROVIDER", "lmstudio")
+
+        if provider == "lmstudio":
+            llm = ChatOpenAI(
+                model=model_name,
+                base_url=base_url,
+                api_key=api_key,
+                temperature=0,
+                timeout=120,
+                max_retries=1,
+            )
         else:
             llm = ChatOpenAI(model=model_name, temperature=0, timeout=120, max_retries=1)
 
@@ -1282,16 +1329,16 @@ class RaceSituationAgent:
             RaceSituationOutput with overtake_prob, sc_prob_3lap, threat_level,
             gap_ahead_s, pace_delta_s, and LLM reasoning string.
         """
-        session     = lap_state['session']
-        driver      = lap_state['driver']
-        rival_ahead = lap_state.get('rival_ahead')
-        lap_number  = lap_state['lap_number']
-        gp_name     = lap_state['gp_name']
-        event_name  = lap_state['event_name']
+        session = lap_state["session"]
+        driver = lap_state["driver"]
+        rival_ahead = lap_state.get("rival_ahead")
+        lap_number = lap_state["lap_number"]
+        gp_name = lap_state["gp_name"]
+        event_name = lap_state["event_name"]
 
         self.laps_df = session.laps.pick_accurate().copy()
-        _clean       = self.laps_df[self.laps_df['TrackStatus'] == '1']
-        _wx          = session.weather_data
+        _clean = self.laps_df[self.laps_df["TrackStatus"] == "1"]
+        _wx = session.weather_data
 
         # Who is actually on track at this lap. session.laps carries the WHOLE race
         # (not just laps up to lap_number), so without this a free-text driver_x/
@@ -1300,23 +1347,27 @@ class RaceSituationAgent:
         # (#476) — mirrors pit_strategy_agent's `_live_drivers` (#462). Empty means
         # we could not tell (e.g. lap_number outside the session), so the guard
         # disables (None) rather than rejecting every target.
-        _at_lap = self.laps_df.loc[self.laps_df['LapNumber'] == lap_number, 'Driver'].dropna()
+        _at_lap = self.laps_df.loc[self.laps_df["LapNumber"] == lap_number, "Driver"].dropna()
         self._live_drivers = set(_at_lap) | {driver} if len(_at_lap) else None
-        self._current_lap  = lap_number
+        self._current_lap = lap_number
 
         self.session_meta = {
-            'session':          session,
-            'gp_name':          gp_name,
-            'event_name':       event_name,
-            'year':             lap_state.get('year', 2025),
-            'circuit_cluster':  self.cfg.circuit_cluster_map.get(gp_name, 0),
-            'circuit_sc_rate':  self.cfg.sc_rate_for(event_name),
-            'total_laps':       int(session.total_laps),
-            'fastest_lap_s':    _clean['LapTime'].min().total_seconds(),
-            'AirTemp':          float(_wx['AirTemp'].mean())    if 'AirTemp'   in _wx else 28.0,
-            'TrackTemp':        float(_wx['TrackTemp'].mean())  if 'TrackTemp' in _wx else 38.0,
-            'Humidity':         float(_wx['Humidity'].mean())   if 'Humidity'  in _wx else 50.0,
-            'track_temp_start': float(_wx['TrackTemp'].iloc[0]) if 'TrackTemp' in _wx else 38.0,
+            "session": session,
+            "gp_name": gp_name,
+            "event_name": event_name,
+            "year": lap_state.get("year", 2025),
+            "circuit_cluster": self.cfg.circuit_cluster_map.get(gp_name, 0),
+            "circuit_sc_rate": self.cfg.sc_rate_for(event_name),
+            "total_laps": int(session.total_laps),
+            "fastest_lap_s": _clean["LapTime"].min().total_seconds(),
+            "AirTemp": float(_wx["AirTemp"].mean()) if "AirTemp" in _wx else 28.0,
+            "TrackTemp": float(_wx["TrackTemp"].mean())
+            if "TrackTemp" in _wx
+            else DEFAULT_TRACK_TEMP_C,
+            "Humidity": float(_wx["Humidity"].mean()) if "Humidity" in _wx else 50.0,
+            "track_temp_start": float(_wx["TrackTemp"].iloc[0])
+            if "TrackTemp" in _wx
+            else DEFAULT_TRACK_TEMP_C,
         }
 
         # Carry the RCM events into _run_core so the SC override can read them
@@ -1352,31 +1403,32 @@ class RaceSituationAgent:
         Returns:
             RaceSituationOutput with all fields populated.
         """
-        d      = lap_state['driver']
-        meta   = lap_state['session_meta']
-        wx     = lap_state.get('weather', {})
-        rivals = lap_state.get('rivals', [])
+        d = lap_state["driver"]
+        meta = lap_state["session_meta"]
+        wx = lap_state.get("weather", {})
+        rivals = lap_state.get("rivals", [])
 
-        lap_number = lap_state['lap_number']
-        driver     = meta['driver']
-        gp_name    = meta.get('gp_name', '')
+        lap_number = lap_state["lap_number"]
+        driver = meta["driver"]
+        gp_name = meta.get("gp_name", "")
         # DEFAULT_TOTAL_LAPS: see src/agents/_shared_defaults.py.
-        total_laps = meta.get('total_laps', DEFAULT_TOTAL_LAPS)
-        year       = meta.get('year', 2025)
+        total_laps = meta.get("total_laps", DEFAULT_TOTAL_LAPS)
+        year = meta.get("year", 2025)
 
         # #465 (F6): a defaulted position (previously `.get('position', 20)`) is a
         # SEARCHABLE value, not a safe placeholder — if the real grid has a car at
         # P19, "unknown position" and "genuinely P20" silently produce the same
         # rival_ahead lookup. An unknown position must propagate as "no rival
         # computable", not guess P20.
-        driver_pos  = d.get('position')
+        driver_pos = d.get("position")
         rival_ahead = (
-            next((r['driver'] for r in rivals if r.get('position') == driver_pos - 1), None)
-            if driver_pos is not None else None
+            next((r["driver"] for r in rivals if r.get("position") == driver_pos - 1), None)
+            if driver_pos is not None
+            else None
         )
 
         self.laps_df = _ensure_timedelta_laps(laps_df)
-        event_name   = meta.get('event_name', gp_name)
+        event_name = meta.get("event_name", gp_name)
 
         # Who is actually on track this lap, from the RSM's `rivals` list (a car that
         # retired simply is not in it — the same answer a timing screen gives). Used
@@ -1385,27 +1437,28 @@ class RaceSituationAgent:
         # (#462). An empty rivals list means the roster is unknown, not "only our car
         # is racing", so it disables the guard (None) rather than rejecting every
         # target — same convention as pit_strategy_agent.run_from_state.
-        on_track = {r['driver'] for r in rivals if r.get('driver')}
+        on_track = {r["driver"] for r in rivals if r.get("driver")}
         self._live_drivers = on_track | {driver} if on_track else None
-        self._current_lap  = lap_number
+        self._current_lap = lap_number
 
         self.session_meta = {
-            'session':          None,
-            'gp_name':          gp_name,
-            'event_name':       event_name,
-            'year':             year,
-            'circuit_cluster':  self.cfg.circuit_cluster_map.get(gp_name, 0),
-            'circuit_sc_rate':  self.cfg.sc_rate_for(event_name),
-            'total_laps':       total_laps,
-            'fastest_lap_s':    float(self.laps_df['LapTime'].dt.total_seconds().min())
-                                if len(self.laps_df) > 0 else 90.0,
+            "session": None,
+            "gp_name": gp_name,
+            "event_name": event_name,
+            "year": year,
+            "circuit_cluster": self.cfg.circuit_cluster_map.get(gp_name, 0),
+            "circuit_sc_rate": self.cfg.sc_rate_for(event_name),
+            "total_laps": total_laps,
+            "fastest_lap_s": float(self.laps_df["LapTime"].dt.total_seconds().min())
+            if len(self.laps_df) > 0
+            else 90.0,
             # reading_or_default, not .get(key, default): the producers report an
             # unmeasured reading as the key PRESENT holding None, which .get's default
             # never catches, and _compute_weather_features' float() then raises. That
             # 422'd /recommend on every 2025 lap (#788) — see the helper's docstring.
-            'AirTemp':          reading_or_default(wx, 'air_temp',   28.0),
-            'TrackTemp':        reading_or_default(wx, 'track_temp', 38.0),
-            'Humidity':         reading_or_default(wx, 'humidity',   50.0),
+            "AirTemp": reading_or_default(wx, "air_temp", DEFAULT_AIR_TEMP_C),
+            "TrackTemp": reading_or_default(wx, "track_temp", DEFAULT_TRACK_TEMP_C),
+            "Humidity": reading_or_default(wx, "humidity", 50.0),
             # The session's FIRST track temp, which the RSM now supplies. This used to
             # read `track_temp` — the CURRENT one — so `track_temp_delta` came out 0.0 on
             # every lap of every race, on every shipping path (CLI, arcade, backend,
@@ -1417,7 +1470,7 @@ class RaceSituationAgent:
             # exactly where a late SC decides a result. Falling back to the current temp
             # would reinstate the bug silently, so an absent value degrades to the
             # training default instead.
-            'track_temp_start': wx.get('track_temp_start') or 38.0,
+            "track_temp_start": wx.get("track_temp_start") or DEFAULT_TRACK_TEMP_C,
         }
 
         # Carry the RCM events into _run_core so the SC override can read them.
@@ -1443,25 +1496,25 @@ class RaceSituationAgent:
             Fully populated RaceSituationOutput.
         """
         if not _LANGGRAPH_AVAILABLE:
-            raise ImportError('LangGraph / LangChain not installed.')
+            raise ImportError("LangGraph / LangChain not installed.")
 
         if rival_ahead:
             message = (
-                f'Assess the race situation for driver {driver} at lap {lap_number}. '
-                f'The car ahead is {rival_ahead}. '
-                f'Determine the overtaking probability and Safety Car risk, then provide a threat level.'
+                f"Assess the race situation for driver {driver} at lap {lap_number}. "
+                f"The car ahead is {rival_ahead}. "
+                f"Determine the overtaking probability and Safety Car risk, then provide a threat level."
             )
         else:
             message = (
-                f'Assess the race situation for driver {driver} at lap {lap_number}. '
-                f'No car is within overtaking range (gap > 2.5s). '
-                f'Determine the Safety Car risk and provide a threat level.'
+                f"Assess the race situation for driver {driver} at lap {lap_number}. "
+                f"No car is within overtaking range (gap > 2.5s). "
+                f"Determine the Safety Car risk and provide a threat level."
             )
 
         react_agent = self.get_react_agent()
-        response    = react_agent.invoke({'messages': [HumanMessage(content=message)]})
-        parsed      = _parse_tool_outputs(response['messages'])
-        reasoning   = response['messages'][-1].content
+        response = react_agent.invoke({"messages": [HumanMessage(content=message)]})
+        parsed = _parse_tool_outputs(response["messages"])
+        reasoning = response["messages"][-1].content
 
         # Post-hoc override: when the lap's RCM events confirm a neutralisation is
         # currently deployed, force sc_prob_3lap to 1.0 and flag the output so downstream
@@ -1470,10 +1523,10 @@ class RaceSituationAgent:
         # the patch. The SC/VSC split (#471) rides on the same signal: both are
         # neutralisations (overtake_prob = 0, sc_prob_3lap = 1.0), but only the KIND
         # changes the pit-time saving, carried downstream on vsc_active.
-        neutralization    = _neutralization_from_rcm(getattr(self, "_pending_rcm_events", None) or [])
-        is_neutralized    = neutralization is not Neutralization.NONE
-        is_vsc            = neutralization is Neutralization.VSC
-        raw_sc_prob       = round(parsed['sc_prob_3lap'], 3)
+        neutralization = _neutralization_from_rcm(getattr(self, "_pending_rcm_events", None) or [])
+        is_neutralized = neutralization is not Neutralization.NONE
+        is_vsc = neutralization is Neutralization.VSC
+        raw_sc_prob = round(parsed["sc_prob_3lap"], 3)
         effective_sc_prob = 1.0 if is_neutralized else raw_sc_prob
 
         # Art. 55.8 (SC) / 56.6 (VSC): no overtaking on track. N12 predicts a RACING
@@ -1484,10 +1537,10 @@ class RaceSituationAgent:
         # lengths (55.7/55.10) and pace_delta collapses to the FIA ECU delta. So the model
         # is not merely imprecise here, it is inapplicable: 0.0 is the correct value and
         # the honest one, and it holds identically under a VSC (56.6).
-        raw_overtake_prob       = round(parsed['overtake_prob'], 3)
+        raw_overtake_prob = round(parsed["overtake_prob"], 3)
         effective_overtake_prob = 0.0 if is_neutralized else raw_overtake_prob
 
-        _kind_label       = "VIRTUAL_SAFETY_CAR_DEPLOYED" if is_vsc else "SAFETY_CAR_DEPLOYED"
+        _kind_label = "VIRTUAL_SAFETY_CAR_DEPLOYED" if is_vsc else "SAFETY_CAR_DEPLOYED"
         _overtake_article = "56.6" if is_vsc else "55.8"
         effective_reasoning = (
             reasoning
@@ -1501,19 +1554,20 @@ class RaceSituationAgent:
         )
 
         return RaceSituationOutput(
-            overtake_prob       = effective_overtake_prob,
-            sc_prob_3lap        = effective_sc_prob,
-            gap_ahead_s         = round(parsed['gap_ahead_s'],   2),
-            pace_delta_s        = round(parsed['pace_delta_s'],  3),
-            reasoning           = effective_reasoning,
-            sc_currently_active = is_neutralized,
-            vsc_active          = is_vsc,
+            overtake_prob=effective_overtake_prob,
+            sc_prob_3lap=effective_sc_prob,
+            gap_ahead_s=round(parsed["gap_ahead_s"], 2),
+            pace_delta_s=round(parsed["pace_delta_s"], 3),
+            reasoning=effective_reasoning,
+            sc_currently_active=is_neutralized,
+            vsc_active=is_vsc,
         )
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # RCM context override helper
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 def _classify_rcm_events(rcm_events: list | None) -> list[str]:
     """Classify a lap's RCM events into canonical event-type strings.
@@ -1545,14 +1599,18 @@ def _classify_rcm_events(rcm_events: list | None) -> list[str]:
             classified.append(_radio._classify_rcm_event(ev))
             continue
         if isinstance(ev, dict):
-            classified.append(_radio._classify_rcm_event(_radio.RCMEvent(
-                message=str(ev.get("message", "")),
-                flag=str(ev.get("flag", "") or ""),
-                category=str(ev.get("category", "")),
-                lap=int(ev.get("lap", 0) or 0),
-                racing_number=ev.get("racing_number") or ev.get("RacingNumber"),
-                scope=str(ev.get("scope", "") or ""),
-            )))
+            classified.append(
+                _radio._classify_rcm_event(
+                    _radio.RCMEvent(
+                        message=str(ev.get("message", "")),
+                        flag=str(ev.get("flag", "") or ""),
+                        category=str(ev.get("category", "")),
+                        lap=int(ev.get("lap", 0) or 0),
+                        racing_number=ev.get("racing_number") or ev.get("RacingNumber"),
+                        scope=str(ev.get("scope", "") or ""),
+                    )
+                )
+            )
     return classified
 
 
@@ -1624,6 +1682,7 @@ def _get_default_situation_agent() -> RaceSituationAgent:
 # ─────────────────────────────────────────────────────────────────────────────
 # Public entry points — backward-compatible signatures (unchanged)
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 def run_race_situation_agent(lap_state: dict) -> RaceSituationOutput:
     """Run the Race Situation Agent for one lap and return structured output.

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -32,7 +32,12 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from src.agents._shared_defaults import DEFAULT_TOTAL_LAPS, reading_or_default
+from src.agents._shared_defaults import (
+    DEFAULT_AIR_TEMP_C,
+    DEFAULT_TOTAL_LAPS,
+    DEFAULT_TRACK_TEMP_C,
+    reading_or_default,
+)
 from src.agents.race_state_builder import UNKNOWN_TYRE_LIFE, normalise_compound
 from src.agents.tire_parsing import parse_tool_outputs
 
@@ -40,7 +45,7 @@ from src.agents.tire_parsing import parse_tool_outputs
 # Walker with a root-stop guard so we don't spin forever when the module is
 # imported from outside a git checkout (e.g. uv tool install).
 _REPO_ROOT = Path(__file__).resolve().parent
-while not (_REPO_ROOT / '.git').exists():
+while not (_REPO_ROOT / ".git").exists():
     if _REPO_ROOT.parent == _REPO_ROOT:
         break
     _REPO_ROOT = _REPO_ROOT.parent
@@ -50,6 +55,7 @@ while not (_REPO_ROOT / '.git').exists():
 # to the repo-relative layout when the helper is not importable.
 try:
     from src.f1_strat_manager.data_cache import get_data_root as _get_data_root
+
     _DATA_ROOT = _get_data_root()
 except (ImportError, OSError, RuntimeError):
     # Every way get_data_root() can fail, enumerated against its body in
@@ -60,18 +66,19 @@ except (ImportError, OSError, RuntimeError):
     # the Path.home() branch IS the `uv tool install` path this block exists to
     # serve, and a container with no HOME would take it. Falling back to the
     # repo-relative data/ is right for all three.
-    _DATA_ROOT = _REPO_ROOT / 'data'
+    _DATA_ROOT = _REPO_ROOT / "data"
 
 logger = logging.getLogger(__name__)
 
-_MODEL_DIR  = _DATA_ROOT / 'models' / 'tire_degradation'
-_PROCESSED  = _DATA_ROOT / 'processed'
-_AGENTS_DIR = _DATA_ROOT / 'models' / 'agents'
+_MODEL_DIR = _DATA_ROOT / "models" / "tire_degradation"
+_PROCESSED = _DATA_ROOT / "processed"
+_AGENTS_DIR = _DATA_ROOT / "models" / "agents"
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # TireDegTCN — reproduced from N10 (different state dict layout from legacy N09)
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 class CausalConv1dBlock(nn.Module):
     """Single causal dilated convolution layer with left-side padding.
@@ -93,9 +100,11 @@ class CausalConv1dBlock(nn.Module):
             at inference time for MC Dropout uncertainty estimation.
     """
 
-    def __init__(self, in_ch: int, out_ch: int, kernel_size: int, dilation: int, dropout: float = 0.1):
+    def __init__(
+        self, in_ch: int, out_ch: int, kernel_size: int, dilation: int, dropout: float = 0.1
+    ):
         super().__init__()
-        self.pad  = (kernel_size - 1) * dilation
+        self.pad = (kernel_size - 1) * dilation
         self.conv = nn.Conv1d(in_ch, out_ch, kernel_size, dilation=dilation, padding=0)
         self.norm = nn.LayerNorm(out_ch)
         self.drop = nn.Dropout(dropout)
@@ -162,11 +171,10 @@ class TireDegTCN(nn.Module):
         dropout: float = 0.1,
     ):
         super().__init__()
-        self.input_proj  = nn.Linear(n_features, d_model)
-        self.blocks      = nn.ModuleList([
-            TCNResidualBlock(d_model, kernel_size, 2**i, dropout)
-            for i in range(n_layers)
-        ])
+        self.input_proj = nn.Linear(n_features, d_model)
+        self.blocks = nn.ModuleList(
+            [TCNResidualBlock(d_model, kernel_size, 2**i, dropout) for i in range(n_layers)]
+        )
         self.output_head = nn.Linear(d_model, 1)
 
     def forward(self, x: torch.Tensor, mask: Optional[torch.Tensor] = None) -> torch.Tensor:
@@ -179,6 +187,7 @@ class TireDegTCN(nn.Module):
 # ─────────────────────────────────────────────────────────────────────────────
 # TireAgentConfig
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 @dataclass
 class TireAgentConfig:
@@ -263,12 +272,12 @@ class TireAgentConfig:
 
     n_mc: int = 50
     mc_seed: int = 42
-    model_name: str = 'gpt-4.1-mini'
+    model_name: str = "gpt-4.1-mini"
     cliff_pit_soon_laps: int = 3
-    cliff_monitor_laps: int  = 7
+    cliff_monitor_laps: int = 7
     fresh_reference_tyre_life: int = 3
     fresh_reference_max_pct_of_fastest: float = 1.10
-    deg_cost_floor_s: float   = -2.33
+    deg_cost_floor_s: float = -2.33
     deg_cost_ceiling_s: float = 3.67
 
     def __post_init__(self) -> None:
@@ -279,15 +288,15 @@ class TireAgentConfig:
         except OSError:
             pass  # read-only mount in Docker
 
-        self.routing_cfg                              = self._load_routing_cfg()
-        self.mc_calibration, self.mc_sigma_fallback   = self._load_mc_calibration()
+        self.routing_cfg = self._load_routing_cfg()
+        self.mc_calibration, self.mc_sigma_fallback = self._load_mc_calibration()
         self._load_encoding_maps()
-        self.circuit_cluster_map                      = self._load_circuit_clusters()
+        self.circuit_cluster_map = self._load_circuit_clusters()
         self._load_cliff_thresholds()
 
     def _load_routing_cfg(self) -> dict:
         """Load routing_config.json: compound ID → bundle filename + window size."""
-        with open(self._model_dir / 'routing_config.json') as f:
+        with open(self._model_dir / "routing_config.json") as f:
             return json.load(f)
 
     def _load_mc_calibration(self) -> tuple[dict, float]:
@@ -302,26 +311,26 @@ class TireAgentConfig:
         Returns:
             Tuple (calibration_dict, sigma_fallback).
         """
-        with open(self._model_dir / 'mc_dropout_calibration.json') as f:
+        with open(self._model_dir / "mc_dropout_calibration.json") as f:
             mc_cal = json.load(f)
-        fallback = float(np.mean([v['mean_sigma_s'] for v in mc_cal.values()]))
+        fallback = float(np.mean([v["mean_sigma_s"] for v in mc_cal.values()]))
         return mc_cal, fallback
 
     def _load_encoding_maps(self) -> None:
         """Load encoding_maps.json and set four label-encoding dicts as instance attrs."""
-        with open(self._model_dir / 'encoding_maps.json') as f:
+        with open(self._model_dir / "encoding_maps.json") as f:
             enc = json.load(f)
-        self.team_id_map: dict           = enc['team_id']
-        self.compound_id_map: dict       = enc['compound_id']
-        self.abs_compound_id_map: dict   = enc['absolute_compound_id']
-        self.compound_hardness_map: dict = enc['compound_hardness']
+        self.team_id_map: dict = enc["team_id"]
+        self.compound_id_map: dict = enc["compound_id"]
+        self.abs_compound_id_map: dict = enc["absolute_compound_id"]
+        self.compound_hardness_map: dict = enc["compound_hardness"]
 
     def _load_circuit_clusters(self) -> dict:
         """Load k=4 circuit cluster parquet and return GP_Name → Cluster int dict."""
         cluster_df = pd.read_parquet(
-            _PROCESSED / 'circuit_clustering' / 'circuit_clusters_k4.parquet'
+            _PROCESSED / "circuit_clustering" / "circuit_clusters_k4.parquet"
         )
-        return dict(zip(cluster_df['GP_Name'], cluster_df['Cluster'].astype(int)))
+        return dict(zip(cluster_df["GP_Name"], cluster_df["Cluster"].astype(int)))
 
     def _load_cliff_thresholds(self) -> None:
         """Load cluster-aware and GP-level cliff thresholds from tire_agent_config_v1.json.
@@ -329,22 +338,22 @@ class TireAgentConfig:
         Falls back to empty dicts (global thresholds only) when the file does not
         exist yet — this covers the case where N26 Step 6 has not been run.
         """
-        cfg_path = self.export_dir / 'tire_agent_config_v1.json'
+        cfg_path = self.export_dir / "tire_agent_config_v1.json"
         if cfg_path.exists():
             with open(cfg_path) as f:
                 agent_cfg = json.load(f)
-            cat = agent_cfg.get('cluster_aware_thresholds', {})
+            cat = agent_cfg.get("cluster_aware_thresholds", {})
             self.cliff_pit_soon_by_cluster: dict = {
-                int(k): v for k, v in cat.get('pit_soon_by_cluster', {}).items()
+                int(k): v for k, v in cat.get("pit_soon_by_cluster", {}).items()
             }
             self.cliff_monitor_by_cluster: dict = {
-                int(k): v for k, v in cat.get('monitor_by_cluster', {}).items()
+                int(k): v for k, v in cat.get("monitor_by_cluster", {}).items()
             }
-            self.cliff_overrides_by_gp: dict = cat.get('overrides_by_gp', {})
+            self.cliff_overrides_by_gp: dict = cat.get("overrides_by_gp", {})
         else:
             self.cliff_pit_soon_by_cluster = {}
-            self.cliff_monitor_by_cluster  = {}
-            self.cliff_overrides_by_gp     = {}
+            self.cliff_monitor_by_cluster = {}
+            self.cliff_overrides_by_gp = {}
 
     def get_cliff_thresholds(self, gp_name: str) -> tuple[int, int]:
         """Return (pit_soon_laps, monitor_laps) for the given GP.
@@ -362,11 +371,11 @@ class TireAgentConfig:
         """
         if gp_name in self.cliff_overrides_by_gp:
             ov = self.cliff_overrides_by_gp[gp_name]
-            return ov['pit_soon'], ov['monitor']
+            return ov["pit_soon"], ov["monitor"]
         cluster_id = self.circuit_cluster_map.get(gp_name)
         if cluster_id is not None:
             pit_soon = self.cliff_pit_soon_by_cluster.get(cluster_id, self.cliff_pit_soon_laps)
-            monitor  = self.cliff_monitor_by_cluster.get(cluster_id, self.cliff_monitor_laps)
+            monitor = self.cliff_monitor_by_cluster.get(cluster_id, self.cliff_monitor_laps)
             return pit_soon, monitor
         return self.cliff_pit_soon_laps, self.cliff_monitor_laps
 
@@ -376,16 +385,16 @@ class TireAgentConfig:
         Each .pt file is a self-contained dict from N10: state dict, fitted
         StandardScaler, feature name list, window size, and architecture hparams.
         """
-        cfg    = self.routing_cfg[compound_id]
+        cfg = self.routing_cfg[compound_id]
         bundle = torch.load(
-            self._model_dir / cfg['bundle'],
-            map_location='cpu',
+            self._model_dir / cfg["bundle"],
+            map_location="cpu",
             weights_only=False,
         )
-        model = TireDegTCN(bundle['n_features'], **bundle['model_hparams'])
-        model.load_state_dict(bundle['state_dict'])
+        model = TireDegTCN(bundle["n_features"], **bundle["model_hparams"])
+        model.load_state_dict(bundle["state_dict"])
         model.eval()
-        bundle['model'] = model
+        bundle["model"] = model
         return bundle
 
     def load_all_bundles(self) -> dict:
@@ -403,12 +412,12 @@ CFG = TireAgentConfig()
 # p75 of last-stint-lap FuelAdjustedDegAbsolute in N10 training data (2023-2024).
 # 75% of stints had already pitted by this level — a practical proxy for the cliff.
 CLIFF_THRESHOLD: dict[str, int] = {
-    'C1': 3,  # p75 = 2.20 → ceil = 3
-    'C2': 2,  # p75 = 1.74 → ceil = 2
-    'C3': 2,  # p75 = 1.96 → ceil = 2
-    'C4': 2,  # p75 = 1.75 → ceil = 2
-    'C5': 2,  # p75 = 1.43 → ceil = 2
-    'C6': 2,  # p75 = 1.82 → ceil = 2
+    "C1": 3,  # p75 = 2.20 → ceil = 3
+    "C2": 2,  # p75 = 1.74 → ceil = 2
+    "C3": 2,  # p75 = 1.96 → ceil = 2
+    "C4": 2,  # p75 = 1.75 → ceil = 2
+    "C5": 2,  # p75 = 1.43 → ceil = 2
+    "C6": 2,  # p75 = 1.82 → ceil = 2
 }
 
 # Longest race on the current calendar (Monaco, 78 laps; max observed across
@@ -422,7 +431,9 @@ MAX_RACE_LAPS: int = 78
 
 
 def _reject_contaminated_laps(
-    laps: pd.DataFrame, fastest_lap_s: float, max_pct: float,
+    laps: pd.DataFrame,
+    fastest_lap_s: float,
+    max_pct: float,
 ) -> pd.DataFrame:
     """Drop candidate fresh-reference laps slower than ``max_pct`` times the
     race's fastest lap -- a Safety-Car or red-flag-affected lap that
@@ -432,7 +443,7 @@ def _reject_contaminated_laps(
     Pure and leaf-level so the threshold is testable without model weights --
     the same split ``tire_parsing.py`` made, and for the same reason.
     """
-    return laps[laps['LapTime_s'] <= max_pct * fastest_lap_s]
+    return laps[laps["LapTime_s"] <= max_pct * fastest_lap_s]
 
 
 def _referenced_wear(parsed: dict) -> Optional[float]:
@@ -442,10 +453,10 @@ def _referenced_wear(parsed: dict) -> Optional[float]:
     missing reference into "this tyre is exactly at its fresh pace", which is a
     reading the scorer can also legitimately receive.
     """
-    if 'cum_deg' not in parsed or 'fresh_ref' not in parsed:
+    if "cum_deg" not in parsed or "fresh_ref" not in parsed:
         return None
 
-    wear = parsed['cum_deg'] - parsed['fresh_ref']
+    wear = parsed["cum_deg"] - parsed["fresh_ref"]
     bounded = min(max(wear, CFG.deg_cost_floor_s), CFG.deg_cost_ceiling_s)
     return round(bounded, 4)
 
@@ -453,6 +464,7 @@ def _referenced_wear(parsed: dict) -> Optional[float]:
 # ─────────────────────────────────────────────────────────────────────────────
 # TireOutput
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 @dataclass
 class TireOutput:
@@ -529,26 +541,27 @@ class TireOutput:
     laps_to_cliff_p10: float
     laps_to_cliff_p50: float
     laps_to_cliff_p90: float
-    gp_name: str   = ''
+    gp_name: str = ""
     cumulative_deg_s: float | None = None
     deg_cost_s: float | None = None
     warning_level: str = field(init=False)
-    reasoning: str = ''
+    reasoning: str = ""
 
     def __post_init__(self) -> None:
         pit_soon, monitor = CFG.get_cliff_thresholds(self.gp_name)
         if self.laps_to_cliff_p10 < pit_soon:
-            self.warning_level = 'PIT_SOON'
+            self.warning_level = "PIT_SOON"
         elif self.laps_to_cliff_p10 < monitor:
-            self.warning_level = 'MONITOR'
+            self.warning_level = "MONITOR"
         else:
-            self.warning_level = 'OK'
+            self.warning_level = "OK"
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Feature pipeline helpers (must match N10 training order exactly)
 # Pure functions — receive all required state as arguments, read no globals.
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 def _add_timing_cols(df: pd.DataFrame) -> pd.DataFrame:
     """Convert FastF1 Timedelta columns to float seconds.
@@ -559,30 +572,31 @@ def _add_timing_cols(df: pd.DataFrame) -> pd.DataFrame:
 
     LapsSincePitStop is aliased from TyreLife.
     """
+
     def _to_seconds(df, td_col, s_col):
         if s_col in df.columns:
-            df[s_col] = pd.to_numeric(df[s_col], errors='coerce')
+            df[s_col] = pd.to_numeric(df[s_col], errors="coerce")
         elif td_col in df.columns:
             val = df[td_col]
-            if hasattr(val.iloc[0] if len(val) > 0 else None, 'total_seconds'):
+            if hasattr(val.iloc[0] if len(val) > 0 else None, "total_seconds"):
                 df[s_col] = val.dt.total_seconds()
             else:
-                df[s_col] = pd.to_numeric(val, errors='coerce')
+                df[s_col] = pd.to_numeric(val, errors="coerce")
         else:
-            df[s_col] = float('nan')
+            df[s_col] = float("nan")
         return df
 
-    df = _to_seconds(df, 'LapTime',    'LapTime_s')
-    df = _to_seconds(df, 'Sector1Time', 'Sector1_s')
-    df = _to_seconds(df, 'Sector2Time', 'Sector2_s')
-    df = _to_seconds(df, 'Sector3Time', 'Sector3_s')
-    df['LapsSincePitStop'] = df['TyreLife']
+    df = _to_seconds(df, "LapTime", "LapTime_s")
+    df = _to_seconds(df, "Sector1Time", "Sector1_s")
+    df = _to_seconds(df, "Sector2Time", "Sector2_s")
+    df = _to_seconds(df, "Sector3Time", "Sector3_s")
+    df["LapsSincePitStop"] = df["TyreLife"]
     return df
 
 
 def _add_weather_cols(df: pd.DataFrame, session_meta: dict) -> pd.DataFrame:
     """Ensure weather columns exist; fill from session_meta race averages if absent."""
-    for col in ('AirTemp', 'TrackTemp', 'Humidity', 'Rainfall'):
+    for col in ("AirTemp", "TrackTemp", "Humidity", "Rainfall"):
         if col not in df.columns:
             df[col] = session_meta.get(col, 0.0)
     return df
@@ -595,12 +609,12 @@ def _add_prev_cols(df: pd.DataFrame) -> pd.DataFrame:
     to avoid NaN in the scaler input. Must run before _add_delta_cols.
     """
     for new_col, src_col in [
-        ('Prev_LapTime',  'LapTime_s'),
-        ('Prev_SpeedFL',  'SpeedFL'),
-        ('Prev_SpeedI1',  'SpeedI1'),
-        ('Prev_SpeedI2',  'SpeedI2'),
-        ('Prev_SpeedST',  'SpeedST'),
-        ('Prev_TyreLife', 'TyreLife'),
+        ("Prev_LapTime", "LapTime_s"),
+        ("Prev_SpeedFL", "SpeedFL"),
+        ("Prev_SpeedI1", "SpeedI1"),
+        ("Prev_SpeedI2", "SpeedI2"),
+        ("Prev_SpeedST", "SpeedST"),
+        ("Prev_TyreLife", "TyreLife"),
     ]:
         df[new_col] = df[src_col].shift(1).fillna(df[src_col])
     return df
@@ -612,8 +626,8 @@ def _add_laptime_delta(df: pd.DataFrame) -> pd.DataFrame:
     LapTime_Delta: LapTime_s[i] - LapTime_s[i-1]. Requires Prev_LapTime.
     LapTime_Trend: LapTime_Delta[i] - LapTime_Delta[i-1] (second derivative).
     """
-    df['LapTime_Delta'] = (df['LapTime_s'] - df['Prev_LapTime']).fillna(0)
-    df['LapTime_Trend'] = (df['LapTime_Delta'] - df['LapTime_Delta'].shift(1)).fillna(0)
+    df["LapTime_Delta"] = (df["LapTime_s"] - df["Prev_LapTime"]).fillna(0)
+    df["LapTime_Trend"] = (df["LapTime_Delta"] - df["LapTime_Delta"].shift(1)).fillna(0)
     return df
 
 
@@ -629,25 +643,25 @@ def _add_degradation_rate(df: pd.DataFrame) -> pd.DataFrame:
     Both are shifted by 1 lap (leakage fix matching N10 training) so at position i
     the model sees the rate from lap i-1.
     """
-    tyre_lives = df['TyreLife'].values
-    adj_times  = df['FuelAdjustedLapTime'].values
+    tyre_lives = df["TyreLife"].values
+    adj_times = df["FuelAdjustedLapTime"].values
     n = len(df)
 
-    raw_deg   = np.zeros(n)
+    raw_deg = np.zeros(n)
     raw_accel = np.zeros(n)
 
     for i in range(1, n):
         start = max(0, i - 2)
-        x = tyre_lives[start: i + 1]
-        y = adj_times[start: i + 1]
+        x = tyre_lives[start : i + 1]
+        y = adj_times[start : i + 1]
         if len(x) >= 2 and not np.isnan(y).any():
             raw_deg[i] = np.polyfit(x, y, 1)[0]
 
     for i in range(1, n):
         raw_accel[i] = raw_deg[i] - raw_deg[i - 1]
 
-    df['DegradationRate'] = pd.Series(raw_deg, index=df.index).shift(1).fillna(0)
-    df['DegAcceleration'] = pd.Series(raw_accel, index=df.index).shift(1).fillna(0)
+    df["DegradationRate"] = pd.Series(raw_deg, index=df.index).shift(1).fillna(0)
+    df["DegAcceleration"] = pd.Series(raw_accel, index=df.index).shift(1).fillna(0)
     return df
 
 
@@ -660,8 +674,8 @@ def _add_delta_cols(df: pd.DataFrame) -> pd.DataFrame:
 
 def _add_speed_delta_cols(df: pd.DataFrame) -> pd.DataFrame:
     """Compute trap-speed deltas (current minus previous lap) for all four sensors."""
-    for sensor in ('FL', 'I1', 'I2', 'ST'):
-        df[f'Speed{sensor}_Delta'] = df[f'Speed{sensor}'] - df[f'Prev_Speed{sensor}']
+    for sensor in ("FL", "I1", "I2", "ST"):
+        df[f"Speed{sensor}_Delta"] = df[f"Speed{sensor}"] - df[f"Prev_Speed{sensor}"]
     return df
 
 
@@ -677,14 +691,14 @@ def _add_compound_cols(df: pd.DataFrame, compound_id: str) -> pd.DataFrame:
     with corrupt or out-of-scope compound data, but it is a sentinel by construction, so
     it is logged loudly rather than left invisible.
     """
-    name = str(df['Compound'].iloc[0])
+    name = str(df["Compound"].iloc[0])
     if compound_id not in CFG.abs_compound_id_map:
         logger.warning("Unknown compound_id %r: encoding as C3 (AbsoluteCompoundID=3)", compound_id)
     if name not in CFG.compound_id_map:
         logger.warning("Unknown compound name %r: encoding as SOFT (CompoundID=1)", name)
-    df['AbsoluteCompoundID'] = CFG.abs_compound_id_map.get(compound_id, 3)
-    df['CompoundHardness']   = CFG.compound_hardness_map.get(compound_id, 4)
-    df['CompoundID']         = CFG.compound_id_map.get(name, 1)
+    df["AbsoluteCompoundID"] = CFG.abs_compound_id_map.get(compound_id, 3)
+    df["CompoundHardness"] = CFG.compound_hardness_map.get(compound_id, 4)
+    df["CompoundID"] = CFG.compound_id_map.get(name, 1)
     return df
 
 
@@ -708,14 +722,14 @@ def _add_fuel_cols(df: pd.DataFrame, session_meta: dict) -> pd.DataFrame:
     FuelEffect: cumulative gain from fuel burn = (TyreLife - baseline_tyrelife) * 0.055 s/lap.
     FuelAdjustedLapTime: intermediate column needed by _add_degradation_rate.
     """
-    total_laps = session_meta['total_laps']
+    total_laps = session_meta["total_laps"]
 
-    if 'FuelLoad' not in df.columns:
-        df['FuelLoad'] = ((total_laps - df['LapNumber']) / total_laps).clip(lower=0.0)
+    if "FuelLoad" not in df.columns:
+        df["FuelLoad"] = ((total_laps - df["LapNumber"]) / total_laps).clip(lower=0.0)
 
-    baseline_tyrelife         = df['TyreLife'].iloc[0]
-    df['FuelEffect']          = (df['TyreLife'] - baseline_tyrelife) * 0.055
-    df['FuelAdjustedLapTime'] = df['LapTime_s'] + df['FuelEffect']
+    baseline_tyrelife = df["TyreLife"].iloc[0]
+    df["FuelEffect"] = (df["TyreLife"] - baseline_tyrelife) * 0.055
+    df["FuelAdjustedLapTime"] = df["LapTime_s"] + df["FuelEffect"]
     return df
 
 
@@ -750,25 +764,21 @@ def _add_session_cols(df: pd.DataFrame, session_meta: dict) -> pd.DataFrame:
     because their per-frame recompute reproduces the shipped value exactly
     (0.0000 s delta across all 24 GPs).
     """
-    df['lap_time_pct_of_race_fastest'] = (
-        df['LapTime_s'] / session_meta['fastest_lap_s']
-    )
-    if 'lap_time_vs_cluster_mean' not in df.columns:
-        df['lap_time_vs_cluster_mean'] = (
-            df['LapTime_s'] - session_meta['cluster_mean_lap_s']
-        )
-    df['laps_remaining'] = session_meta['total_laps'] - df['LapNumber']
-    if 'mean_sector_speed' not in df.columns:
-        df['mean_sector_speed'] = (df['SpeedI1'] + df['SpeedI2'] + df['SpeedFL']) / 3
+    df["lap_time_pct_of_race_fastest"] = df["LapTime_s"] / session_meta["fastest_lap_s"]
+    if "lap_time_vs_cluster_mean" not in df.columns:
+        df["lap_time_vs_cluster_mean"] = df["LapTime_s"] - session_meta["cluster_mean_lap_s"]
+    df["laps_remaining"] = session_meta["total_laps"] - df["LapNumber"]
+    if "mean_sector_speed" not in df.columns:
+        df["mean_sector_speed"] = (df["SpeedI1"] + df["SpeedI2"] + df["SpeedFL"]) / 3
 
-    if 'track_status_clean' not in df.columns:
-        status_map = {'1': 0, '2': 1, '3': 2, '4': 2, '5': 2, '6': 1, '7': 1}
-        if 'TrackStatus' in df.columns:
-            df['track_status_clean'] = (
-                df['TrackStatus'].astype(str).map(status_map).fillna(0).astype(int)
+    if "track_status_clean" not in df.columns:
+        status_map = {"1": 0, "2": 1, "3": 2, "4": 2, "5": 2, "6": 1, "7": 1}
+        if "TrackStatus" in df.columns:
+            df["track_status_clean"] = (
+                df["TrackStatus"].astype(str).map(status_map).fillna(0).astype(int)
             )
         else:
-            df['track_status_clean'] = 0
+            df["track_status_clean"] = 0
     return df
 
 
@@ -798,18 +808,17 @@ def _compound_name_to_id(compound_name: str, gp_name: str, year: int) -> str:
     Returns:
         Compound ID string such as 'C3'.
     """
-    compounds_path = _REPO_ROOT / 'data' / 'tire_compounds_by_race.json'
-    fallback = {'SOFT': 'C3', 'MEDIUM': 'C2', 'HARD': 'C1',
-                'INTERMEDIATE': 'INT', 'WET': 'WET'}
+    compounds_path = _REPO_ROOT / "data" / "tire_compounds_by_race.json"
+    fallback = {"SOFT": "C3", "MEDIUM": "C2", "HARD": "C1", "INTERMEDIATE": "INT", "WET": "WET"}
     if not compounds_path.exists():
-        return fallback.get(compound_name.upper(), 'C3')
+        return fallback.get(compound_name.upper(), "C3")
 
     with open(compounds_path) as f:
         alloc = json.load(f)
 
     year_data = alloc.get(str(year), {})
-    gp_data   = year_data.get(gp_name, {})
-    return gp_data.get(compound_name.upper(), fallback.get(compound_name.upper(), 'C3'))
+    gp_data = year_data.get(gp_name, {})
+    return gp_data.get(compound_name.upper(), fallback.get(compound_name.upper(), "C3"))
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -820,6 +829,7 @@ try:
     from langchain_core.tools import tool as lc_tool
     from langchain_openai import ChatOpenAI
     from langchain.agents import create_agent
+
     _LANGGRAPH_AVAILABLE = True
 except ImportError:
     _LANGGRAPH_AVAILABLE = False
@@ -871,6 +881,7 @@ stop becomes unavoidable.
 # TireAgent — encapsulated agent class
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 class TireAgent:
     """Encapsulated Tire Degradation Agent backed by TireDegTCN and LangGraph ReAct.
 
@@ -890,16 +901,16 @@ class TireAgent:
 
     def __init__(self, cfg: TireAgentConfig = CFG) -> None:
         self.cfg: TireAgentConfig = cfg
-        self.bundles: dict        = self.cfg.load_all_bundles()
+        self.bundles: dict = self.cfg.load_all_bundles()
         self.laps_df: pd.DataFrame = pd.DataFrame()
-        self.session_meta: dict    = {}
+        self.session_meta: dict = {}
         # Driver codes actually on track for the CURRENT loaded state (#476). Reset
         # on every run()/run_from_state() call — this instance is a process-level
         # singleton reused across many laps/drivers, so a stale set from a previous
         # call must never leak into the next one's tool-arg validation.
         self._live_drivers: Optional[set] = None
-        self._react_agent          = None
-        self._tools: list          = self._build_tools()
+        self._react_agent = None
+        self._tools: list = self._build_tools()
 
     # ── Feature pipeline (instance methods: use self.bundles / self.cfg) ──────
 
@@ -940,11 +951,11 @@ class TireAgent:
         df = _add_speed_delta_cols(df)
         df = _add_session_cols(df, session_meta)
 
-        df['Cluster'] = session_meta['cluster_id']
-        df['TeamID']  = session_meta['team_id']
-        df['Year']    = session_meta['year']
+        df["Cluster"] = session_meta["cluster_id"]
+        df["TeamID"] = session_meta["team_id"]
+        df["Year"] = session_meta["year"]
 
-        return df[self.bundles[compound_id]['feature_names']].astype(float)
+        return df[self.bundles[compound_id]["feature_names"]].astype(float)
 
     def _fresh_reference(self, driver: str, compound_id: str) -> Optional[float]:
         """What the model said about this same set before it wore, in seconds.
@@ -988,14 +999,14 @@ class TireAgent:
         # that `_build_stint_features` itself only guarantees after this point.
         early_laps = _reject_contaminated_laps(
             _add_timing_cols(early_laps),
-            self.session_meta['fastest_lap_s'],
+            self.session_meta["fastest_lap_s"],
             self.cfg.fresh_reference_max_pct_of_fastest,
         )
         if not len(early_laps):
             return None
 
         tensor = self._build_stint_tensor(early_laps, compound_id, self.session_meta)
-        model = self.bundles[compound_id]['model']
+        model = self.bundles[compound_id]["model"]
         with torch.no_grad():
             model.eval()
             return float(model(tensor).item())
@@ -1031,10 +1042,10 @@ class TireAgent:
             Float32 tensor of shape (1, window, 42) on CPU.
         """
         bundle = self.bundles[compound_id]
-        window = bundle['window']
+        window = bundle["window"]
 
         feat_df = self._build_stint_features(stint_laps, compound_id, session_meta)
-        scaled  = bundle['scaler'].transform(feat_df.fillna(0))
+        scaled = bundle["scaler"].transform(feat_df.fillna(0))
 
         if len(scaled) >= window:
             seq = scaled[-window:]
@@ -1073,15 +1084,15 @@ class TireAgent:
         Returns:
             Filtered and sorted DataFrame, or None if no laps found.
         """
-        driver_laps = self.laps_df.loc[self.laps_df['Driver'] == driver]
+        driver_laps = self.laps_df.loc[self.laps_df["Driver"] == driver]
         compound = self.session_meta.get(
-            f'{driver}_compound',
-            driver_laps['Compound'].iloc[-1] if len(driver_laps) > 0 else 'MEDIUM',
+            f"{driver}_compound",
+            driver_laps["Compound"].iloc[-1] if len(driver_laps) > 0 else "MEDIUM",
         )
         mask = (
-            (self.laps_df['Driver']   == driver) &
-            (self.laps_df['Compound'] == compound) &
-            (self.laps_df['TyreLife'] <= tyre_life)
+            (self.laps_df["Driver"] == driver)
+            & (self.laps_df["Compound"] == compound)
+            & (self.laps_df["TyreLife"] <= tyre_life)
         )
 
         # Scope to THIS stint and to laps that have already happened. N10 built its
@@ -1098,15 +1109,15 @@ class TireAgent:
         #
         # Both keys are optional: the FastF1 path does not supply them and keeps its old
         # behaviour rather than breaking.
-        current_stint = self.session_meta.get(f'{driver}_stint')
-        if current_stint is not None and 'Stint' in self.laps_df.columns:
-            mask &= (self.laps_df['Stint'] == current_stint)
+        current_stint = self.session_meta.get(f"{driver}_stint")
+        if current_stint is not None and "Stint" in self.laps_df.columns:
+            mask &= self.laps_df["Stint"] == current_stint
 
-        current_lap = self.session_meta.get('current_lap')
-        if current_lap is not None and 'LapNumber' in self.laps_df.columns:
-            mask &= (self.laps_df['LapNumber'] <= current_lap)
+        current_lap = self.session_meta.get("current_lap")
+        if current_lap is not None and "LapNumber" in self.laps_df.columns:
+            mask &= self.laps_df["LapNumber"] <= current_lap
 
-        stint = self.laps_df[mask].sort_values('LapNumber')
+        stint = self.laps_df[mask].sort_values("LapNumber")
         return stint if len(stint) > 0 else None
 
     # ── Live-driver guard (#476) ───────────────────────────────────────────────
@@ -1131,8 +1142,8 @@ class TireAgent:
         """
         if self._live_drivers is not None:
             return self._live_drivers
-        if len(self.laps_df) > 0 and 'Driver' in self.laps_df.columns:
-            drivers = set(self.laps_df['Driver'].dropna().unique())
+        if len(self.laps_df) > 0 and "Driver" in self.laps_df.columns:
+            drivers = set(self.laps_df["Driver"].dropna().unique())
             return drivers or None
         return None
 
@@ -1156,14 +1167,14 @@ class TireAgent:
             set, or when the loaded current_lap falls outside [1, total_laps].
             None when the driver checks out and the tool should proceed.
         """
-        live       = self._live_drivers_at_current_lap()
-        lap        = self.session_meta.get('current_lap')
-        total_laps = self.session_meta.get('total_laps')
+        live = self._live_drivers_at_current_lap()
+        lap = self.session_meta.get("current_lap")
+        total_laps = self.session_meta.get("total_laps")
         lap_out_of_range = (
             lap is not None and total_laps is not None and not (1 <= lap <= total_laps)
         )
         if (live is not None and driver not in live) or lap_out_of_range:
-            lap_display = lap if lap is not None else 'unknown'
+            lap_display = lap if lap is not None else "unknown"
             valid = sorted(live) if live is not None else []
             return f"error: '{driver}' is not on track at lap {lap_display}; valid: {valid}"
         return None
@@ -1210,27 +1221,25 @@ class TireAgent:
 
             stint = agent._get_driver_stint(driver, tyre_life)
             if stint is None:
-                return f'No laps found for driver {driver} with tyre_life <= {tyre_life}.'
+                return f"No laps found for driver {driver} with tyre_life <= {tyre_life}."
 
             tensor = agent._build_stint_tensor(stint, compound_id, agent.session_meta)
-            model  = agent.bundles[compound_id]['model']
+            model = agent.bundles[compound_id]["model"]
 
             with torch.no_grad():
                 model.eval()
                 pred = model(tensor).item()
 
-            feat_df  = agent._build_stint_features(stint, compound_id, agent.session_meta)
-            deg_rate = float(feat_df['DegradationRate'].iloc[-1])
+            feat_df = agent._build_stint_features(stint, compound_id, agent.session_meta)
+            deg_rate = float(feat_df["DegradationRate"].iloc[-1])
 
             reference = agent._fresh_reference(driver, compound_id)
-            reference_line = (
-                '' if reference is None else f' | Fresh reference: {reference:.3f} s'
-            )
+            reference_line = "" if reference is None else f" | Fresh reference: {reference:.3f} s"
 
             return (
-                f'Driver {driver} | Compound {compound_id} | TyreLife {tyre_life}\n'
-                f'Cumulative degradation: {pred:.3f} s | Degradation rate: {deg_rate:.4f} s/lap'
-                f'{reference_line}'
+                f"Driver {driver} | Compound {compound_id} | TyreLife {tyre_life}\n"
+                f"Cumulative degradation: {pred:.3f} s | Degradation rate: {deg_rate:.4f} s/lap"
+                f"{reference_line}"
             )
 
         @lc_tool
@@ -1259,10 +1268,10 @@ class TireAgent:
 
             stint = agent._get_driver_stint(driver, tyre_life)
             if stint is None:
-                return f'No laps found for driver {driver} with tyre_life <= {tyre_life}.'
+                return f"No laps found for driver {driver} with tyre_life <= {tyre_life}."
 
             tensor = agent._build_stint_tensor(stint, compound_id, agent.session_meta)
-            model  = agent.bundles[compound_id]['model']
+            model = agent.bundles[compound_id]["model"]
             model.train()  # keep dropout active for MC
             # Seed the dropout masks so identical inputs give an identical band
             # (#735). Order mirrors the holdout twin in src/strategy/eval/
@@ -1283,18 +1292,18 @@ class TireAgent:
                 model.eval()
 
             mean_pred = float(np.mean(preds))
-            mc_std    = float(np.std(preds))
-            sigma     = (
-                float(agent.cfg.mc_calibration[compound_id]['mean_sigma_s'])
+            mc_std = float(np.std(preds))
+            sigma = (
+                float(agent.cfg.mc_calibration[compound_id]["mean_sigma_s"])
                 if compound_id in agent.cfg.mc_calibration
                 else agent.cfg.mc_sigma_fallback
             )
             total_std = np.sqrt(mc_std**2 + sigma**2)
 
-            feat_df  = agent._build_stint_features(stint, compound_id, agent.session_meta)
-            deg_rate = max(float(feat_df['DegradationRate'].abs().iloc[-1]), 0.001)
+            feat_df = agent._build_stint_features(stint, compound_id, agent.session_meta)
+            deg_rate = max(float(feat_df["DegradationRate"].abs().iloc[-1]), 0.001)
 
-            threshold        = CLIFF_THRESHOLD.get(compound_id, 2.5)
+            threshold = CLIFF_THRESHOLD.get(compound_id, 2.5)
             remaining_budget = max(0.0, threshold - mean_pred)
 
             # Flooring the divisor without clamping the quotient produced cliffs beyond
@@ -1314,7 +1323,7 @@ class TireAgent:
             # earlier default of 100 exceeded every race, so an absent key silently
             # disabled the clamp for any race up to 100 laps.
             cliff_ceiling = float(
-                agent.session_meta.get('total_laps', MAX_RACE_LAPS) or MAX_RACE_LAPS
+                agent.session_meta.get("total_laps", MAX_RACE_LAPS) or MAX_RACE_LAPS
             )
 
             p50 = min(remaining_budget / deg_rate, cliff_ceiling)
@@ -1331,10 +1340,10 @@ class TireAgent:
             )
 
             return (
-                f'Driver {driver} | Compound {compound_id} | TyreLife {tyre_life}\n'
-                f'Laps to cliff — P10: {to.laps_to_cliff_p10} | P50: {to.laps_to_cliff_p50} | P90: {to.laps_to_cliff_p90}\n'
-                f'Degradation rate: {deg_rate:.4f} s/lap | MC std: {mc_std:.4f} s | Calibrated sigma: {sigma:.4f} s\n'
-                f'Warning level: {to.warning_level}'
+                f"Driver {driver} | Compound {compound_id} | TyreLife {tyre_life}\n"
+                f"Laps to cliff — P10: {to.laps_to_cliff_p10} | P50: {to.laps_to_cliff_p50} | P90: {to.laps_to_cliff_p90}\n"
+                f"Degradation rate: {deg_rate:.4f} s/lap | MC std: {mc_std:.4f} s | Calibrated sigma: {sigma:.4f} s\n"
+                f"Warning level: {to.warning_level}"
             )
 
         return [predict_tire_deg_tool, estimate_laps_to_cliff_tool]
@@ -1344,9 +1353,9 @@ class TireAgent:
     def get_react_agent(
         self,
         provider: str = None,
-        model_name: str = 'gpt-4.1-mini',
-        base_url: str = 'http://localhost:1234/v1',
-        api_key: str = 'lm-studio',
+        model_name: str = "gpt-4.1-mini",
+        base_url: str = "http://localhost:1234/v1",
+        api_key: str = "lm-studio",
     ):
         """Return the LangGraph ReAct agent, creating it on the first call (lazy).
 
@@ -1367,18 +1376,19 @@ class TireAgent:
         """
         if not _LANGGRAPH_AVAILABLE:
             raise ImportError(
-                'LangGraph / LangChain not installed. '
-                'Install with: pip install langgraph langchain-openai'
+                "LangGraph / LangChain not installed. "
+                "Install with: pip install langgraph langchain-openai"
             )
 
         if self._react_agent is not None:
             return self._react_agent
 
         import os
-        if provider is None:
-            provider = os.environ.get('F1_LLM_PROVIDER', 'lmstudio')
 
-        if provider == 'lmstudio':
+        if provider is None:
+            provider = os.environ.get("F1_LLM_PROVIDER", "lmstudio")
+
+        if provider == "lmstudio":
             llm = ChatOpenAI(
                 model=model_name,
                 base_url=base_url,
@@ -1421,32 +1431,32 @@ class TireAgent:
             TireOutput with deg_rate, laps_to_cliff P10/P50/P90, gp_name,
             warning_level, and reasoning.
         """
-        session     = stint_state['session']
-        driver      = stint_state['driver']
-        compound_id = stint_state['compound_id']
-        tyre_life   = stint_state['tyre_life']
-        gp_name     = stint_state.get('gp_name', '')
+        session = stint_state["session"]
+        driver = stint_state["driver"]
+        compound_id = stint_state["compound_id"]
+        tyre_life = stint_state["tyre_life"]
+        gp_name = stint_state.get("gp_name", "")
 
         self.laps_df = session.laps.pick_accurate().copy()
-        _clean       = self.laps_df[self.laps_df['TrackStatus'] == '1']
-        _weather     = session.weather_data.mean(numeric_only=True)
+        _clean = self.laps_df[self.laps_df["TrackStatus"] == "1"]
+        _weather = session.weather_data.mean(numeric_only=True)
 
         self.session_meta = {
-            'fastest_lap_s':      _clean['LapTime'].min().total_seconds(),
-            'cluster_mean_lap_s': _clean['LapTime'].dt.total_seconds().mean(),
-            'total_laps':         int(session.total_laps),
-            'cluster_id':         self.cfg.circuit_cluster_map.get(gp_name, 0),
-            'team_id':            _encode_team_id(self.cfg.team_id_map, stint_state.get('team', 'Unknown')),
-            'year':               stint_state.get('year', 2025),
-            'AirTemp':   float(_weather.get('AirTemp',   28.0)),
-            'TrackTemp': float(_weather.get('TrackTemp', 38.0)),
-            'Humidity':  float(_weather.get('Humidity',  50.0)),
+            "fastest_lap_s": _clean["LapTime"].min().total_seconds(),
+            "cluster_mean_lap_s": _clean["LapTime"].dt.total_seconds().mean(),
+            "total_laps": int(session.total_laps),
+            "cluster_id": self.cfg.circuit_cluster_map.get(gp_name, 0),
+            "team_id": _encode_team_id(self.cfg.team_id_map, stint_state.get("team", "Unknown")),
+            "year": stint_state.get("year", 2025),
+            "AirTemp": float(_weather.get("AirTemp", DEFAULT_AIR_TEMP_C)),
+            "TrackTemp": float(_weather.get("TrackTemp", DEFAULT_TRACK_TEMP_C)),
+            "Humidity": float(_weather.get("Humidity", 50.0)),
             # Was hardcoded 0.0 (#477) while run_from_state() correctly reads
             # wx.get('rainfall', 0) from the RSM weather dict — mirror that here
             # from the session's own weather data instead of silently telling
             # every dry-model feature the race was rain-free regardless of what
             # actually happened.
-            'Rainfall':  float(_weather.get('Rainfall', 0.0)),
+            "Rainfall": float(_weather.get("Rainfall", 0.0)),
         }
         # No per-lap rivals list on this path (single-shot FastF1 query, not a live
         # simulation lap) — _live_drivers_at_current_lap() falls back to laps_df.
@@ -1471,63 +1481,62 @@ class TireAgent:
         Returns:
             TireOutput with all fields populated.
         """
-        d    = lap_state['driver']
-        meta = lap_state['session_meta']
-        wx   = lap_state.get('weather', {})
+        d = lap_state["driver"]
+        meta = lap_state["session_meta"]
+        wx = lap_state.get("weather", {})
 
-        driver      = meta['driver']
+        driver = meta["driver"]
         # This adapter reads the RAW lap_state, not the RaceState, so the canonical
         # builder's normalisation does not reach it — it has to apply the same rules
         # itself or the unification stops at the object boundary (#784). Both of the
         # old two-arg defaults were also dead on the RSM path and wrong when they did
         # fire: the key is always present, so a stored NaN arrives as the STRING "nan"
         # and a None arrives as None, neither of which .get's default catches.
-        compound    = normalise_compound(d.get('compound'))
-        raw_tyre_life = d.get('tyre_life')
-        tyre_life   = UNKNOWN_TYRE_LIFE if raw_tyre_life is None else raw_tyre_life
-        gp_name     = meta.get('gp_name', '')
-        total_laps  = meta.get('total_laps', DEFAULT_TOTAL_LAPS)
-        year        = meta.get('year', 2025)
-        team        = meta.get('team', 'Unknown')
+        compound = normalise_compound(d.get("compound"))
+        raw_tyre_life = d.get("tyre_life")
+        tyre_life = UNKNOWN_TYRE_LIFE if raw_tyre_life is None else raw_tyre_life
+        gp_name = meta.get("gp_name", "")
+        total_laps = meta.get("total_laps", DEFAULT_TOTAL_LAPS)
+        year = meta.get("year", 2025)
+        team = meta.get("team", "Unknown")
 
         compound_id = (
-            compound if compound.startswith('C')
-            else _compound_name_to_id(compound, gp_name, year)
+            compound if compound.startswith("C") else _compound_name_to_id(compound, gp_name, year)
         )
 
         self.laps_df = laps_df.copy()
 
         # Build session_meta from laps_df (FastF1 Timedelta → float if needed)
-        lt_col = 'LapTime_s' if 'LapTime_s' in self.laps_df.columns else 'LapTime'
-        if lt_col == 'LapTime' and hasattr(self.laps_df[lt_col].iloc[0], 'total_seconds'):
+        lt_col = "LapTime_s" if "LapTime_s" in self.laps_df.columns else "LapTime"
+        if lt_col == "LapTime" and hasattr(self.laps_df[lt_col].iloc[0], "total_seconds"):
             lap_times = self.laps_df[lt_col].dropna().apply(lambda t: t.total_seconds())
         else:
-            lap_times = pd.to_numeric(self.laps_df[lt_col], errors='coerce').dropna()
+            lap_times = pd.to_numeric(self.laps_df[lt_col], errors="coerce").dropna()
 
-        if 'TrackStatus' in self.laps_df.columns:
-            clean_mask  = self.laps_df['TrackStatus'].astype(str) == '1'
+        if "TrackStatus" in self.laps_df.columns:
+            clean_mask = self.laps_df["TrackStatus"].astype(str) == "1"
             clean_times = lap_times[clean_mask] if clean_mask.sum() > 0 else lap_times
         else:
             clean_times = lap_times
 
         self.session_meta = {
-            'fastest_lap_s':      float(clean_times.min()) if len(clean_times) > 0 else 90.0,
-            'cluster_mean_lap_s': float(clean_times.mean()) if len(clean_times) > 0 else 90.0,
-            'total_laps':         total_laps,
-            'cluster_id':         self.cfg.circuit_cluster_map.get(gp_name, 0),
-            'team_id':            _encode_team_id(self.cfg.team_id_map, team),
-            'year':               year,
+            "fastest_lap_s": float(clean_times.min()) if len(clean_times) > 0 else 90.0,
+            "cluster_mean_lap_s": float(clean_times.mean()) if len(clean_times) > 0 else 90.0,
+            "total_laps": total_laps,
+            "cluster_id": self.cfg.circuit_cluster_map.get(gp_name, 0),
+            "team_id": _encode_team_id(self.cfg.team_id_map, team),
+            "year": year,
             # reading_or_default, not .get(key, default): the producers report an
             # unmeasured reading as the key PRESENT holding None, which .get's default
             # never catches. These Nones do not crash here — they flow through
             # _add_weather_cols into the TCN's feature frame and moved the cliff estimate
             # 2.3 laps OPTIMISTIC on the 2025 reference lap, silently. Optimistic is the
             # dangerous direction: it delays the pit call. See the helper's docstring.
-            'AirTemp':   reading_or_default(wx, 'air_temp',   28.0),
-            'TrackTemp': reading_or_default(wx, 'track_temp', 38.0),
-            'Humidity':  reading_or_default(wx, 'humidity',   50.0),
-            'Rainfall':  float(reading_or_default(wx, 'rainfall', 0.0)),
-            f'{driver}_compound': compound,
+            "AirTemp": reading_or_default(wx, "air_temp", DEFAULT_AIR_TEMP_C),
+            "TrackTemp": reading_or_default(wx, "track_temp", DEFAULT_TRACK_TEMP_C),
+            "Humidity": reading_or_default(wx, "humidity", 50.0),
+            "Rainfall": float(reading_or_default(wx, "rainfall", 0.0)),
+            f"{driver}_compound": compound,
             # The stint we are actually in, and the lap we are actually on. N10 trained
             # on windows grouped by ['Year','GP_Name','DriverNumber','Stint'], and the
             # slice below had neither: it matched on Compound alone, so a later stint on
@@ -1536,8 +1545,8 @@ class TireAgent:
             # LAP 59's degradation as current. Both keys travel here rather than through
             # the signature so the FastF1 path, which has neither, degrades to the old
             # behaviour instead of breaking (#449).
-            f'{driver}_stint': d.get('stint'),
-            'current_lap': lap_state.get('lap_number'),
+            f"{driver}_stint": d.get("stint"),
+            "current_lap": lap_state.get("lap_number"),
         }
 
         # Presence-based on-track set for this lap (#476): our own driver plus
@@ -1547,14 +1556,17 @@ class TireAgent:
         # this catches an LLM tool call for a long-retired driver code without
         # reimplementing any retirement/lap-count heuristic.
         self._live_drivers = {driver} | {
-            str(r['driver']) for r in lap_state.get('rivals', []) or [] if r.get('driver')
+            str(r["driver"]) for r in lap_state.get("rivals", []) or [] if r.get("driver")
         }
 
         return self._run_core(driver, compound_id, tyre_life, gp_name)
 
     @staticmethod
     def _conservative_stub(
-        compound_id: str, tyre_life: int, gp_name: str, reason: str,
+        compound_id: str,
+        tyre_life: int,
+        gp_name: str,
+        reason: str,
     ) -> TireOutput:
         """TireOutput with the fixed conservative defaults used whenever a real TCN
         reading is unavailable (no bundle for this compound, or a tool-output parse
@@ -1562,14 +1574,14 @@ class TireAgent:
         instead of masquerading as a genuine reading.
         """
         return TireOutput(
-            compound          = compound_id,
-            current_tyre_life = tyre_life,
-            gp_name           = gp_name,
-            deg_rate          = 0.03,
-            laps_to_cliff_p10 = 20.0,
-            laps_to_cliff_p50 = 30.0,
-            laps_to_cliff_p90 = 40.0,
-            reasoning         = reason,
+            compound=compound_id,
+            current_tyre_life=tyre_life,
+            gp_name=gp_name,
+            deg_rate=0.03,
+            laps_to_cliff_p10=20.0,
+            laps_to_cliff_p50=30.0,
+            laps_to_cliff_p90=40.0,
+            reasoning=reason,
         )
 
     def _run_core(
@@ -1598,7 +1610,9 @@ class TireAgent:
         # compounds return a stub with conservative defaults — no TCN inference.
         if compound_id not in self.bundles:
             return self._conservative_stub(
-                compound_id, tyre_life, gp_name,
+                compound_id,
+                tyre_life,
+                gp_name,
                 reason=(
                     f"[{compound_id} — TCN model not available for wet/intermediate compounds; "
                     f"conservative defaults used]"
@@ -1607,16 +1621,16 @@ class TireAgent:
 
         react_agent = self.get_react_agent()
         msg = (
-            f'Analyse the tyre state for driver {driver}, compound {compound_id}, '
-            f'tyre life {tyre_life} laps. Use both tools and give your recommendation.'
+            f"Analyse the tyre state for driver {driver}, compound {compound_id}, "
+            f"tyre life {tyre_life} laps. Use both tools and give your recommendation."
         )
-        response = react_agent.invoke({'messages': [{'role': 'user', 'content': msg}]})
-        parsed   = _parse_tool_outputs(response['messages'])
+        response = react_agent.invoke({"messages": [{"role": "user", "content": msg}]})
+        parsed = _parse_tool_outputs(response["messages"])
 
-        reasoning = ''
-        for m in reversed(response['messages']):
-            if hasattr(m, 'content') and isinstance(m.content, str) and m.content.strip():
-                if not getattr(m, 'tool_calls', None):
+        reasoning = ""
+        for m in reversed(response["messages"]):
+            if hasattr(m, "content") and isinstance(m.content, str) and m.content.strip():
+                if not getattr(m, "tool_calls", None):
                     reasoning = m.content.strip()
                     break
 
@@ -1629,13 +1643,17 @@ class TireAgent:
         # confident call to box. Fall back to the same conservative stub the
         # wet/intermediate branch above already uses, and say so in the reasoning so the
         # degradation is visible instead of masquerading as a reading (#436).
-        if 'p10' not in parsed:
+        if "p10" not in parsed:
             logger.warning(
-                'Tire tool output did not parse for %s (tyre_life=%s) — using conservative '
-                'defaults instead of a 0.0 cliff', compound_id, tyre_life,
+                "Tire tool output did not parse for %s (tyre_life=%s) — using conservative "
+                "defaults instead of a 0.0 cliff",
+                compound_id,
+                tyre_life,
             )
             return self._conservative_stub(
-                compound_id, tyre_life, gp_name,
+                compound_id,
+                tyre_life,
+                gp_name,
                 reason=(
                     f"[{compound_id} — tire tool output could not be parsed; conservative "
                     f"defaults used] {reasoning}"
@@ -1643,21 +1661,19 @@ class TireAgent:
             )
 
         return TireOutput(
-            compound          = compound_id,
-            current_tyre_life = tyre_life,
-            gp_name           = gp_name,
-            deg_rate          = round(parsed.get('deg_rate', 0.0), 4),
+            compound=compound_id,
+            current_tyre_life=tyre_life,
+            gp_name=gp_name,
+            deg_rate=round(parsed.get("deg_rate", 0.0), 4),
             # `.get(...)` then an explicit None, rather than a numeric default:
             # predict_tire_deg_tool can legitimately be skipped while the cliff
             # tool ran, and 0.0 is a real reading for this quantity.
-            cumulative_deg_s  = (
-                round(parsed['cum_deg'], 4) if 'cum_deg' in parsed else None
-            ),
-            deg_cost_s        = _referenced_wear(parsed),
-            laps_to_cliff_p10 = round(parsed['p10'], 1),
-            laps_to_cliff_p50 = round(parsed.get('p50', 0.0), 1),
-            laps_to_cliff_p90 = round(parsed.get('p90', 0.0), 1),
-            reasoning         = reasoning,
+            cumulative_deg_s=(round(parsed["cum_deg"], 4) if "cum_deg" in parsed else None),
+            deg_cost_s=_referenced_wear(parsed),
+            laps_to_cliff_p10=round(parsed["p10"], 1),
+            laps_to_cliff_p50=round(parsed.get("p50", 0.0), 1),
+            laps_to_cliff_p90=round(parsed.get("p90", 0.0), 1),
+            reasoning=reasoning,
         )
 
 
@@ -1686,6 +1702,7 @@ def _get_default_tire_agent() -> TireAgent:
 # ─────────────────────────────────────────────────────────────────────────────
 # Public entry points — backward-compatible signatures (unchanged)
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 def run_tire_agent(stint_state: dict) -> TireOutput:
     """Run the Tire Agent for a given stint and return a structured TireOutput.

--- a/tests/agents/test_weather_defaults_single_source.py
+++ b/tests/agents/test_weather_defaults_single_source.py
@@ -1,0 +1,93 @@
+"""One air/track temperature pair for the agents, not five (#789).
+
+The same two physical quantities had five different fallback pairs across the two repos,
+three of them feeding models: pace read 25.0/35.0, tire and race_situation read 28.0/38.0.
+Nothing made them move together and nothing said which was right.
+
+These tests assert the EFFECT that keeps them together: no agent module may state a
+temperature fallback of its own. Asserting the constant equals 24.2 would pass forever
+while a fourth literal grew back two files away, which is how this started.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_AGENTS = ROOT / "src" / "agents"
+
+# The modules that build a feature vector from a weather dict. The debug harness and the
+# arcade overlay are deliberately out of scope: neither feeds a model, and #789 says so.
+_MODEL_FACING = ("pace_agent.py", "tire_agent.py", "race_situation_agent.py")
+
+# `reading_or_default(wx, 'air_temp', 28.0)` and friends: a numeric literal in the
+# DEFAULT position of a temperature read.
+#
+# The comma after the quantity name is what makes this precise. `pace_agent` also holds
+# `"AirTemp": (14.5, 33.7)` -- a colon and a two-number tuple, which is N06's measured
+# training range rather than a fallback. A looser pattern flagged it, and a bound that
+# describes where the model was fitted is exactly the thing this rule must not delete.
+_LITERAL_DEFAULT = re.compile(
+    r"""(air_temp|track_temp|AirTemp|TrackTemp)["']?\s*,\s*(\d+\.?\d*)\s*\)""",
+)
+
+
+@pytest.mark.parametrize("module", _MODEL_FACING)
+def test_no_model_facing_agent_states_its_own_temperature_fallback(module):
+    """The relation, not the value: a literal here is a fifth pair waiting to happen."""
+    source = (_AGENTS / module).read_text(encoding="utf-8")
+    # Strip comments so the prose explaining the history does not trip the pattern.
+    code = "\n".join(line.split("#", 1)[0] for line in source.splitlines())
+
+    offenders = [m.group(0).strip() for m in _LITERAL_DEFAULT.finditer(code)]
+    assert offenders == [], (
+        f"{module} states a numeric temperature fallback: {offenders}. Import "
+        f"DEFAULT_AIR_TEMP_C / DEFAULT_TRACK_TEMP_C from _shared_defaults instead."
+    )
+
+
+def test_the_pair_is_the_measured_median_not_a_round_number():
+    """Sourced from the data, and the sourcing is the point.
+
+    A rounded 25/35 looks tidier and is what one of the five pairs used; it is the
+    TrackTemp mean rather than its median. The bound between "measured" and "chosen" is
+    the only thing separating this constant from the four it replaced.
+    """
+    from src.agents._shared_defaults import DEFAULT_AIR_TEMP_C, DEFAULT_TRACK_TEMP_C
+
+    assert DEFAULT_AIR_TEMP_C == pytest.approx(24.2)
+    assert DEFAULT_TRACK_TEMP_C == pytest.approx(34.2)
+
+
+@pytest.mark.data
+@pytest.mark.skipif(
+    not (ROOT / "data" / "processed" / "laps_featured_2025.parquet").exists(),
+    reason="featured parquets absent",
+)
+def test_the_pair_still_matches_the_median_of_the_real_seasons():
+    """Re-measure rather than re-read: the constant is a claim about the dataset.
+
+    Through `augment_featured_laps`, because the 2025 artefact ships without the weather
+    columns (#782) and a direct read would measure two seasons and call it three.
+    """
+    import pandas as pd
+
+    from src.agents._shared_defaults import DEFAULT_AIR_TEMP_C, DEFAULT_TRACK_TEMP_C
+    from src.f1_strat_manager.data_cache import get_data_root
+    from src.f1_strat_manager.laps_augment import augment_featured_laps
+
+    root = get_data_root() / "processed"
+    frames = [
+        augment_featured_laps(pd.read_parquet(root / f"laps_featured_{year}.parquet"), year)[
+            ["AirTemp", "TrackTemp"]
+        ]
+        for year in (2023, 2024, 2025)
+    ]
+    laps = pd.concat(frames, ignore_index=True).apply(pd.to_numeric, errors="coerce").dropna()
+
+    assert len(laps) > 0, "no weather rows survived: the medians below would mean nothing"
+    assert laps["AirTemp"].median() == pytest.approx(DEFAULT_AIR_TEMP_C, abs=0.05)
+    assert laps["TrackTemp"].median() == pytest.approx(DEFAULT_TRACK_TEMP_C, abs=0.05)


### PR DESCRIPTION
## What

Five fallback pairs for the same two physical quantities become one, sourced from the data.

| Site | Was | Now |
|---|---|---|
| `pace_agent` | 25.0 / 35.0 | **24.2 / 34.2** |
| `tire_agent` | 28.0 / 38.0 | **24.2 / 34.2** |
| `race_situation_agent` (4 sites) | 28.0 / 38.0 | **24.2 / 34.2** |

The pair is the median over the **68,122 laps of 2023-2025**, taken through `augment_featured_laps` so the weather columns the 2025 artefact ships without are restored first (#782). AirTemp median 24.20, TrackTemp median 34.20.

## Why those numbers and not the tidier ones

`28.0 / 38.0` sat **3.8 degrees above the median in both quantities**. `pace`'s `35.0` matches the TrackTemp **mean** (35.22) rather than its median, which is how two plausible numbers for one quantity survive side by side for a long time.

## What this does not do

It moves no model input on a replay. Measured through `RaceReplayEngine.replay()` over four races across three seasons, 229 lap states carried a real air and track temperature on **100%** of laps, so these defaults never fire there. This is a dedup of a latent disagreement; the paths where it does bite are the ones with no weather frame at all: a hand-built `session_meta`, a test fixture, or the backend producer that emits `None` per key (#788).

## A measurement of mine that was wrong

A first pass said the defaults fire on **100%** of laps. That was my own call, not the system: reading `rsm.get_lap_state(lap)` **without** the weather frame the engine supplies. `replay_engine.py:137` passes it; calling the state manager directly does not. It is the same wrong-call reading `CLAUDE.md` §11 already records for the arcade temperatures, and the docstring now states which path was measured so the next reader does not repeat it.

## The test

It asserts the **effect**, that no model-facing agent states a temperature literal of its own, rather than that the constant equals 24.2. That immediately paid for itself twice: it found two more literals a targeted replacement had missed, in `tire_agent` and `race_situation_agent`, and its first pattern flagged N06's measured envelope bounds as if they were fallbacks. A bound describing where the model was fitted is the one thing this rule must never delete, so the pattern now requires the comma that marks the default position.

## Out of scope, per the issue

The debug harness (`scripts/debug_agent.py`, 28/45) and the arcade overlay (18/45) are untouched: neither feeds a model. The backend producer sites live in the `src/telemetry` submodule and are a different fix, since the question there is whether a producer should fabricate at all rather than which number it fabricates.

## Checks

- `uvx ruff@0.15.22 check .` and `format --check .` clean under the CI pin
- 213 passed across `tests/agents/` plus both goldens; the single failure is `test_weather_restore`, reproduced on a `dev` worktree and unrelated
- real `f1-sim Lusail NOR McLaren --no-llm`: 57 laps clean, every action identical to before

Closes #789
