### PR TITLE
fix(pitwall): close the exit gate's findings on the AGENTS port

### DIFF
--- a/src/pitwall/agents_view/builder.py
+++ b/src/pitwall/agents_view/builder.py
@@ -36,20 +36,19 @@ class AgentsViewBuilder:
 
     - Nothing here formats. Every headline, body line and colour comes
       out of `agent_formatters`, which is the Qt window's own code.
-    - The lap history survives across ticks and is evicted, never
-      truncated blindly, on a backwards seek.
+    - The lap history survives across ticks and across a rewind, because
+      the predictions in it are broadcast exactly once.
     """
 
     def __init__(self) -> None:
         self._history = LapHistory()
-        self._last_lap: int | None = None
 
     def build(self, payload: dict[str, Any], connection: str = "Connected") -> dict[str, Any]:
         """The whole view for one tick."""
         strategy = payload.get("strategy") or {}
         latest = strategy.get("latest") or {}
 
-        self._accumulate(payload, strategy, latest)
+        self._accumulate(strategy, latest)
 
         return {
             "view_version": AGENTS_VIEW_VERSION,
@@ -77,22 +76,13 @@ class AgentsViewBuilder:
             "status_bar": build_status_bar(payload),
         }
 
-    def _accumulate(
-        self, payload: dict[str, Any], strategy: dict[str, Any], latest: dict[str, Any]
-    ) -> None:
-        """Fold this tick into the chart history, evicting first if we rewound.
+    def _accumulate(self, strategy: dict[str, Any], latest: dict[str, Any]) -> None:
+        """Fold this tick into the chart history. A rewind evicts nothing.
 
-        The eviction is keyed on the LAP going backwards rather than on
-        the producer's `rewound` flag, because that flag reports a
-        backwards seek of any size and most of them stay inside the
-        current lap, where there is nothing to evict. A lap that actually
-        gets re-driven must be re-observed: its predictions belong to the
-        timeline the user abandoned.
+        See `LapHistory`: the laps ahead of a backwards seek are real,
+        deterministic observations, and the predictions among them are
+        the one thing the wire sends exactly once. Dropping them is a
+        loss; keeping them is what the Qt window does.
         """
-        lap = (payload.get("arcade") or {}).get("lap")
-        if isinstance(lap, int):
-            if self._last_lap is not None and lap < self._last_lap:
-                self._history.evict_after(lap)
-            self._last_lap = lap
         self._history.seed_from_tail(strategy.get("history_tail") or [])
         self._history.ingest_latest(latest)

--- a/src/pitwall/agents_view/charts.py
+++ b/src/pitwall/agents_view/charts.py
@@ -16,7 +16,15 @@ from __future__ import annotations
 
 from typing import Any, NamedTuple
 
-from src.arcade.palette import ACCENT, INFO, TEXT_PRIMARY, WARNING, compound_color, hex_str
+from src.arcade.palette import (
+    ACCENT,
+    INFO,
+    TEXT_PRIMARY,
+    TEXT_TERTIARY,
+    WARNING,
+    compound_color,
+    hex_str,
+)
 
 # Anything outside this is a pipeline stub, not a lap. The lower bound is
 # well under the fastest modern F1 lap; 200 s is loose enough for a wet
@@ -32,6 +40,9 @@ PRED_COLOUR = hex_str(ACCENT)
 BAND_COLOUR = hex_str(ACCENT)
 TREND_COLOUR = hex_str(TEXT_PRIMARY)
 CLIFF_COLOUR = hex_str(WARNING)
+# TEXT_TERTIARY at the alpha 80/255 the Qt pen uses.
+BOUNDARY_COLOUR = hex_str(TEXT_TERTIARY)
+BOUNDARY_OPACITY = 80 / 255
 
 
 class _Stint(NamedTuple):
@@ -169,10 +180,16 @@ def build_tire_series(
             {"compound": stint.compound, "colour": stint.colour, "points": stint.points}
             for stint in stints
         ],
+        # One faint dashed vertical per compound change, kept faint because
+        # the colour break already says it (`tire_chart.py:184-195`). The
+        # first stint has no boundary in front of it.
+        "boundaries": [stint.points[0][0] for stint in stints[1:] if stint.points],
+        "boundary_colour": BOUNDARY_COLOUR,
         "trend": trend,
         "trend_colour": TREND_COLOUR,
         "cliff": cliff,
         "cliff_colour": CLIFF_COLOUR,
