### PR TITLE
fix(data): pull the two artefacts a fresh install needs to import the orchestrator

### DIFF
--- a/src/f1_strat_manager/data_cache.py
+++ b/src/f1_strat_manager/data_cache.py
@@ -101,6 +101,12 @@ _DEFAULT_MODEL_PATTERNS: tuple[str, ...] = (
     "data/models/nlp/intent_setfit_modernbert_v1/**",
     "data/models/nlp/ner_v1/bert_bio_v1/**",
     "data/models/nlp/rcm_parser_v1/**",
+    # The RoBERTa sentiment weights, read at MODULE IMPORT by
+    # `radio_agent.py` (a bare `torch.load`, not a lazy accessor). Without
+    # them the orchestrator cannot be imported at all, so the CLI, the
+    # arcade pipeline and every eval tier are unreachable on a clean
+    # install - a harder failure than a degraded feature (#837).
+    "data/models/nlp/bert_sentiment_v1/**",
     "data/models/xgb_laptime_final.json",
     "data/models/xgb_laptime_final_feature_names.json",
     "data/models/xgb_laptime_global_v1.json",
@@ -128,6 +134,13 @@ _DEFAULT_MODEL_PATTERNS: tuple[str, ...] = (
     # missing from this list and from the dataset itself, which stayed invisible
     # because every machine that has run the notebook already had the file (#798).
     "data/processed/undercut_labeled/**",
+    # N13's safety-car labels, read at MODULE IMPORT by
+    # `race_situation_agent.py` to build the per-circuit SC base-rate map.
+    # Same class as the undercut gap above and as the sentiment weights
+    # higher up: import-time, so its absence is not a missing feature but
+    # an orchestrator that cannot be constructed (#837). Three artefacts,
+    # one pattern list, and only one of them had ever been noticed.
+    "data/processed/sc_labeled/**",
     # Radio corpus metadata: small parquets (~430 KB total for the full
     # 2025 calendar) that the runner reads to enumerate per-lap team-radio
     # rows and FIA race-control messages. The matching MP3 audio tree under

--- a/tests/agents/test_weather_restore.py
+++ b/tests/agents/test_weather_restore.py
@@ -154,14 +154,34 @@ def test_the_restore_reproduces_N04s_own_2025_output_exactly():
         "against and this test would hold vacuously"
     )
 
+    # The guard above names the WRONG precondition. What the restore reads is the RAW
+    # tree, one directory per GP, and the curated download ships a single race - so on a
+    # clean install the restore correctly returns NaN for the other 23 and this test
+    # reported "22,197 of 22,760 laps disagree with N04", a number about missing files
+    # and not about alignment. Scope to the races whose raw laps are actually here.
+    available = sorted(
+        {path.name for path in (ROOT / "data" / "raw" / "2025").glob("*") if path.is_dir()}
+        & set(truth["GP_Name"].dropna().unique())
+    )
+    if not available:
+        pytest.skip("no 2025 raw race directories present; the restore has nothing to read")
+
     stripped = truth.drop(columns=list(WEATHER_COLUMNS))
     restored = augment_featured_laps(stripped, 2025)
+    restored = restored[restored["GP_Name"].isin(available)]
+    truth = truth[truth["GP_Name"].isin(available)]
 
     keys = ["GP_Name", "Driver", "LapNumber"]
     joined = restored[[*keys, *WEATHER_COLUMNS]].merge(
         truth[[*keys, *WEATHER_COLUMNS]], on=keys, suffixes=("_mine", "_n04")
     )
     assert len(joined) == len(restored), "every restored lap must find its published twin"
+    # Vacuity is the failure this test exists to catch (see the docstring): a restore that
+    # produced nothing at all would otherwise compare an empty frame and pass.
+    assert joined["TrackTemp_mine"].notna().any(), (
+        f"the restore returned no weather for {available} even though their raw laps are "
+        "present; comparing this would hold vacuously"
+    )
 
     for column in WEATHER_COLUMNS:
         mine, published = joined[f"{column}_mine"], joined[f"{column}_n04"]

--- a/tests/test_construction_artefacts_are_downloadable.py
+++ b/tests/test_construction_artefacts_are_downloadable.py
@@ -22,8 +22,20 @@ _AGENTS = ROOT / "src" / "agents"
 
 # Artefacts read during __init__ rather than lazily, keyed by the agent that needs them.
 # A miss here is not a degraded prediction, it is an agent that cannot be built.
+#
+# The two IMPORT-time entries are worse than construction-time and were the twin this
+# file missed for months (#837): they run under `import`, so the orchestrator cannot be
+# built at all and the CLI, the arcade pipeline and every eval tier are unreachable on a
+# clean install. One member of the trio got a comment in `data_cache.py` and the other
+# two never got a pattern - the repo's dominant defect, inside the guard written for it.
+#
+# HOW TO FIND THE NEXT ONE: build a tree from `_DEFAULT_MODEL_PATTERNS` alone and run
+# `python -c "from src.agents import strategy_orchestrator"`. Whatever it raises on
+# belongs here. A grep will not find it; these are bare module-level reads.
 _CONSTRUCTION_READS = {
     "pit_strategy_agent.py": "data/processed/undercut_labeled/undercut_clean.parquet",
+    "race_situation_agent.py": "data/processed/sc_labeled/sc_labeled_2023_2025.parquet",
+    "radio_agent.py": "data/models/nlp/bert_sentiment_v1/best_roberta_sentiment_model.pt",
 }
 
 


### PR DESCRIPTION
Closes #837, and it is the reason nothing in this area could be verified locally or in CI.

## The gap

Two artefacts are read at **module import**, not lazily. Their absence is not a degraded feature — `from src.agents import strategy_orchestrator` raises, so the CLI, the arcade pipeline and every eval tier are unreachable on a clean install.

| Artefact | Read at | Size |
|---|---|---:|
| `data/processed/sc_labeled/**` | `race_situation_agent.py:260` | 196 KB |
| `data/models/nlp/bert_sentiment_v1/**` | `radio_agent.py:269` | 476 MB |

Both were already on the Hub. The download simply never asked for them.

## Verified by running it, not by reading the list

Downloaded both, then imported:

```
orchestrator IMPORTS on this tree now
P1 gap  -> None
P3 gap  -> 1.42
prompt  -> Gap ahead: none - LEADING the race (defending a gap behind, not chasing)
```

That also closes the one link of #878 I could not verify at the time: the leader's absence surviving all the way into the real `RaceState` and the prompt.

**`tests/agents` goes from 100 passed / 146 skipped to 236 passed.** Two thirds of that suite had never run on this machine.

## The twin, again

`tests/test_construction_artefacts_are_downloadable.py` was written for exactly this class (#798) and watched **one** artefact. These two are its twins — worse, in fact, since import-time beats construction-time. It now watches all three, and its docstring carries how to find a fourth: build a tree from `_DEFAULT_MODEL_PATTERNS` alone and import the orchestrator. A grep will not find them; they are bare module-level reads.

Verified RED: with the two patterns removed, the guard fails on both.

## A guard naming the wrong precondition, surfaced by running the suite

With the suite finally executable, `test_the_restore_reproduces_N04s_own_2025_output_exactly` failed with **"AirTemp: 22197 of 22760 laps disagree with N04"**.

It is not a code defect. Measured: `max diff 0.0000`, and the disagreement sample is **empty** — every one is NaN-versus-value. The restore reads the **raw tree**, one directory per GP, and the curated download ships a single race. The test gates on the featured parquet instead, which is the wrong precondition.

On the race whose raw data is present, the restore is exact:

```
Melbourne laps compared: 563
     AirTemp: 0 disagree
   TrackTemp: 0 disagree
    Humidity: 0 disagree
    Rainfall: 0 disagree
```

So the test now scopes to the races whose raw laps are actually here, skips on an empty set, and asserts the restore produced something — vacuity is the failure its own docstring says it exists to catch. **Verified still RED against a poisoned join** (`direction="nearest"` → `"backward"`): 2 failed.

## One thing I checked and deliberately did NOT file

`Rainfall` restores as `int32` with zero NaN, so on this incomplete tree 40 wet Miami laps read as dry. `laps_augment.py:262-265` already documents that as inherited from N04 on purpose — and on a complete install every GP has weather, so `0` always means measured-dry. My measurement was on the wrong distribution, not a bug.

Closes #837