### PR TITLE
fix(agents): serve the TCN the frame it was trained on

### DIFF
--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -24,7 +24,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import ClassVar, Optional
 
 import numpy as np
 import pandas as pd
@@ -325,6 +325,28 @@ class TireAgentConfig:
         self.abs_compound_id_map: dict = enc["absolute_compound_id"]
         self.compound_hardness_map: dict = enc["compound_hardness"]
 
+    # The per-cluster mean lap time N04 subtracted to build `lap_time_vs_cluster_mean`,
+    # which is a TCN input. MEASURED, not chosen: recovered from `laps_tiredeg.parquet`
+    # as `LapTime_s - lap_time_vs_cluster_mean`, which comes out to ONE value per
+    # cluster with standard deviation exactly 0.0. `tests/agents/test_tire_cluster_mean.py`
+    # re-derives them and fails if they drift.
+    #
+    # Hardcoded rather than read at runtime because neither source ships on a clean
+    # install: `_build_allow_patterns` pulls only `laps_featured_2025.parquet`, and
+    # reading an artefact that is not downloaded is the #798 failure class.
+    #
+    # THE FAMILY MATTERS. N07 builds `laps_tiredeg` by reading the COMBINED
+    # `laps_featured.parquet` (`.nb_py/N07_tiredeg_eda.py:92`) and inheriting its
+    # cluster columns, so the TCN trained on the POOLED clustering. That is the one
+    # `circuit_clusters_k4.parquet` carries, and it agrees with `laps_tiredeg` on 24 of
+    # 24 GPs, where `circuit_clusters_k4_2025.parquet` agrees on only 17.
+    _TRAINED_CLUSTER_MEAN_LAP_S: ClassVar[dict[int, float]] = {
+        0: 100.92462574340107,
+        1: 95.43860940701592,
+        2: 84.6488860957042,
+        3: 81.36461922886834,
+    }
+
     def _load_circuit_clusters(self) -> dict:
         """Load k=4 circuit cluster parquet and return GP_Name → Cluster int dict."""
         cluster_df = pd.read_parquet(
@@ -570,7 +592,15 @@ def _add_timing_cols(df: pd.DataFrame) -> pd.DataFrame:
     - FastF1 raw: LapTime/Sector*Time are pandas Timedelta objects
     - Featured parquet: LapTime_s/Sector*_s are already plain floats
 
-    LapsSincePitStop is aliased from TyreLife.
+    LapsSincePitStop is left alone when the frame already carries it, which both
+    featured artefacts do. It used to be OVERWRITTEN with TyreLife unconditionally,
+    and the two are different quantities: TyreLife is the age of the tyre SET and
+    counts laps run before this race, so they coincide only when the set was fitted
+    at the last stop. The alias disagreed with the trained column on 15.8% of rows.
+    Same defect as #800 on the pace path; this is its twin on the tire path.
+
+    A frame that genuinely lacks the column still gets the alias, because a missing
+    feature would break the scaler outright, and the alias is right four rows in five.
     """
 
     def _to_seconds(df, td_col, s_col):
@@ -590,7 +620,8 @@ def _add_timing_cols(df: pd.DataFrame) -> pd.DataFrame:
     df = _to_seconds(df, "Sector1Time", "Sector1_s")
     df = _to_seconds(df, "Sector2Time", "Sector2_s")
     df = _to_seconds(df, "Sector3Time", "Sector3_s")
-    df["LapsSincePitStop"] = df["TyreLife"]
+    if "LapsSincePitStop" not in df.columns:
+        df["LapsSincePitStop"] = df["TyreLife"]
     return df
 
 
@@ -605,8 +636,18 @@ def _add_weather_cols(df: pd.DataFrame, session_meta: dict) -> pd.DataFrame:
 def _add_prev_cols(df: pd.DataFrame) -> pd.DataFrame:
     """Shift timing and speed measurements back one lap to create prev-lap context.
 
-    First lap of a stint has no predecessor — filled with the current lap's value
-    to avoid NaN in the scaler input. Must run before _add_delta_cols.
+    A row with no predecessor keeps NaN, which is what the TCN trained on: N10's
+    scaler does `fillna(0)` (`.nb_py/N10_tiredeg_compound_finetuning.py:176,181`),
+    so the model learned a raw zero there, not a repeat of the current lap.
+
+    This used to fill the gap with the CURRENT lap's own value, described as "first
+    lap of a stint has no predecessor". Two things were wrong with that. The frame is
+    not grouped by stint here, so the fill actually hit only the first row of the
+    whole frame plus any row whose source was itself missing; and substituting the
+    current lap makes `Prev_X - X` read exactly zero where training read whatever the
+    scaled zero mapped to. It moved the TCN's output by a mean of 0.198 s.
+
+    Must run before _add_delta_cols.
     """
     for new_col, src_col in [
         ("Prev_LapTime", "LapTime_s"),
@@ -616,7 +657,7 @@ def _add_prev_cols(df: pd.DataFrame) -> pd.DataFrame:
         ("Prev_SpeedST", "SpeedST"),
         ("Prev_TyreLife", "TyreLife"),
     ]:
-        df[new_col] = df[src_col].shift(1).fillna(df[src_col])
+        df[new_col] = df[src_col].shift(1)
     return df
 
 
@@ -640,8 +681,17 @@ def _add_degradation_rate(df: pd.DataFrame) -> pd.DataFrame:
 
     DegAcceleration: change in DegradationRate between consecutive laps.
 
-    Both are shifted by 1 lap (leakage fix matching N10 training) so at position i
-    the model sees the rate from lap i-1.
+    NEITHER IS SHIFTED, because training never shifted them. Both used to carry a
+    `.shift(1)` described as a "leakage fix matching N10 training", and that comment
+    named a mechanism training never had: N04 computes both unshifted
+    (`.nb_py/N04_feature_engineering.py:481-504`) and N09 consumed them as stored
+    (`.nb_py/N09_tiredeg_tcn.py:219-220`). Serving a lagged value moved the TCN's
+    output by a mean of 0.185 s, concentrated at cliff onset, which is the one place
+    the number is read against a threshold.
+
+    The lag was not leakage protection either way: `raw_deg[i]` is fitted over laps
+    i-2..i, all of which have already happened at the moment the model is asked about
+    lap i. There was nothing from the future to exclude.
     """
     tyre_lives = df["TyreLife"].values
     adj_times = df["FuelAdjustedLapTime"].values
@@ -660,8 +710,8 @@ def _add_degradation_rate(df: pd.DataFrame) -> pd.DataFrame:
     for i in range(1, n):
         raw_accel[i] = raw_deg[i] - raw_deg[i - 1]
 
-    df["DegradationRate"] = pd.Series(raw_deg, index=df.index).shift(1).fillna(0)
-    df["DegAcceleration"] = pd.Series(raw_accel, index=df.index).shift(1).fillna(0)
+    df["DegradationRate"] = pd.Series(raw_deg, index=df.index)
+    df["DegAcceleration"] = pd.Series(raw_accel, index=df.index)
     return df
 
 
@@ -765,8 +815,12 @@ def _add_session_cols(df: pd.DataFrame, session_meta: dict) -> pd.DataFrame:
     (0.0000 s delta across all 24 GPs).
     """
     df["lap_time_pct_of_race_fastest"] = df["LapTime_s"] / session_meta["fastest_lap_s"]
-    if "lap_time_vs_cluster_mean" not in df.columns:
-        df["lap_time_vs_cluster_mean"] = df["LapTime_s"] - session_meta["cluster_mean_lap_s"]
+    # UNCONDITIONALLY, not guarded on the column's absence. Guarding it kept whatever
+    # the handed-in frame carried, and the featured artefacts carry the 2025 clustering
+    # while `Cluster` beside it comes from the POOLED map the TCN trained on. Serving one
+    # family's delta next to the other family's cluster id is a mix neither model saw:
+    # the two disagree on 100% of rows, mean 5.75 s.
+    df["lap_time_vs_cluster_mean"] = df["LapTime_s"] - session_meta["cluster_mean_lap_s"]
     df["laps_remaining"] = session_meta["total_laps"] - df["LapNumber"]
     if "mean_sector_speed" not in df.columns:
         df["mean_sector_speed"] = (df["SpeedI1"] + df["SpeedI2"] + df["SpeedFL"]) / 3
@@ -1443,7 +1497,14 @@ class TireAgent:
 
         self.session_meta = {
             "fastest_lap_s": _clean["LapTime"].min().total_seconds(),
-            "cluster_mean_lap_s": _clean["LapTime"].dt.total_seconds().mean(),
+            # The TRAINED per-cluster constant, not this race's own mean lap time.
+            # It used to be `_clean["LapTime"].dt.total_seconds().mean()`, which is a
+            # different quantity: N04 subtracted one constant per CLUSTER (std 0.0
+            # within a cluster), and a race's own mean is a per-race number that
+            # happens to have the same units.
+            "cluster_mean_lap_s": TireAgentConfig._TRAINED_CLUSTER_MEAN_LAP_S.get(
+                self.cfg.circuit_cluster_map.get(gp_name, 0), 0.0
+            ),
             "total_laps": int(session.total_laps),
             "cluster_id": self.cfg.circuit_cluster_map.get(gp_name, 0),
             "team_id": _encode_team_id(self.cfg.team_id_map, stint_state.get("team", "Unknown")),
@@ -1521,7 +1582,12 @@ class TireAgent:
 
         self.session_meta = {
             "fastest_lap_s": float(clean_times.min()) if len(clean_times) > 0 else 90.0,
-            "cluster_mean_lap_s": float(clean_times.mean()) if len(clean_times) > 0 else 90.0,
+            # The TRAINED per-cluster constant, for the same reason as the FastF1 path
+            # above: this race's own mean lap time is a different quantity wearing the
+            # same units.
+            "cluster_mean_lap_s": TireAgentConfig._TRAINED_CLUSTER_MEAN_LAP_S.get(
+                self.cfg.circuit_cluster_map.get(gp_name, 0), 0.0
+            ),
             "total_laps": total_laps,
             "cluster_id": self.cfg.circuit_cluster_map.get(gp_name, 0),
             "team_id": _encode_team_id(self.cfg.team_id_map, team),

--- a/tests/agents/test_tire_serving_frame.py
+++ b/tests/agents/test_tire_serving_frame.py
@@ -18,9 +18,21 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from tests.conftest import HAS_TIRE_MODELS as _HAS_MODELS
+
 ROOT = Path(__file__).parent.parent.parent
 _TIREDEG = ROOT / "data" / "processed" / "laps_tiredeg.parquet"
 _CLUSTERS = ROOT / "data" / "processed" / "circuit_clustering"
+
+# EVERY test here, including the ones that only exercise a pure helper. Importing
+# `tire_agent` reads `data/models/tire_degradation/routing_config.json` at module import,
+# so a "hermetic" test that touches one of its functions is not hermetic at all: the three
+# below were written as if they were and went red on CI immediately. Naming the artefact
+# the import needs, rather than the artefact the test body reads, is the same guard-shape
+# defect #798 documented.
+pytestmark = pytest.mark.skipif(
+    not _HAS_MODELS, reason="importing tire_agent reads data/models/ (HF, not git)"
+)
 
 
 def _constants() -> dict[int, float]:

--- a/tests/agents/test_tire_serving_frame.py
+++ b/tests/agents/test_tire_serving_frame.py
@@ -1,0 +1,178 @@
+"""The tire agent serves the TCN the frame it was trained on (W-F8/F9/F10/F11).
+
+Four columns of the serving frame were a different quantity from the trained one, and the
+TCN's output moved by a mean of 0.42 s and up to 4.99 s against cliff thresholds of ~2 s.
+
+The one that needed the most digging was `lap_time_vs_cluster_mean`. N07 builds
+`laps_tiredeg` by reading the COMBINED `laps_featured.parquet` and inheriting its cluster
+columns (`.nb_py/N07_tiredeg_eda.py:92`), so the TCN trained on the POOLED clustering. The
+serving frame kept the 2025 family's delta next to the pooled family's `Cluster`, a mix
+neither model ever saw.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_TIREDEG = ROOT / "data" / "processed" / "laps_tiredeg.parquet"
+_CLUSTERS = ROOT / "data" / "processed" / "circuit_clustering"
+
+
+def _constants() -> dict[int, float]:
+    from src.agents.tire_agent import TireAgentConfig
+
+    return TireAgentConfig._TRAINED_CLUSTER_MEAN_LAP_S
+
+
+# --- the trained constants, re-derived rather than re-read --------------------
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _TIREDEG.exists(), reason="laps_tiredeg absent")
+def test_the_cluster_means_are_the_ones_n04_subtracted():
+    """A hardcoded constant is a claim about the artefact; this re-derives it.
+
+    Recovered as `LapTime_s - lap_time_vs_cluster_mean`, which must come out to ONE
+    value per cluster. If it does not, the feature is not what this code believes and
+    the constants are meaningless rather than merely stale.
+    """
+    laps = pd.read_parquet(
+        _TIREDEG, columns=["Cluster", "LapTime_s", "lap_time_vs_cluster_mean"]
+    ).dropna()
+    implied = laps.assign(mean_lap=laps["LapTime_s"] - laps["lap_time_vs_cluster_mean"])
+
+    by_cluster = implied.groupby("Cluster")["mean_lap"]
+    assert by_cluster.nunique().eq(1).all(), (
+        "the implied cluster mean is not constant within a cluster, so "
+        "lap_time_vs_cluster_mean is not LapTime_s minus a per-cluster constant"
+    )
+
+    constants = _constants()
+    for cluster, value in by_cluster.first().items():
+        assert int(cluster) in constants, f"cluster {cluster} has no declared constant"
+        assert constants[int(cluster)] == pytest.approx(float(value), abs=1e-6), (
+            f"cluster {cluster}: declared {constants[int(cluster)]}, artefact says {value}"
+        )
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _TIREDEG.exists(), reason="laps_tiredeg absent")
+def test_the_served_cluster_delta_reproduces_the_trained_column_exactly():
+    """The effect, over every 2025 row the artefact carries."""
+    laps = pd.read_parquet(
+        _TIREDEG, columns=["Year", "Cluster", "LapTime_s", "lap_time_vs_cluster_mean"]
+    ).dropna(subset=["LapTime_s", "lap_time_vs_cluster_mean"])
+    rows = laps[laps["Year"] == 2025]
+    assert len(rows) > 0, "no 2025 rows: this would hold vacuously"
+
+    served = rows["LapTime_s"] - rows["Cluster"].map(_constants())
+    assert np.abs(served - rows["lap_time_vs_cluster_mean"]).max() == pytest.approx(0.0, abs=1e-9)
+
+
+@pytest.mark.data
+@pytest.mark.skipif(
+    not (_CLUSTERS / "circuit_clusters_k4.parquet").exists() or not _TIREDEG.exists(),
+    reason="cluster artefacts absent",
+)
+def test_the_agent_reads_the_cluster_family_the_tcn_trained_on():
+    """Pooled, not 2025. The two disagree, and the disagreement is the bug.
+
+    Asserting the agreement with the pooled map alone would pass if someone repointed the
+    loader at the 2025 map on a day both happened to agree, so this also asserts that the
+    two maps genuinely differ.
+    """
+    trained = (
+        pd.read_parquet(_TIREDEG, columns=["GP_Name", "Year", "Cluster"])
+        .query("Year == 2025")
+        .drop_duplicates("GP_Name")[["GP_Name", "Cluster"]]
+    )
+    pooled = pd.read_parquet(
+        _CLUSTERS / "circuit_clusters_k4.parquet", columns=["GP_Name", "Cluster"]
+    )
+    season = pd.read_parquet(
+        _CLUSTERS / "circuit_clusters_k4_2025.parquet", columns=["GP_Name", "Cluster"]
+    )
+
+    against_pooled = trained.merge(pooled, on="GP_Name", suffixes=("_t", "_m"))
+    against_season = trained.merge(season, on="GP_Name", suffixes=("_t", "_m"))
+
+    assert (against_pooled["Cluster_t"] == against_pooled["Cluster_m"]).all(), (
+        "the pooled map no longer matches what the TCN trained on"
+    )
+    assert not (against_season["Cluster_t"] == against_season["Cluster_m"]).all(), (
+        "the two cluster families now agree everywhere, so this test can no longer tell "
+        "them apart and the loader could be repointed unnoticed"
+    )
+
+
+# --- the three shift/alias fixes, hermetic -----------------------------------
+
+
+def test_degradation_is_not_lagged():
+    """Training computed both unshifted; a lag moved the TCN 0.185 s at cliff onset."""
+    from src.agents.tire_agent import _add_degradation_rate
+
+    frame = pd.DataFrame(
+        {
+            "TyreLife": range(1, 9),
+            "FuelAdjustedLapTime": [90.0, 90.2, 90.5, 90.9, 91.4, 92.0, 92.7, 93.5],
+        }
+    )
+    out = _add_degradation_rate(frame.copy())
+
+    # A lagged series would repeat the previous row; an unshifted one rises immediately.
+    assert out["DegradationRate"].iloc[1] != pytest.approx(0.0), (
+        "the second lap still reads the first lap's zero, so the shift is back"
+    )
+
+
+def test_a_missing_predecessor_stays_missing():
+    """N10's scaler does fillna(0), so training saw a raw zero, not a repeat of the lap."""
+    from src.agents.tire_agent import _add_prev_cols
+
+    frame = pd.DataFrame({"LapTime_s": [90.0, 91.0], "SpeedFL": [300.0, 301.0]})
+    for col in ("SpeedI1", "SpeedI2", "SpeedST", "TyreLife"):
+        frame[col] = [1.0, 2.0]
+
+    out = _add_prev_cols(frame.copy())
+
+    assert pd.isna(out["Prev_LapTime"].iloc[0]), (
+        "the first row was filled with its own value, which is what training did not do"
+    )
+    assert out["Prev_LapTime"].iloc[1] == pytest.approx(90.0)
+
+
+def test_an_existing_laps_since_pit_is_not_overwritten_by_tyre_life():
+    """They are different quantities and the artefacts carry the real one."""
+    from src.agents.tire_agent import _add_session_cols
+
+    frame = pd.DataFrame(
+        {
+            "LapTime_s": [90.0, 91.0],
+            "Sector1_s": [30.0, 30.0],
+            "Sector2_s": [30.0, 30.0],
+            "Sector3_s": [30.0, 31.0],
+            "TyreLife": [12, 13],
+            "LapsSincePitStop": [3, 4],
+        }
+    )
+    meta = {
+        "fastest_lap_s": 89.0,
+        "cluster_mean_lap_s": 95.0,
+        "total_laps": 50,
+        "cluster_id": 1,
+        "team_id": 0,
+        "year": 2025,
+    }
+    frame["LapNumber"] = [1, 2]
+    for col in ("SpeedI1", "SpeedI2", "SpeedFL"):
+        frame[col] = [300.0, 301.0]
+
+    out = _add_session_cols(frame.copy(), meta)
+
+    assert list(out["LapsSincePitStop"]) == [3, 4], "the real column was stomped with TyreLife"


