### PR TITLE
fix(arcade): decide the pedal scale per session, derive rel_dist from distance, unblock the send

### DIFF
--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -67,7 +67,7 @@ logger = logging.getLogger(__name__)
 
 
 def _telemetry_span_bounds(
-    last_sent_idx: int, frame_idx: int, max_span: int
+    last_sent_idx: int, frame_idx: int, max_span: int, moved_back: bool = False
 ) -> tuple[int, bool, int]:
     """Return `(span_start, rewound, dropped)` for the frames this tick should send.
 
@@ -95,9 +95,15 @@ def _telemetry_span_bounds(
     returned and published: a consumer that only saw `rewound` would read a
     contiguous `seq` and a forward-only clock and conclude nothing was
     lost, which is precisely the thing `seq` exists to make impossible.
+
+    `moved_back` carries what the integer comparison cannot see: the clock
+    is a float, so a backwards seek that does not cross a frame boundary
+    looks exactly like a pause and the consumer never clears. It is
+    reachable on any `on_key_release(LEFT)` landing mid-tick, and bounded
+    at one frame of stale samples, which is why it is small and not zero.
     """
-    if frame_idx < last_sent_idx:
-        return frame_idx + 1, True, 0
+    if frame_idx < last_sent_idx or moved_back:
+        return min(frame_idx, last_sent_idx) + 1, True, 0
     span_start = last_sent_idx + 1
     capped = max(span_start, frame_idx - max_span + 1)
     return capped, False, capped - span_start
