### PR TITLE
fix(agents): feed N06 the real laps-since-pit, not the tyre's age

### DIFF
--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -923,7 +923,16 @@ class PaceAgent:
             # default-left split direction, so no fabricated value is needed.
             position=d.get("position"),
             team=meta.get("team") or "Unknown",
-            laps_since_pit=d.get("tyre_life") or 1,
+            # The REAL laps-since-pit, not the tyre's age. These are different
+            # quantities and coincide only when the set was fitted at the last stop:
+            # measured against N06's trained column they agree on 97.7% of laps at
+            # Lusail and 34.6% at Melbourne, where two thirds of laps were fed the
+            # wrong number. `RaceStateManager.laps_since_pit` reproduces N01's own
+            # definition exactly, so this is a lookup rather than an approximation
+            # (#800). `or` rather than the two-arg get: a producer that has not been
+            # updated reports the key absent, and lap 1 of an unpitted race is 1
+            # under N01's rule anyway.
+            laps_since_pit=d.get("laps_since_pit") or d.get("tyre_life") or 1,
             fuel_load=laps_remaining / max(total_laps, 1),
             year=meta.get("year") or 2025,
             # ``d.get('prev_lap_time') or 90.0``, NOT ``d.get('lap_time_s')``: the

--- a/src/simulation/race_state_manager.py
+++ b/src/simulation/race_state_manager.py
@@ -137,6 +137,10 @@ class RaceStateManager:
         # same reason as the leader times: get_lap_state must stay an O(1) lookup.
         self._stint_baselines: dict[int, int] = self._precompute_stint_baselines()
 
+        # Our driver's pit-in laps, so `laps_since_pit` is an O(1) lookup like the
+        # rest of this class rather than a rescan per lap.
+        self._pit_laps: tuple[int, ...] = self._precompute_pit_laps()
+
         # N04's Prev_LapTime, reconstructed for frames that do not carry it.
         # Precomputed for the same reason as the two above: get_driver_state is an
         # O(1) lookup and a per-lap rescan would break that promise.
@@ -150,6 +154,40 @@ class RaceStateManager:
         # pass brings it back to 3.9 ms. Lazy per driver, because a caller asking
         # about three cars should not pay for twenty.
         self._stint_flags: dict[str, dict[int, dict[str, Any]]] = {}
