### PR TITLE
fix(arcade): the P3 remainder of the Fable wire gate

### DIFF
--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -501,34 +501,28 @@ class F1ArcadeView(arcade.View):
         return GP_TO_LOCATION.get(gp_name, gp_name)
 
     def on_hide_view(self) -> None:
-        """Tear down the strategy driver, stream server, and dashboard subprocess."""
+        """Tear down the strategy driver, the stream server and both companion windows."""
         if self._strategy_connector is not None:
             self._strategy_connector.stop()
         if self._stream_server is not None:
             self._stream_server.stop()
             self._stream_server = None
-        if self._dashboard_proc is not None:
-            try:
-                self._dashboard_proc.terminate()
-                self._dashboard_proc.wait(timeout=3.0)
-            except subprocess.TimeoutExpired:
-                logger.warning("Dashboard did not exit in 3s — killing")
-                self._dashboard_proc.kill()
-            except OSError as exc:
-                # terminate()/wait() on an already-dead or inaccessible
-                # process raise OSError subclasses (e.g. ProcessLookupError);
-                # nothing else is documented for these two calls.
-                logger.warning("Dashboard teardown error: %s", exc)
-            self._dashboard_proc = None
+        # Both subprocesses go through the same helper. `_terminate`'s own
+        # docstring says a second copy of its block would be the twin that
+        # stops getting fixed, and this inline copy was that twin from the
+        # moment the helper was extracted.
+        self._dashboard_proc = self._terminate(self._dashboard_proc, "Dashboard")
         self._pitwall_proc = self._terminate(self._pitwall_proc, "Pitwall")
 
     @staticmethod
     def _terminate(proc: subprocess.Popen | None, name: str) -> None:
         """Stop a companion window process, whatever state it is in.
 
-        Same three outcomes as the dashboard's teardown above, which is why
-        this exists: a second copy of that block would be the twin that
-        stops getting fixed.
+        Three outcomes: it exits, it does not and gets killed, or it was
+        already gone. Every companion window goes through here, which is
+        the point: a second copy of this block would be the twin that stops
+        getting fixed, and for one release the dashboard's teardown was
+        exactly that copy.
         """
         if proc is None:
             return None

--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -193,10 +193,14 @@ STREAM_BROADCAST_EVERY_N_FRAMES: Final[int] = 6
 # tick publishes `dropped` alongside the span - a forward jump is otherwise
 # invisible to a consumer, which sees a contiguous `seq` and a forward clock.
 #
-# The cap is not free. `sendall` runs on the pyglet main thread, so a bigger
-# message freezes the replay sooner against a stalled subscriber, measured at
-# 0.7 s instead of about 130 s. That is why `stream.py` gives every client a
-# send timeout: the cap bounds the message, the timeout bounds the wait.
+# The cap is not free: a bigger message fills a stalled subscriber's socket
+# buffer in fewer broadcasts. Sends run on stream.py's own sender thread and
+# never on the pyglet one (measured: 300 broadcasts against a client that
+# never reads cost the caller 0.98 ms at worst), so the replay cannot freeze;
+# the per-client send timeout is what prunes a subscriber that stops reading.
+# The cap bounds what one tick can carry, the timeout bounds what one client
+# can cost. An earlier version of this comment described the pre-#850
+# architecture, where `sendall` DID run on the pyglet thread.
 STREAM_MAX_SPAN_FRAMES: Final[int] = 250
 # Cap how many LapDecision entries we keep in the broadcast history tail.
 STREAM_HISTORY_TAIL: Final[int] = 30

--- a/src/arcade/dashboard/telemetry_panel.py
+++ b/src/arcade/dashboard/telemetry_panel.py
@@ -271,10 +271,20 @@ class TelemetryPanel(QFrame):
             self._vs_label.hide()
             self._rival_chip.hide()
 
-        # A backwards seek invalidates everything held: the buffers are
+        # Either discontinuity invalidates everything held: the buffers are
         # keyed on distance-within-lap, so they contain samples for track
