### PR TITLE
test(arcade): pin the two unguarded gap mechanisms and republish one number set

### DIFF
--- a/src/arcade/gaps.py
+++ b/src/arcade/gaps.py
@@ -22,11 +22,24 @@ Melbourne 2025, the drift reaches **1877 m for a single car and 1469 m
 between two cars on a 5220 m circuit** — 28 % of a lap, not the "tens of
 metres" an earlier version of this docstring claimed.
 
-Sampled every 500 frames against the timing classification rebuilt from
-the crossings, a descending `dist` sort puts **the wrong car in the lead
-on 85 % of frames**. The coordinate below gets it wrong on **2.0 %** and
-reproduces the whole order exactly on 239 of 305 frames — and of the six
-disagreements, all are cars racing within a tenth of a lap of each other,
+Everything measured below uses ONE convention, stated here because three
+mutually inconsistent versions of these figures were once published in
+two docstrings and a session log:
+
+> Truth is the at-the-line classification rebuilt from `laps.parquet`
+> (`Time` minus `global_t_min`): at replay time t, a driver's key is
+> (laps completed by t, then the time of that last crossing). Only cars
+> STILL RUNNING at the sampled frame are compared, because a retired
+> car's official place is decided by retirement order, which this replay
+> does not model. Sampling is every 500 frames, excluding the opening lap,
+> where no classification exists yet. Melbourne 2025, 300 sampled frames.
+
+Under it, the form this code replaced — `(lap - 1) * circuit_length` added
+to a `dist` that already contains the completed laps — puts **the wrong
+car in the lead on 37 %** of those frames, and so does a plain descending
+`dist` sort. The coordinate below gets the leader wrong on **1.7 %**
+(5 of 300) and reproduces the whole running order exactly on **236 of
+300**. Every one of the five is a pair racing within a tenth of a lap,
 where "leader" legitimately differs between on-track order and the
 at-the-line classification.
 
@@ -35,9 +48,9 @@ is normalising it per car, by the true length of the lap that car is on,
 so the drift cancels instead of accumulating. See `progress`.
 
 The same drift is why `laps_down` cannot be a `dist` difference over a
-circuit length: it disagrees with the positional answer on 4.9 % of
-same-corner pairs, always in the direction that makes a lapped car read
-as a same-lap car.
+circuit length: over 4,934 same-corner pairs (within 2 % of a lap of each
+other) it disagrees with the positional answer on **3.4 %**, always in
+the direction that makes a lapped car read as a same-lap car.
 
 Why the interval is at the line and not live
 --------------------------------------------
@@ -51,19 +64,26 @@ refuted (against `laps.parquet` line-crossing times, over the full race):
 | `(lap - 1) + rel_dist` | 5 ms | +-1 lap spikes: `lap` is a rounded interpolation of a step function |
 | counting `rel_dist` resets | 6.7 ms | p95 92 s: the resampler interpolates `rel_dist` THROUGH its own reset |
 | last crossing of the back car's `rel_dist` | 80 s | worse throughout |
-| **line crossings (this module)** | **17 ms** | **p95 101 ms, worst 568 ms, no tail** |
+| **line crossings (this module)** | **17 ms** | **p95 105 ms, p99 208 ms, worst 568 ms** |
 
-Two honest caveats on that headline figure, both established by an
-adversarial gate that reproduced it exactly:
+That row is 7,017 distinct pairs. Three honest caveats on it:
 
 1. **`laps.parquet` is not an independent artefact.** It is `session.laps`,
    the table that slices the very telemetry these arrays come from, so the
    comparison is a self-consistency check, not an external validation. The
-   residual is one-sided (+22 ms).
-2. **The error budget is not "one frame".** 14.9 % of crossings land more
-   than 40 ms from the parquet time and the worst is 486 ms, because the
-   `lap` field is `np.interp` plus `round` over a step function rather than
-   a true line detector.
+   one place there IS an external check is the chequered flag: NOR-VER
+   comes out at 0.880 s against an official 0.895 s and NOR-RUS at 8.480 s
+   against an official 8.481 s.
+2. **The error budget is not "one frame".** Per crossing (n=921) the error
+   is median 22 ms, p95 67 ms and worst 486 ms, and **9.8 % land more than
+   one 40 ms frame from the parquet time**, because the `lap` field is
+   `np.interp` plus `round` over a step function rather than a true line
+   detector.
+3. **The tail moved when the keying did.** Keying on the LAST frame of an
+   increment measured p95 101 ms / p99 160 ms, and the first-frame keying
+   this module ships improves the per-crossing error while making the pair
+   tail slightly worse. The p95 105 / p99 208 above is the shipped code;
+   the older pair of numbers described the version it replaced.
 
 It costs one property: the interval updates once a lap and steps at the
 line. That is what a real timing screen does, it is labelled `(L)` on
