### PR TITLE
feat(arcade): version and sequence the broadcast payload

### DIFF
--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -46,6 +46,7 @@ from src.arcade.config import (
     STREAM_HOST,
     STREAM_MAX_SPAN_FRAMES,
     STREAM_PORT,
+    STREAM_SCHEMA_VERSION,
     TEXT_PRIMARY,
     TEXT_SECONDARY,
     TEXT_TERTIARY,
@@ -207,6 +208,12 @@ class F1ArcadeView(arcade.View):
         # attached, so a dashboard that connects on lap 40 gets the current
         # tick's span and not 40 laps of backlog.
         self._last_broadcast_idx: int = -1
+        # Counts payloads actually put on the wire, so a consumer can tell a
+        # duplicate read from a skipped one. Both are real: two independent
+        # 10 Hz pollers reading one latest-payload slot were measured
+        # duplicating 15 of 54 reads and skipping 15 of 54. Without a
+        # sequence neither is visible from the consumer side.
+        self._broadcast_seq: int = 0
 
         self._frame_index: float = 0.0
         self._speed_idx: int = DEFAULT_SPEED_IDX
@@ -513,7 +520,10 @@ class F1ArcadeView(arcade.View):
         self._last_broadcast_idx = frame_idx
         if self._stream_server.client_count() == 0:
             return  # no subscriber, skip the serialisation cost
+        self._broadcast_seq += 1
         payload = {
+            "schema_version": STREAM_SCHEMA_VERSION,
+            "seq": self._broadcast_seq,
             "arcade": self._build_arcade_snapshot(frame_idx, span_start, rewound),
             "strategy": self._strategy_state.snapshot_dict(STREAM_HISTORY_TAIL),
             "playback": {

--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -173,6 +173,11 @@ SSE_MAX_CONSECUTIVE_FAILURES: Final[int] = 3
 SSE_BACKOFF_AFTER_FAILURES_S: Final[float] = 10.0
 
 # --- Telemetry stream (arcade -> dashboard process) ----------------------
+# Version of the broadcast payload's shape. Bump it whenever a key is
+# renamed, removed, or changes meaning; adding a key an old consumer can
+# ignore does not need a bump. A consumer that reads a version it does not
+# know should say so rather than silently render a field it guessed at.
+STREAM_SCHEMA_VERSION: Final[int] = 1
 STREAM_HOST: Final[str] = os.environ.get("F1_STREAM_HOST", "127.0.0.1")
 STREAM_PORT: Final[int] = int(os.environ.get("F1_STREAM_PORT", "9998"))
 # Broadcast every N arcade frames. At 60 FPS on_update, N=6 gives ~10 Hz,

--- a/src/arcade/stream.py
+++ b/src/arcade/stream.py
@@ -11,6 +11,26 @@ and trimmed to stdlib-only: the arcade process must not import PySide6 so
 we can launch the dashboard as a subprocess without pulling Qt into the
 replay window. The client class lives in the dashboard package (Qt-aware),
 kept separate so this module never needs to import PySide6.
+
+The payload contract
+--------------------
+Every message is one JSON object on its own line, built by
+`F1ArcadeView._broadcast_if_due`, carrying:
+
+- `schema_version` (`STREAM_SCHEMA_VERSION`): bumped when a key is renamed,
+  removed, or changes meaning. Adding a key an old consumer can ignore does
+  not bump it.
+- `seq`: strictly increasing by 1 per message sent. It exists because a
+  consumer that polls a latest-payload slot on its own timer beats against
+  this producer, and both failure modes are otherwise invisible: a `seq`
+  repeated is a duplicate read, a `seq` skipped is a dropped frame.
+- `arcade`, `strategy`, `playback`: the state itself. The frozen shape lives
+  in `tests/surfaces/test_arcade_wire_contract.py`, which is the thing that
+  actually fails when a producer-side change breaks a consumer.
+
+Nothing non-finite may reach the wire: `json.dumps` writes a bare `NaN`,
+which Python's parser accepts and `JSON.parse` rejects, so one missing
+telemetry value would otherwise drop the whole message for a web consumer.
 """
 
 from __future__ import annotations

--- a/tests/surfaces/test_arcade_wire_contract.py
+++ b/tests/surfaces/test_arcade_wire_contract.py
@@ -1,0 +1,407 @@
+"""The frozen shape of the arcade broadcast payload (#843).
+
+This is the golden-payload test. It builds a complete broadcast the way
+`_broadcast_if_due` does and compares its structure, key by key and type
+by type, against a literal frozen below. A producer-side change that
+renames a key, drops one, or changes its type fails here in CI rather
+than on a consumer's screen.
+
+**Updating the golden is part of the change, not a chore around it.** If
+a diff is intentional, edit `GOLDEN_SHAPE` in the same commit and bump
+`STREAM_SCHEMA_VERSION` when the change is not purely additive. The point
+is that it cannot happen by accident.
+
+The `strategy` half is exercised with fully populated DTOs rather than
+defaults, because a field that is `None` in the fixture freezes as
+`NoneType` and would pin nothing about its real type. That half carries
+the most fields and is the one the PITWALL agents window reads one by one.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("arcade", reason="the arcade replay is an optional surface")
+
+from src.arcade.app import F1ArcadeView  # noqa: E402
+from src.arcade.config import DT, STREAM_SCHEMA_VERSION  # noqa: E402
+from src.arcade.data import FrameData, SessionData  # noqa: E402
+from src.arcade.strategy import (  # noqa: E402
+    LapDecisionDTO,
+    PerAgentOutputsDTO,
+    StartEventDTO,
+    StrategyState,
+)
+
+CIRCUIT_LENGTH_M = 5278.0
+
+
+def _shape(value):
+    """Describe a JSON-shaped value as nested key -> type-name.
+
+    A list is described by its first element, so an empty list and a
+    populated one are different shapes. That is deliberate: the fixture
+    populates every list the payload can carry, so an empty one in the
+    result means the producer stopped filling it.
+    """
+    if isinstance(value, dict):
+        return {key: _shape(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [_shape(value[0])] if value else []
+    return type(value).__name__
+
+
+def _frames(n: int) -> list[FrameData]:
+    return [
+        FrameData(
+            t=i * DT,
+            x=1.0,
+            y=2.0,
+            speed=250.0,
+            gear=7,
+            drs=8,
+            throttle=90.0,
+            brake=5.0,
+            lap=1 + i // 10,
+            dist=float(i) * 10.0,
+            rel_dist=(i % 10) / 10.0,
+            tyre=1,
+            tyre_life=9.0,
+            active=True,
+        )
+        for i in range(n)
+    ]
+
+
+def _decision() -> LapDecisionDTO:
+    """A LapDecisionDTO with every optional field populated.
+
+    Defaults would leave nine fields as `None` and freeze their type as
+    `NoneType`, which pins the key but not the type.
+    """
+    return LapDecisionDTO(
+        lap_number=12,
+        compound="MEDIUM",
+        tyre_life=9,
+        position=4,
+        lap_time_s=81.234,
+        gap_ahead_s=1.42,
+        action="PIT_NOW",
+        confidence=0.71,
+        reasoning="undercut window open",
+        scenario_scores={"PIT_NOW": 0.71, "STAY_OUT": 0.29},
+        pace_mode="PUSH",
+        risk_posture="AGGRESSIVE",
+        pit_lap_target=13,
+        compound_next="HARD",
+        undercut_target="RUS",
+        agent_alerts=["tyre cliff in 2 laps"],
+        guardrail_reason="none",
+        per_agent=PerAgentOutputsDTO(
+            pace={"predicted_lap_time_s": 81.0},
+            tire={"degradation_pct": 12.0},
+            situation={"threat_level": "MEDIUM"},
+            radio={"sentiment": "negative"},
+            pit={"pit_duration_s": 22.4},
+            regulation_context="Art. 55.7",
+            rag={"question": "q", "answer": "a", "articles": ["55.7"], "chunks": ["c"]},
+            active=["pace", "tire"],
+        ),
+        memory_block="lap 11: STAY_OUT",
+        plan_changed=True,
+    )
+
+
+def _view(session: SessionData, state: StrategyState, rival: str | None, clients: int):
+    """A stand-in for `F1ArcadeView` carrying only what `_broadcast_if_due` reads.
+
+    `_build_arcade_snapshot` is bound explicitly because the method under
+    test calls it through `self`. Anything else the broadcast path starts
+    reading will raise here rather than pass against a permissive mock.
+    """
+    view = SimpleNamespace(
+        _session=session,
+        _driver_main="NOR",
+        _driver_rival=rival,
+        _year=2025,
+        _stream_server=SimpleNamespace(client_count=lambda: clients, broadcast=_sent.append),
+        _strategy_state=state,
+        # `_broadcast_if_due` increments the tick then broadcasts when it
+        # wraps to 0, so -1 makes the very next call due.
+        _broadcast_tick=-1,
+        _broadcast_seq=0,
+        _last_broadcast_idx=15,
+        _frame_index=20.0,
+        playback_speed=1.0,
+        _is_paused=False,
+    )
+    view._build_arcade_snapshot = partial(F1ArcadeView._build_arcade_snapshot, view)
+    return view
+
+
+def _payload() -> dict:
+    """Build one broadcast exactly as `_broadcast_if_due` assembles it."""
+    session = SessionData(
+        gp_name="Australia",
+        location="Melbourne",
+        year=2025,
+        frames_by_driver={"NOR": _frames(40), "PIA": _frames(40)},
+        min_lap_number=1,
+        max_lap_number=4,
+        circuit_length_m=CIRCUIT_LENGTH_M,
+        total_frames=40,
+        global_t_min=4260.355,
+    )
+    state = StrategyState()
+    state.start = StartEventDTO(
+        gp="Melbourne",
+        year=2025,
+        driver="NOR",
+        driver2="PIA",
+        team="McLaren",
+        lap_start=1,
+        lap_end=57,
+        total_laps=57,
+        no_llm=False,
+        provider="openai",
+    )
+    state.latest = _decision()
+    state.history = [_decision()]
+
+    _sent.clear()
+    F1ArcadeView._broadcast_if_due(_view(session, state, rival="PIA", clients=1))
+    assert _sent, "the fixture must actually broadcast"
+    return _sent[-1]
+
+
+_sent: list[dict] = []
+
+
+# --- The golden ------------------------------------------------------------
+
+GOLDEN_SHAPE = {
+    "schema_version": "int",
+    "seq": "int",
+    "arcade": {
+        "circuit_length_m": "float",
+        "driver_main": "str",
+        "driver_rival": "str",
+        "drivers": {
+            "NOR": {
+                "active": "bool",
+                "compound": "int",
+                "dist": "float",
+                "lap": "int",
+                "rel_dist": "float",
+                "speed": "float",
+                "tyre_life": "float",
+            },
+            "PIA": {
+                "active": "bool",
+                "compound": "int",
+                "dist": "float",
+                "lap": "int",
+                "rel_dist": "float",
+                "speed": "float",
+                "tyre_life": "float",
+            },
+        },
+        "global_t_min": "float",
+        "gp_name": "str",
+        "lap": "int",
+        "location": "str",
+        "t": "float",
+        "telemetry": {
+            "main": [
+                {
+                    "brake": "float",
+                    "dist": "float",
+                    "drs": "int",
+                    "gear": "int",
+                    "lap": "int",
+                    "speed": "float",
+                    "t": "float",
+                    "throttle": "float",
+                }
+            ],
+            "rewound": "bool",
+            "rival": [
+                {
+                    "brake": "float",
+                    "dist": "float",
+                    "drs": "int",
+                    "gear": "int",
+                    "lap": "int",
+                    "speed": "float",
+                    "t": "float",
+                    "throttle": "float",
+                }
+            ],
+        },
+        "total_laps": "int",
+        "year": "int",
+    },
+    "playback": {
+        "frame_index": "int",
+        "paused": "bool",
+        "speed": "float",
+        "total_frames": "int",
+    },
+    "strategy": {
+        "error": "NoneType",
+        "finished": "bool",
+        "history_tail": [
+            {
+                "action": "str",
+                "agent_alerts": ["str"],
+                "compound": "str",
+                "compound_next": "str",
+                "confidence": "float",
+                "gap_ahead_s": "float",
+                "guardrail_reason": "str",
+                "lap_number": "int",
+                "lap_time_s": "float",
+                "memory_block": "str",
+                "pace_mode": "str",
+                "pit_lap_target": "int",
+                "plan_changed": "bool",
+                "position": "int",
+                "reasoning": "str",
+                "risk_posture": "str",
+                "scenario_scores": {"PIT_NOW": "float", "STAY_OUT": "float"},
+                "tyre_life": "int",
+                "undercut_target": "str",
+            }
+        ],
+        "latest": {
+            "action": "str",
+            "agent_alerts": ["str"],
+            "compound": "str",
+            "compound_next": "str",
+            "confidence": "float",
+            "gap_ahead_s": "float",
+            "guardrail_reason": "str",
+            "lap_number": "int",
+            "lap_time_s": "float",
+            "memory_block": "str",
+            "pace_mode": "str",
+            "per_agent": {
+                "active": ["str"],
+                "pace": {"predicted_lap_time_s": "float"},
+                "pit": {"pit_duration_s": "float"},
+                "radio": {"sentiment": "str"},
+                "rag": {
+                    "answer": "str",
+                    "articles": ["str"],
+                    "chunks": ["str"],
+                    "question": "str",
+                },
+                "regulation_context": "str",
+                "situation": {"threat_level": "str"},
+                "tire": {"degradation_pct": "float"},
+            },
+            "pit_lap_target": "int",
+            "plan_changed": "bool",
+            "position": "int",
+            "reasoning": "str",
+            "risk_posture": "str",
+            "scenario_scores": {"PIT_NOW": "float", "STAY_OUT": "float"},
+            "tyre_life": "int",
+            "undercut_target": "str",
+        },
+        "start": {
+            "driver": "str",
+            "driver2": "str",
+            "gp": "str",
+            "lap_end": "int",
+            "lap_start": "int",
+            "no_llm": "bool",
+            "provider": "str",
+            "team": "str",
+            "total_laps": "int",
+            "year": "int",
+        },
+    },
+}
+
+
+def test_the_payload_shape_is_the_frozen_one():
+    """Every key and type on the wire, pinned.
+
+    `history_tail` deliberately has no `per_agent`: `snapshot_dict` strips
+    it from past decisions so the tail does not re-send 30 copies of the
+    dataclass ten times a second. If it reappears here, that saving is
+    gone.
+    """
+    assert _shape(_payload()) == GOLDEN_SHAPE
+
+
+def test_the_payload_carries_the_schema_version():
+    assert _payload()["schema_version"] == STREAM_SCHEMA_VERSION
+
+
+# --- seq semantics ----------------------------------------------------------
+
+
+def _seq_of(n_broadcasts: int, *, clients: int = 1) -> list[int]:
+    """Drive `_broadcast_if_due` n times and collect the sequence numbers."""
+    session = SessionData(
+        frames_by_driver={"NOR": _frames(400)},
+        circuit_length_m=CIRCUIT_LENGTH_M,
+        total_frames=400,
+    )
+    view = _view(session, StrategyState(), rival=None, clients=clients)
+    view._last_broadcast_idx = -1
+    view._frame_index = 0.0
+    _sent.clear()
+    for _ in range(n_broadcasts):
+        view._broadcast_tick = -1  # force every call to be due
+        view._frame_index += 2.5
+        F1ArcadeView._broadcast_if_due(view)
+    return [p["seq"] for p in _sent]
+
+
+def test_seq_increases_by_exactly_one_per_message():
+    seqs = _seq_of(10)
+
+    assert seqs == list(range(1, 11))
+    assert all(b - a == 1 for a, b in zip(seqs, seqs[1:]))
+
+
+def _classify(seqs: list[int]) -> list[str]:
+    """The rule a polling consumer applies to consecutive `seq` values.
+
+    This is the whole point of the field: without it a consumer reading a
+    latest-payload slot on its own timer cannot tell "nothing new yet"
+    from "I missed two frames", and both happen. Measured against one
+    slot at 10 Hz on each side with a half-period offset: 15 duplicate
+    reads and 15 skips out of 54 polls.
+    """
+    return [
+        "duplicate" if b == a else "clean" if b == a + 1 else f"skipped {b - a - 1}"
+        for a, b in zip(seqs, seqs[1:])
+    ]
+
+
+def test_a_consumer_can_tell_a_duplicate_from_a_skip():
+    """Both failure modes, read off `seq` alone with no other state."""
+    stream = _seq_of(6)
+
+    assert _classify(stream) == ["clean"] * 5
+    # The consumer polled twice before the producer moved on.
+    assert _classify([stream[0], stream[0], stream[1]]) == ["duplicate", "clean"]
+    # The consumer was late and the slot had been overwritten twice.
+    assert _classify([stream[0], stream[3]]) == ["skipped 2"]
+
+
+def test_no_seq_is_burned_while_nobody_is_listening():
+    """The counter must count messages sent, not ticks elapsed.
+
+    If it advanced on ticks with no subscriber, a dashboard that attaches
+    mid-race would see its first `seq` jump by thousands and every gap
+    check downstream would be measuring the wrong thing.
+    """
+    assert _seq_of(10, clients=0) == []


### PR DESCRIPTION
The broadcast was an ad-hoc dict with no version and no delivery semantics. That was fine while the only consumer lived in the same repo, in the same language, spawned by the same process. It stops being fine the moment a consumer polls it instead of being pushed to.

Closes #843.

## Why now, and why this is not a contradiction

The P3 audit deferred exactly this: *"Do not build a schema/versioning layer for the TCP wire yet. One producer, two consumers, same repo, same process boundary; a Pydantic `BroadcastPayload` is worth it only if an external consumer appears."* The trigger condition is now met. This PR is that deferral firing, and it keeps the shape the deferral asked for: **a version tag, a counter and a test**, not a serialisation framework.

## What changed

- **`schema_version`** on every payload. Bumped when a key is renamed, removed, or changes meaning; adding a key an old consumer can ignore does not bump it.
- **`seq`**, strictly increasing by 1 per message actually sent. It is deliberately incremented *after* the no-subscriber return, so it counts messages rather than ticks: if it advanced while nobody was listening, a dashboard attaching mid-race would see its first `seq` jump by thousands and every gap check downstream would be measuring the wrong thing.
- **A golden-payload test** freezing the whole shape, key by key and type by type.
- `stream.py`'s module docstring now states the contract, since that is where someone writing a second consumer will look.

## The delivery problem `seq` exists for

A consumer that reads a single latest-payload slot on its own timer, rather than being pushed to, beats against this producer. Simulated at 10 Hz on both sides with a half-period offset: **duplicate reads on 15 of 54 polls and skipped frames on 15 of 54**. From the consumer side those are invisible without a sequence: "nothing new yet" and "I missed two frames" look identical. With one, a repeated `seq` is a duplicate and a jump is a skip, both detectable with no other state. The test encodes that rule rather than asserting the field exists.

## The golden test

`tests/surfaces/test_arcade_wire_contract.py` builds a complete broadcast the way `_broadcast_if_due` assembles it and compares its structure against a literal. Two decisions worth knowing:

- **The `strategy` half is exercised with fully populated DTOs, not defaults.** Nine `LapDecisionDTO` fields are `None` by default, and a `None` in the fixture freezes as `NoneType`, pinning the key but nothing about its type. That half carries the most fields and is the one the PITWALL agents window reads one by one.
- **The stand-in for the view carries only what `_broadcast_if_due` actually reads.** If the broadcast path starts reading a new attribute, the test raises rather than passing against a permissive mock.

It also pins one thing that is easy to undo by accident: `history_tail` has no `per_agent`, because `snapshot_dict` strips it from past decisions so the tail does not re-send 30 copies of the dataclass ten times a second.

Updating the golden is part of a change, not a chore around it: if a diff is intentional, edit `GOLDEN_SHAPE` in the same commit and bump `STREAM_SCHEMA_VERSION` when the change is not purely additive.

## Adjacent and still open

P3 finding A8: `snapshot_dict` re-runs a recursive `asdict` over the 30-entry history tail ten times a second even when no new decision exists, and `sendall` is blocking, so one stalled subscriber can hitch the pyglet frame loop. That is #199 Phase D.3, not this PR, but this PR makes it matter more.

## Checks

- `tests/surfaces/test_arcade_wire_contract.py`, 5 tests: the frozen shape, the version, `seq` stepping by one, the duplicate-vs-skip classification, and no `seq` burned while nobody is listening.
- Additive only: existing consumers keep working unchanged.
- `ruff check` and `ruff format --check` clean.
