### PR TITLE
fix(agents): decline the overtake call outside the model's trained domain

### DIFF
--- a/docs/pages/agents-api.md
+++ b/docs/pages/agents-api.md
@@ -56,7 +56,7 @@ Only the RAG agent (N30) exposes a module-level `get_rag_react_agent()` factory 
 
 | Field | Type | Description |
 |---|---|---|
-| `overtake_prob` | float | Probability of being overtaken (0–1) |
+| `overtake_prob` | float \| None | Probability that **our car passes the car ahead** (0–1). `None` when that car is farther away than the 2.5 s gap N11 was trained on — the model has no labelled example out there, so it declines rather than extrapolating. `None` is not `0.0`: zero is what the regulation asserts under a Safety Car (Art. 55.8). |
 | `sc_prob_3lap` | float | Safety car probability within 3 laps (0–1) |
 | `sc_currently_active` | bool | Any neutralisation (full Safety Car **or** Virtual Safety Car) is deployed **right now**. Not a prediction: it is read from the lap's RCM events, because N14 was trained to forecast a future SC and cannot recognise one already out. When true it forces the regulatory facts (`sc_prob_3lap = 1.0`, `overtake_prob = 0` per Art. 55.8/56.6, `drs_window = 0` per Art. 22.1(c)) and activates N28. It does **not** force the action: whether to pit under a neutralisation is race state, not a rule. See [Multi-agent system](#/multi-agent). |
 | `vsc_active` | bool | The active neutralisation is specifically a **Virtual** Safety Car (Art. 56), only meaningful when `sc_currently_active` is true. Split out (#471) because a VSC and a full SC differ in pit-time saving, and the Monte Carlo / N28 prompt need to tell them apart, the single `sc_currently_active` flag could not. `sc_active` (a derived property, not a stored field) is true only under a full SC: `sc_currently_active and not vsc_active`. |

--- a/docs/pages/arcade-dashboard.md
+++ b/docs/pages/arcade-dashboard.md
@@ -112,6 +112,8 @@ The arcade broadcasts one JSON dict per frame, roughly 10 Hz, as a newline-termi
         "pace":      { "lap_time_pred": 93.42, "ci_p10": 92.81, "ci_p90": 94.03 },
         "tire":      { "laps_to_cliff_p50": 12, "warning_level": "MONITOR" },
         "situation": { "overtake_prob": 0.42, "sc_prob_3lap": 0.11 },
+        // overtake_prob is null when the car ahead is farther than the 2.5s gap the
+        // model was trained on; the dashboards render that as "—", never as 0%.
         "pit":       { "action": "HOLD", "compound_recommendation": "C3" }
       },
       "reasoning_per_agent": { "pace": "...", "tire": "..." },