@@ -254,7 +274,16 @@ class RaceGapCalculator:
     # --- Where a car is in the race -----------------------------------------
 
     def laps_completed(self, code: str, frame_idx: int) -> int:
-        """How many laps this driver had finished as of `frame_idx`."""
+        """How many laps this driver had finished as of `frame_idx`.
+
+        **0 also answers an unknown code**, which is the collision the
+        class docstring forbids everywhere else. It stays because the only
+        caller that can hold one, `progress`, returns None before reaching
+        this, so the ranked list never contains an unknown driver and no
+        panel can read the two apart. A caller that CAN hold unknown codes
+        must check `progress` first, or this becomes `int | None` and the
+        three internal callers grow a guard.
+        """
         frames = self._crossing_frames.get(code)
         if frames is None or not len(frames):
             return 0

--- a/src/arcade/overlays.py
+++ b/src/arcade/overlays.py
@@ -579,10 +579,13 @@ class LeaderboardPanel:
         contained the completed laps). It is not one: each car accumulates
         the distance IT drove, so two cars at the same corner hold
         different numbers and the drift reaches 1877 m on a 5220 m
-        circuit. Sampled every 500 frames on Melbourne 2025 against the
-        timing classification, a descending `dist` sort puts the wrong car
-        in the lead on 85 % of frames; this key gets it wrong on 0.7 % and
-        reproduces the whole order exactly on 278 of 305 frames.
+        circuit. Measured under the convention stated at the top of
+        `gaps.py` — do not restate figures here under a different one,
+        which is how this docstring and that one came to publish 0.7 % and
+        2.0 % for the same quantity — a descending `dist` sort puts the
+        wrong car in the lead on 37 % of sampled frames; this key gets it
+        wrong on 1.7 % and reproduces the whole running order exactly on
+        236 of 300.
 
         A car whose progress is unknown (FastF1 delivered no
         `RelativeDistance`, which is a whole driver on Melbourne 2025)

--- a/tests/surfaces/test_arcade_leaderboard_gaps.py
+++ b/tests/surfaces/test_arcade_leaderboard_gaps.py
@@ -186,15 +186,65 @@ def test_the_order_is_right_when_dist_and_true_progress_disagree():
 
 
 def test_the_leader_is_the_car_that_has_covered_the_most_track():
-    """Three cars, three different drifts, sampled across the race."""
+    """Three cars, three different drifts, sampled across the race.
+
+    P3's drift is 700 m per lap and not the 160 an earlier version used.
+    At 160 the three cars' `dist` never actually inverted, so this test
+    stayed green against a plain `dist` sort and only one test in the file
+    guarded the defect it was written for. The premise assert below is
+    what stops the fixture drifting back into agreement.
+    """
     session = _session(
         P1=_car(56.0, drift_per_lap_m=-80.0),
         P2=_car(53.0, drift_per_lap_m=0.0),
-        P3=_car(50.0, drift_per_lap_m=160.0),
+        P3=_car(50.0, drift_per_lap_m=700.0),
+    )
+    frames = session.frames_by_driver
+    assert frames["P3"][6000].dist > frames["P1"][6000].dist, (
+        "the fixture must invert the dist order, or a dist sort passes this test"
     )
 
     for idx in (2000, 4000, 6000, N_FRAMES - 1):
         assert _order(session, idx) == ["P1", "P2", "P3"], f"wrong at frame {idx}"
+
+
+def test_the_fraction_is_normalised_by_the_cars_own_lap():
+    """The mechanism the whole coordinate rests on, and nothing was pinning it.
+
+    Replace `_current_lap_bounds`'s body with `return start, circuit_length`
+    and every other test in this file still passes: the fixture laps and
+    the [0, 1] clamp conspire to hide it. So the one sentence both
+    docstrings call "what makes it comparable between cars" could be
+    deleted with the suite green.
+
+    A car that runs 5400 m per lap, exactly half way through its second
+    lap, is at 1.5. Normalised by the circuit constant instead it reads
+    1.54, and every car with a different drift reads differently wrong.
+    """
+    session = _session(SOLO=_car(50.0, drift_per_lap_m=400.0))
+    gaps = RaceGapCalculator(session)
+    idx = 3750  # 150 s at 50 m/s: one lap and a half of true progress
+
+    assert gaps.progress("SOLO", idx) == pytest.approx(1.5, abs=0.005)
+
+
+def test_a_crossing_is_the_first_frame_of_the_increment_and_not_the_last():
+    """The other unpinned invariant: `setdefault`, not assignment.
+
+    The resampled `lap` field can flicker for a few frames around the
+    line, so the same lap increments more than once. Keeping the FIRST
+    occurrence measured p95 error 83 ms -> 68 ms; keeping the last is a
+    one-character change that no test could see.
+    """
+    frames = _car(50.0)
+    # The flicker: lap goes 2, back to 1, then 2 again over three frames.
+    for offset, lap in ((0, 2), (1, 1), (2, 2)):
+        frames[2500 + offset] = FrameData(**{**vars(frames[2500 + offset]), "lap": lap})
+    gaps = RaceGapCalculator(_session(SOLO=frames))
+
+    crossing = gaps._crossings["SOLO"][1]
+
+    assert crossing == pytest.approx(2500 * DT, abs=DT / 2), "the first rise, not the third"
 
 
 def test_a_car_whose_rel_dist_is_missing_is_still_ranked():


