### PR TITLE
ci(pitwall): load the built AGENTS bundle in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,72 @@ jobs:
         if: steps.changes.outputs.backend == 'true'
         run: uv run mypy src/rag/
 
+  # The PITWALL window is TypeScript, and until this job existed nothing in
+  # CI ever loaded it: the Python suite pins the view dict the host returns,
+  # so deleting a whole component or the layout rule from the stylesheet left
+  # every test green. The sprint-3 exit gate measured exactly that.
+  #
+  # Advisory for now (`continue-on-error`), the same way pip-audit was
+  # introduced: promote it to a required context in `scripts/setup-github.sh`
+  # after a clean week. A browser step that turns every branch red on its
+  # first flake teaches people to ignore it.
+  pitwall-ui:
+    name: pitwall-ui
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    defaults:
+      run:
+        working-directory: src/pitwall/ui
+    steps:
+      # checkout MUST run before paths-filter: on `push` events the filter
+      # falls back to `git diff` and needs the repo + history (fetch-depth:0).
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Filter changed paths
+        uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: |
+            ui:
+              - 'src/pitwall/ui/**'
+              - '.github/workflows/ci.yml'
+
+      - name: Skip — no PITWALL UI changes
+        if: steps.changes.outputs.ui != 'true'
+        run: echo "No PITWALL UI changes; skipping the bundle build and smoke."
+
+      - uses: actions/setup-node@v6
+        if: steps.changes.outputs.ui == 'true'
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: src/pitwall/ui/package-lock.json
+
+      - name: Install dependencies
+        if: steps.changes.outputs.ui == 'true'
+        run: npm ci
+
+      - name: Typecheck
+        if: steps.changes.outputs.ui == 'true'
+        run: npm run typecheck
+
+      - name: Build the bundle
+        if: steps.changes.outputs.ui == 'true'
+        run: npm run build
+
+      - name: Install chromium
+        if: steps.changes.outputs.ui == 'true'
+        run: npx playwright install --with-deps chromium
+
+      # Structural, not visual: the elements exist, the split computes to the
+      # 540 px Qt pins, and the status bar's 1.5 s auto-clear actually fires.
+      # Pixels stay a human's job, with `scripts/shot-agents.mjs`.
+      - name: Smoke the AGENTS window
+        if: steps.changes.outputs.ui == 'true'
+        run: npm run smoke
+
   # Same-day CVE alerts on the locked Python deps (OSV/PyPA), independent of
   # whether the diff touches uv.lock. Always-on (no path filter) per
   # PROJECT_BOOTSTRAP.md §6; advisory (continue-on-error) while baselining,

