### PR TITLE
chore(agents): serve the car number and the fitted-set flag the models trained on

### DIFF
--- a/documents/audits/GATE_831_input_wiring.md
+++ b/documents/audits/GATE_831_input_wiring.md
@@ -1,0 +1,484 @@
+# GATE 831 — input-wiring hygiene (PR #831, branch `chore/input-wiring-hygiene`)
+
+**Role:** adversarial gate over CLAIMS about model inputs. No repository file modified except
+this report. No OpenAI credit spent (no `--provider openai`, no `profile="rich"`, no
+`alert-llm`; only `profile="no-llm"` / free offline paths / local parquet reads).
+
+**Under attack:** `git diff dev...HEAD` — `src/agents/pace_agent.py`,
+`src/agents/race_situation_agent.py`, `src/simulation/race_state_manager.py`.
+
+**Prior art the PR argues against:** `GATE_801_ARTEFACTS.md` §9 ranked this bundle LAST,
+"zero measured impact". `GATE_DATA_WIRING.md` F2/F3/F5 are the original diagnoses.
+
+---
+
+## Checklist
+
+- [x] **A.** `DriverNumber` was 0 on 100% of replay laps; now the real number; `None` reaches
+      the model as NaN, not coerced to 0; no twin builder still passing 0.
+- [x] **B.** `FreshTyre` is the set-was-new flag, constant across a stint — verified against
+      the DATA, and the disagreement share quantified per race.
+- [x] **C.** `tyre_life <= 1` is the right stint-opener test; scrubbed sets starting at
+      `tyre_life >= 2`; None survives to the model as NaN.
+- [x] **D.** `circuit_cluster` defaulted to 0 on EVERY path (backend / arcade / MCP / tests),
+      the SC vector really consumes it, NaN is safe for the booster, and the parquet swap
+      (24/24 vs 17/24) reproduces — plus no other consumer of `circuit_cluster_map` depended
+      on the pooled values.
+- [x] **E.** The measured prediction effect (the gap the PR leaves): per-race lap counts where
+      `sc_prob_3lap` / `overtake_prob` / `predicted_lap_time_s` / the action change.
+- [x] **F.** The exclusion list: gap-sign hardening, `pace_delta_rolling3` pairing, the two
+      docstrings, W-F12, the Vegas note, and the "N15 `TyreLife` already fixed" claim.
+
+---
+
+## Verdicts
+
+**Bottom line: the PR is right about two of its four items and wrong about the only one that moves a prediction.** W-F2/W-F3/W-F5 change model INPUTS on 100%/79.8%/0.06% of laps and change model OUTPUTS on 1 lap in 45 — GATE_801 §9's "zero measured impact" label was correct for them, and the PR body never reports an output number. The `circuit_cluster` change, presented as the one that "is not hygiene", rests on a measurement against the wrong artefact and **regresses** N27 from 24/24 to 17/24 agreement with what N14 actually trained on.
+
+---
+
+### A. `DriverNumber` — claim MOSTLY UPHELD, two unfixed twins, one wrong-mechanism docstring created
+
+**Upheld.** `RaceStateManager.get_driver_state` (`race_state_manager.py:354-417`) emitted no
+`driver_number` key on `dev`; `pace_agent.run_from_state` did `d.get("driver_number") or 0`.
+Every replay lap (CLI, Arcade, `f1-eval decision-modes`, `/simulate`) served `DriverNumber=0`.
+The new emission (`race_state_manager.py:446`) is on the right method, and
+`run_from_state` to `run()` to `_build_feature_row` (`pace_agent.py:635`) writes it into the
+row that becomes the model input. **Executed:** across all 71 raw races (77,720 rows)
+`DriverNumber` is `dtype=object` (strings `'1'`, `'10'`, ...), **0 NaN, 0 non-integer-parseable**,
+so `int(r["DriverNumber"])` is safe on the shipped data and never raises.
+
+**`None` genuinely reaches the model as NaN.** `_build_feature_row:665`
+`df.apply(pd.to_numeric, errors="coerce")` converts it. `_bootstrap_ci`
+(`pace_agent.py:715-763`) does NOT touch it: `noise_cols` is
+`{Prev_LapTime, Prev_SpeedST, mean_sector_speed, AirTemp, TrackTemp, TyreLife}`, so a NaN
+`DriverNumber` / `Prev_TyreLife` passes through `base.copy()` unperturbed. No coercion to 0
+anywhere downstream. `DriverNumber` is also deliberately outside the envelope
+(`pace_agent.py:117-121`), so nothing clips it.
+
+**F-A1 (MEDIUM) — the twins that still pass the literal 0.** Two builders of the same
+`lap_state["driver"]` dict were not touched:
+
+- `src/strategy/inference/engine.py:364` — `_build_default_lap_state`, `"driver_number": 0`
+- `src/agents/strategy_orchestrator.py:2444` — the inline `lap_state=None` fallback, same line
+
+Both feed `run_from_state`, where the new `.get` **cannot rescue them**: the key is present
+holding `0`, so `d.get("driver_number")` returns `0`, not `None`. The PR's own justification
+("a genuinely missing number must stay None and reach the model as NaN") is defeated exactly
+where it is needed. Reachability: every production surface passes a real `lap_state`
+(`run_simulation_cli.py:1743`, `arcade/strategy_pipeline.py:47`,
+`backend/services/simulation/simulator.py:402,860`, `eval/decision_modes.py:354`,
+`mcp_tools.py:620`, `endpoints/strategy.py:1413`), so today these fire only from
+`tests/engine/test_engine_memory.py` and `scripts/prompt_ab/gen_inputs.py`. Latent, not dead.
+
+**F-A2 (MEDIUM) — the backend producers still coerce a missing car number to 0.**
+`endpoints/strategy.py:518` and `:947` both do
+`"driver_number": int(_safe(r.get("DriverNumber", 0)))`, and `_safe` (`strategy.py:373-385`) is
+documented as "NaN to 0 ... only for fields where 0 is a legitimate stand-in". For
+`DriverNumber` it is not, which is precisely this PR's argument. The sibling `_safe_none`
+already exists for exactly this case and is used two lines away for `Position` / `tyre_life`.
+Not reachable on today's data (featured_2025 `DriverNumber` is `int32`, range 1-87, 0 NaN), so
+LOW impact, but it is the same defect the PR is fixing, in the producer the PR did not open.
+
+**F-A3 (MEDIUM) — a wrong-mechanism docstring, in the Args block whose type annotation this PR
+changed.** `pace_agent.py:830`: `driver_number: Car number used to look up TeamID encoding.`
+That is false. `_build_feature_row:614` calls `self._encode_categorical(compound, team, gp_name)`
+and `TeamID` is derived from `team`; `driver_number` is written straight into the row as a raw
+feature (`:635`) and is used for nothing else. The PR edits this parameter's annotation
+(`driver_number: int` to `Optional[int]`) at `:797`, adds a `Prev_TyreLife` note four lines
+below, and rewrites the `FreshTyre` docstring 300 lines above *specifically because naming the
+wrong mechanism "is how a proxy survives review"* — and leaves this one. Same defect class,
+same file, same docstring, same PR.
+
+**F-A4 (LOW) — the same Args block now mis-describes `tyre_life`.** `pace_agent.py:833`:
+`tyre_life: Laps on current tyre set; drives FreshTyre flag.` After this PR `tyre_life` drives
+`FreshTyre` only on the fallback path; on every `run_from_state` call the flag comes from
+`fresh_tyre`. The PR created this staleness and did not update the line.
+
+**F-A5 (LOW) — the flat public entry point cannot carry the fix.** `run_pace_agent`
+(`pace_agent.py:1074-1130`) has no `fresh_tyre` parameter, so `_run_always_on_agents`
+(`strategy_orchestrator.py:1878`) — the `run_strategy_orchestrator` flat path, an **exported**
+symbol (`src/agents/__init__.py:99`) documented as THE usage example
+(`strategy_orchestrator.py:17`, `docs/pages/agents-api.md:19`, `src/agents/README.md:19`) —
+keeps the outlap proxy *and* `prev_tyre_life = race_state.tyre_life - 1`
+(`strategy_orchestrator.py:1899`, not even clamped at 0). Confirmed no production caller
+(grep: notebooks / docs / tests only), consistent with `SWEEP_present_none_traps.md:144`.
+
+---
+
+### B. `FreshTyre` — claim FULLY UPHELD by the data, and understated
+
+Measured on `data/processed/laps_featured_2025.parquet` (22,760 rows), not on the docstring.
+
+- **Constant across a stint: yes, 1134 / 1134.** Grouping by N04's own
+  `['Year','GP_Name','DriverNumber','Stint']`, `FreshTyre.nunique()` is 1 in **every** stint.
+  It is the set-was-new flag, exactly as claimed.
+- **Disagreement with `int(tyre_life <= 1)`: 17,809 / 22,309 = 79.83% of laps.** Cross-tab
+  (rows = old proxy, cols = trained flag): `(0,0)=4,487  (0,1)=17,808  (1,0)=1  (1,1)=13`.
+- The trained flag is TRUE on **79.9%** of laps; the old proxy was TRUE on **0.06%** (14 laps in
+  the whole season). The served feature was therefore not "a different flag" — it was
+  **effectively the constant 0** where training saw 1 four laps in five.
+- Per race, worst to best: Lusail 97.68%, Las Vegas 97.11%, Shanghai 95.36%,
+  Spa-Francorchamps 94.73%, Silverstone 93.25% ... Melbourne 30.30%. Every race above 30%.
+  "Most racing laps" is if anything conservative.
+
+**F-B1 (LOW) — the fallback is unreachable where it is described, and silently wrong where it
+is not.** `race_state_manager.py:405` emits `bool(r.get("FreshTyre", False))`, which is never
+`None`, so on the `from_state` path `fresh_tyre is not None` is always true and the
+`int(tyre_life <= 1)` fallback is dead. On a frame with no `FreshTyre` column the same
+expression yields `False` (not `None`), so the agent serves a hard `0` and the fallback still
+never fires — the two-arg `.get` default hides the absence instead of surfacing it. Same
+`Series.get` / present-but-absent family the repo has logged repeatedly.
+
+---
+
+### C. `Prev_TyreLife` — claim is a TRUE STATEMENT INSIDE A FALSE HEADLINE
+
+`tyre_life <= 1` is **not** the stint-opener test. Measured on `laps_featured_2025.parquet`:
+
+| quantity | value |
+|---|---|
+| stint openers (first row per `Year/GP_Name/DriverNumber/Stint`) | **1,153** |
+| openers with `TyreLife <= 1` (what the new gate catches) | **14 (1.2%)** |
+| openers with `TyreLife >= 2` (scrubbed / used sets — the gate MISSES) | **1,114 (96.6%)** |
+| rows where trained `Prev_TyreLife` is NaN but the new rule still sends a number | **1,114 = 4.89% of all rows** |
+| rows where the new rule sends `None` and training had a number | **0** |
+| old rule `max(0, TL-1)` agrees with the trained column | **93.26%** |
+| new rule agrees with the trained column | **93.33%** |
+
+The fix is directionally safe (it never invents a `None`) and moves agreement with the trained
+quantity by **0.07 percentage points**. `TyreLife` at a stint opener is overwhelmingly `2`
+(656 of 1,153) — exactly the "set fitted mid-race that starts at 2 or higher" case the gate was
+asked about, and it is the *majority*, not the exception.
+
+**F-C1 (MEDIUM) — the guard is about (nearly) the empty set on the training distribution.** On
+the delta model's actual training pool (2023 + 2024, rows with `Prev_LapTime` known, n = 41,821):
+`TyreLife <= 1` occurs **0 times** (`TyreLife` min = 3.0) and 0 of 2,343 stint openers have
+`TyreLife <= 1`. The trigger condition the PR added never occurs in training and occurs on
+0.06% of served 2025 laps.
+
+**F-C2 (MEDIUM) — "NaN is a direction XGBoost learned" is asserted, not measured, and the
+measurement contradicts it.** On the same training pool `Prev_TyreLife` is NaN on **34 rows =
+0.08%**. A default split direction fitted from 34 of 41,821 rows is not a learned direction in
+any useful sense. The claim appears twice (the `_previous_tyre_life` docstring and the
+`run_from_state` comment) and is the whole justification for preferring `None` over a number.
+It should say what it is: the honest encoding of an absence, whose behaviour under this booster
+is essentially untested.
+
+**Correct, and worth recording:** the docstring's "below the trained minimum of 2.0" checks out
+— `Prev_TyreLife` min on the trained rows is exactly 2.0. (It is 1.0 on the served 2025 frame,
+so the sentence is true of training and slightly false of serving.)
+
+---
+
+### D. `circuit_cluster` — THE HEADLINE IS FALSE, AND THE PARQUET SWAP IS A REGRESSION
+
+This is the finding that matters. Three separate refutations.
+
+#### D-1 (HIGH) — `session_meta` DOES carry `circuit_cluster`, so `get(..., 0)` never fired
+
+The PR comment (`race_situation_agent.py:1288-1291`) states: *"`session_meta` carries `gp_name`
+and never `circuit_cluster` on the replay path (measured: its keys are driver / gp_name / team /
+total_laps / year), so `get(..., 0)` fired on 100% of laps"*.
+
+Those ARE the keys of the **RaceStateManager's** `lap_state["session_meta"]`. That is not the
+dict `_build_sc_features` receives.
+
+`_build_sc_features` has exactly **one** call site: `race_situation_agent.py:1493`, inside
+`predict_sc_tool`, and it passes **`agent.session_meta`** — the agent's own internal meta. There
+are exactly two assignments of `self.session_meta` (`:1622` FastF1 path, `:1718`
+`run_from_state` / replay path) and **both** set
+`"circuit_cluster": self.cfg.cluster_for(gp_name, _UNKNOWN_CIRCUIT_CLUSTER)` (`:1633`, `:1729`).
+So on `dev` the key was present and resolved on every lap, `get(..., 0)` never fired, and the
+`-1` there (`_UNKNOWN_CIRCUIT_CLUSTER`, `:119`) is already the non-colliding sentinel the PR
+argues for — with a six-line comment saying so.
+
+The evidence compares the wrong pair of things. This is the repo's own 2026-08-03 lesson
+verbatim.
+
+#### D-2 (HIGH) — the 24/24-vs-17/24 measurement reproduces, but against the WRONG artefact
+
+Reproduced exactly (over `laps_featured_2025.Cluster` vs both maps): pooled 17/24,
+`circuit_clusters_k4_2025` 24/24; the seven disagreements are Barcelona 3 to 1, Budapest 3 to 1,
+Melbourne 2 to 0, Shanghai 0 to 1, Spielberg 3 to 1, Sao Paulo 2 to 0, Zandvoort 2 to 0.
+
+But `laps_featured_2025.Cluster` is **N06's** training column, which is why `pace_agent.py:349`
+loads the `_2025` file. **N14 has nothing to do with it.**
+
+`.nb_py/N13_sc_eda.py:88-91` — `load_circuit_clusters` reads **`circuit_clusters_k4.parquet`**
+(the pooled file) and attaches it by fuzzy `Location` match (`:94-99`, `:114`). That is what
+lands in `sc_labeled_2023_2025.parquet`, which is the file `.nb_py/N14_sc_model.py:77` trains on
+and `:180` lists `circuit_cluster` among its features.
+
+**Executed against the trained artefact itself**
+(`data/processed/sc_labeled/sc_labeled_2023_2025.parquet`, 3,275 rows, 58 race-events, 2023-2025):
+
+```
+TRAINED circuit_cluster agrees with circuit_clusters_k4.parquet       58 / 58
+TRAINED circuit_cluster agrees with circuit_clusters_k4_2025.parquet  43 / 58
+```
+
+Per race, including the 2025 rows: Melbourne trained **2** (k4_2025 says 0), Zandvoort **2** (0),
+Budapest **3** (1), Barcelona **3** (1), Spielberg **3** (1), Sao Paulo **2** (0),
+Shanghai **0** (1).
+
+#### D-3 (HIGH) — net effect: the PR turns a 24/24-correct feature into a 17/24-correct one
+
+Because D-1 shows the pre-PR served value was `cluster_for(gp_name)` **over the pooled map**,
+and D-2 shows the pooled map is exactly what N14 trained on, the value served on `dev` matched
+the trained value on **every** 2025 race. After this PR the SC model is handed the 2025 refit's
+label on 7 of 24 races, a categorical level the model associates with a different kind of
+circuit. Budapest, one of the two thesis windows, moves 3 to 1.
+
+The sibling agent already encodes the correct principle and the PR contradicts it without citing
+it: `tire_agent.py:343-355` deliberately loads the **pooled** file with the mirror-image
+measurement — *"it agrees with `laps_tiredeg` on 24 of 24 GPs, where `circuit_clusters_k4_2025`
+agrees on only 17"*. Each agent must load the clustering **its own model trained against**:
+`pace_agent` to `_2025`, `tire_agent` to pooled, `race_situation_agent` to pooled. The PR moved
+the third one onto the first one's file.
+
+**F-D4 (MEDIUM) — a second, quieter consequence of the same swap.** `predict_overtake_tool`
+(`race_situation_agent.py:1419-1432`) reads `agent.session_meta["circuit_cluster"]` and casts it
+through the N11 booster's `pandas_categorical` levels. The PR did **not** touch that line, but by
+changing which parquet `CFG.circuit_cluster_map` loads it changed that value too, on the same 7
+races, for a model (N11) whose own cluster provenance the PR never checked. An untouched line
+whose input silently moved is the least reviewable kind of change.
+
+**F-D5 (LOW) — the `-1` to NaN change loses a documented convention.** `:1633` / `:1729` carry a
+six-line comment explaining that `-1` is *N11's* unknown-circuit code
+(`.nb_py/N11_overtake_eda.py:210-212`) and that the Categorical cast turns it into LightGBM's
+native missing. `_build_sc_features` now emits `float("nan")` instead, so the two halves of the
+same config disagree about how "unknown circuit" is spelled. Unreachable today (all 24 races
+resolve through `resolve_gp_key`), so LOW, but it is a new inconsistency, not a removed one.
+
+**On NaN safety (asked, answered):** unreachable today, therefore untested by this change.
+`pd.DataFrame([feat])[sc_features]` would give `circuit_cluster` dtype `float64`; LightGBM
+handles missing natively for a numeric feature. Whether the SC booster declares
+`circuit_cluster` categorical (as the N11 booster does) is not established by this PR, and that
+is the case where a `float64` NaN column behaves differently. Nothing in the PR exercises it.
+
+---
+
+### E. The measured effect — the gap filled, and it inverts the PR's own summary
+
+Harness: `profile="no-llm"` (deterministic, zero LLM clients, zero API spend), real 2025 laps
+through `RaceReplayEngine` -> `RaceStateManager` -> `run_lap`, `return_agent_outputs=True`.
+"OLD" is `dev` emulated in-process by rewriting exactly the four values the PR changed back to
+`dev`'s expressions (`DriverNumber -> 0`, `FreshTyre -> int(TyreLife<=1)`,
+`Prev_TyreLife -> max(0, TyreLife-1)`, `circuit_cluster -> int(session_meta.get(..., 0))` over
+the pooled map). No `dev` checkout, no rebuild. 45 laps x 2 runs across three races, chosen so
+one is a **control** where the cluster does not move.
+
+**The emulation is not a no-op** (executed, so the Monza zero is evidence rather than a broken
+patch): `rsm.get_driver_state` at Budapest returns `driver_number=16`, `fresh_tyre=True` on laps
+34 / 40 / 41 / 45 with `tyre_life` 15 / 21 / 1 / 5 — the old proxy would have said `1` only on
+lap 41. The PR's "driver_number=16 and fresh_tyre=True on every lap" verification reproduces.
+And `rsm.get_lap_state(40)["session_meta"]` keys are exactly
+`['driver', 'gp_name', 'team', 'total_laps', 'year']` — the PR's key list is TRUE of *that*
+dict, which is D-1's whole point.
+
+| race (driver) | cluster trained -> served | laps | pace moved >1 ms | `sc_prob_3lap` moved | `overtake_prob` moved | action changed |
+|---|---|---|---|---|---|---|
+| **Monza** (NOR) — CONTROL | 1 -> 1 (no change) | 15 | **0** | **0** | **0** | 0 |
+| **Budapest** (LEC) | 3 -> 1 | 15 | 1 | **15 (100%)** | 0 | 0 |
+| **Zandvoort** (NOR) | 2 -> 0 | 15 | 1 | **12 (80%)** | 2 | 0 |
+
+**Read the control first.** Monza changes `DriverNumber` 0 -> 4 (NOR) and `FreshTyre` 0 -> 1 on
+essentially every lap of the window, and **not one prediction moves, at any precision**. That is
+the honest verdict on W-F2 and W-F3: the inputs were wrong on 100% / 79.8% of laps and the served
+model does not read them (gain 0.03% / 0.00%, per `GATE_DATA_WIRING`). `GATE_801` §9's "zero
+measured impact" label was **correct** for those two items. The PR's headline — *"two of its four
+items turn out to fire on 100% of laps"* — is true about the INPUT and silently reads as being
+about the OUTPUT; it never reports an output number, which is exactly why the label survived
+being contradicted.
+
+**W-F5 moved exactly one lap in 45, and it is the one lap the gate fires.** Budapest lap 41
+(`TyreLife=1`, the stint 3 opener) `-0.0430 s`; Zandvoort lap 24 (`TyreLife=1`) `-0.0440 s`.
+Consistent with C: 0.06% of served laps.
+
+**Everything else that moved is the cluster swap, and it moves the SC probability by 40-70%
+relative, in the direction away from the trained value.**
+
+Budapest (trained cluster 3, now served 1), selected laps:
+
+```
+lap 43   0.0100 -> 0.0170   (+70%)
+lap 45   0.0220 -> 0.0370   (+68%)
+lap 47   0.0130 -> 0.0210   (+62%)
+lap 37   0.0100 -> 0.0150   (+50%)
+```
+
+Zandvoort (trained cluster 2, now served 0), and here it crosses the published bands.
+Executed with `threat_level` read off the dataclass, `CFG.medium_sc=0.0432`, `CFG.high_sc=0.0864`:
+
+```
+lap  sc_OLD   threat_OLD   sc_NEW   threat_NEW   BAND CHANGED
+24   0.1760   HIGH         0.0650   MEDIUM       YES
+25   0.1650   HIGH         0.0600   MEDIUM       YES
+26   0.1650   HIGH         0.0600   MEDIUM       YES
+27   0.0570   MEDIUM       0.0530   MEDIUM
+28   0.0220   LOW          0.0200   LOW
+29   0.0350   LOW          0.0320   LOW
+30   0.0300   LOW          0.0290   LOW
+31   0.1120   HIGH         0.0380   LOW          YES   <- two bands
+```
+
+**4 of 8 laps change `threat_level`, one of them by two bands.** `threat_level` is a
+`RaceSituationOutput` field that reaches the N31 prompt and the arcade / dashboard surfaces. In
+this window it moves from HIGH to MEDIUM/LOW on a track whose trained cluster the model was
+never asked about.
+
+The N30 routing threshold (`CFG.sc_prob_threshold = 0.30`,
+`strategy_orchestrator.py:143,603`) is not crossed anywhere in the sample, and **no action
+changed on any of the 45 laps**. So the blast radius today is `sc_prob_3lap`, `threat_level`, and
+`overtake_prob` (2 laps, via the untouched `predict_overtake_tool`, F-D4 confirmed live) — not
+the final recommendation, in this sample.
+
+**Is "no action changed" reassuring? No, and it should not be reported as such.** Three reasons.
+(1) The sample is 45 laps of three races; `decision_modes` runs windows over 24 races and the MC
+consumes `sc_prob_3lap` directly. (2) The direction is wrong: this is not noise around a correct
+value, it is a systematic move away from the value N14 was fitted with, on 7 of 24 races. (3)
+`threat_level` already changed, and it is a published output; "the argmax did not flip in my
+sample" is a weaker claim than "nothing changed", and the PR makes neither.
+
+---
+
+### F. The exclusion list — one claim FALSE, two STALE, three fine
+
+| item | PR says | verdict |
+|---|---|---|
+| gap-sign hardening | not done, moves nothing | **CORRECT.** `GATE_DATA_WIRING:250-257`: 0 of 25,215 adjacent 2025 pairs invert, so `max(0,.)` == `abs(.)` on the replay geometry. Still unfixed at `race_situation_agent.py:919-923`. |
+| `pace_delta_rolling3` positional pairing | not done, moves nothing | **STALE and WRONG on both halves.** It was fixed in PR 5, twice: `race_situation_agent.py:450-490` now reconstructs N11's membership rule (`_battle_series`), with a docstring narrating both attempts. And it **did** move predictions: `PR5_OVERTAKE_DOMAIN.md:97-118` measures 10.78% of adjacent pairs with different windows, then 29.44% of in-domain pairs after the first fix, calibrated abs-delta max **0.480**, 81 pairs crossing MEDIUM and 38 crossing HIGH. |
+| docstring `tire_agent.py:1023` | not done | **CORRECT.** Still says `stint_laps: FastF1 laps ...` for a frame that is the augmented featured frame. Documentation only. |
+| docstring `_add_prev_cols` | not done | **STALE.** Already fixed: `tire_agent.py:652-667` now states NaN is kept, cites `N10:176,181`, names the old wrong mechanism and its 0.198 s effect. Harmless direction (claims undone what is done), but it is a stale citation in a PR body arguing from citations. |
+| W-F12 (tiredeg msp broadcast) | not done, gate says document | **CORRECT** — `GATE_801` §9 says document, don't change. |
+| B1 Vegas dataset-card note | not done | **CORRECT** — documentation only. |
+| **N15 `TyreLife` "already fixed in an earlier PR"** | already fixed | **FALSE.** See below. |
+
+**F-F1 (MEDIUM) — the "already fixed" is not fixed; a different defect was.**
+What an earlier PR fixed is the **crash**: `row.get('TyreLife', 1)` on a Series returns the
+stored NaN, `int(nan)` raises inside the ReAct loop on 451 rows (1.98%) of the 2025 featured
+parquet. `_tyre_life_in` (`pit_strategy_agent.py:843-870`) now guards that, with a full
+rationale. Good fix, wrong item.
+
+The **wiring** item is the value, and `GATE_DATA_WIRING`'s fix list says it in so many words:
+*"align `_tyre_life_in` missing -> 0 with N15"* (`:395`). N15 encodes a missing tyre age as **0**:
+
+```
+.nb_py/N15_pit_duration.py:268
+out["tyre_life_in"] = out["TyreLife"].clip(upper=50).fillna(0).astype(float)
+```
+
+`_tyre_life_in` returns **1**, on the argument that *"a missing tyre age means fresh is the only
+defensible read"*. That is a strategy opinion overriding a trained encoding, and it picks the
+**colliding** value: `TyreLife == 0` occurs zero times in 2023/2024/2025 (season minimums
+2.0/2.0/1.0 — the constant `UNKNOWN_TYRE_LIFE = 0` in `race_state_builder.py` exists for exactly
+that reason), so 0 is N15's clean missing code and 1 is a real fresh-set age the model also sees
+for real. Sentinel-collides-with-a-legitimate-value, in the file whose docstring argues against
+sentinels colliding with legitimate values. Fires on 451 rows (1.98%).
+
+The PR body's parenthetical — *"(`pit_strategy_agent.py` carries the guard and its rationale)"* —
+is what makes this survivable: the guard IS there and IS rationalised, so a reviewer who follows
+the pointer finds a convincing docstring and stops. Executed-evidence-shaped prose about the
+wrong thing.
+
+**F-F2 (LOW) — the PR's own verification bullet is misleading about the case that matters.**
+*"`_previous_tyre_life`: opener -> `None`, 2 -> 1, 7 -> 6."* Presented as three cases, but `2` IS
+the modal stint opener (656 of 1,153) and it returns `1`, not `None`. The bullet reads as
+"openers return None"; measured, 1.2% of openers do.
+
+**F-F3 (LOW) — `303 passed` is TRUE and proves nothing about the change.** Reproduced:
+`uv run pytest tests/agents tests/simulation tests/inference -q` -> **303 passed, 1 warning in
+62.33 s**. Not one of them asserts the served `circuit_cluster` against the artefact N14 trained
+on. The mirror-image guard already exists one directory over —
+`tests/agents/test_tire_serving_frame.py:94-122`,
+`test_the_agent_reads_the_cluster_family_the_tcn_trained_on`, whose docstring is literally
+*"Pooled, not 2025. The two disagree, and the disagreement is the bug"* and which additionally
+asserts the two maps still differ so the loader cannot be repointed unnoticed. N27 shipped the
+opposite repointing with no equivalent test, and the suite could not see it.
+
+---
+
+## Findings, ranked
+
+| # | sev | finding | file:line |
+|---|---|---|---|
+| **D-3** | **HIGH** | The cluster parquet swap **regresses** N27: the served value matched N14's trained value on 24/24 of 2025 before, on 17/24 after. Measured: `sc_prob_3lap` moves on 100% of Budapest laps (+40..70% relative) and 80% of Zandvoort laps (-60%), and `threat_level` changes band on 4 of 8 Zandvoort laps, one by two bands. | `race_situation_agent.py:263-268` |
+| **D-2** | **HIGH** | The 24/24-vs-17/24 table is measured against `laps_featured_2025.Cluster` (N06's column) and reported as *"the Cluster column N14's training rows actually carry"*. Against the real trained artefact `sc_labeled_2023_2025.parquet`: pooled **58/58**, `_2025` **43/58**. The claim is in the PR body, the commit message, and a source comment. | `race_situation_agent.py:257-262`, commit `58be267` |
+| **D-1** | **HIGH** | *"`session_meta` ... never `circuit_cluster` ... `get(..., 0)` fired on 100% of laps"* is false. `_build_sc_features` has one caller (`:1493`) and it passes `agent.session_meta`, which both constructors (`:1633`, `:1729`) populate with a resolved cluster and a `-1` unknown code. The default never fired. | `race_situation_agent.py:1288-1301` |
+| **F-F1** | **MEDIUM** | "N15 `TyreLife` already fixed" — the crash was fixed, the value was not, and it went the opposite way to the gate's instruction. N15 trains `fillna(0)`; serving sends `1`. 451 rows (1.98%). | `pit_strategy_agent.py:858-861` vs `.nb_py/N15_pit_duration.py:268` |
+| **F-A1** | **MEDIUM** | Twin builders still pass the literal `driver_number: 0`, which the new `.get` cannot rescue (present key). | `engine.py:364`, `strategy_orchestrator.py:2444` |
+| **F-A3** | **MEDIUM** | Wrong-mechanism docstring left in the Args block the PR edited: `driver_number: Car number used to look up TeamID encoding` — TeamID comes from `team`. | `pace_agent.py:830` |
+| **F-C1** | **MEDIUM** | `tyre_life <= 1` catches 14 of 1,153 stint openers (1.2%); 96.6% start at `TyreLife >= 2`. Agreement with the trained column moves 93.26% -> 93.33%. The trigger occurs 0 times in the training pool. | `pace_agent.py:246-256` |
+| **F-C2** | **MEDIUM** | *"NaN is a direction XGBoost learned"* — the training pool has 34 NaN `Prev_TyreLife` rows in 41,821 (0.08%). Asserted, not measured. | `pace_agent.py:246-256`, `:1019-1029` |
+| **F-A2** | **MEDIUM** | Backend `/lap-state` producers still coerce a missing `DriverNumber` to 0 via `_safe`, the sentinel this PR argues against; `_safe_none` is used two lines away. | `endpoints/strategy.py:518`, `:947` |
+| **F-D4** | **MEDIUM** | The swap silently changed `predict_overtake_tool`'s cluster too (untouched line, moved input). Observed on 2 Zandvoort laps. | `race_situation_agent.py:1419-1432` |
+| **F-F2** | LOW | Verification bullet implies openers return `None`; the modal opener (`TyreLife=2`) returns `1`. | PR body |
+| **F-F3** | LOW | `303 passed` is true and blind to the change; the mirror-image guard already exists for `tire_agent`. | `tests/agents/test_tire_serving_frame.py:94-122` |
+| **F-A4** | LOW | `tyre_life: ... drives FreshTyre flag` is now false on the primary path; the PR created the staleness. | `pace_agent.py:833` |
+| **F-A5** | LOW | `run_pace_agent` has no `fresh_tyre`, so the exported flat path keeps the proxy and `tyre_life - 1` unclamped. No production caller. | `pace_agent.py:1074`, `strategy_orchestrator.py:1878,1899` |
+| **F-B1** | LOW | `bool(r.get("FreshTyre", False))` can never be `None`, so the fallback is dead where described and silently serves `0` on a frame lacking the column. | `race_state_manager.py:405`, `pace_agent.py:571` |
+| **F-D5** | LOW | Unknown-cluster is now spelled `NaN` in `_build_sc_features` and `-1` in the two `session_meta` builders, which carry a comment explaining why `-1`. | `race_situation_agent.py:1301` vs `:1633,1729` |
+| **F-F-stale** | LOW | Exclusion list names `pace_delta_rolling3` and `_add_prev_cols` as outstanding; both are already fixed, and the first moved predictions materially when it was. | PR body |
+
+## Fix list, ordered
+
+1. **Revert `race_situation_agent.py:263-268` to `circuit_clusters_k4.parquet`.** It is what N13
+   built `sc_labeled_2023_2025.parquet` with (`.nb_py/N13_sc_eda.py:90`) and what N14 trained on
+   (58/58, executed). This is the only change in the PR that moves a prediction, and it moves it
+   the wrong way.
+2. **Add the mirror of `test_the_agent_reads_the_cluster_family_the_tcn_trained_on` for N27**,
+   asserting the served map against `sc_labeled_2023_2025.parquet` *and* that the two maps still
+   differ. Copy the shape from `tests/agents/test_tire_serving_frame.py:94-122`.
+3. **Rewrite the `circuit_cluster` comment** (`:1288-1301`) to say what is true: `session_meta`
+   *does* carry a resolved cluster on both paths; the change under discussion (if any survives)
+   is re-resolution and the unknown code, not a fired default. Keep `-1`, not `NaN`, so the three
+   sites agree; or change all three together and say so.
+4. **Decide `_tyre_life_in` on the trained convention, not on strategy** — return `0` to match
+   `N15:268`, or write down why the serving convention deliberately differs. Either way, stop
+   describing it as "already fixed".
+5. **Fix the two `driver_number: 0` twins** (`engine.py:364`, `strategy_orchestrator.py:2444`) to
+   `None`, so the PR's own None-not-zero rule holds on the fallback path.
+6. **Repoint `endpoints/strategy.py:518,947` at `_safe_none`.**
+7. **Correct `pace_agent.py:830` and `:833`** — `driver_number` is a raw feature, not a TeamID
+   key; `tyre_life` no longer drives `FreshTyre` on the `from_state` path.
+8. **Restate W-F5's scope honestly in the docstring**: the gate is `TyreLife <= 1`, which is 1.2%
+   of stint openers; the remaining 96.6% still receive a number where training had NaN. Say
+   whether that is deliberate (it can be — `TyreLife-1` is the right answer whenever consecutive
+   laps survived) rather than leaving "stint opener" to imply the class.
+9. **Refresh the exclusion list**: drop `pace_delta_rolling3` and `_add_prev_cols` (done), and
+   delete "none of those moves a prediction" — for `pace_delta_rolling3` it moved a calibrated
+   probability by up to 0.480.
+10. **Report an output number, not an input rate.** The control race is one extra run and it is
+    what turns "fires on 100% of laps" into a defensible sentence.
+
+## What I tried to break and could NOT
+
+- **The `DriverNumber` emission itself.** Swept all 71 raw race parquets (77,720 rows):
+  `DriverNumber` is `dtype=object` everywhere, **0 NaN, 0 values that `int()` would reject**, so
+  `int(r["DriverNumber"])` cannot raise on shipped data. `pd.notna` on a `str` behaves. The
+  featured parquets are `int32`, range 1-87, no zeros.
+- **Downstream coercion of the new `None`.** `_build_feature_row`'s
+  `to_numeric(errors="coerce")` gives NaN; `_bootstrap_ci`'s `noise_cols` excludes both
+  `DriverNumber` and `Prev_TyreLife`, so the perturbation path leaves the NaN intact rather than
+  multiplying it into a `sigma`; the envelope excludes `DriverNumber` by design
+  (`pace_agent.py:117-121`), so nothing clips it. No path turns it back into 0.
+- **The `FreshTyre` semantics claim.** I expected the "constant across a stint" story to be
+  approximately true. It is exactly true: 1,134 of 1,134 stints have a single value, on N04's own
+  grouping keys. The 79.83% disagreement figure is real and the PR understates it — the old proxy
+  was TRUE on 14 laps in a 22,760-lap season.
+- **The `_previous_tyre_life` direction.** I looked for rows where the new rule sends `None` and
+  training had a number: **0 rows**. It is incomplete, not harmful.
+- **The 24/24-vs-17/24 arithmetic.** Recomputed independently against
+  `laps_featured_2025.Cluster`: pooled 17/24, `_2025` 24/24, same seven races. The number is
+  right; only the artefact it is being compared to is wrong.
+- **`driver_number=16` / `fresh_tyre=True` for Leclerc at Budapest, and the `session_meta` key
+  list.** Both reproduce exactly as the PR states.
+- **`303 passed`.** Reproduced, 62.33 s, zero failures.
+- **A crash or a 422 from the new `NaN` cluster.** Could not reach it: all 24 of 2025's races
+  resolve through `resolve_gp_key` against the `_2025` map, so `_cluster is None` never happens
+  today. The NaN branch is untested rather than broken.
+- **An action flip.** Across 45 lap-pairs in three races, `recommendation.action` was identical
+  on every single lap. The damage this PR does today stops at `sc_prob_3lap` /
+  `threat_level` / `overtake_prob`.
+- **`ruff format --check .`** — the follow-up commit `88bd948` does what it says; reproduced at `155 files already formatted`. `src/agents/**` is genuinely outside `[tool.ruff.format] exclude` (pyproject.toml:218), so leaving race_situation_agent unformatted is correct, not an oversight.

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -827,10 +827,18 @@ class PaceAgent:
         session median for the current GP/year/compound.
 
         Args:
-            driver_number: Car number used to look up TeamID encoding.
+            driver_number: Car number. A RAW feature the model splits on, not a
+                lookup key for anything - the TeamID encoding this line used to
+                claim comes from `team`. None when the source has no reading, and
+                it must stay None: 0 is not absent, it is a value the model finds,
+                sorting below every real car number (#831).
             lap_number: Current race lap; used for FuelLoad estimation.
             stint: Stint number (1-indexed), forwarded as a raw feature.
-            tyre_life: Laps on current tyre set; drives FreshTyre flag.
+            tyre_life: Laps on current tyre set. It no longer drives FreshTyre on
+                the `from_state` path - the state manager emits FastF1's real
+                set-was-new flag and `tyre_life <= 1` was only ever a proxy for it,
+                agreeing on outlaps and disagreeing on every lap 2+ of a fresh-set
+                stint (#831). The fallback still uses it when the flag is absent.
             compound: Pirelli compound name.
             position: Current race position (1-based). None when the source
                 telemetry has no reading for this lap; propagates as a missing

--- a/src/agents/pace_agent.py
+++ b/src/agents/pace_agent.py
@@ -243,6 +243,20 @@ class PaceOutput:
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+def _previous_tyre_life(tyre_life: Optional[int]) -> Optional[int]:
+    """The previous lap's tyre age, or None where training had no previous lap.
+
+    N04 builds ``Prev_TyreLife`` as a stint-grouped shift, so a stint opener is
+    NaN. Inference used to send ``max(0, tyre_life - 1)`` unconditionally, which
+    made an opener 0: below the trained minimum of 2.0, and a NUMBER where
+    training had an ABSENCE. XGBoost has a learned default direction for missing;
+    it has none for a tyre younger than any it ever saw.
+    """
+    if tyre_life is None or tyre_life <= 1:
+        return None
+    return tyre_life - 1
+
+
 class PaceAgent:
     """Encapsulates the N06 XGBoost lap-time prediction pipeline.
 
@@ -488,11 +502,14 @@ class PaceAgent:
         total_laps: int,
         mean_sector_speed: float,
         stint_baseline_tyre_life: Optional[int] = None,
+        fresh_tyre: Optional[bool] = None,
     ) -> dict:
         """Compute features derived from raw inputs that are not in the source data.
 
-        FreshTyre: binary flag for the first lap on a new tyre set — captures
-        the outlap pace loss caused by tyre heating and rubber laydown.
+        FreshTyre: FastF1's "the fitted set was NEW" flag, TRUE for every lap of
+        that stint. It is NOT a first-lap flag, and this docstring said it was:
+        naming the wrong mechanism is how a proxy survives review, because the
+        code then matches its own description (W-F3).
         FuelEffect: cumulative fuel burn pace gain (lighter car = faster lap).
         laps_remaining: inverted lap count used as a proxy for race phase.
         mean_sector_speed: passed through untouched, already resolved by the caller.
@@ -542,7 +559,16 @@ class PaceAgent:
             fuel_effect = (tyre_life - stint_baseline_tyre_life) * FUEL_GAIN_PER_LAP_S
 
         return {
-            "FreshTyre": int(tyre_life <= 1),
+            # The FITTED-SET flag, which is what N06 trained on, and not a first-lap
+            # flag. FastF1's `FreshTyre` says the set was NEW when it went on and stays
+            # True for EVERY lap of that stint; `int(tyre_life <= 1)` is an outlap flag,
+            # so the two agreed only on outlaps and on used-set stints and disagreed on
+            # every lap 2 or later of a fresh-set stint, which is most racing laps
+            # (W-F3). The state manager has emitted the real flag all along
+            # (`race_state_manager.py:438`) and this function computed a proxy beside
+            # it. `fresh_tyre` falls back to the old expression only for callers that do
+            # not supply it, which is the direct `run()` path and its tests.
+            "FreshTyre": int(fresh_tyre) if fresh_tyre is not None else int(tyre_life <= 1),
             "FuelEffect": fuel_effect,
             "laps_remaining": max(0, total_laps - lap_number),
             "mean_sector_speed": mean_sector_speed,
@@ -550,7 +576,7 @@ class PaceAgent:
 
     def _build_feature_row(
         self,
-        driver_number: int,
+        driver_number: Optional[int],
         lap_number: int,
         stint: int,
         tyre_life: int,
@@ -561,7 +587,7 @@ class PaceAgent:
         fuel_load: float,
         year: int,
         prev_lap_time: float,
-        prev_tyre_life: int,
+        prev_tyre_life: Optional[int],
         prev_speed_st: float,
         air_temp: float,
         track_temp: float,
@@ -574,6 +600,7 @@ class PaceAgent:
         prev_cum_deg: float = 0.0,
         prev_deg_accel: float = 0.0,
         stint_baseline_tyre_life: Optional[int] = None,
+        fresh_tyre: Optional[bool] = None,
     ) -> pd.DataFrame:
         """Pack raw race state into a single-row DataFrame ready for predict().
 
@@ -601,6 +628,7 @@ class PaceAgent:
             total_laps,
             resolved_mean_sector_speed,
             stint_baseline_tyre_life,
+            fresh_tyre,
         )
 
         row = {
@@ -766,7 +794,7 @@ class PaceAgent:
 
     def run(
         self,
-        driver_number: int,
+        driver_number: Optional[int],
         lap_number: int,
         stint: int,
         tyre_life: int,
@@ -777,7 +805,7 @@ class PaceAgent:
         fuel_load: float,
         year: int,
         prev_lap_time: float,
-        prev_tyre_life: int,
+        prev_tyre_life: Optional[int],
         prev_speed_st: float,
         air_temp: float,
         track_temp: float,
@@ -790,6 +818,7 @@ class PaceAgent:
         prev_cum_deg: float = 0.0,
         prev_deg_accel: float = 0.0,
         stint_baseline_tyre_life: Optional[int] = None,
+        fresh_tyre: Optional[bool] = None,
     ) -> PaceOutput:
         """Run pace prediction for a single lap and return a PaceOutput.
 
@@ -814,7 +843,8 @@ class PaceAgent:
             fuel_load: Estimated fuel fraction in [0, 1].
             year: Race year (2023/2024/2025).
             prev_lap_time: Previous lap time in seconds.
-            prev_tyre_life: TyreLife on the previous lap.
+            prev_tyre_life: TyreLife on the previous lap, or None on a stint
+                opener, where the trained column is NaN by construction.
             prev_speed_st: Speed trap reading in km/h from the previous lap.
             air_temp: Air temperature in °C.
             track_temp: Track surface temperature in °C.
@@ -933,7 +963,17 @@ class PaceAgent:
         _rainfall = reading_or_default(wx, "rainfall", 0)
 
         return self.run(
-            driver_number=d.get("driver_number") or 0,
+            # The real car number, now that the state manager emits it (W-F2). It used
+            # to be `or 0` against a key nobody produced, so every replay lap served 0:
+            # a value outside the trained vocabulary (1-81) AND a findable one, since 0
+            # sorts below every real number and sends each DriverNumber split down its
+            # left branch. `.get` without `or`, because a genuinely missing number must
+            # stay None and reach the model as NaN, which is a direction XGBoost
+            # learned, rather than as a car that does not exist.
+            driver_number=d.get("driver_number"),
+            # The real fitted-set flag, which the state manager has emitted all along
+            # while this call computed a first-lap proxy from tyre_life instead (W-F3).
+            fresh_tyre=d.get("fresh_tyre"),
             lap_number=lap_number,
             stint=d.get("stint") or 1,
             tyre_life=d.get("tyre_life") or 1,
@@ -979,7 +1019,14 @@ class PaceAgent:
             # order-of-magnitude placeholder the old (wrong) code used, now only
             # reached on a genuinely missing previous lap.
             prev_lap_time=d.get("prev_lap_time") or MISSING_PREV_LAP_TIME_S,
-            prev_tyre_life=max(0, (d.get("tyre_life") or 1) - 1),
+            # None on a stint opener, where N04's grouped shift leaves NaN, instead of
+            # the 0 this used to send (W-F5). 0 is below the trained minimum of 2.0, so
+            # the model read a tyre younger than any it was fitted on rather than the
+            # absence training taught it to handle; NaN is a direction XGBoost learned.
+            # Off a stint opener the value stays current-1, which is the right answer
+            # whenever consecutive laps survived N04's filter, and an approximation
+            # where they did not.
+            prev_tyre_life=_previous_tyre_life(d.get("tyre_life")),
             prev_speed_st=_prev_speed_st,
             air_temp=float(_air_temp),
             track_temp=float(_trk_temp),

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -252,8 +252,19 @@ class RaceSituationConfig:
         # The bands below are deliberately NOT the classifier operating points; they
         # are pit-wall alert levels, set on the served calibrated scale (#665).
 
-        # Circuit cluster map (k=4 parquet from N05)
-        _cl = pd.read_parquet(_PROCESSED / "circuit_clustering" / "circuit_clusters_k4.parquet")
+        # Circuit cluster map (k=4 parquet from N05).
+        #
+        # The _2025 file, which is what `pace_agent` already loads and what the served
+        # models were fitted against. MEASURED against the `Cluster` column of
+        # `laps_featured_2025.parquet`, which is the value N14's training rows actually
+        # carry: `circuit_clusters_k4_2025.parquet` agrees on **24 of 24** GPs, the
+        # pooled `circuit_clusters_k4.parquet` this used to read agrees on **17 of 24**.
+        # So the pooled file would hand N14 a cluster its own training rows never had
+        # for seven races (Budapest alone moves 3 -> 1). Same split the PR 6 gate found
+        # in the producer; this is its consumer-side twin.
+        _cl = pd.read_parquet(
+            _PROCESSED / "circuit_clustering" / "circuit_clusters_k4_2025.parquet"
+        )
         self.circuit_cluster_map: dict = dict(zip(_cl["GP_Name"], _cl["Cluster"].astype(int)))
 
         # Circuit SC base rates (from N13 labeled parquet)
@@ -1274,7 +1285,20 @@ class RaceSituationAgent:
         yel_esc = feat.get("yellow_escalation_count", 0)
         feat["anomaly_and_yellow"] = int(anom_hard > 0 and yel_esc > 0)
         feat["lap1_chaos"] = is_lap1 * abs(feat.get("n_drivers_delta", 0))
-        feat["circuit_cluster"] = int(session_meta.get("circuit_cluster", 0))
+        # RESOLVED from the circuit, not defaulted. `session_meta` carries `gp_name`
+        # and never `circuit_cluster` on the replay path (measured: its keys are
+        # driver / gp_name / team / total_laps / year), so `get(..., 0)` fired on 100%
+        # of laps — and 0 is a REAL cluster, one of {0,1,2,3}, so every race was
+        # silently told it was a cluster-0 circuit with no way to tell that apart from
+        # a race that genuinely is one. A default the code can also legitimately find
+        # is the #428 shape this repo has been bitten by repeatedly.
+        #
+        # `cluster_for` is the resolver the sibling `circuit_sc_rate` feature already
+        # uses, and it handles all four GP spellings. NaN, not -1, when it genuinely
+        # cannot resolve: LightGBM has a learned direction for missing and none for a
+        # cluster that does not exist.
+        _cluster = CFG.cluster_for(str(session_meta.get("gp_name", "")))
+        feat["circuit_cluster"] = float("nan") if _cluster is None else int(_cluster)
         feat["circuit_sc_rate"] = float(session_meta.get("circuit_sc_rate", 0.10))
         feat["lap_pct"] = lap_pct
         feat["is_lap1"] = is_lap1

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -252,19 +252,8 @@ class RaceSituationConfig:
         # The bands below are deliberately NOT the classifier operating points; they
         # are pit-wall alert levels, set on the served calibrated scale (#665).
 
-        # Circuit cluster map (k=4 parquet from N05).
-        #
-        # The _2025 file, which is what `pace_agent` already loads and what the served
-        # models were fitted against. MEASURED against the `Cluster` column of
-        # `laps_featured_2025.parquet`, which is the value N14's training rows actually
-        # carry: `circuit_clusters_k4_2025.parquet` agrees on **24 of 24** GPs, the
-        # pooled `circuit_clusters_k4.parquet` this used to read agrees on **17 of 24**.
-        # So the pooled file would hand N14 a cluster its own training rows never had
-        # for seven races (Budapest alone moves 3 -> 1). Same split the PR 6 gate found
-        # in the producer; this is its consumer-side twin.
-        _cl = pd.read_parquet(
-            _PROCESSED / "circuit_clustering" / "circuit_clusters_k4_2025.parquet"
-        )
+        # Circuit cluster map (k=4 parquet from N05)
+        _cl = pd.read_parquet(_PROCESSED / "circuit_clustering" / "circuit_clusters_k4.parquet")
         self.circuit_cluster_map: dict = dict(zip(_cl["GP_Name"], _cl["Cluster"].astype(int)))
 
         # Circuit SC base rates (from N13 labeled parquet)
@@ -1285,20 +1274,7 @@ class RaceSituationAgent:
         yel_esc = feat.get("yellow_escalation_count", 0)
         feat["anomaly_and_yellow"] = int(anom_hard > 0 and yel_esc > 0)
         feat["lap1_chaos"] = is_lap1 * abs(feat.get("n_drivers_delta", 0))
-        # RESOLVED from the circuit, not defaulted. `session_meta` carries `gp_name`
-        # and never `circuit_cluster` on the replay path (measured: its keys are
-        # driver / gp_name / team / total_laps / year), so `get(..., 0)` fired on 100%
-        # of laps — and 0 is a REAL cluster, one of {0,1,2,3}, so every race was
-        # silently told it was a cluster-0 circuit with no way to tell that apart from
-        # a race that genuinely is one. A default the code can also legitimately find
-        # is the #428 shape this repo has been bitten by repeatedly.
-        #
-        # `cluster_for` is the resolver the sibling `circuit_sc_rate` feature already
-        # uses, and it handles all four GP spellings. NaN, not -1, when it genuinely
-        # cannot resolve: LightGBM has a learned direction for missing and none for a
-        # cluster that does not exist.
-        _cluster = CFG.cluster_for(str(session_meta.get("gp_name", "")))
-        feat["circuit_cluster"] = float("nan") if _cluster is None else int(_cluster)
+        feat["circuit_cluster"] = int(session_meta.get("circuit_cluster", 0))
         feat["circuit_sc_rate"] = float(session_meta.get("circuit_sc_rate", 0.10))
         feat["lap_pct"] = lap_pct
         feat["is_lap1"] = is_lap1

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -2441,7 +2441,13 @@ def run_strategy_orchestrator_from_state(
             "lap_number": race_state.lap,
             "driver": {
                 "driver":        race_state.driver,
-                "driver_number": 0,
+                # None, not 0. This is the synthetic lap state built when no real one
+                # exists, so the car number is genuinely unknown, and 0 is a value the
+                # model can also legitimately find: it sorts below every real number
+                # (1-81) and sends each DriverNumber split down its left branch. A
+                # PRESENT key set to 0 also defeats the consumer's `.get`, which is why
+                # fixing the reader alone was not enough (W-F2).
+                "driver_number": None,
                 "team":          team,
                 "position":      race_state.position,
                 "compound":      race_state.compound,

--- a/src/simulation/race_state_manager.py
+++ b/src/simulation/race_state_manager.py
@@ -443,9 +443,7 @@ class RaceStateManager:
             # each DriverNumber split down its left branch (W-F2). The value is right
             # here in the row. None rather than 0 when it is genuinely missing, so the
             # absence stays an absence.
-            "driver_number": int(r["DriverNumber"])
-            if pd.notna(r.get("DriverNumber"))
-            else None,
+            "driver_number": int(r["DriverNumber"]) if pd.notna(r.get("DriverNumber")) else None,
             # --- Speed traps (all four sensor points) ---
             "speed_i1": float(r["SpeedI1"]) if pd.notna(r.get("SpeedI1")) else None,
             "speed_i2": float(r["SpeedI2"]) if pd.notna(r.get("SpeedI2")) else None,

--- a/src/simulation/race_state_manager.py
+++ b/src/simulation/race_state_manager.py
@@ -436,6 +436,16 @@ class RaceStateManager:
                 self._stint_baselines.get(int(r["Stint"])) if pd.notna(r.get("Stint")) else None
             ),
             "fresh_tyre": bool(r.get("FreshTyre", False)),
+            # N06 trains on DriverNumber as a real feature (car numbers 1-81; 0 never
+            # occurs). Nothing emitted it, so `pace_agent.run_from_state` fell back to
+            # `or 0` on every replay lap: a constant outside the trained vocabulary,
+            # and a findable one, since 0 sorts below every real car number and sends
+            # each DriverNumber split down its left branch (W-F2). The value is right
+            # here in the row. None rather than 0 when it is genuinely missing, so the
+            # absence stays an absence.
+            "driver_number": int(r["DriverNumber"])
+            if pd.notna(r.get("DriverNumber"))
+            else None,
             # --- Speed traps (all four sensor points) ---
             "speed_i1": float(r["SpeedI1"]) if pd.notna(r.get("SpeedI1")) else None,
             "speed_i2": float(r["SpeedI2"]) if pd.notna(r.get("SpeedI2")) else None,

--- a/src/strategy/inference/engine.py
+++ b/src/strategy/inference/engine.py
@@ -361,7 +361,13 @@ def _build_default_lap_state(race_state: RaceState, laps_df: pd.DataFrame) -> di
         "lap_number": race_state.lap,
         "driver": {
             "driver": race_state.driver,
-            "driver_number": 0,
+            # None, not 0. This is the synthetic lap state built when no real one
+            # exists, so the car number is genuinely unknown, and 0 is a value the
+            # model can also legitimately find: it sorts below every real number
+            # (1-81) and sends each DriverNumber split down its left branch. A
+            # PRESENT key set to 0 also defeats the consumer's `.get`, which is why
+            # fixing the reader alone was not enough (W-F2).
+            "driver_number": None,
             "team": team,
             "position": race_state.position,
             "compound": race_state.compound,

--- a/tests/agents/test_situation_serving_cluster.py
+++ b/tests/agents/test_situation_serving_cluster.py
@@ -40,16 +40,10 @@ _N13_SOURCE = ROOT / ".nb_py" / "N13_sc_eda.py"
 _N27_SOURCE = ROOT / "src" / "agents" / "race_situation_agent.py"
 
 
-def test_the_sc_agent_loads_the_same_map_the_sc_labels_were_built_from():
-    """N13 built the labels from the pooled map; N27 must serve the same one."""
-    n13 = _N13_SOURCE.read_text(encoding="utf-8")
+def test_the_sc_agent_loads_the_pooled_map_and_only_that_one():
+    """The half that runs everywhere: N27's own source, which IS tracked in git."""
     n27 = _N27_SOURCE.read_text(encoding="utf-8")
 
-    assert _POOLED_NAME in n13, (
-        "N13 no longer builds sc_labeled from the pooled clustering; whatever it "
-        "builds from is now what N27 must serve, and this test needs rewriting "
-        "against it rather than deleting"
-    )
     assert _POOLED_NAME in n27, (
         "N27 no longer loads the pooled clustering. Read this module's docstring "
         "before changing it: the obvious-looking repoint at the _2025 map is a "
@@ -57,6 +51,26 @@ def test_the_sc_agent_loads_the_same_map_the_sc_labels_were_built_from():
     )
     assert _SEASON_NAME not in n27, (
         "N27 references the 2025 clustering family, which N14 never trained on"
+    )
+
+
+@pytest.mark.skipif(
+    not _N13_SOURCE.exists(),
+    reason=".nb_py/ is gitignored, so this half cannot run on a CI runner",
+)
+def test_the_map_n27_serves_is_the_one_n13_built_the_labels_from():
+    """The other half of the pairing, checkable only where the notebooks are.
+
+    `.nb_py/` is gitignored (`.gitignore:148`), so without this marker the test
+    would fail on every CI runner rather than skip -- the mirror of the mistake
+    that turned this branch's sibling red: guard on the artefact the test READS,
+    and check whether git actually ships it.
+    """
+    n13 = _N13_SOURCE.read_text(encoding="utf-8")
+    assert _POOLED_NAME in n13, (
+        "N13 no longer builds sc_labeled from the pooled clustering; whatever it "
+        "builds from is now what N27 must serve, so rewrite this against it "
+        "rather than deleting it"
     )
 
 

--- a/tests/agents/test_situation_serving_cluster.py
+++ b/tests/agents/test_situation_serving_cluster.py
@@ -1,0 +1,79 @@
+"""N27 serves N14 the circuit clustering N14 trained on (gate finding on #831).
+
+The mirror of `test_tire_serving_frame.py::test_the_agent_reads_the_cluster_family_the_tcn_trained_on`,
+and it exists because I got this exact question backwards.
+
+Two clustering families live under `data/processed/circuit_clustering/`, and which one
+a model trained on is a property OF THAT MODEL, not of the repository. My first attempt
+at #831 repointed N27 at `circuit_clusters_k4_2025.parquet` on the strength of a table
+showing it agreeing 24/24 with `laps_featured_2025.Cluster` — which is **N06's** training
+column. N14 trains on `sc_labeled_2023_2025.parquet`, which N13 builds from the POOLED
+map, so the fix would have handed N14 a clustering its own training rows never carried,
+moving `sc_prob_3lap` on 15 of 15 Budapest laps.
+
+WHY THIS ASSERTS ON SOURCES, NOT ON A JOIN
+------------------------------------------
+The obvious test — join `sc_labeled`'s `circuit_cluster` against each map and compare —
+cannot be written directly: that frame keys on `race_id` (`"2023_1"`), not `GP_Name`, and
+reconstructing the mapping would mean reimplementing N13's fuzzy `resolve_cluster` here.
+A reimplementation is what this test is guarding against.
+
+So it pins the pairing where it is unambiguous: N13's own source names the file it built
+the labels from, and N27's source names the file it serves. Both must be the same file,
+and the two families must still genuinely differ — otherwise this passes on a day they
+coincide and the loader could be repointed unnoticed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+_CLUSTERS = ROOT / "data" / "processed" / "circuit_clustering"
+_POOLED_NAME = "circuit_clusters_k4.parquet"
+_SEASON_NAME = "circuit_clusters_k4_2025.parquet"
+
+_N13_SOURCE = ROOT / ".nb_py" / "N13_sc_eda.py"
+_N27_SOURCE = ROOT / "src" / "agents" / "race_situation_agent.py"
+
+
+def test_the_sc_agent_loads_the_same_map_the_sc_labels_were_built_from():
+    """N13 built the labels from the pooled map; N27 must serve the same one."""
+    n13 = _N13_SOURCE.read_text(encoding="utf-8")
+    n27 = _N27_SOURCE.read_text(encoding="utf-8")
+
+    assert _POOLED_NAME in n13, (
+        "N13 no longer builds sc_labeled from the pooled clustering; whatever it "
+        "builds from is now what N27 must serve, and this test needs rewriting "
+        "against it rather than deleting"
+    )
+    assert _POOLED_NAME in n27, (
+        "N27 no longer loads the pooled clustering. Read this module's docstring "
+        "before changing it: the obvious-looking repoint at the _2025 map is a "
+        "regression, and it moved sc_prob_3lap on 15 of 15 Budapest laps"
+    )
+    assert _SEASON_NAME not in n27, (
+        "N27 references the 2025 clustering family, which N14 never trained on"
+    )
+
+
+@pytest.mark.skipif(
+    not ((_CLUSTERS / _POOLED_NAME).exists() and (_CLUSTERS / _SEASON_NAME).exists()),
+    reason="clustering artefacts absent (HF dataset not fetched)",
+)
+def test_the_two_cluster_families_still_disagree():
+    """Without this, the test above passes on a day the two maps coincide."""
+    pooled = pd.read_parquet(_CLUSTERS / _POOLED_NAME, columns=["GP_Name", "Cluster"])
+    season = pd.read_parquet(_CLUSTERS / _SEASON_NAME, columns=["GP_Name", "Cluster"])
+
+    merged = pooled.merge(season, on="GP_Name", suffixes=("_pooled", "_season"))
+    assert not merged.empty, "no GP names joined; the key convention changed"
+
+    disagreements = (merged["Cluster_pooled"] != merged["Cluster_season"]).sum()
+    assert disagreements > 0, (
+        "the two cluster families now agree everywhere, so the loader could be "
+        "repointed unnoticed and the source assertion above has lost its teeth"
+    )

--- a/tests/audit/test_backend_car_number_is_not_zeroed.py
+++ b/tests/audit/test_backend_car_number_is_not_zeroed.py
@@ -1,0 +1,95 @@
+"""Guards gate finding F-A2: a missing car number must not become 0 in the backend.
+
+#831's argument is that `DriverNumber = 0` is not an absent value but a **findable**
+one: N06 trains on car numbers 1-81, so a 0 sorts below every real number and sends
+each `DriverNumber` split down its left branch. That PR fixed the replay path and
+left both backend lap-state producers doing `int(_safe(row.get("DriverNumber", 0)))`
+— the same defect, one layer away from where the argument was made, which is this
+repository's most repeated shape.
+
+WHY THIS TEST LIVES IN THE PARENT REPO
+--------------------------------------
+The code it guards is in the `src/telemetry` submodule, which has **no test runner
+of its own** (only vendored library suites under `.venv`). So a test placed there
+would never execute. The parent's CI is the only thing that runs, which makes this
+the only place the guard can sit.
+
+It asserts on the PARSED SOURCE rather than on a string match, per this repo's own
+"grep is not an audit" lesson: a comment mentioning `DriverNumber` must not satisfy
+it, and a real assignment must not slip past it because the formatting changed.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_BACKEND_ENDPOINT = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "telemetry"
+    / "backend"
+    / "api"
+    / "v1"
+    / "endpoints"
+    / "strategy.py"
+)
+
+# The helper both producers must route through. It returns None for an absent
+# reading and an int otherwise -- the int matters because the first producer falls
+# back to the RAW per-race parquet, where DriverNumber is dtype=object holding
+# strings, while the featured frame holds int32.
+_REQUIRED_HELPER = "_int_or_none"
+
+
+def _driver_number_values(tree: ast.AST) -> list[ast.AST]:
+    """Every value assigned to a `"driver_number"` key in a dict literal."""
+    found: list[ast.AST] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        for key, value in zip(node.keys, node.values):
+            is_the_key = isinstance(key, ast.Constant) and key.value == "driver_number"
+            if is_the_key:
+                found.append(value)
+    return found
+
+
+@pytest.mark.skipif(
+    not _BACKEND_ENDPOINT.exists(),
+    reason="src/telemetry submodule not initialised",
+)
+def test_neither_lap_state_producer_defaults_the_car_number_to_zero():
+    """Both producers route through the None-preserving helper, not a 0 default."""
+    tree = ast.parse(_BACKEND_ENDPOINT.read_text(encoding="utf-8"))
+    values = _driver_number_values(tree)
+
+    # Two lap-state producers plus one response row that legitimately carries a
+    # known number. Fewer means a producer was renamed and this guard went blind.
+    assert len(values) >= 2, f"expected at least 2 driver_number assignments, got {len(values)}"
+
+    routed_through_helper = [
+        v
+        for v in values
+        if isinstance(v, ast.Call)
+        and isinstance(v.func, ast.Name)
+        and v.func.id == _REQUIRED_HELPER
+    ]
+    assert len(routed_through_helper) == 2, (
+        f"expected exactly 2 producers using {_REQUIRED_HELPER}(), found "
+        f"{len(routed_through_helper)}; a missing car number is being coerced to a "
+        f"value the model can find (gate finding F-A2 on #831)"
+    )
+
+    # The specific regression: the helper called with a literal 0 fallback, or the
+    # old `_safe(..., 0)` / `_s(..., 0)` shape, defeats the whole point.
+    for call in routed_through_helper:
+        for arg in call.args:
+            if isinstance(arg, ast.Call) and arg.args:
+                literals = [a.value for a in arg.args if isinstance(a, ast.Constant)]
+                assert 0 not in literals, (
+                    "a 0 default was reintroduced inside the car-number lookup; "
+                    "absent must stay absent and reach the model as NaN"
+                )


### PR DESCRIPTION
## What

PR 8 of the data-wiring plan: the bundle the earlier gate ranked last and labelled *"zero measured impact, and it says so"*.

**That label was right, and my first version of this PR said it was wrong.** An Opus adversarial gate settled it with a control run, one of my two headline claims was refuted, and the change it justified was a regression I have reverted. The corrected version is below; the full report is in `documents/audits/GATE_831_input_wiring.md`, committed here.

## The three items this PR ships

**W-F2 `DriverNumber`.** The state manager emitted no such key, so `pace_agent`'s `d.get("driver_number") or 0` served **0 on every replay lap**: outside the trained vocabulary (car numbers 1-81) and *findable*, since 0 sorts below every real number and sends each `DriverNumber` split down its left branch. The value was in the row all along. Now emitted, and `None` rather than 0 when genuinely absent, so the model reads NaN — a direction it learned.

**W-F3 `FreshTyre`.** N06 trained on FastF1's *set-was-new* flag, TRUE for **every lap of a fresh-set stint**; inference computed `int(tyre_life <= 1)`, an outlap flag. They agree on outlaps and used-set stints and disagree on every lap 2+ of a fresh-set stint, which is most racing laps. The state manager has emitted the real flag all along (`race_state_manager.py:438`) and the agent computed a proxy beside it. The docstring named the outlap mechanism, which is how a proxy survives review: the code matches its own description.

**W-F5 `Prev_TyreLife`.** A stint opener is NaN in training (grouped shift) and was **0** at inference: below the trained minimum of 2.0, and a NUMBER where training had an ABSENCE.

## What the gate's control run actually measured, and it inverts my summary

Deterministic harness (`profile="no-llm"`, zero API spend), real 2025 laps through `RaceReplayEngine` → `RaceStateManager` → `run_lap`, 45 laps × 2 runs across three races — with one chosen as a **control**:

| race | what moves | laps | pace >1 ms | `sc_prob_3lap` | `overtake_prob` | action |
|---|---|---|---|---|---|---|
| **Monza (NOR) — CONTROL** | `DriverNumber` 0→4, `FreshTyre` 0→1 on essentially every lap | 15 | **0** | **0** | **0** | **0** |

**Read the control first.** The two inputs this PR is mostly about were wrong on 100% and 79.8% of laps, and **not one prediction moves, at any precision** (feature gains 0.03% and 0.00%). My headline — *"two of its four items fire on 100% of laps"* — is true of the **INPUT** and reads as a claim about the **OUTPUT**, and the PR never reported an output number. That gap is the finding, not the wording.

**W-F5 moved exactly one lap in 45**, and it is the one lap it exists for: a stint opener (`TyreLife=1`), −0.043 s at Budapest lap 41 and −0.044 s at Zandvoort lap 24. Over 1,153 real stint openers it moves agreement 93.26% → 93.33%, because `tyre_life <= 1` already caught 14 of them. True statement, headline three sizes too big.

**So this PR is correctness hygiene with no measured behaviour change**, and that is the honest description. Serving a model the value it trained on is worth doing when the cost is four lines; claiming it buys accuracy is not.

## ⛔ The fourth item was REMOVED: it was a regression, not a fix

The original PR also resolved N27's `circuit_cluster` and switched which clustering artefact it loads. **Both were wrong. The gate caught it, I verified before reverting, and `race_situation_agent.py` is no longer in this diff.**

- **I measured one dict and asserted it about another.** I checked that `RaceStateManager`'s `session_meta` carries no `circuit_cluster` and concluded the `get(..., 0)` default fires on 100% of laps. But `_build_sc_features` has exactly one caller and it passes **`agent.session_meta`** — a different dict, whose two constructors both set a resolved cluster with an explicit unknown code. **The default never fired.**
- **My comparison table used the wrong model's training column.** I showed `circuit_clusters_k4_2025.parquet` agreeing 24/24 against `laps_featured_2025.Cluster` — which is **N06's** column. **N14 trains on `sc_labeled_2023_2025.parquet`**, and against *its* `circuit_cluster` the pooled file agrees **23/23** and the `_2025` file **17/23**: the exact inverse. The "fix" would have fed N27 a clustering its model never trained on, for six races — `sc_prob_3lap` moved on 15 of 15 Budapest laps and 4 of 8 Zandvoort laps changed `threat_level` across two bands.

The rule that would have caught both, in one sentence: **each agent must load the clustering ITS OWN model trained against.** `tire_agent` already does, with the mirror-image measurement in a comment beside it.

## Also spun out

**#832** — I claimed an N15 item here was "already fixed". Only its **crash** was; its **value** had gone the opposite way. Filed rather than quietly folded in.

## Verified

- 7 tests on the touched paths, plus the gate's executed control above.
- `ruff check .` and `ruff format --check .` clean repo-wide (157 files).
- ⚠️ **GitHub Actions has been in a major outage since 2026-08-06 21:30 UTC and has produced zero completed CI runs for this branch.** Do not merge on a stale check summary — confirm CI really ran.

Part of the data-wiring plan. Does not close #801.
