### PR TITLE
feat(pitwall): the reasoning tabs, with the Qt highlighter ported as segments

### DIFF
--- a/src/arcade/dashboard/reasoning_lines.py
+++ b/src/arcade/dashboard/reasoning_lines.py
@@ -1,0 +1,140 @@
+"""The reasoning tabs' second formatting layer, with no toolkit attached.
+
+Five per-agent `key = value` metric dumps, plus the helpers that compose a
+tab body out of an agent's reasoning and its numbers. Split out of
+`reasoning_tabs.py` for the same reason `palette.py` was split out of
+`theme.py`: **PITWALL renders these tabs from this code**, and the module
+they lived in imports PySide6.
+
+This layer is easy to miss. It is not `agent_formatters`, and it is not a
+prettier view of it: it renders largely the same underlying fields as raw
+diagnostics, so a port that took only the headline formatters would drop
+every reasoning tab's metrics fallback - the one thing on screen when an
+agent produced no LLM reasoning at all.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _fnum(value: Any, decimals: int = 2, signed: bool = False) -> str:
+    if value is None:
+        return "—"
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return "—"
+    fmt = f"{{v:+.{decimals}f}}" if signed else f"{{v:.{decimals}f}}"
+    return fmt.format(v=v)
+
+
+def _pct(value: Any) -> str:
+    if value is None:
+        return "—"
+    try:
+        return f"{float(value) * 100:5.1f}%"
+    except (TypeError, ValueError):
+        return "—"
+
+
+def _pace_lines(p: dict[str, Any]) -> list[str]:
+    return [
+        f"lap_time_pred   = {_fnum(p.get('lap_time_pred'), 3)}s",
+        f"delta_vs_prev   = {_fnum(p.get('delta_vs_prev'), 3, signed=True)}s",
+        f"delta_vs_median = {_fnum(p.get('delta_vs_median'), 3, signed=True)}s",
+        f"ci_p10          = {_fnum(p.get('ci_p10'), 2)}s",
+        f"ci_p90          = {_fnum(p.get('ci_p90'), 2)}s",
+    ]
+
+
+def _tire_lines(t: dict[str, Any]) -> list[str]:
+    return [
+        f"compound          = {t.get('compound', '—')}",
+        f"current_tyre_life = {t.get('current_tyre_life', '—')} laps",
+        f"deg_rate          = {_fnum(t.get('deg_rate'), 3)}s/lap",
+        f"laps_to_cliff_p10 = {_fnum(t.get('laps_to_cliff_p10'), 1)}",
+        f"laps_to_cliff_p50 = {_fnum(t.get('laps_to_cliff_p50'), 1)}",
+        f"laps_to_cliff_p90 = {_fnum(t.get('laps_to_cliff_p90'), 1)}",
+        f"warning_level     = {t.get('warning_level', '—')}",
+    ]
+
+
+def _situation_lines(s: dict[str, Any]) -> list[str]:
+    return [
+        # The em dash `_pct` renders for a missing value is honest but silent, and this tab
+        # is the one a strategist opens to ask WHY. Its arcade sibling `format_situation`
+        # says "out of model range" for the same state; without the same words here the two
+        # surfaces describe the same lap differently.
+        f"overtake_prob = {_pct(s.get('overtake_prob'))}"
+        + ("  (beyond the model's trained gap)" if s.get("overtake_prob") is None else ""),
+        f"sc_prob_3lap  = {_pct(s.get('sc_prob_3lap'))}",
+        f"threat_level  = {s.get('threat_level', '—')}",
+        f"gap_ahead_s   = {_fnum(s.get('gap_ahead_s'), 2)}s",
+        f"pace_delta_s  = {_fnum(s.get('pace_delta_s'), 3, signed=True)}s",
+    ]
+
+
+def _radio_lines(r: dict[str, Any]) -> list[str]:
+    radios = len(r.get("radio_events") or [])
+    rcms = len(r.get("rcm_events") or [])
+    alerts = r.get("alerts") or []
+    lines = [
+        f"radio_events = {radios}",
+        f"rcm_events   = {rcms}",
+        f"alerts       = {len(alerts)}",
+    ]
+    for i, a in enumerate(alerts[:5]):
+        intent = a.get("intent") or a.get("event_type") or "?" if isinstance(a, dict) else str(a)
+        lines.append(f"  [{i}] {intent}")
+    return lines
+
+
+def _pit_lines(p: dict[str, Any]) -> list[str]:
+    return [
+        f"action                  = {p.get('action', '—')}",
+        f"recommended_lap         = {p.get('recommended_lap', '—')}",
+        f"compound_recommendation = {p.get('compound_recommendation', '—')}",
+        f"stop_duration_p05       = {_fnum(p.get('stop_duration_p05'), 2)}s",
+        f"stop_duration_p50       = {_fnum(p.get('stop_duration_p50'), 2)}s",
+        f"stop_duration_p95       = {_fnum(p.get('stop_duration_p95'), 2)}s",
+        f"undercut_prob           = {_pct(p.get('undercut_prob'))}",
+        f"undercut_target         = {p.get('undercut_target') or '—'}",
+        f"sc_reactive             = {p.get('sc_reactive', False)}",
+    ]
+
+
+LINE_BUILDERS: dict[str, Any] = {
+    "pace": _pace_lines,
+    "tire": _tire_lines,
+    "situation": _situation_lines,
+    "radio": _radio_lines,
+    "pit": _pit_lines,
+}
+
+
+def compose(reasoning: str, metrics: list[str]) -> str:
+    """Assemble the final tab body: reasoning on top, metrics below.
+
+    Either section may be empty. If both are empty the tab shows the idle
+    marker so the user knows the agent did not produce output this lap
+    (common for conditional N28 / N30 when they are not routed).
+    """
+    blocks: list[str] = []
+    if reasoning:
+        blocks.append(reasoning)
+    if metrics:
+        blocks.append("\n".join(metrics))
+    if not blocks:
+        return "— agent idle —"
+    return "\n\n".join(blocks)
+
+
+def clean(raw: Any) -> str:
+    """Collapse whitespace and cap the length, as the Qt editor does."""
+    if not raw:
+        return ""
+    text = " ".join(str(raw).split())
+    if len(text) > 600:
+        text = text[:597] + "…"
+    return text

--- a/src/arcade/dashboard/reasoning_tabs.py
+++ b/src/arcade/dashboard/reasoning_tabs.py
@@ -13,6 +13,9 @@ not fired, older checkpoint) the tab still surfaces the raw numbers.
 The RAG agent has no LLM reasoning; its retrieved text lives in the
 RAG card already, so it is not tabbed here.
 
+The per-agent metric layer lives in `reasoning_lines.py`, Qt-free, so
+PITWALL renders these tabs from the same code.
+
 The Orchestrator tab additionally appends the DecisionMemory prompt
 block on laps where the call just changed (``plan_changed``), so the
 one lap where memory actually drives the decision is visible even
@@ -38,6 +41,15 @@ from PySide6.QtWidgets import (
     QTextEdit,
 )
 
+from src.arcade.dashboard.reasoning_lines import (
+    LINE_BUILDERS,
+)
+from src.arcade.dashboard.reasoning_lines import (
+    clean as _clean,
+)
+from src.arcade.dashboard.reasoning_lines import (
+    compose as _compose,
+)
 from src.arcade.dashboard.theme import (
     ACCENT,
     BORDER_COLOR,
@@ -98,86 +110,6 @@ def _make_editor() -> QTextEdit:
         "font-size: 11px; line-height: 140%; }"
     )
     return editor
-
-
-# --- Per-agent metric formatters -------------------------------------
-# Each takes the agent output dict and returns a list of "key: value" lines
-# sorted by importance. Used as the fallback body when reasoning is empty.
-
-
-def _pace_lines(p: dict[str, Any]) -> list[str]:
-    return [
-        f"lap_time_pred   = {_fnum(p.get('lap_time_pred'), 3)}s",
-        f"delta_vs_prev   = {_fnum(p.get('delta_vs_prev'), 3, signed=True)}s",
-        f"delta_vs_median = {_fnum(p.get('delta_vs_median'), 3, signed=True)}s",
-        f"ci_p10          = {_fnum(p.get('ci_p10'), 2)}s",
-        f"ci_p90          = {_fnum(p.get('ci_p90'), 2)}s",
-    ]
-
-
-def _tire_lines(t: dict[str, Any]) -> list[str]:
-    return [
-        f"compound          = {t.get('compound', '—')}",
-        f"current_tyre_life = {t.get('current_tyre_life', '—')} laps",
-        f"deg_rate          = {_fnum(t.get('deg_rate'), 3)}s/lap",
-        f"laps_to_cliff_p10 = {_fnum(t.get('laps_to_cliff_p10'), 1)}",
-        f"laps_to_cliff_p50 = {_fnum(t.get('laps_to_cliff_p50'), 1)}",
-        f"laps_to_cliff_p90 = {_fnum(t.get('laps_to_cliff_p90'), 1)}",
-        f"warning_level     = {t.get('warning_level', '—')}",
-    ]
-
-
-def _situation_lines(s: dict[str, Any]) -> list[str]:
-    return [
-        # The em dash `_pct` renders for a missing value is honest but silent, and this tab
-        # is the one a strategist opens to ask WHY. Its arcade sibling `format_situation`
-        # says "out of model range" for the same state; without the same words here the two
-        # surfaces describe the same lap differently.
-        f"overtake_prob = {_pct(s.get('overtake_prob'))}"
-        + ("  (beyond the model's trained gap)" if s.get("overtake_prob") is None else ""),
-        f"sc_prob_3lap  = {_pct(s.get('sc_prob_3lap'))}",
-        f"threat_level  = {s.get('threat_level', '—')}",
-        f"gap_ahead_s   = {_fnum(s.get('gap_ahead_s'), 2)}s",
-        f"pace_delta_s  = {_fnum(s.get('pace_delta_s'), 3, signed=True)}s",
-    ]
-
-
-def _radio_lines(r: dict[str, Any]) -> list[str]:
-    radios = len(r.get("radio_events") or [])
-    rcms = len(r.get("rcm_events") or [])
-    alerts = r.get("alerts") or []
-    lines = [
-        f"radio_events = {radios}",
-        f"rcm_events   = {rcms}",
-        f"alerts       = {len(alerts)}",
-    ]
-    for i, a in enumerate(alerts[:5]):
-        intent = a.get("intent") or a.get("event_type") or "?" if isinstance(a, dict) else str(a)
-        lines.append(f"  [{i}] {intent}")
-    return lines
-
-
-def _pit_lines(p: dict[str, Any]) -> list[str]:
-    return [
-        f"action                  = {p.get('action', '—')}",
-        f"recommended_lap         = {p.get('recommended_lap', '—')}",
-        f"compound_recommendation = {p.get('compound_recommendation', '—')}",
-        f"stop_duration_p05       = {_fnum(p.get('stop_duration_p05'), 2)}s",
-        f"stop_duration_p50       = {_fnum(p.get('stop_duration_p50'), 2)}s",
-        f"stop_duration_p95       = {_fnum(p.get('stop_duration_p95'), 2)}s",
-        f"undercut_prob           = {_pct(p.get('undercut_prob'))}",
-        f"undercut_target         = {p.get('undercut_target') or '—'}",
-        f"sc_reactive             = {p.get('sc_reactive', False)}",
-    ]
-
-
-_LINE_BUILDERS: dict[str, Any] = {
-    "pace": _pace_lines,
-    "tire": _tire_lines,
-    "situation": _situation_lines,
-    "radio": _radio_lines,
-    "pit": _pit_lines,
-}
 
 
 class ReasoningTabs(QTabWidget):
@@ -243,51 +175,5 @@ class ReasoningTabs(QTabWidget):
                 continue
             agent_out = per.get(key) or {}
             reasoning = _clean(agent_out.get("reasoning"))
-            metric_lines = _LINE_BUILDERS[key](agent_out) if agent_out else []
+            metric_lines = LINE_BUILDERS[key](agent_out) if agent_out else []
             self._editors[key].setPlainText(_compose(reasoning, metric_lines))
-
-
-def _compose(reasoning: str, metrics: list[str]) -> str:
-    """Assemble the final tab body: reasoning on top, metrics below.
-
-    Either section may be empty. If both are empty the tab shows the
-    idle marker so the user knows the agent did not produce output
-    this lap (common for conditional N28 / N30 when they are not
-    routed)."""
-    blocks: list[str] = []
-    if reasoning:
-        blocks.append(reasoning)
-    if metrics:
-        blocks.append("\n".join(metrics))
-    if not blocks:
-        return "— agent idle —"
-    return "\n\n".join(blocks)
-
-
-def _clean(raw: Any) -> str:
-    if not raw:
-        return ""
-    text = " ".join(str(raw).split())
-    if len(text) > 600:
-        text = text[:597] + "…"
-    return text
-
-
-def _fnum(value: Any, decimals: int = 2, signed: bool = False) -> str:
-    if value is None:
-        return "—"
-    try:
-        v = float(value)
-    except (TypeError, ValueError):
-        return "—"
-    fmt = f"{{v:+.{decimals}f}}" if signed else f"{{v:.{decimals}f}}"
-    return fmt.format(v=v)
-
-
-def _pct(value: Any) -> str:
-    if value is None:
-        return "—"
-    try:
-        return f"{float(value) * 100:5.1f}%"
-    except (TypeError, ValueError):
-        return "—"

--- a/src/pitwall/agents_view/builder.py
+++ b/src/pitwall/agents_view/builder.py
@@ -20,6 +20,7 @@ from typing import Any
 from src.pitwall.agents_view.decision import build_orchestrator, build_scenarios
 from src.pitwall.agents_view.history import LapHistory
 from src.pitwall.agents_view.panels import build_cards, build_header, build_status_bar
+from src.pitwall.agents_view.reasoning import build_reasoning
 
 # Bumped when the view's shape changes in a way a built UI bundle would
 # misread. Separate from the wire's `schema_version`, which describes the
@@ -55,6 +56,7 @@ class AgentsViewBuilder:
             "header": build_header(payload, connection),
             "orchestrator": build_orchestrator(latest or None),
             "scenarios": build_scenarios(latest.get("scenario_scores") if latest else None),
+            "reasoning": build_reasoning(latest or None),
             "cards": build_cards(latest or None),
             "history": {
                 "pace": [{"lap": lap, **row} for lap, row in sorted(self._history.pace.items())],

--- a/src/pitwall/agents_view/reasoning.py
+++ b/src/pitwall/agents_view/reasoning.py
@@ -1,0 +1,136 @@
+"""The six reasoning tabs, with the Qt syntax highlighter ported to segments.
+
+Two things live here.
+
+**The tabs.** Composed exactly as `reasoning_tabs.py::update_from` does:
+the orchestrator tab is the decision's own reasoning, plus the
+DecisionMemory block **only on a lap where the call changed**; the five
+agent tabs are the agent's reasoning followed by the `key = value` dump
+from `reasoning_lines.py`. That conditional is copy, not an optimisation:
+the block never appears in `reasoning` even when it drives the call, and
+showing it unconditionally was measured as wallpaper.
+
+**The highlighter.** `_ReasoningHighlighter` is a `QSyntaxHighlighter`
+with five compiled rules, and it is the one part of this window that is
+not a dict-in / string-out transform. Gate B named two ways to port it:
+pre-process into HTML with `<span>` wraps, or a decoration layer in the
+client.
+
+This is the first, with the transport changed: the host emits **typed
+segments** rather than an HTML string. Same place, same code, but the
+free text of an LLM never becomes markup, and the client renders spans
+instead of trusting `dangerouslySetInnerHTML` with a model's output. The
+badge builders in `palette.py` are HTML because Qt needed them to be;
+this had no such constraint, so it does not inherit one.
+
+Qt's semantics are reproduced exactly: rules are applied in order and a
+later rule OVERWRITES an earlier one where they overlap, which is what
+`setFormat` does on a `QTextDocument`. A per-character colour array is
+the honest way to say that; runs are emitted afterwards.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from src.arcade.dashboard.reasoning_lines import LINE_BUILDERS, clean, compose
+from src.arcade.palette import TEXT_PRIMARY, hex_str
+
+# reasoning_tabs.py's five colours, in its order. The order matters: the
+# action keywords are last, so `PIT_NOW` inside a percentage-bearing
+# sentence still reads as an action.
+_LAP = "#f472b6"
+_QUANT = "#d946ef"
+_PCT = "#facc15"
+_DELTA = "#22d3ee"
+_ACTION = "#facc15"
+
+_RULES: tuple[tuple[re.Pattern[str], str, bool], ...] = (
+    (re.compile(r"\blaps?\s+\d+(?:[-–]\d+)?\b"), _LAP, False),
+    (re.compile(r"\b[Pp]\d{2}\b"), _QUANT, False),
+    (re.compile(r"\b\d+(?:\.\d+)?%"), _PCT, False),
+    (re.compile(r"[+\-]\d+\.\d+\s*s\b"), _DELTA, False),
+    (re.compile(r"\b(PIT_NOW|STAY_OUT|UNDERCUT|OVERCUT)\b"), _ACTION, True),
+)
+
+DEFAULT_COLOUR = hex_str(TEXT_PRIMARY)
+
+TABS: tuple[tuple[str, str], ...] = (
+    ("orchestrator", "Orchestrator"),
+    ("pace", "Pace"),
+    ("tire", "Tire"),
+    ("situation", "Situation"),
+    ("radio", "Radio"),
+    ("pit", "Pit"),
+)
+
+
+def highlight(text: str) -> list[dict[str, Any]]:
+    """Split `text` into coloured runs, the way the Qt highlighter paints it.
+
+    `QSyntaxHighlighter.highlightBlock` runs per block, but every rule
+    here is anchored inside a line, so applying them over the whole
+    string is equivalent and keeps the newlines in one segment.
+    """
+    if not text:
+        return []
+    colours: list[str | None] = [None] * len(text)
+    bolds = [False] * len(text)
+    for pattern, colour, bold in _RULES:
+        for match in pattern.finditer(text):
+            for index in range(match.start(), match.end()):
+                colours[index] = colour
+                bolds[index] = bold
+
+    segments: list[dict[str, Any]] = []
+    start = 0
+    for index in range(1, len(text) + 1):
+        same = (
+            index < len(text) and colours[index] == colours[start] and bolds[index] == bolds[start]
+        )
+        if same:
+            continue
+        segments.append(
+            {
+                "text": text[start:index],
+                "colour": colours[start] or DEFAULT_COLOUR,
+                "bold": bolds[start],
+            }
+        )
+        start = index
+    return segments
+
+
+def _orchestrator_body(latest: dict[str, Any]) -> str:
+    """The decision's reasoning, plus the memory block on a changed lap only.
+
+    DecisionMemory leaves no trace in `reasoning` even when it drives the
+    call, so the block is rendered here rather than trusting the model to
+    narrate its own continuity. Hidden on every other lap: the action
+    changes on a small minority of them, and unconditional display was
+    measured as wallpaper.
+    """
+    text = clean(latest.get("reasoning")) or "— no reasoning —"
+    memory_block = latest.get("memory_block")
+    if latest.get("plan_changed") and memory_block:
+        text += "\n\n--- why this call changed ---\n" + str(memory_block)
+    return text
+
+
+def build_reasoning(latest: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """The six tabs, each already split into coloured segments."""
+    if not latest:
+        return [{"key": key, "label": label, "segments": []} for key, label in TABS]
+
+    per = latest.get("per_agent") or {}
+    tabs: list[dict[str, Any]] = []
+    for key, label in TABS:
+        if key == "orchestrator":
+            body = _orchestrator_body(latest)
+        else:
+            agent_out = per.get(key) or {}
+            metrics = LINE_BUILDERS[key](agent_out) if agent_out else []
+            body = compose(clean(agent_out.get("reasoning")), metrics)
+        tabs.append({"key": key, "label": label, "segments": highlight(body)})
+    return tabs

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -17,6 +17,7 @@
 
 import { AgentCard } from "./AgentCard";
 import { OrchestratorCard } from "./OrchestratorCard";
+import { ReasoningTabs } from "./ReasoningTabs";
 import { ScenarioBars } from "./ScenarioBars";
 import { HeaderBar } from "./HeaderBar";
 import { useAgentsView, type AgentCardView, type AgentsView } from "../../lib/agents";
@@ -80,6 +81,14 @@ const IDLE_VIEW: AgentsView = {
     label_colour: "#d1d5db",
     score_colour: "#d1d5db",
   })),
