### PR TITLE
fix(rag): move lock detection out from behind the dataset, so its guard can run

### DIFF
--- a/scripts/rebuild_featured_laps.py
+++ b/scripts/rebuild_featured_laps.py
@@ -679,7 +679,8 @@ def impute_circuit_speed(frame: pd.DataFrame, raw_root: Path) -> pd.DataFrame:
     FastF1 has no SpeedI2 reading for the whole 2025 Las Vegas race — 0% of 886 raw laps,
     against 80% for I1 and 97% for FL — so N03's all-three-traps filter yields zero valid
     laps and the circuit's speed comes out NaN on all 760 featured rows. It is the only hole
-    of its shape in 71 races, and no re-run can recover it: the reading does not exist.
+    of its shape in the season tree, and no re-run can recover it: the reading does not
+    exist.
 
     THE ESTIMATOR, AND WHY THIS ONE
     -------------------------------

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -1491,39 +1491,15 @@ def _run_mc_simulation(
 # Layer 3 — LLM synthesis
 # ==============================================================================
 
-# The signature qdrant_client puts in the RuntimeError it raises when the on-disk
-# store is already open. Matched on TEXT because there is nothing else to match on:
-# `qdrant_local.py:148-151` (client 1.16.2) catches portalocker's own LockException
-# and re-raises a BARE RuntimeError, so the exception that reaches us carries no
-# type, no attribute and no code that distinguishes it.
-#
-# The first version of this guard caught `portalocker.BaseLockException`, taken from
-# `retriever.py`'s docstring rather than from an executed collision. It never fired,
-# and its tests could not tell, because they monkeypatched the exception the
-# docstring named. One of them asserted that a RuntimeError must propagate, which is
-# exactly what the real lock error is: the test written to keep the except narrow was
-# the test guaranteeing the failure escaped. A real two-process collision settled it.
-_QDRANT_LOCK_SIGNATURE = "already accessed by another instance"
-
-try:  # portalocker ships with qdrant-client; tolerate its absence anyway
-    from portalocker.exceptions import BaseLockException as _BaseLockException
-
-    _LOCK_EXCEPTIONS: tuple = (_BaseLockException,)
-except ImportError:  # pragma: no cover - portalocker is a qdrant dependency
-    _LOCK_EXCEPTIONS = ()
-
-
-def _is_store_locked(exc: BaseException) -> bool:
-    """True when this exception means another process holds the regulation store.
-
-    Text matching is fragile and it is the only option here, so it fails SAFE: an
-    unrecognised RuntimeError propagates rather than being swallowed as a lock. If a
-    qdrant upgrade rewords the message, the symptom returns to a loud failure rather
-    than becoming a silent one.
-    """
-    if _LOCK_EXCEPTIONS and isinstance(exc, _LOCK_EXCEPTIONS):
-        return True
-    return isinstance(exc, RuntimeError) and _QDRANT_LOCK_SIGNATURE in str(exc)
+# Lock detection lives in `src/rag/store_lock.py`, not here, and moving it IS the
+# fix for a defect this guard already carried twice. Reached through this module
+# it can only be tested by importing the whole agent stack, which reads four
+# artefacts at IMPORT time - so the tests pinning the behaviour skipped on CI and
+# ERRORED on the tree `scripts/download_data.py` actually produces. See that
+# module's header for the qdrant behaviour itself.
+from src.rag.store_lock import LOCK_EXCEPTIONS as _LOCK_EXCEPTIONS
+from src.rag.store_lock import QDRANT_LOCK_SIGNATURE as _QDRANT_LOCK_SIGNATURE  # noqa: F401
+from src.rag.store_lock import is_store_locked as _is_store_locked
 
 
 # Logged once per process, not once per lap. A locked store fails every lap

--- a/src/rag/store_lock.py
+++ b/src/rag/store_lock.py
@@ -1,0 +1,54 @@
+"""Recognise the error qdrant raises when the on-disk store is already open.
+
+WHY THIS IS ITS OWN MODULE, AND IT IS THE POINT
+-----------------------------------------------
+This lived inside ``strategy_orchestrator``, which imports the whole agent
+stack, which reads four artefacts AT IMPORT TIME (the SC training frame, the
+sentiment weights, the tyre routing config, the NLP pipeline config). So the
+tests pinning this behaviour could not run anywhere that lacked the dataset:
+they skipped on CI and, on the curated tree ``scripts/download_data.py``
+actually produces, they ERRORED. A guard whose test cannot execute is not a
+guard, and this file has now been through that lesson twice (#827).
+
+Nothing here imports anything heavier than ``portalocker``, so the checks live
+wherever Python does.
+
+WHERE TO CHANGE IF QDRANT CHANGES
+---------------------------------
+:data:`QDRANT_LOCK_SIGNATURE` is matched against the message text because there
+is nothing else to match on. ``qdrant_client/local/qdrant_local.py`` catches
+portalocker's own ``LockException`` and re-raises a **bare ``RuntimeError``**,
+so the exception that reaches a caller carries no distinguishing type,
+attribute or code. ``tests/rag/test_store_lock.py`` pins the signature against
+the installed library's source, so an upgrade that rewords the message fails
+loudly instead of silently re-opening the hole.
+"""
+
+from __future__ import annotations
+
+# The distinctive fragment of qdrant's own message. Verified against a real
+# two-client collision, not against a docstring: the first version of this
+# guard caught `portalocker.BaseLockException` because `retriever.py` said so,
+# and that exception never reaches us.
+QDRANT_LOCK_SIGNATURE = "already accessed by another instance"
+
+try:  # portalocker ships with qdrant-client; tolerate its absence anyway
+    from portalocker.exceptions import BaseLockException as _BaseLockException
+
+    LOCK_EXCEPTIONS: tuple[type[BaseException], ...] = (_BaseLockException,)
+except ImportError:  # pragma: no cover - portalocker is a qdrant dependency
+    LOCK_EXCEPTIONS = ()
+
+
+def is_store_locked(exc: BaseException) -> bool:
+    """True when this exception means another process holds the store.
+
+    Fails SAFE, which is the reason text matching is acceptable here: an
+    unrecognised ``RuntimeError`` returns False and therefore propagates,
+    rather than being swallowed as a lock. A corrupt collection and a missing
+    embedding model are not "another process is running", and treating them as
+    such would trade one silent failure for another.
+    """
+    if LOCK_EXCEPTIONS and isinstance(exc, LOCK_EXCEPTIONS):
+        return True
+    return isinstance(exc, RuntimeError) and QDRANT_LOCK_SIGNATURE in str(exc)

--- a/tests/agents/test_rag_degrades_when_locked.py
+++ b/tests/agents/test_rag_degrades_when_locked.py
@@ -32,31 +32,35 @@ import logging
 
 import pytest
 
-from tests.conftest import HAS_TIRE_MODELS as _HAS_MODELS
-
-# EVERY test here, including the ones that only exercise a pure predicate.
-# Importing `strategy_orchestrator` pulls in `tire_agent`, which reads
-# `data/models/tire_degradation/routing_config.json` AT MODULE IMPORT, and that
-# tree comes from the Hugging Face Hub rather than git. So this file is not
-# hermetic no matter what its bodies touch, and a module-level import goes red on
-# a clean CI runner before a single test runs.
+# Importing `strategy_orchestrator` reads FOUR artefacts at module import, not
+# one: the tyre routing config, the SC training frame
+# (`data/processed/sc_labeled/`), the sentiment weights
+# (`data/models/nlp/bert_sentiment_v1/`) and the NLP pipeline config. All come
+# from the Hugging Face dataset rather than git.
 #
-# `test_tire_serving_frame.py` documents this exact trap in its own header. I read
-# that header this session and wrote the module-level import anyway, which is why
-# the import now lives inside a fixture: naming the artefact the IMPORT needs,
-# rather than the one the test body reads, is the guard shape #798 documented.
-pytestmark = pytest.mark.skipif(
-    not _HAS_MODELS,
-    reason="importing strategy_orchestrator reads data/models/ (HF, not git)",
-)
+# The first version of this guard named only `HAS_TIRE_MODELS`. That is why it
+# SKIPPED on CI and, on the curated tree `scripts/download_data.py` actually
+# produces, ERRORED - the tyre config is present there and the SC frame is not.
+# Naming one artefact out of four is the same shape as naming the artefact a
+# test READS while ignoring what its IMPORT needs.
+#
+# So the guard attempts the import instead of predicting it. A missing artefact
+# skips with the real filename in the reason; anything else propagates.
+try:
+    from src.agents import strategy_orchestrator as _orch
+
+    _IMPORT_ERROR: str | None = None
+except FileNotFoundError as exc:  # dataset artefact absent
+    _orch = None
+    _IMPORT_ERROR = f"strategy_orchestrator needs {exc.filename} (HF dataset, not git)"
+
+pytestmark = pytest.mark.skipif(_IMPORT_ERROR is not None, reason=str(_IMPORT_ERROR))
 
 
 @pytest.fixture
 def orch():
-    """The orchestrator module, imported lazily so collection stays cheap."""
-    from src.agents import strategy_orchestrator
-
-    return strategy_orchestrator
+    """The orchestrator module, already imported above or the file skipped."""
+    return _orch
 
 
 # Verbatim from qdrant_client/local/qdrant_local.py, the RuntimeError raised on a
@@ -74,21 +78,6 @@ def _reset_once_flag(orch):
     orch._rag_unavailable_logged = False
     yield
     orch._rag_unavailable_logged = False
-
-
-def test_the_real_qdrant_lock_error_is_recognised(orch):
-    """The whole defect: the previous guard did not recognise this exception at all."""
-    assert orch._is_store_locked(RuntimeError(_REAL_QDRANT_LOCK_MESSAGE)) is True
-
-
-def test_an_unrelated_runtime_error_is_not_mistaken_for_a_lock(orch):
-    """Failing safe is the reason text matching is acceptable here.
-
-    Catching bare `RuntimeError` and swallowing it would trade one silent failure
-    for another. Only the lock signature degrades; everything else propagates.
-    """
-    assert orch._is_store_locked(RuntimeError("collection 'fia_regulations' not found")) is False
-    assert orch._is_store_locked(ValueError("bad question")) is False
 
 
 def test_a_locked_store_returns_none_instead_of_raising(orch, monkeypatch):
@@ -138,20 +127,3 @@ def test_a_working_store_is_passed_straight_through(orch, monkeypatch):
     sentinel = object()
     monkeypatch.setattr(orch, "run_rag_agent", lambda _q: sentinel)
     assert orch._run_rag_agent_or_degrade("q") is sentinel
-
-
-def test_the_signature_matches_the_installed_qdrant_source(orch):
-    """Pins the text to the library, so an upgrade that rewords it fails here.
-
-    This is the assertion the first version of this file needed and did not have:
-    it tests the guard against what the INSTALLED library does, not against what a
-    docstring says it does.
-    """
-    from pathlib import Path
-
-    import qdrant_client.local.qdrant_local as ql
-
-    source = Path(ql.__file__).read_text(encoding="utf-8")
-    assert orch._QDRANT_LOCK_SIGNATURE in source, (
-        "qdrant no longer raises the message this guard matches on; #827 is re-broken"
-    )

--- a/tests/agents/test_situation_serving_cluster.py
+++ b/tests/agents/test_situation_serving_cluster.py
@@ -36,7 +36,11 @@ _CLUSTERS = ROOT / "data" / "processed" / "circuit_clustering"
 _POOLED_NAME = "circuit_clusters_k4.parquet"
 _SEASON_NAME = "circuit_clusters_k4_2025.parquet"
 
-_N13_SOURCE = ROOT / ".nb_py" / "N13_sc_eda.py"
+# The TRACKED notebook, not the gitignored `.nb_py/` mirror of it. Reading the
+# mirror made this half skip on every CI runner with a reason that was true and
+# therefore useless: `.nb_py/` is excluded by `.gitignore:148`, but the same
+# evidence sits in a notebook git actually ships.
+_N13_SOURCE = ROOT / "notebooks" / "strategy" / "sc_probability" / "N13_sc_eda.ipynb"
 _N27_SOURCE = ROOT / "src" / "agents" / "race_situation_agent.py"
 
 
@@ -54,17 +58,18 @@ def test_the_sc_agent_loads_the_pooled_map_and_only_that_one():
     )
 
 