### PR DESCRIPTION
Follow-up to #860, from the Fable re-run of the leaderboard-gaps gate (FG-5, FG-1, FG-4, FG-8). No issue: this is test hardening plus a correction to published numbers, and the repo's rule is to right-size the ceremony.

## The tests were not guarding what the docstrings said they guarded

Re-ran the revert experiment against the current file, in a scratch harness with the repo untouched:

| mechanism reverted | tests red, before | tests red, now |
|---|---|---|
| the own-lap normalisation (`return start, circuit_length`) | **0 of 18** | 2 |
| first-increment keying (`setdefault` → assignment) | **0 of 18** | 1 |
| rank by `dist` again | 1 of 18 | 2 |

The first two are the sentences both docstrings call *"what makes it comparable between cars"* and *"measured p95 error 83 ms → 68 ms"*. Either could be deleted with the whole suite green.

The third had one guard, and `test_the_leader_is_the_car_that_has_covered_the_most_track` was not it: at 160 m of drift per lap the three cars' `dist` never actually inverted, so it passed against a plain `dist` sort. Raised to 700 m, with a premise assert so the fixture cannot drift back into agreement.

## Three numbers for one quantity

`gaps.py` said the leader was wrong on **2.0 %** and the order exact on **239 of 305**. `overlays.py` said **0.7 %** and **278 of 305**. The session log said **1.6 %**. At most one could be the measurement, and none named its retiree convention.

Re-measured once, with the convention written into `gaps.py` so the next person restates it rather than inventing one:

> Truth is the at-the-line classification rebuilt from `laps.parquet` (`Time` minus `global_t_min`). Only cars **still running** at the sampled frame are compared, because a retired car's official place is decided by retirement order, which this replay does not model. Every 500 frames, excluding the opening lap. Melbourne 2025, 300 sampled frames.

| quantity | measured |
|---|---|
| leader wrong, this coordinate | **1.7 %** (5 of 300) |
| whole running order exact | **236 of 300** |
| leader wrong, the form this replaced (`(lap-1)*len + dist`) | **37 %** |
| leader wrong, a plain descending `dist` sort | **37 %** |
| at-the-line interval, n=7,017 pairs | median **17 ms**, p95 **105 ms**, p99 **208 ms**, max **568 ms** |
| per crossing, n=921 | median **22 ms**, p95 **67 ms**, max **486 ms**, **9.8 %** above one frame |
| `laps_down`, same-corner pairs, n=4,934 | the `dist` form disagrees on **3.4 %** |

Two of those move a published claim rather than confirming it:

- **The 85 % for a `dist` sort does not reproduce.** Under a stated convention both the plain sort and the double-counting form this code replaced come out at 37 %. The docstring now says 37 % and names which form it measured.
- **The interval tail moved when the keying did.** p95 101 / p99 160 ms described the LAST-frame keying; the first-frame keying that shipped measures p95 105 / p99 208 while improving the per-crossing error. Two true statements about two code versions were sitting in one table as one measurement.

The one genuinely external check in the module is now recorded next to them: the chequered-flag interval reproduces the official result (NOR-VER 0.880 s against 0.895 s, NOR-RUS 8.480 s against 8.481 s). Everything else compares the replay against the table that sliced it.

## Also

`laps_completed` returns 0 for an unknown code, which is what it also returns for "no laps yet" — the collision the class docstring forbids everywhere else. Kept, with the reason written down: the only caller that can hold an unknown code returns `None` before reaching it, and the note says what changes if that stops being true.

## Checks

- `uv run pytest tests/surfaces/test_arcade_leaderboard_gaps.py` → 25 passed.
- Each new guard verified red against its own revert.
- `ruff check` + `ruff format --check` clean.