### PR DESCRIPTION
Second of the nine PRs from the data-wiring gates. Four columns of the tire agent's serving frame carried a different quantity from the trained one; combined, the TCN's output moved by a **mean of 0.42 s and up to 4.99 s**, against cliff thresholds of about 2 s.

## The three straightforward ones

**Degradation was lagged one lap**, under a comment calling it a "leakage fix matching N10 training". That mechanism never existed: N04 computes both unshifted (`.nb_py/N04_feature_engineering.py:481-504`) and N09 consumed them as stored. It was not leakage protection either way, since the rate at lap *i* is fitted over laps *i-2..i*, all of which have already happened.

**`Prev_*` filled a missing predecessor with the current lap's own value.** Training left it NaN and N10's scaler turned that into a raw zero, so the substitution made `Prev_X - X` read exactly zero where training read something else.

**`LapsSincePitStop` was overwritten with `TyreLife`.** Different quantities, the artefacts already carry the real column, and the alias disagreed with it on **22.4%** of 2025 rows. Same defect as #800 on the pace path; this is its twin on the tire path.

## The fourth, which took the digging

`lap_time_vs_cluster_mean` came from the featured artefact, built on the **2025** clustering, while `Cluster` beside it came from the **pooled** map. A mix neither model ever saw.

`.nb_py/N07_tiredeg_eda.py:92` settles it: N07 builds `laps_tiredeg` by reading the **combined** `laps_featured.parquet` and inheriting its cluster columns, so the TCN trained on the pooled family.

