### PR TITLE
fix(arcade): stop broadcasting the no-position car at the start line

### DIFF
--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -110,7 +110,11 @@ def _telemetry_span_bounds(
 
 
 def _frames_to_telemetry_span(
-    frames: list | None, span_start: int, frame_idx: int, circuit_length_m: float
+    frames: list | None,
+    span_start: int,
+    frame_idx: int,
+    circuit_length_m: float,
+    has_position: bool = True,
 ) -> list[dict]:
     """Pack `frames[span_start : frame_idx + 1]` for the wire, oldest first.
 
@@ -122,7 +126,9 @@ def _frames_to_telemetry_span(
         return []
     lo = max(0, span_start)
     hi = min(len(frames) - 1, frame_idx)
-    samples = (_frame_to_telemetry(frames[i], circuit_length_m) for i in range(lo, hi + 1))
+    samples = (
+        _frame_to_telemetry(frames[i], circuit_length_m, has_position) for i in range(lo, hi + 1)
+    )
     return [s for s in samples if s is not None]
 
 
@@ -152,7 +158,7 @@ def _lap_fraction(rel_dist: float) -> float | None:
     return min(1.0, max(0.0, value))
 
 
-def _frame_to_telemetry(frame, circuit_length_m: float) -> dict | None:
+def _frame_to_telemetry(frame, circuit_length_m: float, has_position: bool = True) -> dict | None:
     """Pack a ``FrameData`` into the dict the telemetry window consumes.
 
     Uses ``frame.rel_dist * circuit_length`` as the broadcast ``dist``
@@ -172,7 +178,7 @@ def _frame_to_telemetry(frame, circuit_length_m: float) -> dict | None:
         return None
     throttle = float(frame.throttle)
     brake = float(frame.brake)
-    rel_dist = _lap_fraction(frame.rel_dist)
+    rel_dist = _lap_fraction(frame.rel_dist) if has_position else None
     lap_dist = None if rel_dist is None else round(rel_dist * float(circuit_length_m or 0.0), 1)
     return {
         "lap": int(frame.lap),
@@ -641,7 +647,17 @@ class F1ArcadeView(arcade.View):
             if not frames or frame_idx >= len(frames):
                 continue
             f = frames[frame_idx]
-            lap_fraction = _lap_fraction(f.rel_dist)
+            # A car whose telemetry never places it has NO fraction of the lap,
+            # and the loader cannot say so in the value: it derives `rel_dist`
+            # from a distance that never advances, which comes out as a finite
+            # 0.0 - "at the line", a position a real car can hold. On Melbourne
+            # 2025 that is HAD on all 154,173 frames, 2,935 of them `active`
+            # (#856). Saying it here rather than in the loader keeps the pickle
+            # format untouched: a CACHE_VERSION bump would cost every user a
+            # full reload of every GP to express something the wire expresses
+            # for free.
+            has_position = bool(self._session.has_position.get(code, True))
+            lap_fraction = _lap_fraction(f.rel_dist) if has_position else None
             drivers[code] = {
                 "lap": f.lap,
                 "dist": round(f.dist, 1),
@@ -653,7 +669,7 @@ class F1ArcadeView(arcade.View):
                 # False when this driver's telemetry never places the car, so a
                 # consumer says "no position data" instead of drawing an empty
                 # chart under a populated header.
-                "has_position": bool(self._session.has_position.get(code, True)),
+                "has_position": has_position,
             }
         main_frame = None
         main_frames = self._session.frames_by_driver.get(self._driver_main)
@@ -674,9 +690,20 @@ class F1ArcadeView(arcade.View):
         rival_frames = (
             self._session.frames_by_driver.get(self._driver_rival) if self._driver_rival else None
         )
+        positions = self._session.has_position
+        main_has_position = bool(positions.get(self._driver_main, True))
+        rival_has_position = bool(positions.get(self._driver_rival, True))
         telemetry = {
-            "main": _frames_to_telemetry_span(main_frames, span_start, frame_idx, circuit_length),
-            "rival": _frames_to_telemetry_span(rival_frames, span_start, frame_idx, circuit_length),
+            # `has_position` rides along so the span says the same thing the
+            # drivers block does. Without it the same car reads "no position"
+            # in one half of the payload and "at the line" in the other, and
+            # the telemetry window keys every sample into distance bucket 0.
+            "main": _frames_to_telemetry_span(
+                main_frames, span_start, frame_idx, circuit_length, main_has_position
+            ),
+            "rival": _frames_to_telemetry_span(
+                rival_frames, span_start, frame_idx, circuit_length, rival_has_position
+            ),
             # True when the user seeked backwards. The span is empty and the
             # consumer must drop what it has: a buffer keyed on
             # distance-within-lap holds samples for track the car has not

--- a/src/arcade/dashboard/telemetry_panel.py
+++ b/src/arcade/dashboard/telemetry_panel.py
@@ -246,10 +246,21 @@ class TelemetryPanel(QFrame):
         # A driver whose telemetry never places the car produces four empty
         # charts. Saying so beats a populated header over a blank grid, which
         # reads as a broken panel rather than as absent data.
-        main_car = (arcade.get("drivers") or {}).get(driver_main) or {}
-        blind = main_car.get("has_position") is False
+        #
+        # BOTH charted drivers, not just the main one. The first version read
+        # the main driver alone, so picking the blind car as the RIVAL drew a
+        # single point at x=0 and an empty delta chart under a header that
+        # said nothing was wrong - the same twin the fix two functions below
+        # already names (#856).
+        drivers_block = arcade.get("drivers") or {}
+        blind_codes = [
+            code
+            for code in (driver_main, driver_rival)
+            if code and (drivers_block.get(code) or {}).get("has_position") is False
+        ]
         lap_text = f"LAP {lap}" if lap else "LAP —"
-        self._lap_label.setText(f"{lap_text}  ·  NO POSITION DATA" if blind else lap_text)
+        blind_note = f"  ·  NO POSITION DATA ({', '.join(blind_codes)})" if blind_codes else ""
+        self._lap_label.setText(lap_text + blind_note)
         self._main_chip.set_code(driver_main)
         self._update_legend_codes(driver_main, driver_rival)
         if driver_rival:

--- a/tests/surfaces/test_arcade_broadcast_wire.py
+++ b/tests/surfaces/test_arcade_broadcast_wire.py
@@ -20,12 +20,18 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 pytest.importorskip("arcade", reason="the arcade replay is an optional surface")
 
 from src.arcade.app import F1ArcadeView  # noqa: E402
-from src.arcade.data import DT, FrameData, SessionData  # noqa: E402
+from src.arcade.data import (  # noqa: E402
+    DT,
+    FrameData,
+    SessionData,
+    _lap_fraction_from_distance,
+)
 
 # The three numbers a synthetic session needs to be self-consistent: a
 # circuit length the distances accumulate against, a session-time origin
@@ -78,13 +84,34 @@ def _retired_car(n_frames: int, last_live_index: int) -> list[FrameData]:
 
 
 def _car_without_position_data(n_frames: int) -> list[FrameData]:
-    """A car FastF1 gives no `RelativeDistance` for.
+    """A car FastF1 gives no position channel for, built the way the LOADER builds it.
 
-    Not hypothetical: on Melbourne 2025 this is HAD, NaN on 100 % of his
-    frames and the only non-finite value anywhere in the session.
+    Not hypothetical: on Melbourne 2025 this is HAD. An earlier version of
+    this fixture hand-set `rel_dist` to NaN, which is what FastF1 used to
+    deliver and what the loader can no longer produce: since the derivation
+    moved to `_lap_fraction_from_distance` over the driver's own distance,
+    a car that never moves comes out **finite 0.0** on every frame -
+    measured, one unique value across all 154,173 of his.
+
+    So the fixture runs a flat distance through the real derivation. A
+    hand-set NaN would keep the guard green while asserting about an input
+    production cannot emit, and the value that production DOES emit means
+    "at the line" (#856).
     """
-    frames = _running_car(n_frames)
-    return [FrameData(**{**vars(f), "rel_dist": float("nan")}) for f in frames]
+    dist = np.zeros(n_frames)
+    lap_numbers = np.ones(n_frames, dtype=int)
+    rel_dist = _lap_fraction_from_distance(dist, lap_numbers, CIRCUIT_LENGTH_M)
+    return [
+        FrameData(
+            **{
+                **vars(_frame(i, lap=1, rel_dist=0.0)),
+                "dist": float(dist[i]),
+                "rel_dist": float(rel_dist[i]),
+                "speed": 0.0,
+            }
+        )
+        for i in range(n_frames)
+    ]
 
 
 def _session(n_frames: int = 40) -> SessionData:
@@ -101,6 +128,8 @@ def _session(n_frames: int = 40) -> SessionData:
         circuit_length_m=CIRCUIT_LENGTH_M,
         total_frames=n_frames,
         global_t_min=GLOBAL_T_MIN,
+        # What the loader computes: `frames[-1].dist > frames[0].dist`.
+        has_position={MAIN: True, "SAI": True, "HAD": False},
     )
 
 
@@ -175,17 +204,29 @@ def test_global_t_min_turns_the_frame_clock_back_into_session_time():
 
 
 def test_a_car_with_no_position_data_is_unknown_rather_than_at_the_line():
-    """An absent `rel_dist` must not be clamped to a value that means something.
+    """The value the loader produces for such a car means something, and must not ship.
 
-    `min(1.0, nan)` is `1.0`, and 1.0 is a real position meaning "at the
-    line", so clamping would draw the car with no data exactly on the lap
-    boundary. Unknown is None, which is not a position any car can hold.
+    The old guard was against `min(1.0, nan) == 1.0`. That input is gone:
+    the loader derives the fraction from the driver's own distance, and a
+    car that never moves comes out finite **0.0** — which is not a clamp
+    but is still a position, "at the line", and on Melbourne 2025 it rides
+    the wire on 100 % of HAD's frames with `active` true for 2,935 of them.
+
+    The fixture is built by the real derivation, so this asserts about a
+    state production can actually reach.
     """
-    wire = _snapshot(_session(), frame_idx=3)
+    session = _session()
+    had_frames = session.frames_by_driver["HAD"]
+    assert had_frames[3].rel_dist == 0.0, "the premise: the loader emits a finite at-the-line 0.0"
+
+    wire = _snapshot(session, frame_idx=3)
 
     assert wire["drivers"]["HAD"]["rel_dist"] is None
     assert wire["drivers"][MAIN]["rel_dist"] is not None
     # The two-car telemetry block takes the same route, so it must agree.
+    # It did not: `has_position` was read for the drivers block only, so the
+    # same car read "no position" in one half of the payload and sat in
+    # distance bucket 0 in the other.
     telemetry = _snapshot(_session(), frame_idx=3, rival="HAD")["telemetry"]
     assert telemetry["rival"][0]["dist"] is None
     assert telemetry["main"][0]["dist"] is not None


### PR DESCRIPTION
Closes #856.

Found by the Fable re-run of the sprint-1 wire gate (FF1 + FF2), reproduced independently on the real v10 pickle before acting.

## What

HAD has no usable position channel on Melbourne 2025. The wire published `rel_dist = 0.0` for him on **all 154,173 frames** — one unique value, zero non-finite — with `active` true for the first 2,935. `0.0` is not a clamp, it is a **position**: at the line. Any consumer placing cars from `rel_dist` drew him on the start line at 0 km/h.

That is a sentinel collision. #849 recorded the opposite decision ("non-finite goes to None, never a clamp"); #850 then derived `rel_dist` from `dist`, the None path stopped firing on anything, and `has_position` — added in the same PR — hid the reversal.

Real data, after:

```
HAD : rel_dist=None   has_position=False  active=True  dist=0.0
NOR : rel_dist=0.3039 has_position=True   active=True
rival telemetry span dist values: {None}
main  telemetry span dist sample: [1563.7, 1565.9, 1568.1]
```

## The twin

`has_position` was consumed for the main driver only. Picking HAD as the RIVAL keyed every sample into distance bucket 0 — a single point, an empty delta chart — under a header that said nothing was wrong. Verified offscreen, after the fix:

```
main=NOR rival=HAD -> LAP 1  ·  NO POSITION DATA (HAD)
main=HAD rival=NOR -> LAP 1  ·  NO POSITION DATA (HAD)
main=NOR rival=PIA -> LAP 1
```

The telemetry span had the same twin on the producer side: `has_position` now rides into `_frames_to_telemetry_span`, so the span and the drivers block cannot disagree about the same car.

## Why not in the loader

The gate proposed writing NaN into `FrameData` at load. That is the tidier place and it costs a `CACHE_VERSION` bump — a full reload of every GP for every user — to express something the wire expresses for free. The pickle stays the raw resampled truth; the payload says what is known.

## The fixture was asserting about an unreachable input

`_car_without_position_data` hand-set `rel_dist` to NaN, which is what FastF1 used to deliver and what the loader can no longer produce. The guard was green about the empty set. It now runs a flat distance through the real `_lap_fraction_from_distance`, and the test asserts the premise first:

```python
assert had_frames[3].rel_dist == 0.0, "the premise: the loader emits a finite at-the-line 0.0"
```

## Checks

- `uv run pytest tests/surfaces` → 88 passed, 1 failed (`test_cli_no_llm`, the known curated-download gap, red on `dev` too).
- Real-data snapshot verified, and `json.dumps(..., allow_nan=False)` still accepts the payload.
- `ruff check` + `ruff format --check` clean.
