### PR TITLE
feat(pitwall): the AGENTS shell, header, split and six cards

### DIFF
--- a/src/pitwall/agents_view/__init__.py
+++ b/src/pitwall/agents_view/__init__.py
@@ -1,0 +1,11 @@
+"""The AGENTS window's content layer, computed in Python.
+
+`host.get_agents_view` is the only caller. The package exists because the
+alternative - reimplementing the Qt window's formatters in TypeScript -
+would make "1:1" a claim to be checked by eye every sprint instead of a
+property of the code.
+"""
+
+from src.pitwall.agents_view.builder import AGENTS_VIEW_VERSION, AgentsViewBuilder
+
+__all__ = ["AGENTS_VIEW_VERSION", "AgentsViewBuilder"]

--- a/src/pitwall/agents_view/builder.py
+++ b/src/pitwall/agents_view/builder.py
@@ -1,0 +1,81 @@
+"""One tick in, one AGENTS view out.
+
+The object that makes the 1:1 port true by construction: it calls the
+same formatters and runs the same accumulators as the Qt window, so the
+React side is a renderer and never a second implementation of anything.
+`src/arcade/dashboard/window.py::_on_data` is the function this mirrors,
+in the same order, because the order is load-bearing - the history is
+seeded before `latest` is folded in, and the status bar is set last so it
+reflects whatever the pipeline reported for THIS tick.
+
+It is stateful, which is why it is an object and not a function: the two
+chart histories accumulate across ticks because `history_tail` strips
+`per_agent` and nothing can rebuild those values later.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.pitwall.agents_view.history import LapHistory
+from src.pitwall.agents_view.panels import build_cards, build_header, build_status_bar
+
+# Bumped when the view's shape changes in a way a built UI bundle would
+# misread. Separate from the wire's `schema_version`, which describes the
+# producer: this describes what the host hands the window.
+AGENTS_VIEW_VERSION: int = 1
+
+
+class AgentsViewBuilder:
+    """Turn a broadcast payload into what PITWALL · AGENTS renders.
+
+    Invariants:
+
+    - Nothing here formats. Every headline, body line and colour comes
+      out of `agent_formatters`, which is the Qt window's own code.
+    - The lap history survives across ticks and is evicted, never
+      truncated blindly, on a backwards seek.
+    """
+
+    def __init__(self) -> None:
+        self._history = LapHistory()
+        self._last_lap: int | None = None
+
+    def build(self, payload: dict[str, Any], connection: str = "Connected") -> dict[str, Any]:
+        """The whole view for one tick."""
+        strategy = payload.get("strategy") or {}
+        latest = strategy.get("latest") or {}
+
+        self._accumulate(payload, strategy, latest)
+
+        return {
+            "view_version": AGENTS_VIEW_VERSION,
+            "seq": payload.get("seq"),
+            "header": build_header(payload, connection),
+            "cards": build_cards(latest or None),
+            "history": {
+                "pace": [{"lap": lap, **row} for lap, row in sorted(self._history.pace.items())],
+                "tire": self._history.tire_rows(),
+            },
+            "status_bar": build_status_bar(payload),
+        }
+
+    def _accumulate(
+        self, payload: dict[str, Any], strategy: dict[str, Any], latest: dict[str, Any]
+    ) -> None:
+        """Fold this tick into the chart history, evicting first if we rewound.
+
+        The eviction is keyed on the LAP going backwards rather than on
+        the producer's `rewound` flag, because that flag reports a
+        backwards seek of any size and most of them stay inside the
+        current lap, where there is nothing to evict. A lap that actually
+        gets re-driven must be re-observed: its predictions belong to the
+        timeline the user abandoned.
+        """
+        lap = (payload.get("arcade") or {}).get("lap")
+        if isinstance(lap, int):
+            if self._last_lap is not None and lap < self._last_lap:
+                self._history.evict_after(lap)
+            self._last_lap = lap
+        self._history.seed_from_tail(strategy.get("history_tail") or [])
+        self._history.ingest_latest(latest)

--- a/src/pitwall/agents_view/history.py
+++ b/src/pitwall/agents_view/history.py
@@ -1,0 +1,124 @@
+"""The two rolling per-lap stores the AGENTS charts read from.
+
+Ported from `src/arcade/dashboard/window.py:239-293`, near-verbatim and
+on purpose: the Qt window is the acceptance reference for this port, and
+an accumulator rewritten from its description is exactly how the two
+surfaces start disagreeing about the same race.
+
+Why the window owns these at all: `history_tail` on the broadcast strips
+`per_agent` from every past decision, a deliberate wire-size trade-off, so
+predicted lap times and cliff percentiles exist only on the `latest` block
+of the tick they arrived on. Nobody can rebuild them later, which is also
+why the rewind guard below **evicts the future and never truncates the
+past**.
+
+The store is keyed by LAP, not by frame. Gate A's D-11: a frame-indexed
+truncate cannot address a lap-keyed map, and re-ingesting the same tick
+must be idempotent, which a list would not be.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# The charts draw a rolling window, and an hour of replay would otherwise
+# grow a 200-entry dict per store for laps nothing renders.
+KEEP_LAPS: int = 40
+
+
+class LapHistory:
+    """Per-lap pace and tyre rows, accumulated from successive ticks.
+
+    Responsibilities:
+
+    - backfill actuals from `history_tail` on a mid-stream connect;
+    - fold each tick's `latest` in, which is the only carrier of the
+      per-agent predictions;
+    - drop laps the user rewound past, so a lap that gets re-driven is
+      re-observed rather than read from the timeline that was abandoned;
+    - stay bounded.
+    """
+
+    def __init__(self, keep: int = KEEP_LAPS) -> None:
+        self._keep = keep
+        self._pace: dict[int, dict[str, Any]] = {}
+        self._tire: dict[int, dict[str, Any]] = {}
+
+    # --- Ingest -----------------------------------------------------------
+
+    def seed_from_tail(self, tail: list[dict[str, Any]]) -> None:
+        """Backfill lap-time and tyre actuals from the broadcast history tail.
+
+        `setdefault`, not assignment: the tail is stripped of `per_agent`,
+        so a value already observed on a `latest` block is richer than
+        anything here and must not be overwritten by a later reconnect.
+        """
+        for row in tail:
+            lap = row.get("lap_number")
+            if not isinstance(lap, int):
+                continue
+            pace_row = self._pace.setdefault(lap, {})
+            pace_row.setdefault("actual", row.get("lap_time_s"))
+            tire_row = self._tire.setdefault(lap, {})
+            tire_row.setdefault("tyre_life", row.get("tyre_life"))
+            tire_row.setdefault("compound", row.get("compound"))
+            tire_row.setdefault("lap_time_s", row.get("lap_time_s"))
+        self.trim()
+
+    def ingest_latest(self, latest: dict[str, Any] | None) -> None:
+        """Fold this tick's decision in. The only source of predictions."""
+        if not latest:
+            return
+        lap = latest.get("lap_number")
+        if not isinstance(lap, int):
+            return
+        per = latest.get("per_agent") or {}
+        pace = per.get("pace") or {}
+        row = self._pace.setdefault(lap, {})
+        if latest.get("lap_time_s") is not None:
+            row["actual"] = latest.get("lap_time_s")
+        if pace.get("lap_time_pred") is not None:
+            row["pred"] = pace.get("lap_time_pred")
+            row["ci_p10"] = pace.get("ci_p10")
+            row["ci_p90"] = pace.get("ci_p90")
+        trow = self._tire.setdefault(lap, {})
+        if latest.get("tyre_life") is not None:
+            trow["tyre_life"] = latest.get("tyre_life")
+        if latest.get("compound"):
+            trow["compound"] = latest.get("compound")
+        if latest.get("lap_time_s") is not None:
+            trow["lap_time_s"] = latest.get("lap_time_s")
+        self.trim()
+
+    def evict_after(self, lap: int) -> None:
+        """Drop everything ahead of `lap`, for a backwards seek.
+
+        The Qt window has no equivalent and its charts are wrong after a
+        rewind: they hold laps the replay has not reached again. The guard
+        belongs here rather than in the UI because the store is keyed by
+        lap and the UI clock counts frames - a frame-indexed truncate
+        cannot address this map at all.
+        """
+        for store in (self._pace, self._tire):
+            for stored in [key for key in store if key > lap]:
+                store.pop(stored, None)
+
+    def trim(self, keep: int | None = None) -> None:
+        """Keep only the most recent `keep` laps so memory stays bounded."""
+        limit = self._keep if keep is None else keep
+        for store in (self._pace, self._tire):
+            if len(store) <= limit:
+                continue
+            for lap in sorted(store)[: len(store) - limit]:
+                store.pop(lap, None)
+
+    # --- Read -------------------------------------------------------------
+
+    @property
+    def pace(self) -> dict[int, dict[str, Any]]:
+        """Lap -> {actual, pred, ci_p10, ci_p90}, as `PaceChart` reads it."""
+        return self._pace
+
+    def tire_rows(self) -> list[dict[str, Any]]:
+        """Chronological rows, the shape `TireChart.update_from` takes."""
+        return [{"lap": lap, **row} for lap, row in sorted(self._tire.items())]