--- a/documents/audits/GATE_PR5_OVERTAKE.md
+++ b/documents/audits/GATE_PR5_OVERTAKE.md
@@ -1,0 +1,130 @@
+# GATE — PR5 overtake domain (adversarial audit)
+
+- **Date:** 2026-08-05
+- **Branches:** parent `fix/overtake-domain-gate` · submodule `src/telemetry` `fix/overtake-domain-nullable`
+- **Auditor role:** adversarial gate. Success = finding what is STILL broken. No repo file modified except this report.
+- **Prior context (not re-reported):** GATE_DATA_WIRING.md (F13 + N27 notes), GATE_801_ARTEFACTS.md §6, PR3_GP_KEYSPACE_SWEEP.md, PR4_PACE_INPUTS.md.
+
+## Checklist (claims to verify or refute)
+
+- [x] A. 2.5 s training bound — VERIFIED (model + calibrator + split, executed on artefact + `.nb_py`).
+- [x] B. 43.1% — re-derived EXACTLY (20,449 / 8,816 / 43.1% on the served frame); `rival_ahead` pure position lookup confirmed at both sites.
+- [x] C. `overtake_prob` never reaches MC / decision layer — VERIFIED by exhaustive sweep.
+- [x] D. Neutralisation override ordering — VERIFIED; None cannot leak past it.
+- [x] E. Band direction — structurally down-only; QUANTIFIED: ≤57 pairs lose a MEDIUM, 0 lose a HIGH (the PR does not carry the number).
+- [x] F. **REFUTED IN PART** — arithmetic matches, SERIES does not: 29.4% of in-domain pairs get a different rolling window than N12's rule; 81/38 pairs cross the MEDIUM/HIGH band between rules.
+- [x] G. -1 → LightGBM missing — VERIFIED executed (≡ NaN, ≠ cluster 0, no later fill).
+- [x] H. Parser — one real defect: cross-call field tearing (executed); "legit 0.000" attack killed by the calibrator floor (0.0018).
+- [x] I. Consumers — none crash; `reasoning_tabs.py` unlisted-but-safe; the real miss is the `/situation` route's unscoped frame the gate now rides on (MEDIUM).
+- [x] Bug-class hunt — stale twin docstring (`no_llm.py:156`), dead `pd.notna` guard over a NaN→0.0 sentinel collapse, residual 0.0 sentinels on gap/pace, unscoped-route sibling in the same file.
+- [x] Fixes audited as new code — `_pair_rolling_features` (the F finding), `_fmt_prob` (clean), `_lap_count` (pre-existing, correct), `__post_init__` (correct; NaN input would band LOW without crashing).
+
+## Findings
+
+<!-- appended as confirmed -->
+
+### Claim A — VERIFIED (executed)
+
+- `.nb_py/N11_overtake_eda.py:233-235`: `gap = abs(row_x["Time_s"] - row_y["Time_s"]); if gap > 2.5: continue` — the builder drops every pair beyond 2.5 s before labelling. Note the builder's gap is `abs(...)`; inference clamps `max(0.0, ...)` (equal for the normal positive case).
+- Artefact executed: `overtake_pairs_2023_2025.parquet` = **28,494 rows, max gap exactly 2.5, 0 rows beyond** (2023: 9,230 · 2024: 9,047 · 2025: 10,217).
+- **Calibrator**: `.nb_py/N12_overtake_model.py:655-657` — Platt `LogisticRegression` "fitted on val 2024", i.e. the 9,047 2024 rows of the same ≤2.5 s frame. **N12 split**: `temporal_split` (train 2023+2024 / test 2025) over `load_dataset(overtake_pairs_2023_2025.parquet)` — same frame. The 2.5 s bound therefore applies to the model, the calibrator AND the split. Claim A holds in full.
+
+### Claim B — VERIFIED (re-derived independently)
+
+Executed on the SERVED frame (`augment_featured_laps(laps_featured_2025, 2025)`, 22,760 rows, 24 GPs, 0 NaN in Time_s/LapTime_s), N11's pairing rule with no gap filter:
+- **20,449 position-adjacent pairs; 8,816 outside 2.5 s = 43.1%** — exactly the implementer's numbers.
+- Full-distribution median 2.06 s (matches their "median gap 2.06"). NOTE (LOW): their table line reads as if 2.06/9.11 describe the *outside* subset; the outside subset's own median is **5.16 s**, p90 **15.13 s**. The numbers they printed are of the full adjacent-pair distribution. Cosmetic, not load-bearing.
+- Runtime pairing rule verified in code: `run_from_state` (race_situation_agent.py:1595-1600) and `no_llm.py:172-176` both derive `rival_ahead` from `position == driver_pos - 1` with **no gap filter** — same population as the measurement. Claim B holds.
+
+### Claim C — VERIFIED (exhaustive sweep)
+
+`overtake_prob` grep across parent + submodule + tests + docs (full inventory executed): consumers are the N31 prompt (`strategy_orchestrator.py:1632-1633`), threat_level (`__post_init__`), CLI `_add_situation_row`, arcade `format_situation` + `reasoning_tabs._situation_lines` (`_pct(None)` → "—", pre-existing None-safe helper), arcade `strategy.py:736` `_dump_dataclass` (asdict → JSON null), backend `/situation` `_to_dict` (asdict), backend MCP `predict_situation` (`json.dumps`, null passes), webapp `strategy.ts`/`AgentTabs`/`SituationResultView`, chat `toolResultParsing.numOrUndef` (null → undefined → gauge skipped in `MetricsResult.tsx:64`). `_run_mc_simulation` consumes only `sc_prob_3lap` / `vsc_active` / `sc_currently_active` (strategy_orchestrator.py:1408, 1417); backend simulator stores `_sit_out` but nothing reads it. **No numeric path to the MC or decision layer.**
+
+### Claim D — VERIFIED (code path)
+
+`_run_core` (race_situation_agent.py:1731-1734): `raw_overtake_prob = None if parsed["overtake_prob"] is None else round(parsed["overtake_prob"], 3)`, then `effective_overtake_prob = 0.0 if is_neutralized else raw_overtake_prob` — the neutralisation branch selects the literal 0.0 regardless of None; a None can only pass on a green lap. The override note renders via `_fmt_prob` (line 1744), so no TypeError. Ordering: parse → override → construct. Holds.
+
+### Claim E — quantified (executed, the report does NOT carry this number)
+
+Scored all 8,816 out-of-domain 2025 pairs with the real model+calibrator (N12-style featureization; rolling over the unfiltered adjacent series — an approximation of the old serving path, see caveat):
+- calibrated p: min 0.002 · median 0.003 · **max 0.554**
+- **≥ high_overtake (0.65): 0 pairs** — the old path could never have produced a HIGH from an out-of-domain overtake (calibrator ceiling 0.7659 > 0.65, but the extrapolations top out at 0.554).
+- **≥ medium_overtake (0.40): 57 pairs (0.65% of out-of-domain)** — on those laps the old path could report MEDIUM where the new path reports LOW (unless the SC term independently raises it; medium_sc fires on 13.6% of laps). Direction of every change: DOWN. The report's "an unknown cannot RAISE the band" is true; what it does not say is that ~57 real 2025 laps LOSE a MEDIUM they used to get. That is the intended design (those MEDIUMs were extrapolations), but it is a real behavioural delta the PR text does not quantify.
+- In-domain reference: 8.10% ≥ 0.40, 3.34% ≥ 0.65.
+- Calibrator floor at raw=0: **0.001831 → prints as "0.002"** — a legitimate `P(overtake) = 0.000` string is unreachable, which kills one H attack (see below).
+
+### F — REFUTED IN PART (executed, measured on the served 2025 distribution)
+
+**Claim: "`pace_delta_rolling3` now reproduces N12's rule." It reproduces N12's *arithmetic* (min_periods=1, 2-lap windows, trend sign — verified identical on a clean continuous battle), but NOT N12's *series*. N12's rolling/diff run over the pair's LABELLED series — only laps that survived N11's builder (position-adjacent AND gap ≤ 2.5 AND non-NaN). `_pair_rolling_features` (race_situation_agent.py:455-482) runs over ALL laps where both drivers merely have rows.**
+
+- Synthetic proof (executed): pair freshly caught up, gaps 4.0/3.0/2.0 s over laps 8/9/10. Helper: `rolling3=-1.500, gap_trend=-1.000`. N12's rule (only lap 10 survives the builder → first row of the series): `rolling3=-2.000, gap_trend=0.000`. The divergence hits exactly the just-entered-the-domain battles — the laps the new domain gate makes freshly interesting.
+- Measured over all 11,633 in-domain 2025 adjacent pairs (battle series reconstructed per N11's rule, helper series per the code's rule, both re-scored through the real model+calibrator):
+  - rolling3 window content differs on **3,425 pairs (29.44%)**; gap_trend previous-lap differs on **2,109 (18.13%)**.
+  - |Δ rolling3| mean 0.113 s, p95 0.683 s, max 12.97 s; |Δ gap_trend| mean 0.323 s, p95 1.464 s, max 47.05 s.
+  - Calibrated |Δp|: mean 0.0062, p95 0.0294, **max 0.480**; >0.05 on 409 pairs (3.5%).
+  - **81 pairs cross the 0.40 MEDIUM band and 38 cross the 0.65 HIGH band between the two rules** — larger than the 57-pair effect the PR treats as the headline of claim E.
+- A second series defect folded in: after a position swap-back, the helper includes shared laps where x was AHEAD of y — `_pair_gap_seconds` clamps those to 0.0 (race_situation_agent.py:489) and they enter gap_trend; in N12's frame those laps do not exist for the (x,y) direction at all. N11's gap is also `abs(...)` where the helper clamps `max(0.0, ...)` — same number only when x is genuinely behind.
+- Also confirmed: a NaT LapTime on a shared window lap poisons rolling3 to NaN (no guard at :465-467) where N11's builder dropped such laps — **latent**: LapTime_s NaN = 0 in all three featured frames and the FastF1 path uses `pick_accurate()`.
+- Severity: **HIGH** as a refutation of the PR's stated claim; MEDIUM in mean served effect (0.0062). The fix is a large improvement over the array-position bug it replaced, but "reproduces N12's rule" is false for 3 in 10 scored pairs, and this is the same train/serve-skew class the fix itself was correcting.
+- Corollary: `tests/agents/test_overtake_domain.py:217-258` pins the HELPER's shared-lap series rule (its scenario asserts a trend diffed against a shared non-battle lap), so the test suite now protects the divergent rule; fixing the series rule will rightly require changing that test.
+
+### Claim G — VERIFIED (executed)
+
+Booster `pandas_categorical` = `[['C1'..'C6'], ['C1'..'C6'], [0, 1, 2, 3]]`. Casting `circuit_cluster=-1` with `pd.Categorical(..., categories=[0,1,2,3])` → `isna()=True`, and the prediction is **identical to an explicit NaN** (raw 0.3076 / cal 0.0180 for the probe row) and **different from cluster 0** (raw 0.4402 / cal 0.0472) — so -1 takes LightGBM's native missing path, not the old silent "cluster 0" path. `feat_df` goes straight from the cast to `predict_proba` (race_situation_agent.py:1339-1363) — no fillna in between, and the domain gate returns before the model for OOD pairs. Both call sites (`run` :1531 and `run_from_state` :1618-1624) carry the fix — no unfixed twin.
+
+### Claim H — parser: one real defect found (executed)
+
+- The marker string cannot match the overtake pattern (digits required after `= `) — verified: `[marker only]` → `overtake_prob=None`, gap/pace still parsed from the marker's own `gap=`/`pace_delta=` fields. Tool-never-ran and REFUSED paths also stay None.
+- `in (0.0, None)` preserves the old `== 0.0` semantics for the three 0.0-default keys (float `==` inside `in`).
+- **FINDING (MEDIUM-LOW) — cross-call field tearing.** Executed: messages `[SC, marker(gap=9.11, pace=0.300), scored(0.412, gap=1.20, pace=-0.150)]` parse to `{overtake_prob: 0.412, gap_ahead_s: 9.11, pace_delta_s: 0.3}` — the probability from the SECOND tool call paired with the gap and pace of the FIRST (declined) call. The old parser locked all three fields to the first call that carried numbers; the None default re-opens `overtake_prob` (and only it) for later messages, so a declined-then-scored sequence emits a `RaceSituationOutput` whose `overtake_prob` and `gap_ahead_s` describe DIFFERENT car pairs ("overtake 41% · gap 9.1s" on a dashboard). Reachable only in LLM mode when the ReAct agent calls `predict_overtake_tool` more than once (retry with another rival after a decline — plausible); the no-llm path makes exactly one call. `race_situation_agent.py:961`.
+- The "legitimate 0.000 overwritten by a second message" attack is REAL in code (executed: 0.000-then-0.412 → 0.412) but unreachable in practice: the calibrator floor is 0.001831, printed "0.002" — the tool can never print `P(overtake) = 0.000`. Pre-existing semantics for the other keys.
+
+### Bug-class findings
+
+- **(LOW, wrong-mechanism docstring — the unfixed twin of the parser docstring)** `src/strategy/inference/no_llm.py:156`: "predict_overtake_tool only when a rival ahead is derivable (**parser defaults overtake fields to 0.0 otherwise**)". False on this branch: the parser now defaults `overtake_prob` to None, and every P1/no-rival lap in no-llm mode now emits None (rendered "overtake —"), not 0.0. The module whose behaviour changed most (it drives `f1-sim --no-llm` and the backend simulator) still documents the old sentinel. Exactly the "comment naming the wrong mechanism" class.
+- **(LOW, guard that asserts nothing)** The new domain gate's `pd.notna(gap)` clause (race_situation_agent.py:1350) is dead code: `_build_overtake_features:1096` runs `gap_ahead_s = max(0.0, gap_ahead_s)` first, and `max(0.0, float('nan'))` returns **0.0** (executed) — a NaN gap is converted to a fabricated ZERO gap (in-domain, `drs_window=1` on a green lap) before the gate can see it. `(Timedelta - NaT).total_seconds()` → nan (executed), so the path exists in code. Unreachable on today's artefacts (LapTime_s NaN = 0 in all three featured frames — executed; FastF1 path uses `pick_accurate()`), but the guard documents a protection it does not provide, and the NaN→0.0 collapse is a sentinel collision waiting for the first artefact with a NaT lap.
+- **(INFO)** `src/arcade/dashboard/reasoning_tabs.py:132` is a consumer the PR's table does not list; it is None-safe by accident (`_pct(None)` → "—", a pre-existing helper). It renders a bare "—" without the "(out of model range)" context its sibling `agent_formatters.format_situation` now gives. Cosmetic inconsistency between the two arcade surfaces.
+- **(INFO)** The implementer's own admission checked: the `SituationResult` "would 500 like #788" claim was indeed false and is corrected in both the PR doc and the code comment (`backend/api/v1/endpoints/strategy.py:150-166` states it is documentation-only; verified — no route uses it as `response_model`, all seven declare `StrategyResponse`).
+- **(LOW, residual instance of the class the PR eliminates)** `gap_ahead_s` and `pace_delta_s` keep their 0.0 parse defaults (race_situation_agent.py:944-946). On a lap with no rival ahead (P1, or roster gap), the output carries `overtake —` next to a fabricated `gap 0.0s · Δpace +0.00s/lap` on the arcade wall (`format_situation` renders both unconditionally, agent_formatters.py:211-224) — 0.0 is a findable real gap, so "never measured" and "genuinely nose-to-tail" are the same pixel. Deliberate scope choice per the PR's own docstring ("the other three default to 0.0, unchanged"), but it is the same sentinel pattern one field over.
+
+### MEDIUM — the new domain gate runs on the WRONG RACE for every webapp Model Lab / strategy-tab call (pre-existing scoping defect the gate now rides on)
+
+- `POST /situation` (`backend/api/v1/endpoints/strategy.py:1141-1155`) hands `run_race_situation_agent_from_state` the FULL season frame from `require_laps_df(year)` (`backend/utils/laps_cache.py:44-55`, all 24 races). `run_from_state` does not scope by GP (`race_situation_agent.py:1602`: `self.laps_df = _ensure_timedelta_laps(laps_df)`), and `predict_overtake_tool` looks rows up by `(Driver, LapNumber)` only (:1312-1317).
+- Executed: on the augmented 2025 season frame, `(VER, lap 20)` matches **21 rows across 21 GPs and `iloc[0]` picks Austin** — frame order, not the user's GP. Same for NOR. So a Model Lab "Situation" run for Qatar computes the gap — and therefore the new UNKNOWN/scored decision, plus every other N12/N14 feature — from **Austin's** telemetry. The webapp surfaces this PR carefully made None-aware (`SituationResultView`, `AgentTabs`) render an honest-looking "No prediction / n/a (beyond 2.5s)" that was measured on another circuit.
+- Root cause predates this branch (the scoping lesson landed at `run_lap` and `/recommend`; the per-agent POST routes never got it), and the same file CONTAINS the fix pattern with an explanatory comment for the tyre-eval route (`strategy.py:1019-1026` scopes `gp_df` citing `_scope_laps_to_gp` #429/#480) — the classic one-sibling-fixed-in-the-same-file. The CLI/arcade/no-llm paths are scoped upstream and unaffected. Not re-reported from prior context: none of GATE_DATA_WIRING F13, GATE_801 §6, PR3, PR4 covers route-level row scoping.
+
+---
+
+## Findings ranked
+
+| # | Sev | Finding | Where |
+|---|-----|---------|-------|
+| 1 | HIGH (claim) / MEDIUM (mean effect) | "`pace_delta_rolling3` now reproduces N12's rule" is false for the SERIES: helper rolls over shared laps, N12 over labelled battle laps. 29.44% of in-domain 2025 pairs get a different window; 18.13% a different gap_trend base; calibrated Δp max 0.480; 81 pairs cross the 0.40 band, 38 the 0.65 band. Hits hardest exactly on freshly-caught-up battles. | `src/agents/race_situation_agent.py:455-482` |
+| 2 | MEDIUM | The new domain gate (and every N27 feature) is computed from the WRONG RACE on the webapp per-agent routes: `/situation` passes the unscoped 24-race frame and `(Driver, LapNumber)` lookups resolve to the first GP in frame order (executed: always Austin). Pre-existing defect; this branch's advertised webapp behaviour rides on it, and the scoped sibling with the explanatory comment sits in the same file. | `src/telemetry/backend/api/v1/endpoints/strategy.py:1141-1155` + `race_situation_agent.py:1602` |
+| 3 | MEDIUM-LOW | Parser cross-call field tearing: a declined first overtake call locks gap/pace to pair 1 while the None default lets a second call's probability through — output mixes two car pairs. LLM-mode only (needs 2 tool calls). | `src/agents/race_situation_agent.py:961` |
+| 4 | LOW | Stale twin docstring: `no_llm.py` still says "parser defaults overtake fields to 0.0 otherwise" — the exact mechanism this branch changed, in the module that drives `f1-sim --no-llm` and the backend simulator. | `src/strategy/inference/no_llm.py:156` |
+| 5 | LOW | Dead guard + sentinel collapse: `pd.notna(gap)` in the gate can never see NaN because `max(0.0, nan)` → 0.0 upstream turns an unknown gap into a fabricated zero (in-domain, DRS open). Latent today (0 NaN lap times in all featured frames; FastF1 path picks accurate). | `race_situation_agent.py:1096, 1350` |
+| 6 | LOW | Residual sentinel: `gap_ahead_s` / `pace_delta_s` keep 0.0 defaults, so "never measured" renders as `gap 0.0s` beside the honest `overtake —`. Deliberate scope choice, same class one field over. | `race_situation_agent.py:944-946` |
+| 7 | LOW | PR table's "median gap 2.06 s, p90 9.11 s" describes the FULL adjacent-pair distribution, not the outside subset (whose median is 5.16 s, p90 15.13 s). | `documents/audits/PR5_OVERTAKE_DOMAIN.md` |
+| 8 | INFO | `reasoning_tabs._situation_lines` is an unlisted consumer, safe by accident (`_pct(None)` → "—"), but renders no "(out of model range)" context, unlike its arcade sibling. | `src/arcade/dashboard/reasoning_tabs.py:132` |
+
+## Fix list (by value, then risk)
+
+1. **Scope the per-agent webapp routes to the request's GP** before calling `run_*_from_state` (`/situation`, `/pace`, `/pit`, `/tire`, `/radio` in `backend/api/v1/endpoints/strategy.py`) — reuse the `gp_df` pattern already present at :1019-1026 with the same guard rules as `_scope_laps_to_gp`. Fixes finding 2 and makes every Model Lab number mean what the page says.
+2. **Restrict `_pair_rolling_features` to the pair's BATTLE series**: keep only shared laps that were position-adjacent with gap ≤ 2.5 (and drop NaT laps, mirroring N11's dropna). Fixes finding 1; update `test_the_rolling_window_pairs_by_lap_number_not_by_array_position` to the battle-series expectation, and re-run the Lusail parity check.
+3. **Close the parser tearing window**: parse gap/pace only from the message whose overtake field was accepted (or lock all three fields together per message). Fixes finding 3.
+4. **Update `no_llm.py:156`** to say the parser now yields None when the tool declines or is not called. One line. Fixes finding 4.
+5. **Move the NaN honesty up**: replace `max(0.0, gap_ahead_s)` with a NaN-preserving clamp so the gate's `pd.notna` branch actually protects (declining or NaN-scoring instead of fabricating a 0.0 gap with DRS open). Fixes finding 5.
+6. Optional: give `reasoning_tabs` the same "(out of model range)" wording as `format_situation`; correct the PR doc's median/p90 sentence.
+
+## What I tried to break and could NOT
+
+- **The parse of the marker string**: the overtake regex cannot match "UNKNOWN" (digits required); gap/pace still parse from the marker; REFUSED and never-called paths stay None. Executed.
+- **A legitimate `P(overtake) = 0.000` being overwritten**: unreachable — the Platt floor is 0.001831, printed "0.002". Executed.
+- **The neutralisation override with a declined model**: the ternary picks the literal 0.0 regardless of None; `_fmt_prob` renders the note; ordering parse → override → construct is airtight. Code-verified at :1731-1757.
+- **`__post_init__` raising the band on an unknown, or suppressing SC terms**: structurally impossible (a term removed from an OR chain); executed over the branch's own tests (13/13 pass) and the SC-term cases; also fed it NaN — bands LOW, no crash.
+- **A consumer crashing on None**: swept every consumer in parent + submodule + tests (CLI row, arcade formatter + reasoning tabs + TCP stream via asdict/JSON null, backend `_to_dict`, MCP `json.dumps`, webapp strategy.ts/AgentTabs/SituationResultView/chat `numOrUndef`, MC layer, no-llm engine). None does arithmetic/format on it unguarded. The MC provably never reads it (`_run_mc_simulation` consumes only `sc_prob_3lap`/`vsc_active`/`sc_currently_active`).
+- **The -1 sentinel resolving to a real cluster**: cast → NaN ≡ explicit NaN, ≠ cluster 0, no downstream fill. Executed against the real booster.
+- **The helper's min_periods / 2-lap-window / trend-sign arithmetic**: matches N12 exactly on a clean continuous battle (executed parity check F3), and the helper's fallback path (`no shared laps`) is unreachable from the tool (current lap always shared) but returns N12's min_periods=1 semantics anyway.
+- **The 43.1% measurement**: re-derived independently on the served frame — same numbers to the digit (20,449 / 8,816 / 43.1%).
+- **ruff on the changed files**: green. **Webapp `tsc --noEmit`**: 0 errors. **Branch tests**: 13/13. Executed.