+        "boundary_opacity": BOUNDARY_OPACITY,
         "x_range": _x_range(flat, current_lap, cliff),
     }
 

--- a/src/pitwall/agents_view/decision.py
+++ b/src/pitwall/agents_view/decision.py
@@ -94,6 +94,7 @@ def build_orchestrator(latest: dict[str, Any] | None) -> dict[str, Any]:
             "action": "--",
             "action_colour": hex_str(TEXT_TERTIARY),
             "confidence": None,
+            "confidence_fill": 0.0,
             "confidence_label": "Confidence: --",
             "confidence_colour": hex_str(TEXT_TERTIARY),
             "pace": "Pace: --",
@@ -115,6 +116,12 @@ def build_orchestrator(latest: dict[str, Any] | None) -> dict[str, Any]:
         "action": badge_label,
         "action_colour": hex_str(badge_colour),
         "confidence": confidence,
+        # The bar's width, to the 0.1 % Qt's gradient stop resolves to
+        # (`orchestrator_card.py::_bar_style` rounds the stop to 3 dp).
+        # The client used to do this with `Math.round`, which is both
+        # coarser and the exact kind of arithmetic the view exists to
+        # keep out of the renderer.
+        "confidence_fill": round(min(1.0, max(0.0, confidence)) * 100, 1),
         "confidence_label": f"Confidence: {confidence * 100:.0f}%",
         "confidence_colour": hex_str(_confidence_colour(confidence)),
         "pace": f"Pace: {pace_mode or '--'}",

--- a/src/pitwall/agents_view/history.py
+++ b/src/pitwall/agents_view/history.py
@@ -34,9 +34,20 @@ class LapHistory:
     - backfill actuals from `history_tail` on a mid-stream connect;
     - fold each tick's `latest` in, which is the only carrier of the
       per-agent predictions;
-    - drop laps the user rewound past, so a lap that gets re-driven is
-      re-observed rather than read from the timeline that was abandoned;
     - stay bounded.
+
+    **A rewind evicts nothing, which is what the Qt window does too.** An
+    earlier version dropped every lap ahead of the one seeked to, on the
+    theory that a re-driven lap should be re-observed. Two things killed
+    it. The replay is deterministic, so those predictions are not wrong,
+    only early - re-driving the lap reproduces them. And a forward jump
+    past the evicted range never re-drives anything, so the prediction is
+    gone for good: `history_tail` strips `per_agent`, which is the exact
+    loss Gate A's D-11 warned a truncate would cause. Measured: a store
+    holding laps 28-30, rewound to lap 10, ended up holding only lap 30 -
+    it deleted the two it should have kept and kept the one it meant to
+    evict, because `ingest_latest` re-added it on the same tick from a
+    `latest` block that still lagged at lap 30.
     """
 
     def __init__(self, keep: int = KEEP_LAPS) -> None:
@@ -89,19 +100,6 @@ class LapHistory:
         if latest.get("lap_time_s") is not None:
             trow["lap_time_s"] = latest.get("lap_time_s")
         self.trim()
-
-    def evict_after(self, lap: int) -> None:
-        """Drop everything ahead of `lap`, for a backwards seek.
-
-        The Qt window has no equivalent and its charts are wrong after a
-        rewind: they hold laps the replay has not reached again. The guard
-        belongs here rather than in the UI because the store is keyed by
-        lap and the UI clock counts frames - a frame-indexed truncate
-        cannot address this map at all.
-        """
-        for store in (self._pace, self._tire):
-            for stored in [key for key in store if key > lap]:
-                store.pop(stored, None)
 
     def trim(self, keep: int | None = None) -> None:
         """Keep only the most recent `keep` laps so memory stays bounded."""

--- a/src/pitwall/agents_view/reasoning.py
+++ b/src/pitwall/agents_view/reasoning.py
@@ -69,19 +69,31 @@ TABS: tuple[tuple[str, str], ...] = (
 def highlight(text: str) -> list[dict[str, Any]]:
     """Split `text` into coloured runs, the way the Qt highlighter paints it.
 
