### PR TITLE
fix(arcade): classify a final-lap retirement as out, not as the winner

### DIFF
--- a/src/arcade/gaps.py
+++ b/src/arcade/gaps.py
@@ -93,10 +93,17 @@ screen, and it beats a live number that is right 90 % of the time and
 
 from __future__ import annotations
 
+from typing import Callable
+
 import numpy as np
 
 from src.arcade.config import DT
 from src.arcade.data import SessionData
+
+# `(driver, frame) -> laps completed plus fraction`, WITHOUT flag
+# crossings. Passed in rather than imported so `_flag_frames` cannot
+# depend on the flags it is deciding.
+ProgressAt = Callable[[str, int], float | None]
 
 
 def _telemetry_end_frame(frames: list) -> int:
@@ -119,24 +126,39 @@ def _telemetry_end_frame(frames: list) -> int:
     return int(ended[0]) if len(ended) else len(frames) - 1
 
 
-def _flag_frames(frames_by_driver: dict[str, list], final_lap: int) -> dict[str, int | None]:
+def _flag_frames(
+    frames_by_driver: dict[str, list], final_lap: int, progress_at: ProgressAt
+) -> dict[str, int | None]:
     """The frame each car took the chequered flag, `None` for a retirement.
 
     **The rule is the racing one, and it needs no threshold.** When the
     leader takes the flag every other car takes it the next time it crosses
     the line, so a finisher's telemetry ends at or after the leader's does
-    and a retirement's ends before. The leader is the first car to reach
-    `final_lap`; everyone still producing telemetry at that instant
-    finished the race.
+    and a retirement's ends before.
 
-    Why not "reached the final lap": a car a lap down finishes on
-    `final_lap - 1` and would read as a retirement, which is the same
-    mistake in the other direction. Melbourne 2025 has no lapped finisher,
-    so that version would have measured perfectly and still been wrong.
+    Everything therefore turns on finding the LEADER'S flag, and the
+    obvious answer is wrong. "The first car to reach the final lap" reads
+    a car that crashes a fifth of the way into it as the winner: its
+    telemetry ends first, so it set the flag time, it was then credited a
+    crossing of a lap it never completed, and the tie-break drew it **P1
+    ahead of the actual winner** for the whole flag-to-end window. An
+    earlier version of this docstring claimed the only misclassification
+    was a car retiring in the last fraction of a lap. That was false, and
+    a synthetic three-lap race produced the order `[CRASH, WIN, P2]`.
 
-    The one car this misclassifies is one that retires between the leader's
-    flag and its own last crossing - under a lap of running, and a car that
-    far into the race is classified by the FIA anyway.
+    The rule that holds: **the flag is taken by the car that is LEADING
+    when its telemetry ends.** A winner is ahead of everyone at the moment
+    they stop producing data; a car that crashes is not. `progress_at` is
+    the caller's own coordinate WITHOUT any flag crossings, which is what
+    keeps this from being circular.
+
+    Why not "reached the final lap" on its own: a car a lap down finishes
+    on `final_lap - 1` and would read as a retirement, the same mistake in
+    the other direction. Melbourne 2025 has no lapped finisher and no
+    final-lap retirement, so both wrong versions measured perfectly on it.
+
+    What is left misclassified is a car that retires while leading, which
+    is a car that has already won everything except the last few metres.
 
     `final_lap` of 0 means the loader did not record one; nobody is then
     known to have finished, which is the honest answer and the behaviour
@@ -148,17 +170,36 @@ def _flag_frames(frames_by_driver: dict[str, list], final_lap: int) -> dict[str,
     ends = {
         code: _telemetry_end_frame(frames) for code, frames in frames_by_driver.items() if frames
     }
-    reached_final_lap = [
-        end for code, end in ends.items() if frames_by_driver[code][-1].lap >= final_lap
-    ]
-    if not reached_final_lap:
+    candidates = sorted(
+        (end, code) for code, end in ends.items() if frames_by_driver[code][-1].lap >= final_lap
+    )
+    leader_flag = next(
+        (end for end, code in candidates if _leads_at(code, end, ends, progress_at)),
+        None,
+    )
+    if leader_flag is None:
         return {code: None for code in frames_by_driver}
 
-    leader_flag = min(reached_final_lap)
     return {
         code: (ends[code] if code in ends and ends[code] >= leader_flag else None)
         for code in frames_by_driver
     }
+
+
+def _leads_at(code: str, frame: int, ends: dict[str, int], progress_at: ProgressAt) -> bool:
+    """Is `code` the furthest-along car at `frame`?
+
+    A car past its own end is frozen, which is exactly right here: it has
+    stopped gaining ground and the cars still running go past it.
+    """
+    mine = progress_at(code, frame)
+    if mine is None:
+        return False
+    return all(
+        (other := progress_at(rival, frame)) is None or other <= mine
+        for rival in ends
+        if rival != code
+    )
 
 
 class RaceGapCalculator:
@@ -197,10 +238,21 @@ class RaceGapCalculator:
         self._crossing_frames: dict[str, np.ndarray] = {}
         self._dist: dict[str, np.ndarray] = {}
         self._default_lap_m = float(session.circuit_length_m or 0.0)
-        flag_frames = _flag_frames(session.frames_by_driver, int(session.max_lap_number or 0))
-        self._finished: dict[str, bool] = {
-            code: frame is not None for code, frame in flag_frames.items()
-        }
+        self._finished: dict[str, bool] = {}
+        # TWO passes, and the order is the whole point. Deciding who took
+        # the flag needs the race order, the race order needs `progress`,
+        # and `progress` reads the crossings - so the crossings are built
+        # once WITHOUT flags, the flags are decided against that, and only
+        # then are they added. Doing it in one pass is what let a car that
+        # crashed on the final lap define the flag time for everyone.
+        self._build_crossings(session, flag_frames={})
+        flag_frames = _flag_frames(
+            session.frames_by_driver, int(session.max_lap_number or 0), self.progress
+        )
+        self._finished = {code: frame is not None for code, frame in flag_frames.items()}
+        self._build_crossings(session, flag_frames)
+
+    def _build_crossings(self, session: SessionData, flag_frames: dict[str, int | None]) -> None:
         for code, frames in session.frames_by_driver.items():
             crossings = self._lap_crossings(frames, flag_frames.get(code))
             self._crossings[code] = crossings

--- a/tests/surfaces/test_arcade_leaderboard_gaps.py
+++ b/tests/surfaces/test_arcade_leaderboard_gaps.py
@@ -588,6 +588,51 @@ def test_a_lapped_car_that_takes_the_flag_is_a_finisher_on_its_own_lap():
     assert _order(session, idx) == ["P1", "P2", "P3", "LAPPED"]
 
 
+def test_a_car_that_retires_on_the_final_lap_does_not_take_the_flag():
+    """It set the flag time for everyone and was then drawn P1, ahead of the winner.
+
+    "The leader is the first car to reach the final lap" reads a car that
+    crashes a fifth of the way into it as the winner: its telemetry ends
+    first, so it defined the flag, it was credited a crossing of a lap it
+    never completed, and the tie-break put it top for the whole
+    flag-to-end window. Executed before the fix, the order was
+    `[CRASH, WIN, P2]`.
+
+    The rule that holds is that the flag is taken by the car LEADING when
+    its telemetry ends. Melbourne 2025 has no final-lap retirement, so the
+    broken version measured perfectly on the only race on disk.
+    """
+    crash = _car(50.0, head_start_laps=-0.30, dead_from=6200)
+    session = _finish_session(CRASH=crash)
+    idx = N_FRAMES - 1
+    gaps = RaceGapCalculator(session)
+
+    assert session.frames_by_driver["CRASH"][idx].lap == RACE_LAPS, "it DID reach the final lap"
+    assert gaps.has_finished("CRASH") is False
+    assert gaps.has_finished("P1") is True
+    assert gaps.laps_completed("CRASH", idx) == RACE_LAPS - 1, (
+        "no crossing of the lap it stopped on"
+    )
+    assert _order(session, idx) == ["P1", "P2", "P3", "CRASH"]
+    assert "CRASH OUT" in _labels(session, "P3", idx)
+
+
+def test_the_leader_still_takes_the_flag_when_a_slower_car_ends_first():
+    """The guard must not turn every early ending into a retirement.
+
+    A car a lap down stops producing telemetry before the leader does, on
+    a lap the leader has already passed. It is not leading, so it does not
+    set the flag - and it is also not a finisher, because its telemetry
+    ended before the leader's. Both halves have to hold at once.
+    """
+    session = _finish_session(LAPPED=_car(33.34, dead_from=7498))
+    gaps = RaceGapCalculator(session)
+
+    assert gaps.has_finished("P1") is True, "the leader still takes the flag"
+    assert gaps.has_finished("LAPPED") is True, "and a lapped finisher still finishes"
+    assert gaps.laps_completed("P1", N_FRAMES - 1) == RACE_LAPS
+
+
 def test_without_a_known_final_lap_nobody_is_a_finisher():
     """`max_lap_number` of 0 is what an older cache carries.
 

