### PR TITLE
feat(arcade): broadcast the telemetry span since the last tick, not a single sample

### DIFF
--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -44,6 +44,7 @@ from src.arcade.config import (
     STREAM_BROADCAST_EVERY_N_FRAMES,
     STREAM_HISTORY_TAIL,
     STREAM_HOST,
+    STREAM_MAX_SPAN_FRAMES,
     STREAM_PORT,
     TEXT_PRIMARY,
     TEXT_SECONDARY,
@@ -61,6 +62,53 @@ from src.arcade.overlays import (
 from src.arcade.track import Track
 
 logger = logging.getLogger(__name__)
+
+
+def _telemetry_span_bounds(last_sent_idx: int, frame_idx: int, max_span: int) -> tuple[int, bool]:
+    """Return `(span_start, rewound)` for the frames this tick should send.
+
+    The span is `frames[span_start : frame_idx + 1]`, so `span_start >
+    frame_idx` is how "no new samples" is expressed. Pause and rewind get
+    explicit branches here rather than falling out of a negative slice,
+    which would silently send the wrong window:
+
+    - **forward** (the normal case): everything after the last frame sent,
+      up to and including the current one. Every frame the clock crossed
+      goes out exactly once, at any playback speed.
+    - **paused**: `frame_idx == last_sent_idx`, so the span is empty. Zero
+      new samples, not a repeat of the last one. Repeats are what made a
+      paused arcade look alive on the wire while nothing moved.
+    - **rewound**: the user seeked backwards. The span is empty and the
+      caller is told, because a consumer keyed on distance-within-lap now
+      holds samples for track the car has yet to re-drive, and only a
+      clear fixes that.
+
+    `max_span` caps a span the clock could not have produced smoothly.
+    Normal playback tops out around 60 frames per tick (0.1 s at 8x with
+    the seek multiplier); anything larger means the process stalled, and
+    a stall should not turn into a multi-megabyte blocking `sendall`.
+    """
+    if frame_idx < last_sent_idx:
+        return frame_idx + 1, True
+    span_start = last_sent_idx + 1
+    return max(span_start, frame_idx - max_span + 1), False
+
+
+def _frames_to_telemetry_span(
+    frames: list | None, span_start: int, frame_idx: int, circuit_length_m: float
+) -> list[dict]:
+    """Pack `frames[span_start : frame_idx + 1]` for the wire, oldest first.
+
+    Bounds are clamped to the array rather than trusted: a driver whose
+    telemetry is shorter than the global timeline would otherwise raise
+    at the end of the race.
+    """
+    if not frames:
+        return []
+    lo = max(0, span_start)
+    hi = min(len(frames) - 1, frame_idx)
+    samples = (_frame_to_telemetry(frames[i], circuit_length_m) for i in range(lo, hi + 1))
+    return [s for s in samples if s is not None]
 
 
 def _lap_fraction(rel_dist: float) -> float | None:
@@ -153,6 +201,12 @@ class F1ArcadeView(arcade.View):
         self._stream_server = None
         self._dashboard_proc: subprocess.Popen | None = None
         self._broadcast_tick: int = 0
+        # Highest frame index already put on the wire. -1 means "nothing sent
+        # yet", so the first broadcast emits a single sample rather than the
+        # whole race. Advanced on every due tick even when no client is
+        # attached, so a dashboard that connects on lap 40 gets the current
+        # tick's span and not 40 laps of backlog.
+        self._last_broadcast_idx: int = -1
 
         self._frame_index: float = 0.0
         self._speed_idx: int = DEFAULT_SPEED_IDX
@@ -449,11 +503,18 @@ class F1ArcadeView(arcade.View):
         self._broadcast_tick = (self._broadcast_tick + 1) % STREAM_BROADCAST_EVERY_N_FRAMES
         if self._broadcast_tick != 0:
             return
+        frame_idx = int(self._frame_index)
+        span_start, rewound = _telemetry_span_bounds(
+            self._last_broadcast_idx, frame_idx, STREAM_MAX_SPAN_FRAMES
+        )
+        # Advance the marker before the no-subscriber return, so the span
+        # always covers one tick of playback and never the backlog since
+        # whenever a client last happened to be attached.
+        self._last_broadcast_idx = frame_idx
         if self._stream_server.client_count() == 0:
             return  # no subscriber, skip the serialisation cost
-        frame_idx = int(self._frame_index)
         payload = {
-            "arcade": self._build_arcade_snapshot(frame_idx),
+            "arcade": self._build_arcade_snapshot(frame_idx, span_start, rewound),
             "strategy": self._strategy_state.snapshot_dict(STREAM_HISTORY_TAIL),
             "playback": {
                 "speed": self.playback_speed,
@@ -464,7 +525,7 @@ class F1ArcadeView(arcade.View):
         }
         self._stream_server.broadcast(payload)
 
-    def _build_arcade_snapshot(self, frame_idx: int) -> dict:
+    def _build_arcade_snapshot(self, frame_idx: int, span_start: int, rewound: bool) -> dict:
         """Compact version of the per-frame dict the dashboard needs.
 
         Lighter than the internal `_build_frame_dict` consumed by the
@@ -503,20 +564,30 @@ class F1ArcadeView(arcade.View):
         main_frames = self._session.frames_by_driver.get(self._driver_main)
         if main_frames and frame_idx < len(main_frames):
             main_frame = main_frames[frame_idx]
-        # Live telemetry for the main driver (always) + rival driver when
-        # two-driver mode is active. Published as {main: {...}, rival: {...}}
-        # so the telemetry window can render delta / speed / brake /
-        # throttle charts with both traces overlaid. In single-driver
-        # mode ``rival`` is null and the delta chart collapses to a
-        # "single driver" placeholder.
+        # Telemetry for the main driver (always) + the rival when two-driver
+        # mode is active, published as {main: [...], rival: [...]} — a SPAN
+        # of samples, oldest first, not the single current point.
+        #
+        # The clock advances `delta_time * FPS * speed` indices per second
+        # over 25 Hz data while the broadcast fires at ~10 Hz, so sending one
+        # point per tick discarded 60 % of the trace at 1x and 95 % at 8x: a
+        # speed trace went from a point every 8 metres to one every 170. The
+        # producer already holds the whole array, so the span costs a slice
+        # and no disk read. In single-driver mode `rival` is an empty list
+        # and the delta chart collapses to its "single driver" placeholder.
         circuit_length = float(self._session.circuit_length_m or 0.0)
-        main_tel = _frame_to_telemetry(main_frame, circuit_length)
-        rival_tel: dict | None = None
-        if self._driver_rival:
-            rival_frames = self._session.frames_by_driver.get(self._driver_rival)
-            if rival_frames and frame_idx < len(rival_frames):
-                rival_tel = _frame_to_telemetry(rival_frames[frame_idx], circuit_length)
-        telemetry = {"main": main_tel, "rival": rival_tel}
+        rival_frames = (
+            self._session.frames_by_driver.get(self._driver_rival) if self._driver_rival else None
+        )
+        telemetry = {
+            "main": _frames_to_telemetry_span(main_frames, span_start, frame_idx, circuit_length),
+            "rival": _frames_to_telemetry_span(rival_frames, span_start, frame_idx, circuit_length),
+            # True when the user seeked backwards. The span is empty and the
+            # consumer must drop what it has: a buffer keyed on
+            # distance-within-lap holds samples for track the car has not
+            # re-driven yet, and nothing else would ever evict them.
+            "rewound": rewound,
+        }
         return {
             "gp_name": self._session.gp_name,
             # FastF1's authoritative Location, which is also the folder name

--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -178,6 +178,14 @@ STREAM_PORT: Final[int] = int(os.environ.get("F1_STREAM_PORT", "9998"))
 # Broadcast every N arcade frames. At 60 FPS on_update, N=6 gives ~10 Hz,
 # smooth enough for the live charts without saturating localhost.
 STREAM_BROADCAST_EVERY_N_FRAMES: Final[int] = 6
+# Ceiling on how many telemetry samples one tick may carry. Normal playback
+# cannot reach it: the widest span the clock produces is a ~0.1 s broadcast
+# interval at 8x with the 3x seek multiplier, about 60 frames. It exists for
+# the case the clock did NOT produce smoothly — a GC pause or a blocking load
+# stalls on_update, delta_time comes back large, and the frame index jumps.
+# Without the cap that stall becomes a multi-megabyte blocking sendall on the
+# pyglet thread, i.e. a hitch turning into a freeze.
+STREAM_MAX_SPAN_FRAMES: Final[int] = 250
 # Cap how many LapDecision entries we keep in the broadcast history tail.
 STREAM_HISTORY_TAIL: Final[int] = 30
 

--- a/src/arcade/dashboard/telemetry_panel.py
+++ b/src/arcade/dashboard/telemetry_panel.py
@@ -224,8 +224,13 @@ class TelemetryPanel(QFrame):
             return
         arcade = data.get("arcade") or {}
         telemetry = arcade.get("telemetry") or {}
-        main = telemetry.get("main")
-        rival = telemetry.get("rival")
+        # Both are SPANS: every sample the replay clock crossed since the
+        # previous tick, oldest first. Empty means "no new samples this
+        # tick" (paused, or a backwards seek), never "no driver" — treating
+        # an empty span as absence would blank the charts ten times a
+        # second while the user holds pause.
+        main_span = telemetry.get("main") or []
+        rival_span = telemetry.get("rival") or []
 
         # Lock the X axis the first time we know the circuit length.
         if not self._x_range_set:
@@ -249,17 +254,22 @@ class TelemetryPanel(QFrame):
             self._vs_label.hide()
             self._rival_chip.hide()
 
-        if not main:
+        # A backwards seek invalidates everything held: the buffers are
+        # keyed on distance-within-lap, so they contain samples for track
+        # the car has not re-driven yet and nothing else would evict them.
+        if telemetry.get("rewound"):
             self._reset_buffers()
-            return
 
-        lap_n = int(main.get("lap") or 0)
-        if lap_n != self._current_lap:
-            self._current_lap = lap_n
-            self._main_buffer.clear()
-            self._rival_buffer.clear()
+        # The span can cross a lap boundary at high playback speed, so the
+        # lap-change clear is applied per sample rather than once per tick.
+        for sample in main_span:
+            lap_n = int(sample.get("lap") or 0)
+            if lap_n != self._current_lap:
+                self._current_lap = lap_n
+                self._main_buffer.clear()
+                self._rival_buffer.clear()
+            self._append(self._main_buffer, sample)
 
-        self._append(self._main_buffer, main)
         # Only accumulate rival samples that match the main driver's
         # current lap. When the two drivers are on different laps (one
         # pitted, one lapped, one half a track ahead) the buffer would
@@ -267,11 +277,15 @@ class TelemetryPanel(QFrame):
         # laps, and the delta interpolation produces ~4-6 s spikes at
         # the point where the older-lap samples sort next to the newer
         # ones.
-        if rival and int(rival.get("lap") or 0) == lap_n:
-            self._append(self._rival_buffer, rival)
+        for sample in rival_span:
+            if int(sample.get("lap") or 0) == self._current_lap:
+                self._append(self._rival_buffer, sample)
 
         self._refresh_speed_brake_throttle()
-        self._refresh_delta(has_rival=bool(rival))
+        # Two-driver mode is a property of the session, not of whether this
+        # particular tick happened to carry a rival sample — an empty span
+        # while paused must not collapse the delta chart to its placeholder.
+        self._refresh_delta(has_rival=bool(driver_rival))
 
     # --- Buffer ingestion -------------------------------------------
 

--- a/tests/surfaces/test_arcade_broadcast_wire.py
+++ b/tests/surfaces/test_arcade_broadcast_wire.py
@@ -104,14 +104,22 @@ def _session(n_frames: int = 40) -> SessionData:
     )
 
 
-def _snapshot(session: SessionData, frame_idx: int, rival: str | None = None) -> dict:
+def _snapshot(
+    session: SessionData,
+    frame_idx: int,
+    rival: str | None = None,
+    span_start: int | None = None,
+    rewound: bool = False,
+) -> dict:
+    """Build one broadcast snapshot. Defaults to a one-sample span at `frame_idx`."""
     view = SimpleNamespace(
         _session=session,
         _driver_main=MAIN,
         _driver_rival=rival,
         _year=session.year,
     )
-    return F1ArcadeView._build_arcade_snapshot(view, frame_idx)
+    start = frame_idx if span_start is None else span_start
+    return F1ArcadeView._build_arcade_snapshot(view, frame_idx, start, rewound)
 
 
 # --- #842: the four scalars the wire used to drop ---------------------------
@@ -179,8 +187,8 @@ def test_a_car_with_no_position_data_is_unknown_rather_than_at_the_line():
     assert wire["drivers"][MAIN]["rel_dist"] is not None
     # The two-car telemetry block takes the same route, so it must agree.
     telemetry = _snapshot(_session(), frame_idx=3, rival="HAD")["telemetry"]
-    assert telemetry["rival"]["dist"] is None
-    assert telemetry["main"]["dist"] is not None
+    assert telemetry["rival"][0]["dist"] is None
+    assert telemetry["main"][0]["dist"] is not None
 
 
 def test_the_payload_survives_a_strict_json_parser():

--- a/tests/surfaces/test_arcade_telemetry_span.py
+++ b/tests/surfaces/test_arcade_telemetry_span.py
@@ -1,0 +1,253 @@
+"""The telemetry span the arcade broadcast puts on the wire (#841).
+
+The producer sends every sample the replay clock crossed since the previous
+tick, not the single current point. What makes that correct is arithmetic
+over two integers, so it is tested as arithmetic: the tests below simulate
+the playback clock at each speed and assert the union of the spans is the
+frames the clock actually crossed, once each.
+
+The three cases that used to be accidents rather than branches -- pause,
+backwards seek, and a stalled process -- get a test apiece, because each
+one produced a specific wrong behaviour: repeated samples, a negative
+slice, and an unbounded payload.
+"""
+
+from __future__ import annotations
+
+import math
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("arcade", reason="the arcade replay is an optional surface")
+
+from src.arcade.app import (  # noqa: E402
+    F1ArcadeView,
+    _frames_to_telemetry_span,
+    _telemetry_span_bounds,
+)
+from src.arcade.config import (  # noqa: E402
+    DT,
+    FPS,
+    PLAYBACK_SPEEDS,
+    STREAM_BROADCAST_EVERY_N_FRAMES,
+    STREAM_MAX_SPAN_FRAMES,
+)
+from src.arcade.data import FrameData, SessionData  # noqa: E402
+
+# The real cadence: `on_update` runs at the arcade library default 60 Hz and
+# every 6th call broadcasts, so a tick is one sixth of a second of wall
+# clock. `_broadcast_if_due` counts on_update calls, not replay frames,
+# which is why the loss used to grow with playback speed.
+ON_UPDATE_HZ = 60.0
+TICK_SECONDS = STREAM_BROADCAST_EVERY_N_FRAMES / ON_UPDATE_HZ
+CIRCUIT_LENGTH_M = 5278.0
+
+
+def _collect_spans(speeds_and_ticks, start_frame: float = 0.0):
+    """Run the real clock and bounds arithmetic, returning the frames sent.
+
+    Yields `(span_start, frame_idx)` per tick alongside the running list of
+    every frame index put on the wire, so a test can assert on either.
+    """
+    frame_index = start_frame
+    last_sent = -1
+    sent: list[int] = []
+    spans: list[tuple[int, int]] = []
+    for speed, n_ticks in speeds_and_ticks:
+        for _ in range(n_ticks):
+            frame_index += TICK_SECONDS * FPS * speed
+            frame_idx = int(frame_index)
+            span_start, rewound = _telemetry_span_bounds(
+                last_sent, frame_idx, STREAM_MAX_SPAN_FRAMES
+            )
+            last_sent = frame_idx
+            spans.append((span_start, frame_idx))
+            if not rewound:
+                sent.extend(range(span_start, frame_idx + 1))
+    return sent, spans
+
+
+# --- The acceptance criterion: every frame once, at every speed -------------
+
+
+@pytest.mark.parametrize("speed", PLAYBACK_SPEEDS)
+def test_every_frame_the_clock_crosses_is_sent_exactly_once(speed):
+    """No gaps and no duplicates, at 0.25x through 8x.
+
+    Before the span this failed in both directions: 60 % of frames never
+    left the process at 1x and 95 % at 8x, while at 0.25x the same frame
+    was re-sent because the broadcast outran the clock.
+    """
+    sent, _ = _collect_spans([(speed, 60)])
+
+    assert sent == sorted(sent), "samples must arrive oldest first"
+    assert len(sent) == len(set(sent)), "a sample was sent twice"
+    assert sent == list(range(sent[0], sent[-1] + 1)), "a frame was skipped"
+
+
+def test_the_sample_count_matches_the_frames_the_clock_advanced():
+    """At 1x, one second of playback must deliver 25 samples, not 10."""
+    sent, _ = _collect_spans([(1.0, round(1.0 / TICK_SECONDS))])
+
+    assert len(sent) == pytest.approx(FPS, abs=1)
+
+
+def test_continuity_survives_a_speed_change():
+    """Changing speed mid-race must not tear a hole in the trace."""
+    sent, _ = _collect_spans([(1.0, 20), (8.0, 20), (0.5, 20)])
+
+    assert sent == list(range(sent[0], sent[-1] + 1))
+    assert len(sent) == len(set(sent))
+
+
+# --- The three branches that used to be accidents ---------------------------
+
+
+def test_pause_sends_no_new_samples_rather_than_repeating_the_last_one():
+    """A paused clock does not advance, so there is nothing new to send.
+
+    `_broadcast_if_due` keeps firing while paused (the throttle sits
+    outside the pause gate), so without an explicit empty span the same
+    sample went out ten times a second and any consumer that appends
+    accumulated duplicates.
+    """
+    span_start, rewound = _telemetry_span_bounds(400, 400, STREAM_MAX_SPAN_FRAMES)
+
+    assert span_start > 400, "a paused tick must produce an empty span"
+    assert rewound is False, "pause is not a discontinuity"
+    assert list(range(span_start, 401)) == []
+
+
+def test_a_backwards_seek_is_empty_and_flagged():
+    """Rewind must be a branch, not a negative slice."""
+    span_start, rewound = _telemetry_span_bounds(400, 250, STREAM_MAX_SPAN_FRAMES)
+
+    assert rewound is True
+    assert span_start > 250, "nothing may be appended on a rewind"
+
+
+def test_a_stall_cannot_put_an_unbounded_span_on_the_wire():
+    """A frame-index jump the clock could not produce smoothly is capped.
+
+    Normal playback tops out near 60 frames per tick; a process stall is
+    what produces thousands, and `sendall` is blocking on the pyglet
+    thread.
+    """
+    span_start, rewound = _telemetry_span_bounds(10, 90_000, STREAM_MAX_SPAN_FRAMES)
+
+    assert rewound is False
+    assert 90_000 - span_start + 1 == STREAM_MAX_SPAN_FRAMES
+
+    # The cap must never resurrect a span that pause emptied.
+    paused_start, _ = _telemetry_span_bounds(400, 400, STREAM_MAX_SPAN_FRAMES)
+    assert paused_start == 401
+
+
+def test_the_first_tick_sends_one_sample_not_the_whole_race():
+    """`last_sent_idx` starts at -1, which must mean "nothing yet", not "from zero"."""
+    span_start, _ = _telemetry_span_bounds(-1, 0, STREAM_MAX_SPAN_FRAMES)
+
+    assert span_start == 0
+    assert list(range(span_start, 1)) == [0]
+
+
+# --- Packing the span -------------------------------------------------------
+
+
+def _frames(n: int) -> list[FrameData]:
+    return [
+        FrameData(
+            t=i * DT,
+            x=0.0,
+            y=0.0,
+            speed=200.0 + i,
+            gear=6,
+            drs=0,
+            throttle=80.0,
+            brake=0.0,
+            lap=1 + i // 10,
+            dist=float(i) * 10.0,
+            rel_dist=(i % 10) / 10.0,
+            tyre=1,
+            tyre_life=5.0,
+        )
+        for i in range(n)
+    ]
+
+
+def test_the_span_is_packed_oldest_first_and_keeps_the_sample_shape():
+    packed = _frames_to_telemetry_span(_frames(50), 10, 14, CIRCUIT_LENGTH_M)
+
+    assert len(packed) == 5
+    assert [s["t"] for s in packed] == sorted(s["t"] for s in packed)
+    assert set(packed[0]) == {"lap", "t", "dist", "speed", "throttle", "brake", "gear", "drs"}
+
+
+def test_the_span_is_clamped_to_the_frames_a_driver_actually_has():
+    """A driver whose telemetry is shorter than the global timeline must not raise."""
+    assert _frames_to_telemetry_span(_frames(20), 15, 40, CIRCUIT_LENGTH_M) == pytest.approx(
+        _frames_to_telemetry_span(_frames(20), 15, 19, CIRCUIT_LENGTH_M)
+    )
+    assert _frames_to_telemetry_span([], 0, 5, CIRCUIT_LENGTH_M) == []
+    assert _frames_to_telemetry_span(None, 0, 5, CIRCUIT_LENGTH_M) == []
+    # An empty span is empty, not the whole array.
+    assert _frames_to_telemetry_span(_frames(20), 6, 5, CIRCUIT_LENGTH_M) == []
+
+
+def test_a_span_crossing_a_lap_boundary_carries_both_laps():
+    """The consumer clears per sample, so the producer must not hide the crossing."""
+    packed = _frames_to_telemetry_span(_frames(50), 7, 13, CIRCUIT_LENGTH_M)
+
+    assert {s["lap"] for s in packed} == {1, 2}
+
+
+# --- End to end through the snapshot builder --------------------------------
+
+
+def test_the_snapshot_publishes_spans_and_the_rewind_flag():
+    session = SessionData(
+        gp_name="Australia",
+        location="Melbourne",
+        year=2025,
+        frames_by_driver={"NOR": _frames(50), "PIA": _frames(50)},
+        circuit_length_m=CIRCUIT_LENGTH_M,
+        total_frames=50,
+    )
+    view = SimpleNamespace(_session=session, _driver_main="NOR", _driver_rival="PIA", _year=2025)
+
+    moving = F1ArcadeView._build_arcade_snapshot(view, 20, 16, False)["telemetry"]
+    assert len(moving["main"]) == 5
+    assert len(moving["rival"]) == 5
+    assert moving["rewound"] is False
+
+    paused = F1ArcadeView._build_arcade_snapshot(view, 20, 21, False)["telemetry"]
+    assert paused["main"] == [] and paused["rival"] == []
+
+    rewound = F1ArcadeView._build_arcade_snapshot(view, 20, 21, True)["telemetry"]
+    assert rewound["main"] == []
+    assert rewound["rewound"] is True
+
+
+def test_single_driver_mode_publishes_an_empty_rival_span():
+    session = SessionData(
+        gp_name="Australia",
+        location="Melbourne",
+        year=2025,
+        frames_by_driver={"NOR": _frames(50)},
+        circuit_length_m=CIRCUIT_LENGTH_M,
+        total_frames=50,
+    )
+    view = SimpleNamespace(_session=session, _driver_main="NOR", _driver_rival=None, _year=2025)
+
+    telemetry = F1ArcadeView._build_arcade_snapshot(view, 20, 16, False)["telemetry"]
+
+    assert telemetry["rival"] == []
+    assert len(telemetry["main"]) == 5
+
+
+def test_the_payload_growth_stays_small_at_the_fastest_speed():
+    """Two drivers carry traces, so 8x costs about 20 samples a tick, not 200."""
+    frames_per_tick = TICK_SECONDS * FPS * max(PLAYBACK_SPEEDS)
+
+    assert math.ceil(frames_per_tick) <= 25


### PR DESCRIPTION
The broadcast put **one** telemetry sample on the wire per tick, so most of the resampled telemetry never left the process, and the loss got worse the faster you played.

Closes #841.

## The arithmetic

The playback clock advances `delta_time * FPS * speed` indices per second over 25 Hz data. The broadcast fires every 6th `on_update`, and `main.py` builds the `arcade.Window` without an `update_rate`, so `on_update` runs at the library default 60 Hz: about 10 payloads a second regardless of speed.

| speed | frames/s the clock crosses | samples/s sent (before) | lost |
|---|---|---|---|
| 0.25x | 6.2 | 10 | none, the same sample re-sent ~1.6x |
| 1x | 25 | 10 | **60 %** |
| 4x | 100 | 10 | 90 % |
| 8x | 200 | 10 | **95 %** |

At 8x a speed trace went from a point every 8 metres to a point every 170. It is not a trace at that density, it is a scatter of where the broadcast happened to land.

## What changed

`_build_arcade_snapshot` now publishes `telemetry.main` and `telemetry.rival` as **spans**: every sample the clock crossed since the previous tick, oldest first. The producer already holds the whole array in memory, so this is a slice, not a disk read. Only two drivers carry traces, so the payload grows by roughly 2.5 samples per tick at 1x and 20 at 8x.

**Pause and rewind are now branches rather than accidents**, which is most of the value here:

- **Paused**: `_broadcast_if_due` sits outside the pause gate, so it keeps firing while the clock is frozen. Before, that re-sent the same sample ten times a second and any consumer that appends accumulated duplicates. Now the span is explicitly empty.
- **Rewound**: a backwards seek used to be a negative slice waiting to happen. Now it is an empty span plus a `rewound` flag, and the Qt panel clears on it. That also fixes the second half of the audit's finding: the panel's buffer is keyed on distance-within-lap, so rewinding *within* a lap left samples for track the car had not re-driven, and nothing evicted them until it drove over that distance again.
- **Stalled**: `STREAM_MAX_SPAN_FRAMES` caps a jump the clock could not have produced smoothly. Normal playback tops out near 60 frames per tick; a GC pause or a blocking load is what produces thousands, and `sendall` is blocking on the pyglet thread, so an unbounded span turns a hitch into a freeze.

`_last_broadcast_idx` advances on every due tick **even when no client is attached**, so a dashboard that connects on lap 40 gets one tick of playback rather than 40 laps of backlog.

## The consumer

`src/arcade/dashboard/telemetry_panel.py` is the only reader of this block, so it moves with it. Two things it had to get right:

1. **An empty span means "no new samples", never "no driver".** The old code did `if not main: self._reset_buffers()`, which never fired because a paused arcade kept re-sending. Carried over unchanged it would have blanked the charts ten times a second while the user held pause.
2. **The lap-change clear is per sample, not per tick.** At high speed a single span can cross a lap boundary, so the clear has to happen at the crossing and keep the samples after it.

`has_rival` now reads the session's `driver_rival` rather than "did this tick carry a rival sample", for the same reason as (1).

## Checks

- `tests/surfaces/test_arcade_telemetry_span.py`, 15 tests. The headline one simulates the real clock at each of the six `PLAYBACK_SPEEDS` and asserts the union of the spans is exactly the frames the clock crossed: sorted, no duplicate, no gap. Plus a test each for pause, backwards seek, the stall cap, the first tick, a span crossing a lap boundary, and the clamp when a driver's telemetry is shorter than the global timeline.
- `ruff check` and `ruff format --check` clean.
