### PR TITLE
chore(release): promote dev to main -- the real laps-since-pit and the provider precedence fix

### DIFF
--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -1331,7 +1331,14 @@ def run(args: argparse.Namespace) -> None:
     # actually used: --no-llm builds zero LLM clients (engine no-llm profile),
     # so leaving the env untouched keeps that mode truly offline instead of
     # silently becoming LLM mode if LM Studio happens to be up (audit C-06).
-    if not args.no_llm:
+    #
+    # Only when the flag was actually PASSED, so precedence runs
+    # flag > .env > built-in default. Writing it unconditionally made the flag's
+    # own default clobber a correctly configured `.env`: `.env.example` ships
+    # `F1_LLM_PROVIDER=openai` and INSTALL.md tells users to copy it, yet every
+    # `f1-sim` run went to LM Studio regardless, failed each lap with
+    # APIConnectionError and still exited 0 (#805).
+    if not args.no_llm and args.provider is not None:
         os.environ["F1_LLM_PROVIDER"] = args.provider
 
     # First-run bootstrap: pull data + models from HF Hub when the cache is
@@ -1425,7 +1432,13 @@ def run(args: argparse.Namespace) -> None:
 
     # ── Pre-warm NLP models (suppresses tqdm + LOAD REPORT noise) ────────────
     radio_label = f" · radios={radio_runner.total_radios()}" if radio_runner is not None else ""
-    mode_label = ("no-LLM" if args.no_llm else f"LLM · {args.provider}") + radio_label
+    # The EFFECTIVE provider, not the flag: since #805 the flag may be unset and the
+    # answer then comes from `.env` or from the built-in fallback. Reading `args.provider`
+    # here printed a blank once the default became None, which would have removed the one
+    # line on screen that says where the run is actually pointing -- and that line is what
+    # made #805 diagnosable at all.
+    effective_provider = os.environ.get("F1_LLM_PROVIDER", "lmstudio")
+    mode_label = ("no-LLM" if args.no_llm else f"LLM · {effective_provider}") + radio_label
     with console.status("[dim]Loading agents…[/dim]", spinner="dots"):
         _prewarm_agents(args.no_llm)
 
