### PR TITLE
fix(pitwall): follow a restarted producer instead of freezing on the dead race

### DIFF
--- a/src/pitwall/host.py
+++ b/src/pitwall/host.py
@@ -51,6 +51,16 @@ class PitwallHost:
         A window that has never rendered one passes -1, which is below every
         sequence the producer emits.
 
+        **The comparison is inequality, not "greater than".** The slot holds
+        only the newest payload, so anything the caller has not already
+        rendered is news - including a LOWER sequence, which can only mean
+        the producer restarted. `seq > since_seq` withheld exactly that
+        case: relaunch the arcade with the windows open and both froze on
+        the dead race, `live` and silent, until the new run's sequence
+        passed the old one's. A ten-minute race meant ten minutes of frozen
+        screen. The consumer side already copes, because the new run's
+        `frame_index` jumps backwards and `FrameClock` reports `rewound`.
+
         A payload with no `seq` is returned unconditionally. That only
         happens against a producer older than the one in this repo, where
         there is nothing to compare and the honest answer is the data.
@@ -59,7 +69,7 @@ class PitwallHost:
         if payload is None:
             return None
         seq = payload.get("seq")
-        if seq is None or seq > since_seq:
+        if seq is None or seq != since_seq:
             return payload
         return None
 

--- a/tests/surfaces/test_pitwall_host.py
+++ b/tests/surfaces/test_pitwall_host.py
@@ -56,7 +56,25 @@ def test_a_window_only_gets_a_tick_it_has_not_seen():
     assert host.get_tick(since_seq=-1) == _tick(7), "a window with nothing gets the latest"
     assert host.get_tick(since_seq=6) == _tick(7), "a window one behind gets it"
     assert host.get_tick(since_seq=7) is None, "a window up to date gets nothing new"
-    assert host.get_tick(since_seq=99) is None, "and cannot be handed an older one"
+
+
+def test_a_restarted_producer_is_followed_rather_than_withheld():
+    """The one way the slot can hold a LOWER sequence than the window's own.
+
+    An earlier version asked for `seq > since_seq` and read a lower sequence
+    as "an older payload, do not hand it back". The slot only ever holds the
+    newest payload, so that state is unreachable except by a restart -- and
+    there, withholding froze both windows on the dead race, `live` and
+    silent, for as long as the previous run had lasted.
+
+    The old test asserted the CONSTANT (never hand back a lower seq) rather
+    than the EFFECT (the window must follow a restarted producer), so the
+    freeze was pinned rather than caught.
+    """
+    client = _FakeClient(_tick(3))
+    host = PitwallHost(client, window_count=2)
+
+    assert host.get_tick(since_seq=400) == _tick(3), "a relaunched arcade must reach the window"
 
 
 def test_two_windows_polling_independently_never_disagree():


### PR DESCRIPTION
Closes #854.

Found by the Fable re-run of the sprint-1 wire gate (FF5), verified before acting.

## What

Close the arcade, launch it again, leave the PITWALL windows open: both kept rendering the last tick of the previous race, with `live: true`, silently, for as long as the old race had been running.

`get_tick` returned the payload only when `seq > since_seq`. A new producer restarts its sequence near 1 while `useTick.ts` keeps `lastSeq` forever, so a window sitting at seq 400 was handed `None` until the new run passed 400.

## Why inequality is the right comparison

The slot holds only the newest payload the client has parsed. There is no path that puts an *older* payload in it — so a sequence below the caller's can only mean the producer restarted, which is the one case where withholding is wrong. `src/pitwall/stream_client.py:29-31` already names that scenario as supported.

The consumer side needs no change: the new run's `frame_index` jumps backwards, `FrameClock.advance` reports `rewound`, and panels evict.

The only new behaviour in the non-restart case is that a window whose `since_seq` happens to equal the slot's sequence still gets nothing, which is what it already got.

## The test was pinning the bug

```python
assert host.get_tick(since_seq=99) is None, "and cannot be handed an older one"
```

That asserts the constant (never hand back a lower seq), not the effect (the window must follow a restarted producer). Replaced with `test_a_restarted_producer_is_followed_rather_than_withheld`.

## Checks

- `uv run pytest tests/surfaces/test_pitwall_host.py` → 15 passed.
- `ruff check` + `ruff format --check` clean.