### PR TITLE
feat(pitwall): make the shared formatters importable without Qt

### DIFF
--- a/documents/research/PITWALL_DELIVERY_PLAN.md
+++ b/documents/research/PITWALL_DELIVERY_PLAN.md
@@ -171,6 +171,14 @@ rival overlaid and labelled broadcast tier, and the ring. **Depends on sprint 1*
 the span (#841) and the ring needs `rel_dist` (#842). Retired cars must render as retired, not as
 pending, which needs `active` (#842).
 
+⛔ **Sprint 4 has a prerequisite: #857.** The wire publishes only `lap`, `dist` and `rel_dist` per
+driver — the two coordinates #844 spent a sprint refuting, plus a fraction. It publishes no race
+order, no `progress` and no interval, and a consumer that attaches mid-race cannot rebuild the
+crossing map from a 10 Hz snapshot stream. Decide what the timing band actually needs and publish
+it from the producer, which already owns `self._gaps`; otherwise the DATA window re-derives the
+order from the refuted coordinates and this repo's dominant defect lands one more time. It must
+come after #855, which changed what `progress` returns for a finisher.
+
 **Gate at the end of sprint 6:** adversarial, on tier discipline and on every claim the surface
 makes about what it is showing.
 
@@ -178,7 +186,15 @@ makes about what it is showing.
 
 ## 6. Sprint 7 — retire Qt, package, fix the prose
 
-**Deleting `src/arcade/dashboard/` is bigger than it looks.** Gate B built the reference graph; the
+⛔ **Two modules under `src/arcade/dashboard/` MOVE, they do not get deleted.** Sprint 3 made
+PITWALL render the AGENTS window by calling the Qt window's own formatters, which is what makes
+the port 1:1 by construction rather than by inspection. `agent_formatters.py` and the reasoning
+line builders are therefore live product code with a consumer that outlives Qt; deleting the
+package wholesale takes the AGENTS window's entire content layer with it. Move them to
+`src/pitwall/` and keep going. `src/arcade/palette.py` already lives outside the package for this
+reason and needs nothing.
+
+**Deleting the rest of `src/arcade/dashboard/` is bigger than it looks.** Gate B built the reference graph; the
 one that would not have been found by a doc sweep is
 `tests/agents/test_overtake_domain.py:231`, which imports `format_situation` from the dashboard
 package for a **domain** test. Also: `tests/surfaces/test_arcade_dashboard_imports.py` (13 modules),

--- a/src/arcade/dashboard/agent_formatters.py
+++ b/src/arcade/dashboard/agent_formatters.py
@@ -14,6 +14,13 @@ widget maps ``status`` to the glyph + colour.
 
 No agent package imports: formatters accept plain dicts already
 serialised by ``src/arcade/strategy.py::_dump_dataclass``.
+
+**This module must stay importable without a display stack.** PITWALL's
+host calls these same functions so its AGENTS window is the Qt window's
+output by construction rather than by inspection, and it runs in a
+process that has no Qt. That is why the colours come from
+``src.arcade.palette`` and not from ``dashboard.theme``, which imports
+PySide6 and, through ``classify_action``, pandas.
 """
 
 from __future__ import annotations
@@ -21,7 +28,7 @@ from __future__ import annotations
 import html
 from typing import Any
 
-from src.arcade.dashboard.theme import (
+from src.arcade.palette import (
     DANGER,
     SUCCESS,
     TEXT_PRIMARY,

--- a/src/arcade/dashboard/theme.py
+++ b/src/arcade/dashboard/theme.py
@@ -1,15 +1,25 @@
-"""Dashboard theme: palette, compound colours, action classification.
+"""The Qt half of the dashboard theme: the palette applied to a QApplication.
 
-Constants are duplicated from ``src/arcade/config.py`` on purpose: the
-dashboard runs in its own process and importing the arcade config would
-pull pyglet / arcade / fastf1 into the Qt process (cold start ~2 s and
-no way to ever call the API without paying the price). Keep both files
-in sync when the palette changes upstream: they are the two sources
-of truth for the TFG's visual identity.
+**The colours themselves are no longer here.** They live in
+`src/arcade/palette.py`, which imports nothing but `html` and `typing`,
+and are re-exported below so every widget in this package keeps importing
+them from where it always did.
 
-Values here mirror ``src/telemetry/frontend/app/styles.py`` (the
-Streamlit app's palette) so the dashboard reads as the same product as
-the Streamlit UI and the arcade replay.
+The split exists because PITWALL renders its AGENTS window from the same
+`agent_formatters` that paint the Qt one — that is what makes the port
+1:1 by construction rather than by inspection — and importing this module
+used to drag in PySide6 (a display stack) and, through `classify_action`,
+pandas. Measured: `src.arcade.strategy` alone is 0.410 s. It also made
+`test_the_two_python_palettes_still_mirror_each_other` unrunnable on a
+headless runner, so the one guard against the two Python palettes drifting
+was skipped in CI.
+
+`classify_action` is still imported rather than copied: a hand-written
+twin lived here until 2026-08-01 and drifted, which is the same mechanism
+#620 fixed once for `_ALERT_SEVERITY`.
+
+This whole package is deleted when the Qt windows are retired; `palette.py`
+is not.
 """
 
 from __future__ import annotations
@@ -19,177 +29,66 @@ from typing import Final
 
 from PySide6.QtGui import QColor, QPalette
 
+from src.arcade.palette import (
+    ACCENT,
+    BG_COLOR,
+    BORDER_COLOR,
+    COMPOUND_COLORS,
+    COMPOUND_NAMES,
+    CONTENT_BG,
+    DANGER,
+    INFO,
+    MONO_FONT_STACK,
+    SECONDARY_BG,
+    SUCCESS,
+    TEXT_PRIMARY,
+    TEXT_SECONDARY,
+    TEXT_TERTIARY,
+    WARNING,
+    compound_color,
+    compound_pill_html,
+    flag_chip_html,
+    hex_str,
+)
 from src.arcade.strategy import (
     classify_action,  # noqa: F401 -- re-exported for orchestrator_card.py
 )
 
-# --- Palette (RGB tuples) ------------------------------------------------
-BG_COLOR: Final[tuple[int, int, int]] = (18, 17, 39)  # #121127 PRIMARY_BG
-CONTENT_BG: Final[tuple[int, int, int]] = (24, 22, 51)  # #181633 panel bg
-SECONDARY_BG: Final[tuple[int, int, int]] = (30, 27, 75)  # #1e1b4b elevated
-BORDER_COLOR: Final[tuple[int, int, int]] = (45, 45, 58)  # #2d2d3a
-TEXT_PRIMARY: Final[tuple[int, int, int]] = (255, 255, 255)
-TEXT_SECONDARY: Final[tuple[int, int, int]] = (209, 213, 219)  # #d1d5db
-TEXT_TERTIARY: Final[tuple[int, int, int]] = (156, 163, 175)  # #9ca3af
-ACCENT: Final[tuple[int, int, int]] = (167, 139, 250)  # #a78bfa purple
-SUCCESS: Final[tuple[int, int, int]] = (16, 185, 129)  # #10b981 emerald
-WARNING: Final[tuple[int, int, int]] = (245, 158, 11)  # #f59e0b amber
-DANGER: Final[tuple[int, int, int]] = (239, 68, 68)  # #ef4444 red
-INFO: Final[tuple[int, int, int]] = (59, 130, 246)  # #3b82f6 blue
-
-# --- Compound colours (Pirelli IDs 0-4) ----------------------------------
-COMPOUND_COLORS: Final[dict[int, tuple[int, int, int]]] = {
-    0: (230, 50, 50),  # SOFT
-    1: (230, 200, 50),  # MEDIUM
-    2: (230, 230, 230),  # HARD
-    3: (60, 200, 60),  # INTERMEDIATE
-    4: (60, 130, 230),  # WET
-}
-COMPOUND_NAMES: Final[dict[str, tuple[int, int, int]]] = {
-    "SOFT": COMPOUND_COLORS[0],
-    "MEDIUM": COMPOUND_COLORS[1],
-    "HARD": COMPOUND_COLORS[2],
-    "INTER": COMPOUND_COLORS[3],
-    "INTERMEDIATE": COMPOUND_COLORS[3],
-    "WET": COMPOUND_COLORS[4],
-}
+__all__ = [
+    "ACCENT",
+    "BG_COLOR",
+    "BORDER_COLOR",
+    "COMPOUND_COLORS",
+    "COMPOUND_NAMES",
+    "CONTENT_BG",
+    "DANGER",
+    "INFO",
+    "MONO_FONT_STACK",
+    "SECONDARY_BG",
+    "STREAM_HOST",
+    "STREAM_PORT",
+    "SUCCESS",
+    "TEXT_PRIMARY",
+    "TEXT_SECONDARY",
+    "TEXT_TERTIARY",
+    "WARNING",
+    "apply_dark_palette",
+    "classify_action",
+    "compound_color",
+    "compound_pill_html",
+    "flag_chip_html",
+    "hex_str",
+    "qcolor",
+]
 
 # --- Stream config (must match src/arcade/config.py) ---------------------
 STREAM_HOST: Final[str] = os.environ.get("F1_STREAM_HOST", "127.0.0.1")
 STREAM_PORT: Final[int] = int(os.environ.get("F1_STREAM_PORT", "9998"))
 
-# --- Action classification ---------------------------------------------------
-# `classify_action` is imported from src.arcade.strategy (not duplicated): a
-# hand-copied version lived here until this cleanup (2026-08-01), mirrored
-# under a "mirrors X" comment -- the same drift mechanism #620 already fixed
-# once for `_ALERT_SEVERITY` (imported above, not defined here either), just
-# not yet triggered for this one. The extra pandas import this pulls in from
-# strategy.py is a small addition next to the PySide6 + pyqtgraph cost this
-# process already pays on cold start.
-
 
 def qcolor(rgb: tuple[int, int, int]) -> QColor:
     """Small helper so widgets can do ``self.setPalette(qcolor(ACCENT))``."""
     return QColor(rgb[0], rgb[1], rgb[2])
-
-
-def hex_str(rgb: tuple[int, int, int]) -> str:
-    """Return ``#rrggbb`` for Qt stylesheet strings."""
-    return f"#{rgb[0]:02x}{rgb[1]:02x}{rgb[2]:02x}"
-
-
-# --- Monospace font chain ------------------------------------------------
-# Fira Code (+ its Nerd Font variant) ships with programming ligatures and
-# a lot of monospace glyphs that align neatly for metric tables. Users
-# who have it installed get the richer look; the Consolas / Courier New
-# fallbacks keep the rendering legible when not.
-MONO_FONT_STACK: Final[str] = (
-    "'FiraCode Nerd Font Mono', 'Fira Code', 'JetBrains Mono', 'Consolas', 'Courier New', monospace"
-)
-
-
-# --- Compound pill HTML (Pirelli-style badge) ---------------------------
-# Compound labels come through the pipeline in several shapes: the
-# friendly agent form ("SOFT", "MEDIUM", "HARD", "INTER", "WET") and the
-# raw Pirelli id ("C1"…"C6"). Both should paint the same pill colour —
-# red for soft, yellow for medium, white for hard, green for inter,
-# blue for wet. The function returns an HTML snippet that QLabel can
-# render in rich-text mode next to plain text.
-
-_COMPOUND_COLOUR_BY_LABEL: Final[dict[str, tuple[int, int, int]]] = {
-    "SOFT": (230, 50, 50),
-    "MEDIUM": (230, 200, 50),
-    "HARD": (230, 230, 230),
-    "INTER": (60, 200, 60),
-    "INTERMEDIATE": (60, 200, 60),
-    "WET": (60, 130, 230),
-    "S": (230, 50, 50),
-    "M": (230, 200, 50),
-    "H": (230, 230, 230),
-    "I": (60, 200, 60),
-    "W": (60, 130, 230),
-    # Pirelli Cx mapping per the dry-race convention — hardest compounds
-    # white, medium yellow, softest red.
-    "C1": (230, 230, 230),
-    "C2": (230, 230, 230),
-    "C3": (230, 200, 50),
-    "C4": (230, 50, 50),
-    "C5": (230, 50, 50),
-    "C6": (230, 50, 50),
-}
-
-
-def compound_color(compound: str) -> tuple[int, int, int]:
-    """Map any compound label to a Pirelli-style colour tuple."""
-    key = (compound or "").upper().strip()
-    return _COMPOUND_COLOUR_BY_LABEL.get(key, TEXT_SECONDARY)
-
-
-def compound_pill_html(compound: str | None) -> str:
-    """Return a colored rounded pill as a Qt rich-text span.
-
-    Used inline in ``QLabel.setText`` so the compound always reads as a
-    Pirelli-style badge without having to embed a child widget.
-    Unknown labels collapse to a neutral dash pill to keep the layout
-    aligned."""
-    label = (compound or "—").strip() or "—"
-    colour = compound_color(label)
-    # Dark text on light/saturated backgrounds, white on dim ones.
-    lum = 0.299 * colour[0] + 0.587 * colour[1] + 0.114 * colour[2]
-    fg = BG_COLOR if lum > 180 else TEXT_PRIMARY
-    # Qt rich-text: single quotes in the font stack are fine since we use
-    # double quotes for the style attribute.
-    font_stack = MONO_FONT_STACK
-    return (
-        '<span style="'
-        f"background-color: {hex_str(colour)}; "
-        f"color: {hex_str(fg)}; "
-        "padding: 1px 7px; border-radius: 7px; "
-        "font-weight: 800; font-size: 10px; "
-        f"font-family: {font_stack};"
-        f'">{label}</span>'
-    )
-
-
-# --- Alert flag chips ---------------------------------------------------
-# Radio / RCM intents collapse to a colored chip matching the broadcast
-# flag semantics — red for red-flag / safety-car, amber for VSC / yellow,
-# blue for ops "PROBLEM" / "WARNING" radios. Anything unknown stays
-# neutral grey so the reader is never misled by an unstyled label.
-
-_FLAG_BG_BY_INTENT: Final[dict[str, tuple[int, int, int]]] = {
-    "SAFETY_CAR": DANGER,
-    "RED_FLAG": DANGER,
-    "VSC": WARNING,
-    "VIRTUAL_SAFETY_CAR": WARNING,
-    "YELLOW_FLAG": WARNING,
-    # Same tier as YELLOW_FLAG (matches _ALERT_SEVERITY's own severity-2 grouping
-    # in strategy.py). A sector-scoped double yellow (rcm_events.py's
-    # classify_rcm_event returns this exact event type) was missing this key and
-    # fell through to the neutral-grey default -- the same bug shape #398 fixed
-    # in _ALERT_SEVERITY, alive here independently because this is a third,
-    # separately maintained severity mapping (found by the 2026-08-01 cleanup's
-    # adversarial gate).
-    "YELLOW_FLAG_SECTOR": WARNING,
-    "PROBLEM": INFO,
-    "WARNING": INFO,
-    "PENALTY": DANGER,
-}
-
-
-def flag_chip_html(intent: str | None) -> str:
-    """Coloured pill for a single alert intent or RCM event type."""
-    key = (intent or "—").upper().strip() or "—"
-    bg = _FLAG_BG_BY_INTENT.get(key, TEXT_TERTIARY)
-    label = key.replace("_", " ")
-    return (
-        '<span style="'
-        f"background-color: {hex_str(bg)}; "
-        f"color: {hex_str(TEXT_PRIMARY)}; "
-        "padding: 1px 6px; border-radius: 6px; "
-        "font-weight: 700; font-size: 10px; letter-spacing: 0.3px;"
-        f'">{label}</span>'
-    )
 
 
 def apply_dark_palette(app) -> None:

--- a/src/arcade/palette.py
+++ b/src/arcade/palette.py
@@ -1,0 +1,189 @@
+"""The product's visual vocabulary, with no toolkit attached.
+
+Colours, the compound and flag maps, and the two HTML badge builders that
+turn a compound or an alert intent into a coloured pill. Nothing here
+imports Qt, pyglet or pandas, which is the whole point: **PITWALL renders
+the AGENTS window from the same formatters that paint the Qt one**, and
+those formatters need six colour tuples and two badge builders, not a
+widget toolkit and a dataframe library.
+
+Measured before the split: importing `src.arcade.strategy` (which
+`dashboard/theme.py` does, for `classify_action`) costs 0.410 s and pulls
+pandas, against 0.025 s for `src.arcade.config`. A module that answers
+"what colour is a MEDIUM tyre" should cost neither that nor a display
+stack.
+
+It lives outside `src/arcade/dashboard/` deliberately. That whole package
+is deleted when the Qt windows are retired, and this must survive it.
+
+**These values are still a deliberate copy of `src/arcade/config.py`'s**,
+kept separate because the two run in different processes and importing
+the arcade config from a UI process would pull pyglet and fastf1 in with
+it. `tests/surfaces/test_pitwall_tokens.py` is what stops the copies
+drifting, and it can finally run in CI now that reading them needs no
+libEGL.
+"""
+
+from __future__ import annotations
+
+import html
+from typing import Final
+
+# --- Palette (RGB tuples) ------------------------------------------------
+BG_COLOR: Final[tuple[int, int, int]] = (18, 17, 39)  # #121127 PRIMARY_BG
+CONTENT_BG: Final[tuple[int, int, int]] = (24, 22, 51)  # #181633 panel bg
+SECONDARY_BG: Final[tuple[int, int, int]] = (30, 27, 75)  # #1e1b4b elevated
+BORDER_COLOR: Final[tuple[int, int, int]] = (45, 45, 58)  # #2d2d3a
+TEXT_PRIMARY: Final[tuple[int, int, int]] = (255, 255, 255)
+TEXT_SECONDARY: Final[tuple[int, int, int]] = (209, 213, 219)  # #d1d5db
+TEXT_TERTIARY: Final[tuple[int, int, int]] = (156, 163, 175)  # #9ca3af
+ACCENT: Final[tuple[int, int, int]] = (167, 139, 250)  # #a78bfa purple
+SUCCESS: Final[tuple[int, int, int]] = (16, 185, 129)  # #10b981 emerald
+WARNING: Final[tuple[int, int, int]] = (245, 158, 11)  # #f59e0b amber
+DANGER: Final[tuple[int, int, int]] = (239, 68, 68)  # #ef4444 red
+INFO: Final[tuple[int, int, int]] = (59, 130, 246)  # #3b82f6 blue
+
+# --- Compound colours (Pirelli IDs 0-4) ----------------------------------
+COMPOUND_COLORS: Final[dict[int, tuple[int, int, int]]] = {
+    0: (230, 50, 50),  # SOFT
+    1: (230, 200, 50),  # MEDIUM
+    2: (230, 230, 230),  # HARD
+    3: (60, 200, 60),  # INTERMEDIATE
+    4: (60, 130, 230),  # WET
+}
+COMPOUND_NAMES: Final[dict[str, tuple[int, int, int]]] = {
+    "SOFT": COMPOUND_COLORS[0],
+    "MEDIUM": COMPOUND_COLORS[1],
+    "HARD": COMPOUND_COLORS[2],
+    "INTER": COMPOUND_COLORS[3],
+    "INTERMEDIATE": COMPOUND_COLORS[3],
+    "WET": COMPOUND_COLORS[4],
+}
+
+
+def hex_str(rgb: tuple[int, int, int]) -> str:
+    """Return ``#rrggbb``, for a Qt stylesheet or a CSS declaration alike."""
+    return f"#{rgb[0]:02x}{rgb[1]:02x}{rgb[2]:02x}"
+
+
+# --- Monospace font chain ------------------------------------------------
+# Fira Code (+ its Nerd Font variant) ships with programming ligatures and
+# a lot of monospace glyphs that align neatly for metric tables. Users
+# who have it installed get the richer look; the Consolas / Courier New
+# fallbacks keep the rendering legible when not.
+MONO_FONT_STACK: Final[str] = (
+    "'FiraCode Nerd Font Mono', 'Fira Code', 'JetBrains Mono', 'Consolas', 'Courier New', monospace"
+)
+
+
+# --- Compound pill HTML (Pirelli-style badge) ---------------------------
+# Compound labels come through the pipeline in several shapes: the
+# friendly agent form ("SOFT", "MEDIUM", "HARD", "INTER", "WET") and the
+# raw Pirelli id ("C1"…"C6"). Both should paint the same pill colour —
+# red for soft, yellow for medium, white for hard, green for inter,
+# blue for wet. The function returns an HTML snippet that a QLabel can
+# render in rich-text mode, and that a browser renders identically.
+
+_COMPOUND_COLOUR_BY_LABEL: Final[dict[str, tuple[int, int, int]]] = {
+    "SOFT": (230, 50, 50),
+    "MEDIUM": (230, 200, 50),
+    "HARD": (230, 230, 230),
+    "INTER": (60, 200, 60),
+    "INTERMEDIATE": (60, 200, 60),
+    "WET": (60, 130, 230),
+    "S": (230, 50, 50),
+    "M": (230, 200, 50),
+    "H": (230, 230, 230),
+    "I": (60, 200, 60),
+    "W": (60, 130, 230),
+    # Pirelli Cx mapping per the dry-race convention — hardest compounds
+    # white, medium yellow, softest red.
+    "C1": (230, 230, 230),
+    "C2": (230, 230, 230),
+    "C3": (230, 200, 50),
+    "C4": (230, 50, 50),
+    "C5": (230, 50, 50),
+    "C6": (230, 50, 50),
+}
+
+
+def compound_color(compound: str) -> tuple[int, int, int]:
+    """Map any compound label to a Pirelli-style colour tuple."""
+    key = (compound or "").upper().strip()
+    return _COMPOUND_COLOUR_BY_LABEL.get(key, TEXT_SECONDARY)
+
+
+def compound_pill_html(compound: str | None) -> str:
+    """Return a coloured rounded pill as a rich-text span.
+
+    Used inline in a label so the compound always reads as a
+    Pirelli-style badge without having to embed a child widget.
+    Unknown labels collapse to a neutral dash pill to keep the layout
+    aligned.
+
+    The label is HTML-escaped. It comes off the wire, and an unescaped
+    ``<`` broke Qt's rich-text parser long before PITWALL made these
+    strings reach a webview.
+    """
+    label = (compound or "—").strip() or "—"
+    colour = compound_color(label)
+    # Dark text on light/saturated backgrounds, white on dim ones.
+    lum = 0.299 * colour[0] + 0.587 * colour[1] + 0.114 * colour[2]
+    fg = BG_COLOR if lum > 180 else TEXT_PRIMARY
+    # Single quotes in the font stack are fine since the style attribute
+    # uses double quotes.
+    font_stack = MONO_FONT_STACK
+    return (
+        '<span style="'
+        f"background-color: {hex_str(colour)}; "
+        f"color: {hex_str(fg)}; "
+        "padding: 1px 7px; border-radius: 7px; "
+        "font-weight: 800; font-size: 10px; "
+        f"font-family: {font_stack};"
+        f'">{html.escape(label)}</span>'
+    )
+
+
+# --- Alert flag chips ---------------------------------------------------
+# Radio / RCM intents collapse to a coloured chip matching the broadcast
+# flag semantics — red for red-flag / safety-car, amber for VSC / yellow,
+# blue for ops "PROBLEM" / "WARNING" radios. Anything unknown stays
+# neutral grey so the reader is never misled by an unstyled label.
+
+_FLAG_BG_BY_INTENT: Final[dict[str, tuple[int, int, int]]] = {
+    "SAFETY_CAR": DANGER,
+    "RED_FLAG": DANGER,
+    "VSC": WARNING,
+    "VIRTUAL_SAFETY_CAR": WARNING,
+    "YELLOW_FLAG": WARNING,
+    # Same tier as YELLOW_FLAG (matches _ALERT_SEVERITY's own severity-2 grouping
+    # in strategy.py). A sector-scoped double yellow (rcm_events.py's
+    # classify_rcm_event returns this exact event type) was missing this key and
+    # fell through to the neutral-grey default -- the same bug shape #398 fixed
+    # in _ALERT_SEVERITY, alive here independently because this is a third,
+    # separately maintained severity mapping (found by the 2026-08-01 cleanup's
+    # adversarial gate).
+    "YELLOW_FLAG_SECTOR": WARNING,
+    "PROBLEM": INFO,
+    "WARNING": INFO,
+    "PENALTY": DANGER,
+}
+
+
+def flag_chip_html(intent: str | None) -> str:
+    """Coloured pill for a single alert intent or RCM event type.
+
+    The label is HTML-escaped for the same reason as the compound pill:
+    it originates in agent output, not in this file.
+    """
+    key = (intent or "—").upper().strip() or "—"
+    bg = _FLAG_BG_BY_INTENT.get(key, TEXT_TERTIARY)
+    label = key.replace("_", " ")
+    return (
+        '<span style="'
+        f"background-color: {hex_str(bg)}; "
+        f"color: {hex_str(TEXT_PRIMARY)}; "
+        "padding: 1px 6px; border-radius: 6px; "
+        "font-weight: 700; font-size: 10px; letter-spacing: 0.3px;"
+        f'">{html.escape(label)}</span>'
+    )

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -1,0 +1,68 @@
+"""What PITWALL's AGENTS window is built out of.
+
+The window is a 1:1 port of the Qt strategy window, and the way that is
+kept true is not inspection: **the host calls the same formatters the Qt
+window calls**, so the two cannot describe the same lap differently. This
+file guards the properties that make that possible.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+REUSED_BY_PITWALL = (
+    "src.arcade.dashboard.agent_formatters",
+    "src.arcade.palette",
+)
+
+
+def _import_in_a_fresh_interpreter(module: str) -> set[str]:
+    """Top-level packages a cold import of `module` pulls in.
+
+    A subprocess, not `sys.modules`: by the time pytest reaches this file
+    another test has already imported PySide6, so an in-process check
+    would assert about the session's history rather than about the module.
+    """
+    script = textwrap.dedent(f"""
+        import sys
+        import {module}  # noqa: F401
+        print(",".join(sorted({{name.split(".")[0] for name in sys.modules}})))
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=True
+    )
+    return set(result.stdout.strip().split(","))
+
+
+def test_the_reused_formatters_need_no_display_stack_and_no_dataframes():
+    """PITWALL's host runs in a process with no Qt, and should not pay for pandas.
+
+    Both were true before the palette split: `agent_formatters` imported
+    `dashboard.theme`, which imports PySide6 and — through
+    `classify_action` — `src.arcade.strategy`, measured at 0.410 s and
+    pandas. Six colour tuples and two badge builders should cost neither.
+
+    This is also what un-skipped the palette-mirror test below: reading
+    the Python palette needed libEGL on a headless runner, so the one
+    guard against the two copies drifting never ran in CI.
+    """
+    for module in REUSED_BY_PITWALL:
+        loaded = _import_in_a_fresh_interpreter(module)
+        assert "PySide6" not in loaded, f"{module} drags in a display stack"
+        assert "pandas" not in loaded, f"{module} drags in pandas"
+        assert "pyglet" not in loaded and "arcade" not in loaded, f"{module} drags in the replay"
+
+
+def test_the_badge_builders_escape_what_comes_off_the_wire():
+    """Compound labels and alert intents are agent output, not literals here.
+
+    In Qt an unescaped `<` breaks the rich-text parser; in PITWALL these
+    strings reach a webview, where the same characters are markup.
+    """
+    from src.arcade.palette import compound_pill_html, flag_chip_html
+
+    assert "&lt;b&gt;" in compound_pill_html("<b>SOFT")
+    assert "<b>" not in compound_pill_html("<b>SOFT").removeprefix("<span")
+    assert "&lt;" in flag_chip_html("A<B")

--- a/tests/surfaces/test_pitwall_tokens.py
+++ b/tests/surfaces/test_pitwall_tokens.py
@@ -78,32 +78,51 @@ def test_the_canonical_source_actually_defines_the_tokens_the_ui_uses():
 
 
 def test_the_two_python_palettes_still_mirror_each_other():
-    """`dashboard/theme.py` is a copy of `config.py` and says so.
+    """`palette.py` is a copy of `config.py`'s tuples and says so.
 
-    It disappears when `src/arcade/dashboard/` is deleted in sprint 7. Until
-    then a silent divergence between them would put the arcade HUD and the
-    Qt dashboard on different colours with nothing to catch it.
+    The two run in different processes, so the duplication is deliberate;
+    a silent divergence would put the arcade HUD, the Qt dashboard and
+    PITWALL's AGENTS window on different colours with nothing to catch it.
+
+    **This used to be skipped in CI.** The copy lived in
+    `dashboard/theme.py`, importing it needed libEGL on a headless runner,
+    and `importorskip` therefore skipped the only guard the pair had. The
+    Qt-free split is what made it run.
     """
-    # Skip on the module that actually fails, not on PySide6: PySide6 itself
-    # imports fine on a headless runner and `theme.py`'s Qt submodule is what
-    # needs libEGL. `exc_type` is explicit because pytest 9.1 stops swallowing
-    # ImportError by default.
+    from src.arcade import config, palette
+
+    shared = [
+        name
+        for name in dir(config)
+        if name.isupper() and isinstance(getattr(config, name), tuple) and hasattr(palette, name)
+    ]
+
+    assert len(shared) >= 8, "the palette names moved; this test is checking nothing"
+    for name in shared:
+        assert getattr(palette, name) == getattr(config, name), f"{name} drifted between the copies"
+
+
+def test_the_qt_theme_still_serves_the_same_tuples_it_re_exports():
+    """`dashboard/theme.py` keeps every name its widgets import.
+
+    The split moved the values out and left re-exports behind, so a widget
+    doing `from ...theme import ACCENT` must still get the same object. If
+    Qt is unavailable this skips — but the pair above is guarded either
+    way now, which is the point of the split.
+    """
     theme = pytest.importorskip(
         "src.arcade.dashboard.theme",
         reason="the Qt dashboard is an optional surface and needs a display stack",
         exc_type=ImportError,
     )
-    from src.arcade import config
+    from src.arcade import palette
 
-    shared = [
-        name
-        for name in dir(config)
-        if name.isupper() and isinstance(getattr(config, name), tuple) and hasattr(theme, name)
-    ]
-
-    assert len(shared) >= 8, "the palette names moved; this test is checking nothing"
-    for name in shared:
-        assert getattr(theme, name) == getattr(config, name), f"{name} drifted between the copies"
+    for name in ("ACCENT", "SUCCESS", "WARNING", "DANGER", "TEXT_PRIMARY", "MONO_FONT_STACK"):
+        assert getattr(theme, name) is getattr(palette, name), (
+            f"{name} is no longer the same object"
+        )
+    assert theme.compound_pill_html is palette.compound_pill_html
+    assert theme.flag_chip_html is palette.flag_chip_html
 
 
 # The Python palette predates the webapp's current tokens and has NOT been


### PR DESCRIPTION
Sprint 3, PR 1 of 6. The AGENTS window is a 1:1 port, and the way that is kept true is not inspection: **the PITWALL host calls the same formatters that paint the Qt window**, so the two cannot describe the same lap differently. This PR is what makes those formatters importable from a process that has no Qt.

## The split

`src/arcade/palette.py` is new and holds the toolkit-free half of `dashboard/theme.py`: the RGB tuples, the compound and flag maps, `hex_str`, `compound_color`, and the two badge builders. `theme.py` keeps `qcolor` and `apply_dark_palette`, re-exports everything else, and every widget's imports are unchanged.

**It lives outside `src/arcade/dashboard/` deliberately.** That package is deleted in sprint 7 and this has to survive it.

Measured, cold import of `src.arcade.dashboard.agent_formatters`:

| | before | after |
|---|---|---|
| wall time | 0.44 s | **0.010 s** |
| PySide6 loaded | yes | **no** |
| pandas loaded | yes (via `classify_action` → `src.arcade.strategy`, 0.410 s on its own) | **no** |
| modules imported | 620 | **85** |

## The bonus: a guard that had never run

`test_the_two_python_palettes_still_mirror_each_other` is the only thing standing between `config.py`'s palette and its copy. It was skipped in CI, because reading the copy meant importing `theme.py`, which needs libEGL on a headless runner. It now reads `palette.py` and always runs. A second test keeps the Qt re-exports honest and skips when Qt is unavailable — so the pair is guarded either way, which is the point.

## One real fix that came with it

`compound_pill_html` and `flag_chip_html` did not escape their labels, and those labels come off the wire. In Qt a `<` in a compound label breaks the rich-text parser; in PITWALL the same strings reach a webview, where those characters are markup. Both escape now, which changes nothing for `MEDIUM` and `SAFETY_CAR`.

## Two notes written into the delivery plan

- **Sprint 7 must MOVE `agent_formatters.py` and the reasoning line builders, not delete them.** They are now live product code with a consumer that outlives Qt. Deleting `src/arcade/dashboard/` wholesale would take the AGENTS window's whole content layer with it.
- **Sprint 4 is gated on #857.** The wire publishes only the coordinates #844 refuted, so the DATA window's timing band would re-derive the order from them.

## Checks

- `uv run pytest tests/surfaces` → 98 passed, 1 failed (`test_cli_no_llm`, the known curated-download gap, red on `dev` too).
- Import purity asserted in a **subprocess**, not from `sys.modules`: by the time pytest reaches that file another test has already imported PySide6, so an in-process check would assert about the session's history rather than about the module.
- `ruff check .` + `ruff format --check .` clean.
