### PR TITLE
fix(pitwall): keep the status bar up while streaming and stop the card clipping its tooltip

### DIFF
--- a/src/pitwall/agents_view/decision.py
+++ b/src/pitwall/agents_view/decision.py
@@ -166,6 +166,12 @@ def build_scenarios(scores: dict[str, Any] | None) -> list[dict[str, Any]]:
                 "key": key,
                 "label": SCENARIO_LABELS[key],
                 "fill": fill,
+                # The bar's width in per cent, to the 0.1 % Qt's gradient
+                # stop resolves to. Its twin one card up already came from
+                # here; this one was still scaling 0-1 in the renderer,
+                # unrounded, which is the arithmetic the view exists to
+                # keep out of it.
+                "fill_pct": round(fill * 100, 1),
                 "score": f"{value:+.2f}" if present else "  --",
                 "is_winner": is_winner,
                 "bar_colour": hex_str(ACCENT if is_winner else TEXT_SECONDARY),

--- a/src/pitwall/agents_view/reasoning.py
+++ b/src/pitwall/agents_view/reasoning.py
@@ -54,6 +54,8 @@ _RULES: tuple[tuple[re.Pattern[str], str, bool], ...] = (
     (re.compile(r"\b(PIT_NOW|STAY_OUT|UNDERCUT|OVERCUT)\b"), _ACTION, True),
 )
 
