### PR TITLE
fix(arcade): make the dev rig publish the per_agent keys the agents actually emit

### DIFF
--- a/documents/dev_docs/migration/pitwall/README.md
+++ b/documents/dev_docs/migration/pitwall/README.md
@@ -43,11 +43,17 @@ locked to the circuit length. Status bar reads `lap 24 · live`.
 
 ## Read these with three caveats
 
-1. **The agent-card numbers are placeholders.** The producer that fed these
-   builds `PerAgentOutputsDTO` with plausible-looking keys that do not all
-   match what the cards read, so PACE shows `+0.000s` and TIRE shows
-   `deg — s/lap`. The **layout, the states and the copy are real**; the
-   figures in those two cards are not. Everything in the left column is real.
+1. **The agent-card numbers in `legacy-qt-strategy.png` are placeholders, and
+   that was a defect in the rig, not a property of the window.** The producer
+   that fed this capture built `PerAgentOutputsDTO` with plausible-looking
+   keys that did not match what the cards read, so PACE shows `+0.000s`,
+   TIRE shows `deg — s/lap`, SITUATION shows `safety car 0%`, and PIT and RAG
+   sit on their trigger hints because `active` carried block names instead of
+   the `N28` / `N30` routing tokens. **Fixed in #853**: re-running
+   `scripts/dev_pitwall_producer.py` today populates all six cards, so a fresh
+   capture will legitimately differ from this one. The **layout, the states
+   and the copy** in this image are real; the figures in those cards are not.
+   Everything in the left column is real.
 2. **The windows were resized before capture.** At their default geometry the
    right column is clipped mid-card and the reasoning tabs get about 268 px,
    which is why the `why this call changed` block normally falls below the

--- a/scripts/dev_pitwall_producer.py
+++ b/scripts/dev_pitwall_producer.py
@@ -63,19 +63,99 @@ def decision(lap: int, action: str, confidence: float) -> LapDecisionDTO:
         agent_alerts=["tyre cliff in 2 laps", "DRS window opens on the main straight"],
         guardrail_reason="none",
         per_agent=PerAgentOutputsDTO(
-            pace={"predicted_lap_time_s": 81.0, "actual_lap_time_s": 81.3, "delta_s": 0.3},
-            tire={"degradation_pct": 62.0, "cliff_lap": lap + 2, "ci_low": 55.0, "ci_high": 68.0},
-            situation={"threat_level": "MEDIUM", "overtake_prob": 0.34, "sc_prob": 0.08},
-            radio={"sentiment": "negative", "intent": "GRIP_COMPLAINT", "confidence": 0.81},
-            pit={"pit_duration_s": 22.4, "p10": 21.1, "p90": 24.8},
+            # Every key below is a real field of the agent's own output
+            # dataclass, and `active` carries the real routing tokens. An
+            # earlier version invented plausible names ("predicted_lap_time_s",
+            # "degradation_pct", "sc_prob") and lower-cased the routing list,
+            # so the tool built to stop the cards being idle rendered
+            # "Dnext +0.000s", "deg - s/lap", "safety car 0%" and left both
+            # conditional cards on their trigger hint. See #853.
+            pace={
+                "lap_time_pred": 81.0 + (lap % 5) * 0.11,
+                "delta_vs_prev": -0.204,
+                "delta_vs_median": 0.118,
+                "ci_p10": 80.45,
+                "ci_p90": 81.55,
+                "reasoning": (
+                    "Pace is holding inside the predicted envelope; the last three laps "
+                    "sit within 0.1 s of the stint median."
+                ),
+            },
+            tire={
+                "compound": "MEDIUM",
+                "current_tyre_life": lap - 8,
+                "deg_rate": 0.031,
+                "laps_to_cliff_p10": 4.0,
+                "laps_to_cliff_p50": 6.0,
+                "laps_to_cliff_p90": 9.0,
+                "cumulative_deg_s": 0.42,
+                "deg_cost_s": 0.18,
+                "warning_level": "MONITOR",
+                "reasoning": "Degradation is inside the envelope but the cliff is six laps out.",
+            },
+            situation={
+                "overtake_prob": 0.34,
+                "sc_prob_3lap": 0.08,
+                "threat_level": "MEDIUM",
+                "gap_ahead_s": 1.42,
+                "pace_delta_s": -0.12,
+                "sc_currently_active": False,
+                "vsc_active": False,
+                "reasoning": "DRS threat building: the gap to PIA has closed for three laps.",
+            },
+            radio={
+                "radio_events": [
+                    {
+                        "driver": "NOR",
+                        "message": "Rear grip is going away, especially through the last sector.",
+                        "analysis": {"intent": "PROBLEM", "sentiment": "negative"},
+                    }
+                ],
+                "rcm_events": [
+                    {
+                        "lap": lap,
+                        "flag": "YELLOW",
+                        "event_type": "YELLOW_FLAG_SECTOR",
+                        "message": "Yellow flag in sector 2 - debris on the racing line.",
+                    }
+                ],
+                "alerts": [{"intent": "PROBLEM", "driver": "NOR"}],
+                "corrections": [],
+                "reasoning": "The driver reports rear grip fading; sector 2 is under yellow.",
+            },
+            pit={
+                "action": "PIT_NOW",
+                "recommended_lap": lap + 1,
+                "compound_recommendation": "HARD",
+                "stop_duration_p05": 21.14,
+                "stop_duration_p50": 22.40,
+                "stop_duration_p95": 24.81,
+                "undercut_prob": 0.63,
+                "undercut_target": "RUS",
+                "sc_reactive": False,
+                "reasoning": "The undercut window against RUS is open for two more laps.",
+            },
             regulation_context="Art. 55.7 - drivers must respect the delta under Safety Car",
             rag={
                 "question": "Does a Safety Car change the mandatory compound rule?",
                 "answer": "No. Art. 30.5(m) still requires two specifications in a dry race.",
-                "articles": ["30.5(m)", "55.7"],
-                "chunks": ["...at least two specifications of dry-weather tyre..."],
+                "articles": ["Article 30.5(m)", "Article 55.7"],
+                "chunks": [
+                    {
+                        "article": "Article 30.5(m)",
+                        "doc_type": "Sporting Regulations",
+                        "year": 2025,
+                        "text": (
+                            "...each driver must use at least two specifications of "
+                            "dry-weather tyre during the race..."
+                        ),
+                    }
+                ],
             },
-            active=["pace", "tire", "situation", "pit"],
+            # The routing layer emits agent IDs, not block names
+            # (`_decide_agents_to_call` in strategy_orchestrator.py), and the
+            # cards gate on exactly these two tokens.
+            active=["N28", "N30"],
         ),
         memory_block=f"lap {lap - 1}: STAY_OUT (0.58) - undercut window not yet open",
         plan_changed=True,