@@ -2132,9 +2145,18 @@ def _parse_args() -> argparse.Namespace:
     )
     p.add_argument(
         "--provider",
-        default="lmstudio",
+        # None, not "lmstudio": an argparse default is indistinguishable from an
+        # explicit value at the call site, so a default here silently outranked the
+        # `.env` the project tells users to configure (#805). The built-in fallback
+        # still lands on LM Studio, in strategy_orchestrator's own
+        # `os.environ.get("F1_LLM_PROVIDER", "lmstudio")`, so behaviour is unchanged
+        # for anyone who sets neither.
+        default=None,
         choices=["lmstudio", "openai"],
-        help="LLM provider: 'lmstudio' (default) or 'openai' (needs OPENAI_API_KEY in .env)",
+        help=(
+            "LLM provider, overriding F1_LLM_PROVIDER from .env. "
+            "Unset: use .env, falling back to 'lmstudio'."
+        ),
     )
     p.add_argument(
         "--interval",

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -923,7 +923,16 @@ class PaceAgent:
             # default-left split direction, so no fabricated value is needed.
             position=d.get("position"),
             team=meta.get("team") or "Unknown",
-            laps_since_pit=d.get("tyre_life") or 1,
+            # The REAL laps-since-pit, not the tyre's age. These are different
+            # quantities and coincide only when the set was fitted at the last stop:
+            # measured against N06's trained column they agree on 97.7% of laps at
+            # Lusail and 34.6% at Melbourne, where two thirds of laps were fed the
+            # wrong number. `RaceStateManager.laps_since_pit` reproduces N01's own
+            # definition exactly, so this is a lookup rather than an approximation
+            # (#800). `or` rather than the two-arg get: a producer that has not been
+            # updated reports the key absent, and lap 1 of an unpitted race is 1
+            # under N01's rule anyway.
+            laps_since_pit=d.get("laps_since_pit") or d.get("tyre_life") or 1,
             fuel_load=laps_remaining / max(total_laps, 1),
             year=meta.get("year") or 2025,
             # ``d.get('prev_lap_time') or 90.0``, NOT ``d.get('lap_time_s')``: the

--- a/src/simulation/race_state_manager.py
+++ b/src/simulation/race_state_manager.py
@@ -137,6 +137,10 @@ class RaceStateManager:
         # same reason as the leader times: get_lap_state must stay an O(1) lookup.
         self._stint_baselines: dict[int, int] = self._precompute_stint_baselines()
 
+        # Our driver's pit-in laps, so `laps_since_pit` is an O(1) lookup like the
+        # rest of this class rather than a rescan per lap.
+        self._pit_laps: tuple[int, ...] = self._precompute_pit_laps()
+
         # N04's Prev_LapTime, reconstructed for frames that do not carry it.
         # Precomputed for the same reason as the two above: get_driver_state is an
         # O(1) lookup and a per-lap rescan would break that promise.
@@ -150,6 +154,40 @@ class RaceStateManager:
         # pass brings it back to 3.9 ms. Lazy per driver, because a caller asking
         # about three cars should not pay for twenty.
         self._stint_flags: dict[str, dict[int, dict[str, Any]]] = {}
+
+    def _precompute_pit_laps(self) -> tuple[int, ...]:
+        """The lap numbers on which our driver entered the pit lane, ascending.
+
+        ``PitInTime`` is the same signal N01 uses to build ``LapsSincePitStop`` and
+        the same one ``green_flag_stops`` uses to define a real stop, so the three
+        agree on what a pit lap is by construction rather than by coincidence.
+        """
+        if "PitInTime" not in self._driver.columns:
+            return ()
+        pit_rows = self._driver[self._driver["PitInTime"].notna()]
+        return tuple(sorted(int(lap) for lap in pit_rows["LapNumber"].dropna()))
+
+    def laps_since_pit(self, lap_number: int) -> int:
+        """Laps completed since our driver's last pit stop, N01's definition exactly.
+
+        N01 (``notebooks/data_engineering/N01_data_download.ipynb``, "3.
+        LapsSincePitStop") builds the trained column as ``lap - max(pit laps strictly
+        before lap)``, falling back to ``lap`` itself while the driver has not stopped.
+        Reproduced here rather than approximated: recomputing that rule from the raw
+        laps matches the featured parquet's column on **100.0%** of 2,851 laps across
+        four 2025 races.
+
+        WHY THIS EXISTS AT ALL. Inference used to pass ``TyreLife`` for this feature,
+        which is a different quantity: the AGE OF THE TYRE SET, counting laps the set
+        ran before this race. The two coincide only when the set was fitted at the last
+        stop. Measured against the trained column on the same four races, ``TyreLife``
+        reproduces it on 97.7% of laps at Lusail and **34.6%** at Melbourne, where two
+        thirds of laps were fed the wrong number (#800).
+        """
+        earlier = [lap for lap in self._pit_laps if lap < lap_number]
+        if not earlier:
+            return int(lap_number)
+        return int(lap_number - max(earlier))
 
     def _precompute_prev_lap_times(self) -> dict[int, float]:
         """Reconstruct N04's ``Prev_LapTime`` for a frame that has no such column.
@@ -352,6 +390,11 @@ class RaceStateManager:
             "compound": str(r.get("Compound", "")),
             "compound_id": int(r["CompoundID"]) if pd.notna(r.get("CompoundID")) else None,
             "tyre_life": int(r["TyreLife"]) if pd.notna(r.get("TyreLife")) else None,
+            # NOT the same quantity as tyre_life, which is the AGE OF THE SET and counts
+            # laps run before this race. Emitted separately because inference used to
+            # pass tyre_life for N06's LapsSincePitStop and the two only coincide when
+            # the set was fitted at the last stop (#800).
+            "laps_since_pit": self.laps_since_pit(int(lap_number)),
             "stint": int(r["Stint"]) if pd.notna(r.get("Stint")) else None,
             # TyreLife when this stint began — N06's FuelEffect is measured from it.
             # Driver-only on purpose: the pace model runs on our car, and rivals stay

--- a/tests/cli/test_provider_precedence.py
+++ b/tests/cli/test_provider_precedence.py
@@ -1,0 +1,71 @@
+"""`--provider` overrides `.env`; its absence must not (#805).
+
+`.env.example` ships `F1_LLM_PROVIDER=openai` and `INSTALL.md` tells users to copy it,
+but the CLI wrote `os.environ["F1_LLM_PROVIDER"] = args.provider` unconditionally and the
+flag defaulted to `"lmstudio"`. So a correctly configured `.env` was ignored on every run,
+every lap failed with `APIConnectionError`, and the process still exited 0.
+
+An argparse default is indistinguishable from an explicit value at the call site, which is
+the whole mechanism: the fix is that the flag defaults to None and the write only happens
+when it was actually passed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_CLI = ROOT / "scripts" / "run_simulation_cli.py"
+
+
+def _provider_block() -> str:
+    """The `--provider` argument declaration, as source.
+
+    Asserted on the text rather than by importing the CLI, because `_parse_args` builds
+    its parser inline and importing `run_simulation_cli` reads model weights, so a unit
+    test cannot construct the parser. What is in question is not how argparse treats
+    `default=None`, it is whether the code says it.
+    """
+    source = _CLI.read_text(encoding="utf-8")
+    start = source.index('"--provider",')
+    return source[start : source.index('p.add_argument(\n        "--interval"', start)]
+
+
+def test_the_flag_defaults_to_unset_not_to_a_provider():
+    """A default here outranks `.env`, which is exactly the bug."""
+    block = _provider_block()
+
+    assert "default=None," in block, (
+        "an argparse default cannot be told apart from an explicit choice, so any "
+        f"default here silently wins over the .env the project asks users to configure. "
+        f"Block reads:\n{block}"
+    )
+
+
+@pytest.mark.parametrize("provider", ["openai", "lmstudio"])
+def test_both_providers_are_still_accepted(provider):
+    """Passing it must keep working, including passing the fallback explicitly."""
+    assert provider in _provider_block()
+
+
+def test_the_env_is_only_written_when_the_flag_was_passed():
+    """The guard, asserted on the source rather than by importing the whole CLI.
+
+    Importing `run_simulation_cli` builds the agent stack and reads model weights, so a
+    unit test cannot call the function this guard lives in. What matters is the relation:
+    the write must be conditional on the flag being set, not merely on LLM mode.
+    """
+    source = _CLI.read_text(encoding="utf-8")
+
+    assert 'os.environ["F1_LLM_PROVIDER"] = args.provider' in source, (
+        "the write moved or was renamed; this test is describing code that no longer exists"
+    )
+    write_at = source.index('os.environ["F1_LLM_PROVIDER"] = args.provider')
+    guard = source[:write_at].rsplit("if ", 1)[-1]
+
+    assert "args.provider is not None" in guard, (
+        f"the env write is guarded by {guard.splitlines()[0]!r}, which does not check "
+        f"whether --provider was actually passed"
+    )

--- a/tests/simulation/test_laps_since_pit.py
+++ b/tests/simulation/test_laps_since_pit.py
@@ -1,0 +1,158 @@
+"""`laps_since_pit` is its own quantity, not the tyre's age (#800).
+
+Inference passed `TyreLife` for N06's `LapsSincePitStop`. They are different things:
+`TyreLife` is the age of the tyre SET and counts laps it ran before this race, so the
+two coincide only when the set was fitted at the last stop. Measured against the trained
+column they agreed on 100% of NOR's laps at Lusail and **20%** at Melbourne.
+
+The rule is N01's, reproduced rather than approximated: `lap - max(pit laps strictly
+before lap)`, falling back to `lap` while the driver has not stopped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_RACES = ("Lusail", "Melbourne", "Monza", "Silverstone")
+_HAS_DATA = (ROOT / "data" / "processed" / "laps_featured_2025.parquet").exists() and all(
+    (ROOT / "data" / "raw" / "2025" / race / "laps.parquet").exists() for race in _RACES
+)
+
+
+def _manager(pit_laps: list[int], total: int = 10):
+    """A RaceStateManager over a hand-built race where our driver pits on given laps."""
+    from src.simulation.race_state_manager import RaceStateManager
+
+    rows = []
+    for lap in range(1, total + 1):
+        rows.append(
+            {
+                "Driver": "NOR",
+                "DriverNumber": "4",
+                "LapNumber": lap,
+                "LapTime_s": 90.0,
+                "LapTime": pd.Timedelta(seconds=90),
+                "Time": pd.Timedelta(seconds=90 * lap),
+                "TrackStatus": "1",
+                "Position": 1,
+                "Compound": "MEDIUM",
+                "TyreLife": lap,
+                "Stint": 1,
+                "PitInTime": pd.Timedelta(seconds=1) if lap in pit_laps else pd.NaT,
+                "Team": "McLaren",
+            }
+        )
+    return RaceStateManager(pd.DataFrame(rows), "NOR", "McLaren")
+
+
+# --- the rule itself, hermetic -----------------------------------------------
+
+
+def test_before_the_first_stop_it_counts_from_the_start():
+    """N01's fallback: no previous stop means the lap number itself."""
+    rsm = _manager(pit_laps=[])
+
+    assert rsm.laps_since_pit(1) == 1
+    assert rsm.laps_since_pit(7) == 7
+
+
+def test_after_a_stop_it_counts_from_that_stop():
+    rsm = _manager(pit_laps=[4])
+
+    assert rsm.laps_since_pit(4) == 4, "the pit lap itself has no EARLIER stop"
+    assert rsm.laps_since_pit(5) == 1
+    assert rsm.laps_since_pit(9) == 5
+
+
+def test_only_the_most_recent_stop_counts():
+    rsm = _manager(pit_laps=[3, 7])
+
+    assert rsm.laps_since_pit(6) == 3
+    assert rsm.laps_since_pit(8) == 1
+
+
+def test_a_rivals_stop_does_not_reset_our_counter():
+    """The single-driver boundary: this is our car's pit history, nobody else's."""
+    from src.simulation.race_state_manager import RaceStateManager
+
+    rows = []
+    for lap in range(1, 9):
+        for drv in ("NOR", "VER"):
+            rows.append(
+                {
+                    "Driver": drv,
+                    "DriverNumber": "4" if drv == "NOR" else "1",
+                    "LapNumber": lap,
+                    "LapTime_s": 90.0,
+                    "LapTime": pd.Timedelta(seconds=90),
+                    "Time": pd.Timedelta(seconds=90 * lap),
+                    "TrackStatus": "1",
+                    "Position": 1 if drv == "NOR" else 2,
+                    "Compound": "MEDIUM",
+                    "TyreLife": lap,
+                    "Stint": 1,
+                    # Only VER stops.
+                    "PitInTime": pd.Timedelta(seconds=1) if (drv == "VER" and lap == 3) else pd.NaT,
+                    "Team": "McLaren" if drv == "NOR" else "Red Bull",
+                }
+            )
+    rsm = RaceStateManager(pd.DataFrame(rows), "NOR", "McLaren")
+
+    assert rsm.laps_since_pit(6) == 6, "VER's stop must not reset NOR's counter"
+
+
+# --- the value that actually reaches the model -------------------------------
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_DATA, reason="featured parquet or raw races absent")
+def test_the_emitted_value_matches_the_trained_column_and_tyre_life_does_not():
+    """Both halves matter, and the second is why this change exists.
+
+    Asserting only that the new value is right would pass just as happily if the old
+    one had been right too, and would say nothing about whether the change was needed.
+    Melbourne is the case that makes it concrete: `TyreLife` matched on 20% of laps
+    there, so two thirds of the race fed N06 a number from a different quantity.
+    """
+    from src.f1_strat_manager.data_cache import get_data_root
+    from src.simulation.replay_engine import RaceReplayEngine
+
+    featured = pd.read_parquet(
+        get_data_root() / "processed" / "laps_featured_2025.parquet",
+        columns=["GP_Name", "Driver", "LapNumber", "LapsSincePitStop", "TyreLife"],
+    )
+
+    total = matched_new = matched_old = 0
+    for race in _RACES:
+        engine = RaceReplayEngine(
+            get_data_root() / "raw" / "2025" / race, "NOR", "McLaren", interval_seconds=0
+        )
+        emitted = {
+            state["lap_number"]: (
+                state["driver"].get("laps_since_pit"),
+                state["driver"].get("tyre_life"),
+            )
+            for state in engine.replay()
+        }
+        ours = featured[(featured.GP_Name == race) & (featured.Driver == "NOR")]
+        for _, row in ours.iterrows():
+            pair = emitted.get(int(row.LapNumber))
+            if pair is None:
+                continue
+            total += 1
+            matched_new += pair[0] == row.LapsSincePitStop
+            matched_old += pair[1] == row.LapsSincePitStop
+
+    assert total > 0, "no laps compared: this would hold vacuously"
+    assert matched_new == total, (
+        f"laps_since_pit matches the trained column on {matched_new}/{total} laps; "
+        f"the whole point is that it reproduces N01's rule exactly"
+    )
+    assert matched_old < total, (
+        "TyreLife matched the trained column everywhere, so this change fixed nothing "
+        "on the measured races and the claim behind it needs re-checking"
+    )


### PR DESCRIPTION
Third promotion of `dev` to `main`, carrying the last two fixes from this thread.

**This does not cut a release.** release-please only creates or updates its release PR on a push to `main`; the release happens when that PR is merged. #712 (`release 2.6.0`) stays parked until Pitwall exists.

## What it carries

**#807 closes #800** — N06 was fed `TyreLife` where it was trained on `LapsSincePitStop`. Different quantities: `TyreLife` is the age of the tyre **set** and counts laps run before this race.

The issue had been parked with a measurement that refuted the obvious fix (`TyreLife - stint_baseline` reproduces the trained column on **0.0%** of rows). What unblocked it was N01's own definition: `lap - max(pit laps strictly before lap)`, falling back to the lap number. `RaceStateManager` now reproduces that rule exactly.

Verified over 164 of NOR's laps across four 2025 races: **100.0%** match, against 79.3% for `TyreLife` and **20.0%** at Melbourne, where two thirds of the race fed the model a number from a different quantity. Effect on predictions is small and concentrated: mean -0.0056 s over 22,309 laps, up to 1.59 s on the 0.6% of laps where the quantities diverge. An exactness fix, not an accuracy one.

**#808 closes #805** — `--provider`'s default silently overrode `F1_LLM_PROVIDER` from `.env`. `.env.example` ships `openai` and `INSTALL.md` tells users to copy it, yet every `f1-sim` run went to LM Studio, failed each lap with `APIConnectionError` and exited 0. Precedence now runs flag > `.env` > built-in default, and the banner reports the **effective** provider rather than the flag.

## Verification on `dev`

- `uvx ruff@0.15.22 check .`, `format --check .` and `uv run mypy src/rag/` all clean
- strategy goldens and projection golden byte-identical throughout
- real `f1-sim --no-llm` at Lusail (57 laps) and Melbourne (53 laps): every lap OK, zero fatal errors
- provider precedence verified both ways: no flag with `.env=openai` gives `Mode LLM · openai`; `--provider lmstudio` still forces LM Studio
- a full LLM run earlier in this thread completed clean at Miami: 33 laps OK, pit agent 13 invocations, RAG 13, 11 radio alerts, zero failures

## Open after this

**#801** — three defects in the featured artefacts: a stale broadcast `mean_sector_speed` column in the combined file, a Las Vegas hole in the 2025 one, and a duplicated 2023 Spanish GP. It needs a regeneration that touches every model's input, so it is deliberately not folded into a promotion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added accurate tracking of laps completed since the driver’s most recent pit stop.
  - Race and driver data now distinguish laps since pit stop from tyre age.

- **Bug Fixes**
  - Improved pacing decisions by using the correct laps-since-pit value when available.
  - CLI provider settings now respect `.env` values unless explicitly overridden.
  - `--no-llm` mode avoids unnecessary provider configuration.

- **Tests**
  - Added coverage for provider precedence and laps-since-pit calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->