--- a/documents/audits/PR5_OVERTAKE_DOMAIN.md
+++ b/documents/audits/PR5_OVERTAKE_DOMAIN.md
@@ -1,0 +1,128 @@
+# PR 5 — the overtake model has a domain, and it now says so
+
+**Date:** 2026-08-05 · Extends `GATE_DATA_WIRING.md` F13 and its N27 notes, and
+`GATE_801_ARTEFACTS.md` §6. Those are dated findings and stay as written.
+
+## The defect
+
+N11's pair builder **drops every pair more than 2.5 s apart before labelling** — "not an
+active battle" (`.nb_py/N11_overtake_eda.py:233-235`). The model has no labelled example
+beyond it. `predict_overtake_tool` had a lap-range guard and a roster guard but **no gap
+guard**, so `_build_overtake_features` built a 9-second-gap row and LightGBM extrapolated.
+
+### Re-measured rather than quoted
+
+| | pairs | outside the domain |
+|---|---|---|
+| this sweep, 2025, N11's own pairing rule | 20,449 | **8,816 (43.1%)**, median gap 2.06 s, p90 9.11 s, max 91.1 s |
+| the earlier gate | 25,215 | 10,565 (41.9%) |
+
+The denominators differ — a differently filtered starting frame — and the magnitude does
+not. Four in ten "can I pass the car ahead?" questions were answered from outside the
+training set. The labelled artefact settles the bound directly: `overtake_pairs_2023_2025`
+holds 28,494 rows, **max gap exactly 2.500, zero rows beyond**.
+
+### Why this one is worse than a noisy number
+
+`overtake_prob` does **not** reach the Monte Carlo. Traced: it reaches `threat_level`, the
+**N31 prompt**, and the dashboards. An invented probability there is not averaged away, it
+is *argued from* by the model writing the recommendation. And `overtake_prob` is **not** one
+of the 14 fields of the frozen `StrategyRecommendation` contract, so widening it breaks no
+frozen surface.
+
+## The treatment, and why not the other two
+
+Víctor's call, taken before any code was written: **`None` plus an explicit label**.
+
+- **Label only** (the #710 envelope pattern) was the precedent, but #710 labels a *feature*
+  fed to a regressor. This is a *probability* fed to a prompt: labelling it and passing the
+  number anyway leaves the LLM the extrapolation to reason from.
+- **Clamp to 0.0** was rejected for the reason two other fixes in this batch were made: a
+  car 9 s ahead is not one you *cannot* pass, it is one the model has never been shown. And
+  0.0 already means something else here — see below.
+
+### `None` is not `0.0`, and that distinction is the design
+
+Under a neutralisation, `overtake_prob = 0.0` is asserted by the **regulation** (Art. 55.8
+bans overtaking; 56.6 under a VSC), and `_run_core` sets exactly that. Leaving the
+no-answer case on 0.0 made "the rules forbid it" and "the model has no idea" the same
+number to every consumer downstream.
+
+So the neutralisation override still applies **whether or not the model answered** —
+regulation beats absence — while an unscored pair on a green lap keeps its `None`.
+
+## What changed
+
+| site | before | after |
+|---|---|---|
+| `predict_overtake_tool` | scored any gap | returns `P(overtake) = UNKNOWN (gap X.XXs beyond N11's trained 2.5s domain)`; `gap` and `pace_delta` stay, they are measurements |
+| `_parse_tool_outputs` | defaulted `overtake_prob` to **0.0** | defaults to `None` — the trap: with no number in the string, the old default would have quietly produced a real zero |
+| `RaceSituationOutput.overtake_prob` | `float` | `Optional[float]` |
+| `threat_level` | `None` would raise on `>=` | an unknown cannot RAISE the band, and does not suppress the SC terms |
+| N31 prompt | `overtake={p:.2f}` | `overtake=unknown (cars farther apart than the model's trained range)` |
+| `run_simulation_cli._add_situation_row` | `float(getattr(..., 0.0))` → **TypeError** | renders `overtake —` |
+| arcade `format_situation` | `or 0.0` → "overtake 0%" | `overtake — (out of model range)` |
+| backend `SituationResult` | `overtake_prob: float` | `Optional[float]` — documentation only, see below |
+| webapp `SituationResult` | `number` | `number \| null` |
+| webapp `AgentTabs` | `?? 0` → a dial reading 0% | an `n/a` placeholder |
+| webapp `SituationResultView` | unguarded → JS coerces null to a confident "0%" | a "No prediction" panel |
+| 4 doc surfaces | declared a plain float | declare the nullability |
+
+`getattr(obj, name, default)` does **not** substitute for a present-but-None attribute. That
+is the third form of this trap the project has now hit, after `dict.get` and `Series.get`,
+and it is what made 35 of 57 Lusail laps error on the first real run of this branch.
+
+### Two contracts, and one claim of mine that was wrong
+
+They are different things and this document originally blurred them:
+
+- **`StrategyRecommendation`, the frozen 14-field contract** (N31's output). Verified by
+  reading `model_fields`: `action, reasoning, confidence, pit_lap_target, compound_next,
+  undercut_target, pace_mode, target_lap_time_s, risk_posture, contingencies, key_risks,
+  expected_stint_end, scenario_scores, regulation_context`. **`overtake_prob` is not among
+  them**, so nothing frozen moved.
+- **`SituationResult`, the backend model.** It declares the field, and it is **not wired as
+  a `response_model` anywhere** — all seven routes in that file declare `StrategyResponse`,
+  whose `result` is `Dict[str, Any]`.
+
+The comment first written on that change said the old `float` would turn every out-of-domain
+lap into a 500, "the same way #788 did". **That was false**: nothing validates against this
+class, so it could not 500. The change is still right — it is the shape the webapp's
+TypeScript mirrors by hand, and a declaration that lies about nullability is how the first
+route to adopt it for real inherits the 500 — but the stated mechanism was not the
+mechanism, which is the defect class this repo already has a name for.
+
+## Two siblings fixed alongside, both measured first
+
+**`pace_delta_rolling3` paired the two cars by array position.** The earlier gate flagged
+this as "a rule difference with a bounded trigger. Not measured." It is measured now:
+**10.78% of adjacent pairs (2,158 of 20,012)** have windows holding different laps, because
+the featured frame drops pit, out and safety-car laps per driver.
+
+And the rule itself was not "pair by LapNumber": N12 takes
+`groupby(PAIR_KEYS).pace_delta_s.rolling(3, min_periods=1).mean()` over **the pair's own
+series** (`.nb_py/N12_overtake_model.py:141-146`), with `gap_trend` as `.diff()` of the
+pair's gap series. Inference computed a different quantity. `gap_trend` shared the same
+window and is corrected with it rather than left as the next instance of the twin.
+
+**The unknown-circuit sentinel was `0`, a real cluster.** N11's is `-1`. The booster's
+trained levels are `[0,1,2,3]`, so `-1` becomes the missing value LightGBM handles natively.
+Latent — every race resolves today — but it was a live collision waiting for a keyspace miss.
+
+**A prompt line that gave the LLM the wrong reason.** `_run_core` told the model "No car is
+within overtaking range (gap > 2.5s)" whenever `rival_ahead` was None. That value comes from
+a **position lookup with no gap filter at all**: it is None when the driver is leading, when
+the car ahead is missing from the timing feed, or when our own position is unknown. Never
+because of a gap. Corrected to say what is actually true.
+
+## Verification
+
+- `tests/agents/test_overtake_domain.py`, 13 tests. The domain bound is **re-derived from
+  the labelled artefact**, not asserted against the constant. One test pins that the gate is
+  not vacuous (it fires on four pairs in ten); another pins that an unknown does not
+  *suppress* the safety-car path, which a lazy "return LOW when missing" fix would break.
+- `ruff check` + `ruff format --check` green; `mypy src/rag/` green; webapp `tsc --noEmit`
+  exit 0, 0 errors.
+- Real `f1-sim` on Lusail: **all 57 laps OK**, `STAY_OUT·53 PIT_NOW·1 UNDERCUT·3` —
+  identical to the `dev` baseline. The gate corrects the inputs without moving the decisions
+  on that race.

--- a/documents/audits/PR5_OVERTAKE_DOMAIN.md
+++ b/documents/audits/PR5_OVERTAKE_DOMAIN.md
@@ -14,7 +14,7 @@ guard**, so `_build_overtake_features` built a 9-second-gap row and LightGBM ext
 
 | | pairs | outside the domain |
 |---|---|---|
-| this sweep, 2025, N11's own pairing rule | 20,449 | **8,816 (43.1%)**, median gap 2.06 s, p90 9.11 s, max 91.1 s |
+| this sweep, 2025, N11's own pairing rule | 20,449 (median gap 2.06 s, p90 9.11 s) | **8,816 (43.1%)** — of THOSE, median 5.16 s, p90 15.13 s, max 91.1 s |
 | the earlier gate | 25,215 | 10,565 (41.9%) |
 
 The denominators differ — a differently filtered starting frame — and the magnitude does
@@ -104,6 +104,26 @@ And the rule itself was not "pair by LapNumber": N12 takes
 series** (`.nb_py/N12_overtake_model.py:141-146`), with `gap_trend` as `.diff()` of the
 pair's gap series. Inference computed a different quantity. `gap_trend` shared the same
 window and is corrected with it rather than left as the next instance of the twin.
+
+### The first version of that fix was itself skewed, and the gate refuted it
+
+Pairing by LapNumber corrected the arithmetic and left a second, subtler train/serve skew —
+**the same class the fix was correcting.** N12's rows are N11's LABELLED pairs, and N11 only
+emits a row when the cars are position-adjacent **and** within 2.5 s. A lap where the pair
+existed but sat 4 s apart, or where they had swapped order, is simply not in the series N12
+rolled over. The first version rolled over every lap where both cars merely had a row.
+
+Measured by the gate over the 11,633 in-domain 2025 pairs, both rules re-scored through the
+real model and calibrator: the window content differed on **29.44%**, the `gap_trend` base on
+**18.13%**, calibrated |Δp| max **0.480**, and **81 pairs crossed the MEDIUM band, 38 the
+HIGH band** — larger than the 57-pair effect this report had treated as its headline. It bit
+hardest on battles that had just closed up, which is exactly what the domain gate makes
+interesting.
+
+`_battle_series` now reconstructs N11's membership test term for term. The gap helper also
+switched from the caller's `max(0.0, ...)` clamp to N11's `abs(...)`: with adjacency asserted
+separately the two are equal, and the clamp was turning a swapped-order lap into a fabricated
+zero-second gap.
 
 **The unknown-circuit sentinel was `0`, a real cluster.** N11's is `-1`. The booster's
 trained levels are `[0,1,2,3]`, so `-1` becomes the missing value LightGBM handles natively.

--- a/scripts/run_simulation_cli.py
+++ b/scripts/run_simulation_cli.py
@@ -861,15 +861,22 @@ def _add_situation_row(tbl: Table, sit_out) -> None:
     and "safety car") to kill the OT/SC jargon that made the v1 row
     unreadable at first glance.
     """
-    ot = float(getattr(sit_out, "overtake_prob", 0.0)) * 100
-    sc = float(getattr(sit_out, "sc_prob_3lap", 0.0)) * 100
+    # `getattr(obj, name, default)` only substitutes when the ATTRIBUTE IS ABSENT, never
+    # when it is present holding None — the same trap as dict.get and Series.get, which
+    # this project has now hit in all three forms. N27 reports None for a pair beyond the
+    # overtake model's trained range, so `float(...)` raised here on 35 of 57 Lusail laps.
+    _ot = getattr(sit_out, "overtake_prob", None)
+    ot = None if _ot is None else float(_ot) * 100
+    sc = float(getattr(sit_out, "sc_prob_3lap", None) or 0.0) * 100
     th = getattr(sit_out, "threat_level", "LOW")
 
     glyph, g_col = _glyph_for(th)
     headline = Text(f"threat {th}", style=f"bold {g_col}")
 
     ctx = Text()
-    ctx.append(f"overtake {ot:.0f}%", style=COL_DIM)
+    # An em dash, not "0%": the model declining to answer and the model saying there is no
+    # chance would send the strategist in opposite directions.
+    ctx.append("overtake —" if ot is None else f"overtake {ot:.0f}%", style=COL_DIM)
     ctx.append(
         f"  safety car {sc:.0f}%",
         style=COL_WATCH if sc > 15 else COL_DIM,

--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -39,11 +39,17 @@ at a page that no longer exists. See
 |---|---|---|
 | N25 | `PaceOutput` | `lap_time_pred`, `ci_p10`, `ci_p90`, `delta_vs_prev`, `reasoning` |
 | N26 | `TireOutput` | `laps_to_cliff_p10/p50/p90`, `warning_level`, `deg_rate`, `reasoning` |
-| N27 | `RaceSituationOutput` | `overtake_prob`, `sc_prob_3lap`, `threat_level`, `reasoning` |
+| N27 | `RaceSituationOutput` | `overtake_prob` (nullable — see below), `sc_prob_3lap`, `threat_level`, `reasoning` |
 | N28 | `PitStrategyOutput` | `action`, `compound_recommendation`, `stop_duration_p05/p50/p95`, `undercut_prob`, `reasoning` |
 | N29 | `RadioOutput` | `radio_events`, `rcm_events`, `alerts`, `reasoning`, `corrections` |
 | N30 | `RegulationContext` | `answer`, `articles`, `chunks`, `.reasoning` (alias for answer) |
 | N31 | `StrategyRecommendation` | `action`, `reasoning`, `confidence`, `scenario_scores`, `regulation_context` |
+
+**N27's `overtake_prob` is `float | None`.** N11 dropped every training pair more than 2.5 s
+apart before labelling, so the model has no labelled example beyond that gap — 43.1% of real
+position-adjacent pairs in 2025. There it returns `None` rather than an extrapolation. `None`
+is not `0.0`: zero is the value the regulation asserts under a Safety Car (Art. 55.8), and
+consumers have to tell the two apart.
 
 ---
 

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -97,6 +97,27 @@ _EXCLUDE_RE = r"TRACK LIMITS|LAP TIME|PENALTY|PIT LANE|FORMATION|GRID|DRS|SAFETY
 _SC_DEPLOY_EVENT_TYPES: frozenset[str] = frozenset({"SAFETY_CAR_DEPLOYED"})
 _VSC_DEPLOY_EVENT_TYPES: frozenset[str] = frozenset({"VIRTUAL_SAFETY_CAR_DEPLOYED"})
 
+# ── N11's trained domain ──────────────────────────────────────────────────────
+# N11's pair builder DROPS every pair more than 2.5 s apart before labelling — "not an
+# active battle" (`.nb_py/N11_overtake_eda.py:233-235`). The model therefore has no
+# labelled example beyond it, and a probability returned out there is whatever leaf the
+# extrapolation lands in, not an estimate.
+#
+# Measured over all 24 races of 2025 with N11's own pairing rule: 8,816 of 20,449
+# position-adjacent pairs (43.1%) sit outside it, median gap 2.06 s, p90 9.11 s. Four in
+# ten "can I pass the car ahead?" questions were answered from outside the training set.
+_TRAINED_MAX_GAP_S: float = 2.5
+
+# What the tool says instead of a number when it is asked outside that domain. Parsed back
+# by `_parse_tool_outputs`, which must map it to None rather than to its 0.0 default: an
+# unknown probability and a zero one are different claims, and the second is what the
+# regulation asserts under a Safety Car (Art. 55.8).
+_OUT_OF_DOMAIN_MARKER: str = "UNKNOWN"
+
+# N11's unknown-circuit code (`.nb_py/N11_overtake_eda.py:210-212`). Distinct from cluster
+# 0, which is a real kind of track.
+_UNKNOWN_CIRCUIT_CLUSTER: int = -1
+
 # SC release. Art. 55.15's "SAFETY CAR IN THIS LAP" (the real message, which classifies
 # to SAFETY_CAR_ENDING — verified on Qatar 2025 L10 and Spain 2025 L60) means the car
 # enters the pits at the END of that lap, and Art. 55.8 forbids overtaking until the
@@ -328,7 +349,12 @@ class RaceSituationOutput:
             VSC apart from a full SC, which the single flag could not (#471).
     """
 
-    overtake_prob: float
+    # Optional because N11 has a domain and this says so. None means the pair sat farther
+    # apart than any labelled example the model ever saw (43.1% of real adjacent pairs in
+    # 2025), so there is no probability to report — as opposed to 0.0, which under a
+    # Safety Car is a REGULATION FACT (Art. 55.8) rather than an absence. Every consumer
+    # has to tell those two apart, which is the point.
+    overtake_prob: Optional[float]
     sc_prob_3lap: float
     threat_level: str = field(init=False)
     gap_ahead_s: float = 0.0
@@ -338,13 +364,24 @@ class RaceSituationOutput:
     vsc_active: bool = False  # the active neutralisation is specifically a VSC (Art. 56)
 
     def __post_init__(self) -> None:
+        """Band the threat, treating an unknown overtake probability as no evidence.
+
+        An unknown cannot RAISE the band: the alternative is to keep classifying on the
+        extrapolated number, which is how a model's uninformed guess ends up presented to
+        N31 as a threat. It cannot lower it either — the SC terms and the live
+        neutralisation flag are evaluated exactly as before.
+        """
+        overtake_known = self.overtake_prob is not None
+
         if (
             self.sc_currently_active
-            or self.overtake_prob >= CFG.high_overtake
+            or (overtake_known and self.overtake_prob >= CFG.high_overtake)
             or self.sc_prob_3lap >= CFG.high_sc
         ):
             self.threat_level = "HIGH"
-        elif self.overtake_prob >= CFG.medium_overtake or self.sc_prob_3lap >= CFG.medium_sc:
+        elif (
+            overtake_known and self.overtake_prob >= CFG.medium_overtake
+        ) or self.sc_prob_3lap >= CFG.medium_sc:
             self.threat_level = "MEDIUM"
         else:
             self.threat_level = "LOW"
@@ -374,6 +411,129 @@ def _abs_compound(relative: str, gp_name: str, year: int) -> str:
     year_data = TIRE_COMPOUNDS.get(str(year), {})
     gp_data = year_data.get(resolve_gp_key(year_data, gp_name), {})
     return gp_data.get(relative.upper(), relative)
+
+
+def _fmt_prob(value: Optional[float]) -> str:
+    """A probability for human text, or the out-of-domain marker when there is none.
+
+    Exists because `f"{value:.2f}"` raises TypeError on None, and every place that renders
+    this probability into prose — the RCM override note, the N31 prompt, the dashboards —
+    would otherwise have to remember that. One helper beats four remembering.
+    """
+    return _OUT_OF_DOMAIN_MARKER if value is None else f"{value:.2f}"
+
+
+def _pair_rolling_features(
+    laps_recent: pd.DataFrame,
+    driver_x: str,
+    driver_y: str,
+    lap_number: float,
+    gap_ahead_s: float,
+    pace_delta_s: float,
+) -> tuple[float, float]:
+    """N12's ``pace_delta_rolling3`` and ``gap_trend``, over the pair's BATTLE series.
+
+    Both are properties of the battle, not of either car. N12 groups by the pair key,
+    sorts by LapNumber, and takes `rolling(3, min_periods=1).mean()` of that pair's
+    per-lap `pace_delta_s`, with `gap_trend` as `.diff()` of the pair's gap series
+    (`.nb_py/N12_overtake_model.py:141-146`).
+
+    THE SERIES IS THE HARD PART, AND IT TOOK TWO GOES
+    ------------------------------------------------
+    Inference originally took each DRIVER's last three lap times as two arrays and
+    subtracted them by array POSITION, which is a different quantity whenever the two
+    windows hold different laps (10.78% of 2025 adjacent pairs). Replacing that with a
+    LapNumber pairing fixed the arithmetic and left a second, subtler skew: it rolled over
+    every lap where both cars merely have a row.
+
+    N12's rows are the LABELLED pairs, and N11's builder only emits a row when the two cars
+    are position-adjacent AND within 2.5 s (`.nb_py/N11_overtake_eda.py:228-235`). So a lap
+    where the pair existed but was 4 s apart, or where they had swapped order, is simply
+    NOT in the series N12 rolled over. Measured: 29.44% of in-domain 2025 pairs got a
+    different window that way, moving the calibrated probability by up to 0.480 and pushing
+    81 pairs across the MEDIUM band. It bit hardest on battles that had just closed up —
+    exactly the ones the domain gate makes interesting.
+
+    So this reconstructs N11's membership rule, not merely a shared-lap window.
+
+    Without a ``Position`` column the membership cannot be reconstructed at all, and the
+    honest answer is the one N12 gives for the first row of a series (`min_periods=1`): the
+    current lap alone. Guessing a longer history from shared laps is what this docstring
+    exists to warn against.
+    """
+    series = _battle_series(laps_recent, driver_x, driver_y, lap_number)
+    if not series:
+        return pace_delta_s, 0.0
+
+    laps = sorted(series)
+    window = laps[-3:]
+    rolling = float(sum(series[lap]["pace_delta"] for lap in window) / len(window))
+
+    # `.diff()` against the previous BATTLE lap, which is not necessarily lap-1: if the
+    # pair fell out of the domain for two laps and closed up again, N12's series skips
+    # those rows and the diff spans them.
+    trend = 0.0
+    if len(laps) >= 2:
+        current, previous = series[laps[-1]]["gap"], series[laps[-2]]["gap"]
+        if pd.notna(current) and pd.notna(previous):
+            trend = current - previous
+    return rolling, trend
+
+
+def _battle_series(
+    laps_recent: pd.DataFrame, driver_x: str, driver_y: str, lap_number: float
+) -> dict[float, dict[str, float]]:
+    """The laps N11 would have emitted a labelled row for, keyed by LapNumber.
+
+    N11's membership test, term for term: both cars present, x directly behind y on
+    position, gap within the trained bound, and the timing columns actually populated (its
+    builder drops the NaN rows before pairing).
+    """
+    if "Position" not in laps_recent.columns:
+        return {}
+
+    both = laps_recent[laps_recent["Driver"].isin([driver_x, driver_y])]
+    window = both[both["LapNumber"] <= lap_number]
+
+    series: dict[float, dict[str, float]] = {}
+    for lap, rows in window.groupby("LapNumber"):
+        x_rows = rows[rows["Driver"] == driver_x]
+        y_rows = rows[rows["Driver"] == driver_y]
+        if x_rows.empty or y_rows.empty:
+            continue
+        x, y = x_rows.iloc[0], y_rows.iloc[0]
+
+        if not (pd.notna(x.get("Position")) and pd.notna(y.get("Position"))):
+            continue
+        if float(x["Position"]) != float(y["Position"]) + 1:
+            continue  # not adjacent, or they had swapped order on this lap
+        if not (pd.notna(x.get("LapTime")) and pd.notna(y.get("LapTime"))):
+            continue
+
+        gap = _pair_gap_seconds(x, y)
+        if not pd.notna(gap) or gap > _TRAINED_MAX_GAP_S:
+            continue  # N11 dropped it: "not an active battle"
+
+        series[float(lap)] = {
+            "pace_delta": float((x["LapTime"] - y["LapTime"]).total_seconds()),
+            "gap": gap,
+        }
+    return series
+
+
+def _pair_gap_seconds(row_x: pd.Series, row_y: pd.Series) -> float:
+    """One battle lap's gap, by N11's rule.
+
+    `abs`, matching `.nb_py/N11_overtake_eda.py:233`, NOT the `max(0.0, ...)` the caller
+    applies to the current lap: a clamp turns a negative gap into a fabricated zero, and
+    the caller's version is only safe because end-of-lap order guarantees the sign for an
+    adjacent pair. Here the adjacency is asserted separately, so the honest absolute is
+    both correct and equal to it.
+    """
+    t_x, t_y = row_x.get("Time"), row_y.get("Time")
+    if pd.notna(t_x) and pd.notna(t_y):
+        return abs(float((t_x - t_y).total_seconds()))
+    return float("nan")
 
 
 def _lap_count(lap: pd.Series, column: str) -> float:
@@ -813,22 +973,55 @@ def _parse_tool_outputs(messages: list) -> dict:
 
     Returns:
         Dict with: overtake_prob, sc_prob_3lap, gap_ahead_s, pace_delta_s.
-        Missing fields default to 0.0.
+        ``overtake_prob`` is None when the tool declined to answer — the pair sat outside
+        N11's trained gap domain, or the tool was never called. The other three default
+        to 0.0, unchanged.
+
+    WHY overtake_prob IS THE ONE THAT CAN BE None
+    ---------------------------------------------
+    0.0 is not a neutral placeholder for it: it is the value the REGULATION asserts under
+    a Safety Car (Art. 55.8 bans overtaking), and `_run_core` sets exactly that. Leaving
+    the no-answer case on 0.0 made "the rules forbid it" and "the model has no idea"
+    the same number to every consumer downstream, which is the sentinel collision this
+    repo keeps re-finding. They are different claims and they now look different.
     """
-    result = {"overtake_prob": 0.0, "sc_prob_3lap": 0.0, "gap_ahead_s": 0.0, "pace_delta_s": 0.0}
+    result: dict[str, Optional[float]] = {
+        "overtake_prob": None,
+        "sc_prob_3lap": 0.0,
+        "gap_ahead_s": 0.0,
+        "pace_delta_s": 0.0,
+    }
+    overtake_taken = False
+
     for msg in messages:
         content = getattr(msg, "content", "")
         if not isinstance(content, str):
             continue
-        for pattern, key in [
-            (r"P\(overtake\)\s*=\s*(\d+(?:\.\d+)?)", "overtake_prob"),
-            (r"P\(SC 3-lap\)\s*=\s*(\d+(?:\.\d+)?)", "sc_prob_3lap"),
-            (r"gap=([\d.]+)s", "gap_ahead_s"),
-            (r"pace_delta=([-\d.]+)s/lap", "pace_delta_s"),
-        ]:
-            m = re.search(pattern, content)
-            if m and result[key] == 0.0:
-                result[key] = float(m.group(1))
+
+        # The three overtake fields are read TOGETHER, from the first message that carries
+        # an overtake verdict, and then locked. Field-by-field first-match-wins was safe
+        # only while every call produced a number: now that a call can DECLINE, a declined
+        # first call would leave the probability open while its gap and pace_delta had
+        # already been taken, and a second call about a DIFFERENT pair of cars would fill
+        # the hole. The reported gap would then describe one battle and the probability
+        # another. Only reachable in LLM mode, where the agent may call the tool twice.
+        if not overtake_taken and "P(overtake)" in content:
+            overtake_taken = True
+            # No digits in the out-of-domain string, so this stays None by construction.
+            probability = re.search(r"P\(overtake\)\s*=\s*(\d+(?:\.\d+)?)", content)
+            if probability:
+                result["overtake_prob"] = float(probability.group(1))
+            for pattern, key in (
+                (r"gap=([\d.]+)s", "gap_ahead_s"),
+                (r"pace_delta=([-\d.]+)s/lap", "pace_delta_s"),
+            ):
+                match = re.search(pattern, content)
+                if match:
+                    result[key] = float(match.group(1))
+
+        sc = re.search(r"P\(SC 3-lap\)\s*=\s*(\d+(?:\.\d+)?)", content)
+        if sc and result["sc_prob_3lap"] == 0.0:
+            result["sc_prob_3lap"] = float(sc.group(1))
     return result
 
 
@@ -962,7 +1155,12 @@ class RaceSituationAgent:
             gap_ahead_s = float((t_x - t_y).total_seconds())
         else:
             gap_ahead_s = float((driver_x_lap["LapTime"] - driver_y_lap["LapTime"]).total_seconds())
-        gap_ahead_s = max(0.0, gap_ahead_s)
+        # NaN-preserving. `max(0.0, nan)` returns 0.0 in Python — the comparison is False,
+        # so the first argument wins — which turned an unmeasurable gap into the single
+        # most aggressive reading available: zero seconds, inside the trained domain, DRS
+        # window open. The clamp is for a negative gap, which end-of-lap order makes
+        # unreachable for an adjacent pair anyway; it was never meant to absorb an absence.
+        gap_ahead_s = float("nan") if pd.isna(gap_ahead_s) else max(0.0, gap_ahead_s)
 
         pace_delta_s = float((driver_x_lap["LapTime"] - driver_y_lap["LapTime"]).total_seconds())
         tyre_life_x = _lap_count(driver_x_lap, "TyreLife")
@@ -985,36 +1183,14 @@ class RaceSituationAgent:
         compound_y = _abs_compound(str(driver_y_lap.get("Compound", "MEDIUM")), gp_name, year)
         gap_pace_product = gap_ahead_s * pace_delta_s
 
-        _dx = (
-            laps_recent[laps_recent["Driver"] == driver_x_lap["Driver"]]
-            .sort_values("LapNumber")
-            .tail(3)
+        pace_delta_rolling3, gap_trend = _pair_rolling_features(
+            laps_recent,
+            driver_x=str(driver_x_lap["Driver"]),
+            driver_y=str(driver_y_lap["Driver"]),
+            lap_number=lap_number,
+            gap_ahead_s=gap_ahead_s,
+            pace_delta_s=pace_delta_s,
         )
-        _dy = (
-            laps_recent[laps_recent["Driver"] == driver_y_lap["Driver"]]
-            .sort_values("LapNumber")
-            .tail(3)
-        )
-
-        if len(_dx) >= 2 and len(_dy) >= 2:
-            _dx_t = _dx["LapTime"].dt.total_seconds().values
-            _dy_t = _dy["LapTime"].dt.total_seconds().values
-            n_shared = min(len(_dx_t), len(_dy_t))
-            pace_delta_rolling3 = float((_dx_t[:n_shared] - _dy_t[:n_shared]).mean())
-
-            _tx = _dx["Time"] if "Time" in _dx.columns else None
-            if (
-                _tx is not None
-                and pd.notna(_dx.iloc[-2]["Time"])
-                and pd.notna(_dy.iloc[-2]["Time"])
-            ):
-                prev_gap = float((_dx.iloc[-2]["Time"] - _dy.iloc[-2]["Time"]).total_seconds())
-                gap_trend = gap_ahead_s - prev_gap
-            else:
-                gap_trend = 0.0
-        else:
-            pace_delta_rolling3 = pace_delta_s
-            gap_trend = 0.0
 
         return pd.DataFrame(
             [
@@ -1220,7 +1396,9 @@ class RaceSituationAgent:
                 x_rows.iloc[0],
                 y_rows.iloc[0],
                 laps_recent,
-                circuit_cluster=agent.session_meta.get("circuit_cluster", 0),
+                circuit_cluster=agent.session_meta.get(
+                    "circuit_cluster", _UNKNOWN_CIRCUIT_CLUSTER
+                ),
                 gp_name=agent.session_meta.get("gp_name", ""),
                 year=agent.session_meta.get("year", 2025),
             )
@@ -1229,14 +1407,38 @@ class RaceSituationAgent:
                 training_cats = agent.cfg.overtake_model._Booster.pandas_categorical[i]
                 feat_df[col] = pd.Categorical(feat_df[col], categories=training_cats)
 
+            gap = feat_df["gap_ahead_s"].iloc[0]
+            pace = feat_df["pace_delta_s"].iloc[0]
+            drs = "active" if feat_df["drs_window"].iloc[0] else "inactive"
+
+            # Outside N11's trained domain the model is not wrong, it is uninformed: it
+            # never saw a labelled pair this far apart. Say so instead of publishing the
+            # extrapolation. The other two facts are still measurements, so they stay.
+            #
+            # An UNMEASURABLE gap declines too. Whether the pair is inside the domain is
+            # exactly what cannot be established without it, and answering anyway would be
+            # the same fabrication one branch further along.
+            if pd.isna(gap):
+                return (
+                    f"P(overtake) = {_OUT_OF_DOMAIN_MARKER} (the gap could not be measured "
+                    f"on this lap, so whether the pair is inside N11's trained "
+                    f"{_TRAINED_MAX_GAP_S}s domain is unknown) | "
+                    f"gap=unknown | pace_delta={pace:.3f}s/lap | DRS: {drs}"
+                )
+            if float(gap) > _TRAINED_MAX_GAP_S:
+                return (
+                    f"P(overtake) = {_OUT_OF_DOMAIN_MARKER} "
+                    f"(gap {float(gap):.2f}s is beyond N11's trained {_TRAINED_MAX_GAP_S}s "
+                    f"domain; no labelled example exists out here) | "
+                    f"gap={gap:.2f}s | "
+                    f"pace_delta={pace:.3f}s/lap | "
+                    f"DRS: {drs}"
+                )
+
             raw_proba = agent.cfg.overtake_model.predict_proba(feat_df)[:, 1]
             calib_proba = agent.cfg.overtake_calibrator.predict_proba(raw_proba.reshape(-1, 1))[
                 :, 1
             ][0]
-
-            gap = feat_df["gap_ahead_s"].iloc[0]
-            pace = feat_df["pace_delta_s"].iloc[0]
-            drs = "active" if feat_df["drs_window"].iloc[0] else "inactive"
 
             return (
                 f"P(overtake) = {calib_proba:.3f} | "
@@ -1398,7 +1600,13 @@ class RaceSituationAgent:
             "gp_name": gp_name,
             "event_name": event_name,
             "year": lap_state.get("year", 2025),
-            "circuit_cluster": self.cfg.cluster_for(gp_name, 0),
+            # N11's unknown-circuit code, not 0: 0 is a REAL cluster, so an unresolved
+            # circuit used to be scored as a specific kind of track. -1 is what N11's
+            # get_cluster returns (`.nb_py/N11_overtake_eda.py:210-212`), and since the
+            # booster's trained levels are [0,1,2,3] the Categorical cast in
+            # predict_overtake_tool turns it into the missing value LightGBM handles
+            # natively. Latent today — every race resolves — but the collision was real.
+            "circuit_cluster": self.cfg.cluster_for(gp_name, _UNKNOWN_CIRCUIT_CLUSTER),
             "circuit_sc_rate": self.cfg.sc_rate_for(event_name),
             "total_laps": int(session.total_laps),
             "fastest_lap_s": _clean["LapTime"].min().total_seconds(),
@@ -1488,7 +1696,13 @@ class RaceSituationAgent:
             "gp_name": gp_name,
             "event_name": event_name,
             "year": year,
-            "circuit_cluster": self.cfg.cluster_for(gp_name, 0),
+            # N11's unknown-circuit code, not 0: 0 is a REAL cluster, so an unresolved
+            # circuit used to be scored as a specific kind of track. -1 is what N11's
+            # get_cluster returns (`.nb_py/N11_overtake_eda.py:210-212`), and since the
+            # booster's trained levels are [0,1,2,3] the Categorical cast in
+            # predict_overtake_tool turns it into the missing value LightGBM handles
+            # natively. Latent today — every race resolves — but the collision was real.
+            "circuit_cluster": self.cfg.cluster_for(gp_name, _UNKNOWN_CIRCUIT_CLUSTER),
             "circuit_sc_rate": self.cfg.sc_rate_for(event_name),
             "total_laps": total_laps,
             "fastest_lap_s": float(self.laps_df["LapTime"].dt.total_seconds().min())
@@ -1547,9 +1761,17 @@ class RaceSituationAgent:
                 f"Determine the overtaking probability and Safety Car risk, then provide a threat level."
             )
         else:
+            # NOT "no car is within overtaking range (gap > 2.5s)", which is what this
+            # said. `rival_ahead` comes from a POSITION lookup with no gap filter at all
+            # (see its derivation above), so it is None when the driver is leading, when
+            # the car ahead is missing from the timing feed, or when our own position is
+            # unknown — never because of a gap. The prompt was handing the LLM a reason
+            # that was not the reason, and one it could reason from. The gap-domain case
+            # is the tool's own to report, and it now does.
             message = (
                 f"Assess the race situation for driver {driver} at lap {lap_number}. "
-                f"No car is within overtaking range (gap > 2.5s). "
+                f"No car is classified directly ahead (leading, or the car ahead is not "
+                f"in the timing feed), so there is no overtake to score. "
                 f"Determine the Safety Car risk and provide a threat level."
             )
 
@@ -1579,7 +1801,14 @@ class RaceSituationAgent:
         # lengths (55.7/55.10) and pace_delta collapses to the FIA ECU delta. So the model
         # is not merely imprecise here, it is inapplicable: 0.0 is the correct value and
         # the honest one, and it holds identically under a VSC (56.6).
-        raw_overtake_prob = round(parsed["overtake_prob"], 3)
+        #
+        # The override applies whether or not the model answered, and that ordering is the
+        # point: under a neutralisation 0.0 is asserted by the REGULATION, so it holds even
+        # for a pair the model declined to score. An unscored pair on a green lap keeps its
+        # None — "the rules forbid it" and "nobody knows" must not collapse into one number.
+        raw_overtake_prob = (
+            None if parsed["overtake_prob"] is None else round(parsed["overtake_prob"], 3)
+        )
         effective_overtake_prob = 0.0 if is_neutralized else raw_overtake_prob
 
         _kind_label = "VIRTUAL_SAFETY_CAR_DEPLOYED" if is_vsc else "SAFETY_CAR_DEPLOYED"
@@ -1590,7 +1819,7 @@ class RaceSituationAgent:
             else (
                 f"[RCM OVERRIDE: {_kind_label} active — model output "
                 f"sc_prob_3lap={raw_sc_prob:.2f} overridden to 1.00, "
-                f"overtake_prob={raw_overtake_prob:.2f} overridden to 0.00 "
+                f"overtake_prob={_fmt_prob(raw_overtake_prob)} overridden to 0.00 "
                 f"(no overtaking under a neutralisation, Art. {_overtake_article}).] {reasoning}"
             )
         )

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -1621,8 +1621,19 @@ def _build_orchestrator_prompt(
     tire_block = _build_tire_block(tire_out)
 
     if situation_out is not None:
+        # Spelled out rather than rendered as a number, because this line is read by the
+        # LLM that writes the recommendation. N11 never saw a labelled pair beyond 2.5 s,
+        # so on those laps there is no probability to quote — and a synthesised one here
+        # does not get averaged away, it gets ARGUED from. Saying "unknown, the cars are
+        # too far apart for the model" is a fact the model can reason with; a fabricated
+        # 0.07 is one it cannot tell from a measurement.
+        overtake_text = (
+            "unknown (cars farther apart than the model's trained range)"
+            if situation_out.overtake_prob is None
+            else f"{situation_out.overtake_prob:.2f}"
+        )
         sit_block = (
-            f"  [N27 Situation] overtake={situation_out.overtake_prob:.2f}  "
+            f"  [N27 Situation] overtake={overtake_text}  "
             f"sc_3lap={situation_out.sc_prob_3lap:.2f}  "
             f"threat={situation_out.threat_level}\n"
             f"                  reasoning: {situation_out.reasoning or '(empty)'}"

--- a/src/arcade/dashboard/agent_formatters.py
+++ b/src/arcade/dashboard/agent_formatters.py
@@ -203,7 +203,12 @@ def format_situation(s: dict[str, Any] | None) -> Formatted:
             [],
             STATUS_IDLE,
         )
-    ot = float(s.get("overtake_prob", 0.0) or 0.0)
+    # NOT `or 0.0`: N27 reports None when the car ahead is farther than the overtake
+    # model's trained range, and rendering that as "overtake 0%" tells the wall the model
+    # says NO CHANCE when it actually says nothing. The two readings would prompt
+    # opposite calls.
+    _ot_raw = s.get("overtake_prob")
+    ot = None if _ot_raw is None else float(_ot_raw)
     sc = float(s.get("sc_prob_3lap", 0.0) or 0.0)
     gap = float(s.get("gap_ahead_s", 0.0) or 0.0)
     pace_delta = float(s.get("pace_delta_s", 0.0) or 0.0)
@@ -215,7 +220,10 @@ def format_situation(s: dict[str, Any] | None) -> Formatted:
 
     sc_color = WARNING if sc > 0.15 else TEXT_SECONDARY
     body: list[Line] = [
-        (f"overtake {ot * 100:.0f}%", TEXT_SECONDARY),
+        (
+            "overtake — (out of model range)" if ot is None else f"overtake {ot * 100:.0f}%",
+            TEXT_TERTIARY if ot is None else TEXT_SECONDARY,
+        ),
         (f"safety car {sc * 100:.0f}%", sc_color),
         (f"gap {gap:.1f}s · Δpace {_signed(pace_delta, 2)}s/lap", TEXT_TERTIARY),
     ]

--- a/src/strategy/inference/no_llm.py
+++ b/src/strategy/inference/no_llm.py
@@ -153,8 +153,12 @@ def _situation_no_llm(sit_lap_state: dict[str, Any], laps_df: pd.DataFrame):
     """Run N27 with real LightGBM numbers + the RCM SC override, no LLM.
 
     Executes predict_sc_tool always, predict_overtake_tool only when a rival ahead is
-    derivable (parser defaults overtake fields to 0.0 otherwise). ``run_from_state``
-    then applies the SafetyCar RCM override exactly as in LLM mode.
+    derivable. The parser then leaves ``overtake_prob`` as **None**, not 0.0: the tool
+    also declines when the pair is farther apart than N11's trained 2.5 s domain, and
+    "nobody asked", "the model has no example this far out" and "the regulation forbids
+    it" (0.0, Art. 55.8) are three different claims. ``run_from_state`` applies the
+    SafetyCar RCM override afterwards, exactly as in LLM mode, and that override still
+    asserts its 0.0 over a None.
     """
     agent = _get_situation_agent()
     meta = sit_lap_state["session_meta"]

--- a/tests/agents/test_overtake_domain.py
+++ b/tests/agents/test_overtake_domain.py
@@ -1,0 +1,270 @@
+"""N27 declines to score a battle the overtake model never saw, instead of guessing.
+
+N11's pair builder drops every pair more than 2.5 s apart before labelling — "not an active
+battle" (`.nb_py/N11_overtake_eda.py:233-235`) — so the model has no labelled example out
+there. `predict_overtake_tool` had range and roster guards but no gap guard, and LightGBM
+extrapolated happily.
+
+Measured over all 24 races of 2025 with N11's own pairing rule: **8,816 of 20,449
+position-adjacent pairs (43.1%) sit outside the domain**, median gap 2.06 s, p90 9.11 s. The
+earlier audit reported 41.9% over a different denominator (25,215 pairs, a differently
+filtered frame); the two agree on the magnitude and this file re-derives the rate rather
+than quoting either.
+
+The probability does not reach the Monte Carlo — it reaches `threat_level`, the N31 prompt
+and the dashboards. That is why an invented number is worse here than a noisy one: it is not
+averaged, it is argued from.
+
+This file also covers the two siblings fixed alongside it: the rolling-3 window, which paired
+the two cars' laps by array position (diverges on 10.78% of pairs), and the unknown-circuit
+sentinel, which was 0 — a real cluster.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_PAIRS = ROOT / "data" / "processed" / "overtake_labeled" / "overtake_pairs_2023_2025.parquet"
+_FEATURED = ROOT / "data" / "processed" / "laps_featured_2025.parquet"
+_HAS_MODELS = (ROOT / "data" / "models" / "tire_degradation" / "routing_config.json").exists()
+
+# Importing the module builds RaceSituationConfig, which reads data/models/.
+pytestmark = pytest.mark.skipif(
+    not _HAS_MODELS, reason="importing race_situation_agent reads data/models/ (HF, not git)"
+)
+
+
+# --- the domain itself, re-derived from the labelled artefact -----------------
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _PAIRS.exists(), reason="labelled overtake pairs absent")
+def test_the_declared_domain_is_the_one_the_labelled_pairs_span():
+    """The constant is a claim about the training set; this checks it against the set.
+
+    Asserting only `max <= 2.5` would also pass on a training set that happened to stop at
+    1.0, which would make the gate too permissive without anything noticing, so the bound
+    is asserted from BOTH sides.
+    """
+    from src.agents.race_situation_agent import _TRAINED_MAX_GAP_S
+
+    gaps = pd.read_parquet(_PAIRS, columns=["gap_ahead_s"])["gap_ahead_s"]
+    assert gaps.max() == pytest.approx(_TRAINED_MAX_GAP_S, abs=1e-6), (
+        f"the labelled pairs reach {gaps.max()}, the declared domain is {_TRAINED_MAX_GAP_S}"
+    )
+    assert (gaps > _TRAINED_MAX_GAP_S).sum() == 0
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _PAIRS.exists(), reason="labelled overtake pairs absent")
+def test_the_unknown_circuit_code_is_not_a_trained_cluster():
+    """0 was the old default and it is a REAL cluster; the sentinel must not be one."""
+    from src.agents.race_situation_agent import _UNKNOWN_CIRCUIT_CLUSTER
+
+    trained = set(pd.read_parquet(_PAIRS, columns=["circuit_cluster"])["circuit_cluster"].unique())
+    assert _UNKNOWN_CIRCUIT_CLUSTER not in trained, (
+        f"the unknown code {_UNKNOWN_CIRCUIT_CLUSTER} collides with a trained cluster"
+    )
+
+
+@pytest.mark.data
+@pytest.mark.skipif(not _FEATURED.exists(), reason="featured parquet absent")
+def test_the_gate_is_not_vacuous_on_real_races():
+    """A gate that never fires proves nothing. This pins that it fires on four laps in ten.
+
+    Uses N11's own pairing rule — adjacent by Position, gap as |Time_x - Time_y| — so the
+    share measured here is the share of real questions the tool now declines.
+    """
+    from src.agents.race_situation_agent import _TRAINED_MAX_GAP_S
+    from src.f1_strat_manager.laps_augment import augment_featured_laps
+
+    laps = augment_featured_laps(pd.read_parquet(_FEATURED), 2025)
+    laps = laps[laps["Year"] == 2025].copy()
+    if "Time_s" not in laps.columns:
+        laps["Time_s"] = pd.to_timedelta(laps["Time"]).dt.total_seconds()
+
+    gaps: list[float] = []
+    for _gp, race in laps.groupby("GP_Name"):
+        for _lap, grp in race.groupby("LapNumber"):
+            usable = grp.dropna(subset=["Position", "LapTime_s", "Time_s"])
+            usable = usable[usable["Position"] > 0]
+            by_pos = dict(zip(usable["Position"], usable["Time_s"]))
+            for pos, t_x in by_pos.items():
+                t_y = by_pos.get(pos - 1)
+                if t_y is not None:
+                    gaps.append(abs(t_x - t_y))
+
+    assert gaps, "no adjacent pairs found: this would hold vacuously"
+    outside = sum(1 for g in gaps if g > _TRAINED_MAX_GAP_S)
+    share = outside / len(gaps)
+    assert 0.30 < share < 0.55, (
+        f"{share:.1%} of adjacent pairs are out of domain; the fix was measured at 43.1% "
+        "and a large move means the pairing rule or the artefact changed"
+    )
+
+
+# --- the parser: unknown must not become 0.0 ----------------------------------
+
+
+def test_an_out_of_domain_answer_parses_as_unknown_not_as_zero():
+    """The whole point. 0.0 is what the regulation asserts under a Safety Car."""
+    from src.agents.race_situation_agent import _parse_tool_outputs
+
+    class _Msg:
+        content = (
+            "P(overtake) = UNKNOWN (gap 9.11s is beyond N11's trained 2.5s domain; "
+            "no labelled example exists out here) | gap=9.11s | "
+            "pace_delta=0.400s/lap | DRS: inactive"
+        )
+
+    parsed = _parse_tool_outputs([_Msg()])
+    assert parsed["overtake_prob"] is None
+    # The other two are measurements, not model output, so they survive the decline.
+    assert parsed["gap_ahead_s"] == pytest.approx(9.11)
+    assert parsed["pace_delta_s"] == pytest.approx(0.400)
+
+
+def test_an_in_domain_answer_still_parses_to_its_number():
+    from src.agents.race_situation_agent import _parse_tool_outputs
+
+    class _Msg:
+        content = "P(overtake) = 0.412 | gap=1.20s | pace_delta=-0.300s/lap | DRS: active"
+
+    parsed = _parse_tool_outputs([_Msg()])
+    assert parsed["overtake_prob"] == pytest.approx(0.412)
+
+
+def test_a_tool_that_never_ran_leaves_the_probability_unknown():
+    """Previously this defaulted to 0.0, which reads as "no chance" rather than "no answer"."""
+    from src.agents.race_situation_agent import _parse_tool_outputs
+
+    assert _parse_tool_outputs([])["overtake_prob"] is None
+
+
+# --- the consumers ------------------------------------------------------------
+
+
+def test_an_unknown_probability_cannot_raise_the_threat_level():
+    """It is not evidence, so it must not band as if it were. And it must not crash."""
+    from src.agents.race_situation_agent import RaceSituationOutput
+
+    unknown = RaceSituationOutput(overtake_prob=None, sc_prob_3lap=0.0)
+    assert unknown.threat_level == "LOW"
+
+
+def test_an_unknown_probability_does_not_suppress_the_other_signals():
+    """The SC terms and the live-neutralisation flag are evaluated exactly as before.
+
+    Without this, a fix that simply returned LOW whenever the overtake value is missing
+    would pass the test above while silencing the safety-car path on 43% of laps.
+    """
+    from src.agents.race_situation_agent import CFG, RaceSituationOutput
+
+    neutralised = RaceSituationOutput(
+        overtake_prob=None, sc_prob_3lap=0.0, sc_currently_active=True
+    )
+    assert neutralised.threat_level == "HIGH"
+
+    sc_says_so = RaceSituationOutput(overtake_prob=None, sc_prob_3lap=CFG.high_sc)
+    assert sc_says_so.threat_level == "HIGH"
+
+    medium = RaceSituationOutput(overtake_prob=None, sc_prob_3lap=CFG.medium_sc)
+    assert medium.threat_level == "MEDIUM"
+
+
+def test_a_known_probability_bands_exactly_as_it_did():
+    """The in-domain path must be untouched by all of this."""
+    from src.agents.race_situation_agent import CFG, RaceSituationOutput
+
+    assert (
+        RaceSituationOutput(overtake_prob=CFG.high_overtake, sc_prob_3lap=0.0).threat_level
+        == "HIGH"
+    )
+    assert (
+        RaceSituationOutput(overtake_prob=CFG.medium_overtake, sc_prob_3lap=0.0).threat_level
+        == "MEDIUM"
+    )
+    assert RaceSituationOutput(overtake_prob=0.0, sc_prob_3lap=0.0).threat_level == "LOW"
+
+
+def test_the_prose_renderer_never_formats_none_as_a_number():
+    """`f"{None:.2f}"` raises, and this value is rendered into the RCM override note."""
+    from src.agents.race_situation_agent import _OUT_OF_DOMAIN_MARKER, _fmt_prob
+
+    assert _fmt_prob(None) == _OUT_OF_DOMAIN_MARKER
+    assert _fmt_prob(0.4123) == "0.41"
+
+
+def test_the_dashboard_shows_an_absence_rather_than_zero_percent():
+    """ "overtake 0%" and "we cannot say" would prompt opposite calls on the pit wall."""
+    from src.arcade.dashboard.agent_formatters import format_situation
+
+    _headline, _colour, body, _status = format_situation(
+        {"overtake_prob": None, "sc_prob_3lap": 0.1, "threat_level": "LOW"}
+    )
+    overtake_line = next(text for text, _c in body if text.startswith("overtake"))
+    assert "0%" not in overtake_line
+    assert "—" in overtake_line
+
+
+# --- the rolling window -------------------------------------------------------
+
+
+def test_the_rolling_window_pairs_by_lap_number_not_by_array_position():
+    """The sibling defect: one car missing a lap shifted every element of the subtraction.
+
+    X has laps 8, 9, 10; Y is missing lap 9 (a pit or safety-car lap the featured frame
+    drops). Positionally, X's lap 9 paired with Y's lap 10. By LapNumber only laps 8 and 10
+    are shared, and N12's feature is the mean of the PAIR's own per-lap pace deltas.
+    """
+    from src.agents.race_situation_agent import _pair_rolling_features
+
+    def _lap(driver: str, lap: int, lap_time_s: float, elapsed_s: float) -> dict:
+        return {
+            "Driver": driver,
+            "LapNumber": lap,
+            "LapTime": pd.Timedelta(seconds=lap_time_s),
+            "Time": pd.Timedelta(seconds=elapsed_s),
+        }
+
+    laps_recent = pd.DataFrame(
+        [
+            _lap("X", 8, 91.0, 800.0),
+            _lap("X", 9, 92.0, 892.0),
+            _lap("X", 10, 90.0, 982.0),
+            _lap("Y", 8, 90.0, 799.0),
+            _lap("Y", 10, 89.0, 979.0),
+        ]
+    )
+
+    rolling, trend = _pair_rolling_features(
+        laps_recent,
+        driver_x="X",
+        driver_y="Y",
+        lap_number=10,
+        gap_ahead_s=3.0,
+        pace_delta_s=1.0,
+    )
+
+    # Shared laps are 8 and 10: deltas +1.0 and +1.0 -> mean 1.0.
+    assert rolling == pytest.approx(1.0)
+    # The positional version would have used X8-Y8 and X9-Y10 = +1.0 and +3.0 -> 2.0.
+    assert rolling != pytest.approx(2.0)
+    # gap_trend is the pair's own gap series: (982-979) - (800-799) = 2.0.
+    assert trend == pytest.approx(2.0)
+
+
+def test_a_pair_with_no_shared_history_falls_back_to_this_lap():
+    """`min_periods=1` in N12: the first lap of a pair's series still yields a value."""
+    from src.agents.race_situation_agent import _pair_rolling_features
+
+    empty = pd.DataFrame(columns=["Driver", "LapNumber", "LapTime", "Time"])
+    rolling, trend = _pair_rolling_features(
+        empty, driver_x="X", driver_y="Y", lap_number=5, gap_ahead_s=1.0, pace_delta_s=0.25
+    )
+    assert rolling == pytest.approx(0.25)
+    assert trend == 0.0