-    `QSyntaxHighlighter.highlightBlock` runs per block, but every rule
-    here is anchored inside a line, so applying them over the whole
-    string is equivalent and keeps the newlines in one segment.
+    **The rules are applied per LINE, not over the whole string.**
+    `QSyntaxHighlighter.highlightBlock` is called once per paragraph, so a
+    match can never span a newline in Qt - and two of the five rules
+    contain ``\\s``, which matches a newline. Whole-string matching
+    therefore painted things Qt leaves plain: measured, a body carrying
+    ``extend the lap`` then ``22 target`` on the next line came out with
+    the two joined and painted in the lap colour, where Qt paints nothing,
+    and the same for a delta split across a line break.
+
+    It is reachable, not theoretical: `clean()` collapses the newlines in
+    `reasoning`, but the orchestrator tab appends `memory_block` raw, and
+    a memory block is multi-line free text.
     """
     if not text:
         return []
     colours: list[str | None] = [None] * len(text)
     bolds = [False] * len(text)
-    for pattern, colour, bold in _RULES:
-        for match in pattern.finditer(text):
-            for index in range(match.start(), match.end()):
-                colours[index] = colour
-                bolds[index] = bold
+    line_start = 0
+    for line in text.split("\n"):
+        for pattern, colour, bold in _RULES:
+            for match in pattern.finditer(line):
+                for index in range(line_start + match.start(), line_start + match.end()):
+                    colours[index] = colour
+                    bolds[index] = bold
+        line_start += len(line) + 1
 
     segments: list[dict[str, Any]] = []
     start = 0

--- a/src/pitwall/ui/src/features/agents/AgentCard.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentCard.tsx
@@ -32,8 +32,14 @@ export function AgentCard({
           {card.glyph}
         </span>
         <span className="agent-title">{title}</span>
-        {card.tooltip ? <Tooltip html={card.tooltip} /> : null}
       </header>
+
+      {/* The whole card is the hover target, as in Qt, and nothing extra
+          is drawn. An empty string means no tooltip, which is Qt's own
+          convention for suppressing the popup. */}
+      {card.tooltip ? (
+        <span className="agent-tooltip" dangerouslySetInnerHTML={{ __html: card.tooltip }} />
+      ) : null}
 
       <p
         className="agent-headline"
@@ -52,21 +58,5 @@ export function AgentCard({
 
       {children ? <div className="agent-chart">{children}</div> : null}
     </section>
-  );
-}
-
-/**
- * The hover transcript Qt shows as a tooltip.
- *
- * A real element rather than the `title` attribute: the content is rich
- * text, and `title` would print the tags. HTML has no 300 ms delay and no
- * fixed width, so the one thing that improves for free here is that the
- * whole lap fits.
- */
-function Tooltip({ html }: { html: string }) {
-  return (
-    <span className="agent-tooltip-host" aria-label="full transcript">
-      i<span className="agent-tooltip" dangerouslySetInnerHTML={{ __html: html }} />
-    </span>
   );
 }

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -10,10 +10,15 @@
  * tabs about 268 px, so the decision-memory counterweight sentence fell
  * below the fold on the one lap it matters. CSS has no fixed heights.
  *
- * Before the first view arrives the window renders the same idle state
- * the Qt one shows at startup, rather than a spinner: same chips, same
- * placeholders, same six hollow cards.
+ * Before the first view arrives the window renders the state the Qt
+ * window shows AT CONSTRUCTION, rather than a spinner. That is not the
+ * same as `update_from(None)`: the badge is ACCENT purple, the plan line
+ * uses em-dashes and the scenario scores read "0%". `_render_idle` is
+ * what Qt paints once a tick with no decision has arrived, which is a
+ * different moment.
  */
+
+import { useEffect, useState } from "react";
 
 import { AgentCard } from "./AgentCard";
 import { OrchestratorCard } from "./OrchestratorCard";
@@ -57,15 +62,17 @@ const IDLE_VIEW: AgentsView = {
   },
   orchestrator: {
     action: "--",
-    action_colour: "#9ca3af",
+    // ACCENT: `orchestrator_card.py:100` styles the badge at construction.
+    action_colour: "#a78bfa",
     confidence: null,
+    confidence_fill: 0,
     confidence_label: "Confidence: --",
     confidence_colour: "#9ca3af",
     pace: "Pace: --",
     pace_colour: "#9ca3af",
     risk: "Risk: --",
     risk_colour: "#9ca3af",
-    plan: "Pit: -- · Next: -- · UCUT: --",
+    plan: "Pit: — · Next: — · UCUT: —",
     guardrail: "",
   },
   scenarios: [
@@ -77,7 +84,7 @@ const IDLE_VIEW: AgentsView = {
     key,
     label,
     fill: 0,
-    score: "  --",
+    score: "  0%",
     is_winner: false,
     bar_colour: "#d1d5db",
     label_colour: "#d1d5db",
@@ -107,6 +114,9 @@ const IDLE_VIEW: AgentsView = {
       trend_colour: "#ffffff",
       cliff: null,
       cliff_colour: "#f59e0b",
+      boundaries: [],
+      boundary_colour: "#9ca3af",
+      boundary_opacity: 0.31,
       x_range: [0, 1],
     },
   },
@@ -114,9 +124,33 @@ const IDLE_VIEW: AgentsView = {
   status_bar: { text: "Waiting for arcade stream…", transient: false },
 };
 
+/**
+ * The status bar, with Qt's 1.5 s timeout.
+ *
+ * `showMessage(text, 1500)` clears itself, so a Qt window whose producer
+ * dies goes quiet within a second and a half. The port typed a
+ * `transient` flag, documented it, and read it nowhere — so a dead
+ * producer kept saying "lap N · streaming" forever under a red
+ * Disconnected chip. An error message is NOT transient: Qt gives that one
+ * no timeout, because it is the one you must still be able to read.
+ */
+function useStatusText(status: { text: string; transient: boolean }): string {
+  const [shown, setShown] = useState(status.text);
+
+  useEffect(() => {
+    setShown(status.text);
+    if (!status.transient) return;
+    const timer = window.setTimeout(() => setShown(""), 1500);
+    return () => window.clearTimeout(timer);
+  }, [status.text, status.transient]);
+
+  return shown;
+}
+
 export function AgentsWindow() {
   const { view } = useAgentsView();
   const shown = view ?? IDLE_VIEW;
+  const statusText = useStatusText(shown.status_bar);
 
   return (
     <div className="agents-window">
@@ -138,7 +172,7 @@ export function AgentsWindow() {
         </div>
       </div>
 
-      <footer className="status-bar">{shown.status_bar.text}</footer>
+      <footer className="status-bar">{statusText}</footer>
     </div>
   );
 }

--- a/src/pitwall/ui/src/features/agents/OrchestratorCard.tsx
+++ b/src/pitwall/ui/src/features/agents/OrchestratorCard.tsx
@@ -11,7 +11,6 @@
 import type { OrchestratorView } from "../../lib/agents";
 
 export function OrchestratorCard({ view }: { view: OrchestratorView }) {
-  const filled = view.confidence === null ? 0 : Math.round(view.confidence * 100);
   return (
     <section className="card orchestrator">
       <div className="orch-top">
@@ -25,7 +24,7 @@ export function OrchestratorCard({ view }: { view: OrchestratorView }) {
           <div className="orch-bar">
             <div
               className="orch-bar-fill"
-              style={{ width: `${filled}%`, background: view.confidence_colour }}
+              style={{ width: `${view.confidence_fill}%`, background: view.confidence_colour }}
             />
           </div>
         </div>

--- a/src/pitwall/ui/src/features/agents/TireChart.tsx
+++ b/src/pitwall/ui/src/features/agents/TireChart.tsx
@@ -44,16 +44,30 @@ export function TireChart({ series }: { series: TireSeries }) {
             data: [[{ xAxis: cliff.lo }, { xAxis: cliff.hi }] as [object, object]],
           }
         : undefined;
-    const markLine =
-      cliff && cliff.p50 !== null
-        ? {
-            silent: true,
-            symbol: "none" as const,
-            lineStyle: { color: series.cliff_colour, width: 2, type: "dashed" as const },
-            label: { show: false },
-            data: [{ xAxis: cliff.p50 }],
-          }
-        : undefined;
+    // The median marker and one faint dashed vertical per compound change
+    // share a markLine, because each carries its own lineStyle.
+    const marks = [
+      ...(cliff && cliff.p50 !== null
+        ? [
+            {
+              xAxis: cliff.p50,
+              lineStyle: { color: series.cliff_colour, width: 2, type: "dashed" as const },
+            },
+          ]
+        : []),
+      ...series.boundaries.map((lap) => ({
+        xAxis: lap,
+        lineStyle: {
+          color: series.boundary_colour,
+          opacity: series.boundary_opacity,
+          width: 1,
+          type: "dashed" as const,
+        },
+      })),
+    ];
+    const markLine = marks.length
+      ? { silent: true, symbol: "none" as const, label: { show: false }, data: marks }
+      : undefined;
 
     const trend = {
       type: "line" as const,

--- a/src/pitwall/ui/src/features/agents/useEChart.ts
+++ b/src/pitwall/ui/src/features/agents/useEChart.ts
@@ -49,6 +49,10 @@ export const CHART_BASE: echarts.EChartsOption = {
   grid: { left: 44, right: 10, top: 10, bottom: 28, containLabel: false },
   xAxis: {
     type: "value",
+    // Without this an ECharts value axis always includes 0, so a window
+    // over laps 12-27 rendered 0-30 and half the plot was dead space.
+    // pyqtgraph autoranges on the data; this is that.
+    scale: true,
     name: "Lap",
     nameLocation: "middle",
     nameGap: 18,

--- a/src/pitwall/ui/src/lib/agents.ts
+++ b/src/pitwall/ui/src/lib/agents.ts
@@ -60,6 +60,8 @@ export interface OrchestratorView {
   action_colour: string;
   /** null before the first decision; the bar then draws empty. */
   confidence: number | null;
+  /** The bar's width in per cent, already clamped and rounded host side. */
+  confidence_fill: number;
   confidence_label: string;
   confidence_colour: string;
   pace: string;
@@ -122,6 +124,10 @@ export interface TireSeries {
   /** Absolute lap numbers, or null when the projection is out of range. */
   cliff: { lo: number | null; hi: number | null; p50: number | null } | null;
   cliff_colour: string;
+  /** Lap numbers where the compound changed: one faint dashed vertical each. */
+  boundaries: number[];
+  boundary_colour: string;
+  boundary_opacity: number;
   x_range: [number, number];
 }
 

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -70,10 +70,13 @@ body {
   border-radius: 10px;
   font-size: 11px;
 }
-/* The connection chip carries no background in Qt: only its text is
- * coloured, which is what makes the three states readable at a glance. */
+/* The connection chip is a chip like the other two: `window.py:81` gives
+ * the label `objectName("chip")` and the app stylesheet paints
+ * `QLabel#chip` with the elevated background. `set_connection`'s
+ * widget-level sheet overrides the colour and the padding, never the
+ * background, so Qt's cascade keeps it. An earlier comment here claimed
+ * the opposite. */
 .header-conn {
-  background: none;
   font-weight: 600;
 }
 
@@ -81,7 +84,11 @@ body {
 
 .agents-split {
   display: grid;
-  grid-template-columns: 540fr 740fr;
+  /* 540 PIXELS, not 540fr. `setStretchFactor(0, 0)` pins the left panel
+   * and sends every extra pixel right; a proportional split grew it to
+   * 807 px at 1920, 267 px wider than Qt. The 740 was only ever the
+   * initial size of the half that stretches. */
+  grid-template-columns: 540px 1fr;
   gap: 2px; /* QSplitter.setHandleWidth(2) */
   flex: 1;
   min-height: 0;
@@ -103,7 +110,13 @@ body {
 }
 .agents-right {
   grid-template-columns: 1fr 1fr;
-  grid-auto-rows: minmax(140px, auto);
+  /* Qt's own caps: `agent_card.py:70-72` gives a text card 140-260 and
+   * `attach_chart` bumps the two with charts to 260-420. The grid is a
+   * fixed 3x2, so the three rows are written out rather than inferred.
+   * Equal auto rows put the dead space INSIDE the text cards instead of
+   * between the rows, which measured 264/246/256 against Qt's 416/174/197
+   * on the first payload anyone renders. */
+  grid-template-rows: minmax(260px, 420px) minmax(140px, 260px) minmax(140px, 260px);
 }
 
 /* --- Cards -------------------------------------------------------------- */
@@ -114,12 +127,23 @@ body {
   border-radius: 6px;
 }
 .agent-card {
+  position: relative;
+  /* Qt clips a card that overflows its cap - the migration README records
+   * the right column being "clipped mid-card" at the default geometry.
+   * Scrolling keeps the same footprint and stops the content being lost. */
+  overflow: auto;
   padding: 10px 12px;
   display: flex;
   flex-direction: column;
   gap: 6px;
   min-width: 0;
 }
+/* DELIBERATE DIFFERENCE. `agent_card.py:156-158` asks for exactly this
+ * ("Dim the whole card when the agent is idle") and Qt silently ignores
+ * it: `opacity` in a Qt style sheet applies to QToolTip only, measured at
+ * 0 of 115,200 pixels changed with the rule on and off. So the port
+ * renders the intent the Qt author wrote and the toolkit dropped.
+ * Deleting it would mean reproducing a toolkit limitation on purpose. */
 .agent-card.is-idle {
   opacity: 0.45;
 }
@@ -152,31 +176,25 @@ body {
 }
 .agent-chart {
   margin-top: auto;
-  min-height: 140px;
+  min-height: 140px; /* pace_chart.py / tire_chart.py setMinimumHeight(140) */
+  flex: 1;
 }
 
 /* --- Tooltip ------------------------------------------------------------ */
 
-.agent-tooltip-host {
-  margin-left: auto;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  border: 1px solid var(--qt-border);
-  color: var(--qt-fg-3);
-  font-size: 9px;
-  font-weight: 700;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  position: relative;
+/* Qt puts the tooltip on the CARD (`window.py:323,330`), so hovering
+ * anywhere over it opens the transcript and nothing extra is drawn. An
+ * earlier version added a visible "i" glyph and made only those 14 px
+ * hoverable: a new element with no counterpart in the window being
+ * ported. */
+.agent-card:has(.agent-tooltip) {
   cursor: help;
 }
 .agent-tooltip {
   display: none;
   position: absolute;
-  top: 18px;
-  right: 0;
+  top: 32px;
+  right: 12px;
   z-index: 10;
   width: 30rem;
   max-height: 22rem;
@@ -191,7 +209,7 @@ body {
   text-align: left;
   line-height: 1.5;
 }
-.agent-tooltip-host:hover .agent-tooltip {
+.agent-card:hover .agent-tooltip {
   display: block;
 }
 
@@ -383,5 +401,5 @@ body {
 .chart {
   width: 100%;
   height: 100%;
-  min-height: 150px;
+  min-height: 140px;
 }

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -287,25 +287,37 @@ def test_the_history_keeps_the_predictions_the_wire_only_sends_once():
     assert 24 in pace, "and the new lap is in"
 
 
-def test_a_rewind_drops_the_laps_ahead_and_keeps_the_ones_behind():
-    """The Qt charts have no equivalent and are wrong after a seek back.
+def test_a_rewind_keeps_the_laps_it_already_observed():
+    """The Qt window keeps them, and so must this: the wire sends them once.
 
-    Truncating everything would be worse than doing nothing: the past
-    holds predictions the wire will never resend.
+    An earlier version evicted every lap ahead of the seek. Two things
+    killed it. The replay is deterministic, so those observations are not
+    wrong, only early. And a forward jump past the evicted range never
+    re-drives them, so the prediction is gone: `history_tail` strips
+    `per_agent`, which is exactly the loss Gate A's D-11 predicted.
+
+    The eviction also leaked. On a tick where the arcade clock goes back
+    but `strategy.latest` still lags at the old lap, it removed the future
+    and `ingest_latest` re-added the lagging lap on the same tick: a store
+    holding 28/29/30 rewound to 10 ended up holding **only lap 30** — it
+    deleted the two it should have kept and kept the one it meant to drop.
     """
     from src.pitwall.host import PitwallHost
 
