### PR TITLE
feat(cards): own the Hugging Face cards, and guard them against the Hub

### DIFF
--- a/docs/huggingface/DATASET_CARD.md
+++ b/docs/huggingface/DATASET_CARD.md
@@ -1,0 +1,59 @@
+---
+license: apache-2.0
+language:
+- en
+tags:
+- formula-1
+- motorsport
+- telemetry
+- race-strategy
+- sports-analytics
+- fastf1
+- openf1
+task_categories:
+- tabular-regression
+- time-series-forecasting
+pretty_name: F1 StratLab Strategy Dataset
+---
+
+# F1 StratLab Strategy Dataset
+
+Training data for F1 StratLab, an open-source multi-agent system for Formula 1 race
+strategy. It contains telemetry, lap data, tire stints and race-control messages turned
+into model-ready features for lap-time prediction, tire-degradation modelling, overtake
+and undercut probability, pit-stop duration and team-radio NLP.
+
+Links:
+
+- Project: https://f1stratlab.com
+- Documentation: https://docs.f1stratlab.com
+- Source code: https://github.com/VforVitorio/F1-StratLab
+- Models: https://huggingface.co/VforVitorio/f1-strategy-models
+
+## Coverage
+
+- 70 Grand Prix, 2023 to 2025 seasons.
+- Sources: FastF1 and OpenF1 public APIs.
+- Per-lap telemetry, tire compound and age, stint structure, gaps and race-control events.
+
+## Intended use
+
+Research and educational use for Formula 1 strategy analysis and time-series or tabular ML.
+Not affiliated with Formula 1, the FIA or any team. Raw data is subject to the terms of the
+upstream FastF1 and OpenF1 sources.
+
+## Citation
+
+```bibtex
+@misc{vegasobral2026f1stratlab,
+  author = {Vega, V{\'i}ctor},
+  title  = {F1 StratLab: AI Models for Strategy Recommendations in Formula 1 Races},
+  year   = {2026},
+  note   = {Bachelor's Thesis, Intelligent Systems Engineering, UIE Campus Coru{\~n}a},
+  url    = {https://f1stratlab.com}
+}
+```
+
+## License
+
+Apache 2.0. Author: Víctor Vega (https://github.com/VforVitorio).

--- a/docs/huggingface/MODEL_CARD.md
+++ b/docs/huggingface/MODEL_CARD.md
@@ -1,0 +1,72 @@
+---
+license: apache-2.0
+language:
+- en
+tags:
+- formula-1
+- motorsport
+- race-strategy
+- multi-agent
+- langgraph
+- xgboost
+- lightgbm
+- temporal-convolutional-network
+- sports-analytics
+---
+
+# F1 StratLab Strategy Models
+
+The machine learning models behind F1 StratLab, an open-source multi-agent system for
+Formula 1 race strategy. Six LangGraph sub-agents and a ReAct orchestrator call these
+models to produce pit-stop recommendations, tire-degradation forecasts, overtake and
+undercut probabilities, and answers grounded in the FIA regulations.
+
+Links:
+
+- Project: https://f1stratlab.com
+- Documentation: https://docs.f1stratlab.com
+- Source code: https://github.com/VforVitorio/F1-StratLab
+- Dataset: https://huggingface.co/datasets/VforVitorio/f1-strategy-dataset
+
+## Models
+
+| Task | Algorithm | Metric |
+|---|---|---|
+| Lap-time prediction | XGBoost | MAE 0.410 s |
+| Tire degradation | TCN with Monte Carlo Dropout | P10/P50/P90 quantiles, pit-window detection |
+| Overtake probability | LightGBM | AUC-ROC 0.876 |
+| Safety-car probability | LightGBM | classifier |
+| Pit-stop duration | HistGradientBoosting (quantile) | MAE 0.487 s |
+| Undercut success | LightGBM (binary) | AUC-ROC 0.771 |
+| Team-radio NLP | Whisper, RoBERTa, SetFit, BERT-large | 4-stage pipeline |
+
+## Training data
+
+Built from telemetry, lap data and race-control messages covering 70 Grand Prix across the
+2023 to 2025 seasons, taken from the FastF1 and OpenF1 public APIs. The seasons are not
+interchangeable: every model **trains on 2023 and 2024** and is **tested on 2025**, which is
+the holdout the shipped system infers on (`train_seasons: [2023, 2024]`, `test_season: 2025`
+in each model config). Quoting a figure that pools all three is partly the system reading
+back its own training data. The processed data is
+published as a companion dataset: VforVitorio/f1-strategy-dataset.
+
+## Intended use
+
+Research and educational use for Formula 1 strategy analysis. Not affiliated with Formula 1,
+the FIA or any team. Predictions are estimates, not guarantees.
+
+## Citation
+
+```bibtex
+@misc{vegasobral2026f1stratlab,
+  author = {Vega, V{\'i}ctor},
+  title  = {F1 StratLab: AI Models for Strategy Recommendations in Formula 1 Races},
+  year   = {2026},
+  note   = {Bachelor's Thesis, Intelligent Systems Engineering, UIE Campus Coru{\~n}a},
+  url    = {https://f1stratlab.com}
+}
+```
+
+## License
+
+Apache 2.0. Author: Víctor Vega (https://github.com/VforVitorio).

--- a/scripts/upload_hf_cards.py
+++ b/scripts/upload_hf_cards.py
@@ -1,0 +1,149 @@
+"""Publish the Hugging Face dataset and model cards from this repo.
+
+WHY THIS SCRIPT EXISTS
+----------------------
+The cards used to live in `f1stratlab-web`, the landing-site repo, where nothing
+linked to them and nothing published them. They were a mirror of nothing: the
+site never rendered them, the Hub never received them, and by 2026-08-07 the
+published cards still said "71 Grand Prix" and "MAE 0.392 s" - a race count
+retired when the duplicated 2023 Spanish GP was removed, and a metric the
+registry marks superseded.
+
+They belong here because this is where their evidence is measured. A card and
+the `documents/eval_reports/` run that justifies it now sit in one repo, so the
+place to edit when a number moves is visible from the place the number moves.
+
+WHY AN OPERATOR SCRIPT AND NOT CI
+---------------------------------
+Publishing needs a Hugging Face token with WRITE scope. Putting one in a public
+repository's Actions secrets is a standing risk for something that runs a few
+times a year, so this follows `scripts/upload_radio_corpus.py`: the operator
+runs it with their own local token. Reading a public card needs no token at
+all, which is what lets `tests/audit/test_hf_cards_are_published.py` catch a
+card that was edited and never pushed.
+
+    python scripts/upload_hf_cards.py --dry-run
+    python scripts/upload_hf_cards.py
+
+--- WHERE TO CHANGE IF THE HUB LAYOUT CHANGES ---
+`_CARDS` below is the whole mapping. A Hub repo's card IS its root `README.md`;
+there is no other filename that works.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = next(
+    (p for p in [_SCRIPT_DIR, *_SCRIPT_DIR.parents] if (p / ".git").exists()),
+    _SCRIPT_DIR.parent,
+)
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+@dataclass(frozen=True)
+class Card:
+    """One card and the Hub repo whose ``README.md`` it becomes."""
+
+    local: str
+    repo_id: str
+    repo_type: str
+
+
+# The complete mapping. Both Hub repos exist and are public.
+_CARDS: tuple[Card, ...] = (
+    Card("docs/huggingface/DATASET_CARD.md", "VforVitorio/f1-strategy-dataset", "dataset"),
+    Card("docs/huggingface/MODEL_CARD.md", "VforVitorio/f1-strategy-models", "model"),
+)
+
+
+def _read(card: Card) -> str:
+    """The card's text, or a clear failure naming the file that is missing."""
+    path = _REPO_ROOT / card.local
+    if not path.exists():
+        raise FileNotFoundError(f"card not found: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _published(card: Card) -> str | None:
+    """What the Hub serves today, or None when it has no card yet.
+
+    Read-only and unauthenticated, so this half works for anyone.
+    """
+    from huggingface_hub import hf_hub_download
+    from huggingface_hub.errors import EntryNotFoundError
+
+    try:
+        path = hf_hub_download(card.repo_id, "README.md", repo_type=card.repo_type)
+    except EntryNotFoundError:
+        return None
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _upload(card: Card, text: str, message: str) -> None:
+    """Push the card as the Hub repo's README."""
+    from huggingface_hub import HfApi
+
+    HfApi().upload_file(
+        path_or_fileobj=text.encode("utf-8"),
+        path_in_repo="README.md",
+        repo_id=card.repo_id,
+        repo_type=card.repo_type,
+        commit_message=message,
+    )
+
+
+def run(dry_run: bool, message: str) -> int:
+    """Compare each card with the Hub and push the ones that differ.
+
+    Returns the number of cards that needed publishing, so a caller can tell
+    "nothing to do" from "two pushed" without parsing the output.
+    """
+    pending = 0
+    for card in _CARDS:
+        local = _read(card)
+        live = _published(card)
+        if live is not None and live.strip() == local.strip():
+            print(f"  up to date   {card.repo_id}")
+            continue
+        pending += 1
+        state = "no card on the Hub yet" if live is None else "differs from the Hub"
+        print(f"  needs push   {card.repo_id}  ({state})")
+        if not dry_run:
+            _upload(card, local, message)
+            print(f"  pushed       {card.repo_id}")
+    return pending
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report which cards differ from the Hub without pushing anything.",
+    )
+    parser.add_argument(
+        "--commit-message",
+        default="docs(cards): sync from the F1 StratLab repo",
+        help="Commit message stamped on the Hub revision.",
+    )
+    args = parser.parse_args()
+
+    print(f"F1 StratLab - Hugging Face cards ({'DRY-RUN' if args.dry_run else 'LIVE'})")
+    pending = run(args.dry_run, args.commit_message)
+
+    if pending == 0:
+        print("\nBoth cards already match the Hub.")
+    elif args.dry_run:
+        print(f"\n{pending} card(s) would be pushed. Re-run without --dry-run.")
+    else:
+        print(f"\n{pending} card(s) published.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/audit/test_hf_cards_are_published.py
+++ b/tests/audit/test_hf_cards_are_published.py
@@ -36,7 +36,13 @@ _CARDS = (
     ("docs/huggingface/MODEL_CARD.md", "VforVitorio/f1-strategy-models", "model"),
 )
 
-pytestmark = pytest.mark.data
+# NOT marked `data`, and the distinction matters. That marker means "requires the
+# HF dataset or model weights (skipped on CI runners)"; this needs neither - only
+# an unauthenticated read of two public README files. Marking it `data` would
+# have labelled it as one of the tests nobody expects to run, which is halfway to
+# a guard that never fires, and this whole file exists because of one of those.
+#
+# Confirmed green on a CI runner, so the fetch really executes there.
 
 
 def test_the_test_and_the_publisher_agree_on_which_cards_exist():

--- a/tests/audit/test_hf_cards_are_published.py
+++ b/tests/audit/test_hf_cards_are_published.py
@@ -1,0 +1,92 @@
+"""The published Hugging Face cards must match the ones in this repo.
+
+WHY THIS TEST READS THE HUB AND NOT THE DISK
+--------------------------------------------
+#825 shipped a data fix that reached nobody: `data/processed/**` is gitignored,
+so merging the PR published nothing, and the guard written for it read the
+LOCAL tree. It stayed green for a day while the Hub served three races another
+race's radio corpus.
+
+The cards have exactly that shape and had already drifted the same way. Until
+2026-08-07 they lived in the landing-site repo, where nothing linked to them
+and nothing pushed them, and the published cards still said "71 Grand Prix"
+(a count retired when the duplicated 2023 Spanish GP was removed) and
+"MAE 0.392 s" (which `metrics_registry.md` marks superseded).
+
+So the assertion is deliberately against the artefact a user actually reads.
+Reading a public card needs **no token**, which is the whole reason this is
+possible for cards and was not for the parquets.
+
+Publishing is `python scripts/upload_hf_cards.py`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+
+# Kept in step with `scripts/upload_hf_cards.py::_CARDS` by the first test below,
+# which fails if the two lists ever diverge - a duplicated mapping that drifts is
+# how the card ended up unpublished in the first place.
+_CARDS = (
+    ("docs/huggingface/DATASET_CARD.md", "VforVitorio/f1-strategy-dataset", "dataset"),
+    ("docs/huggingface/MODEL_CARD.md", "VforVitorio/f1-strategy-models", "model"),
+)
+
+pytestmark = pytest.mark.data
+
+
+def test_the_test_and_the_publisher_agree_on_which_cards_exist():
+    """A guard listing different cards from the publisher would guard nothing.
+
+    Reads the publisher's `_CARDS` by PARSING it rather than importing it: the
+    script inserts the repo root on `sys.path` at module scope, and a test that
+    executes a script for one constant inherits every side effect it has. Also
+    per this repo's own lesson that grep is not an audit - the assertion is on
+    the parsed literal, so a mention in a comment cannot satisfy it.
+    """
+    import ast
+
+    source = (ROOT / "scripts" / "upload_hf_cards.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    assignments = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "_CARDS"
+    ]
+    assert len(assignments) == 1, "upload_hf_cards._CARDS is no longer a single literal"
+
+    published = tuple(
+        tuple(a.value for a in call.args)
+        for call in assignments[0].value.elts
+        if isinstance(call, ast.Call)
+    )
+    assert published == _CARDS, (
+        f"scripts/upload_hf_cards.py publishes {published}, this guard checks {_CARDS}"
+    )
+
+
+@pytest.mark.parametrize(("local", "repo_id", "repo_type"), _CARDS)
+def test_the_published_card_matches_the_repo_copy(local, repo_id, repo_type):
+    """Fails the moment a card is edited here and not pushed.
+
+    Whitespace-insensitive at the edges only: the Hub round-trips a trailing
+    newline inconsistently, and a test that fails on that would be turned off
+    within a week, which is the same as not having it.
+    """
+    from huggingface_hub import hf_hub_download
+
+    repo_copy = (ROOT / local).read_text(encoding="utf-8")
+    downloaded = hf_hub_download(repo_id, "README.md", repo_type=repo_type)
+    published = Path(downloaded).read_text(encoding="utf-8")
+
+    assert published.strip() == repo_copy.strip(), (
+        f"{repo_id} serves a card that differs from {local}. "
+        f"Publish with: python scripts/upload_hf_cards.py"
+    )


### PR DESCRIPTION
## The defect

The Hugging Face cards lived in `f1stratlab-web`, the landing-site repo, which was **the one place that could not publish them**:

| | |
|---|---|
| did the site link to them? | **no** — nothing in `components/`, `index.html` or `llms.txt` referenced them |
| did the deploy ship them? | yes, to a live URL nothing pointed at — the rsync had no `docs/` exclude |
| did anything push them to the Hub? | **no** — no sync script, no CI step |
| did this repo have a copy? | **no** |

So they were a mirror of nothing, feeding nobody, drifting by default. As of 2026-08-07 the **published** cards still said:

- `71 Grand Prix` — a count retired when the duplicated 2023 Spanish GP was removed (the distinct total is 70: 22 + 24 + 24)
- `MAE 0.392 s` — which `documents/eval_reports/metrics_registry.md:14` marks `canonical: false` / *"notebook N06 (superseded)"*

## Why here and not there

**This is where their evidence is measured.** A card and the `documents/eval_reports/` run that justifies it now sit in one repo, so the place to edit when a number moves is visible from the place the number moves. This repo also already owns the Hub relationship — `upload_radio_corpus.py` pushes, `data_cache.py` pulls, `HF_DATASET_REPO_ID` lives here.

## What ships

**`scripts/upload_hf_cards.py`** — a sibling of `upload_radio_corpus.py`. Reads each card, compares it with what the Hub serves, pushes only what differs, `--dry-run` available.

An **operator command, not CI**, deliberately: publishing needs a token with WRITE scope, and putting one in a public repository's Actions secrets is a standing risk for something that runs a few times a year. The existing convention already avoids that.

**`tests/audit/test_hf_cards_are_published.py`** — asserts against the **live card**, not the local file:

```python
downloaded = hf_hub_download(repo_id, "README.md", repo_type=repo_type)
assert Path(downloaded).read_text().strip() == repo_copy.strip()
```

That is the gap #825 taught. Its guard read the LOCAL tree while the Hub served three races another race's radio corpus, so it stayed green for a day over a live defect. **Reading a public card needs no token**, which is exactly why this check is possible for cards and was not for the parquets.

The mapping is duplicated between the script and the test on purpose — a guard that imports the thing it guards inherits its side effects. A third test **parses the script's own `_CARDS` literal** with `ast` so the two cannot drift apart, and parses rather than greps, per this repo's own lesson that a mention in a comment must not satisfy an audit.

## Verified, on the artefact rather than the source

Both cards published, then re-fetched with `force_download=True`:

```
VforVitorio/f1-strategy-dataset: '71 Grand Prix'=False  '70 Grand Prix'=True  '0.392'=False
VforVitorio/f1-strategy-models : '71 Grand Prix'=False  '70 Grand Prix'=True  '0.392'=False
```

`pytest tests/audit/test_hf_cards_are_published.py -m data` → **3 passed** against the live Hub. Before publishing, the same three failed — the guard was watched failing before it was trusted passing.

`ruff check .` clean, `ruff format --check .` 163 files clean.

## Companion

`VforVitorio/f1stratlab-web#51` removes the mirrors and excludes `docs/` from the pages rsync, so a future `docs/` there is a deliberate publish rather than an accident.
