### PR TITLE
fix(cli): stop --provider's default from clobbering F1_LLM_PROVIDER

### DIFF
--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -1331,7 +1331,14 @@ def run(args: argparse.Namespace) -> None:
     # actually used: --no-llm builds zero LLM clients (engine no-llm profile),
     # so leaving the env untouched keeps that mode truly offline instead of
     # silently becoming LLM mode if LM Studio happens to be up (audit C-06).
-    if not args.no_llm:
+    #
+    # Only when the flag was actually PASSED, so precedence runs
+    # flag > .env > built-in default. Writing it unconditionally made the flag's
+    # own default clobber a correctly configured `.env`: `.env.example` ships
+    # `F1_LLM_PROVIDER=openai` and INSTALL.md tells users to copy it, yet every
+    # `f1-sim` run went to LM Studio regardless, failed each lap with
+    # APIConnectionError and still exited 0 (#805).
+    if not args.no_llm and args.provider is not None:
         os.environ["F1_LLM_PROVIDER"] = args.provider
 
     # First-run bootstrap: pull data + models from HF Hub when the cache is
@@ -1425,7 +1432,13 @@ def run(args: argparse.Namespace) -> None:
 
     # ── Pre-warm NLP models (suppresses tqdm + LOAD REPORT noise) ────────────
     radio_label = f" · radios={radio_runner.total_radios()}" if radio_runner is not None else ""
-    mode_label = ("no-LLM" if args.no_llm else f"LLM · {args.provider}") + radio_label
+    # The EFFECTIVE provider, not the flag: since #805 the flag may be unset and the
+    # answer then comes from `.env` or from the built-in fallback. Reading `args.provider`
+    # here printed a blank once the default became None, which would have removed the one
+    # line on screen that says where the run is actually pointing -- and that line is what
+    # made #805 diagnosable at all.
+    effective_provider = os.environ.get("F1_LLM_PROVIDER", "lmstudio")
+    mode_label = ("no-LLM" if args.no_llm else f"LLM · {effective_provider}") + radio_label
     with console.status("[dim]Loading agents…[/dim]", spinner="dots"):
         _prewarm_agents(args.no_llm)
 