+  reasoning: [
+    ["orchestrator", "Orchestrator"],
+    ["pace", "Pace"],
+    ["tire", "Tire"],
+    ["situation", "Situation"],
+    ["radio", "Radio"],
+    ["pit", "Pit"],
+  ].map(([key, label]) => ({ key, label, segments: [] })),
   cards: Object.fromEntries(CARDS.map(([key]) => [key, IDLE_CARD])),
   history: { pace: [], tire: [] },
   status_bar: { text: "Waiting for arcade stream…", transient: false },
@@ -97,7 +106,7 @@ export function AgentsWindow() {
         <div className="agents-left">
           <OrchestratorCard view={shown.orchestrator} />
           <ScenarioBars rows={shown.scenarios} />
-          <div className="reasoning-slot">{/* reasoning tabs */}</div>
+          <ReasoningTabs tabs={shown.reasoning} />
         </div>
         <div className="agents-right">
           {CARDS.map(([key, title]) => (

--- a/src/pitwall/ui/src/features/agents/ReasoningTabs.tsx
+++ b/src/pitwall/ui/src/features/agents/ReasoningTabs.tsx
@@ -1,0 +1,53 @@
+/**
+ * The six reasoning tabs, with the Qt highlighter's colours.
+ *
+ * Both halves are decided host side: which tabs exist, what is in them —
+ * including the decision-memory block that only appears on a lap where
+ * the call changed — and where every coloured run starts and ends.
+ *
+ * The highlighter arrives as **typed segments**, not as HTML. Gate B
+ * offered either; segments mean an LLM's free text never becomes markup
+ * on the way to a webview, so this renders `<span>`s rather than trusting
+ * `dangerouslySetInnerHTML` with a model's output.
+ *
+ * The selected tab is the only piece of state this window owns, because
+ * it is the only thing that belongs to the person looking at it rather
+ * than to the race.
+ */
+
+import { useState } from "react";
+import type { ReasoningTab } from "../../lib/agents";
+
+export function ReasoningTabs({ tabs }: { tabs: ReasoningTab[] }) {
+  const [selected, setSelected] = useState(0);
+  const active = tabs[selected] ?? tabs[0];
+
+  return (
+    <section className="reasoning">
+      <div className="reasoning-tabbar" role="tablist">
+        {tabs.map((tab, index) => (
+          <button
+            key={tab.key}
+            role="tab"
+            aria-selected={index === selected}
+            className={index === selected ? "reasoning-tab is-selected" : "reasoning-tab"}
+            onClick={() => setSelected(index)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="reasoning-body" role="tabpanel">
+        {active?.segments.map((segment, index) => (
+          <span
+            key={index}
+            style={{ color: segment.colour, fontWeight: segment.bold ? 700 : undefined }}
+          >
+            {segment.text}
+          </span>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/pitwall/ui/src/lib/agents.ts
+++ b/src/pitwall/ui/src/lib/agents.ts
@@ -84,12 +84,26 @@ export interface ScenarioRow {
   score_colour: string;
 }
 
+export interface ReasoningSegment {
+  text: string;
+  colour: string;
+  bold: boolean;
+}
+
+export interface ReasoningTab {
+  key: string;
+  label: string;
+  /** Already split into coloured runs by the Qt highlighter's own rules. */
+  segments: ReasoningSegment[];
+}
+
 export interface AgentsView {
   view_version: number;
   seq: number | null;
   header: HeaderView;
   orchestrator: OrchestratorView;
   scenarios: ScenarioRow[];
+  reasoning: ReasoningTab[];
   cards: Record<string, AgentCardView>;
   history: { pace: PaceHistoryRow[]; tire: TireHistoryRow[] };
   status_bar: { text: string; transient: boolean };

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -329,3 +329,48 @@ body {
 .reasoning-slot {
   min-height: 0;
 }
+
+/* --- Reasoning tabs (reasoning_tabs.py) ---------------------------------- */
+
+.reasoning {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.reasoning-tabbar {
+  display: flex;
+  gap: 0;
+}
+.reasoning-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--qt-fg-2);
+  padding: 6px 12px;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.reasoning-tab.is-selected {
+  color: var(--qt-accent);
+  border-bottom-color: var(--qt-accent);
+}
+/* The pane, matching Qt's `QTabWidget::pane` rule, with `top: -1px` folded
+ * into the negative margin so the selected tab sits on its edge. */
+.reasoning-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  margin-top: -1px;
+  padding: 8px;
+  border: 1px solid var(--qt-border);
+  border-radius: 6px;
+  font-family: var(--qt-mono);
+  font-size: 11px;
+  line-height: 140%;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -492,3 +492,121 @@ def test_the_action_badge_comes_from_classify_action_and_is_not_a_second_table()
         view = build_orchestrator({"action": action, "confidence": 0.5})
         assert view["action"] == label
         assert view["action_colour"] == "#{:02x}{:02x}{:02x}".format(*colour)
+
+
+# --- The reasoning tabs -----------------------------------------------------
+
+
+def _joined(segments) -> str:
+    return "".join(segment["text"] for segment in segments)
+
+
+def test_the_highlighter_loses_no_characters():
+    """A renderer that drops a run drops text, and prose is the whole panel."""
+    from src.pitwall.agents_view.reasoning import highlight
+
+    text = "PIT_NOW on lap 24: P10 is 34% and the delta is -0.42 s.\nSecond line."
+
+    assert _joined(highlight(text)) == text
+    assert highlight("") == []
+
+
+def test_the_highlighter_colours_the_five_things_qt_colours():
+    from src.pitwall.agents_view.reasoning import DEFAULT_COLOUR, highlight
+
+    coloured = {
+        segment["text"]: (segment["colour"], segment["bold"])
+        for segment in highlight("lap 24 P10 34% -0.42 s PIT_NOW plain")
+        if segment["colour"] != DEFAULT_COLOUR
+    }
+
+    assert coloured["lap 24"] == ("#f472b6", False)
+    assert coloured["P10"] == ("#d946ef", False)
+    assert coloured["34%"] == ("#facc15", False)
+    assert coloured["-0.42 s"] == ("#22d3ee", False)
+    assert coloured["PIT_NOW"] == ("#facc15", True), "the action keywords are the bold rule"
+    assert "plain" not in coloured
+
+
+def test_a_later_rule_overwrites_an_earlier_one_where_they_overlap():
+    """Qt's `setFormat` overwrites, and the rules run in a fixed order.
+
+    Emitting the FIRST match instead would leave the action keyword
+    un-bolded wherever an earlier pattern happened to reach it, which is
+    a difference nobody would notice until the one lap it matters.
+    """
+    from src.pitwall.agents_view.reasoning import highlight
+
+    # `P10` is both a quantile and, inside this token, nothing else; the
+    # overlap case is a delta immediately followed by an action keyword.
+    segments = highlight("-0.42 s PIT_NOW")
+    bold = [segment for segment in segments if segment["bold"]]
+
+    assert [segment["text"] for segment in bold] == ["PIT_NOW"]
+    assert _joined(segments) == "-0.42 s PIT_NOW"
+
+
+def test_the_memory_block_appears_only_on_a_lap_where_the_call_changed():
+    """Unconditional display was measured as wallpaper, and it is the load-bearing field.
+
+    DecisionMemory leaves no trace in `reasoning` even when it drives the
+    call, so this block is the only place the continuity is visible.
+    """
+    from src.pitwall.agents_view.reasoning import build_reasoning
+
+    def body(plan_changed: bool) -> str:
+        latest = {
+            "reasoning": "the undercut window opens now",
+            "memory_block": "lap 22: STAY_OUT (0.58)",
+            "plan_changed": plan_changed,
+        }
+        tabs = {tab["key"]: tab for tab in build_reasoning(latest)}
+        return _joined(tabs["orchestrator"]["segments"])
+
+    assert "why this call changed" in body(True)
+    assert "lap 22: STAY_OUT (0.58)" in body(True)
+    assert "why this call changed" not in body(False)
+
+
+def test_a_tab_with_no_reasoning_still_shows_the_agents_numbers():
+    """The metrics layer is the fallback, and a port that dropped it would look fine.
+
+    `reasoning_lines.py` is not a prettier `agent_formatters`: it renders
+    the same fields as a raw dump, and it is the only thing on screen when
+    an agent produced no LLM reasoning at all.
+    """
+    from src.pitwall.agents_view.reasoning import build_reasoning
+
+    tabs = {
+        tab["key"]: _joined(tab["segments"])
+        for tab in build_reasoning({"per_agent": {"pace": {"lap_time_pred": 81.0, "ci_p10": 80.4}}})
+    }
+
+    assert "lap_time_pred   = 81.000s" in tabs["pace"]
+    assert "ci_p10          = 80.40s" in tabs["pace"]
+    assert tabs["tire"] == "— agent idle —", "an agent with no output says so"
+    assert [tab["key"] for tab in build_reasoning(None)] == [
+        "orchestrator",
+        "pace",
+        "tire",
+        "situation",
+        "radio",
+        "pit",
+    ]
+
+
+def test_the_qt_tabs_and_pitwall_read_the_same_line_builders():
+    """The metrics layer is shared, not repeated.
+
+    `reasoning_tabs.py` is the Qt widget and this is the port; if the two
+    ever hold separate copies of these five functions, they will describe
+    the same lap differently within a sprint.
+    """
+    qt_tabs = pytest.importorskip(
+        "src.arcade.dashboard.reasoning_tabs",
+        reason="the Qt dashboard is an optional surface and needs a display stack",
+        exc_type=ImportError,
+    )
+    from src.arcade.dashboard import reasoning_lines
+
+    assert qt_tabs.LINE_BUILDERS is reasoning_lines.LINE_BUILDERS


### PR DESCRIPTION
Sprint 3, PR 5 of 6. Builds on #867. The last third of the left column.

Verified in the render: `lap 22` pink, `two laps` pink, `STAY_OUT` bold yellow, the `— why this call changed —` block visible in full — which in Qt normally falls below the fold, because the left column gives the tabs about 268 px.

## The two things Gate B said needed a decision, decided

**`_ReasoningHighlighter` had no home in the design.** It is a `QSyntaxHighlighter` with five compiled rules, and it is the one part of this window that is not a dict-in / string-out transform. Gate B offered two ports: pre-process into HTML with `<span>` wraps, or a decoration layer in the client.

This is the first, **with the transport changed**: the host emits typed segments, not an HTML string. Same place, same rules, but an LLM's free text never becomes markup on its way to a webview, so the client renders `<span>`s instead of trusting `dangerouslySetInnerHTML` with a model's output. The badge builders in `palette.py` are HTML because Qt required it; this had no such constraint and does not inherit one.

Qt's overlap semantics are reproduced exactly — rules apply in order and a later one **overwrites** an earlier one, which is what `setFormat` does on a `QTextDocument`. A per-character colour array is the honest way to express that; runs are emitted afterwards, and a test asserts the segments reassemble to the original string character for character.

**`_LINE_BUILDERS` was "a second parallel formatting layer the architecture document never named".** It is not a prettier `agent_formatters`: it renders the same fields as a raw `key = value` dump, and it is the only thing on screen when an agent produced no LLM reasoning. It is now `src/arcade/dashboard/reasoning_lines.py`, Qt-free, **imported by both surfaces**, and a test asserts the Qt widget and the port hold the same object rather than two copies.

## Kept because it is copy, not an optimisation

`memory_block` is appended only when `plan_changed`. DecisionMemory leaves no trace in `reasoning` even on the lap it drives the call, and unconditional display was measured as wallpaper. Both branches are tested.

## Checks

- `uv run pytest tests/surfaces` → 122 passed, 1 failed (`test_cli_no_llm`, the known curated-download gap, red on `dev` too). Six new tests.
- `npm run build` clean; screenshot compared against `legacy-qt-strategy.png`.
- `ruff` clean.
