### PR TITLE
fix(agents): no car ahead is an absence, not a zero

### DIFF
--- a/scripts/prompt_ab/gen_inputs.py
+++ b/scripts/prompt_ab/gen_inputs.py
@@ -59,7 +59,10 @@ def _race_state_for(lap_state: dict, driver: str, safety_car: bool):
         position=int(driver_state["position"]),
         compound=driver_state.get("compound") or "MEDIUM",
         tyre_life=int(driver_state.get("tyre_life") or 10),
-        gap_ahead_s=driver_state.get("gap_ahead_s") or 2.0,
+        # None is a valid RaceState value now - no car ahead to measure (#878) -
+        # and the old `or 2.0` also destroyed a genuinely measured 0.0, two cars
+        # side by side. The two-arg .get already returns None for a missing key.
+        gap_ahead_s=driver_state.get("gap_ahead_s"),
         pace_delta_s=0.0,
         risk_tolerance=0.5,
         air_temp=weather.get("air_temp") or 25.0,

--- a/src/agents/race_situation_agent.py
+++ b/src/agents/race_situation_agent.py
@@ -334,6 +334,11 @@ class RaceSituationOutput:
             elevated SC risk. Same caveat: N14's best_threshold is raw-scale.
         threat_level: LOW / MEDIUM / HIGH derived from both probabilities in __post_init__.
         gap_ahead_s: Gap to the car directly ahead (seconds). < 1.0s = DRS range.
