### PR TITLE
fix(agents): serve N06 the compound scale and the previous trap it trained on

### DIFF
--- a/documents/audits/PR4_PACE_INPUTS.md
+++ b/documents/audits/PR4_PACE_INPUTS.md
@@ -1,0 +1,93 @@
+# PR 4 — the two pace inputs that were a different quantity from the trained column
+
+**Date:** 2026-08-04 · Extends `GATE_DATA_WIRING.md` (W-F1, W-F4) and `GATE_801_ARTEFACTS.md`
+§4-§5. Those are dated findings and stay as written; this records what the pre-implementation
+verification measured, including where the gate's reasoning had to be re-derived.
+
+## W-F1 — CompoundID served on the wrong scale
+
+### Verifying the claim, and the wrong turn on the way
+
+`_load_encoding_maps` read `manifest["categorical_encoding"]["Compound"]`, which is
+**0-based** (SOFT 0 … WET 4), and `_build_feature_row` put the result in the **`CompoundID`**
+column. The parquet's `CompoundID` is **1-based** (SOFT 1 … WET 5, `.nb_py/N01:114`).
+
+The first check appeared to refute this. `.nb_py/N06:87,130` reads that same manifest block
+and maps the `Compound` string through it, which reads as the model having eaten the 0-based
+codes. **It did not.** The manifest's own `features_in` lists the 39 columns the model
+consumed: `CompoundID` is among them and `Compound` is not. The notebook's mapping produces a
+column that never reaches the feature matrix.
+
+The eval harness had this right the whole time, in a docstring:
+
+> *Only `FreshTyre` feeds the delta model directly; `Compound` / `race_phase` are encoded for
+> parity with the notebook (the model consumes the pre-numeric `CompoundID`).*
+> — `src/strategy/eval/pace_holdout.py:48`
+
+So the eval was correct and inference contradicted it. `pace_holdout` needed no change — the
+twin that looked most likely was not one.
+
+### Why it is worse than an off-by-one
+
+N01 does `.fillna(0)`, so **0 is a trained class meaning "no compound reported"**. Served
+0-based, a SOFT lap arrives as that class. The two are then indistinguishable to the model:
+this is the sentinel collision this repo keeps re-finding, not a relabelling.
+
+The old default compounded it: `.get(compound, 1)` returned 1 for an unrecognised string, and
+1 is SOFT on the trained scale — an unknown tyre was served as a specific one.
+
+### Fix
+
+`_N01_COMPOUND_ID` in `pace_agent`, with `_COMPOUND_ID_UNKNOWN = 0` as the default.
+`tests/agents/test_pace_inputs.py` re-derives both from the parquet rather than from N01's
+source, because the parquet is what N06 read.
+
+The manifest block itself is left alone. It is not wrong — it correctly describes N06's
+`encode_features` step — it simply describes a column the model dropped. Reading it for the
+feature encoding was the defect.
+
+## W-F4 — Prev_SpeedST served the current lap's trap
+
+N04 builds every `Prev_*` column in one loop over the same grouped shift
+(`.nb_py/N04:389-392`): `groupby(['Year','GP_Name','DriverNumber','Stint']).shift(1)`. The
+pace agent had no previous trap available and passed `d.get("speed_st") or 300.0` — THIS
+lap's reading — as `prev_speed_st`.
+
+This is the same defect #435 fixed for `Prev_LapTime`, in the same call, left in place for its
+sibling. #435's fix added `_precompute_prev_lap_times` to `RaceStateManager`, which reproduces
+N04's rule including the part that is not guessable: the previous lap is the previous
+**surviving** lap under `filter_baseline_laps`, not `lap_number - 1`, so an out-lap never
+becomes the anchor.
+
+### Fix
+
+`_precompute_prev_lap_times` becomes column-parametric (`_precompute_previous`) and
+`_precompute_prev_speed_traps` reuses it. Two reconstructions of one transform is how the pair
+drifts apart the next time either is corrected.
+
+The `or 300.0` is removed rather than moved. 300 km/h sits **inside** the trained range
+(156-362), so an invented reading was indistinguishable from a measured one, and it fired on
+the first lap of every stint — exactly where the answer is genuinely unknown. NaN says
+unknown, and XGBoost reads a missing feature natively.
+
+## Measured
+
+Served value against the trained column, whole races, NOR 2025:
+
+| | Lusail | Miami |
+|---|---|---|
+| `CompoundID` wrong, before | **46/46 laps (100%)** | **49/49 (100%)** |
+| `Prev_SpeedST` wrong, before | 27/27, mean 6.67 km/h, max 20.0 | 22/27, mean 3.07, max 17.0 |
+| both, after | **0** | **0** |
+| stint openers served NaN where training has none | 19/19 | — |
+
+Input parity is not the outcome that matters. The prediction itself, both fixes together:
+
+| race | laps whose prediction moves | mean | p95 | max |
+|---|---|---|---|---|
+| Lusail | 9 of 57 (16%) | 0.149 s | 0.875 s | **2.887 s** |
+| Miami | 4 of 57 (7%) | 0.104 s | 0.265 s | **3.235 s** |
+
+100% of inputs wrong yields 7-16% of predictions moved because `CompoundID` carries 0.38% of
+N06's gain — the trees split on it only in some regions. Where they do, the error reaches
+three seconds, which is a pit-stop's worth of lap time.

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -177,6 +177,23 @@ _N06_ENVELOPE = OperatingEnvelope(name="n06_laptime_delta", bounds=_N06_TRAINED_
 # stray file cannot silently widen what the agent claims to know.
 _FEATURED_SEASONS: tuple[int, ...] = (2023, 2024, 2025)
 
+# N01's compound codes (`.nb_py/N01_data_download.py:114`), which is what the parquet's
+# `CompoundID` column holds and therefore what N06 was trained on. Not the manifest's
+# 0-based `categorical_encoding.Compound` block: that one encodes a column N06 drops.
+#
+# 0 is a TRAINED CLASS, not a spare slot — N01 does `.fillna(0)`, so every lap whose
+# compound FastF1 did not report reached training as a 0. That is why an off-by-one here
+# is worse than a shift: it makes a SOFT lap indistinguishable from an unreported one.
+# `tests/agents/test_pace_compound_encoding.py` re-derives all of this from the artefact.
+_N01_COMPOUND_ID: dict[str, int] = {
+    "SOFT": 1,
+    "MEDIUM": 2,
+    "HARD": 3,
+    "INTERMEDIATE": 4,
+    "WET": 5,
+}
+_COMPOUND_ID_UNKNOWN: int = 0
+
 
 # Moved to `gp_slugs` by the 2026-08-04 keyspace sweep: five consumers across three
 # modules needed the same normalisation, and it was never pace-specific. Re-exported under
@@ -294,11 +311,17 @@ class PaceAgent:
     def _load_encoding_maps(self, processed_dir: Path) -> tuple[dict, dict, dict]:
         """Load compound, circuit-cluster, and team label-encoding maps.
 
-        Reads the compound encoding from the N06 feature manifest, the circuit
-        cluster assignments from the k=4 clustering parquet (N05), and the
-        team-to-integer map derived from the laps_featured parquet. All three
-        are static training artifacts — they must not be recomputed at inference
+        The compound codes are N01's, the circuit clusters come from the k=4 clustering
+        parquet (N05), and the team map is derived from the laps_featured parquet. All
+        three are static training artifacts — they must not be recomputed at inference
         time to avoid encoding drift between train and serve.
+
+        NOT the manifest's `categorical_encoding.Compound` block, which is what this used
+        to read. That block is 0-based and describes N06's `encode_features` step, whose
+        output column (`Compound`) is NOT among the 39 in `features_in`: the model eats
+        `CompoundID`, N01's 1-based column, straight from the parquet. The eval harness
+        says so in its own docstring — "the model consumes the pre-numeric CompoundID" —
+        and inference contradicted it, so every lap arrived one class low.
 
         Args:
             processed_dir: Root of the processed data directory.
@@ -306,8 +329,7 @@ class PaceAgent:
         Returns:
             Tuple (compound_id, circuit_cluster, team_id) dicts.
         """
-        manifest = json.loads((processed_dir / "feature_manifest_laptime.json").read_text())
-        compound_id = manifest["categorical_encoding"]["Compound"]
+        compound_id = dict(_N01_COMPOUND_ID)
 
         clusters_df = pd.read_parquet(
             processed_dir / "circuit_clustering" / "circuit_clusters_k4_2025.parquet",
@@ -447,7 +469,10 @@ class PaceAgent:
         Returns:
             Tuple (compound_id_int, team_id_int, cluster_int).
         """
-        c_id = self.compound_id.get(compound, 1)
+        # The unknown code, not 1: 1 is SOFT on the trained scale, so an unrecognised
+        # compound string used to be served as a specific tyre rather than as the absent
+        # reading N01 encoded it as.
+        c_id = self.compound_id.get(compound, _COMPOUND_ID_UNKNOWN)
         t_id = self.team_id.get(team, 0)
         # `circuit_cluster` is keyed by the parquet slug; the replay path queries with the
         # metadata name. Miami 2025 missed and took the default, which happens to be its
@@ -885,19 +910,23 @@ class PaceAgent:
         total_laps = meta["total_laps"]
         laps_remaining = max(0, total_laps - lap_number)
 
-        # ``dict.get(key, default)`` only applies the default when *key is
-        # absent* — if the key is present with a None value (FastF1 logs
-        # speed_st=None on laps where the trap beam is not crossed cleanly,
-        # e.g. inlaps, traffic interruptions, sector anomalies), the default
-        # is ignored and None flows into the DataFrame. The feature column
-        # then becomes object dtype and XGBoost rejects it with:
-        #     "DataFrame.dtypes for data must be int, float, bool or category"
-        # That is exactly the crash observed on mid-stint laps. The ``or``
-        # pattern handles both missing-key and None-value cases in one step.
-        # This file's inline guard was the ONLY one of the three agents that handled
-        # present-and-None, and it is now the shared helper the other two adopted rather
-        # than a fourth copy of the pattern (#788).
-        _speed_st = d.get("speed_st") or 300.0
+        # The PREVIOUS lap's trap, which is what N04 built and N06 ate: every `Prev_*`
+        # column is one grouped shift within the stint. This used to read `speed_st`,
+        # THIS lap's trap, so the feature was a lap ahead of itself on every call — the
+        # exact defect #435 fixed for `Prev_LapTime` and left in place for its sibling.
+        #
+        # No `or 300.0`. That default was not a neutral filler: 300 km/h sits inside the
+        # trained range (156-362), so an invented reading was indistinguishable from a
+        # measured one, and it fired on the first lap of every stint, where the answer is
+        # genuinely unknown. NaN says unknown, and XGBoost reads a missing feature
+        # natively through its sparse-aware split direction.
+        #
+        # `.get` alone would return a stored None; `_build_feature_row`'s
+        # `to_numeric(errors='coerce')` turns that into the NaN we want, but converting
+        # here keeps the value numeric all the way down, which is what the envelope
+        # labelling and the bootstrap both assume.
+        _prev_speed_st = d.get("prev_speed_st")
+        _prev_speed_st = float("nan") if _prev_speed_st is None else float(_prev_speed_st)
         _air_temp = reading_or_default(wx, "air_temp", DEFAULT_AIR_TEMP_C)
         _trk_temp = reading_or_default(wx, "track_temp", DEFAULT_TRACK_TEMP_C)
         _humidity = reading_or_default(wx, "humidity", 50.0)
@@ -951,7 +980,7 @@ class PaceAgent:
             # reached on a genuinely missing previous lap.
             prev_lap_time=d.get("prev_lap_time") or MISSING_PREV_LAP_TIME_S,
             prev_tyre_life=max(0, (d.get("tyre_life") or 1) - 1),
-            prev_speed_st=float(_speed_st),
+            prev_speed_st=_prev_speed_st,
             air_temp=float(_air_temp),
             track_temp=float(_trk_temp),
             humidity=float(_humidity),

--- a/src/simulation/race_state_manager.py
+++ b/src/simulation/race_state_manager.py
@@ -145,6 +145,7 @@ class RaceStateManager:
         # Precomputed for the same reason as the two above: get_driver_state is an
         # O(1) lookup and a per-lap rescan would break that promise.
         self._derived_prev_lap: dict[int, float] = self._precompute_prev_lap_times()
+        self._derived_prev_speed_st: dict[int, float] = self._precompute_prev_speed_traps()
 
         # Art. 30.5(m) flags, one timeline per driver, built on first ask.
         # `get_lap_state` needs ours plus one per rival, and the per-lap helper
@@ -237,12 +238,37 @@ class RaceStateManager:
             keeps that as ``None`` rather than inventing a number. An empty map is
             the honest result for a frame lacking the columns this needs.
         """
+        return self._precompute_previous(column="_lap_time_s")
+
+    def _precompute_prev_speed_traps(self) -> dict[int, float]:
+        """The same reconstruction, for N04's ``Prev_SpeedST``.
+
+        N04 builds every ``Prev_*`` column in one loop over the SAME grouped shift
+        (`.nb_py/N04_feature_engineering.py:389-392`), so the previous speed trap obeys
+        the identical rule as the previous lap time: same stint grouping, same survivor
+        filter. #435 restored ``Prev_LapTime`` through this machinery and left its
+        siblings alone, and the pace agent went on feeding the CURRENT lap's trap where
+        training had the previous one.
+
+        Sharing the helper is the point rather than an economy: two reconstructions of
+        one transform is how the pair drifts apart the next time either is corrected.
+        """
+        return self._precompute_previous(column="SpeedST")
+
+    def _precompute_previous(self, column: str) -> dict[int, float]:
+        """``{lap_number: the previous SURVIVING lap's value}`` for one N04 ``Prev_`` column.
+
+        Kept private and column-parametric because the survivor filter, not the shift, is
+        what makes this correct, and it is identical for every such column.
+        """
         needed = {"LapNumber", "LapTime", "Stint"}
         if self._driver.empty or not needed <= set(self._driver.columns):
             return {}
 
         laps = self._driver.copy()
         laps["_lap_time_s"] = laps["LapTime"].map(_to_seconds)
+        if column not in laps.columns:
+            return {}
 
         # N04's filter_baseline_laps, term for term. IsAccurate and Deleted are
         # FastF1 quality flags absent from some hand-built frames, so a missing
@@ -258,7 +284,7 @@ class RaceStateManager:
         if ordered.empty:
             return {}
 
-        previous = ordered.groupby("Stint", sort=False)["_lap_time_s"].shift(1)
+        previous = ordered.groupby("Stint", sort=False)[column].shift(1)
         return {
             int(lap): float(value)
             for lap, value in zip(ordered["LapNumber"], previous, strict=True)
@@ -415,6 +441,16 @@ class RaceStateManager:
             "speed_i2": float(r["SpeedI2"]) if pd.notna(r.get("SpeedI2")) else None,
             "speed_fl": float(r["SpeedFL"]) if pd.notna(r.get("SpeedFL")) else None,
             "speed_st": float(r["SpeedST"]) if pd.notna(r.get("SpeedST")) else None,
+            # N04's Prev_SpeedST, emitted for exactly the reason prev_lap_time above is:
+            # the pace agent had no previous trap to read, so it served THIS lap's
+            # (`d.get('speed_st') or 300.0`) into a feature trained on the preceding
+            # one. Same producer, same rule, same None-means-unknown convention — the
+            # first lap of a stint genuinely has no predecessor and says so.
+            "prev_speed_st": (
+                float(r["Prev_SpeedST"])
+                if pd.notna(r.get("Prev_SpeedST"))
+                else self._derived_prev_speed_st.get(int(lap_number))
+            ),
             # --- Fuel (linear depletion estimate from FuelLoad feature) ---
             "fuel_load": float(r["FuelLoad"]) if pd.notna(r.get("FuelLoad")) else None,
             # --- Track & pit state ---

--- a/tests/agents/test_pace_inputs.py
+++ b/tests/agents/test_pace_inputs.py
@@ -1,0 +1,182 @@
+"""N06 is served the columns it was trained on: CompoundID's scale and the previous trap.
+
+Two inputs of the pace agent were a different quantity from the trained column.
+
+`CompoundID` was read from the manifest's `categorical_encoding.Compound` block, which is
+0-based. The model's 39 `features_in` include `CompoundID` and not `Compound`, so what it
+ate is N01's 1-based column straight from the parquet. Every lap arrived one class low, and
+because N01 encodes an unreported compound as 0, a SOFT lap was served as the code that
+means "no compound reading".
+
+`Prev_SpeedST` was served `speed_st` — THIS lap's trap — where N04 builds every `Prev_*`
+column as one grouped shift within the stint. That is the defect #435 fixed for
+`Prev_LapTime` and left in place for its sibling, in the same call.
+
+Measured before the fix, per race: 100% of laps had the wrong CompoundID; the trap differed
+on 27 of 27 Lusail laps (mean 6.67 km/h, max 20.0). The prediction itself moved on 16% of
+Lusail laps and 7% of Miami's, max 2.89 s and 3.24 s.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_PROCESSED = ROOT / "data" / "processed"
+_FEATURED = _PROCESSED / "laps_featured_2025.parquet"
+_RACE = ROOT / "data" / "raw" / "2025" / "Lusail"
+
+# The same artefact pair `test_pace_circuit_speed.py` gates on, so the two files skip and
+# run together rather than disagreeing about what "the pace model is present" means.
+_HAS_MODEL = (ROOT / "data" / "models" / "lap_time" / "xgb_laptime_delta_final.json").exists() and (
+    _PROCESSED / "laps_featured.parquet"
+).exists()
+
+
+# --- the compound scale, re-derived from the artefact -------------------------
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _FEATURED.exists(), reason="featured parquet absent")
+def test_the_declared_compound_codes_are_the_ones_the_parquet_stores():
+    """The constant is a claim about the trained column; this re-derives it.
+
+    Deliberately checked against the parquet rather than against N01's source: the parquet
+    is what N06 read, so if the two ever disagree it is the parquet that decides.
+    """
+    from src.agents.pace_agent import _N01_COMPOUND_ID
+
+    pairs = (
+        pd.read_parquet(_FEATURED, columns=["Compound", "CompoundID"]).dropna().drop_duplicates()
+    )
+    # Code 0 is the unknown class and its Compound cell is whatever FastF1 failed to
+    # report — the parquet holds both the string 'nan' and the string 'None' against it.
+    # Those are not names to check; the named compounds are the ones with a code.
+    named = pairs[pairs["CompoundID"] != 0]
+    stored = {str(c): int(i) for c, i in zip(named["Compound"], named["CompoundID"])}
+    assert stored, "no named compounds in the artefact: this would hold vacuously"
+
+    for compound, code in stored.items():
+        assert _N01_COMPOUND_ID[compound] == code, (
+            f"{compound}: declared {_N01_COMPOUND_ID[compound]}, artefact stores {code}"
+        )
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _FEATURED.exists(), reason="featured parquet absent")
+def test_the_unknown_code_is_a_class_the_model_saw():
+    """0 is not a spare slot. N01 does `.fillna(0)`, so unreported compounds trained as 0.
+
+    This is what makes the off-by-one worse than a shift: it collides the SOFT class with
+    the absent-reading class instead of merely relabelling it.
+    """
+    from src.agents.pace_agent import _COMPOUND_ID_UNKNOWN, _N01_COMPOUND_ID
+
+    codes = set(
+        pd.read_parquet(_FEATURED, columns=["CompoundID"])["CompoundID"].dropna().astype(int)
+    )
+    assert _COMPOUND_ID_UNKNOWN in codes, "the artefact never stores the unknown code"
+    assert _COMPOUND_ID_UNKNOWN not in _N01_COMPOUND_ID.values(), (
+        "the unknown code collides with a named compound"
+    )
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _HAS_MODEL or not _FEATURED.exists(), reason="pace model absent")
+def test_an_unrecognised_compound_is_served_as_unknown_not_as_soft():
+    """The old default was 1, which is SOFT on the trained scale — a specific tyre."""
+    from src.agents.pace_agent import _COMPOUND_ID_UNKNOWN, PaceAgent
+
+    agent = PaceAgent()
+    code, _team, _cluster = agent._encode_categorical("NOT_A_COMPOUND", "McLaren", "Lusail")
+    assert code == _COMPOUND_ID_UNKNOWN
+
+
+# --- both inputs, against the trained columns, over a whole race ---------------
+
+
+@pytest.fixture(scope="module")
+def served_vs_trained():
+    """Every lap of Lusail 2025 replayed, paired with the featured parquet's own row.
+
+    A whole race rather than a probe row: a hand-built row cannot show that a wrong input
+    only moves the prediction in the regions where the trees split on it, and it was a
+    single probe that nearly had an earlier fix in this file recorded as cosmetic.
+    """
+    from src.f1_strat_manager.laps_augment import augment_featured_laps
+    from src.simulation.replay_engine import RaceReplayEngine
+
+    featured = augment_featured_laps(pd.read_parquet(_FEATURED), 2025)
+    trained = featured[(featured["GP_Name"] == "Lusail") & (featured["Driver"] == "NOR")].set_index(
+        "LapNumber"
+    )
+
+    replay = RaceReplayEngine(_RACE, driver_code="NOR", team="McLaren", interval_seconds=0.0)
+    rows = []
+    for lap_state in replay.replay():
+        lap = lap_state["driver"].get("lap_number")
+        if lap in trained.index:
+            rows.append((lap, lap_state["driver"], trained.loc[lap]))
+    assert rows, "no laps matched: the pairing is wrong, not the code under test"
+    return rows
+
+
+@pytest.mark.data
+@pytest.mark.skipif(
+    not _HAS_MODEL or not _FEATURED.exists() or not _RACE.exists(), reason="model or data absent"
+)
+def test_the_served_compound_id_is_the_trained_one_on_every_lap(served_vs_trained):
+    from src.agents.pace_agent import PaceAgent
+
+    agent = PaceAgent()
+    mismatches = [
+        f"lap {lap}: served {agent._encode_categorical(d.get('compound') or '', '', '')[0]}, "
+        f"trained {int(row['CompoundID'])}"
+        for lap, d, row in served_vs_trained
+        if pd.notna(row.get("CompoundID"))
+        and agent._encode_categorical(d.get("compound") or "", "", "")[0] != int(row["CompoundID"])
+    ]
+    assert mismatches == [], f"{len(mismatches)} laps served the wrong class: {mismatches[:5]}"
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _FEATURED.exists() or not _RACE.exists(), reason="data absent")
+def test_the_producer_emits_the_previous_trap_not_this_lap_s(served_vs_trained):
+    """Value AND absence: the stint's first lap has no predecessor and must say so.
+
+    Asserting only the populated laps would pass on a producer that invented a number for
+    the openers, which is exactly what the `or 300.0` it replaces did — and 300 km/h sits
+    inside the trained range, so the invention was unfalsifiable from the value alone.
+    """
+    wrong_value, invented = [], []
+    for lap, d, row in served_vs_trained:
+        served, trained = d.get("prev_speed_st"), row.get("Prev_SpeedST")
+        if pd.notna(trained):
+            if served is None or abs(float(served) - float(trained)) > 1e-6:
+                wrong_value.append(f"lap {lap}: served {served}, trained {trained}")
+        elif served is not None:
+            invented.append(f"lap {lap}: served {served} where training had none")
+
+    assert wrong_value == [], f"{len(wrong_value)} laps differ: {wrong_value[:5]}"
+    assert invented == [], f"{len(invented)} laps invented a reading: {invented[:5]}"
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _FEATURED.exists() or not _RACE.exists(), reason="data absent")
+def test_the_previous_trap_is_not_simply_the_current_one(served_vs_trained):
+    """Guards against a producer that satisfies the test above by aliasing the columns.
+
+    If `prev_speed_st` were `speed_st` again, the assertions above would still hold on any
+    lap where the two happen to coincide, so this asserts the two genuinely differ.
+    """
+    differing = sum(
+        1
+        for _lap, d, _row in served_vs_trained
+        if d.get("prev_speed_st") is not None
+        and d.get("speed_st") is not None
+        and abs(float(d["prev_speed_st"]) - float(d["speed_st"])) > 1e-6
+    )
+    assert differing > 0, "prev_speed_st never differs from speed_st: it is the same column"


### PR DESCRIPTION
PR 4 of the approved data-wiring plan. Report: `documents/audits/PR4_PACE_INPUTS.md`.

Two pace-agent inputs were a different quantity from the column N06 trained on.

## CompoundID — served on the wrong scale, on every lap

The encoding came from the manifest's `categorical_encoding.Compound` block, which is **0-based**, and landed in the **`CompoundID`** feature, which is **1-based**.

The first check appeared to refute this: N06's notebook reads that same block. It does — and the column it produces is **not among the 39 in `features_in`**. The model eats `CompoundID` straight from the parquet, and the eval harness has said so in a docstring since it was written:

> *"the model consumes the pre-numeric CompoundID"* — `pace_holdout.py:48`

So the eval was right and inference contradicted it. The twin that looked most likely was not one; `pace_holdout` needed no change.

**It is worse than an off-by-one.** N01 does `.fillna(0)`, so **0 is a trained class meaning "no compound reported"** — served 0-based, a SOFT lap is indistinguishable from a lap with no reading. And the old default for an unrecognised string was `1`, which is SOFT on the trained scale: an unknown tyre served as a specific one.

## Prev_SpeedST — served this lap's trap

N04 builds every `Prev_*` column in one loop over one grouped shift within the stint. The agent passed `speed_st` — the CURRENT lap — so the feature was a lap ahead of itself on every call. Same defect #435 fixed for `Prev_LapTime`, in the same call, left in place for its sibling.

`_precompute_prev_lap_times` becomes column-parametric and the trap **reuses** it, rather than getting a second reconstruction of the same rule. The part that is not guessable is the survivor filter: the previous lap is the previous *surviving* one, so an out-lap never becomes the anchor.

The `or 300.0` is **removed, not moved**: 300 km/h sits inside the trained range (156-362), so the invented reading was indistinguishable from a measured one, and it fired on the first lap of every stint — where the answer is genuinely unknown. NaN says unknown; XGBoost reads a missing feature natively.

## Measured

Served value vs the trained column, whole races, NOR 2025:

| | Lusail | Miami |
|---|---|---|
| `CompoundID` wrong, before | **46/46 (100%)** | **49/49 (100%)** |
| `Prev_SpeedST` wrong, before | 27/27, mean 6.67 km/h, max 20.0 | 22/27, mean 3.07, max 17.0 |
| after | **0** | **0** |

Input parity is not the outcome that matters. The prediction itself:

| race | laps whose prediction moves | mean | p95 | max |
|---|---|---|---|---|
| Lusail | 9 of 57 (16%) | 0.149 s | 0.875 s | **2.887 s** |
| Miami | 4 of 57 (7%) | 0.104 s | 0.265 s | **3.235 s** |

100% of inputs wrong gives 7-16% of predictions moved because `CompoundID` carries 0.38% of N06's gain — the trees split on it only in some regions. Where they do, the error reaches three seconds.

## Checks

- `ruff check` + `ruff format --check` green.
- `tests/agents/` + `tests/simulation/`: 269 passed, 1 pre-existing failure (`test_weather_restore`, #801).
- `tests/agents/test_pace_inputs.py` re-derives the codes from the parquet, and asserts **absence** as well as value so a producer that invents a stint-opener reading cannot pass.