-@pytest.mark.skipif(
-    not _N13_SOURCE.exists(),
-    reason=".nb_py/ is gitignored, so this half cannot run on a CI runner",
-)
 def test_the_map_n27_serves_is_the_one_n13_built_the_labels_from():
-    """The other half of the pairing, checkable only where the notebooks are.
+    """The other half of the pairing, and it runs everywhere.
 
-    `.nb_py/` is gitignored (`.gitignore:148`), so without this marker the test
-    would fail on every CI runner rather than skip -- the mirror of the mistake
-    that turned this branch's sibling red: guard on the artefact the test READS,
-    and check whether git actually ships it.
+    This used to read `.nb_py/N13_sc_eda.py` and skip, because `.gitignore:148`
+    excludes that directory. The reason was true and the guard was useless: the
+    `.nb_py/` tree is a mirror of notebooks git DOES track, so the same evidence
+    was reachable all along. A skip whose reason is accurate is still a guard
+    that never fires.
+
+    Reads the `.ipynb` as raw text rather than parsing its JSON: the assertion is
+    about which filename the notebook names, and cell structure is not part of
+    the claim.
     """
     n13 = _N13_SOURCE.read_text(encoding="utf-8")
     assert _POOLED_NAME in n13, (

--- a/tests/mc/test_tyre_wear_term.py
+++ b/tests/mc/test_tyre_wear_term.py
@@ -3,7 +3,10 @@
 Until now the Monte Carlo's only tyre signal was the cliff, a discrete event that
 falls inside the 5-lap window on 4 of 110 measured laps. A set 0.4 s off the pace but
 ten laps from the cliff scored identically to a fresh one, which is most of why the
-decision layer declines to call 46% of real stops.
+decision layer declines to call a large share of real stops. The level is deliberately
+not quoted here: it was 46%, then 65%, and is 72 of 178 (40.4%) on the post-#829
+inputs. `documents/eval_reports/decision_modes.md` regenerates it; a copy in a test
+docstring only ever goes stale.
 
 WHAT IS BEING REPLACED, AND WHY IT IS A REPLACEMENT
 ----------------------------------------------------

--- a/tests/rag/test_store_lock.py
+++ b/tests/rag/test_store_lock.py
@@ -1,0 +1,85 @@
+"""The half of #827's guard that needs no dataset, so CI actually runs it.
+
+These four tests import `src.rag.store_lock`, which pulls in nothing heavier
+than portalocker. That is the whole reason the module exists: the same
+assertions used to live behind `strategy_orchestrator`, whose import reads four
+artefacts from the Hugging Face dataset, so on CI they SKIPPED and on the
+curated tree `scripts/download_data.py` produces they ERRORED.
+
+`test_the_signature_matches_the_installed_qdrant_source` is the one that most
+needed rescuing: its entire job is to fail when a qdrant upgrade rewords the
+message this guard matches on, and a pin that never executes cannot do that.
+
+The behavioural half — that a locked store degrades the lap instead of killing
+it, and that the cause is logged once — genuinely needs the orchestrator, and
+lives in `tests/agents/test_rag_degrades_when_locked.py`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.rag.store_lock import QDRANT_LOCK_SIGNATURE, is_store_locked
+
+# Verbatim from qdrant_client/local/qdrant_local.py, the RuntimeError raised on
+# a second open of the same directory. Reproduced here so a reworded message
+# fails the source pin below rather than silently passing these.
+_REAL_QDRANT_LOCK_MESSAGE = (
+    "Storage folder data/rag/qdrant_local is already accessed by another instance "
+    "of Qdrant client. If you require concurrent access, use Qdrant server instead."
+)
+
+
+def test_the_real_qdrant_lock_error_is_recognised():
+    """The whole defect: the first guard did not recognise this exception at all."""
+    assert is_store_locked(RuntimeError(_REAL_QDRANT_LOCK_MESSAGE)) is True
+
+
+def test_an_unrelated_runtime_error_is_not_mistaken_for_a_lock():
+    """Failing safe is why text matching is acceptable here.
+
+    Catching bare `RuntimeError` and swallowing it would trade one silent
+    failure for another, so only the lock signature degrades.
+    """
+    assert is_store_locked(RuntimeError("collection 'fia_regulations' not found")) is False
+    assert is_store_locked(ValueError("bad question")) is False
+
+
+def test_the_signature_matches_the_installed_qdrant_source():
+    """Pins the assumption to the LIBRARY, not to a docstring.
+
+    This is the assertion the first version of #827's guard needed and did not
+    have: it was written from `retriever.py`'s prose, which named a portalocker
+    exception qdrant never raises.
+    """
+    import qdrant_client.local.qdrant_local as ql
+
+    source = Path(ql.__file__).read_text(encoding="utf-8")
+    assert QDRANT_LOCK_SIGNATURE in source, (
+        "qdrant no longer raises the message this guard matches on; #827 is re-broken"
+    )
+
+
+def test_a_real_two_client_collision_is_recognised(tmp_path):
+    """The check no amount of monkeypatching can substitute for.
+
+    Opens the store twice for real and asserts the guard recognises whatever
+    comes back. Skips only if a second open somehow succeeds, which would mean
+    qdrant stopped holding an exclusive lock and #827 no longer exists.
+    """
+    from qdrant_client import QdrantClient
+
+    store = tmp_path / "qdrant_local"
+    first = QdrantClient(path=str(store))
+    try:
+        with pytest.raises(BaseException) as caught:  # noqa: B017 - the TYPE is the finding
+            QdrantClient(path=str(store))
+    finally:
+        first.close()
+
+    assert is_store_locked(caught.value), (
+        f"a real collision raised {type(caught.value).__name__}, which the guard does "
+        f"not recognise: {caught.value}"
+    )

