### PR TITLE
feat(pitwall): the orchestrator card and the scenario bars

### DIFF
--- a/src/pitwall/agents_view/builder.py
+++ b/src/pitwall/agents_view/builder.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from src.pitwall.agents_view.decision import build_orchestrator, build_scenarios
 from src.pitwall.agents_view.history import LapHistory
 from src.pitwall.agents_view.panels import build_cards, build_header, build_status_bar
 
@@ -52,6 +53,8 @@ class AgentsViewBuilder:
             "view_version": AGENTS_VIEW_VERSION,
             "seq": payload.get("seq"),
             "header": build_header(payload, connection),
+            "orchestrator": build_orchestrator(latest or None),
+            "scenarios": build_scenarios(latest.get("scenario_scores") if latest else None),
             "cards": build_cards(latest or None),
             "history": {
                 "pace": [{"lap": lap, **row} for lap, row in sorted(self._history.pace.items())],

--- a/src/pitwall/agents_view/decision.py
+++ b/src/pitwall/agents_view/decision.py
@@ -1,0 +1,169 @@
+"""The left column's top half: the N31 decision and the scenario scores.
+
+Transcribed from `orchestrator_card.py` and `scenario_bars.py`, including
+their colour maps and their three-branch plan line, and calling
+`classify_action` rather than repeating its table - a hand-copied twin of
+that table lived in `theme.py` until 2026-08-01 and drifted, which is the
+mechanism #620 fixed once already.
+
+`ScenarioBars.update_from` is the one thing here that is an algorithm
+rather than a lookup: the four Monte Carlo scores are position-equivalent
+gains against the STAY_OUT baseline, so they are signed and frequently
+all negative. Shifting by the minimum before scaling is what keeps the
+bar widths valid, and getting the shift, the scale or the tie-break wrong
+changes which scenario reads as the winner.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.arcade.palette import (
+    ACCENT,
+    DANGER,
+    SUCCESS,
+    TEXT_PRIMARY,
+    TEXT_SECONDARY,
+    TEXT_TERTIARY,
+    WARNING,
+    compound_pill_html,
+    hex_str,
+)
+from src.arcade.strategy import classify_action
+
+_PACE_COLOURS: dict[str, tuple[int, int, int]] = {
+    "PUSH": DANGER,
+    "NEUTRAL": TEXT_SECONDARY,
+    "MANAGE": WARNING,
+    "LIFT_AND_COAST": WARNING,
+}
+
+_RISK_COLOURS: dict[str, tuple[int, int, int]] = {
+    "AGGRESSIVE": DANGER,
+    "BALANCED": TEXT_SECONDARY,
+    "NEUTRAL": TEXT_SECONDARY,
+    "CONSERVATIVE": WARNING,
+    "DEFENSIVE": WARNING,
+}
+
+SCENARIO_KEYS: tuple[str, ...] = ("STAY_OUT", "PIT_NOW", "UNDERCUT", "OVERCUT")
+SCENARIO_LABELS: dict[str, str] = {
+    "STAY_OUT": "STAY",
+    "PIT_NOW": "PIT",
+    "UNDERCUT": "UCUT",
+    "OVERCUT": "OCUT",
+}
+
+
+def _confidence_colour(confidence: float) -> tuple[int, int, int]:
+    """The three-tier traffic light `orchestrator_card.py` paints."""
+    if confidence >= 0.66:
+        return SUCCESS
+    if confidence >= 0.33:
+        return WARNING
+    return DANGER
+
+
+def _plan_line(latest: dict[str, Any], action: str) -> str:
+    """`Pit: L24 · Next: <pill> · UCUT: RUS`, or the two empty-state branches.
+
+    On STAY_OUT with no tactical plan the orchestrator leaves all three
+    fields blank deliberately, and three "--" chips read as noise rather
+    than as "nothing scheduled". That branch is copy, not a formatting
+    accident.
+    """
+    pit_target = latest.get("pit_lap_target")
+    compound_next = latest.get("compound_next")
+    undercut_target = latest.get("undercut_target")
+    if not any((pit_target, compound_next, undercut_target)):
+        if action.upper() == "STAY_OUT":
+            return "stint continues · no pit window yet"
+        return "Pit plan pending"
+    bits = [
+        f"Pit: L{pit_target}" if pit_target else "Pit: —",
+        f"Next: {compound_pill_html(compound_next)}" if compound_next else "Next: —",
+        f"UCUT: {undercut_target}" if undercut_target else "UCUT: —",
+    ]
+    return " · ".join(bits)
+
+
+def build_orchestrator(latest: dict[str, Any] | None) -> dict[str, Any]:
+    """The action badge, the confidence bar, the two chips and the plan."""
+    if not latest:
+        return {
+            "action": "--",
+            "action_colour": hex_str(TEXT_TERTIARY),
+            "confidence": None,
+            "confidence_label": "Confidence: --",
+            "confidence_colour": hex_str(TEXT_TERTIARY),
+            "pace": "Pace: --",
+            "pace_colour": hex_str(TEXT_TERTIARY),
+            "risk": "Risk: --",
+            "risk_colour": hex_str(TEXT_TERTIARY),
+            "plan": "Pit: -- · Next: -- · UCUT: --",
+            "guardrail": "",
+        }
+
+    action = str(latest.get("action") or "--")
+    confidence = float(latest.get("confidence") or 0.0)
+    pace_mode = latest.get("pace_mode")
+    risk_posture = latest.get("risk_posture")
+    guardrail = latest.get("guardrail_reason")
+    badge_colour, badge_label = classify_action(action)
+
+    return {
+        "action": badge_label,
+        "action_colour": hex_str(badge_colour),
+        "confidence": confidence,
+        "confidence_label": f"Confidence: {confidence * 100:.0f}%",
+        "confidence_colour": hex_str(_confidence_colour(confidence)),
+        "pace": f"Pace: {pace_mode or '--'}",
+        "pace_colour": hex_str(_PACE_COLOURS.get(str(pace_mode or "").upper(), TEXT_TERTIARY)),
+        "risk": f"Risk: {risk_posture or '--'}",
+        "risk_colour": hex_str(_RISK_COLOURS.get(str(risk_posture or "").upper(), TEXT_TERTIARY)),
+        "plan": _plan_line(latest, action),
+        "guardrail": f"⚠ Guardrail: {guardrail}" if guardrail else "",
+    }
+
+
+def build_scenarios(scores: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Four rows: label, bar fill in [0, 1], signed score, winner flag.
+
+    The fill is min-max normalised across whichever of the four keys are
+    present, so the winner always reaches full width and the worst draws
+    an empty bar whatever the signs. An absent key draws nothing and
+    prints `--`, which is not the same as a score of zero.
+    """
+    raw: dict[str, float] = {}
+    for key, value in (scores or {}).items():
+        try:
+            raw[str(key).upper()] = float(value)
+        except (TypeError, ValueError):
+            continue
+
+    winner = max(raw, key=raw.get) if raw else None
+    if raw:
+        lo, hi = min(raw.values()), max(raw.values())
+        span = (hi - lo) or 1.0
+    else:
+        lo, span = 0.0, 1.0
+
+    rows: list[dict[str, Any]] = []
+    for key in SCENARIO_KEYS:
+        present = key in raw
+        value = raw.get(key, lo)
+        fill = min(1.0, max(0.0, (value - lo) / span)) if present else 0.0
+        is_winner = present and key == winner
+        rows.append(
+            {
+                "key": key,
+                "label": SCENARIO_LABELS[key],
+                "fill": fill,
+                "score": f"{value:+.2f}" if present else "  --",
+                "is_winner": is_winner,
+                "bar_colour": hex_str(ACCENT if is_winner else TEXT_SECONDARY),
+                "label_colour": hex_str(ACCENT if is_winner else TEXT_SECONDARY),
+                "score_colour": hex_str(TEXT_PRIMARY if is_winner else TEXT_SECONDARY),
+            }
+        )
+    return rows

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -16,6 +16,8 @@
  */
 
 import { AgentCard } from "./AgentCard";
+import { OrchestratorCard } from "./OrchestratorCard";
+import { ScenarioBars } from "./ScenarioBars";
 import { HeaderBar } from "./HeaderBar";
 import { useAgentsView, type AgentCardView, type AgentsView } from "../../lib/agents";
 
@@ -50,6 +52,34 @@ const IDLE_VIEW: AgentsView = {
     connection: "Disconnected",
     connection_colour: "#ef4444",
   },
+  orchestrator: {
+    action: "--",
+    action_colour: "#9ca3af",
+    confidence: null,
+    confidence_label: "Confidence: --",
+    confidence_colour: "#9ca3af",
+    pace: "Pace: --",
+    pace_colour: "#9ca3af",
+    risk: "Risk: --",
+    risk_colour: "#9ca3af",
+    plan: "Pit: -- · Next: -- · UCUT: --",
+    guardrail: "",
+  },
+  scenarios: [
+    ["STAY_OUT", "STAY"],
+    ["PIT_NOW", "PIT"],
+    ["UNDERCUT", "UCUT"],
+    ["OVERCUT", "OCUT"],
+  ].map(([key, label]) => ({
+    key,
+    label,
+    fill: 0,
+    score: "  --",
+    is_winner: false,
+    bar_colour: "#d1d5db",
+    label_colour: "#d1d5db",
+    score_colour: "#d1d5db",
+  })),
   cards: Object.fromEntries(CARDS.map(([key]) => [key, IDLE_CARD])),
   history: { pace: [], tire: [] },
   status_bar: { text: "Waiting for arcade stream…", transient: false },
@@ -64,7 +94,11 @@ export function AgentsWindow() {
       <HeaderBar header={shown.header} />
 
       <div className="agents-split">
-        <div className="agents-left">{/* orchestrator, scenarios, reasoning */}</div>
+        <div className="agents-left">
+          <OrchestratorCard view={shown.orchestrator} />
+          <ScenarioBars rows={shown.scenarios} />
+          <div className="reasoning-slot">{/* reasoning tabs */}</div>
+        </div>
         <div className="agents-right">
           {CARDS.map(([key, title]) => (
             <AgentCard key={key} title={title} card={shown.cards[key] ?? IDLE_CARD} />

--- a/src/pitwall/ui/src/features/agents/OrchestratorCard.tsx
+++ b/src/pitwall/ui/src/features/agents/OrchestratorCard.tsx
@@ -1,0 +1,50 @@
+/**
+ * The N31 decision panel: action badge, confidence, the two regime chips,
+ * the plan line and the guardrail.
+ *
+ * 1:1 with `orchestrator_card.py`. Every string and colour is decided
+ * host side, including the plan line's three branches, so the "stint
+ * continues · no pit window yet" copy cannot quietly become three "--"
+ * chips here.
+ */
+
+import type { OrchestratorView } from "../../lib/agents";
+
+export function OrchestratorCard({ view }: { view: OrchestratorView }) {
+  const filled = view.confidence === null ? 0 : Math.round(view.confidence * 100);
+  return (
+    <section className="card orchestrator">
+      <div className="orch-top">
+        <div className="orch-badge" style={{ background: view.action_colour }}>
+          {view.action}
+        </div>
+        <div className="orch-conf">
+          <span className="orch-conf-label">{view.confidence_label}</span>
+          {/* A div rather than <progress>: Qt paints a flat two-stop bar and
+              the native element brings a platform look that is not it. */}
+          <div className="orch-bar">
+            <div
+              className="orch-bar-fill"
+              style={{ width: `${filled}%`, background: view.confidence_colour }}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="orch-chips">
+        <span className="orch-chip" style={{ color: view.pace_colour, borderColor: view.pace_colour }}>
+          {view.pace}
+        </span>
+        <span className="orch-chip" style={{ color: view.risk_colour, borderColor: view.risk_colour }}>
+          {view.risk}
+        </span>
+      </div>
+
+      {/* The plan line can carry a compound pill, which is an HTML span
+          built and escaped in src/arcade/palette.py. */}
+      <p className="orch-plan" dangerouslySetInnerHTML={{ __html: view.plan }} />
+
+      {view.guardrail ? <p className="orch-guardrail">{view.guardrail}</p> : null}
+    </section>
+  );
+}

--- a/src/pitwall/ui/src/features/agents/ScenarioBars.tsx
+++ b/src/pitwall/ui/src/features/agents/ScenarioBars.tsx
@@ -1,0 +1,35 @@
+/**
+ * Four horizontal bars: STAY / PIT / UCUT / OCUT.
+ *
+ * 1:1 with `scenario_bars.py`. The normalisation, the winner and the
+ * `--` for an absent scenario are all decided host side — the Monte
+ * Carlo scores are signed and often all negative, and getting the shift
+ * or the tie-break wrong changes which row reads as the winner, which is
+ * not something a renderer should be able to do.
+ */
+
+import type { ScenarioRow } from "../../lib/agents";
+
+export function ScenarioBars({ rows }: { rows: ScenarioRow[] }) {
+  return (
+    <section className="card scenarios">
+      <h2 className="scenarios-title">SCENARIO SCORES</h2>
+      {rows.map((row) => (
+        <div className="scenario-row" key={row.key}>
+          <span className="scenario-label" style={{ color: row.label_colour }}>
+            {row.label}
+          </span>
+          <span className="scenario-bar">
+            <span
+              className="scenario-bar-fill"
+              style={{ width: `${row.fill * 100}%`, background: row.bar_colour }}
+            />
+          </span>
+          <span className="scenario-score" style={{ color: row.score_colour }}>
+            {row.score}
+          </span>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/src/pitwall/ui/src/lib/agents.ts
+++ b/src/pitwall/ui/src/lib/agents.ts
@@ -55,10 +55,41 @@ export interface TireHistoryRow {
   compound?: string | null;
 }
 
+export interface OrchestratorView {
+  action: string;
+  action_colour: string;
+  /** null before the first decision; the bar then draws empty. */
+  confidence: number | null;
+  confidence_label: string;
+  confidence_colour: string;
+  pace: string;
+  pace_colour: string;
+  risk: string;
+  risk_colour: string;
+  /** Qt rich text: may carry the compound pill. */
+  plan: string;
+  /** Empty string when the orchestrator did not override the MC winner. */
+  guardrail: string;
+}
+
+export interface ScenarioRow {
+  key: string;
+  label: string;
+  /** Min-max normalised across the scenarios present, already clamped. */
+  fill: number;
+  score: string;
+  is_winner: boolean;
+  bar_colour: string;
+  label_colour: string;
+  score_colour: string;
+}
+
 export interface AgentsView {
   view_version: number;
   seq: number | null;
   header: HeaderView;
+  orchestrator: OrchestratorView;
+  scenarios: ScenarioRow[];
   cards: Record<string, AgentCardView>;
   history: { pace: PaceHistoryRow[]; tire: TireHistoryRow[] };
   status_bar: { text: string; transient: boolean };

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -204,3 +204,128 @@ body {
   color: var(--qt-fg-3);
   font-size: 11px;
 }
+
+/* --- Orchestrator card (orchestrator_card.py) ---------------------------- */
+
+.orchestrator {
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.orch-top {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+}
+.orch-badge {
+  min-width: 200px;
+  min-height: 70px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  padding: 14px 18px;
+  color: var(--qt-fg-1);
+  font-size: 26px;
+  font-weight: 800;
+  letter-spacing: 1px;
+  text-align: center;
+}
+.orch-conf {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.orch-conf-label {
+  color: var(--qt-fg-2);
+  font-size: 11px;
+}
+.orch-bar {
+  height: 14px;
+  border-radius: 6px;
+  background: #282834; /* the empty stop of Qt's gradient */
+  overflow: hidden;
+}
+.orch-bar-fill {
+  height: 100%;
+}
+.orch-chips {
+  display: flex;
+  gap: 8px;
+}
+.orch-chip {
+  padding: 4px 10px;
+  border: 1px solid currentColor;
+  border-radius: 10px;
+  font-size: 12px;
+  font-weight: 700;
+}
+.orch-plan {
+  margin: 0;
+  color: var(--qt-fg-2);
+  font-size: 12px;
+}
+.orch-guardrail {
+  margin: 0;
+  color: #ef4444;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+/* --- Scenario bars (scenario_bars.py) ------------------------------------ */
+
+.scenarios {
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.scenarios-title {
+  margin: 0;
+  color: var(--qt-fg-2);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+.scenario-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 0;
+}
+.scenario-label {
+  width: 44px;
+  flex: 0 0 44px;
+  font-size: 11px;
+  font-weight: 600;
+}
+.scenario-bar {
+  flex: 1;
+  min-width: 120px;
+  height: 10px;
+  border: 1px solid var(--qt-border);
+  border-radius: 5px;
+  background: var(--qt-elevated);
+  overflow: hidden;
+  display: block;
+}
+.scenario-bar-fill {
+  display: block;
+  height: 100%;
+}
+.scenario-score {
+  width: 46px;
+  flex: 0 0 46px;
+  text-align: right;
+  font-size: 11px;
+  font-family: var(--qt-mono);
+  white-space: pre;
+}
+
+/* The reasoning tabs land here in PR 5; the slot keeps the column's
+ * `auto auto 1fr` honest in the meantime. */
+.reasoning-slot {
+  min-height: 0;
+}

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -380,3 +380,115 @@ def test_the_status_glyphs_match_the_qt_cards():
     }
 
     assert STATUS_GLYPHS == qt_map
+
+
+# --- The decision panel -----------------------------------------------------
+
+
+def test_the_orchestrator_card_is_the_qt_one_field_for_field():
+    view = _host(_payload()).get_agents_view(-1)["orchestrator"]
+
+    assert view["action"] == "PIT NOW"
+    assert view["action_colour"] == "#ef4444"
+    assert view["confidence_label"] == "Confidence: 71%"
+    assert view["confidence_colour"] == "#10b981", "0.71 is over the 0.66 green tier"
+    assert view["pace"] == "Pace: PUSH"
+    assert view["pace_colour"] == "#ef4444"
+    assert view["risk"] == "Risk: AGGRESSIVE"
+    assert view["plan"].startswith("Pit: L24 · Next: <span")
+    assert view["plan"].endswith("· UCUT: RUS")
+    assert view["guardrail"] == ""
+
+
+def test_the_confidence_tiers_are_the_three_qt_paints():
+    from src.pitwall.agents_view.decision import build_orchestrator
+
+    tiers = {
+        conf: build_orchestrator({"confidence": conf})["confidence_colour"]
+        for conf in (0.0, 0.32, 0.33, 0.65, 0.66, 1.0)
+    }
+
+    assert tiers == {
+        0.0: "#ef4444",
+        0.32: "#ef4444",
+        0.33: "#f59e0b",
+        0.65: "#f59e0b",
+        0.66: "#10b981",
+        1.0: "#10b981",
+    }
+
+
+def test_an_empty_plan_on_stay_out_says_the_stint_continues():
+    """Three "--" chips read as noise; the orchestrator leaves them blank on purpose."""
+    from src.pitwall.agents_view.decision import build_orchestrator
+
+    stay = build_orchestrator({"action": "STAY_OUT", "confidence": 0.5})
+    other = build_orchestrator({"action": "UNDERCUT", "confidence": 0.5})
+    idle = build_orchestrator(None)
+
+    assert stay["plan"] == "stint continues · no pit window yet"
+    assert other["plan"] == "Pit plan pending"
+    assert idle["plan"] == "Pit: -- · Next: -- · UCUT: --"
+    assert idle["action"] == "--"
+
+
+def test_the_guardrail_line_only_exists_when_the_orchestrator_overrode_the_winner():
+    from src.pitwall.agents_view.decision import build_orchestrator
+
+    assert build_orchestrator({"guardrail_reason": "min stint"})["guardrail"] == (
+        "⚠ Guardrail: min stint"
+    )
+    assert build_orchestrator({"guardrail_reason": None})["guardrail"] == ""
+
+
+def test_the_scenario_bars_normalise_across_scores_that_are_all_negative():
+    """The Monte Carlo scores are gains against STAY_OUT and are frequently all negative.
+
+    Shifting by the minimum before scaling is what keeps the widths valid.
+    Get it wrong and the winner is whichever row happens to be least
+    negative in absolute terms, which is a different scenario.
+    """
+    from src.pitwall.agents_view.decision import build_scenarios
+
+    rows = {
+        row["key"]: row
+        for row in build_scenarios(
+            {"STAY_OUT": -0.90, "PIT_NOW": -0.10, "UNDERCUT": -0.50, "OVERCUT": -1.30}
+        )
+    }
+
+    assert rows["PIT_NOW"]["fill"] == 1.0 and rows["PIT_NOW"]["is_winner"]
+    assert rows["OVERCUT"]["fill"] == 0.0
+    assert rows["UNDERCUT"]["fill"] == pytest.approx((-0.50 + 1.30) / 1.20)
+    assert rows["STAY_OUT"]["score"] == "-0.90"
+    assert rows["PIT_NOW"]["bar_colour"] == "#a78bfa", "the winner is the accent"
+    assert rows["STAY_OUT"]["bar_colour"] == "#d1d5db"
+
+
+def test_a_scenario_the_orchestrator_did_not_score_draws_nothing_and_prints_dashes():
+    """Absent is not zero, and an empty bar with `--` is how the Qt row says so."""
+    from src.pitwall.agents_view.decision import build_scenarios
+
+    rows = {row["key"]: row for row in build_scenarios({"PIT_NOW": 0.7, "STAY_OUT": 0.2})}
+
+    assert rows["OVERCUT"]["score"] == "  --"
+    assert rows["OVERCUT"]["fill"] == 0.0
+    assert rows["OVERCUT"]["is_winner"] is False
+    assert [row["key"] for row in build_scenarios(None)] == [
+        "STAY_OUT",
+        "PIT_NOW",
+        "UNDERCUT",
+        "OVERCUT",
+    ], "all four rows exist even with no scores at all"
+
+
+def test_the_action_badge_comes_from_classify_action_and_is_not_a_second_table():
+    """A hand-copied twin of that table lived in theme.py until 2026-08-01 and drifted."""
+    from src.arcade.strategy import classify_action
+    from src.pitwall.agents_view.decision import build_orchestrator
+
+    for action in ("STAY_OUT", "PIT_NOW", "UNDERCUT", "OVERCUT", "DNF", "SOMETHING_NEW"):
+        colour, label = classify_action(action)
+        view = build_orchestrator({"action": action, "confidence": 0.5})
+        assert view["action"] == label
+        assert view["action_colour"] == "#{:02x}{:02x}{:02x}".format(*colour)


### PR DESCRIPTION
Sprint 3, PR 4 of 6. Builds on #866. The left column's top half.

Captured from the real bundle, headless, with the harness from #866: `PIT NOW` in danger red, `Confidence: 71%` over a green bar, the `Pace: PUSH` / `Risk: AGGRESSIVE` outlined chips, `Pit: L24 · Next: HARD · UCUT: RUS` with the Pirelli pill inline, the guardrail line, and the four scenario bars with PIT winning in accent and OCUT reading `--`.

## What is an algorithm here and what is a lookup

`ScenarioBars.update_from` is the only real algorithm in this PR, and it is the one place a renderer could silently change the answer. The four Monte Carlo scores are position-equivalent gains against the STAY_OUT baseline, so they are signed and frequently **all negative**; shifting by the minimum before scaling is what keeps the widths valid, and getting the shift or the tie-break wrong changes which row reads as the winner. It stays in Python, tested with an all-negative set.

Everything else is a lookup or a branch, and all of them are ported rather than re-decided: the three-tier confidence traffic light, the two regime colour maps, and the plan line's three branches — including the STAY_OUT one, where three `--` chips read as noise so the orchestrator's deliberate blank becomes "stint continues · no pit window yet".

`classify_action` is **imported**, not repeated. A hand-copied twin of that table lived in `theme.py` until 2026-08-01 and drifted, which is the mechanism #620 fixed once already. A test asserts the badge against the function for six actions, including an unknown one.

## Checks

- 20 Python tests in `test_pitwall_agents_view.py`, seven of them new. The confidence tiers are asserted at their boundaries (0.32/0.33, 0.65/0.66) rather than in the middle of each band.
- `npm run build` clean; screenshot verified against `legacy-qt-strategy.png` element by element.
- `ruff` clean.

The left column's remaining third (the reasoning tabs) is PR 5.