+
+    def _precompute_pit_laps(self) -> tuple[int, ...]:
+        """The lap numbers on which our driver entered the pit lane, ascending.
+
+        ``PitInTime`` is the same signal N01 uses to build ``LapsSincePitStop`` and
+        the same one ``green_flag_stops`` uses to define a real stop, so the three
+        agree on what a pit lap is by construction rather than by coincidence.
+        """
+        if "PitInTime" not in self._driver.columns:
+            return ()
+        pit_rows = self._driver[self._driver["PitInTime"].notna()]
+        return tuple(sorted(int(lap) for lap in pit_rows["LapNumber"].dropna()))
+
+    def laps_since_pit(self, lap_number: int) -> int:
+        """Laps completed since our driver's last pit stop, N01's definition exactly.
+
+        N01 (``notebooks/data_engineering/N01_data_download.ipynb``, "3.
+        LapsSincePitStop") builds the trained column as ``lap - max(pit laps strictly
+        before lap)``, falling back to ``lap`` itself while the driver has not stopped.
+        Reproduced here rather than approximated: recomputing that rule from the raw
+        laps matches the featured parquet's column on **100.0%** of 2,851 laps across
+        four 2025 races.
+
+        WHY THIS EXISTS AT ALL. Inference used to pass ``TyreLife`` for this feature,
+        which is a different quantity: the AGE OF THE TYRE SET, counting laps the set
+        ran before this race. The two coincide only when the set was fitted at the last
+        stop. Measured against the trained column on the same four races, ``TyreLife``
+        reproduces it on 97.7% of laps at Lusail and **34.6%** at Melbourne, where two
+        thirds of laps were fed the wrong number (#800).
+        """
+        earlier = [lap for lap in self._pit_laps if lap < lap_number]
+        if not earlier:
+            return int(lap_number)
+        return int(lap_number - max(earlier))
 
     def _precompute_prev_lap_times(self) -> dict[int, float]:
         """Reconstruct N04's ``Prev_LapTime`` for a frame that has no such column.
@@ -352,6 +390,11 @@ class RaceStateManager:
             "compound": str(r.get("Compound", "")),
             "compound_id": int(r["CompoundID"]) if pd.notna(r.get("CompoundID")) else None,
             "tyre_life": int(r["TyreLife"]) if pd.notna(r.get("TyreLife")) else None,
+            # NOT the same quantity as tyre_life, which is the AGE OF THE SET and counts
+            # laps run before this race. Emitted separately because inference used to
+            # pass tyre_life for N06's LapsSincePitStop and the two only coincide when
+            # the set was fitted at the last stop (#800).
+            "laps_since_pit": self.laps_since_pit(int(lap_number)),
             "stint": int(r["Stint"]) if pd.notna(r.get("Stint")) else None,
             # TyreLife when this stint began — N06's FuelEffect is measured from it.
             # Driver-only on purpose: the pace model runs on our car, and rivals stay

--- a/tests/simulation/test_laps_since_pit.py
+++ b/tests/simulation/test_laps_since_pit.py
@@ -1,0 +1,158 @@
+"""`laps_since_pit` is its own quantity, not the tyre's age (#800).
+
+Inference passed `TyreLife` for N06's `LapsSincePitStop`. They are different things:
+`TyreLife` is the age of the tyre SET and counts laps it ran before this race, so the
+two coincide only when the set was fitted at the last stop. Measured against the trained
+column they agreed on 100% of NOR's laps at Lusail and **20%** at Melbourne.
+
+The rule is N01's, reproduced rather than approximated: `lap - max(pit laps strictly
+before lap)`, falling back to `lap` while the driver has not stopped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_RACES = ("Lusail", "Melbourne", "Monza", "Silverstone")
+_HAS_DATA = (ROOT / "data" / "processed" / "laps_featured_2025.parquet").exists() and all(
+    (ROOT / "data" / "raw" / "2025" / race / "laps.parquet").exists() for race in _RACES
+)
+
+
+def _manager(pit_laps: list[int], total: int = 10):
+    """A RaceStateManager over a hand-built race where our driver pits on given laps."""
+    from src.simulation.race_state_manager import RaceStateManager
+
+    rows = []
+    for lap in range(1, total + 1):
+        rows.append(
+            {
+                "Driver": "NOR",
+                "DriverNumber": "4",
+                "LapNumber": lap,
+                "LapTime_s": 90.0,
+                "LapTime": pd.Timedelta(seconds=90),
+                "Time": pd.Timedelta(seconds=90 * lap),
+                "TrackStatus": "1",
+                "Position": 1,
+                "Compound": "MEDIUM",
+                "TyreLife": lap,
+                "Stint": 1,
+                "PitInTime": pd.Timedelta(seconds=1) if lap in pit_laps else pd.NaT,
+                "Team": "McLaren",
+            }
+        )
+    return RaceStateManager(pd.DataFrame(rows), "NOR", "McLaren")
+
+
+# --- the rule itself, hermetic -----------------------------------------------
+
+
+def test_before_the_first_stop_it_counts_from_the_start():
+    """N01's fallback: no previous stop means the lap number itself."""
+    rsm = _manager(pit_laps=[])
+
+    assert rsm.laps_since_pit(1) == 1
+    assert rsm.laps_since_pit(7) == 7
+
+
+def test_after_a_stop_it_counts_from_that_stop():
+    rsm = _manager(pit_laps=[4])
+
+    assert rsm.laps_since_pit(4) == 4, "the pit lap itself has no EARLIER stop"
+    assert rsm.laps_since_pit(5) == 1
+    assert rsm.laps_since_pit(9) == 5
+
+
+def test_only_the_most_recent_stop_counts():
+    rsm = _manager(pit_laps=[3, 7])
+
+    assert rsm.laps_since_pit(6) == 3
+    assert rsm.laps_since_pit(8) == 1
+
+
+def test_a_rivals_stop_does_not_reset_our_counter():
+    """The single-driver boundary: this is our car's pit history, nobody else's."""
+    from src.simulation.race_state_manager import RaceStateManager
+
+    rows = []
+    for lap in range(1, 9):
+        for drv in ("NOR", "VER"):
+            rows.append(
+                {
+                    "Driver": drv,
+                    "DriverNumber": "4" if drv == "NOR" else "1",
+                    "LapNumber": lap,
+                    "LapTime_s": 90.0,
+                    "LapTime": pd.Timedelta(seconds=90),
+                    "Time": pd.Timedelta(seconds=90 * lap),
+                    "TrackStatus": "1",
+                    "Position": 1 if drv == "NOR" else 2,
+                    "Compound": "MEDIUM",
+                    "TyreLife": lap,
+                    "Stint": 1,
+                    # Only VER stops.
+                    "PitInTime": pd.Timedelta(seconds=1) if (drv == "VER" and lap == 3) else pd.NaT,
+                    "Team": "McLaren" if drv == "NOR" else "Red Bull",
+                }
+            )
+    rsm = RaceStateManager(pd.DataFrame(rows), "NOR", "McLaren")
+
+    assert rsm.laps_since_pit(6) == 6, "VER's stop must not reset NOR's counter"
+
+
+# --- the value that actually reaches the model -------------------------------
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_DATA, reason="featured parquet or raw races absent")
+def test_the_emitted_value_matches_the_trained_column_and_tyre_life_does_not():
+    """Both halves matter, and the second is why this change exists.
+
+    Asserting only that the new value is right would pass just as happily if the old
+    one had been right too, and would say nothing about whether the change was needed.
+    Melbourne is the case that makes it concrete: `TyreLife` matched on 20% of laps
+    there, so two thirds of the race fed N06 a number from a different quantity.
+    """
+    from src.f1_strat_manager.data_cache import get_data_root
+    from src.simulation.replay_engine import RaceReplayEngine
+
+    featured = pd.read_parquet(
+        get_data_root() / "processed" / "laps_featured_2025.parquet",
+        columns=["GP_Name", "Driver", "LapNumber", "LapsSincePitStop", "TyreLife"],
+    )
+
+    total = matched_new = matched_old = 0
+    for race in _RACES:
+        engine = RaceReplayEngine(
+            get_data_root() / "raw" / "2025" / race, "NOR", "McLaren", interval_seconds=0
+        )
+        emitted = {
+            state["lap_number"]: (
+                state["driver"].get("laps_since_pit"),
+                state["driver"].get("tyre_life"),
+            )
+            for state in engine.replay()
+        }
+        ours = featured[(featured.GP_Name == race) & (featured.Driver == "NOR")]
+        for _, row in ours.iterrows():
+            pair = emitted.get(int(row.LapNumber))
+            if pair is None:
+                continue
+            total += 1
+            matched_new += pair[0] == row.LapsSincePitStop
+            matched_old += pair[1] == row.LapsSincePitStop
+
+    assert total > 0, "no laps compared: this would hold vacuously"
+    assert matched_new == total, (
+        f"laps_since_pit matches the trained column on {matched_new}/{total} laps; "
+        f"the whole point is that it reproduces N01's rule exactly"
+    )
+    assert matched_old < total, (
+        "TyreLife matched the trained column everywhere, so this change fixed nothing "
+        "on the measured races and the claim behind it needs re-checking"
+    )


### PR DESCRIPTION
## What

`run_from_state` passed `TyreLife` for N06's `LapsSincePitStop`. They are different quantities: `TyreLife` is the age of the tyre **set** and counts laps it ran before this race, so the two coincide only when the set was fitted at the last stop.

Third member of the family, after `Prev_Deg*` (#710) and `mean_sector_speed` (#797).

## Why it was left open, and what unblocked it

The issue was parked with a measurement that **refuted the obvious fix**: `TyreLife - stint_baseline` reproduces the trained column on **0.0%** of rows, and swapping to NaN would have replaced a value that is exactly right on four laps in five with an unknown on every lap. The blocker was not knowing N01's own definition.

It is in `notebooks/data_engineering/N01_data_download.ipynb`, section 3:

```
LapsSincePitStop = lap - max(pit laps strictly before lap)     if the driver has stopped
                 = lap                                          otherwise