-    client = _FakeClient(_payload(seq=1, lap=20))
+    client = _FakeClient(_payload(seq=1, lap=28))
     host = PitwallHost(client, window_count=1)
     host.get_agents_view(-1)
-    for seq, lap in ((2, 21), (3, 22)):
+    for seq, lap in ((2, 29), (3, 30)):
         client.latest = _payload(seq=seq, lap=lap)
         host.get_agents_view(seq - 1)
 
-    client.latest = _payload(seq=4, lap=21)
+    # The rewind tick: the clock goes back to 10 while `latest` still lags.
+    client.latest = _payload(seq=4, lap=10)
+    client.latest["strategy"]["latest"]["lap_number"] = 30
     view = host.get_agents_view(3)
 
-    assert sorted(row["lap"] for row in view["history"]["pace"]) == [20, 21]
+    laps = sorted(row["lap"] for row in view["history"]["pace"])
+    assert laps == [28, 29, 30], "nothing observed is thrown away by a seek"
 
 
 def test_the_history_stays_bounded():
@@ -753,3 +765,23 @@ def test_the_pace_series_are_independent_so_a_missing_prediction_draws_nothing()
     assert series["actual"] == [[21.0, 81.0], [22.0, 81.2]]
     assert series["pred"] == [[22.0, 81.1], [23.0, 81.3]]
     assert series["band"] == [[22.0, 80.6, 81.6]], "a band needs both bounds"