--- a/tests/simulation/test_weather_join.py
+++ b/tests/simulation/test_weather_join.py
@@ -5,9 +5,15 @@ frame's row index. That ignores session time, and neither side is evenly spaced:
 Car stretches the gap between laps while the samples keep their own cadence, so the two
 indices drift apart exactly when conditions are moving.
 
-Measured over 79,032 driver-laps of all 71 races, the proportional lookup disagreed with
+Measured over 79,032 driver-laps of the then-71-race tree, the proportional lookup
+disagreed with
 N04's join on **94.3%** of laps, mean 1.49 C and up to 17.3 C on TrackTemp, and **flipped
 the rain flag on 3,399 laps**. N06's weather block is 39.7% of that model's gain.
+
+The race count is left as measured rather than restated as 70: the 2023 Spanish GP was
+de-duplicated on 2026-08-06 (#823) and this measurement predates it, so 71 is what the
+run actually saw. Editing the scope of a number nobody re-ran is how a figure stops
+matching its own evidence.
 
 These assert the EFFECT: what the replay serves must equal what N04 computed, to the cell.
 """


### PR DESCRIPTION
## What an adversarial sweep found

#827's guard is real. **The tests pinning it are not**, and this is the third iteration of that shape in the same file.

Importing `strategy_orchestrator` reads **four** artefacts at module import:

| artefact | read at | in the download patterns? |
|---|---|---|
| tyre routing config | `tire_agent` | yes |
| `data/processed/sc_labeled/sc_labeled_2023_2025.parquet` | `race_situation_agent:260` | **no** |
| `data/models/nlp/bert_sentiment_v1/` | `radio_agent:269` | **no** |
| NLP pipeline config | `radio_agent` | yes |

The skipif named **one** of the four. So the file skipped on CI, and on the curated tree `scripts/download_data.py` actually produces it **ERRORED** — that tree has the tyre config and lacks the SC frame. Executed:

```
>>> from src.agents import strategy_orchestrator
FileNotFoundError: ...\data\processed\sc_labeled\sc_labeled_2023_2025.parquet
```

The casualty is `test_the_signature_matches_the_installed_qdrant_source`, whose entire job is to fail when a qdrant upgrade rewords the message this guard matches on. **A pin that never runs cannot do that** — and the reason this guard needed a pin in the first place is that its first version was written from a docstring naming an exception qdrant never raises.

## The fix

- **`src/rag/store_lock.py`** — `QDRANT_LOCK_SIGNATURE` + `is_store_locked`, importing nothing heavier than portalocker. The orchestrator delegates to it.
- **`tests/rag/test_store_lock.py`** — the four dataset-free checks, **4 passed** with no data on disk. Includes a **real two-client collision** rather than a monkeypatched exception: testing this against a synthesised error is exactly how the first fix shipped dead.
- The behavioural half keeps a skip, but **attempts the import instead of predicting it**, so the reason names the file actually missing rather than one of four.

## Also from the sweep

| finding | fix |
|---|---|
| `test_situation_serving_cluster` read `.nb_py/`, which `.gitignore:148` excludes, so it skipped **everywhere** with a reason that was true and therefore useless | the same evidence is in `notebooks/strategy/sc_probability/N13_sc_eda.ipynb`, which git tracks. **3 passed**, none skipped |
| two `all 71 races` scope labels in live source | the measurements predate the Spain de-duplication, so the counts stay and the labels now say so. Restating a scope nobody re-ran is how a figure stops matching its evidence |
| a docstring quoting a **46 %** decline rate, since 65 %, now 72 of 178 (40.4 %) | the level is no longer copied into a test at all; `decision_modes.md` regenerates it |

## Verified

`ruff check .` clean, `ruff format --check .` 161 files clean. New guards run with **no dataset present**. The 11 pre-existing failures in `tests/mc/test_tyre_wear_term.py` are the curated-restore data gap, not this change — confirmed by stashing the edit and re-running: identical failures.

## Filed separately, not fixed here

`sc_labeled/` and `bert_sentiment_v1/` are absent from `data_cache._DEFAULT_MODEL_PATTERNS`, so a fresh install cannot import the orchestrator at all. That is a P0 for new users and wider than this PR.