-        # the car has not re-driven yet and nothing else would evict them.
-        if telemetry.get("rewound"):
+        # the car has not re-driven yet (a backwards seek) or for a part of
+        # the race the span never covered (a forward jump), and nothing else
+        # would evict them.
+        #
+        # Evicting BEFORE appending matters for the forward jump. The tick
+        # that carries `dropped` also carries a valid post-jump span, and
+        # clearing afterwards threw those samples away — up to 250 of them,
+        # ten seconds of trace the payload had already delivered, leaving
+        # four blank charts to refill over the next ~25 s. The two branches
+        # were the same operation in opposite orders and one of them was
+        # wrong.
+        if telemetry.get("rewound") or telemetry.get("dropped"):
             self._reset_buffers()
 
         # The span can cross a lap boundary at high playback speed, so the
@@ -298,11 +308,6 @@ class TelemetryPanel(QFrame):
             if int(sample.get("lap") or 0) == self._current_lap:
                 self._append(self._rival_buffer, sample)
 
-        if telemetry.get("dropped"):
-            # A forward seek the span could not cover: the frames between
-            # here and the last tick were never sent, so appending would
-            # splice two unrelated parts of the race into one trace.
-            self._reset_buffers()
         self._refresh_speed_brake_throttle(has_rival=bool(driver_rival))
         # Two-driver mode is a property of the session, not of whether this
         # particular tick happened to carry a rival sample — an empty span

--- a/src/arcade/data.py
+++ b/src/arcade/data.py
@@ -160,10 +160,19 @@ def _pedal_multiplier(results: list[dict], channel: str) -> float:
     somewhere in a race and a 0-1 channel never does. One look at the whole
     array replaces three million guesses.
     """
-    peak = max(
-        (float(np.nanmax(r["data"][channel])) for r in results if len(r["data"][channel])),
-        default=0.0,
-    )
+    # `max()` keeps a NaN when the NaN comes FIRST, because every later
+    # `x > nan` is False. One driver whose whole channel is NaN and who
+    # happens to sort first would then flip the multiplier for the entire
+    # session - every throttle above 1 % published as 100.0, for all twenty
+    # cars, depending on nothing but driver order. Filtering the peaks makes
+    # an all-NaN channel contribute nothing instead of deciding the answer.
+    peaks: list[float] = []
+    for result in results:
+        samples = result["data"][channel]
+        finite = samples[np.isfinite(samples)] if len(samples) else samples
+        if len(finite):
+            peaks.append(float(finite.max()))
+    peak = max(peaks, default=0.0)
     return 1.0 if peak > 1.0 else 100.0
 
 
@@ -248,7 +257,6 @@ def _process_driver_data(args: tuple) -> dict | None:
             "brake",
             "lap",
             "dist",
-            "rel_dist",
             "tyre",
             "tyre_life",
         )
@@ -280,12 +288,10 @@ def _process_driver_data(args: tuple) -> dict | None:
         d_lap = (
             tel["Distance"].to_numpy().astype(float) if "Distance" in tel.columns else np.zeros(n)
         )
-        rel_dist = (
-            tel["RelativeDistance"].to_numpy().astype(float)
-            if "RelativeDistance" in tel.columns
-            else np.zeros(n)
-        )
-
+        # FastF1's `RelativeDistance` is deliberately NOT collected. The
+        # resampler stopped consuming it when the fraction became a
+        # derivation over the driver's own distance; extracting it was
+        # three lines of work per lap per driver feeding nothing.
         race_dist = total_dist_so_far + d_lap
         total_dist_so_far += float(d_lap[-1]) if n else 0.0
 
@@ -304,7 +310,6 @@ def _process_driver_data(args: tuple) -> dict | None:
         arrays["brake"].append(brk)
         arrays["lap"].append(np.full(n, lap_no, dtype=float))
         arrays["dist"].append(race_dist)
-        arrays["rel_dist"].append(rel_dist)
         arrays["tyre"].append(np.full(n, tyre, dtype=float))
         arrays["tyre_life"].append(np.full(n, tyre_life, dtype=float))
 

--- a/src/arcade/stream.py
+++ b/src/arcade/stream.py
@@ -84,10 +84,17 @@ def _json_safe(value):
 
 
 def _blame(value, path: str = "") -> str:
-    """Point at the first non-finite leaf in a payload, for the drop log.
+    """Point at the first leaf `json.dumps` cannot encode, for the drop log.
 
     Without it the encoder's message names the type and not the field, and
     the whole reason a broadcast was dropped stays invisible.
+
+    Two kinds of leaf get named, because the sanitiser only handles the
+    first: a non-finite float, which `_json_safe` would have turned into
+    None, and anything the encoder simply cannot take. `np.float32(nan)`,
+    `np.int64` and `np.bool_` are not `float`/`int`/`bool` subclasses, so
+    they slip past the sanitiser, kill the whole tick, and used to leave
+    this function returning the empty string exactly when it was needed.
     """
     if isinstance(value, dict):
         for key, item in value.items():
