### PR TITLE
fix(simulation): join replay weather by session time, as N04 did

### DIFF
--- a/src/simulation/race_state_manager.py
+++ b/src/simulation/race_state_manager.py
@@ -155,6 +155,11 @@ class RaceStateManager:
         # about three cars should not pay for twenty.
         self._stint_flags: dict[str, dict[int, dict[str, Any]]] = {}
 
+        # Per-lap weather aligned by session time, one entry per weather frame the
+        # caller passes. See `_weather_for_lap`: the alignment is a whole-race
+        # merge_asof and doing it per lap would cost the O(1) lookup above.
+        self._weather_aligned: dict[int, pd.DataFrame] = {}
+
     def _precompute_pit_laps(self) -> tuple[int, ...]:
         """The lap numbers on which our driver entered the pit lane, ascending.
 
@@ -486,6 +491,47 @@ class RaceStateManager:
 
         return sorted(states, key=lambda s: s["position"] or 99)
 
+    def _weather_for_lap(self, lap_number: int, weather_df: pd.DataFrame) -> pd.Series:
+        """Our driver's weather sample for this lap, aligned by session time.
+
+        Built once per weather frame and cached: the alignment is a `merge_asof`
+        over the whole race, and paying it per lap would break the O(1) promise
+        `get_lap_state` makes. Keyed by the frame's identity because the replay
+        engine hands the same object on every call.
+
+        Falls back to the FIRST sample when this lap has no session time to join
+        on, which is the row N04 also leaves unmatched. That is a real gap rather
+        than a substituted reading, and it is why the caller still guards every
+        field with `pd.notna`.
+        """
+        cache_key = id(weather_df)
+        aligned = self._weather_aligned.get(cache_key)
+        if aligned is None:
+            from src.f1_strat_manager.weather_restore import weather_for_race
+
+            trained = weather_for_race(self._driver, weather_df)
+            # Wind is display-only and not in N04's four, so it is carried on the
+            # same aligned rows rather than looked up a second way.
+            if "WindSpeed" in weather_df.columns and "Time" in weather_df.columns:
+                samples = weather_df[["Time", "WindSpeed"]].dropna(subset=["Time"])
+                laps = self._driver[["Time"]].dropna(subset=["Time"])
+                if not samples.empty and not laps.empty:
+                    merged = pd.merge_asof(
+                        laps.sort_values("Time"),
+                        samples.sort_values("Time"),
+                        on="Time",
+                        direction="nearest",
+                    )
+                    merged.index = laps.sort_values("Time").index
+                    trained = trained.assign(WindSpeed=merged["WindSpeed"])
+            aligned = trained
+            self._weather_aligned[cache_key] = aligned
+
+        row = self._driver[self._driver["LapNumber"] == lap_number]
+        if not row.empty and row.index[0] in aligned.index:
+            return aligned.loc[row.index[0]]
+        return weather_df.iloc[0]
+
     def get_weather_state(
         self,
         lap_number: int,
@@ -495,12 +541,31 @@ class RaceStateManager:
 
         ``TrackStatus`` is always present (sourced from laps). Optional
         ``weather_df`` (from weather.parquet) adds temperature, humidity,
-        wind, and rainfall when available. The row is picked by mapping the
-        lap fraction onto ``weather_df``'s row index (``int(lap_frac *
-        (len(weather_df) - 1))``): a proportional lookup, not an
-        interpolation between two samples. Weather changes slowly enough
-        over a race that a single nearest row is close enough for a replay
-        demo.
+        wind, and rainfall when available.
+
+        THE ROW IS PICKED BY SESSION TIME, which is how N04 built the trained
+        columns: ``merge_asof(direction='nearest')`` of each lap's ``Time``
+        against the weather samples' ``Time``.
+
+        It used to be picked by mapping the lap fraction onto ``weather_df``'s
+        row index, a proportional lookup that ignores session time entirely, on
+        the reasoning that weather changes slowly enough for a replay demo. The
+        reasoning was wrong twice over. Weather samples are not evenly spaced in
+        time, and neither are laps: a Safety Car or a red flag stretches the gap
+        between two laps while the samples keep their own cadence, so the two
+        indices drift apart exactly when conditions are changing.
+
+        Measured across 26,692 driver-laps of 24 races: the proportional lookup
+        disagreed with N04's join on **92.6%** of laps, mean 1.11 C and up to
+        11.8 C on TrackTemp, and **flipped the rain flag on 1,279 laps**. N06's
+        weather block is 39.7% of that model's gain, and its predictions moved
+        on 26.8% of laps, mean 0.037 s and up to 8.28 s.
+
+        The four trained columns come from ``weather_restore.weather_for_race``,
+        which is the verified reference (22,760/22,760 against N04's own output)
+        rather than a second implementation of the same join. Wind rides on the
+        same aligned row: nothing trains on it, but a second alignment inside one
+        dict is how the two weather paths drifted apart in the first place.
 
         Args:
             lap_number:  1-indexed lap number.
@@ -513,9 +578,7 @@ class RaceStateManager:
         weather: dict[str, Any] = {"track_status": track_status}
 
         if weather_df is not None and not weather_df.empty:
-            lap_frac = (lap_number - 1) / max(self.total_laps - 1, 1)
-            idx = int(lap_frac * (len(weather_df) - 1))
-            w = weather_df.iloc[idx]
+            w = self._weather_for_lap(lap_number, weather_df)
             weather.update(
                 {
                     "air_temp": float(w["AirTemp"]) if pd.notna(w.get("AirTemp")) else None,

--- a/tests/simulation/test_weather_join.py
+++ b/tests/simulation/test_weather_join.py
@@ -1,0 +1,133 @@
+"""The replay serves the weather N04 trained on, joined by session time (W-F7).
+
+`get_weather_state` used to pick its row by mapping the lap fraction onto the weather
+frame's row index. That ignores session time, and neither side is evenly spaced: a Safety
+Car stretches the gap between laps while the samples keep their own cadence, so the two
+indices drift apart exactly when conditions are moving.
+
+Measured over 79,032 driver-laps of all 71 races, the proportional lookup disagreed with
+N04's join on **94.3%** of laps, mean 1.49 C and up to 17.3 C on TrackTemp, and **flipped
+the rain flag on 3,399 laps**. N06's weather block is 39.7% of that model's gain.
+
+These assert the EFFECT: what the replay serves must equal what N04 computed, to the cell.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_RAW = ROOT / "data" / "raw" / "2025"
+
+# One dry evening race, one desert night race, and Las Vegas, whose weather frame is the
+# one this repo has already been bitten by (its SpeedI2 trap is missing for the whole race).
+_RACES = ("Shanghai", "Lusail", "Las_Vegas")
+_HAS_DATA = all((_RAW / race / "weather.parquet").exists() for race in _RACES)
+
+pytestmark = pytest.mark.skipif(not _HAS_DATA, reason="raw 2025 races absent")
+
+
+@pytest.mark.data
+@pytest.mark.parametrize("race", _RACES)
+def test_the_served_weather_equals_n04s_join_cell_for_cell(race):
+    """Not "close to". The alignment IS the trained contract."""
+    from src.f1_strat_manager.weather_restore import weather_for_race
+    from src.simulation.replay_engine import RaceReplayEngine
+
+    race_dir = _RAW / race
+    laps = pd.read_parquet(race_dir / "laps.parquet")
+    weather = pd.read_parquet(race_dir / "weather.parquet")
+    ours = laps[laps["Driver"] == "NOR"]
+    truth = weather_for_race(ours, weather)
+
+    engine = RaceReplayEngine(race_dir, "NOR", "McLaren", interval_seconds=0)
+
+    compared = 0
+    for state in engine.replay():
+        row = ours[ours["LapNumber"] == state["lap_number"]]
+        if row.empty:
+            continue
+        idx = row.index[0]
+        for served_key, trained_col in (
+            ("air_temp", "AirTemp"),
+            ("track_temp", "TrackTemp"),
+            ("humidity", "Humidity"),
+        ):
+            expected = truth.loc[idx, trained_col]
+            served = state["weather"].get(served_key)
+            if pd.isna(expected) or served is None:
+                continue
+            compared += 1
+            assert served == pytest.approx(float(expected)), (
+                f"{race} lap {state['lap_number']} {trained_col}: replay serves {served}, "
+                f"N04's join says {expected}"
+            )
+
+    assert compared > 0, f"{race}: nothing was compared, so this held vacuously"
+
+
+@pytest.mark.data
+def test_the_rain_flag_follows_the_same_join():
+    """The flag that used to flip on 3,399 laps, and the one a wrong value most changes."""
+    from src.f1_strat_manager.weather_restore import weather_for_race
+    from src.simulation.replay_engine import RaceReplayEngine
+
+    race_dir = _RAW / "Shanghai"
+    laps = pd.read_parquet(race_dir / "laps.parquet")
+    weather = pd.read_parquet(race_dir / "weather.parquet")
+    ours = laps[laps["Driver"] == "NOR"]
+    truth = weather_for_race(ours, weather)
+
+    engine = RaceReplayEngine(race_dir, "NOR", "McLaren", interval_seconds=0)
+
+    compared = 0
+    for state in engine.replay():
+        row = ours[ours["LapNumber"] == state["lap_number"]]
+        if row.empty:
+            continue
+        expected = truth.loc[row.index[0], "Rainfall"]
+        if pd.isna(expected):
+            continue
+        compared += 1
+        assert bool(state["weather"]["rainfall"]) == bool(expected), (
+            f"lap {state['lap_number']}: replay says rain={state['weather']['rainfall']}, "
+            f"N04's join says {bool(expected)}"
+        )
+
+    assert compared > 0, "no rain flags compared: this held vacuously"
+
+
+@pytest.mark.data
+def test_the_lookup_is_not_the_proportional_index_it_replaced():
+    """Guard against a silent revert, by proving the two rules genuinely differ here.
+
+    A test that only checks agreement with `weather_for_race` would still pass if someone
+    restored the old lookup on a race where the two happen to coincide. This asserts that
+    Shanghai is NOT such a race, so the test above is doing real work on it.
+    """
+    from src.f1_strat_manager.weather_restore import weather_for_race
+
+    race_dir = _RAW / "Shanghai"
+    laps = pd.read_parquet(race_dir / "laps.parquet")
+    weather = pd.read_parquet(race_dir / "weather.parquet")
+    ours = laps[laps["Driver"] == "NOR"]
+    truth = weather_for_race(ours, weather)
+    total = int(laps["LapNumber"].max())
+
+    differing = 0
+    for idx, lap in ours["LapNumber"].items():
+        expected = truth.loc[idx, "TrackTemp"] if idx in truth.index else None
+        if expected is None or pd.isna(expected):
+            continue
+        fraction = (int(lap) - 1) / max(total - 1, 1)
+        old_row = weather.iloc[int(fraction * (len(weather) - 1))]
+        if abs(float(old_row["TrackTemp"]) - float(expected)) > 1e-9:
+            differing += 1
+
+    assert differing > 0, (
+        "the proportional index agrees with N04's join on every lap of this race, so the "
+        "tests above would pass under the old rule too: pick a different race"
+    )