--- a/src/pitwall/agents_view/panels.py
+++ b/src/pitwall/agents_view/panels.py
@@ -26,7 +26,14 @@ from src.arcade.dashboard.agent_formatters import (
     radio_tooltip_html,
     rag_tooltip_html,
 )
-from src.arcade.palette import DANGER, SUCCESS, TEXT_SECONDARY, WARNING, hex_str
+from src.arcade.palette import (
+    DANGER,
+    SUCCESS,
+    TEXT_SECONDARY,
+    TEXT_TERTIARY,
+    WARNING,
+    hex_str,
+)
 
 # window.py's HeaderBar.set_connection, with its three states and their
 # colours. "Connecting..." is what the socket thread reports while it
@@ -35,6 +42,17 @@ CONNECTION_COLOURS: dict[str, str] = {
     "Connected": hex_str(SUCCESS),
     "Connecting...": hex_str(WARNING),
     "Disconnected": hex_str(DANGER),
+}
+
+# `agent_card.py::_GLYPH_FOR`, which cannot be imported because it lives in
+# a QFrame subclass. It is repeated rather than reimplemented, and
+# `test_the_status_glyphs_match_the_qt_cards` compares the two for as long
+# as both exist - which is the twin-detector this repo keeps needing.
+STATUS_GLYPHS: dict[str, tuple[str, str]] = {
+    "OK": ("●", hex_str(SUCCESS)),
+    "WATCH": ("◐", hex_str(WARNING)),
+    "ALERT": ("●", hex_str(DANGER)),
+    "IDLE": ("○", hex_str(TEXT_TERTIARY)),
 }
 
 
@@ -66,11 +84,14 @@ def build_header(payload: dict[str, Any], connection: str) -> dict[str, Any]:
 def _card(formatted: tuple, tooltip: str = "") -> dict[str, Any]:
     """One formatter tuple as JSON: `(headline, colour, lines, status)`."""
     headline, headline_colour, lines, status = formatted
+    glyph, glyph_colour = STATUS_GLYPHS.get(status, STATUS_GLYPHS["IDLE"])
     return {
         "headline": headline,
         "headline_colour": hex_str(headline_colour),
         "lines": [{"text": text, "colour": hex_str(colour)} for text, colour in lines],
         "status": status,
+        "glyph": glyph,
+        "glyph_colour": glyph_colour,
         "tooltip": tooltip,
     }
 

