### PR TITLE
fix(agents): resolve every GP spelling at the lookups keyed by name

### DIFF
--- a/documents/audits/GATE_801_ARTEFACTS.md
+++ b/documents/audits/GATE_801_ARTEFACTS.md
@@ -1,0 +1,653 @@
+# GATE — #801: the featured artefacts themselves, and the plan to regenerate them
+
+**Date:** 2026-08-04 · **Ref:** `main`/`dev` @ `73788e0b` · **Gate role:** adversarial, read-only on the repo (this file is the only write; `data/` untouched).
+
+**Mandate:** (1) verify the three claims in #801 as CLAIMS, not facts; (2) sweep the three featured
+artefacts against each other and the raw laps for everything #801 did NOT report; (3) settle whether
+`tests/agents/test_weather_restore.py`'s combined-carries-weather claim was ever true; (4) wire the
+regeneration plan so an implementer only executes.
+
+**Not re-reported here** (GATE_DATA_WIRING owns them): F7 weather proportional lookup, F8 deg shift,
+F9 `lap_time_vs_cluster_mean` artefact split, F10 prev-fill, F14 keyspace family. This gate judges the
+ARTEFACTS and the PRODUCER (`.nb_py/N04_feature_engineering.py`), not the consumers.
+
+Findings appended AS CONFIRMED, each with executed evidence.
+
+---
+
+## Audit checklist (updated as worked)
+
+- [x] Claim A — combined broadcasts one season's `mean_sector_speed` → A1 (verified, refined)
+- [x] Claim B — Las Vegas 2025 NaN hole + sweep for unreported holes → B1, B2
+- [x] Claim C — 2023 Spain/Barcelona duplicate + double-count measurement → C1, C2, C3, C3-b
+- [x] Beyond: column-by-column artefact diff (combined vs per-year vs raw) → A2, "could NOT" §1-3
+- [x] The weather-restore test's claim: true against which artefact version? → D1 (never true of the published artefact)
+- [x] Producer logic audit: is regeneration even sufficient? → A2, A3, A4, §2 (NO — producer fixes first), E1 (proof the fixed rebuild reproduces)
+- [x] Part 2 plan: commands, gates, HF upload, ordering vs GATE_DATA_WIRING → runbook §§1-6 + PR table
+
+---
+
+## Findings
+
+### A1 — Claim A VERIFIED, with a sharper mechanism than #801 states: the combined artefact is not "stale for 2025" — it was built with a DIFFERENT rule, and so were the 2023/2024 per-year files. Only `laps_featured_2025.parquet` carries season-true values, and it is exact.
+
+Measured (all four artefacts + both circuit-feature files + all 71 raw `laps.parquet`, N03's rule
+= mean of SpeedI1/I2/FL over laps carrying all three):
+
+- **Combined**: `mean_sector_speed` identical 2023-vs-2025 on **21 of 22** shared GPs (the 22nd is
+  Miami, explained below). Every combined value equals `circuit_features_with_clusters_k4.parquet`
+  exactly (70 of 70 (yr,GP) pairs with a k4 entry, 1 apparent mismatch that is the Miami alias
+  row). The combined's number is N03's **2023+2024 pooled** per-circuit constant, merged on
+  GP_Name with no Year key (`.nb_py/N04_feature_engineering.py:752-757`).
+- **`laps_featured_2023/2024`**: byte-identical to the combined's rows for those years
+  (cell-level diff over ALL 48 columns: **zero differing cells** in 2023 and 2024). They carry the
+  same pooled constant — NOT their own season's measurement (vs raw truth: 2023 mean |Δ| 2.98,
+  max 9.10 km/h at Suzuka; 2024 mean 4.49, max 15.79 at São Paulo).
+- **`laps_featured_2025`**: matches `circuit_features_with_clusters_k4_2025.parquet` exactly on
+  23 of 24 GPs (24th = Las Vegas NaN), and matches the raw-derived 2025 truth to **0.00 km/h mean
+  and max** — it IS the season measurement. #801's spot values reproduce exactly: Silverstone
+  raw 231.36* / per-year 231.36 / combined 249.71; Melbourne 256.84 / 256.84 / 272.44.
+  (*#801 quoted "raw 232.32" for Silverstone from the mean-of-three-traps rule including a
+  different lap filter; under N03's own filter the raw value is 231.36 — i.e. the per-year
+  artefact is not "close to" raw, it EQUALS it. The conclusion of #801 stands, stronger.)
+- **2025 combined-vs-per-year: mean |Δ| 4.77, max 18.35 km/h (Silverstone), 1 of 24 identical
+  (Miami — see A4).**
+
+**Authority verdict:** for 2025, `laps_featured_2025.parquet` is authoritative (season-true and
+exactly reproducible from raw via N03's `_compute_sector_speed`). For 2023/2024 the artefacts
+carry the pooled-training-era constant BY CONSTRUCTION, and that pooled constant is what N06
+trained on — so the 2023/2024 values are authoritative *as the trained quantity* and must NOT be
+"fixed" to season-true without retraining. `pace_agent._load_circuit_mean_sector_speed`'s
+docstring (`src/agents/pace_agent.py:336-378`) already documents this correctly; this gate
+confirms every number in it.
+
+### A2 — The producer CANNOT reproduce the shipped artefacts: current N04 would REGRESS `laps_featured_2025.parquet` on 3 columns and 6,892 Cluster cells. Regeneration with the code as-is makes things WORSE, not better.
+
+- The shipped `laps_featured_2025.parquet` was built by a **pre-2026-02-15 version** of N04:
+  its `Cluster` matches `circuit_clusters_k4_2025.parquet` (KMeans-predict assignments) on 24/24
+  GPs and MISmatches `circuit_clusters_k4.parquet` on 7 GPs (Barcelona 1→3, Budapest 1→3,
+  Melbourne 0→2, Shanghai 1→0, Spielberg 1→3, São Paulo 0→2, Zandvoort 0→2); its
+  `mean_sector_speed` matches the `_2025` circuit features exactly (A1).
+- Commit `11a7ffa` (2026-02-17, "changed 2025 clusters to be the same of 2023-24 instead of
+  using predict method") rewired Step 9 to read `circuit_clusters_k4.parquet` +
+  `circuit_features_with_clusters_k4.parquet` (`.nb_py/N04_feature_engineering.py:1041,1072-1076`).
+  **The artefacts were never regenerated after that commit.** Running today's N04 would flip
+  6,892 Cluster cells, replace every 2025 `mean_sector_speed` with the 2023-24 pooled constant
+  (mean shift 4.77 km/h, max 18.35), and recompute `lap_time_vs_cluster_mean` on all 22,760
+  rows — destroying the exact values the #797 fix, the N06 holdout MAE (0.4104), and
+  `test_pace_circuit_speed.py` were measured against.
+- The Step 9 header comment (`N04:999`) still says "Cluster assignment from saved model
+  (`circuit_clusters_k4_2025.parquet`)" while the code reads the k4 file — a comment naming the
+  wrong mechanism, in the producer, at the exact line that decides this regression.
+- Cell-level diff, combined vs per-year 2025 (same (GP,Driver,LapNumber), Miami aliased):
+  differing columns are EXACTLY `Cluster` (6,892 cells), `mean_sector_speed` (21,903),
+  `lap_time_vs_cluster_mean` (22,760) — and nothing else. All other 44 shared columns are
+  identical. The artefact family split is fully explained by the two write paths
+  (`N04:974/:979` Step 8 with k4 vs `N04:1093` Step 9 pre-`11a7ffa` with k4_2025).
+
+### A3 — Step 9 running after Step 8 CLOBBERS the combined artefact with 2025-only rows: `process_2025_season` calls `finalize_and_save` (`N04:1089`), which unconditionally writes `laps_featured.parquet` (`N04:973-974`). A restart-and-run-all of today's N04 leaves the combined artefact with 22,760 rows and one season.
+
+- `load_all_races()` (`N04:161-167`) globs EVERY year directory under `data/raw/` — today that
+  includes 2025 — so Step 8 writes a 3-season combined + three per-year files. Step 9 then
+  re-runs `finalize_and_save` on the 2025-only frame, overwriting `laps_featured.parquet` with
+  2025-only content, before writing `laps_featured_2025.parquet` a second time at `N04:1093`.
+  The notebook violates its own restart-and-run-all rule: the on-disk end state of a full run is
+  a combined artefact that is not combined.
+- Corollary: the header's "52,340 laps across 47 GPs (2023–2024)" (`N04:7`) describes a
+  `data/raw/` that no longer exists; Step 8's output today depends on which seasons happen to be
+  on disk. The 2025 rows inside the current combined artefact came from exactly this path (they
+  carry the un-aliased `'Miami Gardens'` name — `_GP_NAME_ALIASES_2025` at `N04:1006` is applied
+  only in `_load_raw_2025`, `N04:1028`, never in `load_all_races`).
+
+### A4 — The k4 circuit files carry a hand-grafted `'Miami Gardens'` row that no notebook produces. It is the only reason a Step-8 run over 2025 data does not crash.
+
+- `circuit_clusters_k4.parquet` and `circuit_features_with_clusters_k4.parquet` both contain
+  BOTH `'Miami'` (msp 222.36, the 2023-24 pooled value) and `'Miami Gardens'` (msp 221.38 —
+  which is the **2025-measured** Miami value, equal to `k4_2025`'s Miami row). N03's own code
+  cannot emit a `'Miami Gardens'` row (its 2025 section aliases the name at
+  `.nb_py/N03_circuit_clustering.py:1176-1200`, and its training section never saw 2025 dirs
+  when it was run). Someone grafted the row into the k4 artefacts so that Step 8's merge would
+  not leave `Cluster=NaN` on the 2025 Miami rows — `finalize_and_save` does
+  `laps_featured['Cluster'].astype(int)` (`N04:955`), which raises on NaN.
+- Consequence for regeneration: **re-running N03 would drop the graft**, and a subsequent
+  Step-8 N04 run would crash on `astype(int)` (or, if the crash is "fixed" by filling, silently
+  mis-cluster Miami). Regeneration must either keep the current k4 parquets untouched or move
+  the alias into `load_all_races`. Also note the graft mixes eras inside one file: the
+  `'Miami Gardens'` row's msp is a 2025 measurement sitting in the training-era artefact.
+
+### B1 — Claim B VERIFIED and root-caused: Las Vegas 2025 `mean_sector_speed` NaN on all 760 rows because FastF1's SpeedI2 trap is missing for the ENTIRE 2025 Las Vegas race; N03's all-three-traps filter then yields zero valid laps.
+
+- Raw `data/raw/2025/Las_Vegas/laps.parquet`: SpeedI2 **0%** not-NaN (886 rows), vs I1 80%,
+  FL 97%, ST 100%. 2023/2024 Las Vegas have I2 at 100%/97%. The all-71-races sweep found **no
+  other (year, GP) with a fully-missing speed-trap column** — this is the only one.
+- Propagation: `_compute_sector_speed` (`.nb_py/N03_circuit_clustering.py:686-694`) requires
+  all three traps → zero rows for Las Vegas → `circuit_features_with_clusters_k4_2025.parquet`
+  carries msp NaN → the `how='left'` merge (`N03:1231`) preserves it → featured_2025 NaN ×760.
+- **Regeneration cannot create this value** under N03's rule; the raw data does not contain it.
+  The honest fixes are (a) record the hole in the dataset docs (per #801's own acceptance
+  wording), or (b) change the rule for this circuit (e.g. mean of I1/FL) — which changes the
+  quantity served vs every other race and moves the N06 holdout; (a) is right, (b) is not.
+
+### B2 — Beyond #801: the full-hole sweep found holes #801 did not report.
+
+Full-race (100% NaN) holes per artefact:
+- combined: Las Vegas 2025 `SpeedI2`, `Prev_SpeedI2`, `SpeedI2_Delta` (760 rows each).
+- featured_2025: the same three PLUS `mean_sector_speed` (the reported one).
+- featured_2023 / featured_2024: none.
+
+So the Vegas hole is not one column but FOUR in the 2025 file, and three of them exist in the
+combined too (nobody had catalogued the SpeedI2 family). `Prev_SpeedI2` and `SpeedI2_Delta` are
+N06-adjacent quantities; any consumer assuming "speed traps are always present except msp"
+inherits them.
+
+Partial holes >40% in one race (excluding by-design first-lap-of-stint NaN):
+- featured_2025 Miami: `Stint`, `TyreLife`, `FuelEffect`, `FuelAdjustedLapTime`,
+  `FuelAdjustedDegAbsolute`, `FuelAdjustedDegPercent` at 44% NaN (of 857 rows). **This one is
+  KNOWN**: it is the raw-data tyre-stint hole GATE_tyrelife_nan_rootcause already traced
+  (379 Miami rows of the 451-row gap; stint-shaped, laps 1-24, all 19 drivers in raw), and
+  #790's repair covers it at serving time (`laps_augment.py:231` → `repair_tyre_stints`,
+  `_apply_stint_corrections` at `laps_augment.py:135`). Recorded here only to note that
+  **regeneration does NOT fix it** (the raw parquet is the hole) and does not conflict with
+  the repair (which runs at augment time, downstream of the artefact).
+
+### C1 — Claim C VERIFIED end-to-end, and the duplicate is byte-identical: `data/raw/2023/Spain` and `data/raw/2023/Barcelona` share OpenF1 session key 9102, identical record counts (1312/154/26036/43), extraction timestamps 21s apart (a test run and the real run, per N04's own `fix_spain_cluster_artefact` docstring, `N04:792-796`), and their raw laps are numerically identical row-for-row.
+
+Double-count measurement:
+- featured_2023 (and combined 2023): **1,198 Spain rows + 1,198 Barcelona rows = 5.4% of the
+  22,106-row 2023 season is one race counted twice.** After featuring, the two copies differ in
+  NO column except `GP_Name` (48-column cell diff: zero).
+- **N06 trained on this**: `laps_featured_2023.parquet` is its training set
+  (`.nb_py/N06_laptime_model.py:83`), so the 2023 Spanish GP carries double weight in the
+  shipped lap-time model. Same for anything trained on featured_2023/combined.
+- "71 races" = 70 unique + the duplicate (data/raw dirs: 23+24+24; the 2023 season had 22 races).
+- N04 KNOWS about the duplicate and patches it instead of dropping it: `fix_spain_cluster_artefact`
+  (`N04:792-826`) maps Spain's cluster values to Barcelona's — the claim-true-inside-false-headline
+  pattern: the patch makes the duplicate *consistent*, which is precisely what makes it invisible.
+
+### C2 — `laps_tiredeg.parquet` hides the same duplicate under ONE name (measured below) and drops the `'Miami Gardens'` spelling — the TCN's training artefact has its own naming convention, disagreeing with both featured families.
+
+- `laps_tiredeg`: 68,122 rows — the SAME total as the combined featured artefact — yet it
+  contains NO `'Spain'` and NO `'Miami Gardens'` GP_Name. 2023 row count 22,106 == featured's
+  (which includes 1,198 Spain rows). Row-count identity with zero Spain rows means the Spain
+  copy is still inside under another name.
+- **Measured: `laps_tiredeg` Barcelona 2023 = 2,396 rows — double every other race (next
+  largest: Monaco 1,397) — with 1,198 DUPLICATED `(Driver, Stint, LapNumber)` keys.** The Spain
+  copy was RENAMED to Barcelona, not dropped: the duplicate is now invisible to any GP-name
+  check and collides on the exact key the TCN's sequence builder groups by. Every 2023
+  Barcelona stint in the TCN's training artefact contains each lap twice; a
+  `(GP, Driver, Stint)` groupby sorted by LapNumber yields interleaved duplicate timesteps.
+  This is worse than double weight — it is corrupted training sequences for that race, and it
+  cannot be found by looking for `'Spain'`. (`laps_tiredeg` 2025 also renames to `'Miami'`,
+  857 rows, no doubling — rename only.)
+
+### C3 — The duplicate is COUNTED in the published position-projection ground truth: `measure_projection_ground_truth` (`src/strategy/eval/projection.py:286-300`) iterates every directory under `data/raw/<year>/` — 71 dirs including `Spain` — so the "86.5% within one place / 59.1% exact over 1810 stops in 71 races" sample scores the 2023 Spanish GP's stops twice. `races=71` in its return IS the count of directories, not of races. The N15 pit holdout does the same (`src/strategy/eval/pit_holdout.py:51`, `raw_root.glob("*/*/laps.parquet")`): the duplicated race's stops enter the 2023-24 training pool twice. (Exact stop contribution measured in C3-b below.)
+
+### D1 — The weather-restore test's claim: the combined artefact NEVER carried weather in its PUBLISHED form. The test was written against a machine-local regeneration that was overwritten by an HF re-download 51 minutes after the commit.
+
+Executed evidence:
+- The four PUBLISHED artefacts on `VforVitorio/f1-strategy-dataset` (schema read via
+  `HfFileSystem` + `pyarrow.read_schema`, footer-only): **48 columns each, NONE of
+  AirTemp/TrackTemp/Humidity/Rainfall.** Same for all four LOCAL files today.
+- N04 gained Step 5 (weather) on **2026-02-15** (`e8ce966`). Every artefact on disk and on HF
+  predates that: no weather columns, and featured_2025 still carries the pre-`11a7ffa`
+  (2026-02-17) cluster convention (A2). The published artefacts are a **pre-2026-02-15 build**;
+  the producer has drifted from them for ~6 months.
+- `tests/agents/test_weather_restore.py` was committed 2026-08-03 **09:35** (`f26e256`). Local
+  file mtimes: `laps_featured_2025.parquet` 2026-08-03 **10:06** (HF download batch, together
+  with `circuit_clustering/**` — exactly the `_DEFAULT_MODEL_PATTERNS` set), and
+  `laps_featured.parquet` + `_2023` + `_2024` at **10:26** (a second, wider download; those
+  three are NOT in the allow-patterns, so it was a manual/full pull). The test asserted
+  against a local combined that carried weather — which only a post-2026-02-15 N04 rerun can
+  produce — and that file was replaced by the weather-less HF copy the same morning.
+- The test fails today with `KeyError: "['AirTemp', 'TrackTemp', 'Humidity', 'Rainfall'] not
+  in index"` (executed: `uv run pytest tests/agents/test_weather_restore.py` → 1 failed,
+  7 passed).
+
+**Verdict:** the docstring's claim — "N04's actual output was published all along, and only the
+per-year split dropped them" — was **always false of the published artefact**. Regeneration
+does not *restore* the weather columns to the published dataset; it *creates* them there for
+the first time. (It does restore the local state the test was written against, and the restore
+module's 22,760/22,760 reproduction shows the values will be identical to what the test saw.)
+
+### D2 — HF gap, #797's serving path: `_build_allow_patterns` ships ONLY `laps_featured_2025.parquet`; `pace_agent._load_circuit_mean_sector_speed` reads `laps_featured_{2023,2024,2025}` (`pace_agent.py:381-385`, `_FEATURED_SEASONS = (2023, 2024, 2025)`). On a clean HF install the 2023/2024 files are absent, the loop `continue`s, and every 2023/2024 replay resolves `mean_sector_speed` to NaN with a warning — silently degraded, exactly the failure class #798 documented for `undercut_clean`. `data_cache.py:109` must list all four featured parquets (or the per-year trio) after regeneration.
+
+### C3-b — The duplicate's exact contribution to the published sample, executed with the eval's own functions (`green_flag_stops`, `project_one_stop`): the 2023 `Spain` directory contributes **42 scored stops**, identical to `Barcelona`'s 42 — so **84 of the 1,810 stops (4.6%) are one race scored twice**, and `races=71` counts 70 races. De-duplicated, the sample becomes ~1,768 stops over 70 races. The shipped threshold test survives it: `tests/mc/test_position_projection.py:50-51` asserts `>= 0.80` within-one over `>= 1500` stops — an EFFECT assertion with margin (the good pattern), so removing the duplicate cannot flip it. What DOES have to move: the prose numbers ("1810", "71 races") in `registry`/docs/memory wherever quoted.
+
+### E1 — EXECUTED PROOF that regeneration is safe once the producer is fixed: an in-memory rebuild of `laps_featured_2025` (N04 Steps 1-8 verbatim, Step 9's cluster sources set to the `_2025` files — the pre-`11a7ffa` wiring) reproduces the shipped artefact with **ZERO differing cells across all 48 columns, 22,760/22,760 rows matched**, and the four newly-added weather columns match `weather_restore.weather_for_race`'s output with **0/22,760 mismatches on each of AirTemp/TrackTemp/Humidity/Rainfall**.
+
+- Harness: session-scratchpad script (ephemeral; fully reproducible — it is N04's Step 1-8
+  function bodies copied verbatim from `.nb_py/N04_feature_engineering.py`, the 2025 loader
+  with the Miami alias, the `_2025` cluster sources, and the acceptance-diff snippet in the
+  Appendix below; nothing written under `data/`). This closes the two
+  load-bearing questions at once: (1) the pipeline is deterministic and still value-identical
+  to the February build for every shipped column — the post-build commits (`e8ce966` weather,
+  `6af182e` refactor) are value-neutral, and ONLY `11a7ffa`'s source swap separates today's
+  code from the shipped artefact; (2) the weather columns a regeneration adds are exactly the
+  values the committed restore module already serves, so the pace holdout
+  (`tests/eval/test_ml_recompute_golden.py`: MAE 0.4104 ± 0.01) cannot move.
+- One caveat: the harness output carried one stray extra column from its own simplified
+  loader (53 vs the expected 52 = 48 + 4). The acceptance diff in the plan below compares
+  COLUMN SETS as well as values, so a real rebuild cannot smuggle or lose a column silently.
+
+---
+
+## What I tried to break and could NOT
+
+Verified sound with executed evidence — do not re-audit without cause:
+
+1. **Row parity of combined vs per-year files**: per-year row counts (22,106 / 23,256 /
+   22,760) match the combined's per-year slices exactly; join on (GP, Driver, LapNumber) has
+   zero duplicate keys and zero unmatched rows in all three years (after the Miami alias).
+2. **2023/2024 cross-artefact integrity**: cell-level diff over ALL 48 columns, combined vs
+   per-year — zero differing cells. One build, no drift, no holes (no 100%-NaN race-columns).
+3. **The 2025 split is exactly three columns wide**: everything except `Cluster`,
+   `mean_sector_speed`, `lap_time_vs_cluster_mean` (and the GP naming) is identical between
+   the combined's 2025 rows and `laps_featured_2025.parquet`. The artefact split at
+   `N04:974/:979` vs `:1093` explains 100% of the observed disagreement; no second cause.
+4. **`laps_featured_2025`'s `mean_sector_speed` == the raw truth under N03's own rule**: mean
+   AND max |Δ| = 0.00 km/h across all 23 non-NaN GPs. The per-year 2025 artefact is not
+   approximately right; it is the measurement.
+5. **Speed-trap holes**: the all-71-races sweep found exactly ONE fully-missing trap column
+   anywhere (2025 Las Vegas SpeedI2). No other race hides a Vegas-shaped hole.
+6. **The Spain/Barcelona copies are truly identical** (raw: numerically identical row-for-row;
+   featured: identical on every column except GP_Name) — so de-duplication loses no
+   information, whichever copy is kept.
+7. **Determinism/reproducibility of the producer pipeline** (E1): 48/48 columns exact after
+   six months of code churn, on today's pandas/numpy. Regeneration is not a leap of faith.
+8. **`tests/mc/test_position_projection.py` thresholds** hold under de-duplication (0.865
+   measured vs 0.80 floor; 1,768 vs 1,500 floor).
+9. **N04 exports no model and no manifest** (unlike N16): its only writes are the three
+   `to_parquet` calls at `N04:974/:979/:1093` plus plots — nothing else needs backing up.
+
+Not verified (out of scope, stated so nobody assumes): the VALUES of every engineered column
+against an independent re-derivation (only `mean_sector_speed` and the artefact-vs-artefact
+consistency were re-derived); `laps_tiredeg`'s other 55 columns beyond the keys measured in C2;
+the NLP/radio artefacts.
+
+---
+
+# PART 2 — THE CONSOLIDATED, ORDERED FIX PLAN
+
+Everything known as of 2026-08-04 — this gate's findings (G-*) plus GATE_DATA_WIRING's (W-F*),
+one list, ordered by MEASURED effect on served output, each with the surgical fix and the
+measurement that accepts it. W-F numbers are cited from `GATE_DATA_WIRING.md` (its harness:
+21,247 anchored 2025 laps for N06; 335 stints / 8 races for the TCN), not re-derived; where
+this gate touched the same artefacts the findings were reconciled and NO disagreement was
+found (its F12 broadcast observation is A1's tiredeg-side twin; its cross-cutting note on the
+augment guard is D1's territory and is subsumed by the regeneration).
+
+## The one design rule that governs every fix below
+
+**Serve what the model trained on; regenerate only what reproduces; document what neither
+fixes.** Concretely: the artefact families (featured per-year vs combined vs tiredeg) carry
+three different conventions for `Cluster` / `mean_sector_speed` / `lap_time_vs_cluster_mean`.
+Each shipped model trained on ITS family. Fixes therefore go in the SERVING code (feed each
+model its trained quantity), never in unifying the artefacts — with the single exception of
+the combined artefact's 2025 rows, which nothing trained on and only tests read (their only
+consumers: `test_weather_restore.py:121`, `test_pace_circuit_speed.py:27` existence-guard).
+
+---
+
+One deliberate re-ranking vs GATE_DATA_WIRING's own fix list, stated openly: it placed W-F1
+(CompoundID) above W-F13 and W-F4; by its own measured numbers W-F4 moves more (8.2% of preds,
+mean 0.0083s vs F1's 3.7% / 0.0055s), so this list orders F4 above F1. Nothing else disagrees.
+
+## Ordered fix list
+
+### 1. W-F7 — replace the replay weather lookup with N04's rule [CODE — largest measured mover]
+
+- **Now:** `RaceStateManager.get_weather_state` (`src/simulation/race_state_manager.py:515-518`)
+  does `idx = int((lap-1)/(total-1) * (len(weather_df)-1))` — proportional row-index, ignores
+  session time. Measured: TrackTemp wrong on 92.6% of 26,692 driver-laps (mean 1.11°C, max
+  11.8), rain flag flipped on 1,279 laps; N06 impact 26.8% of preds >1ms, mean 0.0367s, max
+  8.28s.
+- **Fix:** join each lap's session `Time` to the nearest weather sample —
+  `weather_restore.weather_for_race(laps_df, weather_df)` already implements exactly N04's
+  `merge_asof(direction='nearest')` and is verified 22,760/22,760 against N04's output. Build
+  the per-lap weather table once in the RSM constructor (it has `laps_df` with `Time` and
+  `weather_df`), then `get_weather_state(lap)` reads the current driver's lap row from it.
+  Keep `track_temp_start` as-is (first session sample — verified correct).
+- **Blast radius:** every replay-path weather consumer (N06 pace, N27 SC/overtake features,
+  N26 fallback, N28) shifts on ~90% of laps — deliberately, toward the trained quantity. The
+  CLI tire path does NOT change (already N04-faithful via augment). Any golden that snapshots
+  replay recommendations will move; that shift is the fix working, re-freeze after review.
+- **Measure:** before — for one evening race (Shanghai 2025):
+  `python -c` comparing the proportional-index TrackTemp vs `weather_for_race` per lap prints
+  ~2.38°C mean |Δ| today; after the fix the same comparison against `get_weather_state` must
+  print 0.00 for every lap of every race (add as a pytest:
+  `assert get_weather_state(lap)["track_temp"] == restored.loc[lap_row, "TrackTemp"]` over a
+  full 2025 race, parametrised over 3+ races including Las Vegas and a rain race).
+- **Do not touch:** `weather_restore.py` itself (it is the verified reference), and do not
+  "improve" the alignment beyond `nearest` — the alignment IS the trained contract.
+
+### 2. W-F8 + W-F9 + W-F10 + W-F11 — the tire agent's serving frame [CODE, one PR, `src/agents/tire_agent.py`]
+
+Combined measured impact when all four serve the trained quantity: TCN |Δ| mean 0.424s,
+p95 1.226s, max 4.99s (of a ~2s-cliff-threshold quantity) goes to ~0.02s (the F12 residue).
+
+- **W-F8** (`tire_agent.py:663-664`): DELETE the `.shift(1)` on `DegradationRate` and
+  `DegAcceleration` (and the "leakage fix matching N10 training" comment — it names a
+  mechanism training never had; N04 computes both unshifted at
+  `.nb_py/N04_feature_engineering.py:481-504`, N09 consumed them as stored,
+  `.nb_py/N09_tiredeg_tcn.py:219-220`). TCN mean 0.185s, concentrated at cliff onset.
+- **W-F9** (`tire_agent.py:768` + `:954`): the serving frame keeps the FEATURED
+  `lap_time_vs_cluster_mean` while stomping `Cluster` from the k4 map — mixing families. Fix
+  in code: recompute `lap_time_vs_cluster_mean` the way `laps_tiredeg` carries it (tiredeg's
+  cluster family + its cluster-mean table), or join it from `laps_tiredeg.parquet` for the
+  race being replayed. Do NOT regenerate artefacts to "agree": the TCN trained on tiredeg's
+  version (mean disagreement 5.75s), N06 on featured's — unifying breaks one to please the
+  other. TCN mean 0.208s.
+- **W-F10** (`tire_agent.py:619`): `df[src_col].shift(1).fillna(df[src_col])` fills every
+  missing predecessor with the CURRENT lap. Trained convention: leave NaN, let the scaler's
+  `fillna(0)` (N10:176,181) produce the raw zero training saw. Replace with plain
+  `.shift(1)`. Also fix the "first lap of a stint" docstring (wrong mechanism). TCN mean 0.198s.
+- **W-F11** (`tire_agent.py:593`): DELETE `LapsSincePitStop = TyreLife` — the frame already
+  carries N01's real column (present in both artefacts, 100% agreement); guard like FuelLoad.
+  TCN mean 0.005s — last in this PR, but it is one line.
+- **Measure (all four at once):** build `TireAgent._build_stint_features` for the 335-stint
+  harness races and diff `DegradationRate`, `DegAcceleration`, `lap_time_vs_cluster_mean`,
+  `LapsSincePitStop`, `Prev_*` NaN-pattern against `laps_tiredeg.parquet` for the same
+  `(GP, Driver, Stint, LapNumber)` rows. Today: 0.28/0.40 s/lap mean on the deg pair, 100% of
+  rows on ltvcm, 15.8% on LSPS, 6-22% NaN-pattern. Accepted when every column's divergence vs
+  the trained artefact is 0 (deg pair, LSPS, ltvcm) / NaN-pattern-identical (Prev_*) on rows
+  the artefact carries.
+- **Do not touch:** the zero-pad/truncate/scaler path (`tire_agent.py:1048-1067`) — verified
+  verbatim-N09; and `_add_session_cols`' other columns — verified 0.0% divergence.
+
+### 3. W-F14 + W-F6 — one `_normalise_gp_key` at every gp_name-keyed lookup [CODE]
+
+- **Now:** `'Miami Gardens'` (metadata.json name) misses `tire_compounds_by_race.json`
+  (`'Miami'`-keyed) → every 2025 Miami stint routes SOFT to the **C3 TCN bundle instead of
+  C5** (`tire_agent.py:819-821`), compound IDs −2 in N16 (`pit_strategy_agent.py:425-428`);
+  pace `_encode_categorical` (`pace_agent.py:461`) and `_session_median`
+  (`pace_agent.py:734-738`) miss the same key → default cluster + `delta_vs_median=NaN` all
+  race (today masked by Miami's real cluster being the default 1 — latent, not harmless).
+- **Fix:** apply the #797 four-keyspace chain (`_normalise_gp_key` + `slug_from_event_name`)
+  at the four lookups: pace `_encode_categorical`, pace `_session_median`, tire
+  `_compound_name_to_id`, pit `_compound_to_id`. Add the enumeration test
+  `test_pace_circuit_speed.py` already models: every race dir under `data/raw/` resolves in
+  ALL FOUR consumers.
+- **Measure:** before — `TireAgent._compound_name_to_id('SOFT', 'Miami Gardens', 2025)`
+  returns 3 (C3); after — 5 (C5), and the enumeration test passes 71/71 (70/70 post-dedup).
+- **Blast radius:** the 2025 Miami replay's tire outputs change wholesale (that is the fix);
+  nothing else resolves differently today (measured: Miami Gardens is the only 2025 miss).
+
+### 4. W-F4 — feed N06 the PREVIOUS lap's speed trap [CODE]
+
+- **Now:** `pace_agent.run_from_state` (`pace_agent.py:902,956`) feeds `d.get("speed_st")` —
+  the CURRENT lap's trap — where training had the stint-grouped previous
+  (`N04:384-392`). 8.2% of preds move, mean 0.0083s, max 2.44s. Twin of the fixed #435.
+- **Fix:** have `get_driver_state` emit `prev_speed_st` (previous lap's `SpeedST` within the
+  stint, NaN on openers) and wire `run_from_state` to it; keep the current-trap key for
+  other consumers. Kill the `or 300.0` fallback (a findable real value; trained range
+  156-362) — pass NaN.
+- **Measure:** per-lap diff of the served `Prev_SpeedST` vs the featured parquet's column on
+  a replayed race: today 88% differ (mean 4.6 km/h); after, 0 differ on rows the parquet
+  carries.
+
+### 5. W-F1 — CompoundID: serve the 1-based codes the model trained on [CODE + manifest correction]
+
+- **Now:** `_encode_categorical` (`pace_agent.py:459`) uses the manifest's 0-based map →
+  every lap served one compound class low; measured 3.7% of preds move, max 0.221s. The
+  manifest block (`feature_manifest_laptime.json:66-73`) documents an encoding the model
+  never ate.
+- **Fix:** serve N01's 1-based codes (`N01:232,247`: 1=SOFT … 5=WET); correct the manifest
+  block in the same change (else the next reader re-introduces the bug from the docs — the
+  liar's-mirror pattern).
+- **Measure:** before — served CompoundID for a MEDIUM lap = 1; after = 2, equal to the
+  featured parquet's `CompoundID` for the same row, asserted over a full race (0 mismatches).
+
+### 6. W-F13 — gate the overtake tool at its trained 2.5s domain [CODE]
+
+- **Now:** N11 dropped every training pair with gap > 2.5s (`N11:233-235`);
+  `predict_overtake_tool` (`race_situation_agent.py:1140-1204`) has no gap guard — 41.9% of
+  real adjacent pairs (10,565 of 25,215 in 2025) are scored out-of-domain.
+- **Fix:** refuse or explicitly label extrapolation beyond 2.5s (the #710 envelope pattern).
+- **Measure:** the tool called with gap 9.0s today returns a bare probability; after, it
+  returns the out-of-domain marker. Rate of unlabeled out-of-domain calls on a replayed
+  race: 41.9% → 0%.
+
+### 7. G-REGEN — the featured-artefact regeneration (this gate's core deliverable; runbook below) [PRODUCER CODE + ARTEFACT + HF]
+
+Measured serving impact today: **≈0** — E1 proved the regenerated files are value-identical
+on every column any model reads, and the added weather equals what the augment path already
+restores. Its value is: `test_weather_restore.py` red→green, #782/#801 acceptance, the
+published dataset finally matching its producer, and closing D2's clean-install degradation.
+Ordered here, below the code fixes, per the measured-impact standard.
+
+### 8. G-C — de-duplicate the 2023 Spanish GP [DATA + EVAL + HF — ONE-WAY, needs explicit sign-off]
+
+Measured: 84/1,810 of the projection sample is one race twice (C3-b); 5.4% of featured_2023;
+1,198 duplicated TCN training keys hidden inside tiredeg's Barcelona (C2). No serving-path
+effect on 2025 replays. Bundled with G-REGEN's run if the decision lands in time (runbook §5).
+
+### 9. Hygiene bundle [CODE, lowest measured impact — say so plainly]
+
+Measured ≤0.021s or exactly zero: W-F2 (`DriverNumber=0`, moves 0.000s — model importance
+0.03%), W-F3 (`FreshTyre` proxy, 0.000s — importance 0.00%), W-F5 (`Prev_TyreLife` opener
+0-vs-NaN, 0.0003s), W-F12 (tiredeg msp broadcast — document, don't change), N15 missing-
+TyreLife 0-vs-1 (`pit_strategy_agent.py:853-855`, 1.98% of rows), N27 latent cluster default
+0→−1 (`race_situation_agent.py:1449`), gap-sign hardening, `pace_delta_rolling3` positional
+pairing, the two wrong-mechanism docstrings (`tire_agent.py:1023`, `_add_prev_cols`), B1's
+Vegas dataset-card note. None of these moves a prediction today; they are correctness debt.
+
+---
+
+## The regeneration runbook (Part 2 §§1-6 of the mandate)
+
+### §1 What exactly to run — and what NOT
+
+**Do NOT run the notebooks.** Three reasons, each measured: today's N04 Step 9 regresses
+featured_2025 on 3 columns / 6,892 Cluster cells (A2); a full N04 run ends with the combined
+artefact clobbered to 2025-only (A3); a fresh N03 run would refit K-Means on THREE seasons
+(its loader globs every year dir) and drop the grafted `'Miami Gardens'` row the current k4
+files carry (A4). `notebooks/**` is read-only per CLAUDE.md §7 anyway.
+
+**Instead: a rebuild script** (proposed `scripts/rebuild_featured_laps.py`), function bodies
+lifted from `.nb_py/N04_feature_engineering.py` exactly as `weather_restore.py` lifted Step 5
+(the E1 harness `g801_repro25.py` is 90% of it). Behaviour:
+
+1. Build 2023+2024 via Steps 1-8 logic — loader restricted to those two year dirs, k4
+   cluster sources, `fix_spain_cluster_artefact` applied (or Spain dropped, §5) → writes
+   `laps_featured_2023.parquet`, `laps_featured_2024.parquet`.
+2. Build 2025 via Step 9 logic — Miami alias applied, **`circuit_clusters_k4_2025.parquet` +
+   `circuit_features_with_clusters_k4_2025.parquet` as sources** (the pre-`11a7ffa` wiring
+   E1 proved reproduces the shipped file) → writes `laps_featured_2025.parquet`.
+3. `laps_featured.parquet` = `pd.concat` of the three per-year frames (2025 keeps the
+   aliased `'Miami'` name — the combined stops disagreeing with its own splits by
+   construction).
+
+**Network:** none. N04 imports pandas/numpy/matplotlib/seaborn/scipy only; every input is a
+local parquet. (`fastf1`/`get_session`/`requests` appear nowhere in it — verified.)
+
+**Inputs read (must not be touched):** `data/raw/<year>/<gp>/{laps,weather}.parquet` (71
+dirs), `data/processed/circuit_clustering/*.parquet` (all four files, INCLUDING the grafted
+k4 rows — do not "clean" them, A4).
+
+**Outputs / overwrites — back up (checksum) BEFORE the run, all four:**
+`data/processed/laps_featured.parquet`, `laps_featured_2023.parquet`,
+`laps_featured_2024.parquet`, `laps_featured_2025.parquet`. Nothing else: N04 exports no
+model, no manifest (verified — unlike N16, its only writes are the three `to_parquet`s).
+Backup: `Copy-Item data/processed/laps_featured*.parquet <backup_dir>/` + record
+`Get-FileHash` of each; the acceptance diff below runs against these copies.
+
+### §2 Is running the producer even sufficient? NO — the defects are IN the producer
+
+#801 says "the fix is a regeneration rather than code". **Refuted.** Four of the defects live
+in N04/N03's own logic and survive any rerun; two get WORSE:
+
+| Defect | Producer line | Rerun outcome without the code fix |
+|---|---|---|
+| 2025 cluster/msp regression | `N04:1041,1072-1076` (post-`11a7ffa`) | featured_2025 loses its season-true values (A2) |
+| Combined clobber | `N04:973-974` via `N04:1089` | combined ends 2025-only (A3) |
+| Season-broadcast msp in combined | `N04:752-757` (merge on GP_Name, no Year) | reproduced identically — broadcast is BY CONSTRUCTION |
+| Spain duplicate | `N04:792-826` patches, never drops | reproduced identically |
+| Miami dual-name in combined | alias only in `_load_raw_2025` (`N04:1028`) | reproduced identically |
+| Vegas msp hole | raw SpeedI2 100% missing (B1) | reproduced identically — unfixable by rerun |
+
+The rebuild script IS the code fix for the first, second and fifth; the third dissolves under
+combined-as-concat; the fourth is §5's decision; the sixth is documentation.
+
+### §3 Acceptance gates — executable, with expected values
+
+Run in this order; any failure stops the line:
+
+1. **Column-set + value diff vs the backups** (the anti-"silently worse" gate; script =
+   `g801_repro25.py`'s diff block pointed at backup vs new):
+   - featured_2025: identical column VALUES on all 48 backed-up columns (0 differing cells,
+     `atol=1e-6`), 22,760 rows, + exactly 4 new columns {AirTemp, TrackTemp, Humidity,
+     Rainfall}. Las Vegas `mean_sector_speed` still 100% NaN (760 rows) — a regeneration
+     that "fixes" it has changed the rule, reject.
+   - featured_2023/2024: identical on all 48 (minus Spain rows iff §5 approved), + the 4.
+   - combined: == concat of the three per-year files, byte-for-byte per year-slice.
+2. **Weather values == the committed restore** (the alignment gate): for each year,
+   `augment_featured_laps(backup_per_year, year)` vs the new file's weather columns →
+   0 mismatches / 22,760 (2025) and 0 on 2023/2024. (E1 already measured 0/22,760 for 2025.)
+3. `uv run pytest tests/agents/test_weather_restore.py` → **8 passed** (today: 1 failed —
+   the KeyError test goes green). CAVEAT: `test_a_partial_weather_set_is_declined...`
+   (`test_weather_restore.py:168-185`) constructs its "partial" frame by ASSIGNING AirTemp to
+   the artefact — once the artefact natively carries all four, the frame is no longer
+   partial and `assert "TrackTemp" not in result.columns` fails. Update it to DROP three of
+   the four instead (`partial = full.drop(columns=["TrackTemp","Humidity","Rainfall"])`).
+   This is a test written against the artefact era, not a regression.
+4. `uv run pytest tests/agents/test_pace_circuit_speed.py` → all pass unchanged (values
+   identical ⇒ the (year,GP)→msp map identical; Silverstone 2023 249.71 ≠ 2025 231.36,
+   Vegas 2025 NaN, Vegas 2023 ≈228.96 all still hold).
+5. `uv run pytest tests/eval/test_ml_recompute_golden.py` → pace holdout reproduces
+   **0.4104 ± 0.01** (gate 2 guarantees it: same features, same weather values).
+6. `uv run pytest tests/mc/test_position_projection.py` → ≥0.80 within-one over ≥1500 stops
+   (unaffected by regeneration; moves only under §5, within margin).
+
+### §4 Hugging Face: upload and allow-patterns
+
+- **Upload (overwrite in place)**: `data/processed/laps_featured.parquet`,
+  `laps_featured_2023.parquet`, `laps_featured_2024.parquet`, `laps_featured_2025.parquet`
+  to `VforVitorio/f1-strategy-dataset`. These are the ONLY artefacts the run changes.
+- **Do NOT upload**: anything under `data/raw/` (unchanged), `laps_tiredeg.parquet`
+  (unchanged — its C2 duplicate is a separate, retrain-gated decision), the
+  `circuit_clustering/` files (unchanged inputs), any backup copies.
+- **If §5 approved**: additionally DELETE `data/raw/2023/Spain/**` from the HF dataset (and
+  locally) — otherwise the next `snapshot_download`/full pull resurrects the duplicate.
+- **`_build_allow_patterns` / `_DEFAULT_MODEL_PATTERNS`** (`src/f1_strat_manager/data_cache.py:109`):
+  add the three missing featured files next to the existing `laps_featured_2025.parquet`
+  line — `"data/processed/laps_featured.parquet"`, `"...laps_featured_2023.parquet"`,
+  `"...laps_featured_2024.parquet"` — closing D2 (clean installs currently lose #797's
+  2023/2024 resolution silently). Ship this edit in the same PR as the upload.
+
+### §5 Ordering constraints — so nothing is regenerated twice
+
+1. **Producer-fix code review BEFORE any regeneration run** (§2). The rebuild script PR and
+   the artefact swap can be one PR, but the script must be reviewed against E1's evidence
+   first.
+2. **The Spain decision (fix 8) BEFORE the regeneration run.** Dropping Spain changes
+   featured_2023 (22,106 → 20,908 rows) and the combined; deciding it after means running and
+   uploading twice. It needs explicit sign-off because it is one-way and touches published
+   numbers: raw dir deletion (local + HF), projection sample 1,810 → ~1,768 / races 71 → 70
+   (threshold test survives, C3-b), pit-holdout train pool loses the doubled stops, the
+   parametrised `("Spain", 2023)` case in `tests/agents/test_pace_circuit_speed.py:180` must
+   be repointed/removed (with featured Spain rows gone, `_resolve_mean_sector_speed("Spain",
+   2023)` returns NaN — gp_slugs has no 'Spain' alias), and every doc quoting "71 races"
+   needs the footnote. If sign-off is not available, regenerate WITH Spain (keeping
+   `fix_spain_cluster_artefact`) and accept a second run later — state the cost, don't stall
+   the weather fix on it.
+3. **GATE_DATA_WIRING's code fixes (1-6 above) are INDEPENDENT of the regeneration** — no
+   artefact they read changes value (E1). Land them in any order relative to G-REGEN. The one
+   coupling: W-F9 must be fixed in the AGENT (families stay as trained) — do not let the
+   regeneration PR "helpfully" unify `lap_time_vs_cluster_mean` across families; that would
+   convert W-F9's 0.208s defect into a new 5.75s-scale one on whichever model loses.
+4. **`laps_tiredeg` is NOT regenerated** until a TCN retrain is on the table (C2's corrupted
+   Barcelona sequences are baked into the shipped model; regenerating the artefact without
+   retraining only widens train/artefact drift). Document, defer, track.
+5. After upload: re-run gates §3.3-3.6 once more against the HF-downloaded copies (fresh
+   `snapshot_download` into a temp dir) — the published-vs-local mismatch is exactly how D1
+   happened.
+
+### §6 What could go wrong, and how it presents
+
+| Failure | How it presents | What it means |
+|---|---|---|
+| pandas/numpy version drift changes float bits | §3.1 diff shows scattered ≤1e-9 diffs in polyfit-derived cols (`DegradationRate`, `DegAcceleration`) | Harmless if within atol; if larger, pin the env (uv.lock) and re-run — do NOT widen the tolerance |
+| Rebuild uses today's Step 9 sources by mistake | §3.1: exactly 3 columns differ on 2025 (`Cluster` 6,892 cells, msp, ltvcm) — the A2 signature | Wrong cluster sources; fix the script, re-run |
+| Step-8-style clobber sneaks in | combined has 22,760 rows / one year | A3 reproduced; the concat step didn't run |
+| Vegas msp suddenly has a value | §3.1 flags 760 changed cells | The rule changed (I1/FL-only mean?) — reject, that silently shifts the N06 test distribution |
+| Miami rows crash `astype(int)` | `IntCastingNaNError` in the 23-24 build | The k4 graft (A4) was "cleaned" or the alias landed in the 23-24 loader — restore the grafted files from backup |
+| Weather all-NaN for a race | gate §3.2 mismatch counts explode for one GP | That race's `weather.parquet` missing/empty — stop; all 71 have one today (GATE_DATA_WIRING verified) |
+| test_pace_circuit_speed fails on ("Spain", 2023) | after a Spain-dropping run | Expected under §5.2 — the test update is part of that PR, not a regression |
+| Holdout MAE moves >0.01 | gate §3.5 red | The regenerated features are NOT value-identical — §3.1 was skipped or its tolerance widened; restore backups, diff, find the changed column |
+| A second session re-downloads from HF mid-work | mtimes under `data/processed/` jump, weather columns vanish again | The D1 mechanism repeating — re-run §3.1 against backups before trusting anything |
+
+---
+
+## Suggested PR grouping and order
+
+| # | PR | Contents | Why this order |
+|---|---|---|---|
+| 1 | `fix(simulation): weather join on the replay path` | Fix 1 (W-F7) | Largest measured mover; single file; independent of everything |
+| 2 | `fix(agents): tire serving frame matches the trained artefact` | Fix 2 (W-F8/F9/F10/F11 + docstrings) | Second-largest block; one file; contains W-F9's family rule so the regen PR can't get it wrong |
+| 3 | `fix(agents): gp_name keyspace normalisation` | Fix 3 (W-F14/F6) + enumeration test | Unbreaks a whole race's tire routing; touches tire_agent → after PR 2 to avoid conflicts |
+| 4 | `fix(agents): pace model inputs (CompoundID, Prev_SpeedST)` | Fixes 4-5 (W-F4, W-F1 + manifest) | Same file pair, both "serve the trained quantity" |
+| 5 | `fix(agents): overtake domain gate` | Fix 6 (W-F13) | Independent |
+| 6 | `fix(data): regenerate featured artefacts (weather + 2025 conventions + combined=concat)` | Fix 7: rebuild script + §3 gates + `data_cache` patterns + `test_weather_restore` partial-test update + HF upload | After the §5.2 Spain decision; the only PR that touches artefacts |
+| 7 | `fix(data)!: de-duplicate the 2023 Spanish GP` | Fix 8: raw dir removal (local+HF) + test/doc/number updates | Ideally folded into PR 6's single regeneration run with sign-off; standalone otherwise |
+| 8 | `chore(agents): input-wiring hygiene` | Fix 9 bundle | Zero measured impact; last |
+
+PRs 1-5 are pure code and can land in parallel branches (2→3 sequenced on the shared file).
+PR 6 is the only artefact writer; it runs the regeneration exactly once.
+
+---
+
+## Appendix — the acceptance-diff snippet (gate §3.1/§3.2), self-contained
+
+```python
+"""Diff a regenerated featured parquet against its backed-up predecessor.
+Usage: python check_regen.py <backup.parquet> <new.parquet> <year>"""
+import sys
+import numpy as np
+import pandas as pd
+
+backup, new, year = pd.read_parquet(sys.argv[1]), pd.read_parquet(sys.argv[2]), int(sys.argv[3])
+WEATHER = ["AirTemp", "TrackTemp", "Humidity", "Rainfall"]
+KEYS = ["GP_Name", "Driver", "LapNumber"]
+
+# 1. Column contract: nothing lost, exactly the four gained
+lost = set(backup.columns) - set(new.columns)
+gained = set(new.columns) - set(backup.columns)
+assert not lost, f"columns LOST: {lost}"
+assert gained == set(WEATHER), f"unexpected column change: {gained}"
+
+# 2. Row contract (adjust 2023 expectation to 20,908 iff the Spain drop is approved)
+assert len(new) == len(backup), f"rows {len(backup)} -> {len(new)}"
+
+# 3. Every backed-up cell survives (atol absorbs BLAS-level polyfit jitter only)
+j = backup.merge(new, on=KEYS, suffixes=("_old", "_new"), how="outer", indicator=True)
+assert (j["_merge"] == "both").all(), "row set changed"
+for c in backup.columns:
+    if c in KEYS:
+        continue
+    a, b = j[f"{c}_old"], j[f"{c}_new"]
+    if a.dtype.kind in "ifb" and b.dtype.kind in "ifb":
+        bad = ~((a.isna() & b.isna()) | np.isclose(a.astype(float), b.astype(float),
+                                                   rtol=0, atol=1e-6, equal_nan=False))
+    else:
+        bad = (a.astype(str) != b.astype(str)) & ~(a.isna() & b.isna())
+    assert not bad.any(), f"{c}: {int(bad.sum())} cells changed"
+
+# 4. The added weather equals the committed restore (the alignment gate)
+from src.f1_strat_manager.laps_augment import augment_featured_laps
+restored = augment_featured_laps(backup, year)
+jr = restored.merge(new[[*KEYS, *WEATHER]], on=KEYS, suffixes=("_restore", "_new"))
+for c in WEATHER:
+    a, b = jr[f"{c}_restore"], jr[f"{c}_new"]
+    bad = ~((a.isna() & b.isna()) | np.isclose(a.astype(float), b.astype(float),
+                                               rtol=0, atol=1e-9, equal_nan=False))
+    assert not bad.any(), f"weather {c}: {int(bad.sum())} mismatches vs restore"
+
+# 5. The Vegas hole is preserved (a regeneration that 'fixed' it changed the rule)
+if year == 2025:
+    lv = new[new["GP_Name"] == "Las Vegas"]
+    assert lv["mean_sector_speed"].isna().all() and len(lv) == 760
+
+print("OK: regeneration is value-identical + weather matches the restore")
+```
+
+

--- a/documents/audits/GATE_DATA_WIRING.md
+++ b/documents/audits/GATE_DATA_WIRING.md
@@ -1,0 +1,397 @@
+# GATE — Data wiring: training-time producers vs inference-time construction
+
+**Date:** 2026-08-04 · **Ref:** `main`/`dev` @ `73788e0b` · **Gate role:** adversarial, read-only (this file is the only write).
+
+**Question:** feature by feature, for every model the system runs on a 2025 race
+(`RaceReplayEngine.replay()` → `RaceStateManager.get_lap_state()` → `run_from_state()`),
+is the value inference constructs the SAME QUANTITY the producer notebook computed at
+training time? Same quantity, same units, same rule — not "plausible", not "metric reproduces".
+
+**Producers read:** `.nb_py/N01, N04, N06, N09/N10, N12, N14, N15, N16` (plain-`.py` notebook exports).
+**Consumers read:** `src/agents/pace_agent.py`, `tire_agent.py`, `race_situation_agent.py`,
+`pit_strategy_agent.py`, `race_state_builder.py`, `src/simulation/race_state_manager.py`.
+
+Known-fixed priors (NOT re-reported unless the fix itself broke something):
+`mean_sector_speed` speed-trap swap (#797), `LapsSincePitStop`←TyreLife (#800),
+weather columns absent from published artefact (#782), season-broadcast `mean_sector_speed` (#784 era).
+
+Findings are appended AS CONFIRMED, each with producer `file:line`, inference `file:line`,
+and a divergence measured on real 2025 laps.
+
+---
+
+## Audit checklist (updated as worked)
+
+- [x] N06 lap time — 25 features (`pace_agent.py`) — F1-F7, verified list §"could NOT"
+- [x] N26 tire degradation TCN (`tire_agent.py`) — F8-F12, 42 columns diffed vs artefact
+- [x] N27 overtake + SC (`race_situation_agent.py`) — F13 + notes (SC feature internals vs
+      N13/N14 producers only spot-checked: weather sourcing, cluster default, thresholds
+      already covered by the #450 audit — residual risk noted, not exhausted)
+- [x] N28 pit: N15 duration + N16 undercut (`pit_strategy_agent.py`) — F14 + verified notes
+- [x] Cross-cutting: keyspace family (F6/F14), manifest-vs-training (F1/F8), artefact
+      disagreements (F9, undercut_clean dual key), weather join (F7)
+
+---
+
+## Findings
+
+### F1 — N06 `CompoundID`: trained on N01's 1-based codes, served the manifest's 0-based codes — off by one on EVERY lap [code-level CONFIRMED; impact measured below]
+
+- **Producer:** the served delta model trains on `df23_d[FEATURES_DELTA]` (`.nb_py/N06_laptime_model.py:1380`), and `FEATURES_DELTA` contains `CompoundID` inherited from `FEATURES_PROD` (`N06:1245-1259`). `CompoundID` in the featured parquet is N01's mapping — `.nb_py/N01_data_download.py:232` ("1=Soft, 2=Medium, 3=Hard, 4=Inter, 5=Wet"), applied at `N01:247`. **Measured in the artefact** (`laps_featured_2025.parquet`): SOFT→1, MEDIUM→2, HARD→3, INTERMEDIATE→4.
+- **The false headline:** N06's `encode_features` (`N06:128-133`) maps the `Compound` STRING column through the manifest's 0-based map (SOFT:0…WET:4) — but writes it into a column named `Compound`, which is **not in `features_in`**. The re-encoding is orphaned; the model consumed the untouched 1-based `CompoundID` column. The manifest's `categorical_encoding.Compound` block (`data/processed/feature_manifest_laptime.json:66-73`) is true about what `encode_features` did and false about what the model ate.
+- **Inference:** `pace_agent.py:318-319` loads `manifest["categorical_encoding"]["Compound"]` (0-based) as `self.compound_id`; `_encode_categorical` (`pace_agent.py:459`) feeds `self.compound_id.get(compound, 1)`. So a MEDIUM lap is served CompoundID=1 — which the trained model learned as SOFT. Every compound is shifted one class down, on 100% of laps, on every path (replay, CLI, backend — they all go through `_build_feature_row`).
+- **Failing scenario:** any 2025 lap on HARDs: training saw 3, inference feeds 2 (=trained MEDIUM). The model's compound-dependent degradation signal is systematically read one compound softer.
+
+### F2 — N06 `DriverNumber`: lap_state has no such key, so inference feeds the constant 0 where training saw car numbers 1–81 [code-level CONFIRMED; impact measured below]
+
+- **Producer:** `DriverNumber` is a real trained feature (`xgb_laptime_delta_feature_names.json:2`), int car numbers (featured 2025: 1, 4, 5, 6, 7, 10, 12, 14, …; 0 never occurs).
+- **Inference:** `RaceStateManager.get_driver_state` (`race_state_manager.py:354-417`) emits NO `driver_number` key — the dict has `driver` (the three-letter code) but no number. `pace_agent.run_from_state` (`pace_agent.py:909`) does `d.get("driver_number") or 0` → **0 on every replay lap**, a constant outside the trained vocabulary. Bug class: "feature hardcoded to a constant where training saw a distribution" + "sentinel that is a findable value" (0 sorts below every real car number, so every DriverNumber split sends the row down its left branch).
+- **Failing scenario:** every lap of every replay. The envelope cannot catch it — identifiers were deliberately excluded from bounds (`pace_agent.py:117-119`).
+
+### F3 — N06 `FreshTyre`: trained = FastF1's set-was-new flag (constant across the whole stint); inference = outlap flag `int(tyre_life <= 1)` [code-level CONFIRMED; share + impact measured below]
+
+- **Producer:** N06 consumes the parquet's `FreshTyre` cast to int (`N06:132`); that column is FastF1's flag for "the fitted set was NEW", which stays True for **every lap of a fresh-set stint**.
+- **Inference:** `_compute_derived` (`pace_agent.py:526`) builds `FreshTyre = int(tyre_life <= 1)` — a first-lap-of-stint flag. The docstring (`pace_agent.py:476-477`, "binary flag for the first lap on a new tyre set — captures the outlap pace loss") names the wrong mechanism: that is not what the trained column measures. The RSM even emits the real thing (`fresh_tyre`, `race_state_manager.py:405`) and `run_from_state` ignores it — dropped input.
+- **Divergence shape:** agree on outlaps and on all laps of used-set stints; disagree on every lap ≥ 2 of a fresh-set stint (training 1, inference 0) — the majority of racing laps.
+
+### F4 — N06 `Prev_SpeedST`: trained = PREVIOUS lap's speed trap (stint-grouped shift); inference = THIS lap's trap [code-level CONFIRMED; magnitude + impact measured below]
+
+- **Producer:** `N04_feature_engineering.py:384-392` — `Prev_SpeedST = grp['SpeedST'].shift(1)` grouped by `['Year','GP_Name','DriverNumber','Stint']`.
+- **Inference:** `run_from_state` (`pace_agent.py:902,956`) feeds `d.get("speed_st")` — and `get_driver_state` emits `speed_st` from **the current lap's row** (`race_state_manager.py:410`). This is the #435 `prev_lap_time` bug's un-fixed twin: `prev_lap_time` was rewired to the real previous lap (parquet `Prev_LapTime` / reconstruction), but `prev_speed_st` still receives the current lap's reading on every call. The featured parquet even carries `Prev_SpeedST`; the raw replay parquet carries `SpeedST` per lap from which the true rule is computable — neither is used.
+- Fallback `or 300.0` is additionally a findable real value (trained range 156–362 km/h), masking missing-trap laps as plausible readings.
+
+### F5 — N06 `Prev_TyreLife`: trained = stint-shift over SURVIVING laps (NaN on stint openers); inference = `max(0, tyre_life - 1)` always [code-level CONFIRMED; share measured below]
+
+- **Producer:** `N04:390` `Prev_TyreLife = grp['TyreLife'].shift(1)` — stint-grouped, over the featured frame that `filter_baseline_laps` has already thinned, so the "previous" lap can be ≥2 laps back; stint openers are NaN (and the delta model drops them only via `LapTime_Delta` NaN, `N06:1377-1378`).
+- **Inference:** `pace_agent.py:955` `prev_tyre_life=max(0, (d.get("tyre_life") or 1) - 1)` — always exactly current−1, and **0 on outlaps** where training had NaN (0 is below the trained min 2.0; the envelope will warn, but the model still reads 0 as a value, not as missing).
+
+### F6 — `Cluster` + `delta_vs_median`: the gp_name keyspace fix (#797) was applied to `_resolve_mean_sector_speed` only — its twins `_encode_categorical` and `_session_median` still take the raw metadata name [MEASURED: 2025 Miami misses]
+
+- **Producer:** `Cluster` comes from `circuit_clusters_k4_2025.parquet` keyed by parquet slug (`'Miami'`, `'Las Vegas'`, …).
+- **Inference:** `_encode_categorical` (`pace_agent.py:461`) does `self.circuit_cluster.get(gp_name, 1)` with `gp_name` straight from `metadata.json` via `session_meta` — no `_normalise_gp_key`. **Measured over all 24 races of `data/raw/2025/`:** every metadata `gp_name` resolves except **`'Miami Gardens'`**, which is `'Miami'` in both the cluster parquet and `laps_featured_2025`. Every lap of the 2025 Miami replay is served the DEFAULT cluster 1 instead of Miami's real cluster, and `_session_median` (`pace_agent.py:734-738`) finds no rows → `delta_vs_median=NaN` for the whole race.
+- Same bug class as the lesson of 2026-07-16 (one copy fixed, its twin not): `_resolve_mean_sector_speed` got the four-keyspace chain and a test; the two other consumers of `gp_name` in the same class did not.
+
+---
+
+## Measured impact on the served N06 delta model (real 2025 laps)
+
+Harness: `laps_featured_2025.parquet`, 21,247 anchored laps (`Prev_LapTime` known — the laps
+where the model has a real anchor; the other 1,513 are dominated by the documented 90.0
+placeholder). Base = trained-truth values from the artefact; variant = the value inference
+constructs from the same row; weather held constant across base/variant except in F7.
+Model: `xgb_laptime_delta_final.json`. Deltas are on the model's output (s), which moves the
+absolute prediction 1:1 (`pred = prev + delta`).
+
+Served-model feature importances (gain): TrackTemp 20.9%, LapsSincePitStop 16.2%, AirTemp
+12.5%, Prev_LapTime 11.9%, Prev_DegradationRate 7.5% … Prev_SpeedST 2.9% … CompoundID 0.55%,
+DriverNumber 0.03%, **FreshTyre 0.00%**.
+
+| Finding | value differs on | preds moved >1ms | mean\|Δ\| | p95\|Δ\| | max\|Δ\| |
+|---|---|---|---|---|---|
+| F1 CompoundID (manifest 0-based) | 100.0% | 3.7% | 0.0055s | ~0 | 0.221s |
+| F2 DriverNumber=0 | 100% | **0.0%** | 0.0000s | 0 | 0.000s |
+| F3 FreshTyre outlap-flag | 79.7% | **0.0%** | 0.0000s | 0 | 0.000s |
+| F4 Prev_SpeedST=current trap | 88% (mean 4.6 km/h, p95 19.0) | 8.2% | 0.0083s | 0.0125s | 2.438s |
+| F5 Prev_TyreLife=TL−1 | 1.8% of known rows (+66 NaN→0) | 0.2% | 0.0003s | 0 | 0.262s |
+| F6 Cluster Miami→default 1 | 0% — **Miami's real cluster IS 1** | 0.0% | 0 | 0 | 0 |
+| F1–F5 combined | — | 11.4% | 0.0136s | 0.0719s | 2.567s |
+
+Honest downgrades from the code-level read: **F2 and F3 move nothing** — the served delta
+model has 0.03% / 0.00% importance on DriverNumber / FreshTyre, so the wrong quantity is fed
+but never read. F6's cluster default coincides with Miami's real cluster (1), so only
+`delta_vs_median` (NaN all race) actually degrades today; the Cluster defect is latent — it
+bites the day any keyspace-missing race has cluster ≠ 1. **F4 is the largest single-feature
+mover** and F1 is systematic but small. Severity ranks by these numbers, not by how wrong
+the wiring looks.
+
+### F7 — HIGH. The weather block: training = N04's `merge_asof(nearest)` on session `Time`; serving replay = proportional row-index lookup. Largest measured mover in N06.
+
+- **Producer:** N04 Step 5, reproduced verbatim by `src/f1_strat_manager/weather_restore.py:57-94`
+  (`merge_asof(direction="nearest")` joining each driver-lap's session `Time` to the nearest
+  weather sample; docstring records the committed 22,760/22,760 reproduction against N04's own
+  combined-parquet output).
+- **Inference (replay path):** `RaceStateManager.get_weather_state`
+  (`race_state_manager.py:515-518`): `idx = int((lap-1)/(total-1) * (len(weather_df)-1))` —
+  a lap-number-proportional index into the weather frame, ignoring session time entirely.
+  Every weather consumer on the replay path eats this: N06 (AirTemp/TrackTemp/Humidity/
+  Rainfall = 39.7% of the served model's gain), N14's SC features, N26, N28.
+- **Measured on all 24 races of 2025, 26,692 driver-laps:**
+  - TrackTemp differs (>0.05°C) on **92.6%** of laps — mean |Δ| 1.11°C, p95 3.40, max 11.80°C.
+  - AirTemp differs on 84.5% (mean 0.38°C), Humidity on 76.2% (mean 2.27%, max 17).
+  - **Rainfall flag flips on 4.79% of laps (1,279 laps)** — a dry lap served as wet or wet as dry.
+  - Worst races (mean |TrackTemp Δ|): Shanghai 2.38°C, Las Vegas 2.20, Spa 2.15, Miami 2.07.
+- **Prediction impact (weather block swap, same 21,247-lap frame): 26.8% of laps move >1ms,
+  mean |Δ| 0.0367s, p95 0.1189s, max 8.280s** — roughly 3× the combined effect of F1–F5.
+- **Failing scenario:** any race where track temperature drifts monotonically (evening races:
+  Las Vegas, Lusail) — the proportional index reads the session's time axis as if laps were
+  uniform, so every SC-lengthened lap shifts every later lap's weather sample; the 8.28s tail
+  laps are rain-flag flips.
+- **Blast-radius caveat, measured:** on the CLI PMV path the TIRE model does NOT eat this —
+  its laps_df is the augmented featured frame, whose per-lap weather is restored by the
+  N04-faithful `weather_restore.weather_for_race`. F7 hits the consumers that read
+  `lap_state["weather"]`: N06 pace, N27's SC/overtake features, and any weather default path.
+
+---
+
+## N26 — tire degradation TCN (`src/agents/tire_agent.py`)
+
+Harness: for **335 real 2025 stints across 8 races** (Melbourne, Shanghai, Barcelona,
+Silverstone, Monza, Lusail, Austin, Sakhir), build the agent's own 42-feature frame via
+`TireAgent._build_stint_features` on the exact serving path (race-scoped augmented featured
+frame, session_meta as `run_from_state` builds it), and diff EVERY column against
+`laps_tiredeg.parquet` — the artefact N09/N10 actually trained on (N10 `.nb_py:63`) — for the
+same `(GP, Driver, Stint, LapNumber)` rows. Then run each compound's TCN bundle on both frames.
+
+**Aggregate divergence of the agent's frame vs the trained truth, TCN output (cumulative
+fuel-adjusted degradation, the quantity the ~2s cliff thresholds are compared against):
+mean |Δ| = 0.424s, p50 = 0.302s, p95 = 1.226s, max = 4.99s.** Attribution by single-group
+swap (base = trained-truth frame):
+
+| cause | TCN mean\|Δ\| | p95 | max |
+|---|---|---|---|
+| F8 deg pair shift bug | 0.185s | 0.510s | 4.609s |
+| F9 lap_time_vs_cluster_mean artefact split | 0.208s | 0.811s | 2.709s |
+| F10 Prev_*/delta fillna block | 0.198s | 0.546s | 1.934s |
+| F12 mean_sector_speed convention | 0.021s | 0.079s | 0.267s |
+| F11 LapsSincePitStop=TyreLife | 0.005s | 0.032s | 0.174s |
+| ALL combined | 0.424s | 1.226s | 4.989s |
+
+### F8 — HIGH. `DegradationRate`/`DegAcceleration`: the agent lags them by one lap; training never did. The "leakage fix matching N10 training" comment matches nothing.
+
+- **Producer:** N04 `add_degradation_rate_features` (`.nb_py/N04_feature_engineering.py:481-504`):
+  `DegradationRate[i]` = polyfit slope over laps `[i-2..i]` — **includes lap i, no shift**;
+  `DegAcceleration[i] = deg[i] - deg[i-1]`, also unshifted. N09 consumed the stored columns
+  as-is: `PRODUCTION_FEATURES = BASE_FEATURES` (`.nb_py/N09_tiredeg_tcn.py:219-220`) — the
+  `LAPTIME_SHORTCUTS` set only defines the (unused-in-production) PURE variant. No `shift`
+  exists anywhere in N09/N10's feature construction. The manifest's "use their lagged values"
+  note (`tiredeg_feature_manifest.json:66-67`) was ADVICE the notebooks never took.
+- **Inference:** `tire_agent.py:663-664` — `.shift(1).fillna(0)` on both, with a comment
+  ("Both are shifted by 1 lap (leakage fix matching N10 training)") that names a mechanism
+  absent from training. The agent follows the manifest's advice instead of the model's
+  actual diet: every window position reads the slope of `[i-3..i-1]` where training saw
+  `[i-2..i]` — a one-lap-stale degradation signal at every timestep.
+- **Measured:** value-level mean |Δ| 0.28 s/lap (DegradationRate) / 0.40 (DegAcceleration)
+  vs the artefact; TCN impact above. Failing scenario: the cliff onset lap — exactly when
+  the slope spikes — is seen one lap late, on a model whose whole job is cliff timing.
+
+### F9 — HIGH. `lap_time_vs_cluster_mean`: two artefacts of the same thing disagree (mean 5.75s), and serving feeds the one the model was NOT trained on.
+
+- **Measured artefact-vs-artefact** (22,760 joined 2025 rows): `laps_featured_2025.parquet`
+  vs `laps_tiredeg.parquet` differ on **100% of rows, mean |Δ| 5.75s, p95 11.78s** for
+  `lap_time_vs_cluster_mean`, and on **30.3% of rows for `Cluster` itself** — the two
+  artefact families used different clusterings (`circuit_clusters_k4` vs `k4_2025`), so
+  N07 recomputed the cluster-mean delta against different cluster assignments.
+- **Inference:** the TCN trained on the tiredeg version. `_add_session_cols`
+  (`tire_agent.py:768`) keeps the FEATURED column when present — the serving frame always
+  carries it — so 100% of serving rows get the other family's quantity. Meanwhile
+  `_build_stint_features` (`tire_agent.py:954`) stomps `Cluster` from the k4 map, which
+  MATCHES tiredeg — so the served frame mixes families: tiredeg's Cluster with featured's
+  cluster-mean delta. TCN impact: mean 0.208s, p95 0.811s.
+
+### F10 — MEDIUM. `_add_prev_cols` fills EVERY missing predecessor with the CURRENT lap's value; training's "no reading" was a scaled zero. The docstring says "first lap of a stint" — wrong mechanism.
+
+- **Producer:** N04's `Prev_*` are stint-grouped shifts, NaN where no predecessor survives
+  (`N04:384-392`); N09/N10 scale with `fillna(0)` (`N10:176,181`), so the trained "missing"
+  signal is a raw zero.
+- **Inference:** `tire_agent.py:619` — `df[src_col].shift(1).fillna(df[src_col])` fills EVERY
+  NaN in the shifted series (stint openers AND every lap whose predecessor reading is NaN)
+  with the current lap's value. Measured NaN-pattern divergence per column: Prev_SpeedI1 22.0%,
+  Prev_SpeedST 16.7%, LapTime_Trend 13.1%, Prev_LapTime/Prev_TyreLife/deltas 6.1% of rows.
+  Where both sides have values they agree exactly (mean |Δ| = 0) — the defect is purely the
+  missing-value convention. TCN impact: mean 0.198s, p95 0.546s.
+
+### F11 — LOW (measured), one-line fix. `LapsSincePitStop = TyreLife` — the #800 bug's un-fixed twin, stomping a trained column the frame already carries.
+
+- **Producer:** N01's pit counter (`N01:262-282`), present in both featured and tiredeg
+  artefacts (they agree 100%).
+- **Inference:** `tire_agent.py:593` overwrites it unconditionally with `TyreLife`, even
+  though the serving frame carries the real column two keys away. Measured on the 335-stint
+  frame: 15.8% of rows differ, mean 2.48 laps (used-set stints, where the tyre's age ≠ laps
+  since the stop). The pace agent got the RSM `laps_since_pit` fix (#800); this alias
+  survived. TCN impact is small (0.005s mean) because the TCN barely reads it — but the fix
+  is deleting one line, since the guarded pattern used for FuelLoad already covers it.
+
+### F12 — LOW. `mean_sector_speed`: the tiredeg artefact broadcasts ONE per-GP value across seasons (95.5% of GPs identical 2023 vs 2025); serving feeds the per-year 2025 measurement — season-correct, training-inconsistent.
+
+- The inverse of #797: for N06 the per-year value is right because N06 trained per-year rows
+  from per-year artefacts; the TCN trained on tiredeg's broadcast convention, so the "right"
+  2025 value differs from the trained quantity on 96.1% of rows (mean 4.31 km/h). Impact
+  0.021s mean — record, don't panic.
+
+### N26 notes (no measured impact, keep honest)
+
+- `_build_stint_tensor`'s docstring line (`tire_agent.py:1023-1024`) still says short stints
+  are "left-padded by repeating the first row" — the body zero-pads (correctly, per N09).
+  Wrong-mechanism docstring, one line.
+- N09 trains with input = laps 1..L−1 and target at L (`N09 Step 2`); the agent's window
+  includes the current lap, so its "current degradation" reading is, by the training
+  contract, the model's estimate for the NEXT step. Consistent construction, shifted
+  interpretation — worth one sentence in the tool's docstring, not a code change.
+- Cluster keyspace: the tire agent's k4 map contains BOTH 'Miami' and 'Miami Gardens'
+  (both cluster 1), so the F6 keyspace miss does not reproduce here.
+
+---
+
+## N27 — overtake + SC (`src/agents/race_situation_agent.py`)
+
+### F13 — MEDIUM. No domain gate on the overtake tool: N11 trained ONLY on pairs within 2.5s; 41.9% of real adjacent pairs are farther than that, and the tool scores them anyway.
+
+- **Producer:** N11's pair builder drops every pair with `gap > 2.5` before labeling
+  (`.nb_py/N11_overtake_eda.py:233-235`) — the model has never seen a labeled example
+  beyond 2.5s.
+- **Inference:** `predict_overtake_tool` (`race_situation_agent.py:1140-1204`) has range
+  and roster guards but NO gap guard; `_build_overtake_features` happily builds a 9s-gap
+  row and LightGBM extrapolates.
+- **Measured on all 24 races of 2025 (25,215 position-adjacent pairs, N11's own pairing
+  rule):** 41.9% of pairs have gap > 2.5s (p50 1.98s, p90 9.27s). Four in ten "score my
+  car vs the car ahead" calls on the replay path are answered from outside the trained
+  domain, unlabeled by any envelope (#710 family, N27 edition).
+
+### N27 notes
+
+- `gap_ahead_s`: N11 uses `abs(Time_x − Time_y)` (`N11:233`), inference uses
+  `max(0.0, t_x − t_y)` (`race_situation_agent.py:919-923`). **Measured: 0 of 25,215
+  adjacent pairs invert (t_x < t_y)** — end-of-lap position order guarantees the sign, so
+  the difference is unreachable for adjacent pairs. Only an LLM tool call naming an
+  inverted (non-adjacent) pair would hit it, and it would then read gap=0.0 + DRS open.
+  Cheap hardening, not a live bug.
+- `circuit_cluster` unknown default is 0 (`race_situation_agent.py:1449`), a REAL cluster;
+  N11's unknown was −1 (`N11:212`). Only fires on a keyspace miss — the k4 map carries
+  both Miami spellings, so no 2025 race hits it today. Latent sentinel.
+- `pace_delta_rolling3` (`race_situation_agent.py:957-961`) pairs the two drivers'
+  last-3-lap arrays positionally (`[:n_shared]`), not by LapNumber; N12 rolled over the
+  battle-pair series (`N12:141-146`). Diverges only when one driver misses a lap in the
+  window. Not measured — flagged as a rule difference with a bounded trigger.
+- Weather for the SC features comes from `lap_state["weather"]` → F7's proportional-lookup
+  misalignment applies to `track_temp`/`air_temp`/`humidity` here too (TrackTemp differs on
+  92.6% of laps, mean 1.11°C). `track_temp_start` itself is correctly the session's first
+  sample (`race_state_manager.py:538-542`).
+
+---
+
+## N28 — pit duration (N15) + undercut (N16) (`src/agents/pit_strategy_agent.py`)
+
+### F14 — HIGH (for the 2025 Miami replay), keyspace family. `tire_compounds_by_race.json` is keyed 'Miami'; the replay's gp_name is 'Miami Gardens' — compound resolution falls back TWO steps hard on every lap of that race, and it routes the tire agent's BUNDLE choice.
+
+- **Measured:** `tc['2025']['Miami']` = {SOFT: C5, MEDIUM: C4, HARD: C3}. The fallback used
+  on a keyspace miss is {SOFT: C3, MEDIUM: C2, HARD: C1}
+  (`tire_agent.py:812`, `pit_strategy_agent.py` `_COMPOUND_FALLBACK`).
+- **Consumers hit on a 2025 Miami replay** (`gp_name='Miami Gardens'` from metadata.json):
+  - `tire_agent._compound_name_to_id` (`tire_agent.py:819-821`): SOFT stints route to the
+    **C3 TCN bundle instead of C5** — wrong model, wrong window, wrong scaler — and
+    `AbsoluteCompoundID`/`CompoundHardness` encode 3/4 where training for that stint's
+    physics would say 5/2. The whole race, every stint.
+  - `pit_strategy_agent._compound_to_id` (`pit_strategy_agent.py:425-428`): N16's
+    `compound_x_id`/`compound_y_id` come out 2 low (`compound_delta` survives because both
+    shift equally).
+  - Same family as F6 (pace `_encode_categorical`/`_session_median`). The fix is one
+    normalisation (`_normalise_gp_key`) applied at every gp_name-keyed lookup, plus the
+    enumeration test `test_pace_circuit_speed.py` already models.
+- **Bonus artefact finding:** `undercut_clean.parquet` itself contains BOTH `'Miami'` (12
+  stops) and `'Miami Gardens'` (3 stops) as distinct `circuit_key` values — the dual
+  keyspace leaked into the training artefact, splitting one circuit's statistics.
+
+### N28 notes (verified, mostly clean)
+
+- N15 encoders verified against `.nb_py/N15_pit_duration.py`: compound order {SOFT:0…WET:4}
+  + unknown −1 ✓ (`N15:253,265` vs `pit_strategy_agent.py:133-136`), tyre-life clip at 50 ✓
+  (`N15` "cell 11" vs `_MAX_TRAINED_TYRE_LIFE`), feature list ✓ (`N15:312`).
+- ONE convention drift: training filled missing TyreLife with **0** (`N15` engineer_features:
+  `.clip(upper=50).fillna(0)`); `_tyre_life_in` returns **1** for missing
+  (`pit_strategy_agent.py:853-855`) with a docstring arguing "fresh". Trained missing = 0,
+  served missing = 1. Reachable on 1.98% of 2025 rows (the 451 NaN-TyreLife rows). LOW.
+- N16 `pos_gap` order verified: `pos_X_before − pos_Y_before` (`N16:654`) = the agent's
+  construction (#444 fix holds). `Lap_gap` = canonical 1-lap offset ✓ documented. `pit_delta_X`
+  is a deliberate distribution→constant substitution (`traversal + 4.5`) where training saw
+  per-stop measured values (mean 24.7s, per-circuit std up to 23.6s at Monaco) — documented
+  design (#444), recorded here so nobody rediscovers it as a bug.
+
+---
+
+## Cross-cutting
+
+- **The augment guard's claim is false for the CURRENT local artefacts**
+  (`laps_augment.py:203-205`: "2023 and 2024 take this exit by construction" — measured:
+  `laps_featured_2023/2024.parquet` carry NO weather columns locally, so `wants_weather=True`
+  and the restore path runs for the training seasons too). Because `weather_restore`
+  reproduces N04's join, the VALUES are right; the docstring's mechanism is wrong. This is
+  #801's territory (featured-artefact regeneration) — noted, not re-litigated.
+- **The manifest as a liar's mirror:** `feature_manifest_laptime.json` documents an encoding
+  (0-based Compound) the served model never ate (F1), and `tiredeg_feature_manifest.json`
+  advises a lag the training never applied (F8). Both times the inference code trusted the
+  documentation over the training data. The gate rule this suggests: **wire inference to
+  what the notebook DID, not to what the manifest SAYS, and verify by diffing against the
+  artefact.**
+
+---
+
+## What I tried to break and could NOT
+
+Verified same-quantity, same-rule, with executed evidence — do not re-audit without cause:
+
+1. **`FuelLoad` (N06):** serving `(total−lap)/total` vs N01's `round(1 − lap/max_lap, 4)` —
+   max |Δ| 0.000049 across four 2025 races (rounding only). Same `max_lap` source
+   (raw-frame max = `RaceStateManager.total_laps`, `race_state_manager.py:130`).
+2. **`laps_since_pit` (N06):** RSM rule vs N01's trained column — 0 mismatches on 3,795
+   driver-laps across Melbourne/Lusail/Monza/Silverstone 2025. The #800 fix holds on the
+   pace path (the tire path is F11).
+3. **`FuelEffect` (N06 + N26):** `(TyreLife − stint_baseline) * 0.055` with baseline =
+   stint min ✓ — 0.0% divergence on 5,804 stint-lap rows vs the trained artefact.
+4. **N26 frame vs trained artefact, clean columns:** TyreLife, Position, FuelLoad, LapTime_s,
+   Sector1-3_s, Speed traps, TeamID, CompoundID, AbsoluteCompoundID, CompoundHardness,
+   Cluster (k4-stomp matches tiredeg), AirTemp/TrackTemp/Humidity/Rainfall (augmented
+   featured path), `lap_time_pct_of_race_fastest`, `laps_remaining`, `track_status_clean`,
+   Year — 0.0% divergence over 5,804 rows / 335 stints.
+5. **N26 zero-pad + truncate-from-start + scaler-`fillna(0)`:** verbatim N09
+   (`tire_agent.py:1048-1067` vs `N09 _pad_or_truncate`, `N10:133-140,176-181`).
+6. **Overtake gap sign (N27):** 0 of 25,215 adjacent 2025 pairs invert, so `max(0,·)` ≡
+   `abs(·)` on the replay's pair geometry. `Time` restoration via `_ensure_timedelta_laps`
+   feeds the N11-trained gap rule (#447 fix holds).
+7. **N15 encoders (N28):** compound order, unknown −1, tyre-life clip 50, feature order —
+   all match the notebook.
+8. **GP scoping:** `_scope_laps_to_gp` runs before every agent call on the RSM path
+   (`strategy_orchestrator.py:2471`), so the season-frame leak (#465 family) is closed on
+   the paths audited here.
+9. **Pace `Stint`/`TyreLife`/`Position`/`prev_lap_time` wiring:** parquet-sourced, rule-true
+   (`prev_lap_time` reconstruction reproduces N04's filtered stint-shift; #728 fix holds).
+
+---
+
+## Fix list, ordered by measured impact
+
+1. **F7 — replace `get_weather_state`'s proportional row-index lookup with the N04 rule**
+   (merge_asof nearest on session `Time`, already implemented in
+   `weather_restore.weather_for_race`): removes the largest measured N06 mover (26.8% of
+   laps, mean 0.037s, max 8.28s, 1,279 flipped rain flags) and cleans N27's SC weather
+   features on the same path.
+2. **F8 — delete the `.shift(1)` on `DegradationRate`/`DegAcceleration` in
+   `tire_agent.py:663-664`** (training is unshifted): mean 0.185s / p95 0.51s of TCN output
+   on every stint, concentrated exactly at cliff onset.
+3. **F9 — serve `lap_time_vs_cluster_mean` from the quantity the TCN trained on** (recompute
+   with tiredeg's cluster family, or regenerate the artefacts to agree): mean 0.208s / p95
+   0.81s of TCN output. Requires deciding which artefact family is canonical (#801 adjacent).
+4. **F10 — stop filling missing predecessors with the current lap in `_add_prev_cols`**
+   (`tire_agent.py:619`): let NaN flow to the scaler's `fillna(0)` as trained. Mean 0.198s /
+   p95 0.55s of TCN output. Also fix the "first lap of a stint" docstring (wrong mechanism).
+5. **F14/F6 — one `_normalise_gp_key` at every gp_name-keyed lookup** (pace
+   `_encode_categorical` + `_session_median`, tire `_compound_name_to_id`, pit
+   `_compound_to_id`), with an all-71-races enumeration test like
+   `test_pace_circuit_speed.py`: un-breaks the entire 2025 Miami replay (wrong TCN bundle,
+   compound codes 2 off) and the latent Cluster default.
+6. **F1 — feed N06 the parquet's 1-based CompoundID** (or retrain with the manifest
+   encoding): 100% of laps off by one class; measured 3.7% of predictions move, max 0.221s.
+   Fix the manifest's `categorical_encoding` block in the same change.
+7. **F13 — gate `predict_overtake_tool` at the trained 2.5s domain** (refuse or label as
+   extrapolation): 41.9% of adjacent-pair calls are out-of-domain today.
+8. **F4 — pass the parquet's `Prev_SpeedST` (or the RSM's previous-lap trap) instead of the
+   current lap's `speed_st`** (`pace_agent.py:956`): 8.2% of predictions move, max 2.44s.
+9. **F11 — delete `tire_agent.py:593`** (`LapsSincePitStop = TyreLife`) and guard like
+   FuelLoad: measured impact small (0.005s) but it is a one-line fix for a wrong quantity on
+   15.8% of rows.
+10. **F2/F3/F5/F12 + notes — bundle as a hygiene PR:** emit `driver_number` in
+    `get_driver_state` and stop defaulting to 0; read the RSM's `fresh_tyre` instead of the
+    outlap proxy; stint-opener `Prev_TyreLife` → NaN not 0; document the tiredeg
+    `mean_sector_speed` broadcast convention; fix the two wrong-mechanism docstrings
+    (`tire_agent.py:1023`, `_add_prev_cols`); align `_tyre_life_in` missing→0 with N15.
+    All measured ≤0.021s or zero — correctness debt, not fires.
+

--- a/documents/audits/PR3_GP_KEYSPACE_SWEEP.md
+++ b/documents/audits/PR3_GP_KEYSPACE_SWEEP.md
@@ -1,0 +1,130 @@
+# PR 3 — the gp_name keyspace, swept across every consumer
+
+**Date:** 2026-08-04 · **Extends** `GATE_DATA_WIRING.md` (W-F14, W-F6) and
+`GATE_801_ARTEFACTS.md` §3. Those are dated findings and stay as written; this file records
+what the pre-implementation sweep measured on top of them.
+
+## Why a sweep before the fix
+
+The gate named four gp_name-keyed lookups. This is the fourth time the same defect class has
+surfaced (#448, #450, #797, now this), and every previous fix repaired the site that hurt and
+left the others. So the question asked before writing any code was not "is Miami broken?" but
+**"which races, and which lookups, in total?"**
+
+## Scope, measured
+
+### Races
+
+Every `data/raw/<year>/<race>/metadata.json` gp_name against every gp_name-keyed table:
+
+| table | keys | race dirs that do not resolve |
+|---|---|---|
+| `tire_compounds_by_race.json` (per year) | 22 / 24 / 24 | `2023 Spain`, `2025 Miami Gardens` |
+| `circuit_clusters_k4_2025`, `laps_featured_2025`, `laps_tiredeg` | 24 | `2023 Spain`, `2025 Miami Gardens` |
+| `circuit_clusters_k4`, `circuit_features_with_clusters_k4` | 25 | `2023 Spain` |
+| `laps_featured.parquet` (combined) | 26 | none |
+
+**2 of 71 race dirs**, and `2023 Spain` is not a spelling mismatch: it is the duplicate folder
+of `2023 Barcelona` (same OpenF1 session 9102), which PR 6 removes. **The only genuine
+keyspace mismatch is Miami 2025**, where the artefacts say `Miami` and `metadata.json` says
+`Miami Gardens`.
+
+A first pass of this sweep reported `tire_compounds_by_race` as 6 keys and 71 misses. That
+probe read the file flat; it is nested by year. The table above calls the real consumers.
+
+### Consumers
+
+Probed with the name the replay path actually passes (`metadata.json["gp_name"]`, per
+`replay_engine.py:114`), for the compounds Miami 2025 genuinely ran — it ran no SOFT, and on
+SOFT the pit agent's fallback is 5 while Miami's SOFT is C5, so a SOFT-only probe reports a
+miss as a hit:
+
+| consumer | `'Miami Gardens'` | `'Miami'` |
+|---|---|---|
+| `tire_agent._compound_name_to_id` MEDIUM / HARD | `C2` / `C1` | **`C4` / `C3`** |
+| `pit_strategy_agent._compound_to_id` MEDIUM / HARD | `3` / `1` | **`4` / `3`** |
+| `race_situation_agent._abs_compound` MEDIUM / HARD | `'MEDIUM'` / `'HARD'` | **`C4` / `C3`** |
+| `pace_agent._session_median` MEDIUM / HARD | `None` / `None` | **91.419 / 91.228** |
+| `pace_agent._encode_categorical` (cluster) | 1 (default) | 1 (real) |
+| `TireAgentConfig.circuit_cluster_map` | 1 | 1 |
+
+**Five broken consumers, not four.** `race_situation_agent._abs_compound` reads the same JSON
+and was not in the gate's list; its failure mode differs from the other two — it returns the
+RELATIVE name (`'HARD'`) where the caller expects a `Cx` string.
+
+Then a second pass over the whole tree — every `.get(gp_name`, every `GP_Name ==` mask —
+found **four more**, which is why this section is written after the fix rather than before it:
+
+| site | what an unresolved name does |
+|---|---|
+| `strategy/inference/engine.py:144` | the scoped mask comes out empty and the guard falls back to **the unscoped season frame** — the whole race runs against all 24 GPs, which is the #429/#448 regression that fallback's own warning names |
+| `nlp/radio_runner.py:402` | no driver-code map, so radio speakers degrade to synthetic `D{n}` labels |
+| backend `strategy.py:1028,1031` | the third `session_meta` builder, raw `.get` again — the same twin the PR 2 gate caught for `cluster_mean_lap_s` |
+| backend `telemetry.py:332` | 404s on a GP whose data is present; the parameter's own description promises the alternate form is accepted |
+
+Two sites were examined and deliberately left alone: `laps_augment.py:100` already resolves
+the rename through its own `_FRIENDLY_TO_FOLDER` table (friendly→folder, the other
+direction), and the backend's remaining `df["GP_Name"] == gp` masks are fed from
+`available_gps`, which returns that same frame's `unique()` — they match by construction.
+
+The two cluster lookups resolve today, each for its own reason, and neither is safe:
+
+- `pace._encode_categorical` misses and falls back to cluster 1, which happens to be Miami's
+  real cluster. Coincidence, not correctness.
+- `TireAgentConfig.circuit_cluster_map` hits, because **the pooled clustering artefacts hold
+  Miami twice** — `Miami` and `Miami Gardens` are two rows of `circuit_clusters_k4.parquet`
+  (25 rows for 24 circuits), both cluster 1. The same duplicate-circuit defect as
+  Spain/Barcelona, in the clustering. When PR 6 de-duplicates the artefacts, this lookup
+  starts missing unless it is normalised now.
+
+### Spellings in play
+
+Six, and no single resolver covers them:
+
+| spelling | source | `slug_from_event_name` | `normalise_gp_key` |
+|---|---|---|---|
+| `Miami` | parquet / JSON | `Miami` | `Miami` |
+| `Miami Gardens` | `metadata.json` | `None` | `Miami` |
+| `Miami_Gardens` | folder name, used when `metadata.json` is absent | `None` | `Miami` |
+| `Miami Grand Prix` | FastF1 event name | `Miami` | `Miami_Grand_Prix` ✗ |
+
+`slug_from_event_name` handles FastF1 names and fails on the metadata form;
+`normalise_gp_key` handles the metadata and folder forms and mangles the FastF1 one. The chain
+must try both, which is what `_resolve_mean_sector_speed` already does since #797.
+
+## The fix
+
+One resolver, in the module whose job this is:
+
+- `gp_slugs.normalise_gp_key` — moved out of `pace_agent` (it was never pace-specific).
+- `gp_slugs.resolve_gp_key(keys, gp_name)` — returns the spelling of `gp_name` present in
+  `keys`, trying raw → slug → normalised → normalised slug, and returning `gp_name` unchanged
+  when none is present, so every existing fallback still fires exactly as before.
+
+Applied at every call site above — thirteen in the parent repo and the backend submodule.
+Where a config already owned the map, the resolution went into a `cluster_for()` method next
+to the `sc_rate_for()` / `traversal_for()` that were already doing this for their own tables,
+rather than repeating the call at each of the six raw `.get(gp_name, 0)` sites.
+
+Query-side only: no lookup table is re-keyed, because re-keying a map that holds both `Miami`
+and `Miami Gardens` would silently drop one of them.
+
+`FOLDER_ALIASES` gains `'Spain': 'Barcelona'`. That folder is the duplicate, not a rename, so
+the entry is a stopgap: it makes the folder replayable today and goes inert when PR 6 removes
+it. The alias only fires where `'Spain'` is not itself a key, so the combined
+`laps_featured.parquet`, which stores both, is unaffected.
+
+## Verification
+
+`tests/agents/test_gp_keyspace.py` enumerates **every race directory on disk against every
+consumer**, rather than asserting Miami. That is the difference between this fix and the three
+before it: a fifth mismatch, in any season, fails the suite instead of shipping.
+
+Before / after, `2025 Miami Gardens`:
+
+| | before | after |
+|---|---|---|
+| `_compound_name_to_id('HARD', ...)` | `C1` | `C3` |
+| `_compound_to_id('HARD', ...)` | `1` | `3` |
+| `_abs_compound('HARD', ...)` | `'HARD'` | `C3` |
+| `_session_median('HARD', ...)` | `None` | `91.228` |

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -34,7 +34,11 @@ from src.agents._shared_defaults import (
     DEFAULT_TRACK_TEMP_C,
     reading_or_default,
 )
-from src.f1_strat_manager.gp_slugs import canonical_gp_name, slug_from_event_name
+from src.f1_strat_manager.gp_slugs import (
+    normalise_gp_key,
+    resolve_gp_key,
+    slug_from_event_name,
+)
 
 # Safe in this direction: envelope.py is a leaf that imports nothing from src.agents.
 from src.strategy.inference.envelope import OperatingEnvelope
@@ -174,28 +178,10 @@ _N06_ENVELOPE = OperatingEnvelope(name="n06_laptime_delta", bounds=_N06_TRAINED_
 _FEATURED_SEASONS: tuple[int, ...] = (2023, 2024, 2025)
 
 
-def _normalise_gp_key(gp_name: str) -> str:
-    """One spelling for a GP, applied to BOTH sides of the circuit-speed lookup.
-
-    A GP is written four ways across this project: the parquet slug ('Miami'), the raw
-    folder ('Miami_Gardens'), the metadata.json name the replay engine puts into
-    `session_meta` ('Miami Gardens', with a SPACE), and the FastF1 event name ('Miami
-    Grand Prix'). Worse, the artefacts do not agree with each other: the combined
-    `laps_featured.parquet` calls this race 'Miami' in 2023-2024 and 'Miami Gardens' in
-    2025, so even a lookup whose query is spelled correctly can miss on the season.
-
-    Normalising the KEYS at load time and the query the same way is what `gp_slugs`'s own
-    docstring prescribes, and it is why this is a function rather than a longer candidate
-    list at the call site: a chain of guesses at the query end still fails the moment the
-    stored spelling is the odd one, which is exactly how the first version of this lookup
-    sent every lap of the 2025 Miami race to NaN.
-
-    Underscores first, because `canonical_gp_name`'s alias table is keyed by the folder
-    form, so 'Miami Gardens' has to become 'Miami_Gardens' before it can become 'Miami'.
-    """
-    if not gp_name:
-        return ""
-    return canonical_gp_name(gp_name.replace(" ", "_"))
+# Moved to `gp_slugs` by the 2026-08-04 keyspace sweep: five consumers across three
+# modules needed the same normalisation, and it was never pace-specific. Re-exported under
+# the old private name so the #797 call sites and their tests do not move.
+_normalise_gp_key = normalise_gp_key
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -278,6 +264,11 @@ class PaceAgent:
             self._load_circuit_mean_sector_speed(processed_dir)
         )
         self.laps_ref: pd.DataFrame = self._load_reference_laps(processed_dir)
+        # Cached because `_session_median` resolves the caller's spelling against it on
+        # every lap, and a `.unique()` over the whole reference frame is not a per-lap cost.
+        self._reference_gp_names: frozenset[str] = frozenset(
+            self.laps_ref["GP_Name"].dropna().astype(str).unique()
+        )
 
     # ── Loaders ───────────────────────────────────────────────────────────────
 
@@ -458,7 +449,10 @@ class PaceAgent:
         """
         c_id = self.compound_id.get(compound, 1)
         t_id = self.team_id.get(team, 0)
-        cluster = self.circuit_cluster.get(gp_name, 1)
+        # `circuit_cluster` is keyed by the parquet slug; the replay path queries with the
+        # metadata name. Miami 2025 missed and took the default, which happens to be its
+        # real cluster - a coincidence, not correctness (PR3_GP_KEYSPACE_SWEEP.md).
+        cluster = self.circuit_cluster.get(resolve_gp_key(self.circuit_cluster, gp_name), 1)
         return c_id, t_id, cluster
 
     def _compute_derived(
@@ -731,8 +725,12 @@ class PaceAgent:
         Returns:
             Median lap time in seconds, or None when no matching laps exist.
         """
+        # The parquet spells this race 'Miami'; the replay path asks for 'Miami Gardens'.
+        # Unresolved, the mask was empty for the whole race and N31 lost delta_vs_median
+        # on every lap (PR3_GP_KEYSPACE_SWEEP.md).
+        stored_name = resolve_gp_key(self._reference_gp_names, gp_name)
         mask = (
-            (self.laps_ref["GP_Name"] == gp_name)
+            (self.laps_ref["GP_Name"] == stored_name)
             & (self.laps_ref["Year"] == year)
             & (self.laps_ref["Compound"] == compound)
         )

--- a/src/agents/pit_strategy_agent.py
+++ b/src/agents/pit_strategy_agent.py
@@ -67,6 +67,7 @@ except (ImportError, OSError, RuntimeError):
 from src.f1_strat_manager.gp_slugs import (  # noqa: E402
     canonical_gp_name,
     rekey_by_slug,
+    resolve_gp_key,
     slug_from_event_name,
 )
 
@@ -422,7 +423,12 @@ def _compound_to_id(compound: str, gp_name: str, year: int) -> int:
     Returns:
         Integer compound number (1–6).
     """
-    cx_str = TIRE_COMPOUNDS.get(str(year), {}).get(gp_name, {}).get(compound.upper(), '')
+    # The keyspace trap: queried with the metadata name ('Miami Gardens') this missed and
+    # returned _COMPOUND_FALLBACK, which for 2025 Miami is 1 where the answer is 3 (HARD)
+    # and 3 where it is 4 (MEDIUM). SOFT happens to coincide, which is why a SOFT-only
+    # probe reported the site as healthy (PR3_GP_KEYSPACE_SWEEP.md).
+    year_data = TIRE_COMPOUNDS.get(str(year), {})
+    cx_str = year_data.get(resolve_gp_key(year_data, gp_name), {}).get(compound.upper(), '')
     if cx_str and cx_str.startswith('C') and cx_str[1:].isdigit():
         return int(cx_str[1:])
     return _COMPOUND_FALLBACK.get(compound.upper(), 3)

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -376,6 +376,25 @@ def _abs_compound(relative: str, gp_name: str, year: int) -> str:
     return gp_data.get(relative.upper(), relative)
 
 
+def _lap_count(lap: pd.Series, column: str) -> float:
+    """An integer lap count from a lap row, or NaN when the artefact has none.
+
+    `int()` on a NaN raises, and these columns are NOT reliably populated: 44% of the 2025
+    Miami rows in `laps_featured_2025.parquet` carry no `TyreLife` at all (492 of 857 after
+    augmentation, against 0 at Lusail). That crash never surfaced because the frame handed
+    to the agents was the whole season and the (Driver, LapNumber) lookup landed on some
+    other race's row; scoping the frame correctly is what exposed it.
+
+    NaN rather than a substitute: LightGBM reads a missing feature natively, and inventing
+    a tyre age here is how a sentinel ends up indistinguishable from a real value. The
+    absent data itself is an artefact defect, not something inference can repair.
+    """
+    value = lap.get(column)
+    if value is None or pd.isna(value):
+        return float("nan")
+    return int(value)
+
+
 def _agg(grp: pd.DataFrame) -> pd.Series:
     """Aggregate lap times for one lap group into mean, std, min scalars."""
     lt = grp["LapTime"].dt.total_seconds().dropna()
@@ -946,13 +965,13 @@ class RaceSituationAgent:
         gap_ahead_s = max(0.0, gap_ahead_s)
 
         pace_delta_s = float((driver_x_lap["LapTime"] - driver_y_lap["LapTime"]).total_seconds())
-        tyre_life_x = int(driver_x_lap["TyreLife"])
-        tyre_life_y = int(driver_y_lap["TyreLife"])
+        tyre_life_x = _lap_count(driver_x_lap, "TyreLife")
+        tyre_life_y = _lap_count(driver_y_lap, "TyreLife")
         tyre_life_diff = tyre_life_x - tyre_life_y
         speed_trap_delta = float(driver_x_lap.get("SpeedST", 300.0)) - float(
             driver_y_lap.get("SpeedST", 300.0)
         )
-        lap_number = int(driver_x_lap["LapNumber"])
+        lap_number = _lap_count(driver_x_lap, "LapNumber")
         # DRS is unavailable under SC/VSC (Art. 22.1(c): activation only resumes one lap
         # after a safety car period, two in the 2023 regulation). The gap-based rule
         # below cannot know that, so a neutralised lap used to report an open DRS window

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -60,7 +60,11 @@ except (ImportError, OSError, RuntimeError):
     # repo-relative data/ is right for all three.
     _DATA_ROOT = _REPO_ROOT / "data"
 
-from src.f1_strat_manager.gp_slugs import rekey_by_slug, slug_from_event_name  # noqa: E402
+from src.f1_strat_manager.gp_slugs import (  # noqa: E402
+    rekey_by_slug,
+    resolve_gp_key,
+    slug_from_event_name,
+)
 
 _MODELS = _DATA_ROOT / "models"
 _PROCESSED = _DATA_ROOT / "processed"
@@ -263,6 +267,18 @@ class RaceSituationConfig:
         slug = slug_from_event_name(event_name) or event_name
         return self.circuit_sc_rate_map.get(slug, 0.10)
 
+    def cluster_for(self, gp_name: str, default: Optional[int] = None) -> Optional[int]:
+        """This circuit's cluster, whichever of its four spellings the caller holds.
+
+        `sc_rate_for` above already resolves ONE keyspace for this same config; the cluster
+        map next to it did not, which is the one-copy-fixed-its-twin-not pattern this repo
+        keeps producing. Four spellings need both resolvers, not just the slug one
+        (PR3_GP_KEYSPACE_SWEEP.md).
+        """
+        return self.circuit_cluster_map.get(
+            resolve_gp_key(self.circuit_cluster_map, gp_name), default
+        )
+
 
 # ── Module-level config singleton ─────────────────────────────────────────────
 # Kept at module level because RaceSituationOutput.__post_init__ reads
@@ -349,8 +365,15 @@ class RaceSituationOutput:
 
 
 def _abs_compound(relative: str, gp_name: str, year: int) -> str:
-    """Map SOFT/MEDIUM/HARD → Cx string using TIRE_COMPOUNDS; fallback to input."""
-    return TIRE_COMPOUNDS.get(str(year), {}).get(gp_name, {}).get(relative.upper(), relative)
+    """Map SOFT/MEDIUM/HARD → Cx string using TIRE_COMPOUNDS; fallback to input.
+
+    The fifth consumer of this JSON, and the one the earlier keyspace sweeps missed. Its
+    failure mode is the loudest of the three: unresolved it returns the RELATIVE name
+    ('HARD') where the caller expects a Cx string (PR3_GP_KEYSPACE_SWEEP.md).
+    """
+    year_data = TIRE_COMPOUNDS.get(str(year), {})
+    gp_data = year_data.get(resolve_gp_key(year_data, gp_name), {})
+    return gp_data.get(relative.upper(), relative)
 
 
 def _agg(grp: pd.DataFrame) -> pd.Series:
@@ -1356,7 +1379,7 @@ class RaceSituationAgent:
             "gp_name": gp_name,
             "event_name": event_name,
             "year": lap_state.get("year", 2025),
-            "circuit_cluster": self.cfg.circuit_cluster_map.get(gp_name, 0),
+            "circuit_cluster": self.cfg.cluster_for(gp_name, 0),
             "circuit_sc_rate": self.cfg.sc_rate_for(event_name),
             "total_laps": int(session.total_laps),
             "fastest_lap_s": _clean["LapTime"].min().total_seconds(),
@@ -1446,7 +1469,7 @@ class RaceSituationAgent:
             "gp_name": gp_name,
             "event_name": event_name,
             "year": year,
-            "circuit_cluster": self.cfg.circuit_cluster_map.get(gp_name, 0),
+            "circuit_cluster": self.cfg.cluster_for(gp_name, 0),
             "circuit_sc_rate": self.cfg.sc_rate_for(event_name),
             "total_laps": total_laps,
             "fastest_lap_s": float(self.laps_df["LapTime"].dt.total_seconds().min())

--- a/src/agents/tire_agent.py
+++ b/src/agents/tire_agent.py
@@ -68,6 +68,8 @@ except (ImportError, OSError, RuntimeError):
     # repo-relative data/ is right for all three.
     _DATA_ROOT = _REPO_ROOT / "data"
 
+from src.f1_strat_manager.gp_slugs import resolve_gp_key  # noqa: E402
+
 logger = logging.getLogger(__name__)
 
 _MODEL_DIR = _DATA_ROOT / "models" / "tire_degradation"
@@ -377,6 +379,19 @@ class TireAgentConfig:
             self.cliff_monitor_by_cluster = {}
             self.cliff_overrides_by_gp = {}
 
+    def cluster_for(self, gp_name: str, default: Optional[int] = None) -> Optional[int]:
+        """This circuit's cluster, whichever of its four spellings the caller holds.
+
+        The map is keyed by the parquet slug ('Miami'); the replay path queries with the
+        metadata name ('Miami Gardens'). Today that particular query still lands, but only
+        because the pooled clustering artefact carries the race TWICE under both spellings
+        (25 rows for 24 circuits) - a duplicate PR 6 removes, at which point an unresolved
+        query would start defaulting silently. See PR3_GP_KEYSPACE_SWEEP.md.
+        """
+        return self.circuit_cluster_map.get(
+            resolve_gp_key(self.circuit_cluster_map, gp_name), default
+        )
+
     def get_cliff_thresholds(self, gp_name: str) -> tuple[int, int]:
         """Return (pit_soon_laps, monitor_laps) for the given GP.
 
@@ -391,10 +406,11 @@ class TireAgentConfig:
         Returns:
             Tuple (pit_soon_laps, monitor_laps) as integers.
         """
-        if gp_name in self.cliff_overrides_by_gp:
-            ov = self.cliff_overrides_by_gp[gp_name]
+        override_key = resolve_gp_key(self.cliff_overrides_by_gp, gp_name)
+        if override_key in self.cliff_overrides_by_gp:
+            ov = self.cliff_overrides_by_gp[override_key]
             return ov["pit_soon"], ov["monitor"]
-        cluster_id = self.circuit_cluster_map.get(gp_name)
+        cluster_id = self.cluster_for(gp_name)
         if cluster_id is not None:
             pit_soon = self.cliff_pit_soon_by_cluster.get(cluster_id, self.cliff_pit_soon_laps)
             monitor = self.cliff_monitor_by_cluster.get(cluster_id, self.cliff_monitor_laps)
@@ -889,7 +905,10 @@ def _compound_name_to_id(compound_name: str, gp_name: str, year: int) -> str:
         alloc = json.load(f)
 
     year_data = alloc.get(str(year), {})
-    gp_data = year_data.get(gp_name, {})
+    # The JSON is keyed by the parquet slug. Queried with the metadata name, 2025 Miami
+    # missed and took the fallback, routing MEDIUM/HARD stints to the C2/C1 TCN bundle
+    # instead of C4/C3 for the whole race (PR3_GP_KEYSPACE_SWEEP.md).
+    gp_data = year_data.get(resolve_gp_key(year_data, gp_name), {})
     return gp_data.get(compound_name.upper(), fallback.get(compound_name.upper(), "C3"))
 
 
@@ -1521,10 +1540,10 @@ class TireAgent:
             # within a cluster), and a race's own mean is a per-race number that
             # happens to have the same units.
             "cluster_mean_lap_s": TireAgentConfig._TRAINED_CLUSTER_MEAN_LAP_S.get(
-                self.cfg.circuit_cluster_map.get(gp_name, 0), 0.0
+                self.cfg.cluster_for(gp_name, 0), 0.0
             ),
             "total_laps": int(session.total_laps),
-            "cluster_id": self.cfg.circuit_cluster_map.get(gp_name, 0),
+            "cluster_id": self.cfg.cluster_for(gp_name, 0),
             "team_id": _encode_team_id(self.cfg.team_id_map, stint_state.get("team", "Unknown")),
             "year": stint_state.get("year", 2025),
             "AirTemp": float(_weather.get("AirTemp", DEFAULT_AIR_TEMP_C)),
@@ -1604,10 +1623,10 @@ class TireAgent:
             # above: this race's own mean lap time is a different quantity wearing the
             # same units.
             "cluster_mean_lap_s": TireAgentConfig._TRAINED_CLUSTER_MEAN_LAP_S.get(
-                self.cfg.circuit_cluster_map.get(gp_name, 0), 0.0
+                self.cfg.cluster_for(gp_name, 0), 0.0
             ),
             "total_laps": total_laps,
-            "cluster_id": self.cfg.circuit_cluster_map.get(gp_name, 0),
+            "cluster_id": self.cfg.cluster_for(gp_name, 0),
             "team_id": _encode_team_id(self.cfg.team_id_map, team),
             "year": year,
             # reading_or_default, not .get(key, default): the producers report an

--- a/src/f1_strat_manager/gp_slugs.py
+++ b/src/f1_strat_manager/gp_slugs.py
@@ -25,6 +25,7 @@ path on first run.
 from __future__ import annotations
 
 import logging
+from collections.abc import Container
 from typing import Final, Optional
 
 logger = logging.getLogger(__name__)
@@ -76,6 +77,12 @@ COUNTRY_SLUG_BY_GP: dict[str, str] = {
 # by :func:`canonical_gp_name` and do NOT belong here.
 FOLDER_ALIASES: dict[str, str] = {
     "Miami_Gardens": "Miami",  # 2025 raw folder; 2023/2024 used "Miami"
+    # `data/raw/2023/Spain` is the SAME session as `data/raw/2023/Barcelona` (OpenF1 key
+    # 9102, byte-identical laps, extracted 21 s apart); 2024 and 2025 keep only Barcelona,
+    # and no lookup table is keyed 'Spain'. Replaying that folder today misses every
+    # compound and cluster lookup. The duplicate itself is a data defect with its own
+    # owner; this makes the folder resolve meanwhile, and stays inert once it is gone.
+    "Spain": "Barcelona",
 }
 
 
@@ -172,6 +179,55 @@ def slug_from_event_name(event_name: str) -> Optional[str]:
     if event_name in EVENT_NAME_BY_SLUG:
         return event_name  # already a slug
     return SLUG_BY_EVENT_NAME.get(event_name)
+
+
+def normalise_gp_key(gp_name: str) -> str:
+    """Collapse the metadata and folder spellings of a GP onto the parquet slug.
+
+    ``'Miami Gardens'`` (what ``metadata.json`` carries, and therefore what the replay
+    engine puts into ``session_meta``) and ``'Miami_Gardens'`` (the raw folder name, used
+    when that file is absent) both become ``'Miami'``. Underscores first, because
+    :func:`canonical_gp_name`'s alias table is keyed by the folder form, so the space has
+    to become an underscore before the alias can fire.
+
+    NOT a replacement for :func:`slug_from_event_name`: this one mangles the FastF1 event
+    name (``'Qatar Grand Prix'`` → ``'Qatar_Grand_Prix'``), while that one returns ``None``
+    for the metadata form. Neither covers all four spellings, which is why
+    :func:`resolve_gp_key` tries both rather than picking one.
+
+    Lived in ``pace_agent`` until the 2026-08-04 sweep found five consumers needing it.
+    """
+    if not gp_name:
+        return ""
+    return canonical_gp_name(gp_name.replace(" ", "_"))
+
+
+def resolve_gp_key(keys: Container[str], gp_name: str) -> str:
+    """Return the spelling of ``gp_name`` that ``keys`` actually holds.
+
+    A GP is written four ways across this project — the parquet slug (``'Miami'``), the
+    metadata name (``'Miami Gardens'``), the raw folder (``'Miami_Gardens'``) and the
+    FastF1 event name (``'Miami Grand Prix'``) — and the lookup tables are not keyed
+    consistently between them. Every consumer that queries one of those tables with a name
+    from another keyspace misses and takes its fallback, silently: the 2025 Miami replay
+    read the C1/C2 tyre bundle instead of C3/C4 in three agents at once (#448, #450, #797,
+    and the 2026-08-04 sweep in ``documents/audits/PR3_GP_KEYSPACE_SWEEP.md``).
+
+    Resolving on the QUERY side rather than re-keying the table is deliberate: the pooled
+    clustering artefacts hold BOTH ``'Miami'`` and ``'Miami Gardens'`` as separate rows, so
+    re-keying would silently drop one of the two.
+
+    Returns ``gp_name`` unchanged when nothing resolves, so the caller's own fallback (and
+    its warning) still fires exactly as before.
+    """
+    if not gp_name:
+        return gp_name
+    slug = slug_from_event_name(gp_name)
+    candidates = (gp_name, slug, normalise_gp_key(gp_name), normalise_gp_key(slug or ""))
+    for candidate in candidates:
+        if candidate and candidate in keys:
+            return candidate
+    return gp_name
 
 
 def rekey_by_slug(table: dict, table_name: str) -> dict:

--- a/src/nlp/radio_runner.py
+++ b/src/nlp/radio_runner.py
@@ -59,7 +59,11 @@ import pandas as pd
 # ``f1_strat_manager.gp_slugs`` so the lazy first-run downloader in
 # ``data_cache`` can resolve slugs without dragging in the full
 # ``src.agents`` package init (which loads RoBERTa / BERT / Whisper).
-from src.f1_strat_manager.gp_slugs import COUNTRY_SLUG_BY_GP, resolve_gp_slug
+from src.f1_strat_manager.gp_slugs import (
+    COUNTRY_SLUG_BY_GP,
+    resolve_gp_key,
+    resolve_gp_slug,
+)
 
 __all__ = [
     "COUNTRY_SLUG_BY_GP",
@@ -399,7 +403,8 @@ class RadioPipelineRunner:
         falls back to the ``D{n}`` synthetic codes downstream.
         """
         try:
-            sub = laps_df[laps_df["GP_Name"] == gp_name]
+            names = set(laps_df["GP_Name"].dropna().astype(str))
+            sub = laps_df[laps_df["GP_Name"] == resolve_gp_key(names, gp_name)]
             sub = sub[["DriverNumber", "Driver"]].drop_duplicates()
             return {int(row.DriverNumber): str(row.Driver) for row in sub.itertuples()}
         except Exception as exc:  # noqa: BLE001 — log + degrade gracefully

--- a/src/strategy/inference/engine.py
+++ b/src/strategy/inference/engine.py
@@ -78,6 +78,7 @@ from src.agents.strategy_orchestrator import (
     best_mc_candidate,
     race_context_from_lap_state,
 )
+from src.f1_strat_manager.gp_slugs import resolve_gp_key
 
 # The profiles #169 delivers. ``fast`` (direct-mode sub-agents + event-triggered
 # N31, audit F3/F11) is a later phase and is rejected with a pointing error so
@@ -141,7 +142,12 @@ def _scope_laps_to_gp(
             )
         return laps_df
 
-    scoped = laps_df[laps_df["GP_Name"] == gp_name]
+    # Resolve the spelling first: the replay path scopes with the metadata name while the
+    # frame is keyed by the parquet slug, so 2025 Miami matched nothing and took the
+    # fallback below — the whole race ran on the UNSCOPED season frame, which is the very
+    # regression the fallback's warning names (PR3_GP_KEYSPACE_SWEEP.md).
+    stored_name = resolve_gp_key(set(laps_df["GP_Name"].dropna().astype(str)), gp_name)
+    scoped = laps_df[laps_df["GP_Name"] == stored_name]
     if scoped.empty:
         logger.warning(
             "GP %r not found in the laps frame (%d rows, %d GPs); falling back to the "

--- a/tests/agents/test_gp_keyspace.py
+++ b/tests/agents/test_gp_keyspace.py
@@ -1,0 +1,209 @@
+"""Every race directory resolves in every gp_name-keyed lookup.
+
+The fourth occurrence of one defect (#448, #450, #797, and the 2026-08-04 sweep in
+`documents/audits/PR3_GP_KEYSPACE_SWEEP.md`): a GP is spelled four ways across this project
+and a lookup keyed by one of them is queried with another, so it misses and takes its
+fallback without a word. Each previous fix repaired the site that hurt and left the rest.
+
+This file is the enumeration that ends that: every race directory on disk, against every
+consumer, so a FIFTH mismatch in any season fails the suite instead of shipping. Testing
+Miami alone would pass the moment Miami is fixed and say nothing about the next race.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.f1_strat_manager.gp_slugs import normalise_gp_key, resolve_gp_key
+from tests.conftest import HAS_TIRE_MODELS as _HAS_MODELS
+
+ROOT = Path(__file__).parent.parent.parent
+_DATA = ROOT / "data"
+_RAW = _DATA / "raw"
+_PROCESSED = _DATA / "processed"
+_COMPOUNDS = _DATA / "tire_compounds_by_race.json"
+
+# The three compounds a dry race can run. HARD and MEDIUM matter most here: the pit agent's
+# SOFT fallback is 5, and 2025 Miami's SOFT is C5, so a SOFT-only check reports that site as
+# healthy while it is broken. The first version of the sweep did exactly that.
+_DRY_COMPOUNDS = ("SOFT", "MEDIUM", "HARD")
+
+
+def _races() -> list[tuple[int, str, str]]:
+    """(year, folder, gp_name) for every race directory carrying a metadata.json.
+
+    `gp_name` is read the way `replay_engine._parse_meta` reads it, because that is the
+    string the agents are actually handed.
+    """
+    found: list[tuple[int, str, str]] = []
+    for year_dir in sorted(p for p in _RAW.iterdir() if p.is_dir() and p.name.isdigit()):
+        for race_dir in sorted(p for p in year_dir.iterdir() if p.is_dir()):
+            meta_path = race_dir / "metadata.json"
+            if not meta_path.exists():
+                continue
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            found.append((int(year_dir.name), race_dir.name, meta.get("gp_name", race_dir.name)))
+    return found
+
+
+# --- the resolver itself, hermetic -------------------------------------------
+
+
+def test_neither_resolver_alone_covers_the_four_spellings():
+    """Why `resolve_gp_key` chains both instead of picking one.
+
+    Asserting the chain works is not enough: someone simplifying it back to a single
+    resolver needs the reason in front of them, and both halves of that reason are here.
+    """
+    from src.f1_strat_manager.gp_slugs import slug_from_event_name
+
+    assert slug_from_event_name("Miami Gardens") is None, "the slug resolver alone suffices"
+    assert normalise_gp_key("Qatar Grand Prix") != "Lusail", "the normaliser alone suffices"
+
+
+@pytest.mark.parametrize(
+    "spelling",
+    ["Miami", "Miami Gardens", "Miami_Gardens", "Miami Grand Prix"],
+)
+def test_every_spelling_resolves_to_the_stored_key(spelling):
+    """All four forms find the one key a table actually holds."""
+    assert resolve_gp_key({"Miami": 1}, spelling) == "Miami"
+
+
+def test_an_unknown_name_passes_through_unchanged():
+    """So the caller's own fallback and warning still fire, unchanged."""
+    assert resolve_gp_key({"Miami": 1}, "Nowhere") == "Nowhere"
+    assert resolve_gp_key({}, "") == ""
+
+
+def test_a_table_holding_two_spellings_keeps_both_reachable():
+    """The pooled clustering artefact carries Miami twice; re-keying would drop one.
+
+    This is why the fix resolves on the QUERY side. If someone converts it to a load-time
+    re-key, this assertion is what tells them a row went missing.
+    """
+    both = {"Miami": 1, "Miami Gardens": 2}
+    assert resolve_gp_key(both, "Miami Gardens") == "Miami Gardens"
+    assert resolve_gp_key(both, "Miami") == "Miami"
+
+
+# --- the enumeration, over real data -----------------------------------------
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _RAW.exists() or not _COMPOUNDS.exists(), reason="raw data absent")
+def test_every_race_resolves_in_the_compound_allocation():
+    """The JSON behind three agents: tire, pit and race-situation.
+
+    A miss is invisible from the return value (the fallback is itself a valid Cx), so this
+    asks the artefact whether the key resolved, not what the function returned.
+    """
+    alloc = json.loads(_COMPOUNDS.read_text(encoding="utf-8"))
+
+    unresolved = []
+    for year, folder, gp_name in _races():
+        year_data = alloc.get(str(year), {})
+        if not year_data:
+            continue  # a season the allocation does not cover is not a keyspace failure
+        if resolve_gp_key(year_data, gp_name) not in year_data:
+            unresolved.append(f"{year} {gp_name!r} (data/raw/{year}/{folder})")
+
+    assert unresolved == [], (
+        f"{len(unresolved)} race(s) miss tire_compounds_by_race.json and would silently "
+        f"take the compound fallback: {unresolved}"
+    )
+
+
+@pytest.mark.data
+@pytest.mark.skipif(
+    not _RAW.exists() or not (_PROCESSED / "circuit_clustering").exists(),
+    reason="clustering artefacts absent",
+)
+@pytest.mark.parametrize(
+    "artefact", ["circuit_clusters_k4.parquet", "circuit_clusters_k4_2025.parquet"]
+)
+def test_every_race_resolves_in_the_cluster_maps(artefact):
+    """Pooled for tire/race-situation, 2025 for pace. Both are queried by gp_name.
+
+    The 2025 map covers one season, so only that season's races are asserted against it.
+    """
+    path = _PROCESSED / "circuit_clustering" / artefact
+    if not path.exists():
+        pytest.skip(f"{artefact} absent")
+    keys = set(pd.read_parquet(path, columns=["GP_Name"])["GP_Name"].astype(str))
+    seasons = {2025} if "2025" in artefact else None
+
+    unresolved = [
+        f"{year} {gp_name!r}"
+        for year, _folder, gp_name in _races()
+        if (seasons is None or year in seasons) and resolve_gp_key(keys, gp_name) not in keys
+    ]
+    assert unresolved == [], f"{artefact}: {len(unresolved)} race(s) unresolved: {unresolved}"
+
+
+@pytest.mark.data
+@pytest.mark.skipif(
+    not _RAW.exists() or not (_PROCESSED / "laps_featured_2025.parquet").exists(),
+    reason="featured parquet absent",
+)
+def test_every_2025_race_resolves_in_the_pace_reference_frame():
+    """`_session_median` masks this frame by name; an unresolved name yields no laps."""
+    names = set(
+        pd.read_parquet(_PROCESSED / "laps_featured_2025.parquet", columns=["GP_Name"])[
+            "GP_Name"
+        ].astype(str)
+    )
+    unresolved = [
+        f"2025 {gp_name!r}"
+        for year, _folder, gp_name in _races()
+        if year == 2025 and resolve_gp_key(names, gp_name) not in names
+    ]
+    assert unresolved == [], (
+        f"{len(unresolved)} race(s) would give N31 delta_vs_median=None for a whole "
+        f"race: {unresolved}"
+    )
+
+
+# --- the consumers, end to end -----------------------------------------------
+
+
+@pytest.mark.data
+@pytest.mark.skipif(
+    not _HAS_MODELS or not _COMPOUNDS.exists(), reason="importing the agents reads data/models/"
+)
+def test_the_three_compound_consumers_agree_across_every_race_and_compound():
+    """The functions themselves, not just their tables.
+
+    All three read the same JSON and each degrades differently on a miss: tire returns the
+    fallback Cx, pit an int that is 2 low on HARD, race-situation the RELATIVE name. Run
+    against the metadata spelling, they must equal what the slug spelling gives.
+    """
+    from src.agents.pit_strategy_agent import _compound_to_id
+    from src.agents.race_situation_agent import _abs_compound
+    from src.agents.tire_agent import _compound_name_to_id
+
+    alloc = json.loads(_COMPOUNDS.read_text(encoding="utf-8"))
+
+    disagreements = []
+    for year, _folder, gp_name in _races():
+        year_data = alloc.get(str(year), {})
+        stored = resolve_gp_key(year_data, gp_name)
+        if stored not in year_data:
+            continue  # covered by the allocation test above; not this one's job
+        for compound in _DRY_COMPOUNDS:
+            for label, fn in (
+                ("tire", _compound_name_to_id),
+                ("pit", _compound_to_id),
+                ("rsa", _abs_compound),
+            ):
+                if fn(compound, gp_name, year) != fn(compound, stored, year):
+                    disagreements.append(f"{label} {year} {gp_name!r} {compound}")
+
+    assert disagreements == [], (
+        f"{len(disagreements)} consumer/race/compound combinations answer differently for "
+        f"the metadata spelling than for the stored one: {disagreements[:10]}"
+    )


### PR DESCRIPTION
PR 3 of the approved data-wiring plan. Sweep report: `documents/audits/PR3_GP_KEYSPACE_SWEEP.md`.

## What was wrong

A Grand Prix is written four ways here — the parquet slug `Miami`, the `metadata.json` name the replay engine passes (`Miami Gardens`), the raw folder `Miami_Gardens`, and the FastF1 event name `Miami Grand Prix`. Nine lookups queried a table keyed by one of those with a name from another. A miss is silent: each takes its own fallback.

This is the fourth occurrence of the same defect (#448, #450, #797). Each earlier fix repaired the site that hurt and left the others, so this one was measured across the whole tree before any code was written.

## Scope, measured before the fix

**Races: 2 of 71.** `2025 Miami Gardens` is the genuine mismatch. `2023 Spain` is not a spelling problem — it is the duplicate folder of `2023 Barcelona` (same OpenF1 session), which a later PR removes.

**Consumers: 9, where the gate had found 4.**

| consumer | `'Miami Gardens'` | `'Miami'` |
|---|---|---|
| `tire_agent._compound_name_to_id` MEDIUM / HARD | `C2` / `C1` | **`C4` / `C3`** |
| `pit_strategy_agent._compound_to_id` MEDIUM / HARD | `3` / `1` | **`4` / `3`** |
| `race_situation_agent._abs_compound` | `'MEDIUM'` / `'HARD'` | **`C4` / `C3`** |
| `pace_agent._session_median` | `None` | **91.419 / 91.228** |
| `pace_agent._encode_categorical` | default cluster | real cluster |
| `engine._scope_laps_to_gp` | empty mask, falls back to **the unscoped season frame** | the race |
| `radio_runner` driver map | synthetic `D{n}` labels | driver codes |
| backend `strategy.py` × 2 | raw `.get` on the third `session_meta` builder | resolved |
| backend `telemetry.py` | 404 on data that is present | the race |

The engine one is the worst: an unresolved name makes the scoped frame empty, and the guard then hands the agents **all 24 Grands Prix at once** — the exact regression that fallback's own warning names.

Two sites were examined and deliberately left alone: `laps_augment.py` already resolves the rename through its own table in the other direction, and the backend's remaining `GP_Name ==` masks are fed from `available_gps`, which returns that frame's own `unique()`.

## The fix

`normalise_gp_key` moves out of `pace_agent` (it was never pace-specific) and joins a new `resolve_gp_key` in `gp_slugs`. Neither existing resolver covers all four spellings alone — `slug_from_event_name` returns `None` for the metadata form, `normalise_gp_key` mangles the FastF1 one — so the chain tries both.

Resolution is query-side. The pooled clustering artefacts carry Miami **twice**, under both spellings (25 rows for 24 circuits), so re-keying at load would silently drop one.

## Verification

`tests/agents/test_gp_keyspace.py` enumerates **every race directory against every consumer**, not Miami. Testing Miami would pass the moment Miami is fixed and say nothing about the next race.

Two probes were wrong on the way and the report records both: one read the year-nested compound JSON as flat, and one probed SOFT only — 2025 Miami ran no SOFT, and its SOFT is C5 while the pit agent's SOFT fallback is 5, so a broken site reported as healthy.

## Checks

- `ruff check` + `ruff format --check` green.
- `mypy src/rag/` green.
- Full suite: 693 passed. The 5 failures are reproduced identically on clean `dev` in a worktree, so none belong to this PR; they skip on CI for want of data and weights.