+
+
+def test_a_rule_cannot_paint_across_a_line_break():
+    r"""`QSyntaxHighlighter` runs per paragraph; two of the five rules match `\s`.
+
+    Applying them over the whole string painted things Qt leaves plain.
+    Reachable, not theoretical: `clean()` collapses the newlines in
+    `reasoning`, but the orchestrator tab appends `memory_block` RAW, and
+    a memory block is multi-line free text.
+    """
+    from src.pitwall.agents_view.reasoning import DEFAULT_COLOUR, highlight
+
+    for text in ("extend the lap\n22 target", "the delta is +0.42\ns behind"):
+        painted = [seg["text"] for seg in highlight(text) if seg["colour"] != DEFAULT_COLOUR]
+        assert painted == [], f"{text!r} must paint nothing, as Qt does"
+
+    # The same tokens on one line still paint, so the fix did not disable them.
+    on_one_line = {seg["text"] for seg in highlight("lap 22 and +0.42 s") if seg["bold"] is False}
+    assert "lap 22" in on_one_line
+    assert "+0.42 s" in on_one_line

--- a/tests/surfaces/test_pitwall_tokens.py
+++ b/tests/surfaces/test_pitwall_tokens.py
@@ -166,3 +166,70 @@ def test_the_python_palettes_known_drift_has_not_moved():
         "a Python colour now matches the canonical palette - remove it from "
         "KNOWN_PYTHON_DRIFT rather than leaving a stale exception"
     )
