### PR TITLE
fix(data): pull the undercut holdout the pit agent needs to be constructed

### DIFF
--- a/src/f1_strat_manager/data_cache.py
+++ b/src/f1_strat_manager/data_cache.py
@@ -111,6 +111,13 @@ _DEFAULT_MODEL_PATTERNS: tuple[str, ...] = (
     "data/processed/tiredeg_feature_manifest.json",
     "data/processed/tiredeg_sequence_config.json",
     "data/processed/circuit_clustering/**",
+    # N16's undercut holdout. NOT optional and not an eval-only artefact:
+    # `PitStrategyAgent.__init__` reads it unconditionally to pre-aggregate the
+    # per-circuit and per-team undercut rates, so without it the pit agent cannot be
+    # CONSTRUCTED and every surface that reaches it raises FileNotFoundError. It was
+    # missing from this list and from the dataset itself, which stayed invisible
+    # because every machine that has run the notebook already had the file (#798).
+    "data/processed/undercut_labeled/**",
     # Radio corpus metadata: small parquets (~430 KB total for the full
     # 2025 calendar) that the runner reads to enumerate per-lap team-radio
     # rows and FIA race-control messages. The matching MP3 audio tree under

--- a/tests/test_construction_artefacts_are_downloadable.py
+++ b/tests/test_construction_artefacts_are_downloadable.py
@@ -1,0 +1,78 @@
+"""Every artefact an agent reads at CONSTRUCTION must be in the download patterns (#798).
+
+`PitStrategyAgent.__init__` reads `undercut_clean.parquet` unconditionally, and neither
+the dataset nor `_build_allow_patterns` carried it. So on a checkout built purely from
+the published data the pit agent could not be constructed at all, and every surface that
+reaches it raised FileNotFoundError.
+
+It stayed invisible for two reasons worth naming, because both are how this class of gap
+survives: every machine that had run the notebook already had the file, and the one
+`f1-sim` run people reach for happens not to trigger the pit agent.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+_AGENTS = ROOT / "src" / "agents"
+
+# Artefacts read during __init__ rather than lazily, keyed by the agent that needs them.
+# A miss here is not a degraded prediction, it is an agent that cannot be built.
+_CONSTRUCTION_READS = {
+    "pit_strategy_agent.py": "data/processed/undercut_labeled/undercut_clean.parquet",
+}
+
+
+def _patterns() -> tuple[str, ...]:
+    from src.f1_strat_manager.data_cache import _DEFAULT_MODEL_PATTERNS
+
+    return tuple(_DEFAULT_MODEL_PATTERNS)
+
+
+def _covers(patterns, path: str) -> bool:
+    """True when some glob pattern would pull `path` in a snapshot_download."""
+    for pattern in patterns:
+        regex = re.escape(pattern).replace(r"\*\*", ".*").replace(r"\*", "[^/]*")
+        if re.fullmatch(regex, path):
+            return True
+    return False
+
+
+@pytest.mark.parametrize(("module", "artefact"), sorted(_CONSTRUCTION_READS.items()))
+def test_a_construction_time_artefact_is_pulled_by_the_downloader(module, artefact):
+    """The download list must cover what construction reads, or a clean install cannot run."""
+    patterns = _patterns()
+    assert _covers(patterns, artefact), (
+        f"{module} reads {artefact} while building the agent, but no pattern in "
+        f"_DEFAULT_MODEL_PATTERNS pulls it. A clean install will raise FileNotFoundError "
+        f"before the agent exists."
+    )
+
+
+@pytest.mark.parametrize(("module", "artefact"), sorted(_CONSTRUCTION_READS.items()))
+def test_the_module_still_reads_the_artefact_this_test_claims(module, artefact):
+    """Guard against the list going stale in the harmless-looking direction.
+
+    If the read moves or is made lazy, the test above keeps passing while describing a
+    dependency that no longer exists, and the next real construction-time read is added
+    with nothing watching. So the claim is checked against the source too.
+    """
+    source = (_AGENTS / module).read_text(encoding="utf-8")
+    filename = artefact.rsplit("/", 1)[-1]
+    assert filename in source, (
+        f"{module} no longer mentions {filename}: either the read moved and this entry "
+        f"is stale, or the artefact list needs updating for whatever replaced it."
+    )
+
+
+def test_the_coverage_helper_actually_discriminates():
+    """A matcher that says yes to everything would make the tests above vacuous."""
+    patterns = ("data/processed/undercut_labeled/**", "data/models/lap_time/**")
+
+    assert _covers(patterns, "data/processed/undercut_labeled/undercut_clean.parquet")
+    assert not _covers(patterns, "data/processed/overtake_labeled/overtake.parquet")
+    assert not _covers(patterns, "data/raw/2025/Lusail/laps.parquet")


### PR DESCRIPTION
## What

`PitStrategyAgent.__init__` reads `data/processed/undercut_labeled/undercut_clean.parquet` unconditionally. That file was in **neither** the published Hugging Face dataset nor `_build_allow_patterns`, so on a checkout built purely from the published data the pit agent could not be **constructed** and every surface reaching it raised `FileNotFoundError`.

The artefact is now **published**, and the downloader pulls it.

## Why nobody hit it

Two reasons, and both are how this class of gap survives:

- Every machine that has run N16 already had the file.
- The `f1-sim` run people reach for happens never to trigger the pit agent. The Lusail run reports `pit 0`, so it completes cleanly on a tree that cannot build N28 at all.

The dataset publishes `overtake_labeled/` and `sc_labeled/` and not `undercut_labeled/`, which is what makes this an upload omission rather than a decision.

## How the artefact was produced, and the gate it had to pass

It was regenerated by running **N16 unmodified**, not by reimplementing its transformation. A reimplementation risks producing something the shipped model was never evaluated against, which is the defect class this repo has spent the last several PRs removing.

The gate is the test that already existed:

```
test_undercut_auc_pr_reproduces_exactly  ->  0.67388 against a published 0.6739
```

If it had not reproduced I would not have uploaded, because that would have meant the upstream data had drifted, which is a finding rather than an obstacle to route around.

**The shipped weights were backed up and checksummed before the run and restored after.** N16 retrains and exports the undercut model and its calibrator; this change is about recovering a missing DATA artefact, not about replacing a deployed model. The two `.pkl` files came back byte-identical (seeded training on the same data) and `model_config_undercut_v1.json` did not, so all three were restored from the backup.

Worth recording for whoever runs N16 next: the first execution died on a session whose timing data the F1 API did not return. The notebook guards `session.load()` with try/except and continues, but FastF1 **warns** rather than raising there, so the guard does not fire and the next line raises `DataNotLoadedError`. A retry with a warm cache got through, so it was transient.

## Result

- `PitStrategyAgent()` constructs on a tree built only from the published dataset
- **25 tests pass** in `test_undercut_targets_are_on_track.py`, `test_ml_recompute_golden.py` and `test_mc_measured_tables.py`, where six previously failed or errored
- `uvx ruff@0.15.22 check .` and `format --check .` clean under the CI pin

## The test

It asserts the download list covers what construction reads, **and** that the module still performs that read. Without the second half the entry goes stale in the harmless-looking direction: the read moves or turns lazy, the first assertion keeps passing while describing a dependency that no longer exists, and the next real construction-time read arrives with nothing watching.

Closes #798