--- a/tests/agents/test_overtake_domain.py
+++ b/tests/agents/test_overtake_domain.py
@@ -145,6 +145,33 @@ def test_a_tool_that_never_ran_leaves_the_probability_unknown():
     assert _parse_tool_outputs([])["overtake_prob"] is None
 
 
+def test_a_declined_call_does_not_let_a_later_pair_fill_its_probability():
+    """The three overtake fields describe ONE battle and must be read from one message.
+
+    Introduced by the decline path and caught by the adversarial gate: field-by-field
+    first-match-wins was safe only while every call produced a number. With a decline, the
+    first call's gap and pace_delta were taken while the probability stayed open, and a
+    second call about a different pair filled it — a reported gap from one battle beside a
+    probability from another.
+    """
+    from src.agents.race_situation_agent import _parse_tool_outputs
+
+    class _Declined:
+        content = (
+            "P(overtake) = UNKNOWN (gap 9.11s is beyond N11's trained 2.5s domain) | "
+            "gap=9.11s | pace_delta=0.400s/lap | DRS: inactive"
+        )
+
+    class _OtherPair:
+        content = "P(overtake) = 0.512 | gap=0.80s | pace_delta=-0.900s/lap | DRS: active"
+
+    parsed = _parse_tool_outputs([_Declined(), _OtherPair()])
+
+    assert parsed["overtake_prob"] is None, "the second pair's probability filled the hole"
+    assert parsed["gap_ahead_s"] == pytest.approx(9.11)
+    assert parsed["pace_delta_s"] == pytest.approx(0.400)
+
+
 # --- the consumers ------------------------------------------------------------
 
 
