### PR TITLE
fix(pitwall,arcade): un-clip the tooltip for real and close the third audit round

### DIFF
--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -160,9 +160,13 @@ FASTF1_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "fastf1"
 ARCADE_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "arcade"
 # v11: the all-NaN pedal channel fix, which runs at BUILD time. A v10 cache
 # built before it has the wrong multiplier baked in and the fix cannot reach
-# it; the same commit also dropped `rel_dist` from the cached arrays, so two
-# incompatible payloads were sharing one tag.
-CACHE_VERSION: Final[str] = "v11"  # pedal peak ignores NaN, rel_dist no longer cached
+# it. That is the whole reason. (An earlier version of this comment added
+# "and rel_dist left the cached arrays" - false: `FrameData.rel_dist` is
+# still derived and pickled per frame. What #863 removed was the raw
+# `RelativeDistance` extraction in the worker intermediate, which nothing
+# had consumed since v10 and which left the cached bytes identical. A
+# maintainer trusting the old sentence would have deleted its readers.)
+CACHE_VERSION: Final[str] = "v11"  # pedal peak ignores NaN
 
 # --- Multiprocessing pool -------------------------------------------------
 # Serial by default — Windows spawn + pickling a loaded session across 8

--- a/src/arcade/gaps.py
+++ b/src/arcade/gaps.py
@@ -49,8 +49,11 @@ so the drift cancels instead of accumulating. See `progress`.
 
 The same drift is why `laps_down` cannot be a `dist` difference over a
 circuit length: over 4,934 same-corner pairs (within 2 % of a lap of each
-other) it disagrees with the positional answer on **3.4 %**, always in
-the direction that makes a lapped car read as a same-lap car.
+other) it disagrees with the positional answer on **3.4 %** — 169 pairs,
+measured as `int((d_front - d_back) / L)`, truncation toward zero, which
+is the convention this sentence used to leave unstated (a `//` floor
+gives 34.1 %). **Not "always"**: 148 of the 169 run in the direction that
+makes a lapped car read as a same-lap car, and 21 run the other way.
 
 Why the interval is at the line and not live
 --------------------------------------------