--- a/tests/surfaces/test_arcade_wire_contract.py
+++ b/tests/surfaces/test_arcade_wire_contract.py
@@ -19,8 +19,10 @@ the most fields and is the one the PITWALL agents window reads one by one.
 
 from __future__ import annotations
 
+import ast
 import json
 from functools import partial
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -38,6 +40,7 @@ from src.arcade.strategy import (  # noqa: E402
 )
 
 CIRCUIT_LENGTH_M = 5278.0
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _shape(value):
@@ -101,15 +104,36 @@ def _decision() -> LapDecisionDTO:
         undercut_target="RUS",
         agent_alerts=["tyre cliff in 2 laps"],
         guardrail_reason="none",
+        # Real field names, taken from the agents' own output dataclasses and
+        # guarded by `test_the_per_agent_fixture_uses_the_producers_real_field_names`.
+        # An invented set used to live here and agreed with the dev producer's
+        # invented set, so this file was green while pinning a contract no
+        # producer emits, and every consumer built against it rendered blanks
+        # (#853).
         per_agent=PerAgentOutputsDTO(
-            pace={"predicted_lap_time_s": 81.0},
-            tire={"degradation_pct": 12.0},
-            situation={"threat_level": "MEDIUM"},
-            radio={"sentiment": "negative"},
-            pit={"pit_duration_s": 22.4},
+            pace={"lap_time_pred": 81.0, "delta_vs_prev": -0.2},
+            tire={"compound": "MEDIUM", "laps_to_cliff_p50": 6.0, "warning_level": "MONITOR"},
+            situation={"threat_level": "MEDIUM", "sc_prob_3lap": 0.08},
+            radio={
+                # Populated, not empty: `_shape` describes a list by its first
+                # element, so empty lists would pin nothing about what the
+                # radio card reads out of these entries.
+                "radio_events": [
+                    {
+                        "driver": "NOR",
+                        "message": "rear grip going away",
+                        "analysis": {"intent": "PROBLEM", "sentiment": "negative"},
+                    }
+                ],
+                "rcm_events": [
+                    {"lap": 12, "flag": "YELLOW", "event_type": "YELLOW_FLAG", "message": "debris"}
+                ],
+                "alerts": [{"driver": "NOR", "intent": "PROBLEM"}],
+            },
+            pit={"stop_duration_p50": 22.4, "compound_recommendation": "HARD"},
             regulation_context="Art. 55.7",
             rag={"question": "q", "answer": "a", "articles": ["55.7"], "chunks": ["c"]},
-            active=["pace", "tire"],
+            active=["N28", "N30"],
         ),
         memory_block="lap 11: STAY_OUT",
         plan_changed=True,
