### PR TITLE
fix(arcade): bump the cache tag the pedal fix cannot otherwise reach

### DIFF
--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -158,7 +158,11 @@ FLAG_COLORS: Final[dict[str, tuple[int, int, int]]] = {
 REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
 FASTF1_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "fastf1"
 ARCADE_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "arcade"
-CACHE_VERSION: Final[str] = "v10"  # pedal scale per session, rel_dist from dist, has_position
+# v11: the all-NaN pedal channel fix, which runs at BUILD time. A v10 cache
+# built before it has the wrong multiplier baked in and the fix cannot reach
+# it; the same commit also dropped `rel_dist` from the cached arrays, so two
+# incompatible payloads were sharing one tag.
+CACHE_VERSION: Final[str] = "v11"  # pedal peak ignores NaN, rel_dist no longer cached
 
 # --- Multiprocessing pool -------------------------------------------------
 # Serial by default — Windows spawn + pickling a loaded session across 8

--- a/src/arcade/stream.py
+++ b/src/arcade/stream.py
@@ -95,20 +95,31 @@ def _blame(value, path: str = "") -> str:
     `np.int64` and `np.bool_` are not `float`/`int`/`bool` subclasses, so
     they slip past the sanitiser, kill the whole tick, and used to leave
     this function returning the empty string exactly when it was needed.
+
+    **The oracle is the encoder, not an allowlist.** An allowlist of
+    `str/int/float/bool/None` blames a tuple, which `json.dumps` encodes
+    perfectly well as an array — and because the first blame wins, a
+    payload carrying both a tuple and a real culprit named the tuple and
+    never reached the culprit. The drop log then pointed at an innocent
+    field while the tick that died stayed unexplained.
     """
     if isinstance(value, dict):
         for key, item in value.items():
             found = _blame(item, f"{path}.{key}" if path else str(key))
             if found:
                 return found
-    elif isinstance(value, list):
+        return ""
+    if isinstance(value, (list, tuple)):
         for index, item in enumerate(value):
             found = _blame(item, f"{path}[{index}]")
             if found:
                 return found
-    elif isinstance(value, float) and not math.isfinite(value):
+        return ""
+    if isinstance(value, float) and not math.isfinite(value):
         return f"{path or '<root>'}={value}"
-    elif not isinstance(value, (str, int, float, bool, type(None))):
+    try:
+        json.dumps(value)
+    except (TypeError, ValueError):
         return f"{path or '<root>'}=<{type(value).__name__}>"
     return ""
 

--- a/tests/surfaces/test_arcade_leaderboard_gaps.py
+++ b/tests/surfaces/test_arcade_leaderboard_gaps.py
@@ -343,7 +343,14 @@ def test_no_assumed_speed_constant_survives_in_the_gap_path():
 
 
 def test_laps_down_is_positional_and_survives_the_accumulation_drift():
-    """The case the `dist` form got wrong on 4.9 % of same-corner pairs.
+    """The case the `dist` form gets wrong.
+
+    The rate carried here used to be "4.9 % of same-corner pairs", which
+    is a number nothing in this repo measured: the figure #862 actually
+    published for same-corner disagreement is 3.4 % over n=4,934, under a
+    convention this docstring never stated. An unsourced percentage in a
+    test is how a wrong number gets quoted back as evidence, so it is gone
+    rather than swapped for one whose population may differ.
 
     Both cars sit at the same point on track, exactly one lap apart, and
     the lapped car runs long enough per lap that its `dist` deficit is

--- a/tests/surfaces/test_arcade_stream_server.py
+++ b/tests/surfaces/test_arcade_stream_server.py
@@ -135,3 +135,21 @@ def test_the_drop_log_names_the_leaf_the_encoder_choked_on():
     ):
         assert _blame({"per_agent": [{"pace": leaf}]}) == f"per_agent[0].pace=<{name}>"
     assert _blame({"a": 1, "b": "ok", "c": None, "d": True, "e": 1.5}) == ""
+
+
+def test_the_drop_log_does_not_blame_a_leaf_the_encoder_can_take():
+    """A tuple encodes as an array, and blaming it hid the real culprit.
+
+    The allowlist version answered `a=<tuple>` for a payload `json.dumps`
+    handles fine — and because the first blame wins, a payload carrying
+    both a tuple and a genuine culprit named the tuple and stopped. The
+    drop log accused an innocent field while the tick that actually died
+    went unexplained. The oracle is now the encoder itself.
+    """
+    import numpy as np
+
+    from src.arcade.stream import _blame
+
+    assert _blame({"a": (1, 2)}) == "", "a tuple is JSON-encodable"
+    assert _blame({"a": (1, 2), "b": np.float32("nan")}) == "b=<float32>", "reach the real one"
+    assert _blame({"a": ({"deep": np.int64(3)},)}) == "a[0].deep=<int64>", "recurse into tuples"


### PR DESCRIPTION
## What

The three P3 findings from the second adversarial audit round that were not folded into #875 / #876.

| # | Finding | Fix |
|---|---|---|
| AF-6 | **The all-NaN pedal fix cannot reach an already-built v10 cache.** `_pedal_multiplier` runs at *build* time, so a pickle written between `d24a59e` (v8→v10, the pedal-scale-per-session fix) and `9641cf1` (the NaN fix) has the wrong multiplier baked in and the fix silently does not apply. `9641cf1` also dropped `rel_dist` from the cached arrays without bumping, so two incompatible payloads were sharing one tag. | `CACHE_VERSION` → **v11** |
| AF-5 | **`_blame` accuses a leaf the encoder can take.** `json.dumps({"a": (1,2)})` is `{"a": [1, 2]}`, but the allowlist branch answered `a=<tuple>`. The first blame wins, so `{"a": (1,2), "b": np.float32("nan")}` named the tuple and **never reached the real culprit** — the drop log accused an innocent field while the tick that actually died went unexplained. | recurse into tuples; use `json.dumps` itself as the oracle instead of a type allowlist |
| AF-4 | An **unsourced 4.9 %** in a gaps docstring. Nothing in the repo measured it; the figure #862 published for same-corner disagreement is 3.4 % over n=4,934, under a convention the docstring never stated. | removed rather than swapped — the population may differ, and an unsourced percentage in a test is how a wrong number gets quoted back as evidence |

## Checks

Measured before and after, myself:

```
before   _blame({'a': (1,2)})                        -> 'a=<tuple>'
         _blame({'a': (1,2), 'b': np.float32('nan')}) -> 'a=<tuple>'   # culprit unreachable
after    _blame({'a': (1,2)})                        -> ''
         _blame({'a': (1,2), 'b': np.float32('nan')}) -> 'b=<float32>'
         _blame({'a': ({'deep': np.int64(3)},)})     -> 'a[0].deep=<int64>'
```

43 passed across the three touched test files, one of them new. `ruff check` and `ruff format --check` clean.

## Cost

The v11 bump makes the first launch of each GP pay one full reload, same as v10 did. That is the price of the fix reaching anyone who already ran a race on this branch.

## One finding deliberately NOT fixed here

**AF-3** — `has_finished` never reaches the wire. It belongs with #857 (the leaderboard payload) in sprint 4, not in a P3 cleanup.