@@ -214,30 +241,34 @@ def test_the_dashboard_shows_an_absence_rather_than_zero_percent():
 # --- the rolling window -------------------------------------------------------
 
 
+def _battle_lap(
+    driver: str, lap: int, lap_time_s: float, elapsed_s: float, position: float
+) -> dict:
+    return {
+        "Driver": driver,
+        "LapNumber": lap,
+        "LapTime": pd.Timedelta(seconds=lap_time_s),
+        "Time": pd.Timedelta(seconds=elapsed_s),
+        "Position": position,
+    }
+
+
 def test_the_rolling_window_pairs_by_lap_number_not_by_array_position():
-    """The sibling defect: one car missing a lap shifted every element of the subtraction.
+    """The first sibling defect: one car missing a lap shifted every subtraction.
 
     X has laps 8, 9, 10; Y is missing lap 9 (a pit or safety-car lap the featured frame
-    drops). Positionally, X's lap 9 paired with Y's lap 10. By LapNumber only laps 8 and 10
-    are shared, and N12's feature is the mean of the PAIR's own per-lap pace deltas.
+    drops). Positionally, X's lap 9 paired with Y's lap 10. By LapNumber only 8 and 10 are
+    shared, and both are inside the domain here, so both are battle laps.
     """
     from src.agents.race_situation_agent import _pair_rolling_features
 
-    def _lap(driver: str, lap: int, lap_time_s: float, elapsed_s: float) -> dict:
-        return {
-            "Driver": driver,
-            "LapNumber": lap,
-            "LapTime": pd.Timedelta(seconds=lap_time_s),
-            "Time": pd.Timedelta(seconds=elapsed_s),
-        }
-
     laps_recent = pd.DataFrame(
         [
-            _lap("X", 8, 91.0, 800.0),
-            _lap("X", 9, 92.0, 892.0),
-            _lap("X", 10, 90.0, 982.0),
-            _lap("Y", 8, 90.0, 799.0),
-            _lap("Y", 10, 89.0, 979.0),
+            _battle_lap("X", 8, 91.0, 800.0, 5.0),
+            _battle_lap("X", 9, 92.0, 892.0, 5.0),
+            _battle_lap("X", 10, 90.0, 982.0, 5.0),
+            _battle_lap("Y", 8, 90.0, 799.0, 4.0),
+            _battle_lap("Y", 10, 89.0, 981.0, 4.0),
         ]
     )
 
@@ -246,23 +277,124 @@ def test_the_rolling_window_pairs_by_lap_number_not_by_array_position():
         driver_x="X",
         driver_y="Y",
         lap_number=10,
-        gap_ahead_s=3.0,
+        gap_ahead_s=1.0,
         pace_delta_s=1.0,
     )
 
-    # Shared laps are 8 and 10: deltas +1.0 and +1.0 -> mean 1.0.
+    # Battle laps 8 and 10: deltas +1.0 and +1.0 -> mean 1.0.
     assert rolling == pytest.approx(1.0)
     # The positional version would have used X8-Y8 and X9-Y10 = +1.0 and +3.0 -> 2.0.
     assert rolling != pytest.approx(2.0)
-    # gap_trend is the pair's own gap series: (982-979) - (800-799) = 2.0.
-    assert trend == pytest.approx(2.0)
+    # gap_trend over the battle series: (982-981) - (800-799) = 0.0.
+    assert trend == pytest.approx(0.0)
+
+
+def test_a_lap_the_pair_spent_outside_the_domain_is_not_in_the_series():
+    """The second sibling defect, and the one the adversarial gate refuted the fix on.
+
+    N12 rolled over N11's LABELLED rows, and N11 only emits a row when the cars are
+    position-adjacent AND within 2.5 s. A lap where the pair existed but sat 4 s apart is
+    not in that series at all. Rolling over it anyway moved the calibrated probability by
+    up to 0.480 and pushed 81 of the 2025 pairs across the MEDIUM band — worst precisely on
+    battles that had just closed up, which is what the domain gate makes interesting.
+
+    Laps 8 and 9 sit 4.0 s and 3.0 s apart; only lap 10 is a battle lap, so `min_periods=1`
+    gives that lap alone and there is no earlier battle lap to diff against.
+    """
+    from src.agents.race_situation_agent import _pair_rolling_features
+
+    laps_recent = pd.DataFrame(
+        [
+            _battle_lap("X", 8, 91.0, 804.0, 5.0),
+            _battle_lap("X", 9, 92.0, 895.0, 5.0),
+            _battle_lap("X", 10, 90.0, 983.0, 5.0),
+            _battle_lap("Y", 8, 90.0, 800.0, 4.0),
+            _battle_lap("Y", 9, 89.0, 892.0, 4.0),
+            _battle_lap("Y", 10, 88.0, 981.0, 4.0),
+        ]
+    )
+
+    rolling, trend = _pair_rolling_features(
+        laps_recent,
+        driver_x="X",
+        driver_y="Y",
+        lap_number=10,
+        gap_ahead_s=2.0,
+        pace_delta_s=2.0,
+    )
+
+    assert rolling == pytest.approx(2.0), "a lap outside the trained gap entered the series"
+    assert trend == 0.0, "a non-battle lap was used as the previous gap"
+
+
+def test_a_lap_where_the_cars_had_swapped_order_is_not_in_the_series():
+    """N11 pairs X with the car at `Position - 1`; after a swap-back that row is not ours.
+
+    The gate found the gap helper's clamp turning such a lap into a fabricated 0.0 s gap,
+    which then entered gap_trend as if it were a reading.
+    """
+    from src.agents.race_situation_agent import _pair_rolling_features
+
+    laps_recent = pd.DataFrame(
+        [
+            # Lap 9: X is AHEAD of Y, so for the (X chasing Y) pair this lap does not exist.
+            _battle_lap("X", 9, 92.0, 890.0, 4.0),
+            _battle_lap("Y", 9, 89.0, 891.0, 5.0),
+            _battle_lap("X", 10, 90.0, 982.0, 5.0),
+            _battle_lap("Y", 10, 88.0, 981.0, 4.0),
+        ]
+    )
+
+    rolling, trend = _pair_rolling_features(
+        laps_recent,
+        driver_x="X",
+        driver_y="Y",
+        lap_number=10,
+        gap_ahead_s=1.0,
+        pace_delta_s=2.0,
+    )
+
+    assert rolling == pytest.approx(2.0)
+    assert trend == 0.0
+
+
+def test_without_a_position_column_no_history_is_invented():
+    """The membership rule needs Position; absent it, N12's first-row semantics is honest.
+
+    Guessing a longer window from merely-shared laps is exactly the skew this helper was
+    rewritten to remove, so it must not come back as a fallback.
+    """
+    from src.agents.race_situation_agent import _pair_rolling_features
+
+    no_position = pd.DataFrame(
+        [
+            {
+                "Driver": driver,
+                "LapNumber": 9,
+                "LapTime": pd.Timedelta(seconds=lap_time),
+                "Time": pd.Timedelta(seconds=elapsed),
+            }
+            for driver, lap_time, elapsed in (("X", 91.0, 891.0), ("Y", 90.0, 890.0))
+        ]
+    )
+
+    rolling, trend = _pair_rolling_features(
+        no_position,
+        driver_x="X",
+        driver_y="Y",
+        lap_number=10,
+        gap_ahead_s=1.0,
+        pace_delta_s=0.75,
+    )
+    assert rolling == pytest.approx(0.75)
+    assert trend == 0.0
 
 
 def test_a_pair_with_no_shared_history_falls_back_to_this_lap():
     """`min_periods=1` in N12: the first lap of a pair's series still yields a value."""
     from src.agents.race_situation_agent import _pair_rolling_features
 