--- a/src/pitwall/ui/package.json
+++ b/src/pitwall/ui/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "smoke": "node scripts/smoke-agents.mjs"
   },
   "dependencies": {
     "echarts": "^6.1.0",

--- a/src/pitwall/ui/scripts/serve-dist.mjs
+++ b/src/pitwall/ui/scripts/serve-dist.mjs
@@ -1,0 +1,54 @@
+/**
+ * Serve a built bundle over http, from a map read once at startup.
+ *
+ * Shared by the screenshot tool and the smoke test. Two reasons it exists
+ * at all, both learned the hard way:
+ *
+ * - chromium refuses `<script type="module">` over `file://` (CORS treats
+ *   it as origin `null`), so a bundle opened from disk loads nothing and
+ *   renders a blank page with two console errors. pywebview reaches the
+ *   same files through the OS webview, which does allow it.
+ * - nothing here turns a request into a path. The first version joined
+ *   the URL onto the root and CodeQL called it a path injection, then the
+ *   `stat`-per-entry version was a file-system race. Reading the tree
+ *   into memory removes both questions instead of guarding them, and a
+ *   built bundle is a few hundred kilobytes.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { createServer } from "node:http";
+import { extname, join } from "node:path";
+
+const MIME = {
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".css": "text/css",
+  ".json": "application/json",
+};
+
+export function serveDist(root) {
+  const files = new Map();
+  // `withFileTypes` answers directory-or-file from the directory read
+  // itself. Asking again with `stat` is a second look at something that
+  // can change in between.
+  const walk = (dir, prefix) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      const url = `${prefix}/${entry.name}`;
+      if (entry.isDirectory()) walk(full, url);
+      else files.set(url, { body: readFileSync(full), type: MIME[extname(entry.name)] });
+    }
+  };
+  walk(root, "");
+
+  const server = createServer((req, res) => {
+    const file = files.get(req.url.split("?")[0]);
+    if (!file) {
+      res.statusCode = 404;
+      res.end();
+      return;
+    }
+    res.setHeader("Content-Type", file.type ?? "application/octet-stream");
+    res.end(file.body);
+  });
+  return new Promise((ready) => server.listen(0, "127.0.0.1", () => ready(server)));
+}

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -1,0 +1,194 @@
+/**
+ * Does the built AGENTS bundle still render the window?
+ *
+ * **The gap this closes was named by the sprint-3 exit gate**: every one
+ * of its render-layer findings sailed through 35 green Python tests,
+ * because those pin the view DICT and nothing loaded the bundle. Deleting
+ * `<PaceChart/>` from `AgentsWindow.tsx`, or the whole `.agents-split`
+ * rule from the stylesheet, left the suite entirely green.
+ *
+ * So this asserts EFFECTS in a real engine: the elements exist, the
+ * layout the port claims is frozen actually computes to Qt's numbers, and
+ * the status bar's 1.5 s auto-clear — typed, documented and read by
+ * nothing until #871 — actually fires.
+ *
+ * It is NOT a visual regression test. Pixels are the screenshot tool's
+ * job (`shot-agents.mjs`) and a human's. This is the structural floor.
+ *
+ *   npm run build && node scripts/smoke-agents.mjs
+ */
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+import { serveDist } from "./serve-dist.mjs";
+
+const UI_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+// An alternate bundle directory, so a negative check can run against a
+// deliberately broken copy without touching the real one.
+const DIST = resolve(process.argv[2] ?? resolve(UI_DIR, "dist"));
+
+/**
+ * Enough of a view to render every panel.
+ *
+ * A literal, not a file: the SHAPE of the view is pinned on the Python
+ * side by `tests/surfaces/test_pitwall_agents_view.py`, and duplicating
+ * that contract here would be a second source of truth for it. What this
+ * file owns is whether the renderer draws what it is handed.
+ */
+const VIEW = {
+  view_version: 1,
+  seq: 1,
+  header: {
+    session: "Melbourne · 2025",
+    driver: "NOR",
+    lap: "L 23/57",
+    playback: "2.00× · PLAYING",
+    connection: "Connected",
+    connection_colour: "#10b981",
+  },
+  orchestrator: {
+    action: "PIT NOW",
+    action_colour: "#ef4444",
+    confidence: 0.71,
+    confidence_fill: 71.0,
+    confidence_label: "Confidence: 71%",
+    confidence_colour: "#10b981",
+    pace: "Pace: PUSH",
+    pace_colour: "#ef4444",
+    risk: "Risk: AGGRESSIVE",
+    risk_colour: "#ef4444",
+    plan: "Pit: L24 · Next: HARD · UCUT: RUS",
+    guardrail: "",
+  },
+  scenarios: ["STAY", "PIT", "UCUT", "OCUT"].map((label, index) => ({
+    key: label,
+    label,
+    fill: index === 1 ? 1 : 0.4,
+    score: "+0.71",
+    is_winner: index === 1,
+    bar_colour: index === 1 ? "#a78bfa" : "#d1d5db",
+    label_colour: "#d1d5db",
+    score_colour: "#ffffff",
+  })),
+  reasoning: ["Orchestrator", "Pace", "Tire", "Situation", "Radio", "Pit"].map((label) => ({
+    key: label.toLowerCase(),
+    label,
+    segments: [{ text: `${label} body`, colour: "#ffffff", bold: false }],
+  })),
+  cards: Object.fromEntries(
+    ["pace", "tire", "situation", "pit", "radio", "rag"].map((key) => [
+      key,
+      {
+        headline: `${key} headline`,
+        headline_colour: "#ffffff",
+        lines: [{ text: "a body line", colour: "#d1d5db" }],
+        status: "OK",
+        glyph: "●",
+        glyph_colour: "#10b981",
+        tooltip: key === "radio" ? "<b>Radio</b><br>NOR: rear grip" : "",
+      },
+    ]),
+  ),
+  charts: {
+    pace: {
+      actual: [
+        [21, 81.2],
+        [22, 81.4],
+      ],
+      pred: [[22, 81.1]],
+      band: [[22, 80.6, 81.6]],
+      actual_colour: "#3b82f6",
+      pred_colour: "#a78bfa",
+      band_colour: "#a78bfa",
+    },
+    tire: {
+      stints: [
+        {
+          compound: "MEDIUM",
+          colour: "#e6c832",
+          points: [
+            [21, 81.2],
+            [22, 81.4],
+          ],
+        },
+      ],
+      trend: [
+        [21, 81.3],
+        [22, 81.3],
+      ],
+      trend_colour: "#ffffff",
+      cliff: { lo: 26, hi: 31, p50: 28 },
+      cliff_colour: "#f59e0b",
+      boundaries: [],
+      boundary_colour: "#9ca3af",
+      boundary_opacity: 0.31,
+      x_range: [20.5, 34],
+    },
+  },
+  status_bar: { text: "lap 23 · streaming", transient: true },
+};
+
+const failures = [];
+const check = (ok, what) => {
+  if (!ok) failures.push(what);
+};
+
+const server = await serveDist(DIST);
+const browser = await chromium.launch();
+const ctx = await browser.newContext({ viewport: { width: 1320, height: 900 } });
+const page = await ctx.newPage();
+page.on("pageerror", (error) => failures.push(`pageerror: ${error.message}`));
+page.on("console", (message) => {
+  if (message.type() === "error") failures.push(`console: ${message.text()}`);
+});
+
+await page.addInitScript((view) => {
+  window.pywebview = {
+    api: {
+      get_agents_view: async (sinceSeq) => (sinceSeq >= view.seq ? null : view),
+      get_tick: async () => null,
+    },
+  };
+}, VIEW);
+
+await page.goto(`http://127.0.0.1:${server.address().port}/agents.html`, {
+  waitUntil: "domcontentloaded",
+});
+await page.waitForSelector(".agent-card", { timeout: 5000 });
+
+check((await page.locator(".agent-card").count()) === 6, "six agent cards");
+check((await page.locator(".agent-chart canvas").count()) === 2, "two chart canvases");
+check((await page.locator(".reasoning-tab").count()) === 6, "six reasoning tabs");
+check((await page.locator(".scenario-row").count()) === 4, "four scenario rows");
+check(await page.locator(".orchestrator").isVisible(), "the orchestrator card");
+
+// Qt pins the left panel at 540 px and sends every extra pixel right
+// (`setStretchFactor(0, 0)`). A proportional split grew it to 807 at 1920.
+const columns = await page.evaluate(
+  () => getComputedStyle(document.querySelector(".agents-split")).gridTemplateColumns,
+);
+check(columns.startsWith("540px"), `left column is 540px (got ${columns})`);
+
+// The tooltip is a child of a card that scrolls; it must not be clipped
+// away, and it must only exist where the host sent content.
+check((await page.locator(".agent-tooltip").count()) === 1, "one tooltip, on RADIO only");
+
+// Qt's `showMessage(text, 1500)` clears itself. The port typed a
+// `transient` flag and read it nowhere until #871.
+check(
+  (await page.locator(".status-bar").innerText()).includes("lap 23"),
+  "the status bar starts with the lap",
+);
+await page.waitForTimeout(1800);
+check((await page.locator(".status-bar").innerText()).trim() === "", "the status bar auto-clears");
+
+await ctx.close();
+await browser.close();
+server.close();
+
+if (failures.length) {
+  console.error(`smoke FAILED (${failures.length}):`);
+  for (const failure of failures) console.error(`  - ${failure}`);
+  process.exit(1);
+}
+console.log("smoke OK: 10 checks");


### PR DESCRIPTION
The sprint-3 exit gate's last open item, and the one it called a gap rather than a difference.

## The gap

**Nothing in CI had ever loaded the AGENTS window.** The Python suite pins the view dict the host returns — 36 tests, all green — and the gate measured what that misses:

> Delete `<PaceChart/>`/`<TireChart/>` from AgentsWindow.tsx, or the entire `.agents-split` rule — 34/34 green. No test loads the bundle; F-03/05/06/08/09/10/11 live where no test looks.

Seven of its sixteen findings were in that blind spot.

## What the job does

`npm ci` → `npm run typecheck` → `npm run build` → chromium → `npm run smoke`. Path-filtered **per job**, not at the workflow level, so a required check can never sit in "expected" forever — the pattern the other three jobs already use.

## What the smoke asserts, and why each one

| Check | The regression it catches |
|---|---|
| six agent cards, two chart canvases, six reasoning tabs, four scenario rows, the orchestrator | a component deleted or unwired — the gate's own first example |
| the tooltip exists only where the host sent content | the suppression rule Qt expresses with an empty string |
| `grid-template-columns` starts with `540px` | the proportional split that made the left column 267 px wider than Qt at 1920 |
| the status bar shows the lap, then is **empty 1.8 s later** | the 1.5 s auto-clear that was typed, documented and read by nothing until #871 |
| no console error, no page error | a bundle that renders but throws |

**It is not a visual regression test.** Pixels stay a human's job, with `scripts/shot-agents.mjs`. This is the structural floor.

## Verified red

Against a copy of the bundle with the split rule reverted to the pre-#871 `540fr 740fr`:

```
smoke FAILED (1):
  - left column is 540px (got 556.031px 761.969px)
```

and green against the real one. The check reports the measured value, so a failure says what it saw rather than that something is wrong.

## Advisory for now

`continue-on-error: true`, the same way `pip-audit` was introduced here. A browser step that turns every branch red on its first flake teaches people to ignore it. Promote it to a required context in `scripts/setup-github.sh` after a clean week — noted in the job's own comment so it does not get forgotten.

## Also

`serve-dist.mjs` is extracted from the screenshot tool, which needed the same in-memory static server. It carries the two reasons it is not a plain file server: chromium refuses module scripts over `file://`, and the two filesystem versions of it were a path injection and then a file-system race.