--- a/tests/surfaces/test_arcade_wire_contract.py
+++ b/tests/surfaces/test_arcade_wire_contract.py
@@ -520,6 +520,39 @@ def test_the_per_agent_fixture_uses_the_producers_real_field_names():
         )
 
 
+def test_the_dev_producer_uses_the_same_real_field_names():
+    """The twin. #853 fixed the fixture AND the producer; only one got a guard.
+
+    `scripts/dev_pitwall_producer.py` is what every PITWALL sprint develops
+    against, and sprints 4 to 6 will edit it. Guarding the fixture and not
+    the producer leaves unprotected the exact file whose invented keys made
+    the reference window render `pred 0.00s` for a whole sprint.
+
+    Read with `ast`, like the fixture guard: importing the producer loads a
+    session and opens a socket.
+    """
+    source = (REPO_ROOT / "scripts" / "dev_pitwall_producer.py").read_text(encoding="utf-8")
+    call = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call) and getattr(node.func, "id", "") == "PerAgentOutputsDTO"
+    )
+    blocks = {
+        keyword.arg: {key.value for key in keyword.value.keys}
+        for keyword in call.keywords
+        if isinstance(keyword.value, ast.Dict)
+    }
+
+    for block, (path, class_name) in _PER_AGENT_SOURCES.items():
+        assert block in blocks, f"the producer stopped sending a {block} block"
+        unknown = blocks[block] - _dataclass_field_names(path, class_name)
+        assert not unknown, f"the dev producer invents {sorted(unknown)} in {block}"
+
+    active = next(keyword for keyword in call.keywords if keyword.arg == "active")
+    tokens = [element.value for element in active.value.elts]
+    assert tokens and all(t.startswith("N") and t[1:].isdigit() for t in tokens), tokens
+
+
 def test_the_routing_list_carries_agent_ids_and_not_block_names():
     """`active` gates the two conditional cards, and it is not the block keys.
 


### PR DESCRIPTION
## What

A car retiring **on the final lap** was classified a finisher and drawn **P1, ahead of the winner**. Found by a second adversarial audit run over the step-0 fixes themselves (AF-1, P2).

## Why it happened

#860 gave the replay a notion of a finisher, and made it distance-based: the leader's flag distance, then everyone past it. That cannot tell "reached the end of the race" from "stopped somewhere on the last lap", and the leader's own flag was picked as the largest `end` — which a car clamped mid-final-lap by the resampler also produces.

There is also a circular dependency underneath it: `_flag_frames` reads crossings, and the crossings need to know who finished. The first version resolved it by guessing.

## How

| Before | After |
|---|---|
| one construction pass, flag guessed from the largest `end` | two passes: build crossings with no flag info to learn each end, then rebuild with the real flag frames |
| flag = `max(ends)` | flag = the end of the car that is **leading at its own end** |
| `has_finished` = distance past a threshold | `has_finished` = presence at the flag |

## Checks

- synthetic race: `['CRASH','WIN','P2']` → `['WIN','P2','CRASH']`, retirement `has_finished=False`, renders **OUT**
- **Melbourne 2025 unchanged**: 14 finishers, same order, NOR-VER 0.880 s at the flag, NOR-RUS 8.480 s — the same numbers #862 measured against the official classification
- `tests/surfaces/test_arcade_leaderboard_gaps.py` 27 passed, two of them new
- one extra guard: the dev producer's `PerAgentOutputsDTO` field names, read with `ast`. #853 fixed the fixture *and* the producer and only the fixture got a test — the twin that never got the fix, again, in the file every remaining PITWALL sprint develops against.

## Out of scope

`has_finished` still does not reach the wire (AF-3, P3). It belongs with #857, the leaderboard payload, in sprint 4.

Closes #873
