### PR TITLE
feat(pitwall): the pace and tyre charts, in ECharts

### DIFF
--- a/src/pitwall/agents_view/builder.py
+++ b/src/pitwall/agents_view/builder.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from src.pitwall.agents_view.charts import build_pace_series, build_tire_series
 from src.pitwall.agents_view.decision import build_orchestrator, build_scenarios
 from src.pitwall.agents_view.history import LapHistory
 from src.pitwall.agents_view.panels import build_cards, build_header, build_status_bar
@@ -58,6 +59,17 @@ class AgentsViewBuilder:
             "scenarios": build_scenarios(latest.get("scenario_scores") if latest else None),
             "reasoning": build_reasoning(latest or None),
             "cards": build_cards(latest or None),
+            "charts": {
+                "pace": build_pace_series(self._history.pace),
+                "tire": build_tire_series(
+                    self._history.tire_rows(),
+                    latest.get("lap_number") if latest else None,
+                    (latest.get("per_agent") or {}).get("tire") if latest else None,
+                ),
+            },
+            # The raw stores stay on the view as well: the charts are a
+            # rendering of them, and a test that could only see the drawn
+            # series could not tell an accumulator bug from a plotting one.
             "history": {
                 "pace": [{"lap": lap, **row} for lap, row in sorted(self._history.pace.items())],
                 "tire": self._history.tire_rows(),

--- a/src/pitwall/agents_view/charts.py
+++ b/src/pitwall/agents_view/charts.py
@@ -1,0 +1,227 @@
+"""The two embedded charts' series, computed where the Qt widgets compute them.
+
+`pace_chart.py` and `tire_chart.py` together are about 250 lines and only
+part of that is drawing. The rest is judgement about what may be plotted:
+a sanity window on lap times, per-stint segmentation, a centred rolling
+mean, and a cliff band whose geometry is keyed off the CURRENT lap. All
+of it is ported here so the client only places marks.
+
+The one thing that does NOT come across is pyqtgraph's autoscale. ECharts
+does its own, and the X clamp below is the part that mattered: without it
+a bad p90 stretched the axis to the cliff horizon and flattened the real
+series to a hairline.
+"""
+
+from __future__ import annotations
+
+from typing import Any, NamedTuple
+
+from src.arcade.palette import ACCENT, INFO, TEXT_PRIMARY, WARNING, compound_color, hex_str
+
+# Anything outside this is a pipeline stub, not a lap. The lower bound is
+# well under the fastest modern F1 lap; 200 s is loose enough for a wet
+# Monaco or a Safety Car lap.
+SANE_LAP_TIME_S: tuple[float, float] = (30.0, 200.0)
+# Cliff projections above this horizon are TCN early-stint noise: the MC
+# Dropout samples have no history to converge on and return tens of
+# thousands of laps.
+CLIFF_MAX_SANE_LAPS: float = 100.0
+
+ACTUAL_COLOUR = hex_str(INFO)
+PRED_COLOUR = hex_str(ACCENT)
+BAND_COLOUR = hex_str(ACCENT)
+TREND_COLOUR = hex_str(TEXT_PRIMARY)
+CLIFF_COLOUR = hex_str(WARNING)
+
+
+class _Stint(NamedTuple):
+    """A contiguous run of laps on one compound, and its Pirelli colour."""
+
+    compound: str
+    colour: str
+    points: list[list[float]]
+
+
+def _sane_lap_time(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    low, high = SANE_LAP_TIME_S
+    return seconds if low <= seconds <= high else None
+
+
+def _sane_cliff(value: Any) -> float | None:
+    """Strictly positive and inside the horizon, else unknown.
+
+    `None` rather than a placeholder: a suppressed band is a band that is
+    not drawn, and a zero would be a lap number the chart could plot.
+    """
+    if value is None:
+        return None
+    try:
+        laps = float(value)
+    except (TypeError, ValueError):
+        return None
+    return laps if 0.0 < laps <= CLIFF_MAX_SANE_LAPS else None
+
+
+def build_pace_series(history: dict[int, dict[str, Any]]) -> dict[str, Any]:
+    """Actual, predicted and the P10-P90 band, each skipping what it lacks.
+
+    Three independent series rather than one table with holes: laps before
+    the window connected carry only an actual, and the predicted line has
+    to start where the per-agent payload first arrived rather than draw a
+    line through zero.
+    """
+    actual: list[list[float]] = []
+    pred: list[list[float]] = []
+    band: list[list[float]] = []
+    for lap in sorted(history):
+        row = history[lap]
+        observed = _sane_lap_time(row.get("actual"))
+        predicted = _sane_lap_time(row.get("pred"))
+        low = _sane_lap_time(row.get("ci_p10"))
+        high = _sane_lap_time(row.get("ci_p90"))
+        if observed is not None:
+            actual.append([float(lap), observed])
+        if predicted is not None:
+            pred.append([float(lap), predicted])
+        if low is not None and high is not None:
+            band.append([float(lap), low, high])
+    return {
+        "actual": actual,
+        "pred": pred,
+        "band": band,
+        "actual_colour": ACTUAL_COLOUR,
+        "pred_colour": PRED_COLOUR,
+        "band_colour": BAND_COLOUR,
+    }
+
+
+def _build_stints(rows: list[dict[str, Any]]) -> list[_Stint]:
+    """Group chronological rows into per-compound stints.
+
+    A stint ends the moment the compound label changes between two
+    observed laps. Rows with no usable lap time are skipped rather than
+    ending the stint, so a missing measurement does not split one run into
+    two artificial halves; a row with no compound inherits the previous
+    one, so a briefly dropped field does not paint a blank segment.
+    """
+    stints: list[_Stint] = []
+    current: _Stint | None = None
+    last_compound: str | None = None
+    for row in rows:
+        seconds = _sane_lap_time(row.get("lap_time_s"))
+        if seconds is None:
+            continue
+        try:
+            lap = float(row.get("lap", 0))
+        except (TypeError, ValueError):
+            continue
+        compound = str(row.get("compound") or "").upper().strip() or last_compound or "MEDIUM"
+        if current is None or compound != current.compound:
+            current = _Stint(compound, hex_str(compound_color(compound)), [])
+            stints.append(current)
+        current.points.append([lap, seconds])
+        last_compound = compound
+    return stints
+
+
+def _rolling_mean(values: list[float], window: int = 3) -> list[float]:
+    """Centred rolling mean with `min_periods=1` edges.
+
+    Three points on purpose: heavier smoothing visibly lags the trend over
+    the 25-30 lap window this chart shows, which defeats the overlay. The
+    edges average over whatever exists so the line starts at the first lap
+    rather than at `window // 2`.
+    """
+    if not values:
+        return []
+    half = window // 2
+    out: list[float] = []
+    for index in range(len(values)):
+        chunk = values[max(0, index - half) : min(len(values), index + half + 1)]
+        out.append(sum(chunk) / len(chunk))
+    return out
+
+
+def build_tire_series(
+    rows: list[dict[str, Any]], current_lap: int | None, tire_out: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Per-stint segments, the smoothing overlay, and the cliff annotations.
+
+    The compound change is a BREAK, not a colour change on one line: each
+    stint is its own series, so nothing is drawn through the in-lap and
+    the out-lap, which are neither the same length as each other nor as a
+    racing lap.
+    """
+    stints = _build_stints(rows)
+    flat = [point for stint in stints for point in stint.points]
+    smoothed = _rolling_mean([point[1] for point in flat])
+    trend = [[point[0], value] for point, value in zip(flat, smoothed)]
+
+    cliff = _build_cliff(current_lap, tire_out)
+    return {
+        "stints": [
+            {"compound": stint.compound, "colour": stint.colour, "points": stint.points}
+            for stint in stints
+        ],
+        "trend": trend,
+        "trend_colour": TREND_COLOUR,
+        "cliff": cliff,
+        "cliff_colour": CLIFF_COLOUR,
+        "x_range": _x_range(flat, current_lap, cliff),
+    }
+
+
+def _build_cliff(current_lap: int | None, tire_out: dict[str, Any] | None) -> dict[str, Any] | None:
+    """The band at `[lap + p10, lap + p90]` and the marker at `lap + p50`.
+
+    Keyed off the CURRENT lap, because the percentiles are laps REMAINING.
+    Suppressed whole when the projection is outside the sane horizon: an
+    unreadable band is worse than none, and the TCN emits those on the
+    first laps of every stint.
+    """
+    if current_lap is None or not tire_out:
+        return None
+    p10 = _sane_cliff(tire_out.get("laps_to_cliff_p10"))
+    p50 = _sane_cliff(tire_out.get("laps_to_cliff_p50"))
+    p90 = _sane_cliff(tire_out.get("laps_to_cliff_p90"))
+    if p10 is None and p50 is None and p90 is None:
+        return None
+    lap = float(current_lap)
+    return {
+        "lo": None if p10 is None else lap + p10,
+        "hi": None if p90 is None else lap + p90,
+        "p50": None if p50 is None else lap + p50,
+    }
+
+
+def _x_range(
+    points: list[list[float]], current_lap: int | None, cliff: dict[str, Any] | None
+) -> list[float]:
+    """Clamp the lap axis so a bad p90 cannot flatten the series to a hairline.
+
+    ⚠ **The one deliberate deviation from the Qt chart in this sprint.**
+    `tire_chart.py::_anchor_x_range` extends the axis by the whole sane
+    cliff horizon whenever the band is visible - `x_max += 100` - so on
+    lap 23 with a cliff six laps out the axis runs to 123 and the stint
+    occupies about eight per cent of the width. That is not a bad-value
+    guard doing its job, it fires on every normal cliff. Here the axis
+    stops three laps past whichever is further, the last observed lap or
+    the band's own upper edge, which bounds it for the same reason
+    without the unreadable result. Flagged rather than smuggled: it is a
+    visible difference and the exit gate should see it named.
+    """
+    laps = [point[0] for point in points]
+    if current_lap is not None:
+        laps.append(float(current_lap))
+    if not laps:
+        return [0.0, 1.0]
+    high = max(laps)
+    if cliff and cliff.get("hi") is not None:
+        high = max(high, cliff["hi"])
+    return [min(laps) - 0.5, high + 3.0]

--- a/src/pitwall/ui/package-lock.json
+++ b/src/pitwall/ui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pitwall-ui",
       "version": "0.0.0",
       "dependencies": {
+        "echarts": "^6.1.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -1392,6 +1393,16 @@
         }
       }
     },
+    "node_modules/echarts": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.1.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.402",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.402.tgz",
@@ -1791,6 +1802,12 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1925,6 +1942,15 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zrender": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
     }
   }
 }

--- a/src/pitwall/ui/package.json
+++ b/src/pitwall/ui/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "echarts": "^6.1.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -20,6 +20,8 @@ import { OrchestratorCard } from "./OrchestratorCard";
 import { ReasoningTabs } from "./ReasoningTabs";
 import { ScenarioBars } from "./ScenarioBars";
 import { HeaderBar } from "./HeaderBar";
+import { PaceChart } from "./PaceChart";
+import { TireChart } from "./TireChart";
 import { useAgentsView, type AgentCardView, type AgentsView } from "../../lib/agents";
 
 /** Grid order, reading across then down, exactly as `window.py` adds them. */
@@ -90,6 +92,24 @@ const IDLE_VIEW: AgentsView = {
     ["pit", "Pit"],
   ].map(([key, label]) => ({ key, label, segments: [] })),
   cards: Object.fromEntries(CARDS.map(([key]) => [key, IDLE_CARD])),
+  charts: {
+    pace: {
+      actual: [],
+      pred: [],
+      band: [],
+      actual_colour: "#3b82f6",
+      pred_colour: "#a78bfa",
+      band_colour: "#a78bfa",
+    },
+    tire: {
+      stints: [],
+      trend: [],
+      trend_colour: "#ffffff",
+      cliff: null,
+      cliff_colour: "#f59e0b",
+      x_range: [0, 1],
+    },
+  },
   history: { pace: [], tire: [] },
   status_bar: { text: "Waiting for arcade stream…", transient: false },
 };
@@ -110,7 +130,10 @@ export function AgentsWindow() {
         </div>
         <div className="agents-right">
           {CARDS.map(([key, title]) => (
-            <AgentCard key={key} title={title} card={shown.cards[key] ?? IDLE_CARD} />
+            <AgentCard key={key} title={title} card={shown.cards[key] ?? IDLE_CARD}>
+              {key === "pace" ? <PaceChart series={shown.charts.pace} /> : null}
+              {key === "tire" ? <TireChart series={shown.charts.tire} /> : null}
+            </AgentCard>
           ))}
         </div>
       </div>

--- a/src/pitwall/ui/src/features/agents/PaceChart.tsx
+++ b/src/pitwall/ui/src/features/agents/PaceChart.tsx
@@ -1,0 +1,66 @@
+/**
+ * Predicted lap time against actual, with the P10-P90 credible band.
+ *
+ * 1:1 with `pace_chart.py`: solid blue actual, dashed purple predicted,
+ * translucent purple band. What may be plotted was decided host side —
+ * the 30-200 s sanity window, and three independent series so a lap that
+ * has an actual but no prediction does not drag the dashed line to zero.
+ *
+ * The band is ECharts' stacked-area idiom: an invisible line at P10 and
+ * a filled one carrying the height to P90. `stack` needs the height, not
+ * the absolute value, which is the one place this file does arithmetic.
+ */
+
+import { useMemo } from "react";
+import type { EChartsOption } from "echarts";
+import type { PaceSeries } from "../../lib/agents";
+import { CHART_BASE, useEChart } from "./useEChart";
+
+export function PaceChart({ series }: { series: PaceSeries }) {
+  const option = useMemo<EChartsOption>(
+    () => ({
+      ...CHART_BASE,
+      series: [
+        {
+          type: "line",
+          name: "p10",
+          stack: "band",
+          data: series.band.map(([lap, low]) => [lap, low]),
+          lineStyle: { opacity: 0 },
+          itemStyle: { opacity: 0 },
+          symbol: "none",
+          silent: true,
+        },
+        {
+          type: "line",
+          name: "band",
+          stack: "band",
+          data: series.band.map(([lap, low, high]) => [lap, high - low]),
+          lineStyle: { opacity: 0 },
+          areaStyle: { color: series.band_colour, opacity: 0.2 },
+          symbol: "none",
+          silent: true,
+        },
+        {
+          type: "line",
+          name: "predicted",
+          data: series.pred,
+          lineStyle: { color: series.pred_colour, width: 2, type: "dashed" },
+          itemStyle: { color: series.pred_colour },
+          symbol: "none",
+        },
+        {
+          type: "line",
+          name: "actual",
+          data: series.actual,
+          lineStyle: { color: series.actual_colour, width: 2 },
+          itemStyle: { color: series.actual_colour },
+          symbol: "none",
+        },
+      ],
+    }),
+    [series],
+  );
+
+  return <div className="chart" ref={useEChart(option)} />;
+}

--- a/src/pitwall/ui/src/features/agents/TireChart.tsx
+++ b/src/pitwall/ui/src/features/agents/TireChart.tsx
@@ -1,0 +1,76 @@
+/**
+ * Lap time over laps, coloured per stint, with the cliff projection.
+ *
+ * 1:1 with `tire_chart.py`. Three things it gets from the host and does
+ * not re-derive:
+ *
+ * - **one series per stint, not one line coloured by compound.** A single
+ *   line would be drawn through the in-lap and the out-lap, which are
+ *   neither the same length as each other nor as a racing lap. The break
+ *   IS the compound change.
+ * - the 3-lap centred rolling mean behind the dashed overlay;
+ * - the cliff band at `[lap + p10, lap + p90]` and the marker at
+ *   `lap + p50`, suppressed whole outside the sane horizon because the
+ *   TCN emits tens of thousands of laps on the first laps of a stint.
+ */
+
+import { useMemo } from "react";
+import type { EChartsOption } from "echarts";
+import type { TireSeries } from "../../lib/agents";
+import { CHART_BASE, useEChart } from "./useEChart";
+
+export function TireChart({ series }: { series: TireSeries }) {
+  const option = useMemo<EChartsOption>(() => {
+    const stints = series.stints.map((stint) => ({
+      type: "line" as const,
+      name: stint.compound,
+      data: stint.points,
+      lineStyle: { color: stint.colour, width: 2 },
+      itemStyle: { color: stint.colour },
+      symbol: "circle" as const,
+      symbolSize: 4,
+    }));
+
+    // The band and the median live on the FIRST series as marks, which is
+    // how ECharts attaches geometry that is not itself data.
+    const cliff = series.cliff;
+    const markArea =
+      cliff && cliff.lo !== null && cliff.hi !== null
+        ? {
+            silent: true,
+            itemStyle: { color: series.cliff_colour, opacity: 0.16 },
+            // A 2D mark area is a two-element tuple, and ECharts types it
+            // as exactly that; an inferred array is one element short.
+            data: [[{ xAxis: cliff.lo }, { xAxis: cliff.hi }] as [object, object]],
+          }
+        : undefined;
+    const markLine =
+      cliff && cliff.p50 !== null
+        ? {
+            silent: true,
+            symbol: "none" as const,
+            lineStyle: { color: series.cliff_colour, width: 2, type: "dashed" as const },
+            label: { show: false },
+            data: [{ xAxis: cliff.p50 }],
+          }
+        : undefined;
+
+    const trend = {
+      type: "line" as const,
+      name: "trend",
+      data: series.trend,
+      lineStyle: { color: series.trend_colour, width: 1, type: "dashed" as const, opacity: 0.6 },
+      symbol: "none" as const,
+      markArea,
+      markLine,
+    };
+
+    return {
+      ...CHART_BASE,
+      xAxis: { ...CHART_BASE.xAxis, min: series.x_range[0], max: series.x_range[1] },
+      series: [trend, ...stints],
+    };
+  }, [series]);
+
+  return <div className="chart" ref={useEChart(option)} />;
+}

--- a/src/pitwall/ui/src/features/agents/useEChart.ts
+++ b/src/pitwall/ui/src/features/agents/useEChart.ts
@@ -1,0 +1,71 @@
+/**
+ * Mount one ECharts instance on a div and push options into it imperatively.
+ *
+ * **Chart data never goes through React state.** That is the web form of
+ * P3 finding A6 — the Qt dashboard rebuilt six cards, six highlighted
+ * text areas and two whole charts ten times a second for content that
+ * changes once a lap — applied before it happens rather than after.
+ *
+ * `animationDurationUpdate: 0` is the contract
+ * `useFirstPaintAnimation.ts` already encodes in the webapp: the entrance
+ * sweep plays once, on the first `setOption` for a new series, and every
+ * later update lands instantly. On a screen fed ten times a second, the
+ * difference between that and animating updates is the difference between
+ * polish and nausea.
+ */
+
+import { useEffect, useRef } from "react";
+import * as echarts from "echarts";
+
+export function useEChart(option: echarts.EChartsOption | null) {
+  const host = useRef<HTMLDivElement | null>(null);
+  const chart = useRef<echarts.ECharts | null>(null);
+
+  useEffect(() => {
+    if (!host.current) return;
+    chart.current = echarts.init(host.current, undefined, { renderer: "canvas" });
+    const resize = () => chart.current?.resize();
+    const observer = new ResizeObserver(resize);
+    observer.observe(host.current);
+    return () => {
+      observer.disconnect();
+      chart.current?.dispose();
+      chart.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!chart.current || !option) return;
+    chart.current.setOption({ ...option, animationDurationUpdate: 0 }, { notMerge: true });
+  }, [option]);
+
+  return host;
+}
+
+/** Axis and grid styling shared by both cards, from the Qt charts' own look. */
+export const CHART_BASE: echarts.EChartsOption = {
+  backgroundColor: "transparent",
+  animationDurationUpdate: 0,
+  grid: { left: 44, right: 10, top: 10, bottom: 28, containLabel: false },
+  xAxis: {
+    type: "value",
+    name: "Lap",
+    nameLocation: "middle",
+    nameGap: 18,
+    nameTextStyle: { color: "#d1d5db", fontSize: 10 },
+    axisLine: { lineStyle: { color: "#2d2d3a" } },
+    axisLabel: { color: "#d1d5db", fontSize: 10 },
+    splitLine: { lineStyle: { color: "rgba(255,255,255,0.06)" } },
+  },
+  yAxis: {
+    type: "value",
+    name: "Lap time (s)",
+    nameLocation: "middle",
+    nameGap: 34,
+    nameTextStyle: { color: "#d1d5db", fontSize: 10 },
+    scale: true,
+    axisLine: { lineStyle: { color: "#2d2d3a" } },
+    axisLabel: { color: "#d1d5db", fontSize: 10 },
+    splitLine: { lineStyle: { color: "rgba(255,255,255,0.06)" } },
+  },
+};

--- a/src/pitwall/ui/src/lib/agents.ts
+++ b/src/pitwall/ui/src/lib/agents.ts
@@ -97,6 +97,34 @@ export interface ReasoningTab {
   segments: ReasoningSegment[];
 }
 
+export interface PaceSeries {
+  /** `[lap, seconds]`, already filtered to plausible lap times. */
+  actual: [number, number][];
+  pred: [number, number][];
+  /** `[lap, p10, p90]`. */
+  band: [number, number, number][];
+  actual_colour: string;
+  pred_colour: string;
+  band_colour: string;
+}
+
+export interface TireStint {
+  compound: string;
+  colour: string;
+  points: [number, number][];
+}
+
+export interface TireSeries {
+  /** One entry per compound run: the break IS the compound change. */
+  stints: TireStint[];
+  trend: [number, number][];
+  trend_colour: string;
+  /** Absolute lap numbers, or null when the projection is out of range. */
+  cliff: { lo: number | null; hi: number | null; p50: number | null } | null;
+  cliff_colour: string;
+  x_range: [number, number];
+}
+
 export interface AgentsView {
   view_version: number;
   seq: number | null;
@@ -105,6 +133,7 @@ export interface AgentsView {
   scenarios: ScenarioRow[];
   reasoning: ReasoningTab[];
   cards: Record<string, AgentCardView>;
+  charts: { pace: PaceSeries; tire: TireSeries };
   history: { pace: PaceHistoryRow[]; tire: TireHistoryRow[] };
   status_bar: { text: string; transient: boolean };
 }

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -374,3 +374,14 @@ body {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
+
+/* --- The two embedded charts --------------------------------------------- */
+
+/* Qt gives a card with a chart a 260-420 px height band; here the grid row
+ * grows and the chart takes what is left, which is the same intent without
+ * the two magic numbers. */
+.chart {
+  width: 100%;
+  height: 100%;
+  min-height: 150px;
+}

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -610,3 +610,146 @@ def test_the_qt_tabs_and_pitwall_read_the_same_line_builders():
     from src.arcade.dashboard import reasoning_lines
 
     assert qt_tabs.LINE_BUILDERS is reasoning_lines.LINE_BUILDERS
+
+
+# --- The two embedded charts ------------------------------------------------
+
+
+def test_a_stub_lap_time_never_reaches_a_chart():
+    """One value orders of magnitude off flattens the real series to a hairline.
+
+    The TCN emits them on the first laps of a stint, and the guard is the
+    30-200 s window both Qt charts apply before plotting anything.
+    """
+    from src.pitwall.agents_view.charts import build_pace_series, build_tire_series
+
+    pace = build_pace_series({1: {"actual": 4000.0}, 2: {"actual": 81.0}, 3: {"actual": 2.0}})
+    tire = build_tire_series(
+        [
+            {"lap": 1, "lap_time_s": 4000.0, "compound": "MEDIUM"},
+            {"lap": 2, "lap_time_s": 81.0, "compound": "MEDIUM"},
+        ],
+        current_lap=2,
+        tire_out=None,
+    )
+
+    assert pace["actual"] == [[2.0, 81.0]]
+    assert tire["stints"][0]["points"] == [[2.0, 81.0]]
+
+
+def test_the_compound_change_is_a_break_and_not_a_colour_change_on_one_line():
+    """A single line would be drawn through the in-lap and the out-lap.
+
+    Those are neither the same length as each other nor as a racing lap,
+    so the segment between them is a straight line through a number that
+    never happened. One series per stint is the fix, and the colour break
+    is where the compound changed.
+    """
+    from src.pitwall.agents_view.charts import build_tire_series
+
+    rows = [
+        {"lap": 1, "lap_time_s": 81.0, "compound": "MEDIUM"},
+        {"lap": 2, "lap_time_s": 81.4, "compound": "MEDIUM"},
+        {"lap": 3, "lap_time_s": 83.0, "compound": "HARD"},
+        {"lap": 4, "lap_time_s": 82.2, "compound": "HARD"},
+    ]
+
+    stints = build_tire_series(rows, current_lap=4, tire_out=None)["stints"]
+
+    assert [stint["compound"] for stint in stints] == ["MEDIUM", "HARD"]
+    assert [len(stint["points"]) for stint in stints] == [2, 2]
+    assert stints[0]["colour"] != stints[1]["colour"]
+
+
+def test_a_missing_lap_time_does_not_split_a_stint_and_a_missing_compound_inherits():
+    from src.pitwall.agents_view.charts import build_tire_series
+
+    rows = [
+        {"lap": 1, "lap_time_s": 81.0, "compound": "SOFT"},
+        {"lap": 2, "lap_time_s": None, "compound": "SOFT"},
+        {"lap": 3, "lap_time_s": 81.5, "compound": None},
+    ]
+
+    stints = build_tire_series(rows, current_lap=3, tire_out=None)["stints"]
+
+    assert len(stints) == 1, "a gap in the measurement is not a pit stop"
+    assert stints[0]["compound"] == "SOFT"
+    assert [point[0] for point in stints[0]["points"]] == [1.0, 3.0]
+
+
+def test_the_trend_is_a_three_lap_centred_mean_with_min_periods_one():
+    """Heavier smoothing lags visibly over a 30-lap window, which defeats it.
+
+    The edges average over whatever exists so the line starts at the first
+    lap rather than at `window // 2`.
+    """
+    from src.pitwall.agents_view.charts import _rolling_mean
+
+    assert _rolling_mean([1.0, 2.0, 3.0, 10.0]) == pytest.approx([1.5, 2.0, 5.0, 6.5])
+    assert _rolling_mean([]) == []
+    assert _rolling_mean([7.0]) == [7.0]
+
+
+def test_the_cliff_band_is_anchored_on_the_current_lap():
+    """The percentiles are laps REMAINING, so the band is `lap + p`, not `p`."""
+    from src.pitwall.agents_view.charts import build_tire_series
+
+    cliff = build_tire_series(
+        [{"lap": 23, "lap_time_s": 81.0, "compound": "MEDIUM"}],
+        current_lap=23,
+        tire_out={"laps_to_cliff_p10": 4.0, "laps_to_cliff_p50": 6.0, "laps_to_cliff_p90": 9.0},
+    )["cliff"]
+
+    assert cliff == {"lo": 27.0, "hi": 32.0, "p50": 29.0}
+
+
+def test_an_early_stint_projection_suppresses_the_whole_annotation():
+    """The MC Dropout samples return tens of thousands of laps on lap 1-3.
+
+    An unreadable band is worse than none, and a zero would be a lap
+    number the chart could plot.
+    """
+    from src.pitwall.agents_view.charts import build_tire_series
+
+    rows = [{"lap": 2, "lap_time_s": 81.0, "compound": "MEDIUM"}]
+    absurd = {"laps_to_cliff_p10": 40000.0, "laps_to_cliff_p50": -3.0, "laps_to_cliff_p90": 90000.0}
+
+    assert build_tire_series(rows, current_lap=2, tire_out=absurd)["cliff"] is None
+    assert build_tire_series(rows, current_lap=None, tire_out=absurd)["cliff"] is None
+    assert build_tire_series(rows, current_lap=2, tire_out=None)["cliff"] is None
+
+
+def test_the_lap_axis_stops_just_past_the_band_and_not_a_hundred_laps_later():
+    """The deliberate deviation from Qt, asserted so it cannot drift back.
+
+    `tire_chart.py` extends the axis by the whole 100-lap horizon whenever
+    a band is visible, which on lap 23 runs the axis to 123 and squeezes
+    the stint into eight per cent of the width. It fires on every normal
+    cliff, not just a bad one.
+    """
+    from src.pitwall.agents_view.charts import build_tire_series
+
+    series = build_tire_series(
+        [{"lap": lap, "lap_time_s": 81.0, "compound": "MEDIUM"} for lap in range(14, 24)],
+        current_lap=23,
+        tire_out={"laps_to_cliff_p10": 4.0, "laps_to_cliff_p50": 6.0, "laps_to_cliff_p90": 9.0},
+    )
+
+    assert series["x_range"] == [13.5, 35.0]
+
+
+def test_the_pace_series_are_independent_so_a_missing_prediction_draws_nothing():
+    """A lap with an actual and no prediction must not pull the dashed line to zero."""
+    from src.pitwall.agents_view.charts import build_pace_series
+
+    series = build_pace_series(
+        {
+            21: {"actual": 81.0},
+            22: {"actual": 81.2, "pred": 81.1, "ci_p10": 80.6, "ci_p90": 81.6},
+            23: {"pred": 81.3},
+        }
+    )
+
+    assert series["actual"] == [[21.0, 81.0], [22.0, 81.2]]
+    assert series["pred"] == [[22.0, 81.1], [23.0, 81.3]]
+    assert series["band"] == [[22.0, 80.6, 81.6]], "a band needs both bounds"


### PR DESCRIPTION
Sprint 3, PR 6 of 6. Builds on #868. The last two panels.

## What crossed and what did not

`pace_chart.py` and `tire_chart.py` are about 250 lines together, and most of it is not drawing — it is judgement about what may be plotted. All of that stays in Python:

| | |
|---|---|
| the 30-200 s sanity window | one stub value flattens the real series to a hairline, and the TCN emits them on the first laps of a stint |
| per-stint segmentation | **the compound change is a BREAK, not a colour change on one line**: a single line is drawn through the in-lap and the out-lap, which are neither the same length as each other nor as a racing lap |
| the 3-lap centred rolling mean | with `min_periods=1` edges, so the overlay starts at the first lap |
| the cliff band | `[lap + p10, lap + p90]` with a marker at `lap + p50` — the percentiles are laps REMAINING — suppressed **whole** outside the sane horizon |
| three independent pace series | a lap with an actual and no prediction must not pull the dashed line to zero |

What did not cross is pyqtgraph's autoscale; ECharts does its own.

## Chart data never goes through React state

`useEChart` mounts the instance once and pushes options through a ref. That is the web form of P3 finding A6 — the Qt dashboard rebuilt six cards, six highlighted text areas and two whole charts ten times a second for content that changes once a lap — applied before it happens rather than after. `animationDurationUpdate: 0` is the contract `useFirstPaintAnimation.ts` already encodes: the entrance sweep plays once, every later update lands instantly.

## ⚠ One deliberate deviation, flagged rather than smuggled

`tire_chart.py::_anchor_x_range` extends the lap axis by the **whole 100-lap cliff horizon** whenever the band is visible. On lap 23 with a cliff six laps out that runs the axis to 123 and the stint occupies about eight per cent of the width. It is not a bad-value guard doing its job — it fires on every normal cliff, and it was invisible until #853 made the dev rig emit a cliff at all.

Here the axis stops three laps past whichever is further, the last observed lap or the band's upper edge. Bounded for the same reason, readable in the normal case. It is a **visible difference from the Qt window**, so it is named in the code, asserted in a test, and listed here for the exit gate rather than left to be discovered.

## Checks

- 34 tests in `test_pitwall_agents_view.py`, eight new and all on the algorithms: the stub filter, the stint break, a missing lap time not splitting a stint, the rolling mean at its edges, the band anchor, the suppressed absurd projection, the axis clamp, and the three independent pace series.
- `npm run build` clean. Screenshot: the yellow MEDIUM stint, the dashed trend overlay, the amber band at laps 27-32 and the dashed marker at 29.
- `ruff` clean.