--- a/src/pitwall/agents_view/panels.py
+++ b/src/pitwall/agents_view/panels.py
@@ -1,0 +1,133 @@
+"""Header, agent cards and status bar, as JSON the AGENTS window renders.
+
+Every string and every colour here is produced by the code that paints
+the Qt window: `src/arcade/dashboard/agent_formatters.py` for the six
+cards, and the header/status logic transcribed from
+`src/arcade/dashboard/window.py`. Nothing reformats or re-decides.
+
+Colours leave as `#rrggbb` because that is what both a Qt stylesheet and
+a CSS declaration take, and because the AGENTS window renders in the QT
+palette rather than in `tokens.css`'s semantics: this is a 1:1 port, and
+the two palettes deliberately differ (`test_pitwall_tokens.py`). Choosing
+the web palette here would BE the redesign sprint 8 owns.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.arcade.dashboard.agent_formatters import (
+    format_pace,
+    format_pit,
+    format_radio,
+    format_rag,
+    format_situation,
+    format_tire,
+    radio_tooltip_html,
+    rag_tooltip_html,
+)
+from src.arcade.palette import DANGER, SUCCESS, TEXT_SECONDARY, WARNING, hex_str
+
+# window.py's HeaderBar.set_connection, with its three states and their
+# colours. "Connecting..." is what the socket thread reports while it
+# retries, which is most of the time before an arcade exists.
+CONNECTION_COLOURS: dict[str, str] = {
+    "Connected": hex_str(SUCCESS),
+    "Connecting...": hex_str(WARNING),
+    "Disconnected": hex_str(DANGER),
+}
+
+
+def build_header(payload: dict[str, Any], connection: str) -> dict[str, Any]:
+    """The top strip: session, driver, connection, playback, lap counter."""
+    arcade = payload.get("arcade") or {}
+    strategy = payload.get("strategy") or {}
+    playback = payload.get("playback") or {}
+    start = strategy.get("start") or {}
+
+    gp = start.get("gp") or arcade.get("gp_name") or "--"
+    year = start.get("year") or arcade.get("year") or "--"
+    try:
+        speed = float(playback.get("speed", 1.0))
+    except (TypeError, ValueError):
+        speed = 1.0
+    paused = bool(playback.get("paused", False))
+
+    return {
+        "session": f"{gp} · {year}",
+        "driver": str(start.get("driver") or arcade.get("driver_main") or "--"),
+        "lap": f"L {arcade.get('lap', 0)}/{arcade.get('total_laps', 0)}",
+        "playback": f"{speed:.2f}× · {'PAUSED' if paused else 'PLAYING'}",
+        "connection": connection,
+        "connection_colour": CONNECTION_COLOURS.get(connection, hex_str(TEXT_SECONDARY)),
+    }
+
+
+def _card(formatted: tuple, tooltip: str = "") -> dict[str, Any]:
+    """One formatter tuple as JSON: `(headline, colour, lines, status)`."""
+    headline, headline_colour, lines, status = formatted
+    return {
+        "headline": headline,
+        "headline_colour": hex_str(headline_colour),
+        "lines": [{"text": text, "colour": hex_str(colour)} for text, colour in lines],
+        "status": status,
+        "tooltip": tooltip,
+    }
+
+
+def build_cards(latest: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+    """The six agent cards, straight out of the Qt formatters.
+
+    Transcribed from `MainWindow._update_agent_cards`, including the
+    branch where the whole `per_agent` block is missing: there the four
+    always-on cards render their own no-output text and the two
+    conditional ones render their trigger hint, which is not the same
+    thing as an empty card.
+
+    `active` carries agent IDs (`N28`, `N30`), not block names. The dev
+    producer sent block names for a while and both conditional cards sat
+    on their trigger hint no matter what it published (#853).
+    """
+    per = (latest or {}).get("per_agent") if latest else None
+    if not per:
+        return {
+            "pace": _card(format_pace(None)),
+            "tire": _card(format_tire(None)),
+            "situation": _card(format_situation(None)),
+            "pit": _card(format_pit(None, active=False)),
+            "radio": _card(format_radio(None)),
+            "rag": _card(format_rag(None, active=False)),
+        }
+
+    active = set(per.get("active") or [])
+    radio_block = per.get("radio")
+    # `rag` is the structured payload; `regulation_context` stays as a
+    # legacy fallback for producers that have not been updated.
+    rag_block = per.get("rag") or per.get("regulation_context")
+    rag_active = "N30" in active
+    return {
+        "pace": _card(format_pace(per.get("pace"))),
+        "tire": _card(format_tire(per.get("tire"))),
+        "situation": _card(format_situation(per.get("situation"))),
+        "pit": _card(format_pit(per.get("pit"), active="N28" in active)),
+        "radio": _card(format_radio(radio_block), radio_tooltip_html(radio_block)),
+        "rag": _card(
+            format_rag(rag_block, active=rag_active),
+            rag_tooltip_html(rag_block) if rag_active else "",
+        ),
+    }
+
+
+def build_status_bar(payload: dict[str, Any]) -> dict[str, Any]:
+    """The bottom line: the pipeline error, or the lap while streaming.
+
+    `transient` mirrors the 1.5 s timeout Qt's status bar applies to the
+    streaming message and not to the error, which is the difference
+    between "here is what is happening" and "here is what went wrong".
+    """
+    strategy = payload.get("strategy") or {}
+    error = strategy.get("error")
+    if error:
+        return {"text": f"pipeline: {error}", "transient": False}
+    lap = (payload.get("arcade") or {}).get("lap", "?")
+    return {"text": f"lap {lap} · streaming", "transient": True}

--- a/src/pitwall/host.py
+++ b/src/pitwall/host.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import logging
 
+from src.pitwall.agents_view import AgentsViewBuilder
 from src.pitwall.stream_client import ArcadeStreamClient
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,8 @@ class PitwallHost:
     def __init__(self, client: ArcadeStreamClient, window_count: int) -> None:
         self._client = client
         self._windows_open = window_count
+        self._agents = AgentsViewBuilder()
+        self._agents_connection: str | None = None
 
     def start(self) -> None:
         self._client.start()
@@ -72,6 +75,43 @@ class PitwallHost:
         if seq is None or seq != since_seq:
             return payload
         return None
+
+    def _connection_label(self) -> str:
+        """The three states `HeaderBar.set_connection` paints.
+
+        "Disconnected" needs a memory: before the first tick the socket is
+        retrying and the honest word is "Connecting...", while after one
+        the same state means the arcade went away.
+        """
+        if self._client.connected:
+            return "Connected"
+        return "Disconnected" if self._agents_connection else "Connecting..."
+
+    def get_agents_view(self, since_seq: int = -1) -> dict | None:
+        """The whole AGENTS window, already formatted, or None when nothing changed.
+
+        The window is a renderer. Every headline, body line, colour and
+        status glyph in the returned dict is produced by the code that
+        paints the Qt window, so the two cannot describe the same lap
+        differently - which is what "1:1" has to mean if it is going to
+        survive a sprint.
+
+        Returned on a tick the caller has not seen, **and** on a change of
+        connection state with no new tick, which is the only way a window
+        learns the arcade died: once the producer stops, `seq` stops
+        advancing and a purely sequence-driven view would keep rendering
+        the last frame of a dead race with a green "Connected" chip.
+        """
+        connection = self._connection_label()
+        payload = self.get_tick(since_seq)
+        if payload is None:
+            if connection == self._agents_connection:
+                return None
+            payload = self._client.latest
+            if payload is None:
+                return None
+        self._agents_connection = connection
+        return self._agents.build(payload, connection)
 
     def release_window(self) -> int:
         """Record that one window has closed; stop the client at the last one.

--- a/src/pitwall/ui/package-lock.json
+++ b/src/pitwall/ui/package-lock.json
@@ -12,6 +12,7 @@
         "react-dom": "^19.2.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@types/node": "^26.2.0",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
@@ -812,6 +813,22 @@
         "node": "^22.20 || ^24.12 || >=25"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1575,6 +1592,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/src/pitwall/ui/package.json
+++ b/src/pitwall/ui/package.json
@@ -13,6 +13,7 @@
     "react-dom": "^19.2.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@types/node": "^26.2.0",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",

--- a/src/pitwall/ui/scripts/shot-agents.mjs
+++ b/src/pitwall/ui/scripts/shot-agents.mjs
@@ -1,0 +1,96 @@
+/**
+ * Screenshot the built AGENTS window headless, against a stubbed bridge.
+ *
+ * A dev tool, not part of the product. It exists because the acceptance
+ * test for this port is visual - the Qt window rendered beside the React
+ * one - and because a pywebview window cannot be captured without opening
+ * it on somebody's desktop.
+ *
+ * What it captures is the REAL bundle rendering REAL host output: the
+ * view JSON comes from `AgentsViewBuilder` (see the sibling recipe in
+ * `~/.claude/FRONTEND_VISUAL_VERIFICATION.md`), and the only thing faked
+ * is `window.pywebview`, which the OS shell would otherwise inject.
+ *
+ *   npm run build
+ *   node scripts/shot-agents.mjs <view.json> <out.png> [width] [height]
+ *
+ * The Qt side of the comparison is captured with `QWidget.grab()` and
+ * `Qt.WA_DontShowOnScreen` - never a screen rectangle, which returns
+ * whatever is physically in front, and never the `offscreen` platform
+ * plugin, which ships no font database on Windows and renders every
+ * glyph as tofu.
+ */
+import { createReadStream, readFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { dirname, extname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const MIME = {
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".css": "text/css",
+  ".json": "application/json",
+};
+
+/**
+ * Serve `dist/` over http on an ephemeral port.
+ *
+ * Not decoration: chromium refuses `<script type="module">` over file://
+ * (CORS treats it as origin `null`), so the bundle loads nothing and the
+ * screenshot is a blank page with two console errors. pywebview reaches
+ * the same files through the OS webview, which does allow it.
+ */
+function serveDist(root) {
+  const server = createServer((req, res) => {
+    const path = join(root, decodeURIComponent(req.url.split("?")[0]));
+    res.setHeader("Content-Type", MIME[extname(path)] ?? "application/octet-stream");
+    createReadStream(path)
+      .on("error", () => {
+        res.statusCode = 404;
+        res.end();
+      })
+      .pipe(res);
+  });
+  return new Promise((ready) => server.listen(0, "127.0.0.1", () => ready(server)));
+}
+
+const UI_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const [viewPath, out, width = "1320", height = "900"] = process.argv.slice(2);
+
+if (!viewPath || !out) {
+  console.error("usage: node scripts/shot-agents.mjs <view.json> <out.png> [w] [h]");
+  process.exit(2);
+}
+
+const view = JSON.parse(readFileSync(viewPath, "utf8"));
+const server = await serveDist(resolve(UI_DIR, "dist"));
+const bundle = `http://127.0.0.1:${server.address().port}/agents.html`;
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({ viewport: { width: +width, height: +height } });
+const page = await ctx.newPage();
+page.on("console", (m) => console.log(`[console:${m.type()}] ${m.text()}`));
+page.on("pageerror", (e) => console.log(`[pageerror] ${e.message}`));
+
+await page.addInitScript((payload) => {
+  window.pywebview = {
+    api: {
+      // The host returns null once the window is up to date; the stub does
+      // the same, so the poll loop settles instead of re-rendering at 10 Hz
+      // under the screenshot.
+      get_agents_view: async (sinceSeq) => (sinceSeq >= payload.seq ? null : payload),
+      get_tick: async () => null,
+    },
+  };
+}, view);
+
+// `domcontentloaded`, not `networkidle`: a file:// bundle has no network to
+// go idle, and Vite's HMR socket keeps `networkidle` from ever firing in dev.
+await page.goto(bundle, { waitUntil: "domcontentloaded" });
+await page.waitForTimeout(1200);
+await page.screenshot({ path: resolve(out), fullPage: false });
+await ctx.close();
+await browser.close();
+server.close();
+console.log(`saved ${out}`);

--- a/src/pitwall/ui/scripts/shot-agents.mjs
+++ b/src/pitwall/ui/scripts/shot-agents.mjs
@@ -20,7 +20,7 @@
  * plugin, which ships no font database on Windows and renders every
  * glyph as tofu.
  */
-import { readFileSync, readdirSync, statSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { createServer } from "node:http";
 import { dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -50,12 +50,16 @@ const MIME = {
  */
 function serveDist(root) {
   const files = new Map();
+  // `withFileTypes` answers directory-or-file from the directory read
+  // itself. Asking again with `stat` is a second look at something that
+  // can change in between, which CodeQL calls a file-system race and is
+  // right to.
   const walk = (dir, prefix) => {
-    for (const entry of readdirSync(dir)) {
-      const full = join(dir, entry);
-      const url = `${prefix}/${entry}`;
-      if (statSync(full).isDirectory()) walk(full, url);
-      else files.set(url, { body: readFileSync(full), type: MIME[extname(entry)] });
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      const url = `${prefix}/${entry.name}`;
+      if (entry.isDirectory()) walk(full, url);
+      else files.set(url, { body: readFileSync(full), type: MIME[extname(entry.name)] });
     }
   };
   walk(root, "");

--- a/src/pitwall/ui/scripts/shot-agents.mjs
+++ b/src/pitwall/ui/scripts/shot-agents.mjs
@@ -22,7 +22,7 @@
  */
 import { createReadStream, readFileSync } from "node:fs";
 import { createServer } from "node:http";
-import { dirname, extname, join, resolve } from "node:path";
+import { dirname, extname, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
 
@@ -43,7 +43,16 @@ const MIME = {
  */
 function serveDist(root) {
   const server = createServer((req, res) => {
-    const path = join(root, decodeURIComponent(req.url.split("?")[0]));
+    // Resolve, then check the result is still inside `dist`. A URL can
+    // carry `../` and `join` will happily walk out of the root: CodeQL
+    // called this out as a path injection on the first run of this file,
+    // and it is right even for a dev tool on an ephemeral local port.
+    const path = resolve(root, "." + decodeURIComponent(req.url.split("?")[0]));
+    if (path !== root && !path.startsWith(root + sep)) {
+      res.statusCode = 403;
+      res.end();
+      return;
+    }
     res.setHeader("Content-Type", MIME[extname(path)] ?? "application/octet-stream");
     createReadStream(path)
       .on("error", () => {

--- a/src/pitwall/ui/scripts/shot-agents.mjs
+++ b/src/pitwall/ui/scripts/shot-agents.mjs
@@ -20,9 +20,9 @@
  * plugin, which ships no font database on Windows and renders every
  * glyph as tofu.
  */
-import { createReadStream, readFileSync } from "node:fs";
+import { readFileSync, readdirSync, statSync } from "node:fs";
 import { createServer } from "node:http";
-import { dirname, extname, resolve, sep } from "node:path";
+import { dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
 
@@ -34,32 +34,41 @@ const MIME = {
 };
 
 /**
- * Serve `dist/` over http on an ephemeral port.
+ * Serve `dist/` over http, from a map read once at startup.
  *
- * Not decoration: chromium refuses `<script type="module">` over file://
- * (CORS treats it as origin `null`), so the bundle loads nothing and the
- * screenshot is a blank page with two console errors. pywebview reaches
- * the same files through the OS webview, which does allow it.
+ * Two reasons it is not decoration and not a file server. First,
+ * chromium refuses `<script type="module">` over `file://` (CORS treats
+ * it as origin `null`), so the bundle loads nothing and the screenshot
+ * is a blank page with two console errors. pywebview reaches the same
+ * files through the OS webview, which does allow it.
+ *
+ * Second, nothing here turns a request into a path. The first version
+ * joined the URL onto the root and CodeQL called it a path injection -
+ * correctly, because a URL can carry `../`. Reading the bundle into
+ * memory removes the question rather than guarding it, and a built
+ * bundle is a few hundred kilobytes.
  */
 function serveDist(root) {
+  const files = new Map();
+  const walk = (dir, prefix) => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      const url = `${prefix}/${entry}`;
+      if (statSync(full).isDirectory()) walk(full, url);
+      else files.set(url, { body: readFileSync(full), type: MIME[extname(entry)] });
+    }
+  };
+  walk(root, "");
+
   const server = createServer((req, res) => {
-    // Resolve, then check the result is still inside `dist`. A URL can
-    // carry `../` and `join` will happily walk out of the root: CodeQL
-    // called this out as a path injection on the first run of this file,
-    // and it is right even for a dev tool on an ephemeral local port.
-    const path = resolve(root, "." + decodeURIComponent(req.url.split("?")[0]));
-    if (path !== root && !path.startsWith(root + sep)) {
-      res.statusCode = 403;
+    const file = files.get(req.url.split("?")[0]);
+    if (!file) {
+      res.statusCode = 404;
       res.end();
       return;
     }
-    res.setHeader("Content-Type", MIME[extname(path)] ?? "application/octet-stream");
-    createReadStream(path)
-      .on("error", () => {
-        res.statusCode = 404;
-        res.end();
-      })
-      .pipe(res);
+    res.setHeader("Content-Type", file.type ?? "application/octet-stream");
+    res.end(file.body);
   });
   return new Promise((ready) => server.listen(0, "127.0.0.1", () => ready(server)));
 }

--- a/src/pitwall/ui/src/features/agents/AgentCard.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentCard.tsx
@@ -1,0 +1,72 @@
+/**
+ * One sub-agent card, shared by all six.
+ *
+ * A dumb view, like the Qt `AgentCard` it replaces: it does not know
+ * which agent it shows. Title and content arrive from the host, which
+ * produced them with the Qt window's own formatters.
+ *
+ * `dangerouslySetInnerHTML` is deliberate and bounded. The headline and
+ * the body lines can carry the compound pill and the flag chips, which
+ * are HTML spans built in `src/arcade/palette.py`, and every free-text
+ * field inside them is escaped there. It is Qt's restricted rich-text
+ * dialect (`<b>`, `<br>`, `&nbsp;` and those spans), which is debt sprint
+ * 8 unpicks - not a licence to inject arbitrary markup here.
+ */
+
+import type { AgentCardView } from "../../lib/agents";
+
+export function AgentCard({
+  title,
+  card,
+  children,
+}: {
+  title: string;
+  card: AgentCardView;
+  children?: React.ReactNode;
+}) {
+  const idle = card.status === "IDLE";
+  return (
+    <section className={idle ? "card agent-card is-idle" : "card agent-card"}>
+      <header className="agent-card-head">
+        <span className="agent-glyph" style={{ color: card.glyph_colour }}>
+          {card.glyph}
+        </span>
+        <span className="agent-title">{title}</span>
+        {card.tooltip ? <Tooltip html={card.tooltip} /> : null}
+      </header>
+
+      <p
+        className="agent-headline"
+        style={{ color: card.headline_colour }}
+        dangerouslySetInnerHTML={{ __html: card.headline }}
+      />
+
+      {card.lines.map((line, index) => (
+        <p
+          key={index}
+          className="agent-line"
+          style={{ color: line.colour }}
+          dangerouslySetInnerHTML={{ __html: line.text }}
+        />
+      ))}
+
+      {children ? <div className="agent-chart">{children}</div> : null}
+    </section>
+  );
+}
+
+/**
+ * The hover transcript Qt shows as a tooltip.
+ *
+ * A real element rather than the `title` attribute: the content is rich
+ * text, and `title` would print the tags. HTML has no 300 ms delay and no
+ * fixed width, so the one thing that improves for free here is that the
+ * whole lap fits.
+ */
+function Tooltip({ html }: { html: string }) {
+  return (
+    <span className="agent-tooltip-host" aria-label="full transcript">
+      i<span className="agent-tooltip" dangerouslySetInnerHTML={{ __html: html }} />
+    </span>
+  );
+}

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -1,14 +1,78 @@
 /**
- * PITWALL · AGENTS - the 1:1 port of the Qt strategy window.
+ * PITWALL · AGENTS — the 1:1 port of the Qt strategy window.
  *
- * Sprint 2 renders the vertical slice. The real layout is frozen and lands in
- * sprint 3: HeaderBar, a 540/740 horizontal split, and a 3x2 grid of agent
- * cards. It is a port, not a redesign.
+ * The layout is frozen and matches `window.py:141-207`: a header strip, a
+ * horizontal split at 540 / 740, the left column carrying the
+ * orchestrator card, the scenario bars and the reasoning tabs, the right
+ * column a 3x2 grid of agent cards, and a status bar at the bottom.
+ *
+ * **One Qt bug fixes itself here.** The left column gave the reasoning
+ * tabs about 268 px, so the decision-memory counterweight sentence fell
+ * below the fold on the one lap it matters. CSS has no fixed heights.
+ *
+ * Before the first view arrives the window renders the same idle state
+ * the Qt one shows at startup, rather than a spinner: same chips, same
+ * placeholders, same six hollow cards.
  */
 
-import { SliceProof } from "../SliceProof";
-import { useTick } from "../../lib/useTick";
+import { AgentCard } from "./AgentCard";
+import { HeaderBar } from "./HeaderBar";
+import { useAgentsView, type AgentCardView, type AgentsView } from "../../lib/agents";
+
+/** Grid order, reading across then down, exactly as `window.py` adds them. */
+const CARDS: ReadonlyArray<readonly [key: string, title: string]> = [
+  ["pace", "Pace"],
+  ["tire", "Tire"],
+  ["situation", "Situation"],
+  ["pit", "Pit"],
+  ["radio", "Radio"],
+  ["rag", "RAG"],
+];
+
+const IDLE_CARD: AgentCardView = {
+  headline: "--",
+  headline_colour: "#ffffff",
+  lines: [],
+  status: "IDLE",
+  glyph: "○",
+  glyph_colour: "#9ca3af",
+  tooltip: "",
+};
+
+const IDLE_VIEW: AgentsView = {
+  view_version: 0,
+  seq: null,
+  header: {
+    session: "--",
+    driver: "--",
+    lap: "L 0/0",
+    playback: "-- × · --",
+    connection: "Disconnected",
+    connection_colour: "#ef4444",
+  },
+  cards: Object.fromEntries(CARDS.map(([key]) => [key, IDLE_CARD])),
+  history: { pace: [], tire: [] },
+  status_bar: { text: "Waiting for arcade stream…", transient: false },
+};
 
 export function AgentsWindow() {
-  return <SliceProof title="PITWALL · AGENTS" state={useTick()} />;
+  const { view } = useAgentsView();
+  const shown = view ?? IDLE_VIEW;
+
+  return (
+    <div className="agents-window">
+      <HeaderBar header={shown.header} />
+
+      <div className="agents-split">
+        <div className="agents-left">{/* orchestrator, scenarios, reasoning */}</div>
+        <div className="agents-right">
+          {CARDS.map(([key, title]) => (
+            <AgentCard key={key} title={title} card={shown.cards[key] ?? IDLE_CARD} />
+          ))}
+        </div>
+      </div>
+
+      <footer className="status-bar">{shown.status_bar.text}</footer>
+    </div>
+  );
 }

--- a/src/pitwall/ui/src/features/agents/HeaderBar.tsx
+++ b/src/pitwall/ui/src/features/agents/HeaderBar.tsx
@@ -1,0 +1,24 @@
+/**
+ * The 44 px top strip: session, driver, connection, playback, lap counter.
+ *
+ * 1:1 with `window.py::HeaderBar` — same order, same three chips on the
+ * right, same three-state connection colour. Every string is built host
+ * side; this places them.
+ */
+
+import type { HeaderView } from "../../lib/agents";
+
+export function HeaderBar({ header }: { header: HeaderView }) {
+  return (
+    <header className="header-bar">
+      <span className="header-session">{header.session}</span>
+      <span className="header-driver">{header.driver}</span>
+      <span className="header-spacer" />
+      <span className="chip header-conn" style={{ color: header.connection_colour }}>
+        {header.connection}
+      </span>
+      <span className="chip">{header.playback}</span>
+      <span className="chip">{header.lap}</span>
+    </header>
+  );
+}

--- a/src/pitwall/ui/src/lib/agents.ts
+++ b/src/pitwall/ui/src/lib/agents.ts
@@ -1,0 +1,117 @@
+/**
+ * The AGENTS view, typed, and the hook that polls for it.
+ *
+ * **There is deliberately no formatting on this side.** Every string,
+ * colour and glyph below is computed in Python by the same code that
+ * paints the Qt window (`src/pitwall/agents_view/`), so the port is 1:1
+ * by construction rather than by inspection. If you find yourself about
+ * to write a `toFixed(2)` here, the number belongs in `panels.py`.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { whenBridgeReady } from "./bridge";
+
+/** Matches the producer's own ~10 Hz. Polling faster only returns null more often. */
+const POLL_INTERVAL_MS = 100;
+
+export interface CardLine {
+  /** Qt rich text: `<b>`, `<br>`, `&nbsp;` and the two badge spans. */
+  text: string;
+  colour: string;
+}
+
+export interface AgentCardView {
+  headline: string;
+  headline_colour: string;
+  lines: CardLine[];
+  status: "OK" | "WATCH" | "ALERT" | "IDLE";
+  glyph: string;
+  glyph_colour: string;
+  /** Empty string means no tooltip, which is Qt's own convention. */
+  tooltip: string;
+}
+
+export interface HeaderView {
+  session: string;
+  driver: string;
+  lap: string;
+  playback: string;
+  connection: string;
+  connection_colour: string;
+}
+
+export interface PaceHistoryRow {
+  lap: number;
+  actual?: number | null;
+  pred?: number | null;
+  ci_p10?: number | null;
+  ci_p90?: number | null;
+}
+
+export interface TireHistoryRow {
+  lap: number;
+  lap_time_s?: number | null;
+  tyre_life?: number | null;
+  compound?: string | null;
+}
+
+export interface AgentsView {
+  view_version: number;
+  seq: number | null;
+  header: HeaderView;
+  cards: Record<string, AgentCardView>;
+  history: { pace: PaceHistoryRow[]; tire: TireHistoryRow[] };
+  status_bar: { text: string; transient: boolean };
+}
+
+interface AgentsApi {
+  get_agents_view: (sinceSeq: number) => Promise<AgentsView | null>;
+}
+
+export interface AgentsState {
+  view: AgentsView | null;
+  /** False until the first view lands, so the window can say "waiting" honestly. */
+  live: boolean;
+}
+
+/**
+ * One poll loop, sequenced, exactly like `useTick`.
+ *
+ * The host returns null when this window is already up to date, and a
+ * view anyway when the connection state changed with no new tick - which
+ * is the only way the window learns the arcade died, because a dead
+ * producer stops advancing `seq`.
+ */
+export function useAgentsView(): AgentsState {
+  const [state, setState] = useState<AgentsState>({ view: null, live: false });
+  // A ref, not state: the loop must read the newest sequence without
+  // re-subscribing, and a stale closure would ask for the same view forever.
+  const lastSeq = useRef(-1);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: number | undefined;
+
+    const poll = async () => {
+      const api = (window.pywebview?.api ?? null) as AgentsApi | null;
+      const view = api ? await api.get_agents_view(lastSeq.current) : null;
+      if (cancelled) return;
+      if (view) {
+        if (view.seq !== null) lastSeq.current = view.seq;
+        setState({ view, live: true });
+      }
+      timer = window.setTimeout(poll, POLL_INTERVAL_MS);
+    };
+
+    whenBridgeReady().then(() => {
+      if (!cancelled) poll();
+    });
+
+    return () => {
+      cancelled = true;
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, []);
+
+  return state;
+}

--- a/src/pitwall/ui/src/main-agents.tsx
+++ b/src/pitwall/ui/src/main-agents.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { AgentsWindow } from "./features/agents/AgentsWindow";
 import "./styles/tokens.css";
-import "./styles/slice.css";
+import "./styles/agents.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -1,0 +1,206 @@
+/* PITWALL · AGENTS — the Qt window's geometry, in CSS.
+ *
+ * Every number here comes from a Qt call in `src/arcade/dashboard/`:
+ * the 44 px header (`HeaderBar.setFixedHeight`), the 540 / 740 split
+ * (`splitter.setSizes`), the 10 px panel margins and 8 px spacing
+ * (`setContentsMargins` / `setSpacing`), the card border and radius
+ * (`theme.apply_dark_palette`'s `QFrame[card="true"]` rule), and the
+ * font sizes on each widget.
+ *
+ * The COLOURS are the arcade palette, not `tokens.css`. The two
+ * deliberately differ and `test_pitwall_tokens.py` freezes the
+ * difference; adopting the web palette here would be the redesign
+ * sprint 8 owns, not a port. `tokens.css` is still loaded for its type
+ * scale and for the DATA window.
+ */
+
+:root {
+  --qt-bg: #121127;
+  --qt-panel: #181633;
+  --qt-elevated: #1e1b4b;
+  --qt-border: #2d2d3a;
+  --qt-fg-1: #ffffff;
+  --qt-fg-2: #d1d5db;
+  --qt-fg-3: #9ca3af;
+  --qt-accent: #a78bfa;
+  --qt-mono: "FiraCode Nerd Font Mono", "Fira Code", "JetBrains Mono", Consolas, monospace;
+}
+
+body {
+  margin: 0;
+  background: var(--qt-bg);
+  color: var(--qt-fg-1);
+  font-family: var(--font-body, system-ui, sans-serif);
+  font-size: 13px;
+}
+
+.agents-window {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+/* --- Header ------------------------------------------------------------- */
+
+.header-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: 44px;
+  flex: 0 0 44px;
+  padding: 6px 14px;
+  box-sizing: border-box;
+}
+.header-session {
+  font-size: 14px;
+  font-weight: 600;
+}
+.header-driver {
+  color: var(--qt-fg-2);
+  font-size: 13px;
+  margin-left: 6px;
+}
+.header-spacer {
+  flex: 1;
+}
+.chip {
+  color: var(--qt-fg-2);
+  background: var(--qt-elevated);
+  padding: 2px 10px;
+  border-radius: 10px;
+  font-size: 11px;
+}
+/* The connection chip carries no background in Qt: only its text is
+ * coloured, which is what makes the three states readable at a glance. */
+.header-conn {
+  background: none;
+  font-weight: 600;
+}
+
+/* --- The split ---------------------------------------------------------- */
+
+.agents-split {
+  display: grid;
+  grid-template-columns: 540fr 740fr;
+  gap: 2px; /* QSplitter.setHandleWidth(2) */
+  flex: 1;
+  min-height: 0;
+}
+.agents-left,
+.agents-right {
+  padding: 10px;
+  display: grid;
+  gap: 8px;
+  min-height: 0;
+  overflow: auto;
+}
+.agents-left {
+  /* Orchestrator and scenarios size to content; the reasoning tabs take
+   * the rest. In Qt that left them ~268 px and the decision-memory block
+   * fell below the fold. */
+  grid-template-rows: auto auto 1fr;
+  align-content: start;
+}
+.agents-right {
+  grid-template-columns: 1fr 1fr;
+  grid-auto-rows: minmax(140px, auto);
+}
+
+/* --- Cards -------------------------------------------------------------- */
+
+.card {
+  background: var(--qt-panel);
+  border: 1px solid var(--qt-border);
+  border-radius: 6px;
+}
+.agent-card {
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+.agent-card.is-idle {
+  opacity: 0.45;
+}
+.agent-card-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.agent-glyph {
+  font-size: 14px;
+  line-height: 1;
+}
+.agent-title {
+  color: var(--qt-fg-2);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+.agent-headline {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+.agent-line {
+  margin: 0;
+  font-size: 11px;
+  overflow-wrap: anywhere;
+}
+.agent-chart {
+  margin-top: auto;
+  min-height: 140px;
+}
+
+/* --- Tooltip ------------------------------------------------------------ */
+
+.agent-tooltip-host {
+  margin-left: auto;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 1px solid var(--qt-border);
+  color: var(--qt-fg-3);
+  font-size: 9px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  cursor: help;
+}
+.agent-tooltip {
+  display: none;
+  position: absolute;
+  top: 18px;
+  right: 0;
+  z-index: 10;
+  width: 30rem;
+  max-height: 22rem;
+  overflow: auto;
+  padding: 8px 10px;
+  background: var(--qt-elevated);
+  border: 1px solid var(--qt-border);
+  border-radius: 6px;
+  color: var(--qt-fg-2);
+  font-size: 11px;
+  font-weight: 400;
+  text-align: left;
+  line-height: 1.5;
+}
+.agent-tooltip-host:hover .agent-tooltip {
+  display: block;
+}
+
+/* --- Status bar --------------------------------------------------------- */
+
+.status-bar {
+  flex: 0 0 auto;
+  padding: 4px 10px;
+  background: var(--qt-panel);
+  color: var(--qt-fg-3);
+  font-size: 11px;
+}

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -66,3 +66,289 @@ def test_the_badge_builders_escape_what_comes_off_the_wire():
     assert "&lt;b&gt;" in compound_pill_html("<b>SOFT")
     assert "<b>" not in compound_pill_html("<b>SOFT").removeprefix("<span")
     assert "&lt;" in flag_chip_html("A<B")
+
+
+# --- The view the host hands the window -------------------------------------
+
+
+def _latest(lap: int = 23) -> dict:
+    """A LapDecision block with the field names the agents really emit."""
+    return {
+        "lap_number": lap,
+        "compound": "MEDIUM",
+        "tyre_life": lap - 8,
+        "lap_time_s": 81.234,
+        "action": "PIT_NOW",
+        "confidence": 0.71,
+        "reasoning": "the undercut window against RUS opens now",
+        "scenario_scores": {"PIT_NOW": 0.71, "STAY_OUT": 0.29},
+        "pace_mode": "PUSH",
+        "risk_posture": "AGGRESSIVE",
+        "pit_lap_target": lap + 1,
+        "compound_next": "HARD",
+        "undercut_target": "RUS",
+        "memory_block": f"lap {lap - 1}: STAY_OUT (0.58)",
+        "plan_changed": True,
+        "per_agent": {
+            "pace": {
+                "lap_time_pred": 81.0,
+                "delta_vs_prev": -0.204,
+                "delta_vs_median": 0.118,
+                "ci_p10": 80.45,
+                "ci_p90": 81.55,
+            },
+            "tire": {
+                "compound": "MEDIUM",
+                "current_tyre_life": lap - 8,
+                "deg_rate": 0.031,
+                "laps_to_cliff_p10": 4.0,
+                "laps_to_cliff_p50": 6.0,
+                "laps_to_cliff_p90": 9.0,
+                "warning_level": "MONITOR",
+            },
+            "situation": {
+                "overtake_prob": 0.34,
+                "sc_prob_3lap": 0.08,
+                "threat_level": "MEDIUM",
+                "gap_ahead_s": 1.42,
+                "pace_delta_s": -0.12,
+            },
+            "radio": {"radio_events": [], "rcm_events": [], "alerts": []},
+            "pit": {
+                "stop_duration_p05": 21.14,
+                "stop_duration_p50": 22.40,
+                "stop_duration_p95": 24.81,
+                "compound_recommendation": "HARD",
+                "undercut_prob": 0.63,
+                "undercut_target": "RUS",
+                "sc_reactive": False,
+            },
+            "rag": {
+                "question": "q",
+                "answer": "Two dry specifications are still required.",
+                "articles": ["Article 30.5(m)"],
+                "chunks": [],
+            },
+            "active": ["N28", "N30"],
+        },
+    }
+
+
+def _payload(
+    seq: int = 7, lap: int = 23, latest: dict | None = None, tail: list | None = None
+) -> dict:
+    return {
+        "schema_version": 1,
+        "seq": seq,
+        "arcade": {
+            "gp_name": "Melbourne",
+            "year": 2025,
+            "lap": lap,
+            "total_laps": 57,
+            "driver_main": "NOR",
+        },
+        "playback": {"speed": 2.0, "paused": False, "frame_index": 1000, "total_frames": 9000},
+        "strategy": {
+            "start": {"gp": "Melbourne", "year": 2025, "driver": "NOR"},
+            "latest": _latest(lap) if latest is None else latest,
+            "history_tail": tail or [],
+            "error": None,
+        },
+    }
+
+
+class _FakeClient:
+    """Stands in for the socket, so the host's own logic is what is tested."""
+
+    def __init__(self, payload=None, connected=True):
+        self.latest = payload
+        self.connected = connected
+        self.stopped = False
+
+    def start(self):
+        pass
+
+    def stop(self):
+        self.stopped = True
+
+
+def _host(payload=None, connected=True):
+    from src.pitwall.host import PitwallHost
+
+    return PitwallHost(_FakeClient(payload, connected), window_count=1)
+
+
+def test_the_view_is_what_the_qt_window_renders_line_for_line():
+    """The golden. These strings are the Qt cards' own output, not a re-format.
+
+    If a formatter changes, this changes with it, and that diff is the
+    port staying 1:1. A TypeScript reimplementation could satisfy this
+    today and drift tomorrow, which is the whole reason the view is
+    computed in Python.
+    """
+    view = _host(_payload()).get_agents_view(-1)
+
+    assert view["header"] == {
+        "session": "Melbourne · 2025",
+        "driver": "NOR",
+        "lap": "L 23/57",
+        "playback": "2.00× · PLAYING",
+        "connection": "Connected",
+        "connection_colour": "#10b981",
+    }
+    assert view["status_bar"] == {"text": "lap 23 · streaming", "transient": True}
+
+    cards = view["cards"]
+    assert cards["pace"]["headline"] == "Δnext -0.204s (81.00s)"
+    assert [line["text"] for line in cards["pace"]["lines"]] == [
+        "pred 81.00s",
+        "vs median +0.12s",
+        "±0.55s (CI)",
+    ]
+    assert cards["pace"]["status"] == "OK"
+
+    assert cards["tire"]["headline"] == "Cliff ~6 laps · L15"
+    assert cards["tire"]["status"] == "WATCH"
+    assert cards["tire"]["lines"][0]["text"] == "range 4–9 laps"
+
+    assert cards["situation"]["headline"] == "Threat MEDIUM"
+    assert cards["situation"]["headline_colour"] == "#f59e0b"
+    assert [line["text"] for line in cards["situation"]["lines"]] == [
+        "overtake 34%",
+        "safety car 8%",
+        "gap 1.4s · Δpace -0.12s/lap",
+    ]
+
+    assert cards["pit"]["headline"] == "pit 22.40s → HARD"
+    assert cards["radio"]["headline"] == "quiet"
+    assert cards["rag"]["headline"] == "regulation loaded"
+
+
+def test_the_situation_card_says_out_of_range_and_never_zero_per_cent():
+    """`None` and `0` are opposite readings and would prompt opposite calls.
+
+    N27 reports None when the car ahead is beyond the overtake model's
+    trained gap. Rendering that as "overtake 0%" tells the wall the model
+    says NO CHANCE when it says nothing at all.
+    """
+    latest = _latest()
+    latest["per_agent"]["situation"]["overtake_prob"] = None
+
+    view = _host(_payload(latest=latest)).get_agents_view(-1)
+
+    assert view["cards"]["situation"]["lines"][0]["text"] == "overtake — (out of model range)"
+
+
+def test_the_conditional_cards_read_agent_ids_and_not_block_names():
+    latest = _latest()
+    latest["per_agent"]["active"] = []
+
+    cards = _host(_payload(latest=latest)).get_agents_view(-1)["cards"]
+
+    assert cards["pit"]["status"] == "IDLE"
+    assert cards["pit"]["headline"].startswith("triggers on")
+    assert cards["rag"]["status"] == "IDLE"
+    assert cards["rag"]["headline"].startswith("triggers on")
+
+
+def test_a_tick_with_no_per_agent_block_shows_the_idle_copy_and_not_an_empty_card():
+    cards = _host(_payload(latest={"lap_number": 3})).get_agents_view(-1)["cards"]
+
+    assert cards["pace"]["headline"] == "no prediction — stub"
+    assert cards["radio"]["headline"] == "no radio/rcm pipeline output"
+    assert all(card["status"] == "IDLE" for card in cards.values())
+
+
+# --- The accumulators -------------------------------------------------------
+
+
+def test_the_history_keeps_the_predictions_the_wire_only_sends_once():
+    """`history_tail` strips `per_agent`, so nothing can rebuild them later.
+
+    Two ticks a lap apart: the older lap must keep the prediction it
+    carried when it was `latest`, and the tail must not overwrite it with
+    the actual-only row it also describes.
+    """
+    from src.pitwall.host import PitwallHost
+
+    client = _FakeClient(_payload(seq=1, lap=23))
+    host = PitwallHost(client, window_count=1)
+    host.get_agents_view(-1)
+
+    tail = [{"lap_number": 23, "lap_time_s": 81.234, "tyre_life": 15, "compound": "MEDIUM"}]
+    client.latest = _payload(seq=2, lap=24, tail=tail)
+    view = host.get_agents_view(1)
+
+    pace = {row["lap"]: row for row in view["history"]["pace"]}
+    assert pace[23]["pred"] == 81.0, "the prediction survived the tail describing the same lap"
+    assert pace[23]["actual"] == 81.234
+    assert 24 in pace, "and the new lap is in"
+
+
+def test_a_rewind_drops_the_laps_ahead_and_keeps_the_ones_behind():
+    """The Qt charts have no equivalent and are wrong after a seek back.
+
+    Truncating everything would be worse than doing nothing: the past
+    holds predictions the wire will never resend.
+    """
+    from src.pitwall.host import PitwallHost
+
+    client = _FakeClient(_payload(seq=1, lap=20))
+    host = PitwallHost(client, window_count=1)
+    host.get_agents_view(-1)
+    for seq, lap in ((2, 21), (3, 22)):
+        client.latest = _payload(seq=seq, lap=lap)
+        host.get_agents_view(seq - 1)
+
+    client.latest = _payload(seq=4, lap=21)
+    view = host.get_agents_view(3)
+
+    assert sorted(row["lap"] for row in view["history"]["pace"]) == [20, 21]
+
+
+def test_the_history_stays_bounded():
+    from src.pitwall.agents_view.history import KEEP_LAPS, LapHistory
+
+    history = LapHistory()
+    for lap in range(1, KEEP_LAPS + 11):
+        history.ingest_latest({"lap_number": lap, "lap_time_s": 80.0 + lap})
+
+    assert len(history.pace) == KEEP_LAPS
+    assert min(history.pace) == 11, "the oldest laps go, not the newest"
+
+
+# --- The connection chip ----------------------------------------------------
+
+
+def test_the_window_learns_the_arcade_died_even_though_no_tick_arrives():
+    """Once the producer stops, `seq` stops advancing.
+
+    A purely sequence-driven view would keep rendering the last frame of a
+    dead race under a green Connected chip, forever and silently.
+    """
+    from src.pitwall.host import PitwallHost
+
+    client = _FakeClient(_payload(seq=5), connected=True)
+    host = PitwallHost(client, window_count=1)
+    assert host.get_agents_view(-1)["header"]["connection"] == "Connected"
+    assert host.get_agents_view(5) is None, "nothing new, nothing changed"
+
+    client.connected = False
+    view = host.get_agents_view(5)
+
+    assert view is not None, "the state changed, so the window must hear about it"
+    assert view["header"]["connection"] == "Disconnected"
+    assert view["header"]["connection_colour"] == "#ef4444"
+    assert host.get_agents_view(5) is None, "and only once"
+
+
+def test_before_the_first_connection_the_chip_says_connecting():
+    """Retrying is not the same as having been dropped, and the colours differ."""
+    view = _host(_payload(), connected=False).get_agents_view(-1)
+
+    assert view["header"]["connection"] == "Connecting..."
+    assert view["header"]["connection_colour"] == "#f59e0b"
+
+
+def test_nothing_to_render_is_none_rather_than_an_empty_view():
+    assert _host(None, connected=False).get_agents_view(-1) is None

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -12,6 +12,8 @@ import subprocess
 import sys
 import textwrap
 
+import pytest
+
 REUSED_BY_PITWALL = (
     "src.arcade.dashboard.agent_formatters",
     "src.arcade.palette",
@@ -352,3 +354,29 @@ def test_before_the_first_connection_the_chip_says_connecting():
 
 def test_nothing_to_render_is_none_rather_than_an_empty_view():
     assert _host(None, connected=False).get_agents_view(-1) is None
+
+
+def test_the_status_glyphs_match_the_qt_cards():
+    """The twin-detector for the one map that had to be repeated.
+
+    `agent_card.py::_GLYPH_FOR` lives inside a QFrame subclass and cannot
+    be imported from a process with no Qt, so `panels.STATUS_GLYPHS`
+    repeats it. Repeating a map without a guard is how this repo's most
+    frequent defect starts, so the two are compared for as long as both
+    exist. It skips where Qt does not import; the port's own copy is
+    still exercised by every card test above.
+    """
+    agent_card = pytest.importorskip(
+        "src.arcade.dashboard.agent_card",
+        reason="the Qt dashboard is an optional surface and needs a display stack",
+        exc_type=ImportError,
+    )
+    from src.arcade.palette import hex_str
+    from src.pitwall.agents_view.panels import STATUS_GLYPHS
+
+    qt_map = {
+        status: (glyph, hex_str(colour))
+        for status, (glyph, colour) in agent_card._GLYPH_FOR.items()
+    }
+
+    assert STATUS_GLYPHS == qt_map


### PR DESCRIPTION
Sprint 3, PR 3 of 6. Builds on #865.

The AGENTS window's frame: header, the 540/740 split, the 3x2 grid of agent cards, the status bar. The left column is scaffolded and empty; PRs 4 and 5 fill it.

## Rendered, headless, from the real bundle

Captured with the harness below, at 1320x900: six cards, all populated, with the compound pill on TIRE, the PROBLEM flag chip on RADIO, the radio ticker, the article refs on RAG, and the two hover tooltips.

## Every number in the CSS comes from a Qt call

44 px header (`setFixedHeight`), 540/740 (`splitter.setSizes`), 2 px handle, 10 px margins and 8 px spacing (`setContentsMargins`/`setSpacing`), 1 px `#2d2d3a` border and 6 px radius (`apply_dark_palette`'s `QFrame[card="true"]`), and the per-widget font sizes.

**The colours are the arcade palette, not `tokens.css`.** The two deliberately differ and `test_pitwall_tokens.py` freezes the difference; adopting the web palette here would be the redesign sprint 8 owns, not a port. `tokens.css` is still loaded, for its type scale and for the DATA window.

## The Qt bug that fixes itself

The left column is `auto auto 1fr` instead of three fixed heights, so the decision-memory counterweight sentence cannot fall below the fold the way it does in Qt's ~268 px.

## Two things worth knowing

**`dangerouslySetInnerHTML` on the headline and the body lines is deliberate and bounded.** They can carry the compound pill and the flag chips, which are HTML spans built in `src/arcade/palette.py`, where every free-text field is escaped (#864). It is Qt's restricted dialect and it is debt sprint 8 unpicks.

**The window renders the Qt idle state before the first view**, not a spinner: same chips, same `L 0/0`, same six hollow cards, same red Disconnected. That is what the Qt window shows at startup.

## The screenshot harness is committed

`src/pitwall/ui/scripts/shot-agents.mjs`, a dev tool. The exit gate needs the two windows side by side and sprints 8-9 need fresh captures, so it earns its place. Two things it had to solve:

- **It serves `dist/` over http.** Chromium refuses `<script type="module">` over `file://` (origin `null`), so the page renders blank with two console errors. Worth knowing before anyone debugs a blank PITWALL window.
- **The Qt side uses `QWidget.grab()` with `Qt.WA_DontShowOnScreen`.** Not a screen rectangle (returns whatever is in front) and not the `offscreen` platform plugin, which ships no font database on Windows and renders every glyph as tofu — verified both ways.

## Checks

- `npm run build` clean, `tsc -b` clean.
- 13 Python tests, including the new twin-detector: `panels.STATUS_GLYPHS` has to repeat `agent_card._GLYPH_FOR` (it lives inside a QFrame subclass), so the two are compared for as long as both exist.
- `ruff` clean.