-    empty = pd.DataFrame(columns=["Driver", "LapNumber", "LapTime", "Time"])
+    empty = pd.DataFrame(columns=["Driver", "LapNumber", "LapTime", "Time", "Position"])
     rolling, trend = _pair_rolling_features(
         empty, driver_x="X", driver_y="Y", lap_number=5, gap_ahead_s=1.0, pace_delta_s=0.25
     )


### PR DESCRIPTION
PR 5 of the approved data-wiring plan. Reports: `documents/audits/PR5_OVERTAKE_DOMAIN.md` (implementation) and `documents/audits/GATE_PR5_OVERTAKE.md` (the adversarial gate over the finished diff).

## The defect

N11's pair builder **drops every pair more than 2.5 s apart before labelling** — "not an active battle". The model has no labelled example beyond it. `predict_overtake_tool` had a lap-range guard and a roster guard but **no gap guard**, so a nine-second-gap row was built and LightGBM extrapolated.

Re-measured with N11's own pairing rule rather than quoted: **8,816 of 20,449 position-adjacent pairs in 2025 (43.1%)** sit outside it — of those, median gap 5.16 s, p90 15.13 s. The labelled artefact settles the bound directly: 28,494 rows, max gap exactly **2.500**, zero beyond.

`overtake_prob` does **not** reach the Monte Carlo. It reaches `threat_level`, the **N31 prompt**, and the dashboards — so an invented number there is not averaged away, it is *argued from*. It is also **not** among the 14 fields of the frozen `StrategyRecommendation`, so nothing frozen moved.