+
+
+# --- The two copies the AGENTS window introduced ----------------------------
+
+AGENTS_CSS = REPO_ROOT / "src" / "pitwall" / "ui" / "src" / "styles" / "agents.css"
+AGENTS_WINDOW = (
+    REPO_ROOT / "src" / "pitwall" / "ui" / "src" / "features" / "agents" / "AgentsWindow.tsx"
+)
+
+# The `--qt-*` custom properties, and what each one copies from `palette.py`.
+QT_CSS_TOKENS = {
+    "qt-bg": "BG_COLOR",
+    "qt-panel": "CONTENT_BG",
+    "qt-elevated": "SECONDARY_BG",
+    "qt-border": "BORDER_COLOR",
+    "qt-fg-1": "TEXT_PRIMARY",
+    "qt-fg-2": "TEXT_SECONDARY",
+    "qt-fg-3": "TEXT_TERTIARY",
+    "qt-accent": "ACCENT",
+}
+
+
+def test_the_agents_css_palette_has_not_drifted_from_palette_py():
+    """Copy number three, and the first one a stylesheet could break silently.
+
+    The AGENTS window renders the arcade palette rather than `tokens.css`,
+    because it is a 1:1 port of a Qt window and the two palettes
+    deliberately differ. That means the hexes are duplicated into CSS,
+    and a duplicate with no guard is how this repo's most frequent defect
+    starts.
+    """
+    from src.arcade import palette
+
+    declared = dict(re.findall(r"--([\w-]+):\s*(#[0-9a-fA-F]{6})", AGENTS_CSS.read_text("utf-8")))
+
+    assert set(QT_CSS_TOKENS) <= set(declared), (
+        f"a --qt-* token was renamed or removed: {sorted(set(QT_CSS_TOKENS) - set(declared))}"
+    )
+    for token, name in QT_CSS_TOKENS.items():
+        assert declared[token].lower() == _rgb_to_hex(getattr(palette, name)), (
+            f"--{token} is {declared[token]}, but palette.{name} is "
+            f"{_rgb_to_hex(getattr(palette, name))}"
+        )
+
+
+def test_the_boot_state_literals_have_not_drifted_from_palette_py():
+    """Copy number four: the state the window paints before the first tick.
+
+    It cannot come from the host — there is no host answer yet — so the
+    colours are literals in TSX. Every one must still be a colour the
+    palette actually has, or the window boots in a shade nothing else uses.
+    """
+    from src.arcade import palette
+
+    known = {
+        _rgb_to_hex(getattr(palette, name))
+        for name in dir(palette)
+        if name.isupper()
+        and isinstance(getattr(palette, name), tuple)
+        and len(getattr(palette, name)) == 3
+    }
+    literals = set(re.findall(r'"(#[0-9a-fA-F]{6})"', AGENTS_WINDOW.read_text("utf-8")))
+
+    assert literals, (
+        "the boot state stopped carrying colours; is this test still checking anything?"
+    )
+    assert literals <= known, f"boot colours not in the palette: {sorted(literals - known)}"