@@ -2132,9 +2145,18 @@ def _parse_args() -> argparse.Namespace:
     )
     p.add_argument(
         "--provider",
-        default="lmstudio",
+        # None, not "lmstudio": an argparse default is indistinguishable from an
+        # explicit value at the call site, so a default here silently outranked the
+        # `.env` the project tells users to configure (#805). The built-in fallback
+        # still lands on LM Studio, in strategy_orchestrator's own
+        # `os.environ.get("F1_LLM_PROVIDER", "lmstudio")`, so behaviour is unchanged
+        # for anyone who sets neither.
+        default=None,
         choices=["lmstudio", "openai"],
-        help="LLM provider: 'lmstudio' (default) or 'openai' (needs OPENAI_API_KEY in .env)",
+        help=(
+            "LLM provider, overriding F1_LLM_PROVIDER from .env. "
+            "Unset: use .env, falling back to 'lmstudio'."
+        ),
     )
     p.add_argument(
         "--interval",

--- a/tests/cli/test_provider_precedence.py
+++ b/tests/cli/test_provider_precedence.py
@@ -1,0 +1,71 @@
+"""`--provider` overrides `.env`; its absence must not (#805).
+
+`.env.example` ships `F1_LLM_PROVIDER=openai` and `INSTALL.md` tells users to copy it,
+but the CLI wrote `os.environ["F1_LLM_PROVIDER"] = args.provider` unconditionally and the
+flag defaulted to `"lmstudio"`. So a correctly configured `.env` was ignored on every run,
+every lap failed with `APIConnectionError`, and the process still exited 0.
+
+An argparse default is indistinguishable from an explicit value at the call site, which is
+the whole mechanism: the fix is that the flag defaults to None and the write only happens
+when it was actually passed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_CLI = ROOT / "scripts" / "run_simulation_cli.py"
+
+
+def _provider_block() -> str:
+    """The `--provider` argument declaration, as source.
+
+    Asserted on the text rather than by importing the CLI, because `_parse_args` builds
+    its parser inline and importing `run_simulation_cli` reads model weights, so a unit
+    test cannot construct the parser. What is in question is not how argparse treats
+    `default=None`, it is whether the code says it.
+    """
+    source = _CLI.read_text(encoding="utf-8")
+    start = source.index('"--provider",')
+    return source[start : source.index('p.add_argument(\n        "--interval"', start)]
+
+
+def test_the_flag_defaults_to_unset_not_to_a_provider():
+    """A default here outranks `.env`, which is exactly the bug."""
+    block = _provider_block()
+
+    assert "default=None," in block, (
+        "an argparse default cannot be told apart from an explicit choice, so any "
+        f"default here silently wins over the .env the project asks users to configure. "
+        f"Block reads:\n{block}"
+    )
+
+
+@pytest.mark.parametrize("provider", ["openai", "lmstudio"])
+def test_both_providers_are_still_accepted(provider):
+    """Passing it must keep working, including passing the fallback explicitly."""
+    assert provider in _provider_block()
+
+
+def test_the_env_is_only_written_when_the_flag_was_passed():
+    """The guard, asserted on the source rather than by importing the whole CLI.
+
+    Importing `run_simulation_cli` builds the agent stack and reads model weights, so a
+    unit test cannot call the function this guard lives in. What matters is the relation:
+    the write must be conditional on the flag being set, not merely on LLM mode.
+    """
+    source = _CLI.read_text(encoding="utf-8")
+
+    assert 'os.environ["F1_LLM_PROVIDER"] = args.provider' in source, (
+        "the write moved or was renamed; this test is describing code that no longer exists"
+    )
+    write_at = source.index('os.environ["F1_LLM_PROVIDER"] = args.provider')
+    guard = source[:write_at].rsplit("if ", 1)[-1]
+
+    assert "args.provider is not None" in guard, (
+        f"the env write is guarded by {guard.splitlines()[0]!r}, which does not check "
+        f"whether --provider was actually passed"
+    )


### PR DESCRIPTION
## What

The CLI wrote `os.environ["F1_LLM_PROVIDER"] = args.provider` unconditionally, and `--provider` defaulted to `"lmstudio"`. So a correctly configured `.env` was ignored on **every** run.

`.env.example` ships `F1_LLM_PROVIDER=openai` and `INSTALL.md:91` tells users to copy it. Follow that, run `f1-sim`, and the run goes to LM Studio at `localhost:1234` regardless: every lap fails with `APIConnectionError` and the process still exits **0**.

## The fix

An argparse default cannot be told apart from an explicit choice at the call site, and that is the whole mechanism. `--provider` now defaults to `None` and the env is written only when the flag was actually passed:

```
flag > .env > built-in default
```

The fallback is still `lmstudio`, in `strategy_orchestrator`'s own `os.environ.get("F1_LLM_PROVIDER", "lmstudio")`, so nothing changes for anyone who sets neither.

## The banner, which is the part worth arguing about

It now reports the **effective** provider instead of the flag. Reading `args.provider` there printed a blank once the default became `None`, which would have removed the one line on screen that says where a run actually points.

That line matters more than it looks. Diagnosing this took **three wrong answers in a row** (machine load, then the network, then GPU memory) while `Mode LLM · lmstudio` had been on screen since the first attempt. A status line nobody reads is still the thing that ends the search once someone does.

## Verified end to end

| Invocation | `.env` | Banner |
|---|---|---|
| `f1-sim Lusail NOR McLaren` | `F1_LLM_PROVIDER=openai` | **`Mode LLM · openai`** (was `lmstudio`) |
| `f1-sim ... --provider lmstudio` | `F1_LLM_PROVIDER=openai` | `Mode LLM · lmstudio` |

## Not fixed here

A run where every lap failed still exits 0. That is the same exit-status trap already recorded for `[FATAL]` output and it deserves its own change rather than riding along with a precedence fix.

## Checks

- `uvx ruff@0.15.22 check .` and `format --check .` clean under the CI pin
- `tests/cli/test_provider_precedence.py` passes; it asserts the default is unset, that both choices survive, and that the env write is guarded on the flag being passed rather than merely on LLM mode
- a real `f1-sim --no-llm` at Lusail: 57 laps, zero fatal errors

Closes #805
