### PR TITLE
fix(arcade): enforce the wire's non-finite promise and flag forward seeks

### DIFF
--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -52,6 +52,7 @@ from src.arcade.config import (
     TEXT_TERTIARY,
 )
 from src.arcade.data import FrameData, SessionData
+from src.arcade.gaps import RaceGapCalculator
 from src.arcade.overlays import (
     ControlsLegend,
     DriverInfoPanel,
@@ -192,6 +193,11 @@ class F1ArcadeView(arcade.View):
 
         self._session = session_data
         self._track = track
+        # Built once: finding the lap-line crossings walks every driver's
+        # frames, and each query afterwards is two dict lookups. Building it
+        # lazily would put that walk inside a frame rather than inside the
+        # load the user is already waiting through.
+        self._gaps = RaceGapCalculator(session_data)
         self._driver_main = driver_main
         self._driver_rival = driver_rival
         self._year = year
@@ -640,26 +646,23 @@ class F1ArcadeView(arcade.View):
         if self._driver_rival:
             self._draw_car(self._driver_rival, self._car_label_rival, above=False)
 
-        track_len = self._session.circuit_length_m or 5300.0
-        self._leaderboard.draw(
-            frame, self._session.driver_colors, track_len, self._selected_drivers
-        )
+        self._leaderboard.draw(frame, self._session.driver_colors, self._selected_drivers)
         # Anchor the race-events pill right under the leaderboard's bottom
         # edge — the leaderboard's row count varies per session, so we read
         # ``bottom_y`` (set during draw above) instead of hard-coding an offset.
         self._race_events.set_top(self._leaderboard.bottom_y - RaceEventsPanel.GAP_FROM_LEADERBOARD)
         self._race_events.draw()
         self._weather.draw(frame, self.window.height)
-        sorted_progress = self._leaderboard.sorted_progress(frame, track_len)
+        sorted_progress = self._leaderboard.sorted_progress(frame)
         # DRIVER_BOX_GAP also controls the weather → main-driver gap for
         # a consistent rhythm between the three stacked cards.
         self._driver_info_main.set_top(self._weather.bottom_y - DRIVER_BOX_GAP)
-        self._driver_info_main.draw(frame, sorted_progress)
+        self._driver_info_main.draw(frame, sorted_progress, self._gaps)
         if self._driver_info_rival:
             self._driver_info_rival.set_top(
                 self._weather.bottom_y - DRIVER_BOX_GAP - DRIVER_BOX_HEIGHT - DRIVER_BOX_GAP
             )
-            self._driver_info_rival.draw(frame, sorted_progress)
+            self._driver_info_rival.draw(frame, sorted_progress, self._gaps)
 
         if self._show_progress_bar:
             self._progress_bar.draw(self.window.width, frame_idx)

--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -646,23 +646,25 @@ class F1ArcadeView(arcade.View):
         if self._driver_rival:
             self._draw_car(self._driver_rival, self._car_label_rival, above=False)
 
-        self._leaderboard.draw(frame, self._session.driver_colors, self._selected_drivers)
+        self._leaderboard.draw(
+            frame, self._session.driver_colors, self._gaps, frame_idx, self._selected_drivers
+        )
         # Anchor the race-events pill right under the leaderboard's bottom
         # edge — the leaderboard's row count varies per session, so we read
         # ``bottom_y`` (set during draw above) instead of hard-coding an offset.
         self._race_events.set_top(self._leaderboard.bottom_y - RaceEventsPanel.GAP_FROM_LEADERBOARD)
         self._race_events.draw()
         self._weather.draw(frame, self.window.height)
-        sorted_progress = self._leaderboard.sorted_progress(frame)
+        sorted_progress = self._leaderboard.sorted_progress(frame, self._gaps, frame_idx)
         # DRIVER_BOX_GAP also controls the weather → main-driver gap for
         # a consistent rhythm between the three stacked cards.
         self._driver_info_main.set_top(self._weather.bottom_y - DRIVER_BOX_GAP)
-        self._driver_info_main.draw(frame, sorted_progress, self._gaps)
+        self._driver_info_main.draw(frame, sorted_progress, self._gaps, frame_idx)
         if self._driver_info_rival:
             self._driver_info_rival.set_top(
                 self._weather.bottom_y - DRIVER_BOX_GAP - DRIVER_BOX_HEIGHT - DRIVER_BOX_GAP
             )
-            self._driver_info_rival.draw(frame, sorted_progress, self._gaps)
+            self._driver_info_rival.draw(frame, sorted_progress, self._gaps, frame_idx)
 
         if self._show_progress_bar:
             self._progress_bar.draw(self.window.width, frame_idx)

--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -66,8 +66,10 @@ from src.arcade.track import Track
 logger = logging.getLogger(__name__)
 
 
-def _telemetry_span_bounds(last_sent_idx: int, frame_idx: int, max_span: int) -> tuple[int, bool]:
-    """Return `(span_start, rewound)` for the frames this tick should send.
+def _telemetry_span_bounds(
+    last_sent_idx: int, frame_idx: int, max_span: int
+) -> tuple[int, bool, int]:
+    """Return `(span_start, rewound, dropped)` for the frames this tick should send.
 
     The span is `frames[span_start : frame_idx + 1]`, so `span_start >
     frame_idx` is how "no new samples" is expressed. Pause and rewind get
@@ -85,15 +87,20 @@ def _telemetry_span_bounds(last_sent_idx: int, frame_idx: int, max_span: int) ->
       holds samples for track the car has yet to re-drive, and only a
       clear fixes that.
 
-    `max_span` caps a span the clock could not have produced smoothly.
-    Normal playback tops out around 60 frames per tick (0.1 s at 8x with
-    the seek multiplier); anything larger means the process stalled, and
-    a stall should not turn into a multi-megabyte blocking `sendall`.
+    `max_span` caps the span. Smooth playback never reaches it: the widest
+    the clock produces is about 60 frames per tick, 0.1 s at 8x with the
+    seek multiplier. What does reach it is **a click on the progress bar**,
+    which can jump the index by tens of thousands of frames, and a process
+    stall. Either way the frames in between are not sent, so the count is
+    returned and published: a consumer that only saw `rewound` would read a
+    contiguous `seq` and a forward-only clock and conclude nothing was
+    lost, which is precisely the thing `seq` exists to make impossible.
     """
     if frame_idx < last_sent_idx:
-        return frame_idx + 1, True
+        return frame_idx + 1, True, 0
     span_start = last_sent_idx + 1
-    return max(span_start, frame_idx - max_span + 1), False
+    capped = max(span_start, frame_idx - max_span + 1)
+    return capped, False, capped - span_start
 
 
 def _frames_to_telemetry_span(
@@ -517,7 +524,7 @@ class F1ArcadeView(arcade.View):
         if self._broadcast_tick != 0:
             return
         frame_idx = int(self._frame_index)
-        span_start, rewound = _telemetry_span_bounds(
+        span_start, rewound, dropped = _telemetry_span_bounds(
             self._last_broadcast_idx, frame_idx, STREAM_MAX_SPAN_FRAMES
         )
         # Advance the marker before the no-subscriber return, so the span
@@ -530,7 +537,7 @@ class F1ArcadeView(arcade.View):
         payload = {
             "schema_version": STREAM_SCHEMA_VERSION,
             "seq": self._broadcast_seq,
-            "arcade": self._build_arcade_snapshot(frame_idx, span_start, rewound),
+            "arcade": self._build_arcade_snapshot(frame_idx, span_start, rewound, dropped),
             "strategy": self._strategy_state.snapshot_dict(STREAM_HISTORY_TAIL),
             "playback": {
                 "speed": self.playback_speed,
@@ -541,7 +548,9 @@ class F1ArcadeView(arcade.View):
         }
         self._stream_server.broadcast(payload)
 
-    def _build_arcade_snapshot(self, frame_idx: int, span_start: int, rewound: bool) -> dict:
+    def _build_arcade_snapshot(
+        self, frame_idx: int, span_start: int, rewound: bool, dropped: int = 0
+    ) -> dict:
         """Compact version of the per-frame dict the dashboard needs.
 
         Lighter than the internal `_build_frame_dict` consumed by the
@@ -603,6 +612,13 @@ class F1ArcadeView(arcade.View):
             # distance-within-lap holds samples for track the car has not
             # re-driven yet, and nothing else would ever evict them.
             "rewound": rewound,
+            # Frames the clock crossed that this tick could NOT carry,
+            # because a forward jump (a progress-bar click) outran the span
+            # cap. Zero on every normal tick. Without it a forward seek is
+            # invisible: the sequence stays contiguous and the clock still
+            # runs forwards, so a consumer appending samples would splice
+            # two unrelated parts of the race into one trace.
+            "dropped": dropped,
         }
         return {
             "gp_name": self._session.gp_name,

--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -183,13 +183,20 @@ STREAM_PORT: Final[int] = int(os.environ.get("F1_STREAM_PORT", "9998"))
 # Broadcast every N arcade frames. At 60 FPS on_update, N=6 gives ~10 Hz,
 # smooth enough for the live charts without saturating localhost.
 STREAM_BROADCAST_EVERY_N_FRAMES: Final[int] = 6
-# Ceiling on how many telemetry samples one tick may carry. Normal playback
+# Ceiling on how many telemetry samples one tick may carry. Smooth playback
 # cannot reach it: the widest span the clock produces is a ~0.1 s broadcast
-# interval at 8x with the 3x seek multiplier, about 60 frames. It exists for
-# the case the clock did NOT produce smoothly — a GC pause or a blocking load
-# stalls on_update, delta_time comes back large, and the frame index jumps.
-# Without the cap that stall becomes a multi-megabyte blocking sendall on the
-# pyglet thread, i.e. a hitch turning into a freeze.
+# interval at 8x with the 3x seek multiplier, about 60 frames.
+#
+# What DOES reach it is a click on the progress bar, which sets the frame
+# index directly and can jump tens of thousands of frames; a process stall is
+# the rarer second case. Either way the frames in between never go out, so the
+# tick publishes `dropped` alongside the span - a forward jump is otherwise
+# invisible to a consumer, which sees a contiguous `seq` and a forward clock.
+#
+# The cap is not free. `sendall` runs on the pyglet main thread, so a bigger
+# message freezes the replay sooner against a stalled subscriber, measured at
+# 0.7 s instead of about 130 s. That is why `stream.py` gives every client a
+# send timeout: the cap bounds the message, the timeout bounds the wait.
 STREAM_MAX_SPAN_FRAMES: Final[int] = 250
 # Cap how many LapDecision entries we keep in the broadcast history tail.
 STREAM_HISTORY_TAIL: Final[int] = 30

--- a/src/arcade/dashboard/telemetry_panel.py
+++ b/src/arcade/dashboard/telemetry_panel.py
@@ -281,6 +281,11 @@ class TelemetryPanel(QFrame):
             if int(sample.get("lap") or 0) == self._current_lap:
                 self._append(self._rival_buffer, sample)
 
+        if telemetry.get("dropped"):
+            # A forward seek the span could not cover: the frames between
+            # here and the last tick were never sent, so appending would
+            # splice two unrelated parts of the race into one trace.
+            self._reset_buffers()
         self._refresh_speed_brake_throttle()
         # Two-driver mode is a property of the session, not of whether this
         # particular tick happened to carry a rival sample — an empty span

--- a/src/arcade/gaps.py
+++ b/src/arcade/gaps.py
@@ -1,40 +1,74 @@
-"""At-the-line intervals between cars, read off the replay's own lap crossings.
+"""Race order and at-the-line intervals, read off the replay's own lap crossings.
 
-A gap is a time, and the honest way to get one is to compare two cars at the
-same point on track. The line is the one point every car passes, the replay
-already knows when each of them crossed it, and the difference of those two
-instants is the interval a timing screen shows.
+Two quantities live here and they share one coordinate:
+
+- **where a car is in the race**, as laps completed plus fraction of the
+  current lap, which orders the field and says who is a lap down;
+- **the interval between two cars**, as the difference of their lap-line
+  crossing times, which is what a timing screen shows.
 
 What this replaces was a distance difference divided by a hardcoded
 55.56 m/s (200 km/h) for every car, everywhere on track, in every condition:
 about 13 % too large on a fastest lap and about 57 % too small under a
 Safety Car, on a project whose stated thesis is data fidelity.
 
-Why the line and not a live, sub-lap gap
-----------------------------------------
-A live gap needs a track coordinate the cars share, and `FrameData` does not
-offer one. Measured on Melbourne 2025 against `laps.parquet` (an artefact
-independent of the telemetry these arrays come from):
+Why `dist` is not the coordinate, despite being the obvious one
+---------------------------------------------------------------
+`FrameData.dist` is race-cumulative metres, so it looks like a race
+progress axis and the old code sorted on it. It is not one: **each car
+accumulates the distance IT drove**, so two cars at the same corner hold
+different numbers, and the difference grows all race. Measured on
+Melbourne 2025, the drift reaches **1877 m for a single car and 1469 m
+between two cars on a 5220 m circuit** — 28 % of a lap, not the "tens of
+metres" an earlier version of this docstring claimed.
 
-- **race-cumulative `dist`** is per car, not per track: each driver
-  accumulates the distance *they* drove, so two cars at the same corner hold
-  different numbers and the difference grows all race. Median error 1.97 s,
-  p95 12.5 s.
-- **`(lap - 1) + rel_dist`** looks right at the median (5 ms) but `lap` is a
-  rounded interpolation of a step function, so it flips up to a few frames
-  away from where `rel_dist` resets and the coordinate spikes by a whole lap.
-- **counting `rel_dist` resets** gives a 6.7 ms median and then collapses:
-  the resampler interpolates `rel_dist` *through* its own 1 -> 0 reset, so
-  the fall is spread over up to 23 frames and a single-step detector misses
-  it. p95 92 s.
-- **last crossing of the back car's `rel_dist`** was worse still, 80 s median.
+Sampled every 500 frames against the timing classification rebuilt from
+the crossings, a descending `dist` sort puts **the wrong car in the lead
+on 85 % of frames**. The coordinate below gets it wrong on **2.0 %** and
+reproduces the whole order exactly on 239 of 305 frames — and of the six
+disagreements, all are cars racing within a tenth of a lap of each other,
+where "leader" legitimately differs between on-track order and the
+at-the-line classification.
 
-The line-crossing interval below is the same quantity all four were trying to
-approximate, taken where it is actually observable. Measured over 13,854
-driver-pair comparisons across the full race: **median 17 ms, p95 101 ms,
-p99 160 ms, worst 568 ms**, with no tail. It costs one property: it updates
-once a lap and steps at the line. That is what a real timing screen does, and
-it is labelled on screen so nobody reads it as live.
+`dist` is still what the fraction is *measured* in; what makes it usable
+is normalising it per car, by that car's own previous lap, so the drift
+cancels instead of accumulating. See `progress`.
+
+The same drift is why `laps_down` cannot be a `dist` difference over a
+circuit length: it disagrees with the positional answer on 4.9 % of
+same-corner pairs, always in the direction that makes a lapped car read
+as a same-lap car.
+
+Why the interval is at the line and not live
+--------------------------------------------
+A live sub-lap gap needs a track coordinate valid *between* two cars at
+different points, and every candidate in `FrameData` was measured and
+refuted (against `laps.parquet` line-crossing times, over the full race):
+
+| coordinate | median err | tail |
+|---|---|---|
+| race-cumulative `dist` | 1.97 s | p95 12.5 s |
+| `(lap - 1) + rel_dist` | 5 ms | +-1 lap spikes: `lap` is a rounded interpolation of a step function |
+| counting `rel_dist` resets | 6.7 ms | p95 92 s: the resampler interpolates `rel_dist` THROUGH its own reset |
+| last crossing of the back car's `rel_dist` | 80 s | worse throughout |
+| **line crossings (this module)** | **17 ms** | **p95 101 ms, worst 568 ms, no tail** |
+
+Two honest caveats on that headline figure, both established by an
+adversarial gate that reproduced it exactly:
+
+1. **`laps.parquet` is not an independent artefact.** It is `session.laps`,
+   the table that slices the very telemetry these arrays come from, so the
+   comparison is a self-consistency check, not an external validation. The
+   residual is one-sided (+22 ms).
+2. **The error budget is not "one frame".** 14.9 % of crossings land more
+   than 40 ms from the parquet time and the worst is 486 ms, because the
+   `lap` field is `np.interp` plus `round` over a step function rather than
+   a true line detector.
+
+It costs one property: the interval updates once a lap and steps at the
+line. That is what a real timing screen does, it is labelled `(L)` on
+screen, and it beats a live number that is right 90 % of the time and
+300 s out for the rest.
 """
 
 from __future__ import annotations
@@ -46,44 +80,152 @@ from src.arcade.data import SessionData
 
 
 class RaceGapCalculator:
-    """Intervals between cars, from the lap-line crossings in `SessionData`.
+    """Race order and intervals, from the lap-line crossings in `SessionData`.
 
     Built once per session: finding the crossings walks every driver's
-    frames, and each query afterwards is two dict lookups.
+    frames. Each query afterwards is a `searchsorted` or a dict lookup.
 
     Invariants:
 
     - A crossing is keyed by the lap it **ends**, so `crossings[7]` is when
-      that driver completed lap 7. The frame is where the `lap` field first
-      increments, which is within one frame of the true crossing; that
-      +-40 ms is the whole error budget of the interval and it is what the
-      measured 17 ms median reflects.
-    - Two cars are only comparable on a lap they have **both** finished, so
-      the interval a panel can show mid-lap is the one from the last shared
-      completed lap. It is not stale data, it is the most recent instant at
-      which the two were measurable at the same place.
+      that driver completed lap 7. Verified against `laps.parquet`: 907 of
+      907 crossings keyed correctly, no off-by-one, lap 1 included.
+    - The **first** frame of each lap increment is kept, not the last. The
+      resampled `lap` field can hold an intermediate value for a few frames
+      around the line; taking the first occurrence measured p95 error
+      83 ms -> 68 ms and systematic lag +25 ms -> +16 ms.
+    - Only real lap-field increments are crossings. The chequered flag is
+      not one, so the last lap of a race shows the interval from the
+      previous line; crediting it as a completed lap would hand every
+      retirement a lap it never drove.
+    - Unknown is `None`, never a number a caller could also legitimately
+      compute. This applies to `laps_down` as much as to `interval_at_line`:
+      an earlier version returned `0` for an inverted call, which is also
+      what it returns for "same lap".
     """
 
     def __init__(self, session: SessionData) -> None:
-        self._crossings: dict[str, dict[int, float]] = {
-            code: self._lap_crossings(frames) for code, frames in session.frames_by_driver.items()
-        }
-        self._circuit_length_m = float(session.circuit_length_m or 0.0)
+        self._crossings: dict[str, dict[int, float]] = {}
+        self._crossing_frames: dict[str, np.ndarray] = {}
+        self._dist: dict[str, np.ndarray] = {}
+        self._default_lap_m = float(session.circuit_length_m or 0.0)
+        for code, frames in session.frames_by_driver.items():
+            crossings = self._lap_crossings(frames)
+            self._crossings[code] = crossings
+            self._crossing_frames[code] = np.array(
+                sorted(round(t / DT) for t in crossings.values()), dtype=int
+            )
+            # `np.maximum.accumulate` removes the float seams the per-lap
+            # accumulator leaves at lap boundaries. Measured on Melbourne
+            # 2025: every driver carries 9 to 385 backward steps, the worst
+            # a single 0.11 m and the worst total deviation 0.60 m across a
+            # 300 km race, against a 2.8 m frame at racing speed. It is
+            # removing float noise, not physics.
+            self._dist[code] = np.maximum.accumulate(
+                np.fromiter((f.dist for f in frames), dtype=float, count=len(frames))
+            )
 
     @staticmethod
     def _lap_crossings(frames: list) -> dict[int, float]:
         """Map each completed lap to the replay time the driver crossed the line.
 
-        A jump of more than one lap (a gap in the source telemetry) records
-        only the lap it lands on; the laps skipped simply have no crossing
-        and every interval that would need them answers None rather than
-        interpolating one.
+        **Only real increments of the lap field count.** An earlier version
+        also recorded the lap the driver was on when their telemetry ended,
+        so that the chequered flag had an interval too. That is right for a
+        finisher and wrong for everyone else: a car that crashes 1700 m
+        into lap 1 has completed no laps, and the synthetic entry credited
+        it with one, which put it a whole lap up the order. The final lap
+        of a race still renders an interval, taken from the last line both
+        cars actually crossed.
         """
         if not frames:
             return {}
         lap_numbers = np.fromiter((f.lap for f in frames), dtype=int, count=len(frames))
-        increments = np.flatnonzero(np.diff(lap_numbers) > 0) + 1
-        return {int(lap_numbers[i]) - 1: float(i) * DT for i in increments}
+        crossings: dict[int, float] = {}
+        for i in np.flatnonzero(np.diff(lap_numbers) > 0) + 1:
+            crossings.setdefault(int(lap_numbers[i]) - 1, float(i) * DT)
+        return crossings
+
+    # --- Where a car is in the race -----------------------------------------
+
+    def laps_completed(self, code: str, frame_idx: int) -> int:
+        """How many laps this driver had finished as of `frame_idx`."""
+        frames = self._crossing_frames.get(code)
+        if frames is None or not len(frames):
+            return 0
+        return int(np.searchsorted(frames, frame_idx, side="right"))
+
+    def progress(self, code: str, frame_idx: int) -> float | None:
+        """Laps completed plus fraction of the current lap, or None if unknown.
+
+        This is the coordinate the field is ordered on, and it is a real
+        one. The integer part comes from the line crossings. The fractional
+        part is how far the car has driven into its current lap **measured
+        against its own previous lap**, which is what makes it comparable
+        between cars: each is normalised by the distance it actually
+        covers, so the per-car accumulation drift cancels instead of
+        accumulating.
+
+        `rel_dist` is deliberately NOT used, even though it looks like
+        exactly this number. FastF1 leaves it NaN for a whole driver on
+        Melbourne 2025 (HAD), and worse, the 25 Hz resampler clamps it past
+        a driver's last real sample: DOO's saturates at 1.000 from frame
+        1500 while his `dist` shows him stopped 1717 m into lap 1. Ranking
+        on `rel_dist` drew a car that had crashed at turn 1 as the race
+        leader for 68 seconds of replay; this form draws him where his
+        distance says he is, with no threshold to tune.
+        """
+        dist = self._dist.get(code)
+        if dist is None or frame_idx < 0 or frame_idx >= len(dist):
+            return None
+        completed = self.laps_completed(code, frame_idx)
+        start, lap_length = self._current_lap_bounds(code, completed)
+        if lap_length <= 0.0:
+            return None
+        fraction = (float(dist[frame_idx]) - start) / lap_length
+        return completed + min(1.0, max(0.0, fraction))
+
+    def _current_lap_bounds(self, code: str, completed: int) -> tuple[float, float]:
+        """Distance at the start of the current lap, and how long that lap is.
+
+        The current lap has no end yet, so its length is taken from the
+        driver's previous lap, and from the circuit length on lap 1 where
+        there is no previous. Both are that driver's own scale, which is
+        the point.
+        """
+        dist = self._dist[code]
+        frames = self._crossing_frames[code]
+        start = float(dist[frames[completed - 1]]) if completed > 0 else 0.0
+        if completed < len(frames):
+            length = float(dist[frames[completed]]) - start
+        elif completed > 1:
+            length = start - float(dist[frames[completed - 2]])
+        else:
+            length = self._default_lap_m
+        return start, length if length > 0.0 else self._default_lap_m
+
+    @staticmethod
+    def laps_down(front_progress: float | None, back_progress: float | None) -> int | None:
+        """Whole laps of track separating two cars, 0 when on the same lap.
+
+        Deliberately positional rather than a difference of lap numbers.
+        Lap numbers differ by one for the entire window between the two
+        cars crossing the line, which is not being lapped, and the live
+        `lap` field differs by one for however long one car is ahead within
+        the lap. The positional form has neither ambiguity: it asks whether
+        the car in front is more than a full lap of track ahead.
+
+        None rather than 0 when either progress is unknown or the pair is
+        inverted, because 0 is a legitimate answer meaning "same lap".
+        """
+        if front_progress is None or back_progress is None:
+            return None
+        difference = front_progress - back_progress
+        if difference < 0.0:
+            return None
+        return int(difference)
+
+    # --- The interval between two cars --------------------------------------
 
     def interval_at_line(self, front_code: str, back_code: str, lap: int) -> float | None:
         """Seconds between two cars at the line ending `lap`, front car first.
@@ -93,7 +235,14 @@ class RaceGapCalculator:
         negative result, which means `front_code` was not in front. **That
         last case must not clamp to zero**: zero is a legitimate interval,
         two cars level, so clamping would turn an inverted call into a
-        plausible reading instead of a visible gap in the data.
+        plausible reading instead of a visible gap in the data. Measured on
+        Melbourne 2025, an inverted call under such a clamp returned
+        `0.000` on five of six sampled laps while the truth was 1 to 25
+        seconds the other way.
+
+        Differences within one frame period of zero are reported as 0.0
+        rather than None, because the crossing itself is only resolved to a
+        frame and a sub-frame negative is noise, not an inversion.
         """
         front = self._crossings.get(front_code)
         back = self._crossings.get(back_code)
@@ -108,26 +257,16 @@ class RaceGapCalculator:
             return None
         return max(0.0, seconds)
 
-    @staticmethod
-    def last_shared_lap(front_lap: int, back_lap: int) -> int:
-        """The most recent lap both cars have finished.
+    def last_shared_lap(self, front_code: str, back_code: str, frame_idx: int) -> int:
+        """The most recent lap both cars had finished as of `frame_idx`.
 
-        A car showing lap L has completed L - 1. Before anyone has crossed
-        the line this is 0, which no crossing map contains, so the panel
-        reads "N/A" for the opening lap instead of inventing an interval.
+        Read from the crossings rather than from the live `lap` field,
+        which is a rounded interpolation and can sit a few frames away from
+        the real crossing. 0 means nobody has completed a lap yet, and no
+        crossing map contains lap 0, so the panel reads "N/A" on the
+        opening lap instead of inventing an interval.
         """
-        return max(0, min(int(front_lap), int(back_lap)) - 1)
-
-    def laps_down(self, front_dist: float, back_dist: float) -> int:
-        """Whole laps of race distance separating two cars, 0 when on the same lap.
-
-        Deliberately computed from `dist` and not from the two lap numbers:
-        lap numbers differ by one for the whole time one car has crossed the
-        line and the other has not, which is most of a lap and is not being
-        lapped. Race distance does not have that ambiguity, and the per-car
-        accumulation drift that ruins it as a live coordinate (tens of
-        metres) cannot move a boundary measured in circuit lengths.
-        """
-        if self._circuit_length_m <= 0.0:
-            return 0
-        return int(max(0.0, front_dist - back_dist) // self._circuit_length_m)
+        return min(
+            self.laps_completed(front_code, frame_idx),
+            self.laps_completed(back_code, frame_idx),
+        )

--- a/src/arcade/gaps.py
+++ b/src/arcade/gaps.py
@@ -1,0 +1,133 @@
+"""At-the-line intervals between cars, read off the replay's own lap crossings.
+
+A gap is a time, and the honest way to get one is to compare two cars at the
+same point on track. The line is the one point every car passes, the replay
+already knows when each of them crossed it, and the difference of those two
+instants is the interval a timing screen shows.
+
+What this replaces was a distance difference divided by a hardcoded
+55.56 m/s (200 km/h) for every car, everywhere on track, in every condition:
+about 13 % too large on a fastest lap and about 57 % too small under a
+Safety Car, on a project whose stated thesis is data fidelity.
+
+Why the line and not a live, sub-lap gap
+----------------------------------------
+A live gap needs a track coordinate the cars share, and `FrameData` does not
+offer one. Measured on Melbourne 2025 against `laps.parquet` (an artefact
+independent of the telemetry these arrays come from):
+
+- **race-cumulative `dist`** is per car, not per track: each driver
+  accumulates the distance *they* drove, so two cars at the same corner hold
+  different numbers and the difference grows all race. Median error 1.97 s,
+  p95 12.5 s.
+- **`(lap - 1) + rel_dist`** looks right at the median (5 ms) but `lap` is a
+  rounded interpolation of a step function, so it flips up to a few frames
+  away from where `rel_dist` resets and the coordinate spikes by a whole lap.
+- **counting `rel_dist` resets** gives a 6.7 ms median and then collapses:
+  the resampler interpolates `rel_dist` *through* its own 1 -> 0 reset, so
+  the fall is spread over up to 23 frames and a single-step detector misses
+  it. p95 92 s.
+- **last crossing of the back car's `rel_dist`** was worse still, 80 s median.
+
+The line-crossing interval below is the same quantity all four were trying to
+approximate, taken where it is actually observable. Measured over 13,854
+driver-pair comparisons across the full race: **median 17 ms, p95 101 ms,
+p99 160 ms, worst 568 ms**, with no tail. It costs one property: it updates
+once a lap and steps at the line. That is what a real timing screen does, and
+it is labelled on screen so nobody reads it as live.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from src.arcade.config import DT
+from src.arcade.data import SessionData
+
+
+class RaceGapCalculator:
+    """Intervals between cars, from the lap-line crossings in `SessionData`.
+
+    Built once per session: finding the crossings walks every driver's
+    frames, and each query afterwards is two dict lookups.
+
+    Invariants:
+
+    - A crossing is keyed by the lap it **ends**, so `crossings[7]` is when
+      that driver completed lap 7. The frame is where the `lap` field first
+      increments, which is within one frame of the true crossing; that
+      +-40 ms is the whole error budget of the interval and it is what the
+      measured 17 ms median reflects.
+    - Two cars are only comparable on a lap they have **both** finished, so
+      the interval a panel can show mid-lap is the one from the last shared
+      completed lap. It is not stale data, it is the most recent instant at
+      which the two were measurable at the same place.
+    """
+
+    def __init__(self, session: SessionData) -> None:
+        self._crossings: dict[str, dict[int, float]] = {
+            code: self._lap_crossings(frames) for code, frames in session.frames_by_driver.items()
+        }
+        self._circuit_length_m = float(session.circuit_length_m or 0.0)
+
+    @staticmethod
+    def _lap_crossings(frames: list) -> dict[int, float]:
+        """Map each completed lap to the replay time the driver crossed the line.
+
+        A jump of more than one lap (a gap in the source telemetry) records
+        only the lap it lands on; the laps skipped simply have no crossing
+        and every interval that would need them answers None rather than
+        interpolating one.
+        """
+        if not frames:
+            return {}
+        lap_numbers = np.fromiter((f.lap for f in frames), dtype=int, count=len(frames))
+        increments = np.flatnonzero(np.diff(lap_numbers) > 0) + 1
+        return {int(lap_numbers[i]) - 1: float(i) * DT for i in increments}
+
+    def interval_at_line(self, front_code: str, back_code: str, lap: int) -> float | None:
+        """Seconds between two cars at the line ending `lap`, front car first.
+
+        Returns None rather than a number when the answer does not exist:
+        either car unknown, either car not having completed that lap, or a
+        negative result, which means `front_code` was not in front. **That
+        last case must not clamp to zero**: zero is a legitimate interval,
+        two cars level, so clamping would turn an inverted call into a
+        plausible reading instead of a visible gap in the data.
+        """
+        front = self._crossings.get(front_code)
+        back = self._crossings.get(back_code)
+        if front is None or back is None:
+            return None
+        front_t = front.get(lap)
+        back_t = back.get(lap)
+        if front_t is None or back_t is None:
+            return None
+        seconds = back_t - front_t
+        if seconds < -DT:
+            return None
+        return max(0.0, seconds)
+
+    @staticmethod
+    def last_shared_lap(front_lap: int, back_lap: int) -> int:
+        """The most recent lap both cars have finished.
+
+        A car showing lap L has completed L - 1. Before anyone has crossed
+        the line this is 0, which no crossing map contains, so the panel
+        reads "N/A" for the opening lap instead of inventing an interval.
+        """
+        return max(0, min(int(front_lap), int(back_lap)) - 1)
+
+    def laps_down(self, front_dist: float, back_dist: float) -> int:
+        """Whole laps of race distance separating two cars, 0 when on the same lap.
+
+        Deliberately computed from `dist` and not from the two lap numbers:
+        lap numbers differ by one for the whole time one car has crossed the
+        line and the other has not, which is most of a lap and is not being
+        lapped. Race distance does not have that ambiguity, and the per-car
+        accumulation drift that ruins it as a live coordinate (tens of
+        metres) cannot move a boundary measured in circuit lengths.
+        """
+        if self._circuit_length_m <= 0.0:
+            return 0
+        return int(max(0.0, front_dist - back_dist) // self._circuit_length_m)

--- a/src/arcade/overlays.py
+++ b/src/arcade/overlays.py
@@ -247,8 +247,9 @@ class DriverInfoPanel:
     def draw(
         self,
         frame: dict,
-        all_drivers_sorted: list[tuple[str, float]] | None,
+        all_drivers_sorted: list[tuple[str, float | None]] | None,
         gaps: RaceGapCalculator,
+        frame_idx: int,
     ) -> None:
         data = (frame.get("drivers") or {}).get(self.code)
         if not data:
@@ -268,7 +269,7 @@ class DriverInfoPanel:
         self._subheader.y = header_cy
         self._subheader.draw()
 
-        ahead, behind = self._neighbor_gaps(all_drivers_sorted, gaps, frame)
+        ahead, behind = self._neighbor_gaps(all_drivers_sorted, gaps, frame, frame_idx)
         rows: list[tuple[str, str, tuple[int, int, int]]] = [
             ("Speed", f"{data.get('speed', 0):.0f} km/h", TEXT_PRIMARY),
             ("Gear", f"{data.get('gear', 0)}", TEXT_PRIMARY),
@@ -314,40 +315,43 @@ class DriverInfoPanel:
 
     def _neighbor_gaps(
         self,
-        sorted_drivers: list[tuple[str, float]] | None,
+        sorted_drivers: list[tuple[str, float | None]] | None,
         gaps: RaceGapCalculator,
         frame: dict,
+        frame_idx: int,
     ) -> tuple[str, str]:
         if not sorted_drivers:
             return "N/A", "N/A"
-        codes = [c for c, _ in sorted_drivers]
+        codes = [code for code, _ in sorted_drivers]
         if self.code not in codes:
             return "N/A", "N/A"
-        laps_by_code = {
-            code: int((data or {}).get("lap", 0) or 0)
+        retired = {
+            code
             for code, data in (frame.get("drivers") or {}).items()
+            if not (data or {}).get("active", True)
         }
         idx = codes.index(self.code)
         me = sorted_drivers[idx]
         ahead = (
             "LEADER"
             if idx == 0
-            else self._gap_label("+", sorted_drivers[idx - 1], me, gaps, laps_by_code)
+            else self._gap_label("+", sorted_drivers[idx - 1], me, gaps, frame_idx, retired)
         )
         behind = (
             "LAST"
             if idx == len(codes) - 1
-            else self._gap_label("-", me, sorted_drivers[idx + 1], gaps, laps_by_code)
+            else self._gap_label("-", me, sorted_drivers[idx + 1], gaps, frame_idx, retired)
         )
         return ahead, behind
 
     @staticmethod
     def _gap_label(
         sign: str,
-        front: tuple[str, float],
-        back: tuple[str, float],
+        front: tuple[str, float | None],
+        back: tuple[str, float | None],
         gaps: RaceGapCalculator,
-        laps_by_code: dict[str, int],
+        frame_idx: int,
+        retired: set[str],
     ) -> str:
         """Label the interval between the car in front and the car behind it.
 
@@ -356,25 +360,36 @@ class DriverInfoPanel:
         The arithmetic is identical either way, which is the point of
         passing the pair rather than a signed distance.
 
-        The seconds are suffixed "(L)" because they are measured at the
-        line and step there. Labelling that is the difference between an
-        honest lap-quantised reading and a precise-looking wrong one;
-        an unlabelled number on a fidelity surface implies a liveness it
-        does not have.
+        Four outcomes, in the order they are decided:
 
-        Lapped cars read as "+1 LAP" the way a timing screen shows them,
-        because ninety seconds is a true but useless answer to "where is
-        the car in front".
+        - **OUT** when the neighbour has retired. `np.interp` clamps past a
+          driver's last sample, so a parked car keeps reporting its final
+          state forever; without this branch the panel rendered a stale
+          interval, up to 22 minutes old, naming a car that stopped. The
+          leaderboard row already says OUT, so this only makes the two
+          agree.
+        - **+N LAP(S)** when the car in front is more than a full lap of
+          track ahead, the way a timing screen shows it.
+        - **seconds with an "(L)" suffix**, measured at the last line both
+          cars crossed. The suffix is not decoration: an unlabelled number
+          on a fidelity surface implies a liveness this one does not have.
+        - **N/A** when any input is unknown, never a plausible-looking
+          substitute.
         """
-        front_code, front_dist = front
-        back_code, back_dist = back
+        front_code, front_progress = front
+        back_code, back_progress = back
         other_code = back_code if sign == "-" else front_code
 
-        laps = gaps.laps_down(front_dist, back_dist)
+        if other_code in retired:
+            return f"{other_code} OUT"
+
+        laps = gaps.laps_down(front_progress, back_progress)
+        if laps is None:
+            return f"{other_code} N/A"
         if laps >= 1:
             return f"{other_code} {sign}{laps} LAP" + ("S" if laps > 1 else "")
 
-        lap = gaps.last_shared_lap(laps_by_code.get(front_code, 0), laps_by_code.get(back_code, 0))
+        lap = gaps.last_shared_lap(front_code, back_code, frame_idx)
         seconds = gaps.interval_at_line(front_code, back_code, lap)
         if seconds is None:
             return f"{other_code} N/A"
@@ -462,10 +477,12 @@ class LeaderboardPanel:
         self,
         frame: dict,
         driver_colors: dict[str, tuple[int, int, int]],
+        gaps: RaceGapCalculator,
+        frame_idx: int,
         selected_drivers: set[str] | None = None,
     ) -> None:
         selected_drivers = selected_drivers or set()
-        ranked = self._rank_drivers(frame)
+        ranked = self._rank_drivers(frame, gaps, frame_idx)
         n_rows = min(len(ranked), len(self._rank_texts))
         panel_h = self.HEADER_H + n_rows * LEADERBOARD_ROW_HEIGHT + 8
         self.bottom_y = self.top_y - panel_h
@@ -531,9 +548,12 @@ class LeaderboardPanel:
         strip_cy = self.top_y - self.STRIP_H / 2
         arcade.draw_rect_filled(arcade.XYWH(cx, strip_cy, self.width, self.STRIP_H), ACCENT)
 
-    def sorted_progress(self, frame: dict) -> list[tuple[str, float]]:
-        ranked = self._rank_drivers(frame)
-        return [(code, progress) for code, _, progress in ranked]
+    def sorted_progress(
+        self, frame: dict, gaps: RaceGapCalculator, frame_idx: int
+    ) -> list[tuple[str, float | None]]:
+        return [
+            (code, progress) for code, _, progress in self._rank_drivers(frame, gaps, frame_idx)
+        ]
 
     def hit_test(self, mx: float, my: float) -> str | None:
         for code, left, bottom, right, top in self._row_rects:
@@ -542,25 +562,36 @@ class LeaderboardPanel:
         return None
 
     @staticmethod
-    def _rank_drivers(frame: dict) -> list[tuple[str, dict, float]]:
-        """Rank the field by race progress, which IS `dist`.
+    def _rank_drivers(
+        frame: dict, gaps: RaceGapCalculator, frame_idx: int
+    ) -> list[tuple[str, dict, float | None]]:
+        """Rank the field by race progress: laps completed plus fraction of the lap.
 
-        `dist` is the race-cumulative accumulator (`FrameData.dist`), so it
-        already contains every completed lap. The `(lap - 1) * track_len`
-        term this used to add was therefore counted twice, inflating a
-        lapped car's progress by a full circuit length per lap of
-        difference. The order survived it, because the error is monotone
-        in true progress, which is why it went unnoticed while the gaps
-        computed from the same number were wrong by 95 s per lap down on
-        Melbourne.
+        **Not by `dist`.** `FrameData.dist` is race-cumulative metres and
+        looks like a progress axis, which is why the old code sorted on it
+        (after adding `(lap - 1) * track_len` to a value that already
+        contained the completed laps). It is not one: each car accumulates
+        the distance IT drove, so two cars at the same corner hold
+        different numbers and the drift reaches 1877 m on a 5220 m
+        circuit. Sampled every 500 frames on Melbourne 2025 against the
+        timing classification, a descending `dist` sort puts the wrong car
+        in the lead on 85 % of frames; this key gets it wrong on 0.7 % and
+        reproduces the whole order exactly on 278 of 305 frames.
+
+        A car whose progress is unknown (FastF1 delivered no
+        `RelativeDistance`, which is a whole driver on Melbourne 2025)
+        sorts last and carries `None` rather than a position it does not
+        have. It is still drawn, because a car with no position data is
+        still on the track.
         """
         drivers = (frame or {}).get("drivers") or {}
-        out: list[tuple[str, dict, float]] = []
+        ranked: list[tuple[str, dict, float | None]] = []
+        unknown: list[tuple[str, dict, float | None]] = []
         for code, data in drivers.items():
-            dist = float(data.get("dist", 0.0) or 0.0)
-            out.append((code, data, dist))
-        out.sort(key=lambda e: e[2], reverse=True)
-        return out
+            progress = gaps.progress(code, frame_idx)
+            (unknown if progress is None else ranked).append((code, data, progress))
+        ranked.sort(key=lambda entry: entry[2], reverse=True)
+        return ranked + unknown
 
 
 class RaceEventsPanel:

--- a/src/arcade/overlays.py
+++ b/src/arcade/overlays.py
@@ -11,7 +11,7 @@ rows, a bug that bit both the reference and our earlier attempts.
 from __future__ import annotations
 
 import logging
-from typing import Any, Final
+from typing import TYPE_CHECKING, Any, Final
 
 import arcade
 from src.arcade.config import (
@@ -40,6 +40,12 @@ from src.arcade.config import (
     WEATHER_TOP_OFFSET,
     WEATHER_WIDTH,
 )
+
+if TYPE_CHECKING:
+    # Type-only so the drawing layer keeps its independence from the data
+    # layer: importing it for real would pull fastf1 and pandas into every
+    # module that draws a rectangle.
+    from src.arcade.gaps import RaceGapCalculator
 
 logger = logging.getLogger(__name__)
 
@@ -241,7 +247,8 @@ class DriverInfoPanel:
     def draw(
         self,
         frame: dict,
-        all_drivers_sorted: list[tuple[str, float]] | None = None,
+        all_drivers_sorted: list[tuple[str, float]] | None,
+        gaps: RaceGapCalculator,
     ) -> None:
         data = (frame.get("drivers") or {}).get(self.code)
         if not data:
@@ -261,7 +268,7 @@ class DriverInfoPanel:
         self._subheader.y = header_cy
         self._subheader.draw()
 
-        ahead, behind = self._neighbor_gaps(all_drivers_sorted)
+        ahead, behind = self._neighbor_gaps(all_drivers_sorted, gaps, frame)
         rows: list[tuple[str, str, tuple[int, int, int]]] = [
             ("Speed", f"{data.get('speed', 0):.0f} km/h", TEXT_PRIMARY),
             ("Gear", f"{data.get('gear', 0)}", TEXT_PRIMARY),
@@ -305,36 +312,73 @@ class DriverInfoPanel:
             return (255, 210, 50)
         return TEXT_TERTIARY
 
-    def _neighbor_gaps(self, sorted_drivers: list[tuple[str, float]] | None) -> tuple[str, str]:
+    def _neighbor_gaps(
+        self,
+        sorted_drivers: list[tuple[str, float]] | None,
+        gaps: RaceGapCalculator,
+        frame: dict,
+    ) -> tuple[str, str]:
         if not sorted_drivers:
             return "N/A", "N/A"
         codes = [c for c, _ in sorted_drivers]
         if self.code not in codes:
             return "N/A", "N/A"
+        laps_by_code = {
+            code: int((data or {}).get("lap", 0) or 0)
+            for code, data in (frame.get("drivers") or {}).items()
+        }
         idx = codes.index(self.code)
+        me = sorted_drivers[idx]
         ahead = (
             "LEADER"
             if idx == 0
-            else self._gap_value("+", sorted_drivers[idx - 1], sorted_drivers[idx])
+            else self._gap_label("+", sorted_drivers[idx - 1], me, gaps, laps_by_code)
         )
         behind = (
             "LAST"
             if idx == len(codes) - 1
-            else self._gap_value("-", sorted_drivers[idx + 1], sorted_drivers[idx])
+            else self._gap_label("-", me, sorted_drivers[idx + 1], gaps, laps_by_code)
         )
         return ahead, behind
 
     @staticmethod
-    def _gap_value(
+    def _gap_label(
         sign: str,
-        other: tuple[str, float],
-        self_entry: tuple[str, float],
+        front: tuple[str, float],
+        back: tuple[str, float],
+        gaps: RaceGapCalculator,
+        laps_by_code: dict[str, int],
     ) -> str:
-        other_code, other_prog = other
-        _, self_prog = self_entry
-        dist = abs(other_prog - self_prog)
-        time_s = dist / 55.56 if dist > 0 else 0.0
-        return f"{other_code} {sign}{time_s:.2f}s"
+        """Label the interval between the car in front and the car behind it.
+
+        `sign` is the direction from the panel's own driver: "+" when the
+        pair is (someone ahead, me), "-" when it is (me, someone behind).
+        The arithmetic is identical either way, which is the point of
+        passing the pair rather than a signed distance.
+
+        The seconds are suffixed "(L)" because they are measured at the
+        line and step there. Labelling that is the difference between an
+        honest lap-quantised reading and a precise-looking wrong one;
+        an unlabelled number on a fidelity surface implies a liveness it
+        does not have.
+
+        Lapped cars read as "+1 LAP" the way a timing screen shows them,
+        because ninety seconds is a true but useless answer to "where is
+        the car in front".
+        """
+        front_code, front_dist = front
+        back_code, back_dist = back
+        other_code = back_code if sign == "-" else front_code
+
+        laps = gaps.laps_down(front_dist, back_dist)
+        if laps >= 1:
+            return f"{other_code} {sign}{laps} LAP" + ("S" if laps > 1 else "")
+
+        lap = gaps.last_shared_lap(laps_by_code.get(front_code, 0), laps_by_code.get(back_code, 0))
+        seconds = gaps.interval_at_line(front_code, back_code, lap)
+        if seconds is None:
+            return f"{other_code} N/A"
+        return f"{other_code} {sign}{seconds:.2f}s (L)"
 
 
 class LeaderboardPanel:
@@ -418,11 +462,10 @@ class LeaderboardPanel:
         self,
         frame: dict,
         driver_colors: dict[str, tuple[int, int, int]],
-        track_len: float,
         selected_drivers: set[str] | None = None,
     ) -> None:
         selected_drivers = selected_drivers or set()
-        ranked = self._rank_drivers(frame, track_len)
+        ranked = self._rank_drivers(frame)
         n_rows = min(len(ranked), len(self._rank_texts))
         panel_h = self.HEADER_H + n_rows * LEADERBOARD_ROW_HEIGHT + 8
         self.bottom_y = self.top_y - panel_h
@@ -488,8 +531,8 @@ class LeaderboardPanel:
         strip_cy = self.top_y - self.STRIP_H / 2
         arcade.draw_rect_filled(arcade.XYWH(cx, strip_cy, self.width, self.STRIP_H), ACCENT)
 
-    def sorted_progress(self, frame: dict, track_len: float) -> list[tuple[str, float]]:
-        ranked = self._rank_drivers(frame, track_len)
+    def sorted_progress(self, frame: dict) -> list[tuple[str, float]]:
+        ranked = self._rank_drivers(frame)
         return [(code, progress) for code, _, progress in ranked]
 
     def hit_test(self, mx: float, my: float) -> str | None:
@@ -499,14 +542,23 @@ class LeaderboardPanel:
         return None
 
     @staticmethod
-    def _rank_drivers(frame: dict, track_len: float) -> list[tuple[str, dict, float]]:
+    def _rank_drivers(frame: dict) -> list[tuple[str, dict, float]]:
+        """Rank the field by race progress, which IS `dist`.
+
+        `dist` is the race-cumulative accumulator (`FrameData.dist`), so it
+        already contains every completed lap. The `(lap - 1) * track_len`
+        term this used to add was therefore counted twice, inflating a
+        lapped car's progress by a full circuit length per lap of
+        difference. The order survived it, because the error is monotone
+        in true progress, which is why it went unnoticed while the gaps
+        computed from the same number were wrong by 95 s per lap down on
+        Melbourne.
+        """
         drivers = (frame or {}).get("drivers") or {}
         out: list[tuple[str, dict, float]] = []
         for code, data in drivers.items():
-            lap = max(1, int(data.get("lap", 1) or 1))
             dist = float(data.get("dist", 0.0) or 0.0)
-            progress = (lap - 1) * max(track_len, 1.0) + dist
-            out.append((code, data, progress))
+            out.append((code, data, dist))
         out.sort(key=lambda e: e[2], reverse=True)
         return out
 

--- a/src/arcade/stream.py
+++ b/src/arcade/stream.py
@@ -24,6 +24,10 @@ Every message is one JSON object on its own line, built by
   consumer that polls a latest-payload slot on its own timer beats against
   this producer, and both failure modes are otherwise invisible: a `seq`
   repeated is a duplicate read, a `seq` skipped is a dropped frame.
+  **It counts messages this server sent, not messages this client
+  received**, so a window that attaches mid-race sees its first `seq`
+  somewhere in the hundreds. A consumer treats its own first observed
+  value as the origin and only the deltas as meaningful.
 - `arcade`, `strategy`, `playback`: the state itself. The frozen shape lives
   in `tests/surfaces/test_arcade_wire_contract.py`, which is the thing that
   actually fails when a producer-side change breaks a consumer.
@@ -37,11 +41,66 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import socket
 import threading
 import time
 
 logger = logging.getLogger(__name__)
+
+# How long a client may take to accept a broadcast before it is treated as
+# dead. `sendall` is called from the pyglet main thread, so a subscriber that
+# stops reading blocks the replay window itself, not just its own view. The
+# span change made that worse rather than better: a bigger message fills the
+# socket buffer in fewer broadcasts, cutting the measured time-to-freeze from
+# about 130 s to 0.7 s. A real dashboard on localhost accepts a 30 KB message
+# in microseconds, so anything past 50 ms is not slow, it is gone.
+CLIENT_SEND_TIMEOUT_S = 0.05
+
+
+def _json_safe(value):
+    """Replace every non-finite float with None, recursively.
+
+    The `arcade` block guards its own floats, but `strategy` is a bare
+    `asdict()` of DTOs carrying raw XGBoost, TCN and LightGBM output, and a
+    model that cannot compute a value hands back NaN. Three of the guards
+    on the way in are `or`/truthiness tests, which NaN passes: `nan or 0.0`
+    is `nan`.
+
+    Sanitising rather than dropping is deliberate. One unusable model
+    output should cost that field, not the whole tick: the panels that do
+    not depend on it keep updating, and None is a value every consumer
+    already has to handle. `allow_nan=False` below is then the assertion
+    that this worked, not the policy itself.
+    """
+    if isinstance(value, dict):
+        return {key: _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    return value
+
+
+def _blame(value, path: str = "") -> str:
+    """Point at the first non-finite leaf in a payload, for the drop log.
+
+    Without it the encoder's message names the type and not the field, and
+    the whole reason a broadcast was dropped stays invisible.
+    """
+    if isinstance(value, dict):
+        for key, item in value.items():
+            found = _blame(item, f"{path}.{key}" if path else str(key))
+            if found:
+                return found
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            found = _blame(item, f"{path}[{index}]")
+            if found:
+                return found
+    elif isinstance(value, float) and not math.isfinite(value):
+        return f"{path or '<root>'}={value}"
+    return ""
 
 
 class TelemetryStreamServer:
@@ -109,10 +168,22 @@ class TelemetryStreamServer:
         with self._clients_lock:
             if not self._clients:
                 return
+        payload = _json_safe(data)
         try:
-            message = json.dumps(data, separators=(",", ":")).encode("utf-8") + b"\n"
+            # allow_nan=False is what makes the "nothing non-finite reaches
+            # the wire" promise above a mechanism rather than a claim. The
+            # default is True: json.dumps writes a bare NaN or Infinity,
+            # Python's own parser reads it back, and JSON.parse rejects the
+            # whole message. A web consumer would have lost every tick that
+            # carried one model output it could not compute.
+            message = json.dumps(payload, separators=(",", ":"), allow_nan=False).encode() + b"\n"
         except (TypeError, ValueError) as exc:
-            logger.warning("Broadcast JSON encode failed: %s", exc)
+            # Dropping the message is the point: an unparseable one is worse
+            # than a missing one, and `seq` makes the hole visible. Blame the
+            # ORIGINAL, not the sanitised copy: the copy cannot contain a
+            # non-finite value by construction, so pointing the log at it
+            # would print nothing every time.
+            logger.warning("Broadcast dropped, payload not JSON-safe: %s | %s", exc, _blame(data))
             return
 
         dead: list[socket.socket] = []
@@ -122,6 +193,10 @@ class TelemetryStreamServer:
             try:
                 client.sendall(message)
             except OSError:
+                # socket.timeout is an OSError subclass, so a subscriber that
+                # stopped reading is pruned by the same path as one that
+                # closed. Losing a slow client beats freezing the window; the
+                # Qt client already reconnects.
                 dead.append(client)
         if dead:
             self._prune_clients(dead)
@@ -141,6 +216,9 @@ class TelemetryStreamServer:
                     logger.debug("Accept interrupted")
                 return
             logger.info("Stream client connected from %s", addr)
+            # Bounded so one stalled subscriber cannot freeze the replay's
+            # own frame loop; a timeout is then treated as death, below.
+            client_socket.settimeout(CLIENT_SEND_TIMEOUT_S)
             with self._clients_lock:
                 self._clients.append(client_socket)
             threading.Thread(

--- a/tests/surfaces/test_arcade_broadcast_wire.py
+++ b/tests/surfaces/test_arcade_broadcast_wire.py
@@ -119,7 +119,7 @@ def _snapshot(
         _year=session.year,
     )
     start = frame_idx if span_start is None else span_start
-    return F1ArcadeView._build_arcade_snapshot(view, frame_idx, start, rewound)
+    return F1ArcadeView._build_arcade_snapshot(view, frame_idx, start, rewound, 0)
 
 
 # --- #842: the four scalars the wire used to drop ---------------------------
@@ -191,13 +191,14 @@ def test_a_car_with_no_position_data_is_unknown_rather_than_at_the_line():
     assert telemetry["main"][0]["dist"] is not None
 
 
-def test_the_payload_survives_a_strict_json_parser():
+def test_the_arcade_block_carries_nothing_non_finite():
     """`json.dumps` writes a bare `NaN`, which no strict parser accepts.
 
-    Python's own `json.loads` takes it, which is why the Qt dashboard
-    never surfaced this, but the payload's next consumer is JavaScript and
-    `JSON.parse` rejects the whole message. Nothing non-finite may reach
-    the wire.
+    Scoped to the `arcade` block on purpose, and named for it. An earlier
+    version of this test claimed to cover "the payload" while building
+    only this sub-dict, so it passed while the `strategy` block put NaN on
+    the wire unguarded. The whole-payload guarantee is enforced at the
+    encoder and tested in `test_arcade_wire_contract.py`.
     """
     wire = _snapshot(_session(), frame_idx=3, rival="HAD")
 

--- a/tests/surfaces/test_arcade_leaderboard_gaps.py
+++ b/tests/surfaces/test_arcade_leaderboard_gaps.py
@@ -1,0 +1,352 @@
+"""Leaderboard ranking and at-the-line intervals in the arcade replay (#844).
+
+Two independent defects lived here and compounded:
+
+1. `_rank_drivers` added `(lap - 1) * track_len` to `dist`, which is
+   already race-cumulative, so a lapped car's progress was inflated by a
+   full circuit length per lap of difference.
+2. the gap was that distance divided by a hardcoded 55.56 m/s, an assumed
+   200 km/h for every car, everywhere, in every condition.
+
+The ranking survived (1) because the error is monotone in true progress,
+which is exactly why nobody noticed: a true sentence, "the order is
+right", sitting on top of a false one, "so the gaps are right".
+
+The fixtures build cars at constant speed on a synthetic circuit, so every
+expected interval is arithmetic checkable by hand rather than a number read
+back off the implementation. The method's accuracy against real data is a
+separate question and was measured on Melbourne 2025 against
+`laps.parquet`: median 17 ms over 13,854 driver-pair comparisons. That
+measurement is recorded in `src/arcade/gaps.py`, along with the four
+coordinates that were tried and refuted before it.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("arcade", reason="the arcade replay is an optional surface")
+
+from src.arcade.config import DT  # noqa: E402
+from src.arcade.data import FrameData, SessionData  # noqa: E402
+from src.arcade.gaps import RaceGapCalculator  # noqa: E402
+from src.arcade.overlays import DriverInfoPanel, LeaderboardPanel  # noqa: E402
+
+CIRCUIT_LENGTH_M = 5000.0
+LAP_SECONDS = 100.0  # at 50 m/s, so a lap is a round number of frames
+N_FRAMES = 8000  # 320 s at 25 Hz: long enough that even a 25 m/s car finishes a lap
+
+
+def _car(speed_mps: float, head_start_m: float = 0.0, dead_from: int | None = None):
+    """A car at constant speed: `dist`, `lap` and `t` all relate by hand-checkable maths."""
+    frames = []
+    for i in range(N_FRAMES):
+        live = dead_from is None or i <= dead_from
+        idx = i if live else dead_from
+        dist = head_start_m + speed_mps * idx * DT
+        frames.append(
+            FrameData(
+                t=i * DT,
+                x=0.0,
+                y=0.0,
+                speed=speed_mps * 3.6,
+                gear=7,
+                drs=0,
+                throttle=100.0,
+                brake=0.0,
+                lap=1 + int(dist // CIRCUIT_LENGTH_M),
+                dist=dist,
+                rel_dist=(dist % CIRCUIT_LENGTH_M) / CIRCUIT_LENGTH_M,
+                tyre=1,
+                tyre_life=5.0,
+                active=live,
+            )
+        )
+    return frames
+
+
+def _session(**cars) -> SessionData:
+    return SessionData(
+        gp_name="Test",
+        location="Test",
+        year=2025,
+        frames_by_driver=dict(cars),
+        circuit_length_m=CIRCUIT_LENGTH_M,
+        total_frames=N_FRAMES,
+    )
+
+
+def _frame(session: SessionData, idx: int) -> dict:
+    """The internal frame dict `on_draw` builds, for the drawing panels."""
+    return {
+        "t": idx * DT,
+        "lap": 1,
+        "drivers": {
+            code: {
+                "lap": frames[idx].lap,
+                "dist": frames[idx].dist,
+                "speed": frames[idx].speed,
+                "tyre": frames[idx].tyre,
+                "active": frames[idx].active,
+            }
+            for code, frames in session.frames_by_driver.items()
+        },
+    }
+
+
+def _ranked(session: SessionData, idx: int) -> list[tuple[str, float]]:
+    return [(code, prog) for code, _, prog in LeaderboardPanel._rank_drivers(_frame(session, idx))]
+
+
+def _panel(code: str):
+    """A stand-in for DriverInfoPanel: `_neighbor_gaps` reads only `self.code`.
+
+    Constructing the real panel allocates `arcade.Text` objects, which want
+    a GL context CI does not have. Duck-typing keeps the test honest in the
+    other direction too: if the method starts reading another attribute it
+    raises here instead of passing.
+    """
+    stand_in = SimpleNamespace(code=code, _gap_label=DriverInfoPanel._gap_label)
+    stand_in._neighbor_gaps = lambda *a: DriverInfoPanel._neighbor_gaps(stand_in, *a)
+    return stand_in
+
+
+# --- Defect 1: the ranking's progress term ----------------------------------
+
+
+def test_progress_is_dist_and_is_not_inflated_by_the_lap_term():
+    """A lapped car must not gain a circuit length of phantom progress.
+
+    LAP has driven 9600 m (lap 2); SLO has driven 3200 m (lap 1). True
+    separation is 6400 m. The old term added `(2-1) * 5000` to LAP alone,
+    which on Melbourne worked out to about 95 s of fabricated gap per lap
+    of difference once divided by the 55.56 constant.
+    """
+    session = _session(LAP=_car(60.0), SLO=_car(20.0))
+    ranked = LeaderboardPanel._rank_drivers(_frame(session, N_FRAMES - 1))
+
+    order = [code for code, _, _ in ranked]
+    progress = {code: prog for code, _, prog in ranked}
+    real_separation = (
+        session.frames_by_driver["LAP"][-1].dist - session.frames_by_driver["SLO"][-1].dist
+    )
+
+    assert order == ["LAP", "SLO"]
+    assert progress["LAP"] - progress["SLO"] == pytest.approx(real_separation)
+    assert progress["LAP"] - progress["SLO"] != pytest.approx(real_separation + CIRCUIT_LENGTH_M)
+
+
+def test_the_order_is_unchanged_by_the_fix():
+    """The bug never broke the order, and the fix must not either."""
+    session = _session(A=_car(70.0), B=_car(60.0), C=_car(50.0), D=_car(20.0))
+
+    for idx in (100, 1000, N_FRAMES - 1):
+        order = [code for code, _, _ in LeaderboardPanel._rank_drivers(_frame(session, idx))]
+        assert order == ["A", "B", "C", "D"]
+
+
+# --- Defect 2: the interval itself ------------------------------------------
+
+
+def test_the_interval_is_the_difference_of_two_line_crossings():
+    """Two cars at 50 m/s, 500 m apart, is a 10.0 s interval. Nothing else is.
+
+    The old formula divided the same 500 m by 55.56 and returned 9.00 s: a
+    10 % error on a case where both cars are travelling at very nearly the
+    speed the constant was chosen to approximate.
+    """
+    session = _session(FRONT=_car(50.0, head_start_m=500.0), BACK=_car(50.0))
+    gaps = RaceGapCalculator(session)
+
+    assert gaps.interval_at_line("FRONT", "BACK", lap=1) == pytest.approx(10.0, abs=DT)
+    assert gaps.interval_at_line("FRONT", "BACK", lap=1) != pytest.approx(500.0 / 55.56, abs=0.1)
+
+
+def test_a_slow_field_reads_slow_and_a_fast_field_reads_fast():
+    """The whole point: the interval follows the field's real speed.
+
+    The same 500 m of track separation is 20 s under a Safety Car at
+    25 m/s and 7.1 s at 70 m/s. A hardcoded 55.56 answers 9.0 s to both,
+    over-reading the Safety Car case by more than half.
+    """
+    for speed, expected in ((25.0, 20.0), (70.0, 500.0 / 70.0)):
+        session = _session(FRONT=_car(speed, head_start_m=500.0), BACK=_car(speed))
+
+        seconds = RaceGapCalculator(session).interval_at_line("FRONT", "BACK", lap=1)
+
+        assert seconds == pytest.approx(expected, abs=2 * DT)
+        assert seconds != pytest.approx(500.0 / 55.56, abs=0.5)
+
+
+def test_no_assumed_speed_constant_survives_in_the_gap_path():
+    """The literal itself, hunted structurally rather than by grep.
+
+    Parsed as an AST and not searched as text, because both modules
+    explain in prose why the constant is gone and a text search cannot
+    tell an executable 55.56 from a sentence about one. This repo has a
+    standing lesson that a grep is not an audit.
+    """
+    import ast
+    from pathlib import Path
+
+    import src.arcade.gaps as gaps_module
+    import src.arcade.overlays as overlays_module
+
+    for module in (gaps_module, overlays_module):
+        tree = ast.parse(Path(module.__file__).read_text(encoding="utf-8"))
+        numbers = [
+            node.value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant) and isinstance(node.value, (int, float))
+        ]
+        assert 55.56 not in numbers, f"{module.__name__} still carries the 200 km/h divisor"
+
+
+# --- The lapped car, where defect 2 was largest -----------------------------
+
+
+def test_a_lapped_car_reads_as_a_lap_down_not_as_fabricated_seconds():
+    """One circuit length of race distance behind is "+1 LAP" on any timing screen.
+
+    This is the case cause 2 hit hardest: the old code added a whole
+    circuit length to the distance AND divided it by 55.56, so on
+    Melbourne it fabricated roughly 95 s per lap of difference on top of
+    the real deficit.
+    """
+    session = _session(LEAD=_car(60.0), LAPPED=_car(25.0))
+    gaps = RaceGapCalculator(session)
+    idx = N_FRAMES - 1
+    lead = ("LEAD", session.frames_by_driver["LEAD"][idx].dist)
+    lapped = ("LAPPED", session.frames_by_driver["LAPPED"][idx].dist)
+    laps_by_code = {code: session.frames_by_driver[code][idx].lap for code in ("LEAD", "LAPPED")}
+
+    assert lead[1] - lapped[1] > CIRCUIT_LENGTH_M
+    assert gaps.laps_down(lead[1], lapped[1]) >= 1
+
+    label = DriverInfoPanel._gap_label("+", lead, lapped, gaps, laps_by_code)
+    assert label.endswith("LAP") or label.endswith("LAPS")
+    assert "s (L)" not in label
+
+
+def test_a_lap_number_that_differs_by_one_is_not_being_lapped():
+    """One car past the line and the other not is most of every lap, not a lapping.
+
+    `laps_down` therefore reads race distance, not lap numbers: the two
+    cars below are seconds apart and must read in seconds.
+    """
+    session = _session(FRONT=_car(50.0, head_start_m=200.0), BACK=_car(50.0))
+    idx = 2450  # FRONT crossed at 96 s, BACK crosses at 100 s
+    front_lap = session.frames_by_driver["FRONT"][idx].lap
+    back_lap = session.frames_by_driver["BACK"][idx].lap
+    gaps = RaceGapCalculator(session)
+
+    assert front_lap - back_lap == 1, "the fixture must straddle a line crossing"
+    assert (
+        gaps.laps_down(
+            session.frames_by_driver["FRONT"][idx].dist,
+            session.frames_by_driver["BACK"][idx].dist,
+        )
+        == 0
+    )
+
+
+def test_cars_on_the_same_lap_read_in_seconds_and_say_they_are_at_the_line():
+    """The "(L)" suffix is not decoration: it is what stops a lap-quantised
+    number being read as a live one on a fidelity surface."""
+    session = _session(FRONT=_car(50.0, head_start_m=300.0), BACK=_car(50.0))
+    gaps = RaceGapCalculator(session)
+    # Past 100 s, so BACK has crossed the line too and lap 1 is shared.
+    idx = 3000
+    front = ("FRONT", session.frames_by_driver["FRONT"][idx].dist)
+    back = ("BACK", session.frames_by_driver["BACK"][idx].dist)
+    laps_by_code = {code: session.frames_by_driver[code][idx].lap for code in ("FRONT", "BACK")}
+
+    label = DriverInfoPanel._gap_label("+", front, back, gaps, laps_by_code)
+
+    assert label.startswith("FRONT +")
+    assert label.endswith("s (L)")
+    assert float(label.split("+")[1].split("s")[0]) == pytest.approx(6.0, abs=2 * DT)
+
+
+# --- Unknown stays unknown --------------------------------------------------
+
+
+def test_an_interval_nobody_has_driven_yet_is_none():
+    """Before both cars have finished a lap there is no interval to show."""
+    session = _session(FRONT=_car(50.0, head_start_m=500.0), BACK=_car(50.0))
+    gaps = RaceGapCalculator(session)
+
+    assert gaps.interval_at_line("FRONT", "BACK", lap=0) is None
+    assert gaps.interval_at_line("FRONT", "BACK", lap=99) is None
+    assert gaps.interval_at_line("NOBODY", "BACK", lap=1) is None
+    assert gaps.last_shared_lap(1, 1) == 0, "nobody has completed a lap on lap 1"
+    assert gaps.last_shared_lap(21, 20) == 19, "the last lap BOTH have finished"
+
+
+def test_a_retired_car_has_no_interval_past_the_lap_it_stopped_on():
+    """Its crossings stop where its telemetry does; nothing extrapolates them."""
+    session = _session(DEAD=_car(50.0, dead_from=100), ALIVE=_car(50.0))
+    gaps = RaceGapCalculator(session)
+
+    assert gaps.interval_at_line("ALIVE", "DEAD", lap=1) is None
+    label = DriverInfoPanel._gap_label(
+        "+", ("ALIVE", 6000.0), ("DEAD", 5000.0), gaps, {"ALIVE": 2, "DEAD": 2}
+    )
+    assert label == "ALIVE N/A"
+
+
+def test_an_inverted_call_is_none_and_never_a_plausible_zero():
+    """Zero is a real interval, two cars level, so it cannot double as "invalid".
+
+    Measured on Melbourne 2025, an inverted call under the previous
+    clamp-to-zero returned `0.000` on five of six sampled laps while the
+    truth was 1 to 25 seconds the other way. This repo has a scar about
+    sentinels that collide with legitimate values.
+    """
+    session = _session(FRONT=_car(50.0, head_start_m=500.0), BACK=_car(50.0))
+    gaps = RaceGapCalculator(session)
+
+    assert gaps.interval_at_line("FRONT", "BACK", lap=1) == pytest.approx(10.0, abs=DT)
+    assert gaps.interval_at_line("BACK", "FRONT", lap=1) is None
+
+
+def test_the_panel_labels_both_neighbours_from_its_own_position():
+    session = _session(P1=_car(50.0, 1000.0), P2=_car(50.0, 500.0), P3=_car(50.0))
+    gaps = RaceGapCalculator(session)
+    idx = 3000  # all three have crossed the line once (P3, the last, at 100 s)
+    panel = _panel("P2")
+
+    ahead, behind = panel._neighbor_gaps(_ranked(session, idx), gaps, _frame(session, idx))
+
+    assert ahead.startswith("P1 +") and ahead.endswith("s (L)")
+    assert behind.startswith("P3 -") and behind.endswith("s (L)")
+    assert float(ahead.split("+")[1].split("s")[0]) == pytest.approx(10.0, abs=2 * DT)
+    assert float(behind.split("-")[1].split("s")[0]) == pytest.approx(10.0, abs=2 * DT)
+
+
+def test_the_leader_and_the_last_car_have_no_neighbour_to_measure():
+    session = _session(P1=_car(50.0, 500.0), P2=_car(50.0))
+    gaps = RaceGapCalculator(session)
+    idx = 3000
+
+    leader = _panel("P1")
+    last = _panel("P2")
+
+    assert leader._neighbor_gaps(_ranked(session, idx), gaps, _frame(session, idx))[0] == "LEADER"
+    assert last._neighbor_gaps(_ranked(session, idx), gaps, _frame(session, idx))[1] == "LAST"
+
+
+# --- The crossings themselves -----------------------------------------------
+
+
+def test_a_crossing_is_keyed_by_the_lap_it_ends():
+    """Off by one here would put every interval on the wrong lap silently."""
+    session = _session(SOLO=_car(50.0))  # 5000 m lap at 50 m/s = 100 s, 320 s of frames
+
+    crossings = RaceGapCalculator(session)._crossings["SOLO"]
+
+    assert sorted(crossings) == [1, 2, 3]
+    for lap in (1, 2, 3):
+        assert crossings[lap] == pytest.approx(lap * LAP_SECONDS, abs=DT)

--- a/tests/surfaces/test_arcade_leaderboard_gaps.py
+++ b/tests/surfaces/test_arcade_leaderboard_gaps.py
@@ -1,24 +1,23 @@
-"""Leaderboard ranking and at-the-line intervals in the arcade replay (#844).
+"""Race order and at-the-line intervals in the arcade replay (#844).
 
-Two independent defects lived here and compounded:
+Two defects lived here and compounded:
 
-1. `_rank_drivers` added `(lap - 1) * track_len` to `dist`, which is
-   already race-cumulative, so a lapped car's progress was inflated by a
-   full circuit length per lap of difference.
+1. the field was ranked by `dist` (after adding `(lap - 1) * track_len` to a
+   value that already contained the completed laps), and `dist` is not a
+   race-progress axis at all: each car accumulates the distance IT drove;
 2. the gap was that distance divided by a hardcoded 55.56 m/s, an assumed
    200 km/h for every car, everywhere, in every condition.
 
-The ranking survived (1) because the error is monotone in true progress,
-which is exactly why nobody noticed: a true sentence, "the order is
-right", sitting on top of a false one, "so the gaps are right".
+**The fixture below carries per-car accumulation drift on purpose.** An
+earlier version of this file did not, and an adversarial gate showed that 8
+of its 14 tests passed with the fix reverted: `dist` and true progress were
+the same quantity by construction, which is the one property the real data
+does not have. `_car(drift_per_lap_m=...)` reproduces it, and the ranking
+tests below fail without the fix.
 
-The fixtures build cars at constant speed on a synthetic circuit, so every
-expected interval is arithmetic checkable by hand rather than a number read
-back off the implementation. The method's accuracy against real data is a
-separate question and was measured on Melbourne 2025 against
-`laps.parquet`: median 17 ms over 13,854 driver-pair comparisons. That
-measurement is recorded in `src/arcade/gaps.py`, along with the four
-coordinates that were tried and refuted before it.
+Accuracy against real data is a separate question, measured on Melbourne
+2025 and recorded in `src/arcade/gaps.py` together with the coordinates
+that were refuted on the way.
 """
 
 from __future__ import annotations
@@ -36,16 +35,30 @@ from src.arcade.overlays import DriverInfoPanel, LeaderboardPanel  # noqa: E402
 
 CIRCUIT_LENGTH_M = 5000.0
 LAP_SECONDS = 100.0  # at 50 m/s, so a lap is a round number of frames
-N_FRAMES = 8000  # 320 s at 25 Hz: long enough that even a 25 m/s car finishes a lap
+N_FRAMES = 8000  # 320 s at 25 Hz
 
 
-def _car(speed_mps: float, head_start_m: float = 0.0, dead_from: int | None = None):
-    """A car at constant speed: `dist`, `lap` and `t` all relate by hand-checkable maths."""
+def _car(
+    speed_mps: float,
+    head_start_laps: float = 0.0,
+    drift_per_lap_m: float = 0.0,
+    dead_from: int | None = None,
+) -> list[FrameData]:
+    """A car at constant speed, with its own per-lap distance accumulation.
+
+    `rel_dist` is the true fraction of the lap and is therefore comparable
+    across cars; `dist` accumulates `CIRCUIT_LENGTH_M + drift_per_lap_m`
+    per lap and is therefore NOT. That asymmetry is the whole defect: on
+    Melbourne 2025 the real drift reaches 1877 m on a 5220 m circuit.
+    """
+    lap_length = CIRCUIT_LENGTH_M + drift_per_lap_m
     frames = []
     for i in range(N_FRAMES):
         live = dead_from is None or i <= dead_from
         idx = i if live else dead_from
-        dist = head_start_m + speed_mps * idx * DT
+        progress = head_start_laps + (speed_mps * idx * DT) / CIRCUIT_LENGTH_M
+        completed = int(progress)
+        fraction = progress - completed
         frames.append(
             FrameData(
                 t=i * DT,
@@ -56,15 +69,20 @@ def _car(speed_mps: float, head_start_m: float = 0.0, dead_from: int | None = No
                 drs=0,
                 throttle=100.0,
                 brake=0.0,
-                lap=1 + int(dist // CIRCUIT_LENGTH_M),
-                dist=dist,
-                rel_dist=(dist % CIRCUIT_LENGTH_M) / CIRCUIT_LENGTH_M,
+                lap=1 + completed,
+                dist=(completed + fraction) * lap_length,
+                rel_dist=fraction,
                 tyre=1,
                 tyre_life=5.0,
                 active=live,
             )
         )
     return frames
+
+
+def _blind_car(speed_mps: float) -> list[FrameData]:
+    """A car FastF1 gives no `RelativeDistance` for. Real: HAD, Melbourne 2025."""
+    return [FrameData(**{**vars(f), "rel_dist": float("nan")}) for f in _car(speed_mps)]
 
 
 def _session(**cars) -> SessionData:
@@ -96,68 +114,111 @@ def _frame(session: SessionData, idx: int) -> dict:
     }
 
 
-def _ranked(session: SessionData, idx: int) -> list[tuple[str, float]]:
-    return [(code, prog) for code, _, prog in LeaderboardPanel._rank_drivers(_frame(session, idx))]
+def _order(session: SessionData, idx: int) -> list[str]:
+    gaps = RaceGapCalculator(session)
+    return [code for code, _, _ in LeaderboardPanel._rank_drivers(_frame(session, idx), gaps, idx)]
 
 
 def _panel(code: str):
     """A stand-in for DriverInfoPanel: `_neighbor_gaps` reads only `self.code`.
 
-    Constructing the real panel allocates `arcade.Text` objects, which want
-    a GL context CI does not have. Duck-typing keeps the test honest in the
-    other direction too: if the method starts reading another attribute it
-    raises here instead of passing.
+    Constructing the real panel allocates `arcade.Text`, which wants a GL
+    context CI does not have. Duck-typing also keeps the test honest the
+    other way: a method that starts reading another attribute raises here
+    instead of passing.
     """
     stand_in = SimpleNamespace(code=code, _gap_label=DriverInfoPanel._gap_label)
     stand_in._neighbor_gaps = lambda *a: DriverInfoPanel._neighbor_gaps(stand_in, *a)
     return stand_in
 
 
-# --- Defect 1: the ranking's progress term ----------------------------------
+def _labels(session: SessionData, code: str, idx: int) -> tuple[str, str]:
+    gaps = RaceGapCalculator(session)
+    frame = _frame(session, idx)
+    ranked = [(c, p) for c, _, p in LeaderboardPanel._rank_drivers(frame, gaps, idx)]
+    return _panel(code)._neighbor_gaps(ranked, gaps, frame, idx)
 
 
-def test_progress_is_dist_and_is_not_inflated_by_the_lap_term():
-    """A lapped car must not gain a circuit length of phantom progress.
+# --- Defect 1: what the field is ranked BY ----------------------------------
 
-    LAP has driven 9600 m (lap 2); SLO has driven 3200 m (lap 1). True
-    separation is 6400 m. The old term added `(2-1) * 5000` to LAP alone,
-    which on Melbourne worked out to about 95 s of fabricated gap per lap
-    of difference once divided by the 55.56 constant.
+
+def test_the_order_is_right_when_dist_and_true_progress_disagree():
+    """The test the old fixture could not express, because it had no drift.
+
+    SLOW runs long per lap, so its `dist` exceeds FAST's while FAST is
+    genuinely ahead on track. Ranking on `dist` inverts them; ranking on
+    laps completed plus fraction of the lap does not.
     """
-    session = _session(LAP=_car(60.0), SLO=_car(20.0))
-    ranked = LeaderboardPanel._rank_drivers(_frame(session, N_FRAMES - 1))
+    session = _session(FAST=_car(52.0), SLOW=_car(50.0, drift_per_lap_m=400.0))
+    idx = N_FRAMES - 1
+    fast = session.frames_by_driver["FAST"][idx]
+    slow = session.frames_by_driver["SLOW"][idx]
 
-    order = [code for code, _, _ in ranked]
-    progress = {code: prog for code, _, prog in ranked}
-    real_separation = (
-        session.frames_by_driver["LAP"][-1].dist - session.frames_by_driver["SLO"][-1].dist
+    # The premise: FAST is ahead on track, and `dist` says the opposite.
+    assert (fast.lap, fast.rel_dist) > (slow.lap, slow.rel_dist), "FAST must be ahead on track"
+    assert fast.dist < slow.dist, "the fixture must reproduce the dist inversion"
+
+    assert _order(session, idx) == ["FAST", "SLOW"]
+
+
+def test_the_leader_is_the_car_that_has_covered_the_most_track():
+    """Three cars, three different drifts, sampled across the race."""
+    session = _session(
+        P1=_car(56.0, drift_per_lap_m=-80.0),
+        P2=_car(53.0, drift_per_lap_m=0.0),
+        P3=_car(50.0, drift_per_lap_m=160.0),
     )
 
-    assert order == ["LAP", "SLO"]
-    assert progress["LAP"] - progress["SLO"] == pytest.approx(real_separation)
-    assert progress["LAP"] - progress["SLO"] != pytest.approx(real_separation + CIRCUIT_LENGTH_M)
+    for idx in (2000, 4000, 6000, N_FRAMES - 1):
+        assert _order(session, idx) == ["P1", "P2", "P3"], f"wrong at frame {idx}"
 
 
-def test_the_order_is_unchanged_by_the_fix():
-    """The bug never broke the order, and the fix must not either."""
-    session = _session(A=_car(70.0), B=_car(60.0), C=_car(50.0), D=_car(20.0))
+def test_a_car_whose_rel_dist_is_missing_is_still_ranked():
+    """The coordinate does not read `rel_dist`, so a NaN one cannot break it.
 
-    for idx in (100, 1000, N_FRAMES - 1):
-        order = [code for code, _, _ in LeaderboardPanel._rank_drivers(_frame(session, idx))]
-        assert order == ["A", "B", "C", "D"]
+    On Melbourne 2025 FastF1 leaves `RelativeDistance` NaN for 100 % of
+    HAD's frames. Ranking on it would have dropped a whole car off the
+    order; ranking on distance-since-the-last-crossing does not notice.
+    """
+    session = _session(SLOW=_car(50.0), BLIND=_blind_car(60.0))
+    idx = 4000
+    gaps = RaceGapCalculator(session)
+
+    ranked = LeaderboardPanel._rank_drivers(_frame(session, idx), gaps, idx)
+
+    assert [code for code, _, _ in ranked] == ["BLIND", "SLOW"], "the faster car leads"
+    assert gaps.progress("BLIND", idx) is not None
+
+
+def test_a_stopped_car_is_ranked_where_its_distance_says_it_stopped():
+    """The defect that made `rel_dist` unusable, reproduced.
+
+    The 25 Hz resampler clamps past a driver's last real sample, and DOO's
+    `rel_dist` saturates at 1.000 from frame 1500 while his distance shows
+    him stopped 1717 m into lap 1. Ranking on `rel_dist` drew a car that
+    had crashed at turn 1 as the race leader for 68 seconds of replay.
+    """
+    session = _session(RUNNING=_car(50.0), CRASHED=_car(50.0, dead_from=600))
+    idx = 4000
+    gaps = RaceGapCalculator(session)
+    stuck = session.frames_by_driver["CRASHED"][idx]
+
+    assert stuck.rel_dist == pytest.approx(0.24, abs=0.01), "frozen a quarter into lap 1"
+    assert gaps.progress("CRASHED", idx) == pytest.approx(0.24, abs=0.01)
+    assert _order(session, idx) == ["RUNNING", "CRASHED"]
 
 
 # --- Defect 2: the interval itself ------------------------------------------
 
 
 def test_the_interval_is_the_difference_of_two_line_crossings():
-    """Two cars at 50 m/s, 500 m apart, is a 10.0 s interval. Nothing else is.
+    """Two cars at 50 m/s, a tenth of a lap apart, is a 10.0 s interval.
 
     The old formula divided the same 500 m by 55.56 and returned 9.00 s: a
-    10 % error on a case where both cars are travelling at very nearly the
-    speed the constant was chosen to approximate.
+    10 % error on a case where both cars travel at very nearly the speed
+    the constant was chosen to approximate.
     """
-    session = _session(FRONT=_car(50.0, head_start_m=500.0), BACK=_car(50.0))
+    session = _session(FRONT=_car(50.0, head_start_laps=0.1), BACK=_car(50.0))
     gaps = RaceGapCalculator(session)
 
     assert gaps.interval_at_line("FRONT", "BACK", lap=1) == pytest.approx(10.0, abs=DT)
@@ -165,14 +226,14 @@ def test_the_interval_is_the_difference_of_two_line_crossings():
 
 
 def test_a_slow_field_reads_slow_and_a_fast_field_reads_fast():
-    """The whole point: the interval follows the field's real speed.
+    """The interval follows the field's real speed, which is the whole point.
 
-    The same 500 m of track separation is 20 s under a Safety Car at
-    25 m/s and 7.1 s at 70 m/s. A hardcoded 55.56 answers 9.0 s to both,
-    over-reading the Safety Car case by more than half.
+    A tenth of a lap is 20 s apart under a Safety Car at 25 m/s and 7.1 s
+    at 70 m/s. A hardcoded 55.56 answers 9.0 s to both, over-reading the
+    Safety Car case by more than half.
     """
     for speed, expected in ((25.0, 20.0), (70.0, 500.0 / 70.0)):
-        session = _session(FRONT=_car(speed, head_start_m=500.0), BACK=_car(speed))
+        session = _session(FRONT=_car(speed, head_start_laps=0.1), BACK=_car(speed))
 
         seconds = RaceGapCalculator(session).interval_at_line("FRONT", "BACK", lap=1)
 
@@ -204,121 +265,138 @@ def test_no_assumed_speed_constant_survives_in_the_gap_path():
         assert 55.56 not in numbers, f"{module.__name__} still carries the 200 km/h divisor"
 
 
-# --- The lapped car, where defect 2 was largest -----------------------------
+# --- Being a lap down -------------------------------------------------------
 
 
-def test_a_lapped_car_reads_as_a_lap_down_not_as_fabricated_seconds():
-    """One circuit length of race distance behind is "+1 LAP" on any timing screen.
+def test_laps_down_is_positional_and_survives_the_accumulation_drift():
+    """The case the `dist` form got wrong on 4.9 % of same-corner pairs.
 
-    This is the case cause 2 hit hardest: the old code added a whole
-    circuit length to the distance AND divided it by 55.56, so on
-    Melbourne it fabricated roughly 95 s per lap of difference on top of
-    the real deficit.
+    Both cars sit at the same point on track, exactly one lap apart, and
+    the lapped car runs long enough per lap that its `dist` deficit is
+    less than a circuit length. The old `dist // circuit_length` form
+    therefore answered 0 and the panel showed a seconds interval for a car
+    a full lap down.
     """
-    session = _session(LEAD=_car(60.0), LAPPED=_car(25.0))
+    # Half the speed, so at 200 s LEAD is on lap 3 and LAPPED on lap 2, both
+    # exactly at the line. A head start would not do: `laps_completed` counts
+    # crossings the replay actually observed, and a car that begins mid-race
+    # never crossed the line for the laps it was handed.
+    session = _session(LEAD=_car(50.0), LAPPED=_car(25.0, drift_per_lap_m=800.0))
     gaps = RaceGapCalculator(session)
-    idx = N_FRAMES - 1
-    lead = ("LEAD", session.frames_by_driver["LEAD"][idx].dist)
-    lapped = ("LAPPED", session.frames_by_driver["LAPPED"][idx].dist)
-    laps_by_code = {code: session.frames_by_driver[code][idx].lap for code in ("LEAD", "LAPPED")}
+    idx = 5000
+    lead = session.frames_by_driver["LEAD"][idx]
+    lapped = session.frames_by_driver["LAPPED"][idx]
 
-    assert lead[1] - lapped[1] > CIRCUIT_LENGTH_M
-    assert gaps.laps_down(lead[1], lapped[1]) >= 1
+    assert lead.rel_dist == pytest.approx(lapped.rel_dist, abs=0.01), "same point on track"
+    assert lead.lap - lapped.lap == 1, "exactly one lap apart"
+    assert lead.dist - lapped.dist < CIRCUIT_LENGTH_M, "the dist form would answer 0 here"
 
-    label = DriverInfoPanel._gap_label("+", lead, lapped, gaps, laps_by_code)
-    assert label.endswith("LAP") or label.endswith("LAPS")
-    assert "s (L)" not in label
+    assert gaps.laps_down(gaps.progress("LEAD", idx), gaps.progress("LAPPED", idx)) == 1
 
 
 def test_a_lap_number_that_differs_by_one_is_not_being_lapped():
-    """One car past the line and the other not is most of every lap, not a lapping.
+    """One car past the line and the other not is most of every lap.
 
-    `laps_down` therefore reads race distance, not lap numbers: the two
-    cars below are seconds apart and must read in seconds.
+    `laps_down` is therefore positional: the two cars below are a fraction
+    of a second apart and must read in seconds.
     """
-    session = _session(FRONT=_car(50.0, head_start_m=200.0), BACK=_car(50.0))
-    idx = 2450  # FRONT crossed at 96 s, BACK crosses at 100 s
-    front_lap = session.frames_by_driver["FRONT"][idx].lap
-    back_lap = session.frames_by_driver["BACK"][idx].lap
+    session = _session(FRONT=_car(50.0, head_start_laps=0.01), BACK=_car(50.0))
     gaps = RaceGapCalculator(session)
+    idx = 2499  # FRONT has crossed the line, BACK has not
+    frames = session.frames_by_driver
 
-    assert front_lap - back_lap == 1, "the fixture must straddle a line crossing"
-    assert (
-        gaps.laps_down(
-            session.frames_by_driver["FRONT"][idx].dist,
-            session.frames_by_driver["BACK"][idx].dist,
-        )
-        == 0
-    )
+    assert frames["FRONT"][idx].lap - frames["BACK"][idx].lap == 1
+    assert gaps.laps_down(gaps.progress("FRONT", idx), gaps.progress("BACK", idx)) == 0
+
+
+def test_a_lapped_car_renders_as_a_lap_down_not_as_seconds():
+    session = _session(LEAD=_car(60.0), LAPPED=_car(25.0))
+    idx = N_FRAMES - 1
+
+    ahead, _ = _labels(session, "LAPPED", idx)
+
+    assert ahead.startswith("LEAD +")
+    assert ahead.endswith("LAP") or ahead.endswith("LAPS")
+    assert "(L)" not in ahead and "s" not in ahead.removesuffix("LAPS")
 
 
 def test_cars_on_the_same_lap_read_in_seconds_and_say_they_are_at_the_line():
     """The "(L)" suffix is not decoration: it is what stops a lap-quantised
     number being read as a live one on a fidelity surface."""
-    session = _session(FRONT=_car(50.0, head_start_m=300.0), BACK=_car(50.0))
+    session = _session(FRONT=_car(50.0, head_start_laps=0.06), BACK=_car(50.0))
+
+    ahead, _ = _labels(session, "BACK", 3000)
+
+    assert ahead.startswith("FRONT +")
+    assert ahead.endswith("s (L)")
+    assert float(ahead.split("+")[1].split("s")[0]) == pytest.approx(6.0, abs=2 * DT)
+
+
+# --- Unknown, retired and inverted stay visible as such ---------------------
+
+
+def test_a_retired_neighbour_reads_OUT_rather_than_a_stale_interval():
+    """`np.interp` clamps past a driver's last sample, so a parked car keeps
+    reporting its final state forever. Without this branch the panel showed
+    an interval up to 22 minutes old naming a car that had stopped."""
+    session = _session(ALIVE=_car(50.0), STOPPED=_car(50.0, head_start_laps=0.2, dead_from=3000))
+    idx = 6000
+
+    assert session.frames_by_driver["STOPPED"][idx].active is False
+    ahead, behind = _labels(session, "ALIVE", idx)
+
+    assert "STOPPED OUT" in (ahead, behind)
+
+
+def test_a_retired_car_keeps_the_laps_it_actually_completed():
+    """Its crossings stop where its telemetry does, and nothing extrapolates."""
+    session = _session(ALIVE=_car(50.0), STOPPED=_car(50.0, dead_from=3000))
     gaps = RaceGapCalculator(session)
-    # Past 100 s, so BACK has crossed the line too and lap 1 is shared.
-    idx = 3000
-    front = ("FRONT", session.frames_by_driver["FRONT"][idx].dist)
-    back = ("BACK", session.frames_by_driver["BACK"][idx].dist)
-    laps_by_code = {code: session.frames_by_driver[code][idx].lap for code in ("FRONT", "BACK")}
 
-    label = DriverInfoPanel._gap_label("+", front, back, gaps, laps_by_code)
-
-    assert label.startswith("FRONT +")
-    assert label.endswith("s (L)")
-    assert float(label.split("+")[1].split("s")[0]) == pytest.approx(6.0, abs=2 * DT)
-
-
-# --- Unknown stays unknown --------------------------------------------------
+    # 3000 frames at 50 m/s is 120 s: one full lap plus a fifth, so exactly
+    # one line crossing. The fifth it was part-way through is not a lap.
+    assert gaps.laps_completed("STOPPED", N_FRAMES - 1) == 1
+    assert gaps.laps_completed("ALIVE", N_FRAMES - 1) == 3
+    assert gaps.interval_at_line("ALIVE", "STOPPED", lap=2) is None
 
 
 def test_an_interval_nobody_has_driven_yet_is_none():
-    """Before both cars have finished a lap there is no interval to show."""
-    session = _session(FRONT=_car(50.0, head_start_m=500.0), BACK=_car(50.0))
+    session = _session(FRONT=_car(50.0, head_start_laps=0.1), BACK=_car(50.0))
     gaps = RaceGapCalculator(session)
 
     assert gaps.interval_at_line("FRONT", "BACK", lap=0) is None
     assert gaps.interval_at_line("FRONT", "BACK", lap=99) is None
     assert gaps.interval_at_line("NOBODY", "BACK", lap=1) is None
-    assert gaps.last_shared_lap(1, 1) == 0, "nobody has completed a lap on lap 1"
-    assert gaps.last_shared_lap(21, 20) == 19, "the last lap BOTH have finished"
-
-
-def test_a_retired_car_has_no_interval_past_the_lap_it_stopped_on():
-    """Its crossings stop where its telemetry does; nothing extrapolates them."""
-    session = _session(DEAD=_car(50.0, dead_from=100), ALIVE=_car(50.0))
-    gaps = RaceGapCalculator(session)
-
-    assert gaps.interval_at_line("ALIVE", "DEAD", lap=1) is None
-    label = DriverInfoPanel._gap_label(
-        "+", ("ALIVE", 6000.0), ("DEAD", 5000.0), gaps, {"ALIVE": 2, "DEAD": 2}
-    )
-    assert label == "ALIVE N/A"
+    assert gaps.last_shared_lap("FRONT", "BACK", frame_idx=100) == 0
 
 
 def test_an_inverted_call_is_none_and_never_a_plausible_zero():
-    """Zero is a real interval, two cars level, so it cannot double as "invalid".
+    """Zero is a real answer for both methods, so it cannot double as "invalid".
 
-    Measured on Melbourne 2025, an inverted call under the previous
-    clamp-to-zero returned `0.000` on five of six sampled laps while the
-    truth was 1 to 25 seconds the other way. This repo has a scar about
-    sentinels that collide with legitimate values.
+    `laps_down` used to return 0 for an inverted pair, which is also what
+    it returns for "same lap" — the twin of a discipline `interval_at_line`
+    spends five docstring lines defending twenty lines above it.
     """
-    session = _session(FRONT=_car(50.0, head_start_m=500.0), BACK=_car(50.0))
+    session = _session(FRONT=_car(50.0, head_start_laps=0.1), BACK=_car(50.0))
     gaps = RaceGapCalculator(session)
+    idx = 3000
+    front, back = gaps.progress("FRONT", idx), gaps.progress("BACK", idx)
 
     assert gaps.interval_at_line("FRONT", "BACK", lap=1) == pytest.approx(10.0, abs=DT)
     assert gaps.interval_at_line("BACK", "FRONT", lap=1) is None
+    assert gaps.laps_down(front, back) == 0
+    assert gaps.laps_down(back, front) is None
+    assert gaps.laps_down(None, back) is None
 
 
 def test_the_panel_labels_both_neighbours_from_its_own_position():
-    session = _session(P1=_car(50.0, 1000.0), P2=_car(50.0, 500.0), P3=_car(50.0))
-    gaps = RaceGapCalculator(session)
-    idx = 3000  # all three have crossed the line once (P3, the last, at 100 s)
-    panel = _panel("P2")
+    session = _session(
+        P1=_car(50.0, head_start_laps=0.2),
+        P2=_car(50.0, head_start_laps=0.1),
+        P3=_car(50.0),
+    )
 
-    ahead, behind = panel._neighbor_gaps(_ranked(session, idx), gaps, _frame(session, idx))
+    ahead, behind = _labels(session, "P2", 3000)
 
     assert ahead.startswith("P1 +") and ahead.endswith("s (L)")
     assert behind.startswith("P3 -") and behind.endswith("s (L)")
@@ -327,26 +405,28 @@ def test_the_panel_labels_both_neighbours_from_its_own_position():
 
 
 def test_the_leader_and_the_last_car_have_no_neighbour_to_measure():
-    session = _session(P1=_car(50.0, 500.0), P2=_car(50.0))
-    gaps = RaceGapCalculator(session)
-    idx = 3000
+    session = _session(P1=_car(50.0, head_start_laps=0.1), P2=_car(50.0))
 
-    leader = _panel("P1")
-    last = _panel("P2")
-
-    assert leader._neighbor_gaps(_ranked(session, idx), gaps, _frame(session, idx))[0] == "LEADER"
-    assert last._neighbor_gaps(_ranked(session, idx), gaps, _frame(session, idx))[1] == "LAST"
+    assert _labels(session, "P1", 3000)[0] == "LEADER"
+    assert _labels(session, "P2", 3000)[1] == "LAST"
 
 
 # --- The crossings themselves -----------------------------------------------
 
 
-def test_a_crossing_is_keyed_by_the_lap_it_ends():
-    """Off by one here would put every interval on the wrong lap silently."""
-    session = _session(SOLO=_car(50.0))  # 5000 m lap at 50 m/s = 100 s, 320 s of frames
+def test_a_crossing_is_keyed_by_the_lap_it_ends_and_only_real_laps_count():
+    """Off by one here would put every interval on the wrong lap silently.
+
+    A synthetic entry for the lap in progress would credit every
+    retirement with a lap it never drove: a car that stops 1700 m into
+    lap 1 would rank a full lap up the field.
+    """
+    session = _session(SOLO=_car(50.0))  # 100 s per lap, 320 s of frames
 
     crossings = RaceGapCalculator(session)._crossings["SOLO"]
 
+    # 320 s of frames at 100 s per lap: three lines crossed, and the fourth
+    # lap still running. The chequered flag is not a crossing.
     assert sorted(crossings) == [1, 2, 3]
     for lap in (1, 2, 3):
         assert crossings[lap] == pytest.approx(lap * LAP_SECONDS, abs=DT)

--- a/tests/surfaces/test_arcade_telemetry_span.py
+++ b/tests/surfaces/test_arcade_telemetry_span.py
@@ -58,7 +58,7 @@ def _collect_spans(speeds_and_ticks, start_frame: float = 0.0):
         for _ in range(n_ticks):
             frame_index += TICK_SECONDS * FPS * speed
             frame_idx = int(frame_index)
-            span_start, rewound = _telemetry_span_bounds(
+            span_start, rewound, _ = _telemetry_span_bounds(
                 last_sent, frame_idx, STREAM_MAX_SPAN_FRAMES
             )
             last_sent = frame_idx
@@ -112,7 +112,7 @@ def test_pause_sends_no_new_samples_rather_than_repeating_the_last_one():
     sample went out ten times a second and any consumer that appends
     accumulated duplicates.
     """
-    span_start, rewound = _telemetry_span_bounds(400, 400, STREAM_MAX_SPAN_FRAMES)
+    span_start, rewound, dropped = _telemetry_span_bounds(400, 400, STREAM_MAX_SPAN_FRAMES)
 
     assert span_start > 400, "a paused tick must produce an empty span"
     assert rewound is False, "pause is not a discontinuity"
@@ -121,32 +121,37 @@ def test_pause_sends_no_new_samples_rather_than_repeating_the_last_one():
 
 def test_a_backwards_seek_is_empty_and_flagged():
     """Rewind must be a branch, not a negative slice."""
-    span_start, rewound = _telemetry_span_bounds(400, 250, STREAM_MAX_SPAN_FRAMES)
+    span_start, rewound, dropped = _telemetry_span_bounds(400, 250, STREAM_MAX_SPAN_FRAMES)
 
     assert rewound is True
     assert span_start > 250, "nothing may be appended on a rewind"
 
 
-def test_a_stall_cannot_put_an_unbounded_span_on_the_wire():
-    """A frame-index jump the clock could not produce smoothly is capped.
+def test_a_forward_jump_is_capped_and_the_lost_frames_are_counted():
+    """A jump smooth playback could not produce is capped and reported.
 
-    Normal playback tops out near 60 frames per tick; a process stall is
-    what produces thousands, and `sendall` is blocking on the pyglet
-    thread.
+    Smooth playback tops out near 60 frames per tick. What reaches the cap
+    is a click on the progress bar, which sets the index directly; a
+    process stall is the rarer second case.
     """
-    span_start, rewound = _telemetry_span_bounds(10, 90_000, STREAM_MAX_SPAN_FRAMES)
+    span_start, rewound, dropped = _telemetry_span_bounds(10, 90_000, STREAM_MAX_SPAN_FRAMES)
 
     assert rewound is False
     assert 90_000 - span_start + 1 == STREAM_MAX_SPAN_FRAMES
+    # The frames the cap could not carry are counted and published, because
+    # a forward jump is otherwise invisible: the sequence stays contiguous
+    # and the clock still runs forwards.
+    assert dropped == 90_000 - 10 - STREAM_MAX_SPAN_FRAMES
+    assert _telemetry_span_bounds(10, 40, STREAM_MAX_SPAN_FRAMES)[2] == 0
 
     # The cap must never resurrect a span that pause emptied.
-    paused_start, _ = _telemetry_span_bounds(400, 400, STREAM_MAX_SPAN_FRAMES)
+    paused_start, _, _ = _telemetry_span_bounds(400, 400, STREAM_MAX_SPAN_FRAMES)
     assert paused_start == 401
 
 
 def test_the_first_tick_sends_one_sample_not_the_whole_race():
     """`last_sent_idx` starts at -1, which must mean "nothing yet", not "from zero"."""
-    span_start, _ = _telemetry_span_bounds(-1, 0, STREAM_MAX_SPAN_FRAMES)
+    span_start, _, _ = _telemetry_span_bounds(-1, 0, STREAM_MAX_SPAN_FRAMES)
 
     assert span_start == 0
     assert list(range(span_start, 1)) == [0]

--- a/tests/surfaces/test_arcade_wire_contract.py
+++ b/tests/surfaces/test_arcade_wire_contract.py
@@ -19,6 +19,7 @@ the most fields and is the one the PITWALL agents window reads one by one.
 
 from __future__ import annotations
 
+import json
 from functools import partial
 from types import SimpleNamespace
 
@@ -227,6 +228,7 @@ GOLDEN_SHAPE = {
                     "throttle": "float",
                 }
             ],
+            "dropped": "int",
             "rewound": "bool",
             "rival": [
                 {
@@ -328,6 +330,68 @@ GOLDEN_SHAPE = {
 }
 
 
+def _minimal_payload() -> dict:
+    """The other end of the range: no rival pinned, no decision yet, an error set.
+
+    The session still carries every car - single-driver mode is a choice of
+    which two are charted, not a smaller field - so only `driver_rival`
+    goes null here, not the `drivers` block.
+    """
+    session = SessionData(
+        gp_name="Australia",
+        location="Melbourne",
+        year=2025,
+        frames_by_driver={"NOR": _frames(40), "PIA": _frames(40)},
+        min_lap_number=1,
+        max_lap_number=4,
+        circuit_length_m=CIRCUIT_LENGTH_M,
+        total_frames=40,
+        global_t_min=4260.355,
+    )
+    state = StrategyState()
+    state.error = "lap 12: pipeline failed"
+    _sent.clear()
+    F1ArcadeView._broadcast_if_due(_view(session, state, rival=None, clients=1))
+    assert _sent, "the fixture must actually broadcast"
+    return _sent[-1]
+
+
+# What the same payload looks like before the first decision exists, with no
+# rival pinned and an error set. Frozen separately rather than unioned into
+# GOLDEN_SHAPE, because a union hides WHICH state makes a field null and a
+# consumer needs exactly that. Five fields differ, and they are the five a
+# type generated from the rich shape alone would get wrong.
+GOLDEN_MINIMAL_DIFFS = {
+    "arcade.driver_rival": "NoneType",
+    "arcade.telemetry.rival": [],
+    "strategy.start": "NoneType",
+    "strategy.latest": "NoneType",
+    "strategy.history_tail": [],
+    "strategy.error": "str",
+}
+
+
+def _highest_diffs(rich, minimal, path: str = "") -> dict:
+    """Where the two shapes part company, reported at the highest node.
+
+    A subtree that collapses to `None` is one difference, not one per leaf:
+    "strategy.latest is null before the first decision" is the fact a
+    consumer needs, and 22 entries saying its fields are absent is noise.
+    """
+    if rich == minimal:
+        return {}
+    if isinstance(rich, dict) and isinstance(minimal, dict):
+        diffs: dict = {}
+        for key in rich:
+            child = f"{path}.{key}" if path else key
+            if key not in minimal:
+                diffs[child] = "absent"
+            else:
+                diffs.update(_highest_diffs(rich[key], minimal[key], child))
+        return diffs
+    return {path: minimal}
+
+
 def test_the_payload_shape_is_the_frozen_one():
     """Every key and type on the wire, pinned.
 
@@ -337,6 +401,19 @@ def test_the_payload_shape_is_the_frozen_one():
     gone.
     """
     assert _shape(_payload()) == GOLDEN_SHAPE
+
+
+def test_the_states_that_make_a_field_null_are_frozen_too():
+    """A consumer typed off the rich shape alone gets five wrong non-nullables.
+
+    Before the first lap the pipeline decides, with no rival pinned and an
+    error set, these five fields differ from the rich payload. Everything
+    else must be identical: if a sixth field starts varying, that is a new
+    optionality nobody declared.
+    """
+    diffs = _highest_diffs(_shape(_payload()), _shape(_minimal_payload()))
+
+    assert diffs == GOLDEN_MINIMAL_DIFFS
 
 
 def test_the_payload_carries_the_schema_version():
@@ -405,3 +482,64 @@ def test_no_seq_is_burned_while_nobody_is_listening():
     check downstream would be measuring the wrong thing.
     """
     assert _seq_of(10, clients=0) == []
+
+
+# --- Nothing non-finite reaches the wire, enforced at the encoder -----------
+
+
+def _sent_bytes(payload: dict) -> list[bytes]:
+    """Run the real `TelemetryStreamServer.broadcast` against a fake socket.
+
+    Through the server, not around it: the guarantee lives in `json.dumps`
+    and the sanitiser that feeds it, and a test that builds the dict and
+    encodes it itself would prove nothing about either.
+    """
+    from src.arcade.stream import TelemetryStreamServer
+
+    written: list[bytes] = []
+    server = TelemetryStreamServer()
+    server._running = True
+    server._clients = [SimpleNamespace(sendall=written.append)]
+    server.broadcast(payload)
+    return written
+
+
+def _reject_non_finite(token: str) -> float:
+    raise AssertionError(f"non-finite token on the wire: {token}")
+
+
+def test_a_nan_from_a_model_costs_its_field_and_not_the_whole_tick():
+    """The `strategy` block is a bare `asdict()` of raw model output.
+
+    A model that cannot compute a value hands back NaN, and three of the
+    guards on the way in are `or`/truthiness tests, which NaN passes:
+    `nan or 0.0` is `nan`. `json.dumps` then writes a bare `NaN` that
+    Python reads back and `JSON.parse` rejects, so one unusable prediction
+    would have dropped every field on the tick for a web consumer.
+
+    The panels that do not depend on that prediction keep updating; the one
+    that does gets `null`, which it already has to handle.
+    """
+    payload = _payload()
+    payload["strategy"]["latest"]["lap_time_s"] = float("nan")
+    payload["strategy"]["latest"]["scenario_scores"]["PIT_NOW"] = float("inf")
+    payload["strategy"]["history_tail"][0]["confidence"] = float("-inf")
+
+    written = _sent_bytes(payload)
+
+    assert written, "a NaN must not silence the whole broadcast"
+    decoded = json.loads(written[0], parse_constant=_reject_non_finite)
+    assert decoded["strategy"]["latest"]["lap_time_s"] is None
+    assert decoded["strategy"]["latest"]["scenario_scores"]["PIT_NOW"] is None
+    assert decoded["strategy"]["history_tail"][0]["confidence"] is None
+    # Everything that was computable is still there.
+    assert decoded["strategy"]["latest"]["action"] == "PIT_NOW"
+    assert decoded["seq"] == payload["seq"]
+
+
+def test_a_payload_that_cannot_be_encoded_is_dropped_rather_than_half_sent():
+    """The encoder is the backstop, and a dropped message is visible in `seq`."""
+    payload = _payload()
+    payload["strategy"]["latest"]["reasoning"] = {1, 2}  # a set is not JSON
+
+    assert _sent_bytes(payload) == []


### PR DESCRIPTION
Follow-up to #845, #846 and #847, closing the P1 findings an adversarial gate raised against them. All three are already on `dev`; this fixes what they got wrong rather than reverting them.

Related to #842, #841, #843. No issue is closed here.

## P1: the wire's own promise had no mechanism

`stream.py`'s module docstring, added in #847, says *"nothing non-finite may reach the wire"*. Nothing enforced it. `json.dumps` defaults to `allow_nan=True`, so it writes a bare `NaN` or `Infinity`, never raises, and the `except (TypeError, ValueError)` on the next line — the exact handler `allow_nan=False` needs — was never reached. Python's own parser reads those tokens back, which is why the Qt dashboard never surfaced it; `JSON.parse` rejects the entire message.

Now: `allow_nan=False`, plus a sanitiser that turns non-finite floats into `null` **before** the encoder sees them. The division is deliberate — the sanitiser is the policy, the encoder flag is the assertion that the policy worked.

## P1: the `strategy` block was the unguarded half

#842 guarded `rel_dist`. It did not guard the largest float surface on the payload: `strategy` is a bare `asdict()` of DTOs carrying raw XGBoost, TCN and LightGBM output, and three of the guards on the way in are `or`/truthiness tests, which NaN passes (`nan or 0.0` is `nan`). The gate proved it end to end over a real socket.

One copy fixed and its twin left alone is this repo's most-repeated defect, and the test that should have caught it was itself the second instance: `test_the_payload_survives_a_strict_json_parser` built only the `arcade` sub-dict while claiming to cover "the payload", so it passed. It is now named for what it checks, and a new test drives the **whole** payload through the real `TelemetryStreamServer.broadcast`.

Sanitising rather than dropping is the deliberate choice: one unusable model output costs that field, not the tick. The panels that do not depend on it keep updating.

## P1: `STREAM_MAX_SPAN_FRAMES` made a latent freeze 186x more likely

`sendall` runs on the pyglet main thread, so a subscriber that stops reading blocks the replay window itself. That predates this sprint (#199 Phase D.3). What this sprint did was enlarge the message: the gate measured the time-to-freeze against a stalled client falling from about 130 s to **0.7 s**, and the product always opens two subscribers.

Minimum fix taken here: every client socket gets a 50 ms send timeout at accept, and `socket.timeout` is an `OSError` subclass so a stalled subscriber is pruned by the same path as a closed one. A dashboard on localhost accepts 30 KB in microseconds; past 50 ms it is not slow, it is gone, and the Qt client already reconnects. **Moving `broadcast` off the pyglet thread onto a queue with a drop-oldest policy is the correct answer and stays #199 D.3** — this is the part that stops the sprint from having made things worse.

## P2: a forward seek dropped frames silently

The span cap was justified in two comments and a test name as protection against "a stall". The mechanism that actually reaches it is **a click on the progress bar**, which sets the frame index directly: the gate measured one click dropping **14,627 frames** with `rewound=False` and a contiguous `seq`. A backward seek was flagged and a forward one was not — the same twin, in the field whose entire documented purpose is making a dropped frame visible.

The tick now publishes `dropped`, the count of frames the span could not carry, and the Qt panel clears its buffers on it rather than splicing two unrelated parts of the race into one trace. The comments and the test name say "a progress-bar click" now, because that is where it bites.

## P2: the golden shape could not express optionality

Four routine runtime states produced a payload the golden declared broken, including `strategy.error` — the one the file's own docstring warns about one paragraph earlier. Sprint 2 typing a React consumer off it would have got five wrong non-nullables.

Fixed with a **second golden** rather than a union: `GOLDEN_MINIMAL_DIFFS` freezes exactly which fields change before the first decision exists, with no rival pinned and an error set. A union would have said "this can be null" and hidden *which state* makes it null, which is the half a consumer needs. If a sixth field starts varying, that is a new optionality nobody declared and the test says so.

## Also corrected

`seq` is per-server, not per-client: the second dashboard window attaches mid-sequence and its first value is arbitrary. #847's commit body justified the field in terms a per-client counter would satisfy. Documented in `stream.py`; a consumer treats its own first observed value as the origin and only the deltas as meaningful.

## A correction to #845's commit message, which cannot be rewritten

It says the anchor matches `laps.parquet` "to 33 ms, under the 40 ms frame period". **That was four sampled laps published as a bound.** Over all 927 driver-laps the honest figure is **median 22 ms, max 486 ms, with 9.7 % above the frame period**. The origin itself is exact — `global_t_min` equals VER's lap-1 `LapStartTime` to the microsecond for all 20 drivers — and the anchor is right; the error bar was not. Do not republish "33 ms".

## Deferred, with reasons

- **The throttle scale heuristic** publishes above 100 % on 5.0 % of real frames and multiplies a 0.8 % throttle by 100 on 2.3 % (72,104 frames). Pre-existing, its own defect, and the unit is knowable at the loader rather than guessable per frame. Its own issue.
- **`rel_dist`'s lap-boundary ramp**: the resampler interpolates it across its own reset, running it backwards through most of the lap for 591 frames across 18 drivers. A data-prep defect in `data.py`, 0.024 % of frames, and #844 stopped depending on `rel_dist` entirely.
- **A per-driver `has_position` flag** so the Qt panel says "no position data for X" instead of rendering four blank charts.

## Checks

- 64 surface tests, including the whole-payload NaN path through the real server, the drop-on-unencodable path, `dropped` on a forward jump, and the second golden.
- `ruff check` and `ruff format --check` clean.