### PR DESCRIPTION
First of the nine PRs from the two data-wiring gates, and the largest measured mover.

## What was wrong

`get_weather_state` picked its row by mapping the lap fraction onto the weather frame's row index. N04, which built the columns every model trained on, picks it by **session time**.

Neither side is evenly spaced. A Safety Car or a red flag stretches the gap between two laps while the samples keep their own cadence, so the two indices drift apart **exactly when conditions are changing**.

## Measured over 79,032 driver-laps, all 71 races

| | before | after |
|---|---|---|
| TrackTemp mean error vs N04 | **1.488 C** | **0.000** |
| max error | 17.3 C | 0.000 |
| laps served the wrong value | **94.3%** | 0.0% |
| rain flag flipped | **3,399 laps** | 0 |

The weather block is **39.7% of N06's model gain**, which is why this ranked first of the nine.

## How

The four trained columns come from `weather_restore.weather_for_race`, which already implements N04's `merge_asof(direction='nearest')` and is verified 22,760/22,760 against N04's own output. **Not a second implementation of the same join** — two implementations of one join is how the weather paths drifted apart in the first place.

Wind rides on the same aligned rows. Nothing trains on it, but a second alignment inside one dict is the same trap.

The alignment is a whole-race `merge_asof`, so it is built once per weather frame and cached, keeping `get_lap_state` the O(1) lookup the class promises.

## Verification

- served value equals N04's join to **0.0000** on every lap of Shanghai, Lusail and Las Vegas
- **66 passed** across `tests/simulation/` and both goldens
- **the strategy goldens do not move**: they score canned sub-agent outputs, not the replay path
- real `f1-sim --no-llm` at Lusail (57 laps) and Shanghai (56 laps): clean, Lusail's actions unchanged
- `uvx ruff@0.15.22 check .` clean

## A note on the test

Besides asserting the served value against N04's join cell for cell, one case asserts that **the two rules genuinely differ on the race it checks**. Without it, someone could restore the old lookup and the suite would still pass if the chosen race happened to be one where both agree.

Refs the plan in `documents/audits/GATE_801_ARTEFACTS.md`