### PR TITLE
feat(pitwall): serve the AGENTS view from the Qt window's own formatters

### DIFF
--- a/src/pitwall/agents_view/__init__.py
+++ b/src/pitwall/agents_view/__init__.py
@@ -1,0 +1,11 @@
+"""The AGENTS window's content layer, computed in Python.
+
+`host.get_agents_view` is the only caller. The package exists because the
+alternative - reimplementing the Qt window's formatters in TypeScript -
+would make "1:1" a claim to be checked by eye every sprint instead of a
+property of the code.
+"""
+
+from src.pitwall.agents_view.builder import AGENTS_VIEW_VERSION, AgentsViewBuilder
+
+__all__ = ["AGENTS_VIEW_VERSION", "AgentsViewBuilder"]

--- a/src/pitwall/agents_view/builder.py
+++ b/src/pitwall/agents_view/builder.py
@@ -1,0 +1,81 @@
+"""One tick in, one AGENTS view out.
+
+The object that makes the 1:1 port true by construction: it calls the
+same formatters and runs the same accumulators as the Qt window, so the
+React side is a renderer and never a second implementation of anything.
+`src/arcade/dashboard/window.py::_on_data` is the function this mirrors,
+in the same order, because the order is load-bearing - the history is
+seeded before `latest` is folded in, and the status bar is set last so it
+reflects whatever the pipeline reported for THIS tick.
+
+It is stateful, which is why it is an object and not a function: the two
+chart histories accumulate across ticks because `history_tail` strips
+`per_agent` and nothing can rebuild those values later.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.pitwall.agents_view.history import LapHistory
+from src.pitwall.agents_view.panels import build_cards, build_header, build_status_bar
+
+# Bumped when the view's shape changes in a way a built UI bundle would
+# misread. Separate from the wire's `schema_version`, which describes the
+# producer: this describes what the host hands the window.
+AGENTS_VIEW_VERSION: int = 1
+
+
+class AgentsViewBuilder:
+    """Turn a broadcast payload into what PITWALL · AGENTS renders.
+
+    Invariants:
+
+    - Nothing here formats. Every headline, body line and colour comes
+      out of `agent_formatters`, which is the Qt window's own code.
+    - The lap history survives across ticks and is evicted, never
+      truncated blindly, on a backwards seek.
+    """
+
+    def __init__(self) -> None:
+        self._history = LapHistory()
+        self._last_lap: int | None = None
+
+    def build(self, payload: dict[str, Any], connection: str = "Connected") -> dict[str, Any]:
+        """The whole view for one tick."""
+        strategy = payload.get("strategy") or {}
+        latest = strategy.get("latest") or {}
+
+        self._accumulate(payload, strategy, latest)
+
+        return {
+            "view_version": AGENTS_VIEW_VERSION,
+            "seq": payload.get("seq"),
+            "header": build_header(payload, connection),
+            "cards": build_cards(latest or None),
+            "history": {
+                "pace": [{"lap": lap, **row} for lap, row in sorted(self._history.pace.items())],
+                "tire": self._history.tire_rows(),
+            },
+            "status_bar": build_status_bar(payload),
+        }
+
+    def _accumulate(
+        self, payload: dict[str, Any], strategy: dict[str, Any], latest: dict[str, Any]
+    ) -> None:
+        """Fold this tick into the chart history, evicting first if we rewound.
+
+        The eviction is keyed on the LAP going backwards rather than on
+        the producer's `rewound` flag, because that flag reports a
+        backwards seek of any size and most of them stay inside the
+        current lap, where there is nothing to evict. A lap that actually
+        gets re-driven must be re-observed: its predictions belong to the
+        timeline the user abandoned.
+        """
+        lap = (payload.get("arcade") or {}).get("lap")
+        if isinstance(lap, int):
+            if self._last_lap is not None and lap < self._last_lap:
+                self._history.evict_after(lap)
+            self._last_lap = lap
+        self._history.seed_from_tail(strategy.get("history_tail") or [])
+        self._history.ingest_latest(latest)

--- a/src/pitwall/agents_view/history.py
+++ b/src/pitwall/agents_view/history.py
@@ -1,0 +1,124 @@
+"""The two rolling per-lap stores the AGENTS charts read from.
+
+Ported from `src/arcade/dashboard/window.py:239-293`, near-verbatim and
+on purpose: the Qt window is the acceptance reference for this port, and
+an accumulator rewritten from its description is exactly how the two
+surfaces start disagreeing about the same race.
+
+Why the window owns these at all: `history_tail` on the broadcast strips
+`per_agent` from every past decision, a deliberate wire-size trade-off, so
+predicted lap times and cliff percentiles exist only on the `latest` block
+of the tick they arrived on. Nobody can rebuild them later, which is also
+why the rewind guard below **evicts the future and never truncates the
+past**.
+
+The store is keyed by LAP, not by frame. Gate A's D-11: a frame-indexed
+truncate cannot address a lap-keyed map, and re-ingesting the same tick
+must be idempotent, which a list would not be.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# The charts draw a rolling window, and an hour of replay would otherwise
+# grow a 200-entry dict per store for laps nothing renders.
+KEEP_LAPS: int = 40
+
+
+class LapHistory:
+    """Per-lap pace and tyre rows, accumulated from successive ticks.
+
+    Responsibilities:
+
+    - backfill actuals from `history_tail` on a mid-stream connect;
+    - fold each tick's `latest` in, which is the only carrier of the
+      per-agent predictions;
+    - drop laps the user rewound past, so a lap that gets re-driven is
+      re-observed rather than read from the timeline that was abandoned;
+    - stay bounded.
+    """
+
+    def __init__(self, keep: int = KEEP_LAPS) -> None:
+        self._keep = keep
+        self._pace: dict[int, dict[str, Any]] = {}
+        self._tire: dict[int, dict[str, Any]] = {}
+
+    # --- Ingest -----------------------------------------------------------
+
+    def seed_from_tail(self, tail: list[dict[str, Any]]) -> None:
+        """Backfill lap-time and tyre actuals from the broadcast history tail.
+
+        `setdefault`, not assignment: the tail is stripped of `per_agent`,
+        so a value already observed on a `latest` block is richer than
+        anything here and must not be overwritten by a later reconnect.
+        """
+        for row in tail:
+            lap = row.get("lap_number")
+            if not isinstance(lap, int):
+                continue
+            pace_row = self._pace.setdefault(lap, {})
+            pace_row.setdefault("actual", row.get("lap_time_s"))
+            tire_row = self._tire.setdefault(lap, {})
+            tire_row.setdefault("tyre_life", row.get("tyre_life"))
+            tire_row.setdefault("compound", row.get("compound"))
+            tire_row.setdefault("lap_time_s", row.get("lap_time_s"))
+        self.trim()
+
+    def ingest_latest(self, latest: dict[str, Any] | None) -> None:
+        """Fold this tick's decision in. The only source of predictions."""
+        if not latest:
+            return
+        lap = latest.get("lap_number")
+        if not isinstance(lap, int):
+            return
+        per = latest.get("per_agent") or {}
+        pace = per.get("pace") or {}
+        row = self._pace.setdefault(lap, {})
+        if latest.get("lap_time_s") is not None:
+            row["actual"] = latest.get("lap_time_s")
+        if pace.get("lap_time_pred") is not None:
+            row["pred"] = pace.get("lap_time_pred")
+            row["ci_p10"] = pace.get("ci_p10")
+            row["ci_p90"] = pace.get("ci_p90")
+        trow = self._tire.setdefault(lap, {})
+        if latest.get("tyre_life") is not None:
+            trow["tyre_life"] = latest.get("tyre_life")
+        if latest.get("compound"):
+            trow["compound"] = latest.get("compound")
+        if latest.get("lap_time_s") is not None:
+            trow["lap_time_s"] = latest.get("lap_time_s")
+        self.trim()
+
+    def evict_after(self, lap: int) -> None:
+        """Drop everything ahead of `lap`, for a backwards seek.
+
+        The Qt window has no equivalent and its charts are wrong after a
+        rewind: they hold laps the replay has not reached again. The guard
+        belongs here rather than in the UI because the store is keyed by
+        lap and the UI clock counts frames - a frame-indexed truncate
+        cannot address this map at all.
+        """
+        for store in (self._pace, self._tire):
+            for stored in [key for key in store if key > lap]:
+                store.pop(stored, None)
+
+    def trim(self, keep: int | None = None) -> None:
+        """Keep only the most recent `keep` laps so memory stays bounded."""
+        limit = self._keep if keep is None else keep
+        for store in (self._pace, self._tire):
+            if len(store) <= limit:
+                continue
+            for lap in sorted(store)[: len(store) - limit]:
+                store.pop(lap, None)
+
+    # --- Read -------------------------------------------------------------
+
+    @property
+    def pace(self) -> dict[int, dict[str, Any]]:
+        """Lap -> {actual, pred, ci_p10, ci_p90}, as `PaceChart` reads it."""
+        return self._pace
+
+    def tire_rows(self) -> list[dict[str, Any]]:
+        """Chronological rows, the shape `TireChart.update_from` takes."""
+        return [{"lap": lap, **row} for lap, row in sorted(self._tire.items())]