@@ -101,6 +108,8 @@ def _blame(value, path: str = "") -> str:
                 return found
     elif isinstance(value, float) and not math.isfinite(value):
         return f"{path or '<root>'}={value}"
+    elif not isinstance(value, (str, int, float, bool, type(None))):
+        return f"{path or '<root>'}=<{type(value).__name__}>"
     return ""
 
 
@@ -269,9 +278,15 @@ class TelemetryStreamServer:
             ).start()
 
     def _keepalive_loop(self, client_socket: socket.socket) -> None:
-        """Hold the socket open until it dies. We do not expect reads from
-        the dashboard; this thread just keeps the FD alive and prunes it
-        once the remote end closes."""
+        """Hold a reference to the socket until the server stops.
+
+        It never reads, so it CANNOT see the remote end close - measured: a
+        client that disconnects is still counted three seconds later, and
+        only disappears once a broadcast fails to send. A dead client is
+        detected by `_send_loop`, never here, so `client_count()` may
+        include ghosts until the next broadcast. The docstring used to
+        promise the prune this loop does not do.
+        """
         try:
             while self._running:
                 time.sleep(1.0)

--- a/tests/surfaces/test_arcade_broadcast_wire.py
+++ b/tests/surfaces/test_arcade_broadcast_wire.py
@@ -275,3 +275,22 @@ def test_location_is_published_and_can_genuinely_disagree_with_the_label():
     assert fallback is GP_NAMES, "an absent year must fall back, not raise"
     disagreeing = {rnd for rnd in canonical if rnd in fallback and canonical[rnd] != fallback[rnd]}
     assert disagreeing, "if the two tables agreed everywhere, location would be redundant"
+
+
+def test_the_pedal_scale_is_not_decided_by_which_driver_sorts_first():
+    """`max()` keeps a NaN that arrives FIRST, because every `x > nan` is False.
+
+    One driver whose whole throttle channel is NaN, sorting ahead of the
+    others, therefore flipped the session multiplier from 1.0 to 100.0 —
+    every pedal reading above 1 % published as 100.0, for all twenty cars,
+    on nothing but driver order. Not triggered on Melbourne 2025, where
+    HAD's pedal channels are real; silent and global when it is.
+    """
+    from src.arcade.data import _pedal_multiplier
+
+    all_nan = {"data": {"throttle": np.full(5, np.nan)}}
+    real = {"data": {"throttle": np.array([0.0, 55.0, 100.0])}}
+
+    assert _pedal_multiplier([all_nan, real], "throttle") == 1.0
+    assert _pedal_multiplier([real, all_nan], "throttle") == 1.0
+    assert _pedal_multiplier([{"data": {"throttle": np.array([0.0, 0.9])}}], "throttle") == 100.0

--- a/tests/surfaces/test_arcade_stream_server.py
+++ b/tests/surfaces/test_arcade_stream_server.py
@@ -110,3 +110,28 @@ def test_nothing_non_finite_reaches_a_socket():
         assert decoded["model"]["lap_time_s"] is None
     finally:
         server._running = False