```

`RaceStateManager` now reproduces that rule and emits `laps_since_pit` next to `tyre_life`, precomputing our driver's pit laps so the lookup stays O(1) like the rest of the class.

## Verified against the trained column

164 of NOR's laps across four 2025 races:

| Race | new `laps_since_pit` | old `TyreLife` |
|---|---|---|
| Lusail | 100.0% | 100.0% |
| Melbourne | **100.0%** | **20.0%** |
| Monza | 100.0% | 88.0% |
| Silverstone | 100.0% | 100.0% |
| **Total** | **100.0%** | 79.3% |

Melbourne is the case worth naming: two thirds of that race fed N06 a number from a different quantity.

## Impact, stated honestly

Small in aggregate and concentrated where the two quantities diverge: mean **-0.0056 s** over 22,309 laps, p95 absolute **0.0000**, maximum **1.59 s**, and more than 0.010 s on **0.6%** of laps. This is an exactness fix, not an accuracy one.

## The test

The data-tier test asserts **both** halves: that the emitted value matches everywhere, **and** that `TyreLife` did not. Asserting only the first would pass just as happily if the change had fixed nothing, and would say nothing about whether it was needed.

The hermetic tests cover the rule itself, including that the pit lap has no earlier stop of its own and that a rival's stop does not reset our counter, which is the single-driver boundary.

## Checks

- `uvx ruff@0.15.22 check .` and `format --check .` clean under the CI pin
- 255 passed across `tests/simulation/`, `tests/agents/` and both goldens; the one failure is `test_weather_restore`, reproduced on a `dev` worktree and unrelated
- real `f1-sim --no-llm` at Melbourne (53 laps) and Lusail (57 laps): every lap OK, zero fatal errors, Lusail's actions unchanged

Closes #800