@@ -295,9 +319,21 @@ GOLDEN_SHAPE = {
             "pace_mode": "str",
             "per_agent": {
                 "active": ["str"],
-                "pace": {"predicted_lap_time_s": "float"},
-                "pit": {"pit_duration_s": "float"},
-                "radio": {"sentiment": "str"},
+                "pace": {"delta_vs_prev": "float", "lap_time_pred": "float"},
+                "pit": {"compound_recommendation": "str", "stop_duration_p50": "float"},
+                "radio": {
+                    "alerts": [{"driver": "str", "intent": "str"}],
+                    "radio_events": [
+                        {
+                            "analysis": {"intent": "str", "sentiment": "str"},
+                            "driver": "str",
+                            "message": "str",
+                        }
+                    ],
+                    "rcm_events": [
+                        {"event_type": "str", "flag": "str", "lap": "int", "message": "str"}
+                    ],
+                },
                 "rag": {
                     "answer": "str",
                     "articles": ["str"],
@@ -305,8 +341,12 @@ GOLDEN_SHAPE = {
                     "question": "str",
                 },
                 "regulation_context": "str",
-                "situation": {"threat_level": "str"},
-                "tire": {"degradation_pct": "float"},
+                "situation": {"sc_prob_3lap": "float", "threat_level": "str"},
+                "tire": {
+                    "compound": "str",
+                    "laps_to_cliff_p50": "float",
+                    "warning_level": "str",
+                },
             },
             "pit_lap_target": "int",
             "plan_changed": "bool",
@@ -421,6 +461,77 @@ def test_the_states_that_make_a_field_null_are_frozen_too():
 
 def test_the_payload_carries_the_schema_version():
     assert _payload()["schema_version"] == STREAM_SCHEMA_VERSION
+
+
+# --- the per_agent contract, against the producer rather than against itself -
+
+
+# Which dataclass in `src/agents/` fills each `per_agent` block. `rag` is
+# absent on purpose: the engine assembles it as a plain dict rather than
+# dumping `RegulationContext`, and the golden already pins its four keys.
+_PER_AGENT_SOURCES: dict[str, tuple[str, str]] = {
+    "pace": ("src/agents/pace_agent.py", "PaceOutput"),
+    "tire": ("src/agents/tire_agent.py", "TireOutput"),
+    "situation": ("src/agents/race_situation_agent.py", "RaceSituationOutput"),
+    "radio": ("src/agents/radio_agent.py", "RadioOutput"),
+    "pit": ("src/agents/pit_strategy_agent.py", "PitStrategyOutput"),
+}
+
+
+def _dataclass_field_names(relative_path: str, class_name: str) -> set[str]:
+    """Annotated attribute names of one dataclass, read from its source.
+
+    Parsed with `ast` rather than imported: importing `src/agents/` pulls
+    torch, xgboost and three transformer checkpoints, which is minutes of
+    CI for a list of strings.
+    """
+    tree = ast.parse((REPO_ROOT / relative_path).read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return {
+                stmt.target.id
+                for stmt in node.body
+                if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name)
+            }
+    raise AssertionError(f"{class_name} is gone from {relative_path}")
+
+
+def test_the_per_agent_fixture_uses_the_producers_real_field_names():
+    """The fixture must be a subset of what the agents actually emit.
+
+    Before #853 it was not, and neither was the dev producer: both invented
+    `predicted_lap_time_s`, `degradation_pct`, `sc_prob`, `pit_duration_s`.
+    They agreed with each other, so this file stayed green while pinning a
+    contract no producer has ever emitted, and the Qt cards - sprint 3's
+    acceptance reference - rendered `pred 0.00s` and `deg - s/lap` against
+    the very rig built to populate them.
+
+    Comparing the fixture against the agents' own dataclasses is what makes
+    this guard about the producer instead of about itself: rename
+    `lap_time_pred` upstream and it goes red.
+    """
+    per_agent = _payload()["strategy"]["latest"]["per_agent"]
+
+    for block, (path, class_name) in _PER_AGENT_SOURCES.items():
+        real = _dataclass_field_names(path, class_name)
+        unknown = set(per_agent[block]) - real
+        assert not unknown, (
+            f"per_agent[{block!r}] invents {sorted(unknown)}; {class_name} has {sorted(real)}"
+        )
+
+
+def test_the_routing_list_carries_agent_ids_and_not_block_names():
+    """`active` gates the two conditional cards, and it is not the block keys.
+
+    `_decide_agents_to_call` returns `{"N28", "N30"}` and the cards test
+    `"N28" in active`. The dev producer used to send
+    `["pace", "tire", "situation", "pit"]`, so both conditional cards stayed
+    on their trigger hint no matter what the rig published.
+    """
+    active = _payload()["strategy"]["latest"]["per_agent"]["active"]
+
+    assert active, "the fixture must exercise the conditional cards"
+    assert all(token.startswith("N") and token[1:].isdigit() for token in active), active
 
 
 # --- seq semantics ----------------------------------------------------------


### PR DESCRIPTION
Closes #853.

Found by the Fable re-run of the sprint-1 wire gate (FF4, its highest-value finding), verified independently before acting.

## What

`scripts/dev_pitwall_producer.py` exists so the agent cards are not idle while the PITWALL AGENTS window is ported. It did the opposite: it invented `per_agent` field names, `tests/surfaces/test_arcade_wire_contract.py` invented the same ones, and the two agreed with each other — so the golden was green while pinning a contract no producer has ever emitted.

Fed through the real Qt formatters, the rig used to render `Δnext +0.000s (0.00s)`, `deg — s/lap`, `safety car 0%`, and both conditional cards on their trigger hint. It now renders:

```
PACE   [OK   ] Δnext -0.204s (81.33s)   · pred 81.33s · vs median +0.12s · ±0.55s (CI)
TIRE   [WATCH] Cliff ~6 laps · L15      · range 4–9 laps · deg 0.031s/lap · MEDIUM · MONITOR
SITU   [WATCH] Threat MEDIUM            · overtake 34% · safety car 8% · gap 1.4s · Δpace -0.12s/lap
RADIO  [ALERT] PROBLEM                  · 1 radios · 1 rcm · RCM L23 YELLOW: … · NOR PROBLEM: "…"
PIT    [WATCH] pit 22.40s → HARD        · range 21.14–24.81s · UCUT 63% → RUS
RAG    [OK   ] regulation loaded        · No. Art. 30.5(m) … · Art. 30.5(m), 55.7
```

## Why

Sprint 3 ports the AGENTS window 1:1 against this rig. Every card built to match the invented keys would render empty against the real arcade, and the committed reference screenshots could not show the difference because they came from the same rig.

A second instance of the same defect lived in the same file and the gate did not name it: `active` carried block names (`["pace", "tire", "situation", "pit"]`) while `_decide_agents_to_call` emits `{"N28", "N30"}` and the cards test `"N28" in active`. Both conditional cards were idle no matter what the rig published.

## How

| Change | Where |
|---|---|
| Real keys from `PaceOutput` / `TireOutput` / `RaceSituationOutput` / `RadioOutput` / `PitStrategyOutput` | `scripts/dev_pitwall_producer.py` |
| `active=["N28", "N30"]` | same |
| Same keys in the fixture, radio lists populated so `_shape` pins their elements | `tests/surfaces/test_arcade_wire_contract.py` |
| `GOLDEN_SHAPE` updated in the same commit, as the file requires | same |
| New guard: the fixture's keys are read from the agents' own dataclasses with `ast` (no import, so no torch/xgboost/transformers in CI) and any invented name fails | same |
| New guard: `active` carries routing tokens, not block names | same |
| Caveat 1 rewritten: the placeholder figures were a rig defect, now fixed, so a fresh capture will legitimately differ | `documents/dev_docs/migration/pitwall/README.md` |

## Checks

- `uv run pytest tests/surfaces/test_arcade_wire_contract.py` → 10 passed.
- Negative check: restoring `predicted_lap_time_s` and `active=["pace","tire"]` turns all three guards red (the golden, the field-name guard and the routing guard), so they assert the effect rather than a constant.
- `ruff check` + `ruff format --check` clean.

## Out of scope

Building both fixtures from `asdict(PaceOutput(...))` so the keys cannot drift at all — it needs the output dataclasses importable without the heavy agent modules. The `ast` guard buys the same protection today at no import cost.