### PR TITLE
fix(arcade): tell taking the chequered flag apart from retiring

### DIFF
--- a/src/arcade/gaps.py
+++ b/src/arcade/gaps.py
@@ -31,8 +31,8 @@ where "leader" legitimately differs between on-track order and the
 at-the-line classification.
 
 `dist` is still what the fraction is *measured* in; what makes it usable
-is normalising it per car, by that car's own previous lap, so the drift
-cancels instead of accumulating. See `progress`.
+is normalising it per car, by the true length of the lap that car is on,
+so the drift cancels instead of accumulating. See `progress`.
 
 The same drift is why `laps_down` cannot be a `dist` difference over a
 circuit length: it disagrees with the positional answer on 4.9 % of
@@ -79,6 +79,68 @@ from src.arcade.config import DT
 from src.arcade.data import SessionData
 
 
+def _telemetry_end_frame(frames: list) -> int:
+    """Index of the first frame past this driver's last real sample.
+
+    The resampler clamps every field beyond that sample, so this is the
+    first frame whose distance is the driver's FINAL distance, and `active`
+    is the only thing that marks it. Taking the last ACTIVE frame instead
+    looks equivalent and is not: it lands a fraction of a frame short of
+    the real end, so a finisher's progress came out at `total + 0.0004`
+    with the remainder differing per car. Every finisher then had a
+    slightly different number, no two ever tied, and the tie-break that
+    exists to order them never fired.
+
+    A driver whose telemetry runs to the end of the session is never
+    inactive, hence the fallback to the last frame.
+    """
+    active = np.fromiter((bool(f.active) for f in frames), dtype=bool, count=len(frames))
+    ended = np.flatnonzero(~active)
+    return int(ended[0]) if len(ended) else len(frames) - 1
+
+
+def _flag_frames(frames_by_driver: dict[str, list], final_lap: int) -> dict[str, int | None]:
+    """The frame each car took the chequered flag, `None` for a retirement.
+
+    **The rule is the racing one, and it needs no threshold.** When the
+    leader takes the flag every other car takes it the next time it crosses
+    the line, so a finisher's telemetry ends at or after the leader's does
+    and a retirement's ends before. The leader is the first car to reach
+    `final_lap`; everyone still producing telemetry at that instant
+    finished the race.
+
+    Why not "reached the final lap": a car a lap down finishes on
+    `final_lap - 1` and would read as a retirement, which is the same
+    mistake in the other direction. Melbourne 2025 has no lapped finisher,
+    so that version would have measured perfectly and still been wrong.
+
+    The one car this misclassifies is one that retires between the leader's
+    flag and its own last crossing - under a lap of running, and a car that
+    far into the race is classified by the FIA anyway.
+
+    `final_lap` of 0 means the loader did not record one; nobody is then
+    known to have finished, which is the honest answer and the behaviour
+    this replay had before finishers existed at all.
+    """
+    if final_lap <= 0:
+        return {code: None for code in frames_by_driver}
+
+    ends = {
+        code: _telemetry_end_frame(frames) for code, frames in frames_by_driver.items() if frames
+    }
+    reached_final_lap = [
+        end for code, end in ends.items() if frames_by_driver[code][-1].lap >= final_lap
+    ]
+    if not reached_final_lap:
+        return {code: None for code in frames_by_driver}
+
+    leader_flag = min(reached_final_lap)
+    return {
+        code: (ends[code] if code in ends and ends[code] >= leader_flag else None)
+        for code in frames_by_driver
+    }
+
+
 class RaceGapCalculator:
     """Race order and intervals, from the lap-line crossings in `SessionData`.
 
@@ -89,15 +151,21 @@ class RaceGapCalculator:
 
     - A crossing is keyed by the lap it **ends**, so `crossings[7]` is when
       that driver completed lap 7. Verified against `laps.parquet`: 907 of
-      907 crossings keyed correctly, no off-by-one, lap 1 included.
+      907 lap-field increments keyed correctly, no off-by-one, lap 1
+      included. The 14 chequered flags below are additional and were not
+      part of that count; they are keyed by the lap the car was on, which
+      is the lap that crossing completes.
     - The **first** frame of each lap increment is kept, not the last. The
       resampled `lap` field can hold an intermediate value for a few frames
       around the line; taking the first occurrence measured p95 error
       83 ms -> 68 ms and systematic lag +25 ms -> +16 ms.
-    - Only real lap-field increments are crossings. The chequered flag is
-      not one, so the last lap of a race shows the interval from the
-      previous line; crediting it as a completed lap would hand every
-      retirement a lap it never drove.
+    - Only real lap-field increments are crossings, **plus the chequered
+      flag for a car that was still running when the leader took it**.
+      Crediting the flag to everyone handed each retirement a lap it never
+      drove; crediting it to nobody left every finisher short of the lap
+      they had just completed, and the ordering that followed was wrong on
+      19 of 20 positions (#855). Who counts as a finisher is decided by
+      `_flag_frames`, not by a threshold.
     - Unknown is `None`, never a number a caller could also legitimately
       compute. This applies to `laps_down` as much as to `interval_at_line`:
       an earlier version returned `0` for an inverted call, which is also
@@ -109,8 +177,12 @@ class RaceGapCalculator:
         self._crossing_frames: dict[str, np.ndarray] = {}
         self._dist: dict[str, np.ndarray] = {}
         self._default_lap_m = float(session.circuit_length_m or 0.0)
+        flag_frames = _flag_frames(session.frames_by_driver, int(session.max_lap_number or 0))
+        self._finished: dict[str, bool] = {
+            code: frame is not None for code, frame in flag_frames.items()
+        }
         for code, frames in session.frames_by_driver.items():
-            crossings = self._lap_crossings(frames)
+            crossings = self._lap_crossings(frames, flag_frames.get(code))
             self._crossings[code] = crossings
             self._crossing_frames[code] = np.array(
                 sorted(round(t / DT) for t in crossings.values()), dtype=int
@@ -126,17 +198,23 @@ class RaceGapCalculator:
             )
 
     @staticmethod
-    def _lap_crossings(frames: list) -> dict[int, float]:
+    def _lap_crossings(frames: list, flag_frame: int | None) -> dict[int, float]:
         """Map each completed lap to the replay time the driver crossed the line.
 