+_SEPARATORS = re.compile(r"(\r\n|\r|\n)")
+
 DEFAULT_COLOUR = hex_str(TEXT_PRIMARY)
 
 TABS: tuple[tuple[str, str], ...] = (
@@ -72,7 +74,8 @@ def highlight(text: str) -> list[dict[str, Any]]:
     **The rules are applied per LINE, not over the whole string.**
     `QSyntaxHighlighter.highlightBlock` is called once per paragraph, so a
     match can never span a newline in Qt - and two of the five rules
-    contain ``\\s``, which matches a newline. Whole-string matching
+    contain ``\\s``, which matches a newline (and a carriage return).
+    Whole-string matching
     therefore painted things Qt leaves plain: measured, a body carrying
     ``extend the lap`` then ``22 target`` on the next line came out with
     the two joined and painted in the lap colour, where Qt paints nothing,
@@ -87,13 +90,19 @@ def highlight(text: str) -> list[dict[str, Any]]:
     colours: list[str | None] = [None] * len(text)
     bolds = [False] * len(text)
     line_start = 0
-    for line in text.split("\n"):
+    # `QTextDocument.setPlainText` starts a new paragraph on \r\n and on a
+    # lone \r as well as on \n, so all three end a match here. Splitting on
+    # \n alone left the one separator Qt also breaks on.
+    for part in _SEPARATORS.split(text):
+        if _SEPARATORS.fullmatch(part):
+            line_start += len(part)
+            continue
         for pattern, colour, bold in _RULES:
-            for match in pattern.finditer(line):
+            for match in pattern.finditer(part):
                 for index in range(line_start + match.start(), line_start + match.end()):
                     colours[index] = colour
                     bolds[index] = bold
-        line_start += len(line) + 1
+        line_start += len(part)
 
     segments: list[dict[str, Any]] = []
     start = 0

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -169,9 +169,21 @@ const columns = await page.evaluate(
 );
 check(columns.startsWith("540px"), `left column is 540px (got ${columns})`);
 
-// The tooltip is a child of a card that scrolls; it must not be clipped
-// away, and it must only exist where the host sent content.
+// The tooltip must exist only where the host sent content, and it must not
+// be clipped by the card. Those two fought each other once: the whole-card
+// hover target put the popup inside a card that had just been given
+// `overflow: auto`, and a 502 px transcript in a 375 px card lost the first
+// 140 px of every line, unreachably — overflow to the LEFT of a scroll box
+// cannot even be scrolled to.
 check((await page.locator(".agent-tooltip").count()) === 1, "one tooltip, on RADIO only");
+const clipping = await page.evaluate(() => {
+  const tooltip = document.querySelector(".agent-tooltip");
+  const card = tooltip.closest(".agent-card");
+  const scroller = tooltip.closest(".agent-card-body");
+  return { cardOverflow: getComputedStyle(card).overflowX, insideTheScroller: Boolean(scroller) };
+});
+check(clipping.cardOverflow === "visible", `the card does not clip (got ${clipping.cardOverflow})`);
+check(!clipping.insideTheScroller, "the tooltip is outside the scrolling box");
 
 // Qt's `showMessage(text, 1500)` clears itself. The port typed a
 // `transient` flag and read it nowhere until #871.
@@ -183,6 +195,38 @@ await page.waitForTimeout(1800);
 check((await page.locator(".status-bar").innerText()).trim() === "", "the status bar auto-clears");
 
 await ctx.close();
+
+// --- and it must NOT clear while the producer is still talking --------------
+//
+// Qt re-arms `showMessage` on every broadcast, so the message is visible
+// the whole time it is streaming. Keyed on the text instead of the tick it
+// re-armed once per LAP, and the bar sat blank for the other eighty
+// seconds of it. The settled stub above cannot see that: it is the dead
+// producer, the case that already worked.
+const live = await browser.newContext({ viewport: { width: 1320, height: 900 } });
+const livePage = await live.newPage();
+await livePage.addInitScript((view) => {
+  let seq = 0;
+  window.pywebview = {
+    api: {
+      // A new sequence every poll, with the SAME status text, which is
+      // what a real producer does for the ~85 s a lap lasts.
+      get_agents_view: async () => ({ ...view, seq: ++seq }),
+      get_tick: async () => null,
+    },
+  };
+}, VIEW);
+await livePage.goto(`http://127.0.0.1:${server.address().port}/agents.html`, {
+  waitUntil: "domcontentloaded",
+});
+await livePage.waitForSelector(".status-bar", { timeout: 5000 });
+await livePage.waitForTimeout(2500);
+check(
+  (await livePage.locator(".status-bar").innerText()).includes("lap 23"),
+  "the status bar stays visible while the producer streams",
+);
+await live.close();
+
 await browser.close();
 server.close();
 
@@ -191,4 +235,4 @@ if (failures.length) {
   for (const failure of failures) console.error(`  - ${failure}`);
   process.exit(1);
 }
-console.log("smoke OK: 10 checks");
+console.log("smoke OK: 13 checks");

--- a/src/pitwall/ui/src/features/agents/AgentCard.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentCard.tsx
@@ -41,22 +41,30 @@ export function AgentCard({
         <span className="agent-tooltip" dangerouslySetInnerHTML={{ __html: card.tooltip }} />
       ) : null}
 
-      <p
-        className="agent-headline"
-        style={{ color: card.headline_colour }}
-        dangerouslySetInnerHTML={{ __html: card.headline }}
-      />
-
-      {card.lines.map((line, index) => (
+      {/* The scroll lives on this box, not on the card. An absolutely
+          positioned popup is clipped by any positioned ancestor that
+          scrolls, and overflow to the LEFT of a scroll container cannot
+          even be scrolled to: measured, a 502 px transcript inside a
+          375 px card lost the first 140 px of every line, unreachably.
+          Qt uses a native QToolTip, which floats above everything. */}
+      <div className="agent-card-body">
         <p
-          key={index}
-          className="agent-line"
-          style={{ color: line.colour }}
-          dangerouslySetInnerHTML={{ __html: line.text }}
+          className="agent-headline"
+          style={{ color: card.headline_colour }}
+          dangerouslySetInnerHTML={{ __html: card.headline }}
         />
-      ))}
 
-      {children ? <div className="agent-chart">{children}</div> : null}
+        {card.lines.map((line, index) => (
+          <p
+            key={index}
+            className="agent-line"
+            style={{ color: line.colour }}
+            dangerouslySetInnerHTML={{ __html: line.text }}
+          />
+        ))}
+
+        {children ? <div className="agent-chart">{children}</div> : null}
+      </div>
     </section>
   );
 }

--- a/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentsWindow.tsx
@@ -10,12 +10,14 @@
  * tabs about 268 px, so the decision-memory counterweight sentence fell
  * below the fold on the one lap it matters. CSS has no fixed heights.
  *
- * Before the first view arrives the window renders the state the Qt
- * window shows AT CONSTRUCTION, rather than a spinner. That is not the
- * same as `update_from(None)`: the badge is ACCENT purple, the plan line
- * uses em-dashes and the scenario scores read "0%". `_render_idle` is
- * what Qt paints once a tick with no decision has arrived, which is a
- * different moment.
+ * Before the first view arrives the window renders what the Qt window
+ * shows at startup, rather than a spinner. That is not the same as
+ * `update_from(None)`: the badge is ACCENT purple, the plan line uses
+ * em-dashes and the scenario scores read "0%" — `_render_idle` is what Qt
+ * paints once a tick with no decision has arrived, a different moment.
+ * The connection chip is the one field taken from Qt's FIRST PAINTED
+ * FRAME rather than from its constructor, because the constructor's grey
+ * lasts milliseconds and is not a state anybody sees.
  */
 
 import { useEffect, useState } from "react";