| | before | after |
|---|---|---|
| `lap_time_vs_cluster_mean` vs trained | disagrees on **100%** of rows, mean 5.75 s | **0.00000000** over 22,760 rows |
| cluster family served | mixed | pooled, matches trained on **24/24** GPs (the 2025 map matches 17) |

Found while fixing it, and not in the gate's list: **`cluster_mean_lap_s` was this race's own mean lap time** in both `session_meta` builders. A per-race number wearing the units of a per-cluster constant.

## A decision worth flagging

The four cluster constants are **hardcoded with a data-tier test that re-derives them from the artefact**, rather than read at runtime. Neither `laps_tiredeg` nor the combined featured parquet ships on a clean install, and reading an artefact that is not downloaded is the #798 failure class.

## Verification

- **401 passed** across `tests/mc`, `tests/agents` and `tests/simulation`; the only failure is the pre-existing `test_weather_restore`, which is #801's artefact defect
- real `f1-sim --no-llm` at Lusail: 57 laps clean, and **one lap moves from STAY_OUT to PIT_NOW** — the tire model acting on the quantity it was trained on
- `uvx ruff@0.15.22 check .` clean

One test asserts that the pooled and 2025 cluster maps **genuinely differ**, so the loader cannot be repointed unnoticed on a day they happen to agree.

Sequenced after #815 only by file overlap with PR 3.