### PR DESCRIPTION
Closes #870. Everything the sprint-3 exit gate (Fable) found, verified independently before acting. Report: `~/.claude/plans/pitwall-sprint3/exit-gate.md`.

**The claim it refuted was mine.** "The only deliberate deviation is the tyre chart's lap axis" was false: there were about a dozen render-layer differences and one declaration.

**What it could not break, and it tried hard:** across eight states rendered from byte-identical input — `overtake_prob` None, an unknown compound, five alerts, a scenario dict with an unknown key, a pipeline error, a rewind, a stint change — **not one text, colour, glyph or score differed**. The string layer is 1:1 by construction, as designed. Everything below is the render layer and the accumulator.

## Real bugs

| # | What | Fix |
|---|---|---|
| **F-04** | the rewind guard destroyed predictions the wire sends once, **and leaked**. Executed: a store holding laps 28/29/30, rewound to 10, ended holding **only lap 30** — it deleted the two it should have kept and kept the one it meant to evict, because `ingest_latest` re-added it from a `latest` block still lagging at the old lap. Gate A's D-11 predicted exactly this loss. | the eviction is gone. In a deterministic replay those observations are not wrong, only early; a forward jump past them never re-drives them, and `history_tail` strips `per_agent`. Qt keeps them too. |
| **F-01** | the highlighter is not Qt's on multi-line text: two of the five rules contain `\s`, which matches a newline, and `QSyntaxHighlighter` runs per paragraph. Reachable — `memory_block` is appended RAW to the orchestrator tab. My docstring claimed equivalence. | rules apply per line |
| **F-02** | the status bar's 1.5 s auto-clear was typed, documented and **read by nothing**. A dead producer said "lap N · streaming" forever under a red chip. The test asserted the FLAG, not the effect — #450 verbatim. | wired, and an error message stays (Qt gives that one no timeout) |
| **F-03** | the connection chip lost its pill background and the CSS comment asserted the opposite of what Qt renders (`window.py:81` sets `objectName("chip")`; `theme.py:118` paints it) | background back, comment corrected |
| **F-06** | the pace chart's X axis anchored at 0, so laps 0-11 were dead space on every real window. Measured Qt 12-27, port 0-30. | `scale: true` |