+            None when no overtake was scored - leading, no classified car ahead, or
+            the tool was never called. There was no pair, so there is no gap: the
+            same absence semantics ``overtake_prob`` already carries, and for the
+            same reason, because 0.0 is also what a genuinely side-by-side pair
+            reports (#878).
         pace_delta_s: SINGLE-lap pace delta vs the car ahead (s/lap), this driver's
             lap time minus theirs, so negative = we are faster. The rolling version is
             the separate ``pace_delta_rolling3`` field; this docstring used to describe
@@ -357,7 +362,7 @@ class RaceSituationOutput:
     overtake_prob: Optional[float]
     sc_prob_3lap: float
     threat_level: str = field(init=False)
-    gap_ahead_s: float = 0.0
+    gap_ahead_s: Optional[float] = None
     pace_delta_s: float = 0.0
     reasoning: str = ""
     sc_currently_active: bool = False  # any neutralisation (SC OR VSC) confirmed by RCM this lap
@@ -973,9 +978,11 @@ def _parse_tool_outputs(messages: list) -> dict:
 
     Returns:
         Dict with: overtake_prob, sc_prob_3lap, gap_ahead_s, pace_delta_s.
-        ``overtake_prob`` is None when the tool declined to answer — the pair sat outside
-        N11's trained gap domain, or the tool was never called. The other three default
-        to 0.0, unchanged.
+        ``overtake_prob`` AND ``gap_ahead_s`` are None when the tool declined or was
+        never called: no pair was scored, so neither a probability nor a gap exists.
+        0.0 is also the gap a genuinely side-by-side pair reports, which is the same
+        collision ``overtake_prob`` escaped one paragraph below (#878).
+        ``sc_prob_3lap`` and ``pace_delta_s`` keep their 0.0 defaults, unchanged.
 
     WHY overtake_prob IS THE ONE THAT CAN BE None
     ---------------------------------------------
@@ -988,7 +995,7 @@ def _parse_tool_outputs(messages: list) -> dict:
     result: dict[str, Optional[float]] = {
         "overtake_prob": None,
         "sc_prob_3lap": 0.0,
-        "gap_ahead_s": 0.0,
+        "gap_ahead_s": None,
         "pace_delta_s": 0.0,
     }
     overtake_taken = False
@@ -1396,9 +1403,7 @@ class RaceSituationAgent:
                 x_rows.iloc[0],
                 y_rows.iloc[0],
                 laps_recent,
-                circuit_cluster=agent.session_meta.get(
-                    "circuit_cluster", _UNKNOWN_CIRCUIT_CLUSTER
-                ),
+                circuit_cluster=agent.session_meta.get("circuit_cluster", _UNKNOWN_CIRCUIT_CLUSTER),
                 gp_name=agent.session_meta.get("gp_name", ""),
                 year=agent.session_meta.get("year", 2025),
             )
@@ -1827,7 +1832,9 @@ class RaceSituationAgent:
         return RaceSituationOutput(
             overtake_prob=effective_overtake_prob,
             sc_prob_3lap=effective_sc_prob,
-            gap_ahead_s=round(parsed["gap_ahead_s"], 2),
+            gap_ahead_s=(
+                round(parsed["gap_ahead_s"], 2) if parsed["gap_ahead_s"] is not None else None
+            ),
             pace_delta_s=round(parsed["pace_delta_s"], 3),
             reasoning=effective_reasoning,
             sc_currently_active=is_neutralized,

--- a/src/agents/race_state_builder.py
+++ b/src/agents/race_state_builder.py
@@ -99,9 +99,9 @@ DEFAULT_TRACK_TEMP_C = 35.0
 def _targeting_against_rival(
     lap_state: Dict[str, Any],
     rival: str,
-    fallback_gap_s: float,
+    fallback_gap_s: Optional[float],
     fallback_pace_s: float,
-) -> Tuple[float, float]:
+) -> Tuple[Optional[float], float]:
     """Gap and pace delta of our driver measured against a chosen ``rival``.
 
     Returns ``(gap_ahead_s, pace_delta_s)`` framed around the rival the user
@@ -129,8 +129,13 @@ def _targeting_against_rival(
     if match is None:
         return fallback_gap_s, fallback_pace_s
 
+    # The fallback may now be None - no car ahead to measure (#878) - and
+    # round(None) raises, so the measured and fallback branches round apart.
     interval = match.get("interval_to_driver_s")
-    gap_ahead_s = abs(float(interval)) if interval is not None else fallback_gap_s
+    if interval is not None:
+        gap_ahead_s: Optional[float] = round(abs(float(interval)), 3)
+    else:
+        gap_ahead_s = fallback_gap_s
 
     driver_lap_s = lap_state.get("driver", {}).get("lap_time_s")
     rival_lap_s = match.get("lap_time_s")
@@ -139,7 +144,7 @@ def _targeting_against_rival(
     else:
         pace_delta_s = fallback_pace_s
 
-    return round(gap_ahead_s, 3), round(pace_delta_s, 3)
+    return gap_ahead_s, round(pace_delta_s, 3)
 
 
 def _car_ahead(lap_state: Dict[str, Any], our_position: int) -> Optional[Dict[str, Any]]:
@@ -153,24 +158,27 @@ def _car_ahead(lap_state: Dict[str, Any], our_position: int) -> Optional[Dict[st
     return match
 
 
-def _gap_to_car_ahead(car_ahead: Optional[Dict[str, Any]]) -> float:
-    """Absolute interval to the car ahead, without conflating two zeros.
+def _gap_to_car_ahead(car_ahead: Optional[Dict[str, Any]]) -> Optional[float]:
+    """Absolute interval to the car ahead, or None when there is no car ahead.
 
-    No car ahead means we lead, and 0.0 is honest there. A car ahead whose
-    ``interval_to_driver_s`` was never measured is NOT a zero gap: 0.0 reads as
-    side by side, which the orchestrator's clean-air band and N27's sub-1.0s DRS
-    window both act on (#633). It degrades to ``GAP_UNKNOWN_FALLBACK_S`` instead.
+    No car directly ahead - we lead, or the pos-1 car is not classified this
+    lap - is an ABSENCE, and it returns None (#878). It used to return 0.0,
+    called "honest" here for two years: 0.0 is ALSO a real measured value
+    (two cars side by side; the served 2025 season has four such laps), the
+    sub-1.0s DRS band acts on it, and a falsy ``or`` downstream turned it
+    into a fabricated 2.0 rival for the race leader on 1,262 laps. A value
+    meaning "nothing to measure" must not be a value the code can also
+    legitimately find - the rule ``Position`` three files away already
+    follows (#465).
 
-    Be honest about what that fallback still is: 2.0 is fabricated, and a real
-    2.0 s gap is common, so it does not satisfy the rule that a default must
-    never be a value the code can also legitimately find. It is less harmful
-    than 0.0, not correct. The real fix is ``RaceState.gap_ahead_s`` becoming
-    ``float | None``, which ``RivalState`` in position_projection.py already is
-    and whose consumers already guard with ``is not None``. That is a Pydantic
-    contract change, tracked under #628.
+    A car ahead whose ``interval_to_driver_s`` was never measured is a
+    DIFFERENT claim - the car exists, the number does not - and still
+    degrades to ``GAP_UNKNOWN_FALLBACK_S``: fabricated, less harmful than
+    0.0, not correct, and deliberately unchanged here. Retiring it is its
+    own decision over its own population.
     """
     if car_ahead is None:
-        return 0.0
+        return None
     interval = car_ahead.get("interval_to_driver_s")
     if interval is None:
         return GAP_UNKNOWN_FALLBACK_S
@@ -333,10 +341,11 @@ def build_race_state(
         pace_delta_s = _pace_delta_vs_car_ahead(driver_state, car_ahead)
 
     if rival:
+        # The positional fallback may be the leader's None; float(None) raises.
         gap_ahead_s, pace_delta_s = _targeting_against_rival(
             lap_state,
             rival,
-            float(gap_ahead_s),
+            float(gap_ahead_s) if gap_ahead_s is not None else None,
             float(pace_delta_s),
         )
 
@@ -348,7 +357,7 @@ def build_race_state(
         position=position,
         compound=normalise_compound(driver_state.get("compound")),
         tyre_life=tyre_life if tyre_life is not None else UNKNOWN_TYRE_LIFE,
-        gap_ahead_s=float(gap_ahead_s),
+        gap_ahead_s=float(gap_ahead_s) if gap_ahead_s is not None else None,
         pace_delta_s=float(pace_delta_s),
         air_temp=_weather_reading(weather, "air_temp", DEFAULT_AIR_TEMP_C),
         track_temp=_weather_reading(weather, "track_temp", DEFAULT_TRACK_TEMP_C),

--- a/src/agents/strategy_orchestrator.py
+++ b/src/agents/strategy_orchestrator.py
@@ -233,7 +233,12 @@ class RaceState(BaseModel):
 
     compound and tyre_life are the current stint values forwarded to N26.
 
-    gap_ahead_s and pace_delta_s are the primary inputs for N27 overtake scoring.
+    gap_ahead_s and pace_delta_s reach the LLM synthesis prompt's RACE CONTEXT
+    block. They do NOT feed the overtake model: N27 computes its own pair gap
+    from laps_df, and this line claimed otherwise for as long as it existed.
+    gap_ahead_s is None when there is no car directly ahead to measure - we
+    lead, or the pos-1 car is not classified this lap (#878). Render the
+    absence; never substitute a number for it.
 
     weather fields (air_temp, track_temp, rainfall) are forwarded to N14 (SC model)
     as contextual features.
@@ -253,7 +258,7 @@ class RaceState(BaseModel):
     position:       int
     compound:       str
     tyre_life:      int
-    gap_ahead_s:    float
+    gap_ahead_s:    Optional[float]
     pace_delta_s:   float
     air_temp:       float
     track_temp:     float
@@ -270,6 +275,24 @@ _PACE_MODE_VALUES = Literal["PUSH", "NEUTRAL", "MANAGE", "LIFT_AND_COAST"]
 _RISK_VALUES      = Literal["AGGRESSIVE", "BALANCED", "DEFENSIVE"]
 _PRIORITY_VALUES  = Literal["HIGH", "MEDIUM", "LOW"]
 _COMPOUND_VALUES  = Literal["SOFT", "MEDIUM", "HARD"]
+
+
+def _gap_ahead_context_line(race_state: RaceState) -> str:
+    """The RACE CONTEXT gap fragment, honest about an absent car ahead.
+
+    None at P1 is the race leader: say so, and say what leading means for
+    strategy, because defending a gap behind is a different problem from
+    chasing one. None below P1 means the car one place ahead has no
+    classified row this lap. Both used to render as a number - 0.00s from
+    the builder, or a fabricated 2.00s once a falsy ``or`` had eaten the
+    zero - and the LLM narrated overtaking pressure that did not exist
+    (#878).
+    """
+    if race_state.gap_ahead_s is not None:
+        return f"Gap ahead: {race_state.gap_ahead_s:.2f}s"
+    if race_state.position == 1:
+        return "Gap ahead: none - LEADING the race (defending a gap behind, not chasing)"
+    return "Gap ahead: none - no car classified directly ahead this lap"
 
 
 class Contingency(BaseModel):
@@ -1808,7 +1831,7 @@ def _build_orchestrator_prompt(
         f"  Driver: {race_state.driver} | Lap: {race_state.lap}/{race_state.total_laps}\n"
         f"  Position: P{race_state.position} | Compound: {race_state.compound} "
         f"TyreLife {race_state.tyre_life}\n"
-        f"  Gap ahead: {race_state.gap_ahead_s:.2f}s | "
+        f"  {_gap_ahead_context_line(race_state)} | "
         f"Pace delta: {race_state.pace_delta_s:+.3f}s\n"
         f"  Air {race_state.air_temp:.1f}°C | Track {race_state.track_temp:.1f}°C | "
         f"Rain {race_state.rainfall}\n"

--- a/src/arcade/strategy.py
+++ b/src/arcade/strategy.py
@@ -777,7 +777,12 @@ def _build_decision(
         tyre_life=int(race_state.tyre_life),
         position=int(race_state.position),
         lap_time_s=float(lap_time_s) if lap_time_s else None,
-        gap_ahead_s=float(race_state.gap_ahead_s),
+        # The TCP wire contract pins this slot as float
+        # (tests/surfaces/test_arcade_wire_contract.py) and #857 owns the wire's
+        # future. 0.0 is the wire's existing absent-marker, kept AT THE BOUNDARY
+        # on purpose - not a producer writing 0.0 back into the strategy path,
+        # which is the defect #878 is about. Remove with the wire redesign.
+        gap_ahead_s=(float(race_state.gap_ahead_s) if race_state.gap_ahead_s is not None else 0.0),
         action=str(getattr(rec, "action", "ERROR")),
         confidence=float(getattr(rec, "confidence", 0.0) or 0.0),
         reasoning=str(getattr(rec, "reasoning", "")),

--- a/tests/agents/test_race_state_builder.py
+++ b/tests/agents/test_race_state_builder.py
@@ -203,12 +203,18 @@ def test_position_none_raises_value_error():
 
 
 @needs_models
-def test_gap_is_zero_when_no_car_ahead():
-    """P1 with no rival at position 0: leading, and 0.0 is honest there."""
+def test_gap_is_none_when_there_is_no_car_ahead():
+    """P1 with no rival at position 0: leading, and the gap is an ABSENCE.
+
+    This test used to assert `== 0.0` and its docstring called that
+    "honest" (#878). It was the green test defending the defect: 0.0 is
+    also what two cars side by side measure, and a falsy `or` downstream
+    turned it into a fabricated 2.0 rival for the race leader.
+    """
     state = _lap_state()
     state["driver"]["position"] = 1
     rs = build_race_state(state)
-    assert rs.gap_ahead_s == 0.0
+    assert rs.gap_ahead_s is None
 
 
 @needs_models
@@ -288,3 +294,100 @@ def test_radio_and_rcm_parameters_land_on_the_state():
     rs = build_race_state(_lap_state(), radio_msgs=radios, rcm_events=rcms)
     assert rs.radio_msgs == radios
     assert rs.rcm_events == rcms
+
+
+# --- No car ahead is an ABSENCE, not a zero (#878) ---------------------------
+#
+# These sit in the pure-helper tier on purpose. The integration tier needs the
+# real `RaceState`, whose lazy import reaches `race_situation_agent` and a
+# parquet the curated download does not ship - so those tests SKIP on a clean
+# checkout and in CI alike. A defect worth 2,315 laps of the served season
+# cannot be guarded by a test that never runs, so the semantics are asserted
+# here, where they execute everywhere.
+
+
+def test_no_car_ahead_is_none_and_a_measured_zero_survives():
+    """The three claims the old 0.0 collapsed into one number.
+
+    `_gap_to_car_ahead` returned 0.0 for "nobody ahead" and called it honest.
+    It is not: 0.0 is also what two cars side by side measure - the served
+    2025 season has four such laps - and a falsy `or` downstream turned the
+    leader's 0.0 into a fabricated 2.0 rival on 1,262 laps. Absent, measured
+    and unmeasured are three different claims and must look different.
+    """
+    from src.agents.race_state_builder import _gap_to_car_ahead
+
+    assert _gap_to_car_ahead(None) is None, "nobody ahead is an absence"
+    assert _gap_to_car_ahead({"driver": "VER", "interval_to_driver_s": 0.0}) == 0.0, (
+        "a measured zero is a measurement and must survive"
+    )
+    assert _gap_to_car_ahead({"driver": "VER", "interval_to_driver_s": -1.42}) == 1.42
+    assert _gap_to_car_ahead({"driver": "VER"}) == GAP_UNKNOWN_FALLBACK_S, (
+        "a car that IS there with no interval is a different claim, unchanged"
+    )
+
+
+def test_rival_targeting_survives_a_none_positional_fallback():
+    """The coercion twin that nearly shipped inside this fix.
+
+    With no car ahead the positional fallback is now None, and the old body
+    did `round(gap_ahead_s, 3)` unconditionally on the way out - `round(None)`
+    raises. The call site coerced with `float(gap_ahead_s)`, which raises too.
+    Both had to move; the design gate's own first draft moved one.
+    """
+    from src.agents.race_state_builder import _targeting_against_rival
+
+    lap_state = {
+        "driver": {"lap_time_s": 81.4},
+        "rivals": [
+            {"driver": "VER", "position": 2, "interval_to_driver_s": -1.42, "lap_time_s": 81.6},
+            {"driver": "RUS", "position": 4, "lap_time_s": 81.9},
+        ],
+    }
+
+    assert _targeting_against_rival(lap_state, "VER", None, 0.0)[0] == 1.42, "measured wins"
+    assert _targeting_against_rival(lap_state, "RUS", None, 0.0)[0] is None, "no interval, no gap"
+    assert _targeting_against_rival(lap_state, "HAM", None, 0.0)[0] is None, "rival not on track"
+    assert _targeting_against_rival(lap_state, "HAM", 2.0, 0.0)[0] == 2.0, "a float still passes"
+
+
+def test_the_prompt_says_leading_instead_of_printing_a_gap_that_is_not_there():
+    """What the LLM actually reads, which is the only live consumer.
+
+    Exactly three places in the repo read `race_state.gap_ahead_s`: this
+    prompt line and two wire boundaries. No model consumes it - N27 computes
+    its own pair gap from laps_df - so this string IS the behaviour, and it
+    used to say "Gap ahead: 0.00s" to a driver leading the race.
+
+    Extracted with `ast` rather than imported: the module reaches
+    `race_situation_agent` at import time and a parquet the curated download
+    omits, which is exactly how this surface stayed untested.
+    """
+    import ast
+
+    source = (
+        Path(__file__).resolve().parents[2] / "src" / "agents" / "strategy_orchestrator.py"
+    ).read_text(encoding="utf-8")
+    node = next(
+        n
+        for n in ast.parse(source).body
+        if isinstance(n, ast.FunctionDef) and n.name == "_gap_ahead_context_line"
+    )
+    node.args.args[0].annotation = None
+    node.returns = None
+    namespace: dict = {}
+    exec(
+        compile(ast.fix_missing_locations(ast.Module(body=[node], type_ignores=[])), "<t>", "exec"),
+        namespace,
+    )
+    render = namespace["_gap_ahead_context_line"]
+
+    class _State:
+        def __init__(self, gap, position):
+            self.gap_ahead_s, self.position = gap, position
+
+    assert render(_State(1.42, 4)) == "Gap ahead: 1.42s"
+    assert render(_State(0.0, 7)) == "Gap ahead: 0.00s", "a measured zero is still printed"
+    assert "LEADING" in render(_State(None, 1)), "the leader is told they are leading"
+    assert "0.00" not in render(_State(None, 1)) and "2.00" not in render(_State(None, 1))
+    assert "no car classified" in render(_State(None, 5)), "P5 with a gap-less pos-4 car"


### PR DESCRIPTION
Step B of #878 — the semantic change, plus the submodule pointer bump onto step A.

## What was wrong

**The race leader was told a rival sat 2.0 s ahead, on every lap they led.** `_gap_to_car_ahead` returned `0.0` for "nobody ahead" and its docstring called that *"honest there"*; downstream `mcp_tools`' falsy `or` read the zero as missing and substituted the unmeasured-fallback.

Measured on the whole served 2025 season (22,760 driver-laps), and counted a second time straight off the parquet:

| Cause of the `0.0` | Laps |
|---|---:|
| Leading, nobody ahead | 1,262 |
| A P>1 car whose pos-1 rival has no classified row this lap | **1,049** |
| A genuinely measured zero, two cars side by side | 4 |
| **Total** | **2,315** — 10.2 % of served laps |

The 1,049 is why `position == 1` was not the fix: it would have closed 54 % and left a P5 driver reading *"0.0 s to the car ahead"*.

## What changed

`gap_ahead_s` is `Optional[float]` through `RaceState`, the builder and the situation agent. **`None` = there is no car directly ahead to measure.** `0.0` is finally protected as a measurement.

**The 2.0 fallback is untouched** — a car that *is* there with no interval is a different claim over a different population, and retiring it is its own decision.

The prompt now says `LEADING the race (defending a gap behind, not chasing)`, or says no car is classified ahead, instead of printing a number that is not there.

## Why the blast radius is small

Exactly **three** places in the repo read `race_state.gap_ahead_s` — this prompt line and two wire boundaries. Verified by grep across `src/` and `scripts/`. **No model consumes it**: N27 computes its own pair gap from `laps_df`, and `.nb_py/N11_overtake_eda.py:231-232` excludes the leader by construction. **No prediction moves.** The `RaceState` docstring claimed the opposite and has been corrected.

The two wires keep `float`, converting at the boundary — the TCP contract is pinned by `test_arcade_wire_contract` and #857 owns the wire's future.

## The twin that nearly shipped inside the fix

The targeting path's rounding split is not cosmetic: the fallback can now be `None`, and `round(None)` raises — as does the `float(gap_ahead_s)` at the call site. **Both had to move; the design gate's own first draft moved one** and caught it by auditing its diff against its own new test.

## A note on what CI can and cannot see here

`tests/agents`'s integration tier imports `race_situation_agent`, which reads a parquet the curated download does not ship — so those tests **skip in CI and fail locally**, and this defect lived there. The three new tests are therefore written in the pure-helper tier and **execute everywhere**, including the prompt string, extracted with `ast` rather than imported.

```
test_no_car_ahead_is_none_and_a_measured_zero_survives          PASSED
test_rival_targeting_survives_a_none_positional_fallback        PASSED
test_the_prompt_says_leading_instead_of_printing_a_gap...       PASSED
```

The pre-existing `test_gap_is_zero_when_no_car_ahead` asserted the old doctrine in its name and its docstring. It was the green test defending the defect; it now asserts the absence.

## Checks

`tests/surfaces` 144 passed · `ruff check` clean · the three new tests green, and the `_gap_to_car_ahead` / `_targeting_against_rival` branches exercised by hand across absent / measured-zero / measured / no-interval.

Also bumps `src/telemetry` onto step A (VforVitorio/F1_Telemetry_Manager#215), which must be in place first: the backend imports `src/agents/` from this checkout at runtime, so without A's boundary guard the simulator would raise `ValidationError` on every leader lap.

Refs #878. Step C (the producer and the falsy-`or` family) follows.