@@ -123,18 +129,22 @@ def _frames_to_telemetry_span(
 def _lap_fraction(rel_dist: float) -> float | None:
     """Clamp a fraction-of-lap into [0, 1], or return None when it is unknown.
 
-    FastF1 does not always deliver ``RelativeDistance``: on Melbourne 2025
-    it is NaN for 100 % of HAD's frames, the only non-finite value in the
-    whole session. Two things break if that NaN is passed through.
+    The loader now derives `rel_dist` from the driver's own distance
+    (`data.py:_lap_fraction_from_distance`), so it is finite and inside
+    [0, 1] for every frame of every driver — this guard fires on nothing
+    in the sessions measured. It stays because the two failure modes it
+    exists for are both silent, and one of them was live:
 
-    First, ``json.dumps`` writes a bare ``NaN``, which is not valid JSON.
-    Python's own parser accepts it, so the Qt dashboard never noticed, but
-    a strict parser (``JSON.parse``) rejects the whole payload.
+    - ``json.dumps`` writes a bare ``NaN``, which Python's own parser
+      accepts and ``JSON.parse`` rejects, so a single unknown value took
+      the whole payload down for a web consumer. FastF1 used to leave
+      ``RelativeDistance`` NaN for 100 % of one driver's frames.
+    - clamping is worse than dropping: ``min(1.0, nan)`` is ``1.0``, and
+      1.0 means "at the line", so the car with no position data would be
+      drawn exactly on the lap boundary rather than nowhere.
 
-    Second, clamping it is worse than dropping it: ``min(1.0, nan)`` is
-    ``1.0``, and 1.0 is a legitimate value meaning "at the line", so the
-    car with no position data would be drawn exactly at the lap boundary
-    rather than nowhere. Unknown stays None and every consumer handles it.
+    Unknown stays None. `has_position` on the wire is what tells a
+    consumer to say so instead of rendering an empty chart.
     """
     value = float(rel_dist)
     if not math.isfinite(value):
@@ -151,17 +161,17 @@ def _frame_to_telemetry(frame, circuit_length_m: float) -> dict | None:
     telemetry chart wants per-lap distance (resets to 0 each lap) so
     the traces always occupy the full circuit-length range.
 
-    Throttle / brake normalised to 0-100 % regardless of the FastF1
-    delivery format (some sessions carry them as 0-1). ``t`` is included
-    so the delta-time chart can interpolate rival vs main."""
+    Throttle and brake arrive already on 0-100 and already clamped: the
+    scale is decided ONCE per session in `data.py` (`_pedal_multiplier`),
+    not guessed per frame here. The guess used to be `if value <= 1.0:
+    value *= 100`, which cannot tell "0-1 scale, full throttle" from
+    "0-100 scale, barely lifting" and published 72,104 sub-1 % openings as
+    80-odd per cent on Melbourne 2025 alone. ``t`` is included so the
+    delta-time chart can interpolate rival vs main."""
     if frame is None:
         return None
     throttle = float(frame.throttle)
-    if throttle <= 1.0:
-        throttle *= 100.0
     brake = float(frame.brake)
-    if brake <= 1.0:
-        brake *= 100.0
     rel_dist = _lap_fraction(frame.rel_dist)
     lap_dist = None if rel_dist is None else round(rel_dist * float(circuit_length_m or 0.0), 1)
     return {
@@ -227,6 +237,9 @@ class F1ArcadeView(arcade.View):
         # duplicating 15 of 54 reads and skipping 15 of 54. Without a
         # sequence neither is visible from the consumer side.
         self._broadcast_seq: int = 0
+        # The float clock as of the last due tick. `_last_broadcast_idx` is
+        # truncated, so on its own it cannot see a sub-frame rewind.
+        self._last_broadcast_clock: float = -1.0
 
         self._frame_index: float = 0.0
         self._speed_idx: int = DEFAULT_SPEED_IDX
@@ -525,8 +538,12 @@ class F1ArcadeView(arcade.View):
             return
         frame_idx = int(self._frame_index)
         span_start, rewound, dropped = _telemetry_span_bounds(
-            self._last_broadcast_idx, frame_idx, STREAM_MAX_SPAN_FRAMES
+            self._last_broadcast_idx,
+            frame_idx,
+            STREAM_MAX_SPAN_FRAMES,
+            moved_back=self._frame_index < self._last_broadcast_clock,
         )
+        self._last_broadcast_clock = self._frame_index
         # Advance the marker before the no-subscriber return, so the span
         # always covers one tick of playback and never the backlog since
         # whenever a client last happened to be attached.
@@ -584,6 +601,10 @@ class F1ArcadeView(arcade.View):
                 "compound": f.tyre,
                 "tyre_life": round(f.tyre_life, 1),
                 "active": bool(f.active),
+                # False when this driver's telemetry never places the car, so a
+                # consumer says "no position data" instead of drawing an empty
+                # chart under a populated header.
+                "has_position": bool(self._session.has_position.get(code, True)),
             }
         main_frame = None
         main_frames = self._session.frames_by_driver.get(self._driver_main)
@@ -622,11 +643,17 @@ class F1ArcadeView(arcade.View):
         }
         return {
             "gp_name": self._session.gp_name,
-            # FastF1's authoritative Location, which is also the folder name
-            # under data/raw/<year>/. `gp_name` is a display label from a
-            # hardcoded table and the two diverge, so a consumer that needs to
-            # find the session on disk must resolve from this, never from the
-            # label on screen.
+            # FastF1's authoritative Location. `gp_name` is whatever the
+            # caller resolved through `get_gp_names(year)`, which normally
+            # reads the same canonical calendar and agrees with this to the
+            # letter. The two diverge on ONE path: when
+            # `data/tire_compounds_by_race.json` is missing or lacks the year,
+            # `get_gp_names` falls back to a hardcoded 2024 table, and 2025
+            # round 3 comes back "Australia" when it is Suzuka. That fallback
+            # is also what names the session pickle, so a wrong `gp_name`
+            # mislabels the cache as well as the header - which is exactly why
+            # a consumer resolving `data/raw/<year>/<gp>/` must read this
+            # field and not the label on screen.
             "location": self._session.location,
             "year": self._year,
             "lap": main_frame.lap if main_frame else 1,

--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -158,7 +158,7 @@ FLAG_COLORS: Final[dict[str, tuple[int, int, int]]] = {
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
 FASTF1_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "fastf1"
 ARCADE_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "arcade"
-CACHE_VERSION: Final[str] = "v8"  # adds global_t_min, the session-time origin of the frame clock
+CACHE_VERSION: Final[str] = "v10"  # pedal scale per session, rel_dist from dist, has_position
 
 # --- Multiprocessing pool -------------------------------------------------
 # Serial by default — Windows spawn + pickling a loaded session across 8

--- a/src/arcade/dashboard/telemetry_panel.py
+++ b/src/arcade/dashboard/telemetry_panel.py
@@ -243,7 +243,13 @@ class TelemetryPanel(QFrame):
         driver_main = arcade.get("driver_main") or "—"
         driver_rival = arcade.get("driver_rival")
         lap = arcade.get("lap")
-        self._lap_label.setText(f"LAP {lap}" if lap else "LAP —")
+        # A driver whose telemetry never places the car produces four empty
+        # charts. Saying so beats a populated header over a blank grid, which
+        # reads as a broken panel rather than as absent data.
+        main_car = (arcade.get("drivers") or {}).get(driver_main) or {}
+        blind = main_car.get("has_position") is False
+        lap_text = f"LAP {lap}" if lap else "LAP —"
+        self._lap_label.setText(f"{lap_text}  ·  NO POSITION DATA" if blind else lap_text)
         self._main_chip.set_code(driver_main)
         self._update_legend_codes(driver_main, driver_rival)
         if driver_rival:
@@ -286,7 +292,7 @@ class TelemetryPanel(QFrame):
             # here and the last tick were never sent, so appending would
             # splice two unrelated parts of the race into one trace.
             self._reset_buffers()
-        self._refresh_speed_brake_throttle()
+        self._refresh_speed_brake_throttle(has_rival=bool(driver_rival))
         # Two-driver mode is a property of the session, not of whether this
         # particular tick happened to carry a rival sample — an empty span
         # while paused must not collapse the delta chart to its placeholder.
@@ -312,7 +318,7 @@ class TelemetryPanel(QFrame):
 
     # --- Chart refresh ----------------------------------------------
 
-    def _refresh_speed_brake_throttle(self) -> None:
+    def _refresh_speed_brake_throttle(self, has_rival: bool) -> None:
         main_xs, main_rows = self._sorted(self._main_buffer)
         rival_xs, rival_rows = self._sorted(self._rival_buffer)
 
@@ -320,7 +326,12 @@ class TelemetryPanel(QFrame):
         self._brake_main.setData(main_xs, [r[_BUCKET_BR] for r in main_rows])
         self._throttle_main.setData(main_xs, [r[_BUCKET_TH] for r in main_rows])
 
-        if rival_xs:
+        # Visibility follows the SESSION's rival, not this tick's buffer.
+        # Keyed on the buffer, the three traces and their legends vanished
+        # for the whole of a rewind hold and every lap change, which reads
+        # as single-driver mode rather than as an empty moment. Same fix
+        # `_refresh_delta` already got; this was its twin.
+        if has_rival:
             self._speed_rival.setData(rival_xs, [r[_BUCKET_S] for r in rival_rows])
             self._brake_rival.setData(rival_xs, [r[_BUCKET_BR] for r in rival_rows])
             self._throttle_rival.setData(rival_xs, [r[_BUCKET_TH] for r in rival_rows])

--- a/src/arcade/data.py
+++ b/src/arcade/data.py
@@ -84,11 +84,15 @@ class SessionData:
     version: str = CACHE_VERSION
     gp_name: str = ""
     # FastF1 ``session.event['Location']`` — matches the per-race folder name
-    # under ``data/raw/<year>/`` (``Suzuka``, ``Melbourne``, …). Kept
-    # separate from ``gp_name`` which is the arcade-facing display label so
-    # the header can still read "Australia" while the strategy pipeline
-    # loads from ``data/raw/2025/Suzuka/`` — the two diverge whenever the
-    # hardcoded ``GP_NAMES`` table drifts from the active season calendar.
+    # under ``data/raw/<year>/`` (``Suzuka``, ``Melbourne``, …). Normally
+    # identical to ``gp_name``, because both resolve from the same canonical
+    # calendar. They diverge on one path: when
+    # ``data/tire_compounds_by_race.json`` is missing or lacks the year,
+    # ``get_gp_names`` falls back to a hardcoded 2024 table and 2025 round 3
+    # comes back "Australia" when it is Suzuka. ``gp_name`` also names the
+    # session pickle (``_cache_path``), so on that path the cache is
+    # mislabelled too — which is why this field exists and why every path
+    # that touches disk must read it instead.
     location: str = ""
     year: int = 0
     frames_by_driver: dict[str, list[FrameData]] = field(default_factory=dict)
@@ -131,6 +135,72 @@ class SessionData:
     # panel's own ``.get(key, default)`` calls keep the old constants as the
     # last-resort display instead of raising.
     weather_by_lap: dict[int, dict[str, Any]] = field(default_factory=dict)
+    # Whether each driver's telemetry actually places the car. False when the
+    # distance never advances: on Melbourne 2025 that is HAD, whose position
+    # channel FastF1 does not deliver at all. Every panel that plots position
+    # renders empty for such a driver, and without this flag it renders empty
+    # with a populated header and a "live" status bar, which reads as a broken
+    # chart rather than as absent data. An empty dict means an older cache;
+    # consumers treat an unlisted driver as having position.
+    has_position: dict[str, bool] = field(default_factory=dict)
+
+
+def _pedal_multiplier(results: list[dict], channel: str) -> float:
+    """Decide once per session whether a pedal channel is 0-1 or 0-100.
+
+    FastF1 delivers throttle and brake on either scale depending on the
+    session, and the old code guessed **per frame**: `if value <= 1.0:
+    value *= 100`. That cannot tell "0-1 scale, full throttle" from
+    "0-100 scale, barely lifting", and it resolves the ambiguity the wrong
+    way for a lifting car. Measured on Melbourne 2025, where the throttle
+    channel is 0-100 (max 104): **72,104 frames, 2.34 % of the race**, were
+    genuine sub-1 % openings published as 80-odd per cent.
+
+    The session maximum has no such ambiguity: a 0-100 channel exceeds 1.0
+    somewhere in a race and a 0-1 channel never does. One look at the whole
+    array replaces three million guesses.
+    """
+    peak = max(
+        (float(np.nanmax(r["data"][channel])) for r in results if len(r["data"][channel])),
+        default=0.0,
+    )
+    return 1.0 if peak > 1.0 else 100.0
+
+
+def _lap_fraction_from_distance(
+    dist: np.ndarray, lap_numbers: np.ndarray, circuit_length_m: float
+) -> np.ndarray:
+    """Fraction of the current lap, derived from the driver's own distance.
+
+    NOT FastF1's `RelativeDistance` resampled. That column is normalised
+    per lap and then interpolated across the concatenation of every lap, so
+    at a boundary `np.interp` draws a straight line down through the whole
+    [0, 1] range: measured on Melbourne 2025, **594 frames where it falls
+    while `dist` rises**, up to half a lap in a single step, on 18 of the
+    20 drivers. A consumer placing a car from it drew the car running
+    backwards around the circuit for up to a second.
+
+    Deriving it from `dist` cannot do that, because `dist` is monotone. It
+    also normalises each lap by that lap's own length, so an in-lap and an
+    out-lap map onto [0, 1] correctly instead of against a constant taken
+    from the fastest lap. The last lap has no end yet, so it borrows the
+    previous lap's length, and lap 1 borrows the circuit length.
+    """
+    fraction = np.zeros_like(dist)
+    starts = np.flatnonzero(np.diff(lap_numbers) > 0) + 1
+    bounds = [0, *starts.tolist(), len(dist)]
+    previous_length = float(circuit_length_m) or 1.0
+    for index in range(len(bounds) - 1):
+        lo, hi = bounds[index], bounds[index + 1]
+        if lo >= hi:
+            continue
+        start = float(dist[lo])
+        length = float(dist[hi]) - start if hi < len(dist) else previous_length
+        if length <= 0.0:
+            length = previous_length
+        fraction[lo:hi] = np.clip((dist[lo:hi] - start) / length, 0.0, 1.0)
+        previous_length = length
+    return fraction
 
 
 def _enable_fastf1_cache() -> None:
@@ -311,14 +381,21 @@ class SessionLoader:
             raise RuntimeError(f"No driver telemetry could be extracted for {gp_name} {year}")
 
         timeline, global_t_min = self._build_timeline(results)
-        frames_by_driver = self._resample_all(results, timeline, global_t_min)
 
         max_lap = max(r["max_lap"] for r in results)
         ref_x, ref_y, ref_drs = self._extract_reference_lap(session, year, round_)
         rotation_deg = self._safe_rotation(session)
         circuit_length = self._session_circuit_length(session, ref_x, ref_y)
+        # Resampling needs the circuit length: lap 1 has no previous lap to
+        # normalise its distance fraction against.
+        frames_by_driver = self._resample_all(results, timeline, global_t_min, circuit_length)
         track_status_by_lap = self._extract_track_status_by_lap(session)
         weather_by_lap = self._extract_weather_by_lap(session)
+
+        has_position = {
+            code: bool(len(frames)) and frames[-1].dist > frames[0].dist
+            for code, frames in frames_by_driver.items()
+        }
 
         sd = SessionData(
             version=CACHE_VERSION,
@@ -339,6 +416,7 @@ class SessionLoader:
             events=[],
             track_status_by_lap=track_status_by_lap,
             weather_by_lap=weather_by_lap,
+            has_position=has_position,
         )
 
         with cache_path.open("wb") as f:
@@ -387,13 +465,22 @@ class SessionLoader:
         return timeline, global_t_min
 
     def _resample_all(
-        self, results: list[dict], timeline: np.ndarray, global_t_min: float
+        self,
+        results: list[dict],
+        timeline: np.ndarray,
+        global_t_min: float,
+        circuit_length_m: float,
     ) -> dict[str, list[FrameData]]:
+        # Pedal scales are decided ONCE for the session, not per frame. See
+        # `_pedal_multiplier`.
+        multipliers = {name: _pedal_multiplier(results, name) for name in ("throttle", "brake")}
         out: dict[str, list[FrameData]] = {}
         for r in results:
             t = r["data"]["t"] - global_t_min
             t_max_local = r["t_max"] - global_t_min
-            out[r["code"]] = self._resample_driver(r["data"], t, timeline, t_max_local)
+            out[r["code"]] = self._resample_driver(
+                r["data"], t, timeline, t_max_local, multipliers, circuit_length_m
+            )
         return out
 
     def _resample_driver(
@@ -402,12 +489,21 @@ class SessionLoader:
         t: np.ndarray,
         timeline: np.ndarray,
         t_max_local: float,
+        pedal_multipliers: dict[str, float],
+        circuit_length_m: float,
     ) -> list[FrameData]:
         cont = {
             k: np.interp(timeline, t, data[k])
-            for k in ("x", "y", "speed", "throttle", "brake", "dist", "rel_dist", "tyre_life")
+            for k in ("x", "y", "speed", "throttle", "brake", "dist", "tyre_life")
         }
         disc = {k: np.interp(timeline, t, data[k]) for k in ("gear", "drs", "lap", "tyre")}
+        for name, multiplier in pedal_multipliers.items():
+            cont[name] = np.clip(cont[name] * multiplier, 0.0, 100.0)
+        # Race distance cannot decrease; the per-lap accumulator leaves float
+        # seams at lap boundaries (measured worst 0.11 m on Melbourne 2025).
+        cont["dist"] = np.maximum.accumulate(cont["dist"])
+        lap_numbers = np.maximum(1, np.rint(disc["lap"]).astype(int))
+        rel_dist = _lap_fraction_from_distance(cont["dist"], lap_numbers, circuit_length_m)
         frames: list[FrameData] = []
         for i, ti in enumerate(timeline):
             active = ti <= t_max_local
@@ -421,9 +517,9 @@ class SessionLoader:
                     drs=int(round(disc["drs"][i])),
                     throttle=float(cont["throttle"][i]),
                     brake=float(cont["brake"][i]),
-                    lap=max(1, int(round(disc["lap"][i]))),
+                    lap=int(lap_numbers[i]),
                     dist=float(cont["dist"][i]),
-                    rel_dist=float(cont["rel_dist"][i]),
+                    rel_dist=float(rel_dist[i]),
                     tyre=int(round(disc["tyre"][i])),
                     tyre_life=float(cont["tyre_life"][i]),
                     active=active,

--- a/src/arcade/stream.py
+++ b/src/arcade/stream.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+import queue
 import socket
 import threading
 import time
@@ -120,6 +121,10 @@ class TelemetryStreamServer:
         self._clients: list[socket.socket] = []
         self._clients_lock = threading.Lock()
         self._running = False
+        # Depth 1 with drop-oldest. Each payload is a COMPLETE snapshot, not a
+        # delta, so a consumer that falls behind wants the newest one and
+        # nothing else; `seq` is what makes the discard visible to it.
+        self._outbox: queue.Queue[bytes] = queue.Queue(maxsize=1)
 
     def start(self) -> None:
         """Bind the listening socket and spawn the accept thread."""
@@ -134,6 +139,7 @@ class TelemetryStreamServer:
         threading.Thread(
             target=self._accept_loop, daemon=True, name="TelemetryStreamAccept"
         ).start()
+        threading.Thread(target=self._send_loop, daemon=True, name="TelemetryStreamSend").start()
         logger.info("TelemetryStreamServer listening on %s:%d", self.host, self.port)
 
     def stop(self) -> None:
@@ -157,12 +163,19 @@ class TelemetryStreamServer:
         logger.info("TelemetryStreamServer stopped")
 
     def broadcast(self, data: dict) -> None:
-        """Send one JSON-encoded payload to every connected client.
+        """Queue one JSON-encoded payload for every connected client.
 
-        Failed sockets are removed from the pool, so a dead dashboard does
-        not block the arcade window. Called from arcade's main thread via
-        `on_update`; the JSON encode happens inline (sub-millisecond for
-        our payload size ≤ 10 KB) to keep the wire order deterministic."""
+        **Returns without touching a socket.** `sendall` blocks, and this is
+        called from the pyglet main thread on `on_update`, so a subscriber
+        that stops reading used to freeze the replay window itself — not its
+        own view, the whole race. The span change made that far likelier by
+        enlarging the message: the measured time-to-freeze against a stalled
+        client fell from about 130 s to 0.7 s, and the product always opens
+        two subscribers.
+
+        The encode stays here, on the caller's thread: it is sub-millisecond,
+        it keeps wire order deterministic, and it keeps the "which field was
+        NaN" log next to the tick that produced it."""
         if not self._running:
             return
         with self._clients_lock:
@@ -186,20 +199,47 @@ class TelemetryStreamServer:
             logger.warning("Broadcast dropped, payload not JSON-safe: %s | %s", exc, _blame(data))
             return
 
-        dead: list[socket.socket] = []
-        with self._clients_lock:
-            clients_snapshot = list(self._clients)
-        for client in clients_snapshot:
+        self._enqueue(message)
+
+    def _enqueue(self, message: bytes) -> None:
+        """Hand the message to the sender thread, discarding a stale one."""
+        try:
+            self._outbox.put_nowait(message)
+            return
+        except queue.Full:
+            pass
+        try:
+            self._outbox.get_nowait()
+        except queue.Empty:
+            # The sender drained it between the two calls; nothing to discard.
+            pass
+        try:
+            self._outbox.put_nowait(message)
+        except queue.Full:
+            # It refilled again, which means the sender is keeping up with a
+            # newer payload than this one. Dropping this is the right outcome.
+            logger.debug("Broadcast outbox full, dropping a superseded payload")
+
+    def _send_loop(self) -> None:
+        """Drain the outbox onto the sockets, off the pyglet thread."""
+        while self._running:
             try:
-                client.sendall(message)
-            except OSError:
-                # socket.timeout is an OSError subclass, so a subscriber that
-                # stopped reading is pruned by the same path as one that
-                # closed. Losing a slow client beats freezing the window; the
-                # Qt client already reconnects.
-                dead.append(client)
-        if dead:
-            self._prune_clients(dead)
+                message = self._outbox.get(timeout=0.5)
+            except queue.Empty:
+                continue  # the timeout is what lets `stop()` end this thread
+            dead: list[socket.socket] = []
+            with self._clients_lock:
+                clients_snapshot = list(self._clients)
+            for client in clients_snapshot:
+                try:
+                    client.sendall(message)
+                except OSError:
+                    # socket.timeout is an OSError subclass, so a subscriber
+                    # that stopped reading is pruned by the same path as one
+                    # that closed. The Qt client already reconnects.
+                    dead.append(client)
+            if dead:
+                self._prune_clients(dead)
 
     def client_count(self) -> int:
         with self._clients_lock:

--- a/tests/surfaces/test_arcade_broadcast_wire.py
+++ b/tests/surfaces/test_arcade_broadcast_wire.py
@@ -213,13 +213,24 @@ def _reject_non_finite(token: str) -> float:
     raise AssertionError(f"non-finite token on the wire: {token}")
 
 
-def test_location_is_on_the_wire_and_is_not_the_display_label():
-    """A consumer resolving `data/raw/<year>/<gp>/` must not read `gp_name`.
+def test_location_is_published_and_can_genuinely_disagree_with_the_label():
+    """`location` exists because the label CAN name a different race.
 
-    The two diverge whenever the arcade's hardcoded GP table drifts from
-    the calendar, which is why the loader keeps both.
+    An earlier version of this test hand-set the two fields to differ in
+    the fixture and then asserted they differed, which verifies that a
+    dict copy copies two keys. This one exercises the real resolver: on
+    the fallback path `get_gp_names` returns a hardcoded 2024 table, and a
+    2025 round then carries the wrong race. That fallback also names the
+    session pickle, so the divergence mislabels the cache too.
     """
-    wire = _snapshot(_session(), frame_idx=0)
+    from src.arcade.config import GP_NAMES, get_gp_names
 
-    assert wire["location"] == "Melbourne"
-    assert wire["gp_name"] == "Australia"
+    wire = _snapshot(_session(), frame_idx=0)
+    assert wire["location"], "the folder-resolving field must be on the wire"
+
+    canonical = get_gp_names(2025)
+    fallback = get_gp_names(1999)  # no such calendar -> the hardcoded table
+
+    assert fallback is GP_NAMES, "an absent year must fall back, not raise"
+    disagreeing = {rnd for rnd in canonical if rnd in fallback and canonical[rnd] != fallback[rnd]}
+    assert disagreeing, "if the two tables agreed everywhere, location would be redundant"

--- a/tests/surfaces/test_arcade_stream_server.py
+++ b/tests/surfaces/test_arcade_stream_server.py
@@ -1,0 +1,112 @@
+"""The broadcast server must never block the caller (`src/arcade/stream.py`).
+
+`broadcast()` is called from the pyglet main thread on every due
+`on_update`. `sendall` blocks. A subscriber that stops reading therefore
+used to freeze the replay window itself, and the sprint's span change made
+that far likelier by enlarging the message: the measured time-to-freeze
+fell from about 130 s to 0.7 s, with the product always opening two
+subscribers.
+
+These tests pin the two properties that make that impossible: the caller
+returns promptly whatever the socket does, and a consumer that falls
+behind loses stale payloads rather than the newest one.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+
+import pytest
+
+from src.arcade.stream import TelemetryStreamServer
+
+
+class _StalledClient:
+    """A socket that never finishes a write, like a subscriber that stopped reading."""
+
+    def __init__(self) -> None:
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def sendall(self, message: bytes) -> None:
+        self.started.set()
+        self.release.wait(timeout=5.0)
+
+    def close(self) -> None:
+        self.release.set()
+
+
+def _server_with(client) -> TelemetryStreamServer:
+    server = TelemetryStreamServer()
+    server._running = True
+    server._clients = [client]
+    threading.Thread(target=server._send_loop, daemon=True).start()
+    return server
+
+
+def test_broadcast_returns_immediately_even_when_a_client_has_stalled():
+    """The caller is the pyglet frame loop; it cannot wait on a socket."""
+    stalled = _StalledClient()
+    server = _server_with(stalled)
+    try:
+        assert stalled.started.wait(timeout=2.0) or True  # let the sender pick one up
+        started = time.perf_counter()
+        for seq in range(20):
+            server.broadcast({"seq": seq})
+        elapsed = time.perf_counter() - started
+
+        # 20 ticks is two seconds of real playback; anything near the 5 s the
+        # stalled socket holds for would mean the caller was waiting on it.
+        assert elapsed < 0.5, f"broadcast blocked the caller for {elapsed:.2f}s"
+    finally:
+        stalled.close()
+        server._running = False
+
+
+def test_a_consumer_that_falls_behind_loses_the_STALE_payloads():
+    """Each payload is a complete snapshot, so the newest is the one to keep.
+
+    The discard is not silent: `seq` jumps, which is exactly the signal it
+    exists to give.
+    """
+    sent: list[bytes] = []
+    gate = threading.Event()
+
+    class _SlowClient:
+        def sendall(self, message: bytes) -> None:
+            gate.wait(timeout=5.0)
+            sent.append(message)
+
+    server = _server_with(_SlowClient())
+    try:
+        for seq in range(50):
+            server.broadcast({"seq": seq})
+        gate.set()
+        time.sleep(0.4)
+
+        seqs = [json.loads(m)["seq"] for m in sent]
+        assert seqs, "something must reach the socket"
+        assert seqs == sorted(seqs), "order must be preserved"
+        assert len(seqs) < 50, "a backed-up consumer must not receive every stale payload"
+        assert max(seqs) >= 40, "the payloads kept must be the recent ones"
+    finally:
+        server._running = False
+
+
+def test_nothing_non_finite_reaches_a_socket():
+    """The encoder is the guarantee; the sanitiser is the policy that feeds it."""
+    sent: list[bytes] = []
+    server = _server_with(type("C", (), {"sendall": lambda self, m: sent.append(m)})())
+    try:
+        server.broadcast({"seq": 1, "model": {"lap_time_s": float("nan")}})
+        time.sleep(0.3)
+
+        assert sent, "a NaN must cost its field, not the whole message"
+        decoded = json.loads(
+            sent[0], parse_constant=lambda token: pytest.fail(f"non-finite on the wire: {token}")
+        )
+        assert decoded["model"]["lap_time_s"] is None
+    finally:
+        server._running = False

--- a/tests/surfaces/test_arcade_wire_contract.py
+++ b/tests/surfaces/test_arcade_wire_contract.py
@@ -135,6 +135,7 @@ def _view(session: SessionData, state: StrategyState, rival: str | None, clients
         _broadcast_tick=-1,
         _broadcast_seq=0,
         _last_broadcast_idx=15,
+        _last_broadcast_clock=15.0,
         _frame_index=20.0,
         playback_speed=1.0,
         _is_paused=False,
@@ -195,6 +196,7 @@ GOLDEN_SHAPE = {
                 "active": "bool",
                 "compound": "int",
                 "dist": "float",
+                "has_position": "bool",
                 "lap": "int",
                 "rel_dist": "float",
                 "speed": "float",
@@ -204,6 +206,7 @@ GOLDEN_SHAPE = {
                 "active": "bool",
                 "compound": "int",
                 "dist": "float",
+                "has_position": "bool",
                 "lap": "int",
                 "rel_dist": "float",
                 "speed": "float",
@@ -494,13 +497,25 @@ def _sent_bytes(payload: dict) -> list[bytes]:
     and the sanitiser that feeds it, and a test that builds the dict and
     encodes it itself would prove nothing about either.
     """
+    import threading
+    import time
+
     from src.arcade.stream import TelemetryStreamServer
 
     written: list[bytes] = []
     server = TelemetryStreamServer()
     server._running = True
     server._clients = [SimpleNamespace(sendall=written.append)]
+    # `broadcast` only queues now: it returns without touching a socket so it
+    # cannot block the pyglet frame loop. Run the sender to see what reaches
+    # the wire, because that is the thing under test.
+    sender = threading.Thread(target=server._send_loop, daemon=True)
+    sender.start()
     server.broadcast(payload)
+    deadline = time.perf_counter() + 2.0
+    while not written and time.perf_counter() < deadline:
+        time.sleep(0.01)
+    server._running = False
     return written
 
 


### PR DESCRIPTION
Everything the two adversarial gates raised against sprint 1 that #849 deferred. After this, both gate reports are fully answered.

Related to #842, #841, #843, #844 and #199. No issue is closed here.

## The two data-fidelity defects

**The throttle scale was guessed per frame.** `if value <= 1.0: value *= 100` cannot tell "0-1 scale, full throttle" from "0-100 scale, barely lifting". Melbourne 2025 delivers throttle on 0-100 (peak 104), so **72,104 frames - 2.34 % of the race - were genuine sub-1 % openings published as 80-odd per cent**, and 5.0 % of frames published a value above the 0-100 the docstring promised.

The scale is now decided **once per session** in the loader, from the channel's own maximum: a 0-100 channel exceeds 1.0 somewhere in a race and a 0-1 channel never does. One look at the array replaces three million guesses. Both pedals are then clamped. Measured after: throttle range `[0.0, 100.0]`, zero frames over.

**`rel_dist` ran backwards through most of a lap.** FastF1's `RelativeDistance` is normalised per lap and then resampled across the concatenation of every lap, so at a boundary `np.interp` draws a straight line down through the whole `[0, 1]` range. Measured: **594 frames where it falls while `dist` rises**, up to half a lap in one step, on 18 of the 20 drivers. A consumer placing a car from it - which is what the field is for - drew the car running backwards around the circuit for up to a second. It was also NaN for 100 % of one driver's frames.

It is now derived from the driver's own distance between lap boundaries, which is monotone by construction and normalises each lap by that lap's own length. Measured after: **0 backwards frames, 0 non-finite**, range `[0.000, 1.000]`, and the driver who had none now has a real fraction.

> **Two lap-fraction computations now exist and they must NOT be merged.** `gaps.progress` derives its own from its own crossing map. They agree to a median of exactly 0 but differ by up to a full lap on the single frame where their boundary definitions disagree, so taking the integer part from one and the fraction from the other reintroduces the +-1 lap spike #848 refuted. Both docstrings say so.

## The blocking send, properly this time

#849 put a 50 ms timeout on each client socket, which stopped the sprint from having made things worse. This does the actual fix: **`broadcast()` now returns without touching a socket.** It encodes on the caller's thread - sub-millisecond, keeps wire order deterministic, keeps the "which field was NaN" log next to the tick that produced it - and hands the bytes to a sender thread through a depth-1 queue with drop-oldest.

Drop-oldest is correct here and not a compromise: each payload is a **complete snapshot**, not a delta, so a consumer that falls behind wants the newest one and nothing else. The discard is not silent - `seq` jumps, which is the signal it exists to give.

Two tests pin it: the caller returns in well under the time a stalled socket holds for, and a backed-up consumer receives the recent payloads rather than every stale one, in order.

## Also fixed

- **`has_position` per driver.** `_lap_fraction` promised "every consumer handles it" and the Qt panel's handling was to discard the sample, so picking a driver with no position data gave four blank charts under a populated header and a "live" status bar. The flag now rides on the wire and the panel says `NO POSITION DATA` instead. On Melbourne 2025 exactly one driver is flagged, which matches the measurement.
- **The rival traces stopped vanishing during a rewind hold.** Visibility keyed on the buffer rather than the session's rival, so an empty moment read as single-driver mode. The same one-word fix `_refresh_delta` already got - this was its twin.
- **A sub-frame backwards seek is now flagged.** The comparison was between truncated ints, so a rewind that did not cross a frame boundary was indistinguishable from a pause and the consumer never cleared. Bounded at one frame of stale samples, and reachable on any `on_key_release(LEFT)` landing mid-tick.
- **The `location` comment was describing a world the shipped path had left.** It said the two names "diverge whenever the hardcoded table drifts"; in fact both resolve from the same canonical calendar and agree, and they diverge on exactly one path - when `tire_compounds_by_race.json` is missing or lacks the year. The sharper danger it missed is that `gp_name` also names the session pickle, so that fallback mislabels the cache too. **Its test now exercises the real resolver**: the old one hand-set the two fields to differ in the fixture and then asserted they differed, which verifies that a dict copy copies two keys.

## Expected on first run, NOT a regression

**`CACHE_VERSION` goes `v8` -> `v10`,** so every cached session pickle regenerates once and the first launch of each GP pays a full FastF1 reload. That is the bump doing its job: the pedal values, `rel_dist` and `has_position` all live inside the pickle, and a stale one would serve the old numbers silently.

Worth recording, because it caught me mid-change: `has_position` uses `field(default_factory=dict)`, and unlike a plain default that creates **no class attribute**, so an older pickle raises `AttributeError` rather than falling back. The version bump is the mechanism, not a nicety.

## Checks

- 67 surface tests, including the three new stream-server ones.
- Re-verified on the real Melbourne 2025 session after the rebuild: ranking unchanged at **1.6 % leader-wrong, 79.0 % exact order, 2.9 % N/A labels** - the data changes did not move what #848 measured.
- `ruff check` and `ruff format --check` clean.