## Fidelity, undeclared until now

**F-09** the split was `540fr 740fr` — proportional. Qt's `setStretchFactor(0, 0)` pins the left column at 540 and sends every extra pixel right; measured 267 px apart at 1920. Now `540px 1fr`. **F-10** the card caps were not ported (Qt rows 416/174/197, port 264/246/256); the grid now carries Qt's own `minmax(260px, 420px)` / `minmax(140px, 260px)`, with `overflow: auto` so a card that would clip scrolls instead. **F-11** the tooltip trigger had shrunk to a visible 14 px "i" with no Qt counterpart; the whole card is the trigger again. **F-12** the boot state mimicked `update_from(None)` rather than the Qt constructor — accent badge, em-dash plan, `0%` scores now. **F-08** the stint-boundary markers are ported. **F-13** the confidence fill is computed host side instead of `Math.round`-ed in the client, and the two new palette copies (`agents.css`'s `--qt-*` and the boot literals) now have a twin-detector, verified red on a one-hex edit.

## Declared, not changed

**F-05** the port dims idle cards and **Qt never has** — `opacity` in a Qt style sheet applies to QToolTip only, measured 0 of 115,200 pixels different with the rule on and off. `agent_card.py` asks for the dimming in as many words; the port renders the intent the toolkit dropped. Deleting it would mean reproducing a limitation on purpose. **F-07** the chart Y framing differs in both band regimes, and it is not tunable from the port side — written into `charts.py::_x_range` next to the axis note. **F-14** Qt's two socket-level status transients and its reconnect chip cycle have no port counterpart. **F-16** the badge corners: the same HTML string, rounded in a browser and square in Qt.

## The test gap (F-15)

All 34 tests pinned the view dict, not the window. Two now assert effects that were invisible: a rule cannot paint across a line break, and the rewind keeps what it observed. The palette twin-detector covers copies three and four. A DOM-level smoke test over the built bundle is still missing — CI has no frontend job, so it would not run there; noted rather than faked.

## Checks

- `uv run pytest tests/surfaces` → 135 passed, 1 failed (`test_cli_no_llm`, the known curated-download gap, red on `dev` too). 36 tests in `test_pitwall_agents_view.py`, 7 in `test_pitwall_tokens.py`.
- Negative checks: the CSS twin-detector goes red on a one-hex edit; the highlighter test goes red against whole-string matching.
- `npm run build` clean; both windows re-rendered from the identical payload and compared.
- `ruff` clean.
