### PR TITLE
feat(arcade): put location, global_t_min, active and rel_dist on the broadcast

### DIFF
--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -11,6 +11,7 @@ panels) has an active GL context from the start.
 from __future__ import annotations
 
 import logging
+import math
 import os
 import subprocess
 import sys
@@ -62,6 +63,28 @@ from src.arcade.track import Track
 logger = logging.getLogger(__name__)
 
 
+def _lap_fraction(rel_dist: float) -> float | None:
+    """Clamp a fraction-of-lap into [0, 1], or return None when it is unknown.
+
+    FastF1 does not always deliver ``RelativeDistance``: on Melbourne 2025
+    it is NaN for 100 % of HAD's frames, the only non-finite value in the
+    whole session. Two things break if that NaN is passed through.
+
+    First, ``json.dumps`` writes a bare ``NaN``, which is not valid JSON.
+    Python's own parser accepts it, so the Qt dashboard never noticed, but
+    a strict parser (``JSON.parse``) rejects the whole payload.
+
+    Second, clamping it is worse than dropping it: ``min(1.0, nan)`` is
+    ``1.0``, and 1.0 is a legitimate value meaning "at the line", so the
+    car with no position data would be drawn exactly at the lap boundary
+    rather than nowhere. Unknown stays None and every consumer handles it.
+    """
+    value = float(rel_dist)
+    if not math.isfinite(value):
+        return None
+    return min(1.0, max(0.0, value))
+
+
 def _frame_to_telemetry(frame, circuit_length_m: float) -> dict | None:
     """Pack a ``FrameData`` into the dict the telemetry window consumes.
 
@@ -82,12 +105,12 @@ def _frame_to_telemetry(frame, circuit_length_m: float) -> dict | None:
     brake = float(frame.brake)
     if brake <= 1.0:
         brake *= 100.0
-    rel_dist = max(0.0, min(1.0, float(frame.rel_dist)))
-    lap_dist = rel_dist * float(circuit_length_m or 0.0)
+    rel_dist = _lap_fraction(frame.rel_dist)
+    lap_dist = None if rel_dist is None else round(rel_dist * float(circuit_length_m or 0.0), 1)
     return {
         "lap": int(frame.lap),
         "t": round(float(frame.t), 3),
-        "dist": round(lap_dist, 1),
+        "dist": lap_dist,
         "speed": round(float(frame.speed), 1),
         "throttle": round(throttle, 1),
         "brake": round(brake, 1),
@@ -445,19 +468,36 @@ class F1ArcadeView(arcade.View):
         """Compact version of the per-frame dict the dashboard needs.
 
         Lighter than the internal `_build_frame_dict` consumed by the
-        panels: we drop fields the dashboard does not use (rel_dist,
-        throttle, brake, active flag) to keep the broadcast JSON small."""
+        panels: `throttle` and `brake` stay out of the 20-car block
+        because only the two featured cars chart them, and they ride in
+        `telemetry` instead.
+
+        `active` and `rel_dist` are here on purpose and are NOT
+        cosmetic. Without `active` a retired car is indistinguishable
+        from a running one: `np.interp` clamps past a driver's last
+        sample, so a lap-1 DNF keeps broadcasting its crash-site `dist`,
+        `speed` and `lap` for the rest of the race. Without `rel_dist`
+        there is no way to place a car around the current lap —
+        `dist % circuit_length_m` is not a substitute, because `dist`
+        accumulates each lap as actually driven (an in-lap and an
+        out-lap are neither the same length as each other nor as the
+        fastest lap `circuit_length_m` is measured from), so the
+        residual drifts across a race and drifts most for the cars that
+        pitted."""
         drivers: dict[str, dict] = {}
         for code, frames in self._session.frames_by_driver.items():
             if not frames or frame_idx >= len(frames):
                 continue
             f = frames[frame_idx]
+            lap_fraction = _lap_fraction(f.rel_dist)
             drivers[code] = {
                 "lap": f.lap,
                 "dist": round(f.dist, 1),
+                "rel_dist": None if lap_fraction is None else round(lap_fraction, 4),
                 "speed": round(f.speed, 1),
                 "compound": f.tyre,
                 "tyre_life": round(f.tyre_life, 1),
+                "active": bool(f.active),
             }
         main_frame = None
         main_frames = self._session.frames_by_driver.get(self._driver_main)