+
+
+def test_the_drop_log_names_the_leaf_the_encoder_choked_on():
+    """`_blame` used to return the empty string for everything but a plain float.
+
+    `np.float32`, `np.int64` and `np.bool_` are not subclasses of Python's
+    float/int/bool, so the sanitiser cannot rewrite them and `json.dumps`
+    cannot encode them: the tick dies whole, which is the right outcome,
+    and the log said nothing about why, which is not. One agent output
+    carrying a `predict()[0]` without its `float()` would drop every tick
+    at 10 Hz behind an empty message.
+    """
+    import numpy as np
+
+    from src.arcade.stream import _blame
+
+    assert _blame({"a": {"b": float("nan")}}) == "a.b=nan"
+    for leaf, name in (
+        (np.float32("nan"), "float32"),
+        (np.float32(1.5), "float32"),
+        (np.int64(3), "int64"),
+        (np.bool_(True), "bool_"),
+    ):
+        assert _blame({"per_agent": [{"pace": leaf}]}) == f"per_agent[0].pace=<{name}>"
+    assert _blame({"a": 1, "b": "ok", "c": None, "d": True, "e": 1.5}) == ""


### PR DESCRIPTION
The P3 remainder of the Fable re-run of the sprint-1 wire gate (FF3, FF7-FF12). No issue per finding: these are one-to-five-line fixes and the repo's rule is to right-size the ceremony. The P1/P2 findings from the same gate are #853-#856, all landed.

| # | What was wrong | Fix |
|---|---|---|
| **FF7** | `_pedal_multiplier` used `max()` over a generator, and `max()` keeps a NaN that arrives **first** — every later `x > nan` is False. One driver whose whole channel is NaN, sorting ahead of the others, flipped the session multiplier from 1.0 to 100.0: every pedal reading above 1 % published as 100.0, for all twenty cars, on nothing but driver order. Latent on Melbourne 2025 (HAD's pedal channels are real); silent and global when it fires. | filter to finite peaks before taking the max, warning-free |
| **FF8** | `_blame` tested `isinstance(value, float)`, so `np.float32`, `np.int64` and `np.bool_` — which the sanitiser also cannot rewrite — killed the whole tick and left the drop log printing an empty string, exactly when it is needed | name any leaf the encoder cannot take |
| **FF3** | the Qt telemetry panel reset its buffers **after** appending on a forward jump and **before** on a rewind. The tick carrying `dropped` also carries a valid post-jump span, so up to 250 samples — ten seconds of trace the payload had already delivered — were appended and then thrown away, leaving four blank charts to refill over ~25 s | evict first for both discontinuities, one branch |
| **FF9** | `config.py` justified `STREAM_MAX_SPAN_FRAMES` with "`sendall` runs on the pyglet main thread", the architecture #850 removed. Measured: 300 broadcasts against a client that never reads cost the caller 0.98 ms at worst. Anyone tuning the constant was reasoning about a threat model two PRs old | describe the shipped mechanism |
| **FF10** | `_keepalive_loop`'s docstring promised it "prunes [the FD] once the remote end closes". Its body is `while running: sleep(1)` — it never touches the socket, so it cannot observe a close. Measured: a disconnected client is still counted three seconds later and only disappears when a broadcast fails | say what it actually does, and that `client_count()` can include ghosts until the next send |
| **FF11** | `_terminate` exists so the teardown block lives once, and its own docstring says "a second copy of that block would be the twin that stops getting fixed". The dashboard teardown was still the inline copy | route both companion windows through it |
| **FF12** | `_process_driver_data` still extracted FastF1's `RelativeDistance` per lap per driver. `_resample_driver` stopped consuming it when the fraction became a derivation over the driver's own distance | delete the extraction, the append and the key |

## Checks

- `uv run pytest tests/surfaces` → 95 passed, 1 failed (`test_cli_no_llm`, the known curated-download gap, red on `dev` too).
- Two new tests, both asserting the effect: the pedal scale is independent of driver order, and the drop log names the leaf for each numpy scalar type.
- FF3 and FF9-FF12 have no test. FF3 is a Qt widget that needs a display and dies in sprint 7; the rest are comments, a dedup with identical behaviour, and dead code. Saying so rather than inventing a test that asserts a comment.
- `ruff check .` + `ruff format --check .` clean.
