### PR TITLE
chore(deps): bump dorny/paths-filter and github/codeql-action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           fetch-depth: 0
 
       - name: Filter changed paths
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -135,7 +135,7 @@ jobs:
           fetch-depth: 0
 
       - name: Filter changed paths
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,12 +31,12 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What

Consolidates dependabot **#769** (`dorny/paths-filter@v3 → v4`) and **#770** (`github/codeql-action@v3 → v4.37.3`) into one PR, and closes **#812** as obsolete.

## Why not just merge the dependabot PRs

**#812 was wrong.** Its title says `cryptography 48.0.1 → 50.0.0` and its diff contains **zero cryptography lines**. Checked all three branches — `main`, `dev` and its own branch all already carry `cryptography 50.0.0`, so the bump it exists to deliver is already shipping. What remained (`+0 -3`) was the removal of three `greenlet 3.3.2` s390x manylinux wheels: `main` has 3, that branch has 0. Nothing here targets s390x, so the impact is nil — but it is a net subtraction in exchange for a bump already in. Closed.

**#770 pinned an exact patch.** `codeql-action@v4.37.3` files a fresh dependabot PR on every patch release, and every other action in these workflows tracks a major (`actions/checkout@v7`, `actions/setup-python@v6`). This PR pins `@v4` instead.

**Neither #769 nor #770 had a single check run.** Their workflow runs had aged out, so "merge if green" had nothing to read. This branch gets a fresh run.

## The bumps

| action | from | to | call sites |
|---|---|---|---|
| `dorny/paths-filter` | `v3` | `v4` | `ci.yml:58`, `ci.yml:138` |
| `github/codeql-action/init` | `v3` | `v4` | `codeql.yml:34` |
| `github/codeql-action/analyze` | `v3` | `v4` | `codeql.yml:40` |

Both `v4` major tags verified as published refs before pinning. Swept every `uses:` in `.github/workflows/` for a forgotten twin — the only other pinned third-party action is `google/osv-scanner-action@v2.3.8`, untouched.

## How this is verified

**The workflows are the test.** Every path-gated job in `ci.yml` runs `dorny/paths-filter` and reads `steps.changes.outputs.*`; `codeql.yml` runs both codeql-action steps across the `python` and `javascript-typescript` matrix. A green run here exercises all four call sites — which beats asserting from a changelog that a major is safe.

Closes #769. Closes #770.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated testing and type-checking workflows to use newer tooling.
  * Updated security analysis workflows to the latest supported action versions.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->