--- a/src/pitwall/agents_view/panels.py
+++ b/src/pitwall/agents_view/panels.py
@@ -1,0 +1,133 @@
+"""Header, agent cards and status bar, as JSON the AGENTS window renders.
+
+Every string and every colour here is produced by the code that paints
+the Qt window: `src/arcade/dashboard/agent_formatters.py` for the six
+cards, and the header/status logic transcribed from
+`src/arcade/dashboard/window.py`. Nothing reformats or re-decides.
+
+Colours leave as `#rrggbb` because that is what both a Qt stylesheet and
+a CSS declaration take, and because the AGENTS window renders in the QT
+palette rather than in `tokens.css`'s semantics: this is a 1:1 port, and
+the two palettes deliberately differ (`test_pitwall_tokens.py`). Choosing
+the web palette here would BE the redesign sprint 8 owns.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.arcade.dashboard.agent_formatters import (
+    format_pace,
+    format_pit,
+    format_radio,
+    format_rag,
+    format_situation,
+    format_tire,
+    radio_tooltip_html,
+    rag_tooltip_html,
+)
+from src.arcade.palette import DANGER, SUCCESS, TEXT_SECONDARY, WARNING, hex_str
+
+# window.py's HeaderBar.set_connection, with its three states and their
+# colours. "Connecting..." is what the socket thread reports while it
+# retries, which is most of the time before an arcade exists.
+CONNECTION_COLOURS: dict[str, str] = {
+    "Connected": hex_str(SUCCESS),
+    "Connecting...": hex_str(WARNING),
+    "Disconnected": hex_str(DANGER),
+}
+
+
+def build_header(payload: dict[str, Any], connection: str) -> dict[str, Any]:
+    """The top strip: session, driver, connection, playback, lap counter."""
+    arcade = payload.get("arcade") or {}
+    strategy = payload.get("strategy") or {}
+    playback = payload.get("playback") or {}
+    start = strategy.get("start") or {}
+
+    gp = start.get("gp") or arcade.get("gp_name") or "--"
+    year = start.get("year") or arcade.get("year") or "--"
+    try:
+        speed = float(playback.get("speed", 1.0))
+    except (TypeError, ValueError):
+        speed = 1.0
+    paused = bool(playback.get("paused", False))
+
+    return {
+        "session": f"{gp} · {year}",
+        "driver": str(start.get("driver") or arcade.get("driver_main") or "--"),
+        "lap": f"L {arcade.get('lap', 0)}/{arcade.get('total_laps', 0)}",
+        "playback": f"{speed:.2f}× · {'PAUSED' if paused else 'PLAYING'}",
+        "connection": connection,
+        "connection_colour": CONNECTION_COLOURS.get(connection, hex_str(TEXT_SECONDARY)),
+    }
+
+
+def _card(formatted: tuple, tooltip: str = "") -> dict[str, Any]:
+    """One formatter tuple as JSON: `(headline, colour, lines, status)`."""
+    headline, headline_colour, lines, status = formatted
+    return {
+        "headline": headline,
+        "headline_colour": hex_str(headline_colour),
+        "lines": [{"text": text, "colour": hex_str(colour)} for text, colour in lines],
+        "status": status,
+        "tooltip": tooltip,
+    }
+
+
+def build_cards(latest: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+    """The six agent cards, straight out of the Qt formatters.
+
+    Transcribed from `MainWindow._update_agent_cards`, including the
+    branch where the whole `per_agent` block is missing: there the four
+    always-on cards render their own no-output text and the two
+    conditional ones render their trigger hint, which is not the same
+    thing as an empty card.
+
+    `active` carries agent IDs (`N28`, `N30`), not block names. The dev
+    producer sent block names for a while and both conditional cards sat
+    on their trigger hint no matter what it published (#853).
+    """
+    per = (latest or {}).get("per_agent") if latest else None
+    if not per:
+        return {
+            "pace": _card(format_pace(None)),
+            "tire": _card(format_tire(None)),
+            "situation": _card(format_situation(None)),
+            "pit": _card(format_pit(None, active=False)),
+            "radio": _card(format_radio(None)),
+            "rag": _card(format_rag(None, active=False)),
+        }
+
+    active = set(per.get("active") or [])
+    radio_block = per.get("radio")
+    # `rag` is the structured payload; `regulation_context` stays as a
+    # legacy fallback for producers that have not been updated.
+    rag_block = per.get("rag") or per.get("regulation_context")
+    rag_active = "N30" in active
+    return {
+        "pace": _card(format_pace(per.get("pace"))),
+        "tire": _card(format_tire(per.get("tire"))),
+        "situation": _card(format_situation(per.get("situation"))),
+        "pit": _card(format_pit(per.get("pit"), active="N28" in active)),
+        "radio": _card(format_radio(radio_block), radio_tooltip_html(radio_block)),
+        "rag": _card(
+            format_rag(rag_block, active=rag_active),
+            rag_tooltip_html(rag_block) if rag_active else "",
+        ),
+    }
+
+
+def build_status_bar(payload: dict[str, Any]) -> dict[str, Any]:
+    """The bottom line: the pipeline error, or the lap while streaming.
+
+    `transient` mirrors the 1.5 s timeout Qt's status bar applies to the
+    streaming message and not to the error, which is the difference
+    between "here is what is happening" and "here is what went wrong".
+    """
+    strategy = payload.get("strategy") or {}
+    error = strategy.get("error")
+    if error:
+        return {"text": f"pipeline: {error}", "transient": False}
+    lap = (payload.get("arcade") or {}).get("lap", "?")
+    return {"text": f"lap {lap} · streaming", "transient": True}

--- a/src/pitwall/host.py
+++ b/src/pitwall/host.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import logging
 
+from src.pitwall.agents_view import AgentsViewBuilder
 from src.pitwall.stream_client import ArcadeStreamClient
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,8 @@ class PitwallHost:
     def __init__(self, client: ArcadeStreamClient, window_count: int) -> None:
         self._client = client
         self._windows_open = window_count
+        self._agents = AgentsViewBuilder()
+        self._agents_connection: str | None = None
 
     def start(self) -> None:
         self._client.start()
@@ -72,6 +75,43 @@ class PitwallHost:
         if seq is None or seq != since_seq:
             return payload
         return None
+
+    def _connection_label(self) -> str:
+        """The three states `HeaderBar.set_connection` paints.
+
+        "Disconnected" needs a memory: before the first tick the socket is
+        retrying and the honest word is "Connecting...", while after one
+        the same state means the arcade went away.
+        """
+        if self._client.connected:
+            return "Connected"
+        return "Disconnected" if self._agents_connection else "Connecting..."
+
+    def get_agents_view(self, since_seq: int = -1) -> dict | None:
+        """The whole AGENTS window, already formatted, or None when nothing changed.
+
+        The window is a renderer. Every headline, body line, colour and
+        status glyph in the returned dict is produced by the code that
+        paints the Qt window, so the two cannot describe the same lap
+        differently - which is what "1:1" has to mean if it is going to
+        survive a sprint.
+
+        Returned on a tick the caller has not seen, **and** on a change of
+        connection state with no new tick, which is the only way a window
+        learns the arcade died: once the producer stops, `seq` stops
+        advancing and a purely sequence-driven view would keep rendering
+        the last frame of a dead race with a green "Connected" chip.
+        """
+        connection = self._connection_label()
+        payload = self.get_tick(since_seq)
+        if payload is None:
+            if connection == self._agents_connection:
+                return None
+            payload = self._client.latest
+            if payload is None:
+                return None
+        self._agents_connection = connection
+        return self._agents.build(payload, connection)
 
     def release_window(self) -> int:
         """Record that one window has closed; stop the client at the last one.

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -66,3 +66,289 @@ def test_the_badge_builders_escape_what_comes_off_the_wire():
     assert "&lt;b&gt;" in compound_pill_html("<b>SOFT")
     assert "<b>" not in compound_pill_html("<b>SOFT").removeprefix("<span")
     assert "&lt;" in flag_chip_html("A<B")
+
+
+# --- The view the host hands the window -------------------------------------
+
+
+def _latest(lap: int = 23) -> dict:
+    """A LapDecision block with the field names the agents really emit."""
+    return {
+        "lap_number": lap,
+        "compound": "MEDIUM",
+        "tyre_life": lap - 8,
+        "lap_time_s": 81.234,
+        "action": "PIT_NOW",
+        "confidence": 0.71,
+        "reasoning": "the undercut window against RUS opens now",
+        "scenario_scores": {"PIT_NOW": 0.71, "STAY_OUT": 0.29},
+        "pace_mode": "PUSH",
+        "risk_posture": "AGGRESSIVE",
+        "pit_lap_target": lap + 1,
+        "compound_next": "HARD",
+        "undercut_target": "RUS",
+        "memory_block": f"lap {lap - 1}: STAY_OUT (0.58)",
+        "plan_changed": True,
+        "per_agent": {
+            "pace": {
+                "lap_time_pred": 81.0,
+                "delta_vs_prev": -0.204,
+                "delta_vs_median": 0.118,
+                "ci_p10": 80.45,
+                "ci_p90": 81.55,
+            },
+            "tire": {
+                "compound": "MEDIUM",
+                "current_tyre_life": lap - 8,
+                "deg_rate": 0.031,
+                "laps_to_cliff_p10": 4.0,
+                "laps_to_cliff_p50": 6.0,
+                "laps_to_cliff_p90": 9.0,
+                "warning_level": "MONITOR",
+            },
+            "situation": {
+                "overtake_prob": 0.34,
+                "sc_prob_3lap": 0.08,
+                "threat_level": "MEDIUM",
+                "gap_ahead_s": 1.42,
+                "pace_delta_s": -0.12,
+            },
+            "radio": {"radio_events": [], "rcm_events": [], "alerts": []},
+            "pit": {
+                "stop_duration_p05": 21.14,
+                "stop_duration_p50": 22.40,
+                "stop_duration_p95": 24.81,
+                "compound_recommendation": "HARD",
+                "undercut_prob": 0.63,
+                "undercut_target": "RUS",
+                "sc_reactive": False,
+            },
+            "rag": {
+                "question": "q",
+                "answer": "Two dry specifications are still required.",
+                "articles": ["Article 30.5(m)"],
+                "chunks": [],
+            },
+            "active": ["N28", "N30"],
+        },
+    }
+
+
+def _payload(
+    seq: int = 7, lap: int = 23, latest: dict | None = None, tail: list | None = None
+) -> dict:
+    return {
+        "schema_version": 1,
+        "seq": seq,
+        "arcade": {
+            "gp_name": "Melbourne",
+            "year": 2025,
+            "lap": lap,
+            "total_laps": 57,
+            "driver_main": "NOR",
+        },
+        "playback": {"speed": 2.0, "paused": False, "frame_index": 1000, "total_frames": 9000},
+        "strategy": {
+            "start": {"gp": "Melbourne", "year": 2025, "driver": "NOR"},
+            "latest": _latest(lap) if latest is None else latest,
+            "history_tail": tail or [],
+            "error": None,
+        },
+    }
+
+
+class _FakeClient:
+    """Stands in for the socket, so the host's own logic is what is tested."""
+
+    def __init__(self, payload=None, connected=True):
+        self.latest = payload
+        self.connected = connected
+        self.stopped = False
+
+    def start(self):
+        pass
+
+    def stop(self):
+        self.stopped = True
+
+
+def _host(payload=None, connected=True):
+    from src.pitwall.host import PitwallHost
+
+    return PitwallHost(_FakeClient(payload, connected), window_count=1)
+
+
+def test_the_view_is_what_the_qt_window_renders_line_for_line():
+    """The golden. These strings are the Qt cards' own output, not a re-format.
+
+    If a formatter changes, this changes with it, and that diff is the
+    port staying 1:1. A TypeScript reimplementation could satisfy this
+    today and drift tomorrow, which is the whole reason the view is
+    computed in Python.
+    """
+    view = _host(_payload()).get_agents_view(-1)
+
+    assert view["header"] == {
+        "session": "Melbourne · 2025",
+        "driver": "NOR",
+        "lap": "L 23/57",
+        "playback": "2.00× · PLAYING",
+        "connection": "Connected",
+        "connection_colour": "#10b981",
+    }
+    assert view["status_bar"] == {"text": "lap 23 · streaming", "transient": True}
+
+    cards = view["cards"]
+    assert cards["pace"]["headline"] == "Δnext -0.204s (81.00s)"
+    assert [line["text"] for line in cards["pace"]["lines"]] == [
+        "pred 81.00s",
+        "vs median +0.12s",
+        "±0.55s (CI)",
+    ]
+    assert cards["pace"]["status"] == "OK"
+
+    assert cards["tire"]["headline"] == "Cliff ~6 laps · L15"
+    assert cards["tire"]["status"] == "WATCH"
+    assert cards["tire"]["lines"][0]["text"] == "range 4–9 laps"
+
+    assert cards["situation"]["headline"] == "Threat MEDIUM"
+    assert cards["situation"]["headline_colour"] == "#f59e0b"
+    assert [line["text"] for line in cards["situation"]["lines"]] == [
+        "overtake 34%",
+        "safety car 8%",
+        "gap 1.4s · Δpace -0.12s/lap",
+    ]
+
+    assert cards["pit"]["headline"] == "pit 22.40s → HARD"
+    assert cards["radio"]["headline"] == "quiet"
+    assert cards["rag"]["headline"] == "regulation loaded"
+
+
+def test_the_situation_card_says_out_of_range_and_never_zero_per_cent():
+    """`None` and `0` are opposite readings and would prompt opposite calls.
+
+    N27 reports None when the car ahead is beyond the overtake model's
+    trained gap. Rendering that as "overtake 0%" tells the wall the model
+    says NO CHANCE when it says nothing at all.
+    """
+    latest = _latest()
+    latest["per_agent"]["situation"]["overtake_prob"] = None
+
+    view = _host(_payload(latest=latest)).get_agents_view(-1)
+
+    assert view["cards"]["situation"]["lines"][0]["text"] == "overtake — (out of model range)"
+
+
+def test_the_conditional_cards_read_agent_ids_and_not_block_names():
+    latest = _latest()
+    latest["per_agent"]["active"] = []
+
+    cards = _host(_payload(latest=latest)).get_agents_view(-1)["cards"]
+
+    assert cards["pit"]["status"] == "IDLE"
+    assert cards["pit"]["headline"].startswith("triggers on")
+    assert cards["rag"]["status"] == "IDLE"
+    assert cards["rag"]["headline"].startswith("triggers on")
+
+
+def test_a_tick_with_no_per_agent_block_shows_the_idle_copy_and_not_an_empty_card():
+    cards = _host(_payload(latest={"lap_number": 3})).get_agents_view(-1)["cards"]
+
+    assert cards["pace"]["headline"] == "no prediction — stub"
+    assert cards["radio"]["headline"] == "no radio/rcm pipeline output"
+    assert all(card["status"] == "IDLE" for card in cards.values())
+
+
+# --- The accumulators -------------------------------------------------------
+
+
+def test_the_history_keeps_the_predictions_the_wire_only_sends_once():
+    """`history_tail` strips `per_agent`, so nothing can rebuild them later.
+
+    Two ticks a lap apart: the older lap must keep the prediction it
+    carried when it was `latest`, and the tail must not overwrite it with
+    the actual-only row it also describes.
+    """
+    from src.pitwall.host import PitwallHost
+
+    client = _FakeClient(_payload(seq=1, lap=23))
+    host = PitwallHost(client, window_count=1)
+    host.get_agents_view(-1)
+
+    tail = [{"lap_number": 23, "lap_time_s": 81.234, "tyre_life": 15, "compound": "MEDIUM"}]
+    client.latest = _payload(seq=2, lap=24, tail=tail)
+    view = host.get_agents_view(1)
+
+    pace = {row["lap"]: row for row in view["history"]["pace"]}
+    assert pace[23]["pred"] == 81.0, "the prediction survived the tail describing the same lap"
+    assert pace[23]["actual"] == 81.234
+    assert 24 in pace, "and the new lap is in"
+
+
+def test_a_rewind_drops_the_laps_ahead_and_keeps_the_ones_behind():
+    """The Qt charts have no equivalent and are wrong after a seek back.
+
+    Truncating everything would be worse than doing nothing: the past
+    holds predictions the wire will never resend.
+    """
+    from src.pitwall.host import PitwallHost
+
+    client = _FakeClient(_payload(seq=1, lap=20))
+    host = PitwallHost(client, window_count=1)
+    host.get_agents_view(-1)
+    for seq, lap in ((2, 21), (3, 22)):
+        client.latest = _payload(seq=seq, lap=lap)
+        host.get_agents_view(seq - 1)
+
+    client.latest = _payload(seq=4, lap=21)
+    view = host.get_agents_view(3)
+
+    assert sorted(row["lap"] for row in view["history"]["pace"]) == [20, 21]
+
+
+def test_the_history_stays_bounded():
+    from src.pitwall.agents_view.history import KEEP_LAPS, LapHistory
+
+    history = LapHistory()
+    for lap in range(1, KEEP_LAPS + 11):
+        history.ingest_latest({"lap_number": lap, "lap_time_s": 80.0 + lap})
+
+    assert len(history.pace) == KEEP_LAPS
+    assert min(history.pace) == 11, "the oldest laps go, not the newest"
+
+
+# --- The connection chip ----------------------------------------------------
+
+
+def test_the_window_learns_the_arcade_died_even_though_no_tick_arrives():
+    """Once the producer stops, `seq` stops advancing.
+
+    A purely sequence-driven view would keep rendering the last frame of a
+    dead race under a green Connected chip, forever and silently.
+    """
+    from src.pitwall.host import PitwallHost
+
+    client = _FakeClient(_payload(seq=5), connected=True)
+    host = PitwallHost(client, window_count=1)
+    assert host.get_agents_view(-1)["header"]["connection"] == "Connected"
+    assert host.get_agents_view(5) is None, "nothing new, nothing changed"
+
+    client.connected = False
+    view = host.get_agents_view(5)
+
+    assert view is not None, "the state changed, so the window must hear about it"
+    assert view["header"]["connection"] == "Disconnected"
+    assert view["header"]["connection_colour"] == "#ef4444"
+    assert host.get_agents_view(5) is None, "and only once"
+
+
+def test_before_the_first_connection_the_chip_says_connecting():
+    """Retrying is not the same as having been dropped, and the colours differ."""
+    view = _host(_payload(), connected=False).get_agents_view(-1)
+
+    assert view["header"]["connection"] == "Connecting..."
+    assert view["header"]["connection_colour"] == "#f59e0b"
+
+
+def test_nothing_to_render_is_none_rather_than_an_empty_view():
+    assert _host(None, connected=False).get_agents_view(-1) is None


### PR DESCRIPTION
Sprint 3, PR 2 of 6. Builds on #864.

## What

`pywebview.api.get_agents_view(since_seq)` returns the whole AGENTS window, already formatted. Every headline, body line, colour and status glyph in it is produced by `src/arcade/dashboard/agent_formatters.py` — the code that paints the Qt window.

**That is the decision, and it is what makes "1:1" a property of the code rather than a claim to re-check by eye every sprint.** The alternative was reimplementing six formatters in TypeScript and comparing screenshots.

## Where the pieces went

| Module | What |
|---|---|
| `agents_view/history.py` | the three reducers from `window.py:239-293`, near-verbatim, plus the rewind guard the Qt window never had |
| `agents_view/panels.py` | header, the six cards, status bar — transcribed from `window.py`, calling the Qt formatters |
| `agents_view/builder.py` | `AgentsViewBuilder`, mirroring `_on_data` in the same order (the order is load-bearing: seed the history, then fold `latest` in, then the status bar) |
| `host.py` | eleven lines: the method, and the connection label |

`host.py` stays a js_api surface, as its own docstring demands. The view is a package because it is ~330 lines and has real state.

## Three decisions worth reading

**The rewind guard is lap-keyed and evicts, it does not truncate.** Gate A's D-11: a frame-indexed truncate cannot address a lap-keyed map. And truncating everything would be worse than doing nothing, because `history_tail` strips `per_agent` — the past holds predictions the wire will never resend. It evicts on the LAP going backwards, not on the producer's `rewound` flag, because that flag fires for any backwards seek and most of them stay inside the current lap where there is nothing to evict.

**The view is returned on a connection change with no new tick.** Once the producer dies, `seq` stops advancing; a purely sequence-driven view would keep rendering the last frame of a dead race under a green Connected chip, forever and silently.

**The colours are the QT palette, not `tokens.css`.** The two deliberately differ and `test_pitwall_tokens.py` freezes the difference. Rendering the port in the web palette would BE the redesign sprint 8 owns.

## Checks

- 12 tests, all asserting real rendered strings rather than a shape: `Δnext -0.204s (81.00s)`, `Cliff ~6 laps · L15`, `pit 22.40s → HARD`.
- The three scars have their own tests: `overtake — (out of model range)` and never `0%`; `active` carrying `N28`/`N30` and not block names; a missing `per_agent` showing the idle copy rather than an empty card.
- The accumulator tests assert the effect: a prediction survives a later `history_tail` describing the same lap, a rewind drops the laps ahead and keeps the ones behind, the store stays bounded from the oldest end.
- `uv run pytest tests/surfaces` → 108 passed, 1 failed (`test_cli_no_llm`, the known curated-download gap, red on `dev` too). `ruff` clean.