@@ -57,8 +59,13 @@ const IDLE_VIEW: AgentsView = {
     driver: "--",
     lap: "L 0/0",
     playback: "-- × · --",
-    connection: "Disconnected",
-    connection_colour: "#ef4444",
+    // Qt builds the chip grey in the constructor and its client thread
+    // flips it to amber within milliseconds; the host's own
+    // `_connection_label` answers "Connecting..." until something has been
+    // rendered. Red "Disconnected" matched none of the three. #871 ported
+    // the badge, the plan line and the scores and left this one behind.
+    connection: "Connecting...",
+    connection_colour: "#f59e0b",
   },
   orchestrator: {
     action: "--",
@@ -84,6 +91,7 @@ const IDLE_VIEW: AgentsView = {
     key,
     label,
     fill: 0,
+    fill_pct: 0,
     score: "  0%",
     is_winner: false,
     bar_colour: "#d1d5db",
@@ -131,10 +139,20 @@ const IDLE_VIEW: AgentsView = {
  * dies goes quiet within a second and a half. The port typed a
  * `transient` flag, documented it, and read it nowhere — so a dead
  * producer kept saying "lap N · streaming" forever under a red
- * Disconnected chip. An error message is NOT transient: Qt gives that one
- * no timeout, because it is the one you must still be able to read.
+ * Disconnected chip.
+ *
+ * **The timer is keyed on `seq`, not on the text.** Qt re-arms
+ * `showMessage` on EVERY broadcast, ten times a second, so the message
+ * stays visible while streaming and clears 1.5 s after the last tick.
+ * Keyed on the text it re-arms once per LAP, because the string does not
+ * change in between — so the bar went blank 1.5 s into every lap and
+ * stayed blank for the other eighty-odd seconds of it. That is the same
+ * bug inverted, and the first version of this hook shipped it.
+ *
+ * An error message is NOT transient: Qt gives that one no timeout,
+ * because it is the one you must still be able to read.
  */
-function useStatusText(status: { text: string; transient: boolean }): string {
+function useStatusText(status: { text: string; transient: boolean }, seq: number | null): string {
   const [shown, setShown] = useState(status.text);
 
   useEffect(() => {
@@ -142,7 +160,7 @@ function useStatusText(status: { text: string; transient: boolean }): string {
     if (!status.transient) return;
     const timer = window.setTimeout(() => setShown(""), 1500);
     return () => window.clearTimeout(timer);
-  }, [status.text, status.transient]);
+  }, [seq, status.text, status.transient]);
 
   return shown;
 }
@@ -150,7 +168,7 @@ function useStatusText(status: { text: string; transient: boolean }): string {
 export function AgentsWindow() {
   const { view } = useAgentsView();
   const shown = view ?? IDLE_VIEW;
-  const statusText = useStatusText(shown.status_bar);
+  const statusText = useStatusText(shown.status_bar, shown.seq);
 
   return (
     <div className="agents-window">

--- a/src/pitwall/ui/src/features/agents/ScenarioBars.tsx
+++ b/src/pitwall/ui/src/features/agents/ScenarioBars.tsx
@@ -22,7 +22,7 @@ export function ScenarioBars({ rows }: { rows: ScenarioRow[] }) {
           <span className="scenario-bar">
             <span
               className="scenario-bar-fill"
-              style={{ width: `${row.fill * 100}%`, background: row.bar_colour }}
+              style={{ width: `${row.fill_pct}%`, background: row.bar_colour }}
             />
           </span>
           <span className="scenario-score" style={{ color: row.score_colour }}>

--- a/src/pitwall/ui/src/lib/agents.ts
+++ b/src/pitwall/ui/src/lib/agents.ts
@@ -79,6 +79,8 @@ export interface ScenarioRow {
   label: string;
   /** Min-max normalised across the scenarios present, already clamped. */
   fill: number;
+  /** The same value as a percentage, rounded host side; this is the width. */
+  fill_pct: number;
   score: string;
   is_winner: boolean;
   bar_colour: string;

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -128,10 +128,12 @@ body {
 }
 .agent-card {
   position: relative;
-  /* Qt clips a card that overflows its cap - the migration README records
-   * the right column being "clipped mid-card" at the default geometry.
-   * Scrolling keeps the same footprint and stops the content being lost. */
-  overflow: auto;
+  /* The scroll is on `.agent-card-body`, not here: a positioned ancestor
+   * that scrolls clips the tooltip popup, and its left overflow is not
+   * even reachable. Qt clips a card that overflows its cap - the
+   * migration README records the right column "clipped mid-card" - so the
+   * footprint is the same and the content stays reachable. */
+  overflow: visible;
   padding: 10px 12px;
   display: flex;
   flex-direction: column;
@@ -146,6 +148,14 @@ body {
  * Deleting it would mean reproducing a toolkit limitation on purpose. */
 .agent-card.is-idle {
   opacity: 0.45;
+}
+.agent-card-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 .agent-card-head {
   display: flex;
@@ -395,9 +405,11 @@ body {
 
 /* --- The two embedded charts --------------------------------------------- */
 
-/* Qt gives a card with a chart a 260-420 px height band; here the grid row
- * grows and the chart takes what is left, which is the same intent without
- * the two magic numbers. */
+/* The 260-420 band lives on the grid row (`.agents-right`), which carries
+ * Qt's own caps; inside it the chart takes whatever the text leaves. An
+ * earlier version of this comment said the row grew freely and that the
+ * two magic numbers were absent - #871 put them in the sheet three
+ * hundred lines above and left the sentence standing. */
 .chart {
   width: 100%;
   height: 100%;

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -777,9 +777,18 @@ def test_a_rule_cannot_paint_across_a_line_break():
     """
     from src.pitwall.agents_view.reasoning import DEFAULT_COLOUR, highlight
 
-    for text in ("extend the lap\n22 target", "the delta is +0.42\ns behind"):
-        painted = [seg["text"] for seg in highlight(text) if seg["colour"] != DEFAULT_COLOUR]
-        assert painted == [], f"{text!r} must paint nothing, as Qt does"
+    # `QTextDocument.setPlainText` starts a paragraph on \r\n and on a lone
+    # \r as well, so all three end a match. Splitting on \n alone left the
+    # carriage return, which is the separator an old-Mac memory block uses.
+    separators = ("\n", "\r\n", "\r")
+    for separator in separators:
+        for text in (
+            f"extend the lap{separator}22 target",
+            f"the delta is +0.42{separator}s behind",
+        ):
+            painted = [seg["text"] for seg in highlight(text) if seg["colour"] != DEFAULT_COLOUR]
+            assert painted == [], f"{text!r} must paint nothing, as Qt does"
+            assert "".join(seg["text"] for seg in highlight(text)) == text, "no character lost"
 
     # The same tokens on one line still paint, so the fix did not disable them.
     on_one_line = {seg["text"] for seg in highlight("lap 22 and +0.42 s") if seg["bold"] is False}

--- a/tests/surfaces/test_pitwall_tokens.py
+++ b/tests/surfaces/test_pitwall_tokens.py
@@ -211,25 +211,74 @@ def test_the_agents_css_palette_has_not_drifted_from_palette_py():
         )
 
 
-def test_the_boot_state_literals_have_not_drifted_from_palette_py():
+# The boot state's colours, SLOT BY SLOT. Membership in the palette is not
+# enough: swapping the badge from ACCENT to DANGER keeps every hex inside
+# the palette and still boots the window in the wrong colour. Measured on a
+# mutated source before this map existed — the membership version passed.
+BOOT_SLOTS = {
+    "action_colour": "ACCENT",
+    "confidence_colour": "TEXT_TERTIARY",
+    "pace_colour": "TEXT_TERTIARY",
+    "risk_colour": "TEXT_TERTIARY",
+    "connection_colour": "WARNING",
+    "bar_colour": "TEXT_SECONDARY",
+    "label_colour": "TEXT_SECONDARY",
+    "score_colour": "TEXT_SECONDARY",
+    "glyph_colour": "TEXT_TERTIARY",
+    "headline_colour": "TEXT_PRIMARY",
+    "actual_colour": "INFO",
+    "pred_colour": "ACCENT",
+    "band_colour": "ACCENT",
+    "trend_colour": "TEXT_PRIMARY",
+    "cliff_colour": "WARNING",
+    "boundary_colour": "TEXT_TERTIARY",
+}
+
+# Copy number five, which had no detector at all: the ECharts axis styling
+# repeats the pens `pace_chart.py` builds from the same two names.
+ECHART_MODULE = (
+    REPO_ROOT / "src" / "pitwall" / "ui" / "src" / "features" / "agents" / "useEChart.ts"
+)
+ECHART_NAMES = ("TEXT_SECONDARY", "BORDER_COLOR")
+
+
+def test_the_boot_state_colours_are_in_the_right_slots():
     """Copy number four: the state the window paints before the first tick.
 
     It cannot come from the host — there is no host answer yet — so the
-    colours are literals in TSX. Every one must still be a colour the
-    palette actually has, or the window boots in a shade nothing else uses.
+    colours are literals in TSX, and each one copies a specific palette
+    name. Asserting only that a hex is SOMEWHERE in the palette lets a
+    wrong-but-known colour through, which is the failure mode a membership
+    test always has.
     """
     from src.arcade import palette
 
-    known = {
-        _rgb_to_hex(getattr(palette, name))
-        for name in dir(palette)
-        if name.isupper()
-        and isinstance(getattr(palette, name), tuple)
-        and len(getattr(palette, name)) == 3
-    }
-    literals = set(re.findall(r'"(#[0-9a-fA-F]{6})"', AGENTS_WINDOW.read_text("utf-8")))
+    source = AGENTS_WINDOW.read_text("utf-8")
+    found = dict(re.findall(r'(\w*_?colour)"?:\s*"(#[0-9a-fA-F]{6})"', source))
 
-    assert literals, (
-        "the boot state stopped carrying colours; is this test still checking anything?"
+    assert set(BOOT_SLOTS) <= set(found), (
+        f"a boot colour slot disappeared: {sorted(set(BOOT_SLOTS) - set(found))}"
     )
-    assert literals <= known, f"boot colours not in the palette: {sorted(literals - known)}"
+    for slot, name in BOOT_SLOTS.items():
+        assert found[slot] == _rgb_to_hex(getattr(palette, name)), (
+            f"{slot} is {found[slot]}, but it copies palette.{name} "
+            f"({_rgb_to_hex(getattr(palette, name))})"
+        )
+
+
+def test_the_chart_axis_palette_has_not_drifted_either():
+    """The fifth copy, and nothing referenced this file before.
+
+    `useEChart.ts` repeats the axis pens `pace_chart.py` builds from
+    BORDER_COLOR and TEXT_SECONDARY. Same duplication as the other four,
+    and it had no guard at all.
+    """
+    from src.arcade import palette
+
+    literals = set(re.findall(r'"(#[0-9a-fA-F]{6})"', ECHART_MODULE.read_text("utf-8")))
+    expected = {_rgb_to_hex(getattr(palette, name)) for name in ECHART_NAMES}
+
+    assert literals, "the chart theme stopped carrying colours"
+    assert literals == expected, (
+        f"the chart axis palette drifted: {sorted(literals)} against {sorted(expected)}"
+    )


### PR DESCRIPTION
## What

Three render defects a second adversarial audit found **in the sprint-3 exit-gate fixes themselves** (#871), plus four P3s. Two of #871's own fixes turned out to break each other.

Every one of these ships green: the 35 view tests pin the dict `PitwallHost` sends, and none of these defects is in the dict.

## The three

| # | Sev | Defect | Fix |
|---|---|---|---|
| A-01 | P1 | The status bar **blanks mid-lap while the producer is streaming**. The timer was keyed on the text, and the text does not change within a lap — so it re-armed once per lap, cleared 1.5 s in, and stayed blank for the other eighty seconds. That is #871's own bug inverted. | key the timer on `seq`; Qt re-arms `showMessage` on every broadcast |
| A-02 | P2 | The RADIO tooltip is **clipped by its own card**. #871 made the whole card the hover target and gave the card `overflow: auto` in the same PR; a 502 px transcript in a 375 px card lost the first 140 px of every line, unreachably — overflow to the *left* of a scroll box cannot be scrolled to. | the scroll moves into a new `.agent-card-body`; the card returns to `overflow: visible`. The tooltip is a sibling of the scroll box, so neither element clips it |
| A-03 | P2 | The boot connection chip is **the twin that never got the fix**. #871 ported the badge, the plan line and the scores from Qt's first painted frame and left the chip on red `Disconnected`, which matches none of Qt's three startup states. | `"Connecting..." / #f59e0b`, which is what the host's own `_connection_label` answers |

## The four P3s

- **A-04** — the highlighter split paragraphs on `\n` only. `QTextDocument.setPlainText` also starts one on `\r\n` and on a lone `\r`.
- **A-05** — `ScenarioBars` recomputed the bar width in TSX from a ratio Python already knows. `fill_pct` now comes from `decision.py`.
- **A-06** — the boot-colour guard asserted **membership** in the palette, so swapping the badge from ACCENT to DANGER passed it. Measured on a mutated source: it did pass. Now slot-wise. And `useEChart.ts`, the fifth copy of the palette, had no guard at all.
- **A-07** — a comment #871 itself made false.

## Checks

- `smoke OK: 13 checks` — two new, both **verified red first**: with `seq` out of the dependency array the live-producer phase fails; with the pre-#871 stylesheet the clipping check fails
- `tests/surfaces` 139 passed (`test_cli_no_llm` fails locally on the curated `data/` download, not on this branch)
- `ruff check` clean, `ruff format --check` clean on every touched file

Closes #874