## null is not zero, and that is the design

Under a neutralisation `overtake_prob = 0.0` is asserted by the **regulation** (Art. 55.8). Leaving the no-answer case on 0.0 made "the rules forbid it" and "the model has no idea" the same number to every consumer. The override still imposes its 0.0 over a declined model; a green-flag unscored pair keeps its `None`.

## What changed

| site | before | after |
|---|---|---|
| `predict_overtake_tool` | scored any gap | returns the `UNKNOWN` marker with the reason; an **unmeasurable** gap declines too |
| `_parse_tool_outputs` | defaulted to **0.0** | `None`, and the three overtake fields are read **together from one message** |
| `RaceSituationOutput` | `float` | `Optional[float]` |
| `threat_level` | would raise on `>=` | an unknown cannot RAISE the band, and does not suppress the SC terms |
| `max(0.0, gap)` | `max(0.0, nan)` → **0.0**, in-domain with DRS open | NaN-preserving |
| N31 prompt, CLI row, arcade, backend model, webapp types + 2 gauges, 4 doc surfaces | a plain number, or `?? 0` | an explicit absence |

The CLI one **crashed 35 of 57 Lusail laps** on the first real run: `getattr(obj, name, 0.0)` does not substitute for a present-but-None attribute — the third form of this trap here, after `dict.get` and `Series.get`.