@@ -157,8 +160,31 @@ def _flag_frames(
     the other direction. Melbourne 2025 has no lapped finisher and no
     final-lap retirement, so both wrong versions measured perfectly on it.
 
-    What is left misclassified is a car that retires while leading, which
-    is a car that has already won everything except the last few metres.
+    **This rule does NOT hold in general, and an earlier version of this
+    paragraph claimed it did with one small residual. Two misses, both
+    measured (#879):**
+
+    1. *Any race whose leader retires on the final lap.* The retiree
+       anchors the flag, is credited the full race distance and is drawn
+       P1 above the actual winner — the exact rendering this code was
+       written to stop — and every car still moving past its stop,
+       **including later genuine retirees**, then reads as a finisher. Not
+       "the last few metres" either: a leader who stops at 40 % of the
+       final lap still anchors.
+    2. *A clean winner, whenever adjacent-lap noise exceeds the flag gap.*
+       At its own end a car's fraction is its final-lap distance over the
+       PREVIOUS lap's own length, and this file measures that per-car
+       variation at a median of 9.2 m and up to 340 m. A winner whose
+       previous lap ran long reads under 1.0; a rival whose previous lap
+       ran short clamps to 1.0 while still short of its line. Constructed
+       and executed: the winner reads `has_finished=False` and P2 takes
+       the flag. Melbourne 2025 survives on a 77 m margin, and both
+       ingredients are present in it.
+
+    There is no threshold-free rule that separates a noisy winner from a
+    final-lap crasher with what the loader caches today; #879 carries the
+    options, of which caching FastF1's official classification is the one
+    that ends the class rather than moving it.
 
     `final_lap` of 0 means the loader did not record one; nobody is then
     known to have finished, which is the honest answer and the behaviour

--- a/src/arcade/stream.py
+++ b/src/arcade/stream.py
@@ -73,10 +73,18 @@ def _json_safe(value):
     not depend on it keep updating, and None is a value every consumer
     already has to handle. `allow_nan=False` below is then the assertion
     that this worked, not the policy itself.
+
+    **Tuples walk with the lists.** `_blame` was taught them and this
+    function was not, so for one commit the pair disagreed about what is
+    encodable: a NaN inside a tuple survived sanitising, killed the whole
+    tick, and the paragraph above became false for exactly the container
+    the sibling had just learned. `json.dumps` writes a tuple as an array,
+    so returning a list changes no wire byte, and `dataclasses.asdict`
+    preserves tuples — the first tuple-typed model field arms it.
     """
     if isinstance(value, dict):
         return {key: _json_safe(item) for key, item in value.items()}
-    if isinstance(value, list):
+    if isinstance(value, (list, tuple)):
         return [_json_safe(item) for item in value]
     if isinstance(value, float) and not math.isfinite(value):
         return None
@@ -105,6 +113,13 @@ def _blame(value, path: str = "") -> str:
     """
     if isinstance(value, dict):
         for key, item in value.items():
+            # The encoder rejects a non-str/int/float/bool/None KEY too, and
+            # walking only the values left this blind to it - the same empty
+            # string the paragraph above says was the original bug, on a
+            # different input class. `{np.int64(lap): prob}` is one
+            # comprehension away from a `per_agent` block.
+            if not isinstance(key, (str, int, float, bool, type(None))):
+                return f"{path or '<root>'}.<key {key!r}>=<{type(key).__name__}>"
             found = _blame(item, f"{path}.{key}" if path else str(key))
             if found:
                 return found

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -64,6 +64,11 @@ const VIEW = {
     key: label,
     label,
     fill: index === 1 ? 1 : 0.4,
+    // #876 moved the bar width host-side to `fill_pct` and did not migrate
+    // this stub. React drops `width: undefined%`, so all four bars measured
+    // 382 px - winner and losers identical - and the smoke stayed green
+    // because it counted rows and never measured one.
+    fill_pct: index === 1 ? 100 : 40,
     score: "+0.71",
     is_winner: index === 1,
     bar_colour: index === 1 ? "#a78bfa" : "#d1d5db",
@@ -129,7 +134,13 @@ const VIEW = {
 };
 
 const failures = [];
+// Counted, not written down. Two artifacts in a row shipped a hand-typed
+// total that had drifted from the real one ("36 tests" over 35, then
+// "13 checks" over 12) - harmless until someone deletes a check and
+// trusts the number.
+let checks = 0;
 const check = (ok, what) => {
+  checks += 1;
   if (!ok) failures.push(what);
 };
 
@@ -160,6 +171,13 @@ check((await page.locator(".agent-card").count()) === 6, "six agent cards");
 check((await page.locator(".agent-chart canvas").count()) === 2, "two chart canvases");
 check((await page.locator(".reasoning-tab").count()) === 6, "six reasoning tabs");
 check((await page.locator(".scenario-row").count()) === 4, "four scenario rows");
+
+// ...and the winner's bar is actually wider. Counting rows passed over a
+// board where every bar rendered full width.
+const barWidths = await page.evaluate(() =>
+  [...document.querySelectorAll(".scenario-bar-fill")].map((el) => Math.round(el.getBoundingClientRect().width)),
+);
+check(barWidths[1] > barWidths[0] && barWidths[0] > 0, `the bars carry their fill (${barWidths})`);
 check(await page.locator(".orchestrator").isVisible(), "the orchestrator card");
 
 // Qt pins the left panel at 540 px and sends every extra pixel right
@@ -169,21 +187,32 @@ const columns = await page.evaluate(
 );
 check(columns.startsWith("540px"), `left column is 540px (got ${columns})`);
 
-// The tooltip must exist only where the host sent content, and it must not
-// be clipped by the card. Those two fought each other once: the whole-card
-// hover target put the popup inside a card that had just been given
-// `overflow: auto`, and a 502 px transcript in a 375 px card lost the first
-// 140 px of every line, unreachably — overflow to the LEFT of a scroll box
-// cannot even be scrolled to.
+// The tooltip must appear only where the host sent content, and NOTHING
+// may clip it. Two fixes failed here and the second was passed by a check
+// written right here: it asserted the card's `overflow` and the popup's
+// DOM placement — the MECHANISM — and never hovered or measured. The
+// popup had escaped the card and was being amputated 130 px by
+// `.agents-right` instead. So this hovers and measures the rendered box
+// against every scrolling ancestor, which is the EFFECT and the only
+// thing that was ever in question.
+check((await page.locator(".agent-tooltip").count()) === 0, "no tooltip before hover");
+await page.locator(".agent-card").nth(4).hover();
+await page.waitForTimeout(200);
 check((await page.locator(".agent-tooltip").count()) === 1, "one tooltip, on RADIO only");
-const clipping = await page.evaluate(() => {
-  const tooltip = document.querySelector(".agent-tooltip");
-  const card = tooltip.closest(".agent-card");
-  const scroller = tooltip.closest(".agent-card-body");
-  return { cardOverflow: getComputedStyle(card).overflowX, insideTheScroller: Boolean(scroller) };
+
+const clip = await page.evaluate(() => {
+  const box = document.querySelector(".agent-tooltip").getBoundingClientRect();
+  const cut = [];
+  for (let node = document.querySelector(".agent-tooltip").parentElement; node; node = node.parentElement) {
+    const style = getComputedStyle(node);
+    if (style.overflowX === "visible" && style.overflowY === "visible") continue;
+    const edge = node.getBoundingClientRect();
+    if (edge.left > box.left + 1 || edge.right < box.right - 1) cut.push(node.className || node.tagName);
+  }
+  return { cut, onScreen: box.left >= 0 && box.right <= window.innerWidth };
 });
-check(clipping.cardOverflow === "visible", `the card does not clip (got ${clipping.cardOverflow})`);
-check(!clipping.insideTheScroller, "the tooltip is outside the scrolling box");
+check(clip.cut.length === 0, `nothing clips the tooltip (cut by ${clip.cut.join(", ")})`);
+check(clip.onScreen, "the tooltip stays inside the viewport");
 
 // Qt's `showMessage(text, 1500)` clears itself. The port typed a
 // `transient` flag and read it nowhere until #871.
@@ -235,4 +264,4 @@ if (failures.length) {
   for (const failure of failures) console.error(`  - ${failure}`);
   process.exit(1);
 }
-console.log("smoke OK: 13 checks");
+console.log(`smoke OK: ${checks} checks`);

--- a/src/pitwall/ui/src/features/agents/AgentCard.tsx
+++ b/src/pitwall/ui/src/features/agents/AgentCard.tsx
@@ -13,7 +13,47 @@
  * 8 unpicks - not a licence to inject arbitrary markup here.
  */
 
+import { useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
 import type { AgentCardView } from "../../lib/agents";
+
+/**
+ * The popup, rendered OUTSIDE the window tree.
+ *
+ * **Two attempts got this wrong before, the same way.** An absolutely
+ * positioned popup is clipped by any scrolling ancestor, and overflow to
+ * the LEFT of a scroll box cannot even be scrolled to. The first fix put
+ * the scroll on the card; the second moved the scroll to
+ * `.agent-card-body` and the clip simply became the next ancestor up —
+ * `.agents-right`, which scrolls because Qt clips that column too. At
+ * 1320x900 it amputated 130 px off every transcript line, and the check
+ * that was supposed to catch it asserted the card's `overflow` and the
+ * popup's DOM placement — the mechanism, never the rendered box.
+ *
+ * A portal ends the class rather than moving it: Qt's `QToolTip` is a
+ * top-level window clipped by nothing, and `position: fixed` in the body
+ * is the same thing. The clamp keeps it on screen near either edge.
+ */
+function Tooltip({ html, anchor }: { html: string; anchor: DOMRect }) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [left, setLeft] = useState(anchor.left);
+
+  useLayoutEffect(() => {
+    const width = ref.current?.offsetWidth ?? 0;
+    setLeft(Math.max(8, Math.min(anchor.left, window.innerWidth - width - 8)));
+  }, [anchor]);
+
+  return createPortal(
+    <span
+      ref={ref}
+      className="agent-tooltip"
+      style={{ top: anchor.top + 32, left }}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />,
+    document.body,
+  );
+}
 
 export function AgentCard({
   title,
@@ -25,8 +65,16 @@ export function AgentCard({
   children?: React.ReactNode;
 }) {
   const idle = card.status === "IDLE";
+  // The whole card is the hover target, as in Qt, and an empty tooltip
+  // string is Qt's own convention for suppressing the popup.
+  const [anchor, setAnchor] = useState<DOMRect | null>(null);
+
   return (
-    <section className={idle ? "card agent-card is-idle" : "card agent-card"}>
+    <section
+      className={idle ? "card agent-card is-idle" : "card agent-card"}
+      onMouseEnter={(event) => card.tooltip && setAnchor(event.currentTarget.getBoundingClientRect())}
+      onMouseLeave={() => setAnchor(null)}
+    >
       <header className="agent-card-head">
         <span className="agent-glyph" style={{ color: card.glyph_colour }}>
           {card.glyph}
@@ -34,19 +82,13 @@ export function AgentCard({
         <span className="agent-title">{title}</span>
       </header>
 
-      {/* The whole card is the hover target, as in Qt, and nothing extra
-          is drawn. An empty string means no tooltip, which is Qt's own
-          convention for suppressing the popup. */}
-      {card.tooltip ? (
-        <span className="agent-tooltip" dangerouslySetInnerHTML={{ __html: card.tooltip }} />
-      ) : null}
+      {card.tooltip && anchor ? <Tooltip html={card.tooltip} anchor={anchor} /> : null}
 
-      {/* The scroll lives on this box, not on the card. An absolutely
-          positioned popup is clipped by any positioned ancestor that
-          scrolls, and overflow to the LEFT of a scroll container cannot
-          even be scrolled to: measured, a 502 px transcript inside a
-          375 px card lost the first 140 px of every line, unreachably.
-          Qt uses a native QToolTip, which floats above everything. */}
+      {/* The card scrolls here, not on the card itself, so the card is not
+          a scrolling ancestor of anything. Qt clips a card that overflows
+          its cap - the migration README records the right column "clipped
+          mid-card" - so the footprint matches and the content stays
+          reachable. */}
       <div className="agent-card-body">
         <p
           className="agent-headline"

--- a/src/pitwall/ui/src/styles/agents.css
+++ b/src/pitwall/ui/src/styles/agents.css
@@ -201,12 +201,15 @@ body {
   cursor: help;
 }
 .agent-tooltip {
-  display: none;
-  position: absolute;
-  top: 32px;
-  right: 12px;
+  /* `fixed`, in the body, via a portal: nothing in the window tree can
+   * clip it. Two earlier fixes kept it inside the card and only moved
+   * which ancestor did the clipping. `top`/`left` come from the hovered
+   * card's rect, so there is no `:hover` rule here - the card mounts and
+   * unmounts the popup. */
+  position: fixed;
   z-index: 10;
   width: 30rem;
+  max-width: calc(100vw - 16px);
   max-height: 22rem;
   overflow: auto;
   padding: 8px 10px;
@@ -218,9 +221,6 @@ body {
   font-weight: 400;
   text-align: left;
   line-height: 1.5;
-}
-.agent-card:hover .agent-tooltip {
-  display: block;
 }
 
 /* --- Status bar --------------------------------------------------------- */

--- a/tests/surfaces/test_arcade_leaderboard_gaps.py
+++ b/tests/surfaces/test_arcade_leaderboard_gaps.py
@@ -624,13 +624,18 @@ def test_a_car_that_retires_on_the_final_lap_does_not_take_the_flag():
     assert "CRASH OUT" in _labels(session, "P3", idx)
 
 
-def test_the_leader_still_takes_the_flag_when_a_slower_car_ends_first():
-    """The guard must not turn every early ending into a retirement.
+def test_a_lapped_car_neither_sets_the_flag_nor_loses_its_finish():
+    """The guard must not turn a lapped finisher into a retirement.
 
-    A car a lap down stops producing telemetry before the leader does, on
-    a lap the leader has already passed. It is not leading, so it does not
-    set the flag - and it is also not a finisher, because its telemetry
-    ended before the leader's. Both halves have to hold at once.
+    A car a lap down runs to the end on a lap the leader has already
+    passed. It is never leading, so it must not set the flag; and it took
+    the chequered flag all the same, so it must still read as a finisher.
+    Both halves have to hold at once.
+
+    The name and the docstring used to say the opposite of the asserts -
+    "ends first" for a car that ends 49 frames LATER, and "not a finisher"
+    directly above `has_finished("LAPPED") is True`. A test whose prose
+    contradicts its body is how the wrong behaviour gets defended later.
     """
     session = _finish_session(LAPPED=_car(33.34, dead_from=7498))
     gaps = RaceGapCalculator(session)

--- a/tests/surfaces/test_arcade_stream_server.py
+++ b/tests/surfaces/test_arcade_stream_server.py
@@ -153,3 +153,42 @@ def test_the_drop_log_does_not_blame_a_leaf_the_encoder_can_take():
     assert _blame({"a": (1, 2)}) == "", "a tuple is JSON-encodable"
     assert _blame({"a": (1, 2), "b": np.float32("nan")}) == "b=<float32>", "reach the real one"
     assert _blame({"a": ({"deep": np.int64(3)},)}) == "a[0].deep=<int64>", "recurse into tuples"
+
+
+def test_the_drop_log_names_an_unencodable_dict_KEY_too():
+    """The encoder rejects keys as well, and the walker only read values.
+
+    So the whole class came back on a different input: `{np.int64(lap):
+    prob}` is one comprehension away from a `per_agent` block, it kills
+    the tick, and the log printed the same empty suffix the function was
+    rewritten to stop printing.
+    """
+    import numpy as np
+
+    from src.arcade.stream import _blame
+
+    assert _blame({np.int64(3): "score"}) == "<root>.<key 3>=<int64>"
+    assert _blame({"b": {b"raw": 1}}) == "b.<key b'raw'>=<bytes>"
+
+
+def test_the_sanitiser_walks_tuples_like_the_blame_function_does():
+    """The twin. One walker learned tuples and the other did not.
+
+    `_json_safe` promises "one unusable model output should cost that
+    field, not the whole tick". For one commit that was false for exactly
+    the container `_blame` had just been taught: a NaN inside a tuple
+    survived sanitising and killed the broadcast. `dataclasses.asdict`
+    preserves tuples, so the first tuple-typed model field arms it.
+    """
+    import json
+    import math
+
+    from src.arcade.stream import _json_safe
+
+    cleaned = _json_safe({"quantiles": (1.0, float("nan"), 3.0)})
+
+    assert cleaned == {"quantiles": [1.0, None, 3.0]}, "the NaN became None, the tuple a list"
+    assert json.dumps(cleaned, allow_nan=False), "and the payload now encodes"
+    assert not any(
+        isinstance(v, float) and not math.isfinite(v) for v in cleaned["quantiles"] if v is not None
+    )

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -477,6 +477,33 @@ def test_the_scenario_bars_normalise_across_scores_that_are_all_negative():
     assert rows["STAY_OUT"]["bar_colour"] == "#d1d5db"
 
 
+def test_the_percentage_the_bar_actually_renders_is_on_the_0_to_100_scale():
+    """`fill_pct` is the number the stylesheet consumes, and nothing pinned it.
+
+    #876 moved this arithmetic out of TSX so it would be testable and then
+    tested `fill` instead, which no longer renders anything: regressing
+    `fill_pct` to `round(fill, 1)` left every Python test and the browser
+    smoke green while every bar drew at under one percent. The scale is
+    the whole point of the field, so it is what this asserts.
+    """
+    from src.pitwall.agents_view.decision import build_scenarios
+
+    rows = {
+        row["key"]: row
+        for row in build_scenarios(
+            {"STAY_OUT": -0.90, "PIT_NOW": -0.10, "UNDERCUT": -0.50, "OVERCUT": -1.30}
+        )
+    }
+
+    assert rows["PIT_NOW"]["fill_pct"] == 100.0, "the winner fills the bar, in percent"
+    assert rows["OVERCUT"]["fill_pct"] == 0.0
+    assert rows["UNDERCUT"]["fill_pct"] == pytest.approx(66.7, abs=0.05)
+    for row in rows.values():
+        assert row["fill_pct"] == pytest.approx(row["fill"] * 100, abs=0.05), (
+            "the two fields must agree; they are one number in two units"
+        )
+
+
 def test_a_scenario_the_orchestrator_did_not_score_draws_nothing_and_prints_dashes():
     """Absent is not zero, and an empty bar with `--` is how the Qt row says so."""
     from src.pitwall.agents_view.decision import build_scenarios

--- a/tests/surfaces/test_pitwall_tokens.py
+++ b/tests/surfaces/test_pitwall_tokens.py
@@ -239,7 +239,7 @@ BOOT_SLOTS = {
 ECHART_MODULE = (
     REPO_ROOT / "src" / "pitwall" / "ui" / "src" / "features" / "agents" / "useEChart.ts"
 )
-ECHART_NAMES = ("TEXT_SECONDARY", "BORDER_COLOR")
+ECHART_SITES = (("TEXT_SECONDARY", 4), ("BORDER_COLOR", 2))
 
 
 def test_the_boot_state_colours_are_in_the_right_slots():
@@ -272,13 +272,49 @@ def test_the_chart_axis_palette_has_not_drifted_either():
     `useEChart.ts` repeats the axis pens `pace_chart.py` builds from
     BORDER_COLOR and TEXT_SECONDARY. Same duplication as the other four,
     and it had no guard at all.
+
+    **Counted per site, not as a set.** Set equality passes when ONE of
+    the four `#d1d5db` sites becomes `rgba(209,213,219,0.4)`: the hex is
+    still present elsewhere, so the set is unchanged and a real render
+    drift goes green. Measured on a mutated copy before this counted.
+    """
+    from collections import Counter
+
+    from src.arcade import palette
+
+    source = ECHART_MODULE.read_text("utf-8")
+    found = Counter(hex_.lower() for hex_ in re.findall(r'"(#[0-9a-fA-F]{6})"', source))
+    expected = Counter({_rgb_to_hex(getattr(palette, name)): count for name, count in ECHART_SITES})
+
+    assert found, "the chart theme stopped carrying colours"
+    assert found == expected, f"the chart axis palette drifted: {found} against {expected}"
+
+    # The two splitLine pens are rgba, so the hex regex above cannot see them
+    # at all. They are value-paired with pyqtgraph's grid alpha.
+    assert source.count("rgba(255,255,255,0.06)") == 2, "the grid alpha moved"
+
+
+def test_the_two_raw_hexes_in_the_stylesheet_are_guarded_too():
+    """The pair the `--qt-*` guard structurally cannot see.
+
+    `test_the_agents_css_palette_has_not_drifted_from_palette_py` reads
+    custom-property declarations, so a literal written straight into a
+    rule is invisible to it. #876's wording -- "useEChart.ts stops being
+    the ONE palette copy with no detector" -- was literally true and
+    stepped around these two.
     """
     from src.arcade import palette
 
-    literals = set(re.findall(r'"(#[0-9a-fA-F]{6})"', ECHART_MODULE.read_text("utf-8")))
-    expected = {_rgb_to_hex(getattr(palette, name)) for name in ECHART_NAMES}
+    css = AGENTS_CSS.read_text("utf-8")
+    declared = set(re.findall(r"--[\w-]+:\s*(#[0-9a-fA-F]{6})", css))
+    raw = sorted({hex_.lower() for hex_ in re.findall(r"(#[0-9a-fA-F]{6})", css)} - declared)
 
-    assert literals, "the chart theme stopped carrying colours"
-    assert literals == expected, (
-        f"the chart axis palette drifted: {sorted(literals)} against {sorted(expected)}"
+    assert raw == ["#282834", "#ef4444"], (
+        f"a new raw hex entered the stylesheet: {raw}. Either use a --qt-* token or add it here "
+        "with the palette name it copies."
     )
+    assert "#ef4444" == _rgb_to_hex(palette.DANGER), "the guardrail rule copies DANGER"
+    # #282834 is the empty half of the confidence/scenario bar. It is NOT in
+    # palette.py: `orchestrator_card.py` writes it straight into its Qt
+    # stylesheet too, so freezing it here is what makes the pair monitored.
+    assert css.count("#282834") == 1, "the empty-bar shade is used in exactly one rule"


### PR DESCRIPTION
## The headline

**#876's tooltip fix did not work, and the check I wrote to prove it did was asserting the wrong thing.**

The popup escaped the card and was then clipped by `.agents-right`, which scrolls because Qt clips that column too — **130 px off the left of every transcript line at 1320×900**, unreachably. My check asserted the card's `overflow` and the popup's DOM placement (the *mechanism*) and never hovered or measured (the *effect*). That is the #450 pattern, inside the harness built to kill the #450 pattern.

Measured before and after, by hand:

```
before   tooltip left=412 right=914 width=502   clippers=[agents-right cutLeft:130]
after    tooltip left=552 right=1054 width=502  clippers=[]
after (900px viewport)  left=390 right=892      clippers=[]     # clamp holds
```

The popup is now a portal into `document.body` with `position: fixed` — which is what Qt's `QToolTip` actually is, a top-level window clipped by nothing. Three attempts in, the class is ended rather than moved.

**The new check was verified red against the pre-fix bundle first**, which is the step that was missing last time:

```
smoke FAILED (2):
  - no tooltip before hover
  - nothing clips the tooltip (cut by agents-right)
```

## The rest of the round

| # | Sev | Defect | Fix |
|---|---|---|---|
| G3-08 | **P2** | above | portal + effect assertion |
| G3-01 | P3 | **The twin, again, inside the PR answering the audit that named both lines.** `_blame` learned tuples; `_json_safe` did not, so the pair disagreed about what is encodable and a NaN inside a tuple still cost the whole tick | one line, plus a test |
| G3-02 | P3 | `_blame` returns `""` for an unencodable dict **KEY** — the encoder rejects those too — so the drop log ends in `\| ` exactly when it is needed | walk the keys |
| G3-11 | P3 | `fill_pct` was asserted by **nothing**, and the smoke's own stub was never migrated: React drops `width: undefined%`, so all four bars rendered **full width, winner and losers identical**, green | stub + width assertion + a Python pin of the 0–100 scale |
| G3-10 | P3 | The chart guard used set equality, so changing **one** of four `#d1d5db` sites to `rgba(...)` left it green; and two raw hexes in the stylesheet had no guard at all — #876's "the ONE copy with no detector" was literally true and stepped around them | count per site; assert the two rgba twins; guard the raw pair |
| G3-09 | P3 | `smoke OK: 13 checks` over 12 calls — the same enumeration defect as #871's "36 tests" over 35 | the counter counts |

## Prose that was false, in the code that claimed it

- **The cache comment** said `rel_dist` left the cached arrays. It did not — `FrameData.rel_dist` is still derived and pickled per frame; what #863 removed was the unconsumed raw extraction, which left the bytes identical. A maintainer trusting it would have deleted its readers. **v11 is owed for the pedal peak alone.**
- **The flag-anchor docstring** claimed the rule holds with one small residual → **#879**, below.
- **The `laps_down` docstring** said the disagreement runs "always" one way over 3.4 %; it runs the other way 21 times in 169, under a truncation convention it never stated. #877 fixed the test twin and named this defect in its own commit body while leaving the original.
- **A new #875 test's name and docstring** described the opposite fixture and the opposite verdict from its asserts ("ends first" for a car ending 49 frames later; "not a finisher" directly above `has_finished(...) is True`).

## Filed, not fixed here

**#879 — the flag anchor can classify the winner as a retirement.** Constructed and executed: `has_finished(WIN)=False`, `has_finished(P2)=True`, with WIN crossing 1.0 s first. There is no threshold-free rule that separates a noisy winner from a final-lap crasher with what the loader caches today, and the honest answer is to cache FastF1's official `Status`. That is a `CACHE_VERSION` bump and a design call, so it is an issue and not a smuggled commit. The false confidence is out of the docstring in this PR.

## Checks

- `tests/surfaces` **142 passed** (`test_cli_no_llm` red locally on the curated `data/` download, red on `dev` too)
- **All three new guards verified RED on a deliberate break** — `fill_pct` regressed to `round(fill, 1)`, one `#d1d5db` turned to `rgba`, `#ef4444` turned to `#ff0000`: 3 failed, 42 passed. Then restored and green.
- `smoke OK: 14 checks` · `tsc -b` clean · `ruff check` + `ruff format --check` clean

Closes #874