@@ -479,9 +519,19 @@ class F1ArcadeView(arcade.View):
         telemetry = {"main": main_tel, "rival": rival_tel}
         return {
             "gp_name": self._session.gp_name,
+            # FastF1's authoritative Location, which is also the folder name
+            # under data/raw/<year>/. `gp_name` is a display label from a
+            # hardcoded table and the two diverge, so a consumer that needs to
+            # find the session on disk must resolve from this, never from the
+            # label on screen.
+            "location": self._session.location,
             "year": self._year,
             "lap": main_frame.lap if main_frame else 1,
             "t": main_frame.t if main_frame else 0.0,
+            # Session-time origin of `t`: `t + global_t_min` is FastF1
+            # SessionTime seconds, the clock laps/weather/intervals parquet
+            # are keyed on. `t` alone is only `frame_index * DT`.
+            "global_t_min": round(float(self._session.global_t_min), 3),
             "total_laps": self._session.max_lap_number,
             # Circuit length lets the telemetry window anchor the X axis
             # once and forget — without it the charts would autorange to

--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -158,7 +158,7 @@ FLAG_COLORS: Final[dict[str, tuple[int, int, int]]] = {
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
 FASTF1_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "fastf1"
 ARCADE_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "arcade"
-CACHE_VERSION: Final[str] = "v7"  # adds weather_by_lap, real FastF1 weather for the weather panel
+CACHE_VERSION: Final[str] = "v8"  # adds global_t_min, the session-time origin of the frame clock
 
 # --- Multiprocessing pool -------------------------------------------------
 # Serial by default — Windows spawn + pickling a loaded session across 8

--- a/src/arcade/data.py
+++ b/src/arcade/data.py
@@ -99,6 +99,15 @@ class SessionData:
     circuit_rotation_deg: float = 0.0
     total_frames: int = 0
     timeline: np.ndarray = field(default_factory=lambda: np.zeros(0))
+    # Session-time origin of the frame clock, in seconds. `timeline` starts at
+    # 0.0 by construction (`_build_timeline`), so a frame's `t` is an offset,
+    # not a session time, and on its own it is just `frame_index * DT`. Adding
+    # this back recovers FastF1 `SessionTime` seconds — the clock that
+    # `laps.parquet` (`Time`, `LapStartTime`, `Sector*SessionTime`) and
+    # `weather.parquet` are keyed on. Without it nothing on the broadcast can
+    # be joined by time to anything on disk, which is why `intervals.parquet`
+    # is downloaded for every race and read by nothing.
+    global_t_min: float = 0.0
     ref_lap_xy: tuple[np.ndarray, np.ndarray] = field(
         default_factory=lambda: (np.zeros(0), np.zeros(0))
     )
@@ -324,6 +333,7 @@ class SessionLoader:
             circuit_rotation_deg=rotation_deg,
             total_frames=len(timeline),
             timeline=timeline,
+            global_t_min=float(global_t_min),
             ref_lap_xy=(ref_x, ref_y),
             ref_lap_drs=ref_drs,
             events=[],

--- a/tests/surfaces/test_arcade_broadcast_wire.py
+++ b/tests/surfaces/test_arcade_broadcast_wire.py
@@ -1,0 +1,216 @@
+"""Contract tests for the arcade TCP broadcast payload (`src/arcade/app.py`).
+
+The broadcast is the only channel between the replay process and every
+downstream surface, so the shape of the dict it puts on the wire is a
+contract, not an implementation detail. These tests pin the fields whose
+absence caused, or would cause, a downstream surface to render something
+false.
+
+**Why the tests build a stand-in for the view instead of an `F1ArcadeView`.**
+Constructing the real view needs an `arcade.Window`, which needs a GL
+context, which CI does not have. The payload builders read exactly four
+attributes off `self`, so the tests call them as plain functions with a
+namespace carrying those four. That is deliberate: if a builder starts
+reading a fifth attribute, these tests fail loudly with `AttributeError`
+rather than passing against a mock that quietly grew a new field.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("arcade", reason="the arcade replay is an optional surface")
+
+from src.arcade.app import F1ArcadeView  # noqa: E402
+from src.arcade.data import DT, FrameData, SessionData  # noqa: E402
+
+# The three numbers a synthetic session needs to be self-consistent: a
+# circuit length the distances accumulate against, a session-time origin
+# that is emphatically not zero (a zero origin would let a broken anchor
+# pass), and a driver who is on the wire.
+CIRCUIT_LENGTH_M = 5278.0
+GLOBAL_T_MIN = 3612.5
+MAIN = "NOR"
+
+
+def _frame(index: int, lap: int, rel_dist: float, *, active: bool = True) -> FrameData:
+    """One synthetic 25 Hz slice, with `dist` race-cumulative as the loader builds it."""
+    return FrameData(
+        t=index * DT,
+        x=0.0,
+        y=0.0,
+        speed=250.0,
+        gear=7,
+        drs=0,
+        throttle=100.0,
+        brake=0.0,
+        lap=lap,
+        dist=(lap - 1) * CIRCUIT_LENGTH_M + rel_dist * CIRCUIT_LENGTH_M,
+        rel_dist=rel_dist,
+        tyre=1,
+        tyre_life=8.0,
+        active=active,
+    )
+
+
+def _running_car(n_frames: int) -> list[FrameData]:
+    """A car that keeps circulating for the whole synthetic session."""
+    return [_frame(i, lap=1 + i // 10, rel_dist=(i % 10) / 10.0) for i in range(n_frames)]
+
+
+def _retired_car(n_frames: int, last_live_index: int) -> list[FrameData]:
+    """A car whose telemetry stops at `last_live_index`.
+
+    Past that point the loader's `np.interp` clamps, so every later frame
+    repeats the final real sample verbatim and only `active` records that
+    the car is gone. The fixture reproduces that clamp rather than
+    inventing a distinguishable value, because the clamp is the reason
+    the flag has to be on the wire.
+    """
+    frames = [_frame(i, lap=1 + i // 10, rel_dist=(i % 10) / 10.0) for i in range(n_frames)]
+    frozen = frames[last_live_index]
+    for i in range(last_live_index + 1, n_frames):
+        frames[i] = FrameData(**{**vars(frozen), "t": i * DT, "active": False})
+    return frames
+
+
+def _car_without_position_data(n_frames: int) -> list[FrameData]:
+    """A car FastF1 gives no `RelativeDistance` for.
+
+    Not hypothetical: on Melbourne 2025 this is HAD, NaN on 100 % of his
+    frames and the only non-finite value anywhere in the session.
+    """
+    frames = _running_car(n_frames)
+    return [FrameData(**{**vars(f), "rel_dist": float("nan")}) for f in frames]
+
+
+def _session(n_frames: int = 40) -> SessionData:
+    return SessionData(
+        gp_name="Australia",  # the display label
+        location="Melbourne",  # the folder name under data/raw/<year>/
+        year=2025,
+        frames_by_driver={
+            MAIN: _running_car(n_frames),
+            "SAI": _retired_car(n_frames, last_live_index=5),
+            "HAD": _car_without_position_data(n_frames),
+        },
+        max_lap_number=1 + (n_frames - 1) // 10,
+        circuit_length_m=CIRCUIT_LENGTH_M,
+        total_frames=n_frames,
+        global_t_min=GLOBAL_T_MIN,
+    )
+
+
+def _snapshot(session: SessionData, frame_idx: int, rival: str | None = None) -> dict:
+    view = SimpleNamespace(
+        _session=session,
+        _driver_main=MAIN,
+        _driver_rival=rival,
+        _year=session.year,
+    )
+    return F1ArcadeView._build_arcade_snapshot(view, frame_idx)
+
+
+# --- #842: the four scalars the wire used to drop ---------------------------
+
+
+def test_every_car_carries_active_and_rel_dist():
+    """A consumer iterating `drivers` must be able to place and qualify each car."""
+    wire = _snapshot(_session(), frame_idx=3)
+
+    assert set(wire["drivers"]) == {MAIN, "SAI", "HAD"}
+    for code, car in wire["drivers"].items():
+        assert "active" in car, f"{code} has no liveness flag"
+        assert "rel_dist" in car, f"{code} cannot be placed around the lap"
+        if car["rel_dist"] is not None:
+            assert 0.0 <= car["rel_dist"] <= 1.0
+
+
+def test_a_retired_car_is_flagged_while_its_other_fields_stay_frozen():
+    """The exact failure #842 describes: a DNF broadcasting as if it were racing.
+
+    `lap`, `dist` and `speed` are identical before and after the car
+    stops, because `np.interp` clamps. `active` is the only field that
+    changes, so it is the only one a timing tower or a track ring can
+    key off.
+    """
+    session = _session()
+    live = _snapshot(session, frame_idx=5)["drivers"]["SAI"]
+    dead = _snapshot(session, frame_idx=30)["drivers"]["SAI"]
+
+    assert live["active"] is True
+    assert dead["active"] is False
+    # Everything else is indistinguishable — that is the whole point.
+    assert dead["lap"] == live["lap"]
+    assert dead["dist"] == live["dist"]
+    assert dead["speed"] == live["speed"]
+    # The car the fixture keeps running must not be caught by the same net.
+    assert _snapshot(session, frame_idx=30)["drivers"][MAIN]["active"] is True
+
+
+def test_global_t_min_turns_the_frame_clock_back_into_session_time():
+    """`t` alone is `frame_index * DT`; only `t + global_t_min` is joinable.
+
+    FastF1 session time is what `laps.parquet` (`Time`, `LapStartTime`,
+    `Sector*SessionTime`) and `weather.parquet` are keyed on, so this sum
+    is the join key that did not exist before.
+    """
+    frame_idx = 17
+    wire = _snapshot(_session(), frame_idx)
+
+    assert wire["t"] == pytest.approx(frame_idx * DT)
+    assert wire["global_t_min"] == pytest.approx(GLOBAL_T_MIN)
+    assert wire["t"] + wire["global_t_min"] == pytest.approx(GLOBAL_T_MIN + frame_idx * DT)
+
+
+def test_a_car_with_no_position_data_is_unknown_rather_than_at_the_line():
+    """An absent `rel_dist` must not be clamped to a value that means something.
+
+    `min(1.0, nan)` is `1.0`, and 1.0 is a real position meaning "at the
+    line", so clamping would draw the car with no data exactly on the lap
+    boundary. Unknown is None, which is not a position any car can hold.
+    """
+    wire = _snapshot(_session(), frame_idx=3)
+
+    assert wire["drivers"]["HAD"]["rel_dist"] is None
+    assert wire["drivers"][MAIN]["rel_dist"] is not None
+    # The two-car telemetry block takes the same route, so it must agree.
+    telemetry = _snapshot(_session(), frame_idx=3, rival="HAD")["telemetry"]
+    assert telemetry["rival"]["dist"] is None
+    assert telemetry["main"]["dist"] is not None
+
+
+def test_the_payload_survives_a_strict_json_parser():
+    """`json.dumps` writes a bare `NaN`, which no strict parser accepts.
+
+    Python's own `json.loads` takes it, which is why the Qt dashboard
+    never surfaced this, but the payload's next consumer is JavaScript and
+    `JSON.parse` rejects the whole message. Nothing non-finite may reach
+    the wire.
+    """
+    wire = _snapshot(_session(), frame_idx=3, rival="HAD")
+
+    encoded = json.dumps(wire)
+    assert "NaN" not in encoded
+    assert "Infinity" not in encoded
+    # `parse_constant` fires on exactly the tokens a strict parser rejects.
+    json.loads(encoded, parse_constant=_reject_non_finite)
+
+
+def _reject_non_finite(token: str) -> float:
+    raise AssertionError(f"non-finite token on the wire: {token}")
+
+
+def test_location_is_on_the_wire_and_is_not_the_display_label():
+    """A consumer resolving `data/raw/<year>/<gp>/` must not read `gp_name`.
+
+    The two diverge whenever the arcade's hardcoded GP table drifts from
+    the calendar, which is why the loader keeps both.
+    """
+    wire = _snapshot(_session(), frame_idx=0)
+
+    assert wire["location"] == "Melbourne"
+    assert wire["gp_name"] == "Australia"


### PR DESCRIPTION
Four scalars the arcade computes and then drops before the broadcast. Each one blocks something specific downstream, and together they cost about 12 bytes per car per tick.

Closes #842.

## What

- **`global_t_min` on `SessionData` and on the wire.** `_build_timeline` builds `np.arange(0.0, global_t_max - global_t_min, DT)`, so a frame's `t` is exactly `frame_index * DT` and carries no information beyond the index. The offset that would make it a session time was computed, used to zero the per-driver clocks, and thrown away. Adding it back is the only join key the wire has ever had.
- **`active` and `rel_dist` in the per-car block.** `np.interp` clamps past a driver's last real sample, so a retired car keeps broadcasting its final `lap`, `dist`, `speed`, `compound` and `tyre_life` at 10 Hz exactly like a running one. `active` is the only field that separates them. `rel_dist` is fraction-of-lap; `dist % circuit_length_m` is not a substitute, because `dist` accumulates each lap as actually driven while `circuit_length_m` is measured off the fastest lap, so the residual drifts across a race and drifts most for the cars that pitted.
- **`location` once per payload.** `gp_name` is a display label from a hardcoded table; `location` is FastF1's own value and is also the folder name under `data/raw/<year>/`. A consumer that needs to find the session on disk must not read the label on screen.
- **`CACHE_VERSION` bumped `v7` -> `v8`.**

## A defect this PR would have introduced, found while measuring it

Putting `rel_dist` on the wire surfaced that FastF1 does not always deliver `RelativeDistance`. On Melbourne 2025 it is **NaN for 100 % of HAD's frames** - the only non-finite value anywhere in the session. Two independent problems follow, and both are fixed here:

1. **`json.dumps` writes a bare `NaN`, which is not valid JSON.** Python's own parser accepts it, which is why the Qt dashboard would never have surfaced this, but the payload's next consumer is JavaScript and `JSON.parse` rejects the entire message. One car with no position data would have taken the whole broadcast down.
2. **Clamping it is worse than dropping it.** `min(1.0, nan)` is `1.0`, and 1.0 is a legitimate value meaning "at the line", so the car with no data would be drawn exactly on the lap boundary rather than nowhere. Unknown is `None`; a value the code can also legitimately find is never a sentinel.

The same clamp already existed 15 lines away in `_frame_to_telemetry`, where it has been silently turning a missing `RelativeDistance` into a car parked on the start/finish line. **Both call sites now go through one `_lap_fraction` helper**, because one copy fixed and its twin left alone is this repo's most-repeated defect.

Measured after the fix: 201 snapshots sampled across the real race encode and re-parse under a strict parser, with `rel_dist: null` for HAD in all 201 and a real fraction for everyone else. The 20-car block costs about 2.5 KB per tick.

## Verified on real data, not argued

Melbourne 2025, loaded through the real `SessionLoader`:

```
global_t_min = 4260.355 s          (= VER lap 1 LapStartTime, 01:11:00.355)

 lap  wire t+anchor   laps.parquet    delta s
   2       4377.755       4377.726      0.029
  10       5477.475       5477.450      0.025
  25       6837.675       6837.652      0.023
  40       8448.315       8448.348     -0.033

worst |delta| = 0.033 s   (frame period DT = 0.040 s)
```

The wire now lands in the same clock as `laps.parquet` to within one frame period. Without the anchor the same four deltas would each be about -4260 s.

`active` on the same race: the three lap-1 retirements (SAI, DOO, HAD) go inactive at frame 2934, and ALO / BOR / LAW at laps 33 / 46 / 47, matching `laps.parquet`'s last lap per driver exactly. Past that point every other field is **byte-identical** to the driver's final real sample, checked frame by frame - which is the argument for the flag, not a nice-to-have: there is nothing else to key off.

The stale-cache path was exercised rather than assumed: rewriting the cached pickle with `version="v7"` and reloading regenerates it as `v8` with the anchor populated.

Also re-checked independently rather than taken from the audit: `data.py` really does build `dist` race-cumulative (`race_dist = total_dist_so_far + d_lap`), and the frame clock really is FastF1 `SessionTime` seconds.

## Expected on first run, NOT a regression

**The `CACHE_VERSION` bump invalidates every cached session pickle under `data/cache/arcade/`.** The first launch of each GP after this lands pays a full FastF1 reload (the cold path, a couple of minutes) instead of the usual warm start. That is the bump doing its job: a `v7` pickle has no `global_t_min`, and the dataclass default would hand it back as `0.0` - a silently wrong anchor rather than a crash. Regenerating once is the point. Every subsequent run of the same GP is warm again.

## Not in scope

The broadcast still has no version and no sequence number, and the telemetry block still carries one sample per tick instead of the span since the last tick. Those are #843 and #841, next in this sprint.

## Checks

- `pytest tests/surfaces/test_arcade_broadcast_wire.py` - 6 new tests covering the retired-car freeze, the missing-`RelativeDistance` car, a strict-JSON parse of the whole payload, the anchor arithmetic and `location` vs `gp_name`.
- `ruff check` and `ruff format --check` clean.
- Additive only: every new key is one existing consumers ignore.


---

### CORRECTION (2026-08-08)

**The `worst |delta| = 0.033 s` above is four sampled laps published as a bound, and it is not one.** Re-measured over all 927 driver-laps of the same race, twice independently:

| | |
|---|---|
| median | **22 ms** |
| p95 | **67 ms** |
| max | **486 ms** (NOR, lap 31) |
| above the 40 ms frame period | **9.8 % of driver-laps** |

The four laps this PR sampled (2 / 10 / 25 / 40) genuinely have a worst delta of 33 ms. The origin itself is exact: lap-1 `LapStartTime` matches to 0.000 ms for all twenty drivers, so the anchor this PR adds does what it claims. Only the tail figure was wrong.

Recorded here as well as in #849 because this body is the first durable artefact a future reader of #845 meets, and a sample maximum presented as a bound is the failure mode this repo has a standing lesson about.