## Two siblings, measured before being touched

- **`pace_delta_rolling3` paired the cars by array position.** The earlier gate called it "a bounded trigger, not measured": it is **10.78% of adjacent pairs**.
- **The unknown-circuit sentinel was `0`, a real cluster.** N11's is `-1`, which the Categorical cast turns into LightGBM's missing value. Latent, and it says so.

## What the adversarial gate refuted

**It caught the fix for the first sibling being skewed itself**, in the very class it was correcting. N12 rolls over N11's **labelled** rows; the first version rolled over every lap where both cars merely had a row. Measured over the 11,633 in-domain pairs, both rules re-scored through the real model: window differs on **29.44%**, calibrated |Δp| up to **0.480**, **81 pairs cross the MEDIUM band** — larger than the 57-pair effect this branch had called its headline. `_battle_series` now reconstructs N11's membership test term for term, and the old test, which pinned the divergent rule, moves with it.

It also found the parser tearing introduced by the decline path, the dead `pd.notna` guard behind the `max(0.0, nan)` clamp, a stale twin docstring in `no_llm.py`, and that this report's own median/p90 described the wrong subset. All fixed.

One gate finding is **deliberately left for its own PR**: `POST /situation` hands the agent the unscoped 24-race frame, so `(VER, lap 20)` resolves to **Austin** whatever race was asked for. Pre-existing, affects all five per-agent routes, and bundling it here would make this diff unreviewable.

## Checks

- `ruff check` + `ruff format --check` green; `mypy src/rag/` green; webapp `tsc --noEmit` exit 0.
- `tests/agents/test_overtake_domain.py`: **17 tests**. The domain bound is re-derived from the labelled artefact; one test pins that the gate is not vacuous; another that an unknown does not *suppress* the safety-car path.
- Full suite: 711 passed, only the pre-existing failures.
- Real `f1-sim`: Lusail **57/57 OK** `STAY_OUT·53 PIT_NOW·1 UNDERCUT·3` and Miami **33/33 OK** `STAY_OUT·24 UNDERCUT·9` — both identical to the `dev` baseline. The gate corrects the inputs without moving a decision on either race.