-        **Only real increments of the lap field count.** An earlier version
-        also recorded the lap the driver was on when their telemetry ended,
-        so that the chequered flag had an interval too. That is right for a
-        finisher and wrong for everyone else: a car that crashes 1700 m
-        into lap 1 has completed no laps, and the synthetic entry credited
-        it with one, which put it a whole lap up the order. The final lap
-        of a race still renders an interval, taken from the last line both
-        cars actually crossed.
+        **Only real increments of the lap field count, plus the chequered
+        flag when `flag_frame` says this car took one.** An earlier version
+        recorded the end of every driver's telemetry as a crossing, which
+        credited a car that crashed 1700 m into lap 1 with a completed lap
+        and put it a whole lap up the order. The correction then swung the
+        other way and recorded no flag at all, which left every finisher on
+        the lap before their last and made the classification unreadable
+        (#855). `flag_frame` is the discrimination the first two versions
+        both lacked.
+
+        A finisher's flag is keyed by the lap they were **on** when their
+        telemetry ended, which is the lap that crossing completes. That is
+        the leader's `max_lap_number` and one less for a car a lap down, so
+        the same line works for both without asking who is lapped.
         """
         if not frames:
             return {}
@@ -144,7 +222,34 @@ class RaceGapCalculator:
         crossings: dict[int, float] = {}
         for i in np.flatnonzero(np.diff(lap_numbers) > 0) + 1:
             crossings.setdefault(int(lap_numbers[i]) - 1, float(i) * DT)
+        if flag_frame is not None:
+            crossings.setdefault(int(lap_numbers[flag_frame]), float(flag_frame) * DT)
         return crossings
+
+    def has_finished(self, code: str) -> bool:
+        """Whether this car took the chequered flag rather than stopping.
+
+        The replay knows when a car's telemetry ends; on its own that says
+        nothing about why. Every consumer that renders "OUT" needs this,
+        because without it the winner's row reads OUT from the instant he
+        wins and 19 of 20 rows read OUT at the final frame.
+        """
+        return bool(self._finished.get(code, False))
+
+    def last_crossing_frame(self, code: str, frame_idx: int) -> int:
+        """Frame of this car's most recent crossing, the tie-break for equal progress.
+
+        Two cars that have both finished sit at exactly the same progress -
+        the total laps - and the one that got there first is ahead. That is
+        the only situation where the value is read, so the 0 returned for a
+        car with no crossings yet cannot collide with it: a car with no
+        crossings has progress below 1 and can never tie with one that has.
+        """
+        frames = self._crossing_frames.get(code)
+        completed = self.laps_completed(code, frame_idx)
+        if frames is None or completed <= 0:
+            return 0
+        return int(frames[completed - 1])
 
     # --- Where a car is in the race -----------------------------------------
 
@@ -161,10 +266,14 @@ class RaceGapCalculator:
         This is the coordinate the field is ordered on, and it is a real
         one. The integer part comes from the line crossings. The fractional
         part is how far the car has driven into its current lap **measured
-        against its own previous lap**, which is what makes it comparable
-        between cars: each is normalised by the distance it actually
-        covers, so the per-car accumulation drift cancels instead of
-        accumulating.
+        against that lap's own length for this car** (see
+        `_current_lap_bounds`), which is what makes it comparable between
+        cars: each is normalised by the distance it actually covers, so the
+        per-car accumulation drift cancels instead of accumulating.
+
+        A car that has finished sits at exactly the total laps, because its
+        flag is a crossing and its distance is frozen at it. Ordering two
+        finishers therefore needs `last_crossing_frame`, not this number.
 
         `rel_dist` is deliberately NOT used, even though it looks like
         exactly this number. FastF1 leaves it NaN for a whole driver on
@@ -188,10 +297,21 @@ class RaceGapCalculator:
     def _current_lap_bounds(self, code: str, completed: int) -> tuple[float, float]:
         """Distance at the start of the current lap, and how long that lap is.
 
-        The current lap has no end yet, so its length is taken from the
-        driver's previous lap, and from the circuit length on lap 1 where
-        there is no previous. Both are that driver's own scale, which is
-        the point.
+        **In a replay the current lap usually has an end.** The crossing
+        that closes it is already in the array, so its true end-to-end
+        length in this driver's own distance is known and is what gets
+        used. The previous lap only stands in past the driver's LAST
+        crossing, and the circuit length only on lap 1 where there is no
+        previous. All three are that driver's own scale, which is the
+        point: normalising by it is what cancels the per-car accumulation
+        drift instead of letting it accumulate.
+
+        The docstring said "taken from the driver's previous lap" as though
+        the fallback were the rule. Measured on Melbourne 2025 the two
+        differ by a median 9.2 m and up to 340 m, so a refactorer who
+        implemented the sentence would have changed behaviour, and until
+        `test_the_fraction_is_normalised_by_the_cars_own_lap` existed no
+        test could see it.
         """
         dist = self._dist[code]
         frames = self._crossing_frames[code]

--- a/src/arcade/overlays.py
+++ b/src/arcade/overlays.py
@@ -325,10 +325,14 @@ class DriverInfoPanel:
         codes = [code for code, _ in sorted_drivers]
         if self.code not in codes:
             return "N/A", "N/A"
+        # Inactive is not retired. A finisher's telemetry ends the moment he
+        # takes the flag, so reading `active` alone put "NOR OUT" on the
+        # winner's neighbours from the instant he won, and 19 of 20 rows
+        # read OUT at the final frame (#855).
         retired = {
             code
             for code, data in (frame.get("drivers") or {}).items()
-            if not (data or {}).get("active", True)
+            if not (data or {}).get("active", True) and not gaps.has_finished(code)
         }
         idx = codes.index(self.code)
         me = sorted_drivers[idx]
@@ -515,7 +519,9 @@ class LeaderboardPanel:
                     (*ACCENT, 70),
                 )
 
-            is_out = not data.get("active", True)
+            # Same rule as the neighbour label: a car that took the flag is
+            # inactive and is not out.
+            is_out = not data.get("active", True) and not gaps.has_finished(code)
             rt = self._rank_texts[i]
             rt.text = f"{i + 1:>2}"
             rt.color = TEXT_TERTIARY
@@ -583,6 +589,13 @@ class LeaderboardPanel:
         sorts last and carries `None` rather than a position it does not
         have. It is still drawn, because a car with no position data is
         still on the track.
+
+        **The tie-break is not decoration.** Every car that has finished
+        sits at exactly the total laps, so from the leader's flag to the
+        end of the replay the whole podium ties and a plain sort falls back
+        to dict insertion order. Ordering ties by who crossed first is what
+        makes those last seconds - the frame the replay parks on, and the
+        one a viewer reads as the result - the actual classification.
         """
         drivers = (frame or {}).get("drivers") or {}
         ranked: list[tuple[str, dict, float | None]] = []
@@ -590,7 +603,10 @@ class LeaderboardPanel:
         for code, data in drivers.items():
             progress = gaps.progress(code, frame_idx)
             (unknown if progress is None else ranked).append((code, data, progress))
-        ranked.sort(key=lambda entry: entry[2], reverse=True)
+        ranked.sort(
+            key=lambda entry: (entry[2], -gaps.last_crossing_frame(entry[0], frame_idx)),
+            reverse=True,
+        )
         return ranked + unknown
 
 

--- a/tests/surfaces/test_arcade_leaderboard_gaps.py
+++ b/tests/surfaces/test_arcade_leaderboard_gaps.py
@@ -85,15 +85,39 @@ def _blind_car(speed_mps: float) -> list[FrameData]:
     return [FrameData(**{**vars(f), "rel_dist": float("nan")}) for f in _car(speed_mps)]
 
 
-def _session(**cars) -> SessionData:
+def _session(*, max_lap_number: int = 0, **cars) -> SessionData:
+    """A session of synthetic cars.
+
+    `max_lap_number` defaults to 0, which is what `SessionData` itself
+    defaults to and means "the loader recorded no final lap". Nobody can
+    then be known to have finished, so the tests that predate finishers
+    keep exercising the same code path they always did.
+    """
     return SessionData(
         gp_name="Test",
         location="Test",
         year=2025,
         frames_by_driver=dict(cars),
         circuit_length_m=CIRCUIT_LENGTH_M,
+        max_lap_number=max_lap_number,
         total_frames=N_FRAMES,
     )
+
+
+# A three-lap race. A car takes the flag by running out of telemetry while
+# still ON its final lap: that is what the real data does, because the
+# resampler stops at the last sample, which is at the line, before the lap
+# field would have incremented. Frame `dead_from + 1` is therefore the flag,
+# and is the first frame carrying the car's frozen final distance.
+RACE_LAPS = 3
+_FLAG_FRAME = {"P1": 7450, "P2": 7475, "P3": 7500}
+
+
+def _finisher(code: str) -> list[FrameData]:
+    """One of three cars that cross the line 1.0 s apart on the final lap."""
+    flag = _FLAG_FRAME[code]
+    head_start = (7500 - flag) / 2500 * 1.0  # laps of head start, so they stagger
+    return _car(50.0, head_start_laps=head_start, dead_from=flag - 1)
 
 
 def _frame(session: SessionData, idx: int) -> dict:
@@ -412,6 +436,119 @@ def test_the_leader_and_the_last_car_have_no_neighbour_to_measure():
 
 
 # --- The crossings themselves -----------------------------------------------
+
+
+# --- Taking the flag is not retiring (#855) ---------------------------------
+
+
+def _finish_session(**extra) -> SessionData:
+    return _session(
+        max_lap_number=RACE_LAPS,
+        # Inserted in the WRONG order on purpose: every finisher sits at
+        # exactly RACE_LAPS, so a plain sort keeps whatever order the dict
+        # was built in and the test would pass without the tie-break.
+        P3=_finisher("P3"),
+        P1=_finisher("P1"),
+        P2=_finisher("P2"),
+        **extra,
+    )
+
+
+def test_the_final_classification_is_the_order_the_cars_crossed_the_line():
+    """The last seconds of the replay, which is the state a viewer reads as THE result.
+
+    Before #855 the flag was not a crossing, so every finisher stayed on
+    the lap before their last and their fraction of the final lap was
+    measured against the length of the PREVIOUS one. Whoever's final lap
+    ran long clamped at exactly 1.0 and jumped above everyone else.
+    Measured on Melbourne 2025 the board agreed with the official
+    classification on 1 of 20 positions: VER (P2) was drawn 8th.
+    """
+    session = _finish_session()
+    idx = N_FRAMES - 1
+    gaps = RaceGapCalculator(session)
+
+    # The premise: all three are level on progress, so only the tie-break
+    # can separate them.
+    assert [gaps.progress(c, idx) for c in ("P1", "P2", "P3")] == [float(RACE_LAPS)] * 3
+
+    assert _order(session, idx) == ["P1", "P2", "P3"]
+
+
+def test_a_car_that_took_the_flag_is_not_rendered_as_retired():
+    """`active` goes False the instant a finisher's telemetry ends.
+
+    Reading it alone put "OUT" on the winner from the moment he won: 19 of
+    20 rows at the final frame of Melbourne 2025, the whole podium among
+    them.
+    """
+    session = _finish_session(RETIRED=_car(50.0, dead_from=3000))
+    idx = N_FRAMES - 1
+    gaps = RaceGapCalculator(session)
+
+    assert session.frames_by_driver["P1"][idx].active is False, "the premise: it looks retired"
+    assert gaps.has_finished("P1") is True
+    assert gaps.has_finished("RETIRED") is False
+
+    ahead, behind = _labels(session, "P2", idx)
+    assert ahead == "P1 +1.00s (L)", ahead
+    assert behind.startswith("P3 -"), behind
+    assert "OUT" not in ahead + behind
+
+    assert "RETIRED OUT" in _labels(session, "P3", idx)
+
+
+def test_the_flag_is_a_crossing_so_the_final_lap_finally_has_an_interval():
+    """The three cross 1.0 s apart, and that is what the last lap must read.
+
+    On Melbourne 2025 this reproduces the published result: NOR-VER comes
+    out at 0.880 s against an official 0.895 s, and NOR-RUS at 8.480 s
+    against an official 8.481 s - an external check, unlike the rest of
+    this module's accuracy work, which compares the replay against the
+    table that sliced it.
+    """
+    gaps = RaceGapCalculator(_finish_session())
+
+    assert gaps.laps_completed("P1", N_FRAMES - 1) == RACE_LAPS
+    assert gaps.interval_at_line("P1", "P2", lap=RACE_LAPS) == pytest.approx(1.0, abs=DT)
+    assert gaps.interval_at_line("P1", "P3", lap=RACE_LAPS) == pytest.approx(2.0, abs=DT)
+    assert gaps.interval_at_line("P2", "P1", lap=RACE_LAPS) is None, "inverted stays None"
+
+
+def test_a_lapped_car_that_takes_the_flag_is_a_finisher_on_its_own_lap():
+    """The case that kills the obvious rule, and that Melbourne 2025 cannot show.
+
+    "A finisher is a car that reached the final lap" measures perfectly on
+    a race where every finisher was on the lead lap, and calls a lapped
+    finisher a retirement. The rule shipped is the racing one instead: when
+    the leader takes the flag, everyone still running takes it at their
+    next line - so a finisher's telemetry ends at or after the leader's.
+
+    LAPPED is on lap 2 when P1 wins and crosses its own line 2 s later. It
+    must be credited lap 2, not the leader's lap 3.
+    """
+    session = _finish_session(LAPPED=_car(33.34, dead_from=7498))
+    idx = N_FRAMES - 1
+    gaps = RaceGapCalculator(session)
+
+    assert session.frames_by_driver["LAPPED"][idx].lap == RACE_LAPS - 1, "never reached lap 3"
+    assert gaps.has_finished("LAPPED") is True
+    assert gaps.laps_completed("LAPPED", idx) == RACE_LAPS - 1
+    assert gaps.progress("LAPPED", idx) == pytest.approx(float(RACE_LAPS - 1))
+    assert _order(session, idx) == ["P1", "P2", "P3", "LAPPED"]
+
+
+def test_without_a_known_final_lap_nobody_is_a_finisher():
+    """`max_lap_number` of 0 is what an older cache carries.
+
+    The honest answer is then that nothing is known about who finished,
+    which is exactly how this replay behaved before finishers existed.
+    """
+    session = _session(P1=_finisher("P1"), P2=_finisher("P2"))
+    gaps = RaceGapCalculator(session)
+
+    assert gaps.has_finished("P1") is False
+    assert gaps.laps_completed("P1", N_FRAMES - 1) == RACE_LAPS - 1, "no flag crossing"
 
 
 def test_a_crossing_is_keyed_by_the_lap_it_ends_and_only_real_laps_count():


### PR DESCRIPTION
Closes #855.

Found by the Fable re-run of the leaderboard-gaps gate (FG-2 P1 + FG-3 P2), both reproduced independently before acting.

Two symptoms, one missing concept: the replay could tell "still producing telemetry" from "not", but not "retired" from "took the flag".

## Before and after, Melbourne 2025, final frame

| | before | after |
|---|---|---|
| final classification | agrees with the official result on **1 of 20** positions (VER P2 drawn 8th, RUS P3 drawn 9th) | **all 14 finishers in the right order** |
| rows rendering `OUT` | **19 of 20**, the whole podium among them | **6**, which is the six retirements |
| interval on the last lap | none (the flag was not a crossing) | NOR-VER **0.880 s**, NOR-RUS **8.480 s** |

Those last two are an **external** check, unlike the rest of this module's accuracy work: the official gaps are 0.895 s and 8.481 s.

## The mechanism

The flag was deliberately not a crossing, because crediting it to everyone handed a car that crashed on lap 1 a lap it never drove. The cost of crediting it to nobody was never measured: every finisher stayed on the lap before their last, and their fraction of the final lap was divided by the length of the **previous** one. Whoever's last lap ran long clamped at exactly `1.0` and jumped above everyone still at `0.99x`.

The fix records the flag for finishers only. Two decisions inside it are worth reading:

**Who is a finisher is the racing rule, not a threshold.** When the leader takes the flag, everyone else takes it at their next line — so a finisher's telemetry ends at or after the leader's and a retirement's ends before. The obvious alternative ("a car that reached the final lap") measures perfectly on Melbourne 2025 and is wrong: a car a lap down finishes on `final_lap - 1` and would read as a retirement. `test_a_lapped_car_that_takes_the_flag_is_a_finisher_on_its_own_lap` is red under that version and green under this one.

**The flag frame is the first INACTIVE frame, not the last active one.** They look equivalent. The last active frame lands a fraction of a frame short of the real end, so each finisher came out at `total + 0.0004` with a different remainder, no two ever tied, and the tie-break never fired — the first attempt at this fix produced a *worse* order than the bug. The first inactive frame is where the resampler's clamp has already frozen the distance, so every finisher lands on exactly `total`.

## Changes

| Change | Where |
|---|---|
| `_flag_frames` + `_telemetry_end_frame` | `src/arcade/gaps.py` |
| the flag as a crossing, keyed by the lap the car was on | `RaceGapCalculator._lap_crossings` |
| `has_finished` and `last_crossing_frame` | same |
| tie-break on equal progress | `overlays.LeaderboardPanel._rank_drivers` |
| `OUT` only for `inactive and not finished`, on the row and the label | `overlays.py` |
| the fraction is normalised by the CURRENT lap, not the previous one (the docstrings described the fallback as the rule; measured divergence median 9.2 m, max 340 m) | `gaps.py` docstrings |

`max_lap_number` of 0 — what an older cache carries — means nobody is known to have finished, which is exactly how the replay behaved before. No `CACHE_VERSION` bump: everything is derived at construction from fields the pickle already holds.

## Checks

- `uv run pytest tests/surfaces` → 90 passed, 1 failed (`test_cli_no_llm`, the known curated-download gap, red on `dev` too).
- Five new tests. Negative check, each mechanism reverted in a scratch harness (the repo untouched): no tie-break → 3 red; no flag crossing → 4 red; the "reached the final lap" discriminator → 1 red, exactly the lapped-finisher test.
- `ruff check` + `ruff format --check` clean.

## Deliberately not here

The published leader-wrong / whole-order-exact figures in `gaps.py` and `overlays.py` disagree with each other and were measured on the code this PR changes. They are re-measured under one stated convention in the follow-up, together with the tests that pin the normalisation itself.