### PR TITLE
fix(arcade): take the chequered flag from the official classification, not from odometer noise

### DIFF
--- a/src/arcade/config.py
+++ b/src/arcade/config.py
@@ -166,7 +166,7 @@ ARCADE_CACHE_DIR: Final[Path] = get_data_root() / "cache" / "arcade"
 # `RelativeDistance` extraction in the worker intermediate, which nothing
 # had consumed since v10 and which left the cached bytes identical. A
 # maintainer trusting the old sentence would have deleted its readers.)
-CACHE_VERSION: Final[str] = "v11"  # pedal peak ignores NaN
+CACHE_VERSION: Final[str] = "v12"  # + official classification (SessionData.official_status)
 
 # --- Multiprocessing pool -------------------------------------------------
 # Serial by default — Windows spawn + pickling a loaded session across 8

--- a/src/arcade/data.py
+++ b/src/arcade/data.py
@@ -143,6 +143,19 @@ class SessionData:
     # chart rather than as absent data. An empty dict means an older cache;
     # consumers treat an unlisted driver as having position.
     has_position: dict[str, bool] = field(default_factory=dict)
+    # FastF1's official classification ``Status`` per driver abbreviation
+    # ({"NOR": "Finished", "DOO": "Retired", ...}), read off
+    # ``session.results`` at load time. The replay always replays a
+    # COMPLETED session, so who took the chequered flag is a recorded fact;
+    # deriving it from telemetry noise misclassified a wall-clock winner as
+    # a retirement and a final-lap crasher as the winner (#879).
+    # ``RaceGapCalculator`` treats this as the source of truth and keeps the
+    # derived anchor only as the fallback for sessions that have none. Only
+    # the status string is stored: position columns would be cached unread,
+    # which is how ``intervals.parquet`` came to be downloaded every race
+    # and read by nothing. Empty dict means an older cache or a results
+    # table FastF1 could not deliver.
+    official_status: dict[str, str] = field(default_factory=dict)
 
 
 def _pedal_multiplier(results: list[dict], channel: str) -> float:
@@ -396,6 +409,7 @@ class SessionLoader:
         frames_by_driver = self._resample_all(results, timeline, global_t_min, circuit_length)
         track_status_by_lap = self._extract_track_status_by_lap(session)
         weather_by_lap = self._extract_weather_by_lap(session)
+        official_status = self._extract_official_status(session, driver_codes)
 
         has_position = {
             code: bool(len(frames)) and frames[-1].dist > frames[0].dist
@@ -422,6 +436,7 @@ class SessionLoader:
             track_status_by_lap=track_status_by_lap,
             weather_by_lap=weather_by_lap,
             has_position=has_position,
+            official_status=official_status,
         )
 
         with cache_path.open("wb") as f:
@@ -714,6 +729,46 @@ class SessionLoader:
             ),
             "rain_state": "WET" if bool(row.get("Rainfall")) else "DRY",
         }
+
+    def _extract_official_status(self, session: Any, driver_codes: dict) -> dict[str, str]:
+        """Map each driver abbreviation to FastF1's official ``Status`` string.
+
+        ``session.results`` is indexed by driver number - the same
+        ``session.drivers`` enumeration ``load()`` built ``driver_codes``
+        from, so the keys here match ``frames_by_driver`` by construction.
+        That matters: a table keyed one way and queried another misses on
+        every lookup while looking perfectly healthy (#448).
+
+        Interpreting the vocabulary is ``gaps._took_flag_officially``'s job,
+        not this one's - this stores the fact and one place decides what it
+        means. A missing row or an empty status is left OUT rather than
+        stored as a guess; the gap calculator then falls back to the derived
+        rule for that driver and logs the disagreement.
+        """
+        try:
+            results = session.results
+            if results is None or results.empty:
+                return {}
+            out: dict[str, str] = {}
+            for number, code in driver_codes.items():
+                if number not in results.index:
+                    continue
+                status = results.loc[number, "Status"]
+                if isinstance(status, str) and status:
+                    out[code] = status
+            return out
+        except Exception as exc:  # noqa: BLE001 - the enumeration is the point
+            # Reading ``session.results`` can raise fastf1's
+            # DataNotLoadedError, which subclasses Exception DIRECTLY - the
+            # same trap ``_extract_weather_by_lap`` documents: a narrow tuple
+            # lets it escape and kills the whole arcade load for a session
+            # that should have degraded to the derived flag rule.
+            logger.warning(
+                "Official classification unavailable (%s) - the flag logic "
+                "falls back to the derived rule",
+                exc,
+            )
+            return {}
 
     def _safe_rotation(self, session: Any) -> float:
         try:

--- a/src/arcade/gaps.py
+++ b/src/arcade/gaps.py
@@ -96,12 +96,15 @@ screen, and it beats a live number that is right 90 % of the time and
 
 from __future__ import annotations
 
+import logging
 from typing import Callable
 
 import numpy as np
 
 from src.arcade.config import DT
 from src.arcade.data import SessionData
+
+logger = logging.getLogger(__name__)
 
 # `(driver, frame) -> laps completed plus fraction`, WITHOUT flag
 # crossings. Passed in rather than imported so `_flag_frames` cannot
@@ -129,62 +132,59 @@ def _telemetry_end_frame(frames: list) -> int:
     return int(ended[0]) if len(ended) else len(frames) - 1
 
 
+_TOOK_FLAG_STATUSES = frozenset({"Finished", "Lapped", "Disqualified"})
+
+
+def _took_flag_officially(status: str) -> bool:
+    """Whether this FastF1 ``Status`` string means the car took the chequered flag.
+
+    The vocabulary is the one the data actually serves: every 2023-2025
+    race carries exactly ``Finished`` / ``Lapped`` / ``Retired`` /
+    ``Disqualified``. ``Lapped`` is a CLASSIFIED finisher one or more laps
+    down, and a modern ``Disqualified`` is post-race, so that car took the
+    flag too. The one case this mis-renders is a mid-race black flag, which
+    no season in range contains and which the disagreement warning below
+    would surface. ``startswith("+")`` accepts the deep-historical Ergast
+    spellings at zero cost.
+
+    **Deliberately NOT fastf1's own** ``DriverResult.dnf``, which is
+    ``not (Status[3:6] == "Lap" or Status == "Finished")``. ``"Lapped"[3:6]``
+    is ``"ped"``, so upstream's own predicate calls every lapped finisher a
+    DNF - the exact defect class #879 exists to kill - and even its docs'
+    ``"+ 1 Lap"`` spelling fails its own slice.
+    """
+    return status in _TOOK_FLAG_STATUSES or status.startswith("+")
+
+
 def _flag_frames(
-    frames_by_driver: dict[str, list], final_lap: int, progress_at: ProgressAt
+    frames_by_driver: dict[str, list],
+    final_lap: int,
+    progress_at: ProgressAt,
+    official_status: dict[str, str],
 ) -> dict[str, int | None]:
     """The frame each car took the chequered flag, `None` for a retirement.
 
-    **The rule is the racing one, and it needs no threshold.** When the
-    leader takes the flag every other car takes it the next time it crosses
-    the line, so a finisher's telemetry ends at or after the leader's does
-    and a retirement's ends before.
+    **The official classification is the source of truth when the loader
+    cached one** (`SessionData.official_status`, off `session.results`).
+    The replay always replays a COMPLETED session, so who finished is a
+    recorded fact rather than something to infer from odometer noise
+    (#879). A car the official result says finished takes the flag at its
+    own telemetry end - every car takes the flag at its own line, which is
+    where its telemetry stops - and a car it says retired takes none.
 
-    Everything therefore turns on finding the LEADER'S flag, and the
-    obvious answer is wrong. "The first car to reach the final lap" reads
-    a car that crashes a fifth of the way into it as the winner: its
-    telemetry ends first, so it set the flag time, it was then credited a
-    crossing of a lap it never completed, and the tie-break drew it **P1
-    ahead of the actual winner** for the whole flag-to-end window. An
-    earlier version of this docstring claimed the only misclassification
-    was a car retiring in the last fraction of a lap. That was false, and
-    a synthetic three-lap race produced the order `[CRASH, WIN, P2]`.
+    **The derived rule stays as the fallback**, for a session with no
+    official result: a future live feed, a synthetic session in the tests,
+    or a results table FastF1 could not deliver. It is a guess with two
+    measured misses (see `_derived_flag_frames`), which is why it is the
+    fallback and not the answer.
 
-    The rule that holds: **the flag is taken by the car that is LEADING
-    when its telemetry ends.** A winner is ahead of everyone at the moment
-    they stop producing data; a car that crashes is not. `progress_at` is
-    the caller's own coordinate WITHOUT any flag crossings, which is what
-    keeps this from being circular.
+    When both can answer, the derived one is still computed and every
+    disagreement is logged with the drivers and statuses named. Two code
+    paths answering the same question is this repo's own defect class, so
+    a divergence has to surface rather than pass silently.
 
-    Why not "reached the final lap" on its own: a car a lap down finishes
-    on `final_lap - 1` and would read as a retirement, the same mistake in
-    the other direction. Melbourne 2025 has no lapped finisher and no
-    final-lap retirement, so both wrong versions measured perfectly on it.
-
-    **This rule does NOT hold in general, and an earlier version of this
-    paragraph claimed it did with one small residual. Two misses, both
-    measured (#879):**
-
-    1. *Any race whose leader retires on the final lap.* The retiree
-       anchors the flag, is credited the full race distance and is drawn
-       P1 above the actual winner — the exact rendering this code was
-       written to stop — and every car still moving past its stop,
-       **including later genuine retirees**, then reads as a finisher. Not
-       "the last few metres" either: a leader who stops at 40 % of the
-       final lap still anchors.
-    2. *A clean winner, whenever adjacent-lap noise exceeds the flag gap.*
-       At its own end a car's fraction is its final-lap distance over the
-       PREVIOUS lap's own length, and this file measures that per-car
-       variation at a median of 9.2 m and up to 340 m. A winner whose
-       previous lap ran long reads under 1.0; a rival whose previous lap
-       ran short clamps to 1.0 while still short of its line. Constructed
-       and executed: the winner reads `has_finished=False` and P2 takes
-       the flag. Melbourne 2025 survives on a 77 m margin, and both
-       ingredients are present in it.
-
-    There is no threshold-free rule that separates a noisy winner from a
-    final-lap crasher with what the loader caches today; #879 carries the
-    options, of which caching FastF1's official classification is the one
-    that ends the class rather than moving it.
+    A driver the official table does not cover falls back to the derived
+    answer for that driver alone, under the same warning.
 
     `final_lap` of 0 means the loader did not record one; nobody is then
     known to have finished, which is the honest answer and the behaviour
@@ -196,6 +196,58 @@ def _flag_frames(
     ends = {
         code: _telemetry_end_frame(frames) for code, frames in frames_by_driver.items() if frames
     }
+    derived = _derived_flag_frames(frames_by_driver, final_lap, ends, progress_at)
+    if not official_status:
+        return derived
+
+    flags: dict[str, int | None] = {}
+    for code in frames_by_driver:
+        status = official_status.get(code)
+        if status is None:
+            flags[code] = derived.get(code)
+        else:
+            flags[code] = ends.get(code) if _took_flag_officially(status) else None
+    _warn_where_the_derived_rule_disagrees(flags, derived, official_status)
+    return flags
+
+
+def _derived_flag_frames(
+    frames_by_driver: dict[str, list],
+    final_lap: int,
+    ends: dict[str, int],
+    progress_at: ProgressAt,
+) -> dict[str, int | None]:
+    """The fallback: infer the flag from telemetry alone. A guess, twice wrong.
+
+    The rule: when the leader takes the flag every other car takes it the
+    next time it crosses the line, so a finisher's telemetry ends at or
+    after the leader's and a retirement's ends before. The leader's flag is
+    anchored on **the car that is LEADING when its own telemetry ends**;
+    `progress_at` is the caller's coordinate WITHOUT any flag crossings,
+    which is what keeps this from being circular. "First to reach the final
+    lap" was tried and crowned a final-lap crasher (`[CRASH, WIN, P2]`,
+    executed); "reached the final lap" alone reads a lapped finisher as a
+    retirement.
+
+    **Two measured misses, unfixable with telemetry alone (#879):**
+
+    1. *A race whose leader retires on the final lap.* The retiree anchors,
+       is credited the full race distance, is drawn P1 above the actual
+       winner, and every car still moving past its stop - later genuine
+       retirees included - reads as a finisher. A leader stopping at 40 %
+       of the final lap still anchors.
+    2. *A clean winner, whenever adjacent-lap noise exceeds the flag gap.*
+       At its own end a car's fraction is its final-lap distance over the
+       PREVIOUS lap's own length, and this file measures that per-car
+       variation at a median of 9.2 m and up to 340 m. Constructed and
+       executed: the winner reads `has_finished=False` and P2 takes the
+       flag. Melbourne 2025 survives on a 77 m margin with both ingredients
+       present in it.
+
+    There is no threshold-free telemetry rule that separates a noisy winner
+    from a final-lap crasher, which is why the official classification is
+    the primary path and this one only answers when nothing better exists.
+    """
     candidates = sorted(
         (end, code) for code, end in ends.items() if frames_by_driver[code][-1].lap >= final_lap
     )
@@ -210,6 +262,37 @@ def _flag_frames(
         code: (ends[code] if code in ends and ends[code] >= leader_flag else None)
         for code in frames_by_driver
     }
+
+
+def _warn_where_the_derived_rule_disagrees(
+    official: dict[str, int | None],
+    derived: dict[str, int | None],
+    official_status: dict[str, str],
+) -> None:
+    """Log every driver the two flag paths classify differently.
+
+    The official result wins either way; this exists so a disagreement is
+    evidence in the log instead of a silent divergence between the replay
+    and a future live feed running the derived rule. On Melbourne 2025 the
+    two paths agree on all twenty drivers and this stays quiet.
+    """
+    disagreements = []
+    for code, frame in official.items():
+        if code not in official_status:
+            continue
+        derived_finished = derived.get(code) is not None
+        if (frame is not None) == derived_finished:
+            continue
+        verdict = "finished" if frame is not None else "retired"
+        other = "finished" if derived_finished else "retired"
+        disagreements.append(
+            f"{code} (official {official_status[code]!r} -> {verdict}, derived -> {other})"
+        )
+    if disagreements:
+        logger.warning(
+            "Flag classification: official result overrides the derived rule for %s",
+            ", ".join(disagreements),
+        )
 
 
 def _leads_at(code: str, frame: int, ends: dict[str, int], progress_at: ProgressAt) -> bool:
@@ -252,7 +335,9 @@ class RaceGapCalculator:
       drove; crediting it to nobody left every finisher short of the lap
       they had just completed, and the ordering that followed was wrong on
       19 of 20 positions (#855). Who counts as a finisher is decided by
-      `_flag_frames`, not by a threshold.
+      `_flag_frames` - the official classification when
+      the loader cached one, the derived anchor otherwise - not by a
+      threshold.
     - Unknown is `None`, never a number a caller could also legitimately
       compute. This applies to `laps_down` as much as to `interval_at_line`:
       an earlier version returned `0` for an inverted call, which is also
@@ -273,7 +358,10 @@ class RaceGapCalculator:
         # crashed on the final lap define the flag time for everyone.
         self._build_crossings(session, flag_frames={})
         flag_frames = _flag_frames(
-            session.frames_by_driver, int(session.max_lap_number or 0), self.progress
+            session.frames_by_driver,
+            int(session.max_lap_number or 0),
+            self.progress,
+            session.official_status,
         )
         self._finished = {code: frame is not None for code, frame in flag_frames.items()}
         self._build_crossings(session, flag_frames)

--- a/tests/surfaces/test_arcade_leaderboard_gaps.py
+++ b/tests/surfaces/test_arcade_leaderboard_gaps.py
@@ -22,6 +22,7 @@ that were refuted on the way.
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -674,3 +675,167 @@ def test_a_crossing_is_keyed_by_the_lap_it_ends_and_only_real_laps_count():
     assert sorted(crossings) == [1, 2, 3]
     for lap in (1, 2, 3):
         assert crossings[lap] == pytest.approx(lap * LAP_SECONDS, abs=DT)
+
+
+# --- Defect 3: who took the flag, when the official result is on disk --------
+#
+# #879: there is no threshold-free telemetry rule that separates a noisy
+# winner from a final-lap crasher. The replay replays a COMPLETED session,
+# so the loader now caches FastF1's official classification and the
+# calculator consumes it; the derived anchor stays only as the fallback for
+# sessions that have none (synthetic tests, a future live feed).
+
+
+def _own_lengths_frame(i: int, lap: int, dist: float, live: bool) -> FrameData:
+    return FrameData(
+        t=i * DT,
+        x=0.0,
+        y=0.0,
+        speed=180.0,
+        gear=7,
+        drs=0,
+        throttle=100.0,
+        brake=0.0,
+        lap=lap,
+        dist=dist,
+        rel_dist=0.0,
+        tyre=1,
+        tyre_life=5.0,
+        active=live,
+    )
+
+
+def _own_lengths_car(lap_lengths_m: list[float]) -> list[FrameData]:
+    """A car whose laps have different OWN lengths, at a constant 50 m/s.
+
+    This is the noise #879 measured on Melbourne 2025 (adjacent-lap
+    own-length deltas of median 9.2 m, up to 340 m): `dist` accumulates
+    what the car actually drove, so at its own telemetry end a car's
+    final-lap fraction is measured against the PREVIOUS lap's own length.
+    `_car` cannot express it — all its laps are the same length.
+    """
+    speed = 50.0
+    frames: list[FrameData] = []
+    dist = 0.0
+    for lap_no, length in enumerate(lap_lengths_m, start=1):
+        for i in range(int(round(length / speed / DT))):
+            frames.append(_own_lengths_frame(len(frames), lap_no, dist + speed * i * DT, True))
+        dist += length
+    while len(frames) < N_FRAMES:
+        frames.append(_own_lengths_frame(len(frames), len(lap_lengths_m), dist, False))
+    return frames
+
+
+def test_the_wall_clock_winner_finishes_when_the_official_result_says_so():
+    """#879 miss 2, closed: adjacent-lap noise no longer decides the flag.
+
+    WIN's previous lap ran 100 m long, so at its own end its fraction reads
+    5000/5100 < 1.0; P2's ran 50 m short, so P2 clamps to 1.0 while still
+    short of its line. The derived anchor then crowns P2 and classifies the
+    wall-clock winner — who crossed 1.0 s earlier — as a retirement. The
+    official result knows both finished, and it is on disk.
+    """
+    session = _session(
+        max_lap_number=3,
+        WIN=_own_lengths_car([5000.0, 5100.0, 5000.0]),
+        P2=_own_lengths_car([5000.0, 4950.0, 5200.0]),
+    )
+    session.official_status = {"WIN": "Finished", "P2": "Finished"}
+    idx = N_FRAMES - 1
+    gaps = RaceGapCalculator(session)
+
+    assert gaps.has_finished("WIN") is True, "the wall-clock winner took the flag"
+    assert gaps.has_finished("P2") is True
+    assert _order(session, idx) == ["WIN", "P2"]
+    assert gaps.interval_at_line("WIN", "P2", lap=3) == pytest.approx(1.0, abs=DT)
+
+
+def test_a_leading_final_lap_retiree_is_out_and_takes_nobody_with_it():
+    """#879 miss 1, closed: the retiring leader neither wins nor launders others.
+
+    CRASH leads by 0.3 laps and stops ~100 m short of its final line; RET2
+    is a genuine retirement that stops after the winner's flag. The derived
+    anchor let CRASH define the flag: it was drawn P1 with the full race
+    distance and RET2 inherited a finish. The official result says both
+    retired.
+    """
+    session = _finish_session(
+        CRASH=_car(50.0, head_start_laps=0.30, dead_from=6700),
+        RET2=_car(50.0, head_start_laps=-0.50, dead_from=7600),
+    )
+    session.official_status = {
+        "P1": "Finished",
+        "P2": "Finished",
+        "P3": "Finished",
+        "CRASH": "Retired",
+        "RET2": "Retired",
+    }
+    idx = N_FRAMES - 1
+    gaps = RaceGapCalculator(session)
+
+    assert gaps.has_finished("CRASH") is False
+    assert gaps.has_finished("RET2") is False
+    assert gaps.has_finished("P1") is True
+    assert _order(session, idx) == ["P1", "P2", "P3", "CRASH", "RET2"]
+    assert "CRASH OUT" in _labels(session, "P3", idx)
+
+
+@pytest.mark.parametrize("lapped_status", ["Lapped", "+1 Lap"])
+def test_official_truth_survives_a_telemetry_dropout(lapped_status):
+    """A car FastF1 loses mid-race but that officially finished stays FIN.
+
+    Telemetry absence is not retirement: a dropout that ends a car's frames
+    before the leader's flag made the derived rule call it a retirement.
+    The official row knows better. 'Lapped' is the spelling every 2023-2025
+    race actually serves (executed against jolpica; China 2025 classifies
+    BOR/HUL/TSU P14-P16 with it); '+1 Lap' is the deep-historical Ergast
+    form. NOT fastf1's own `DriverResult.dnf`, which calls 'Lapped' a DNF.
+    """
+    session = _finish_session(DROP=_car(33.34, dead_from=7000))
+    session.official_status = {
+        "P1": "Finished",
+        "P2": "Finished",
+        "P3": "Finished",
+        "DROP": lapped_status,
+    }
+    gaps = RaceGapCalculator(session)
+
+    assert gaps.has_finished("DROP") is True
+
+
+def test_a_disagreement_between_official_and_derived_is_logged(caplog):
+    """Two code paths answering one question is this repo's own defect class.
+
+    The official result wins, but a divergence from the derived rule must
+    become evidence in the log — it is the net that catches a vocabulary
+    surprise (a DSQ spelling, a status FastF1 renames) instead of letting
+    the replay and a future live feed drift apart silently.
+    """
+    session = _finish_session(CRASH=_car(50.0, head_start_laps=0.30, dead_from=6700))
+    session.official_status = {
+        "P1": "Finished",
+        "P2": "Finished",
+        "P3": "Finished",
+        "CRASH": "Retired",
+    }
+    with caplog.at_level(logging.WARNING):
+        RaceGapCalculator(session)
+
+    flagged = [r for r in caplog.records if "Flag classification" in r.message]
+    assert flagged, "the official-vs-derived disagreement must be logged"
+    assert any("CRASH" in r.message and "Retired" in r.message for r in flagged)
+
+
+def test_no_warning_when_official_and_derived_agree(caplog):
+    """Melbourne 2025 in miniature: agreement on every driver stays silent."""
+    session = _finish_session(RETIRED=_car(50.0, dead_from=3000))
+    session.official_status = {
+        "P1": "Finished",
+        "P2": "Finished",
+        "P3": "Finished",
+        "RETIRED": "Retired",
+    }
+    with caplog.at_level(logging.WARNING):
+        RaceGapCalculator(session)
+
+    assert not [r for r in caplog.records if "Flag classification" in r.message]

--- a/tests/surfaces/test_arcade_official_status.py
+++ b/tests/surfaces/test_arcade_official_status.py
@@ -1,0 +1,50 @@
+"""SessionLoader._extract_official_status: the facts cached for #879's flag logic.
+
+No arcade/pyglet dependency: data.py imports fastf1 and pandas only, so this
+file needs no importorskip("arcade").
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+
+from src.arcade.data import SessionLoader
+
+
+def _extract(session, driver_codes):
+    return SessionLoader()._extract_official_status(session, driver_codes)
+
+
+def test_statuses_are_keyed_by_abbreviation_in_the_frames_keyspace():
+    """Results are indexed by driver NUMBER; frames by ABBREVIATION (#448)."""
+    df = pd.DataFrame({"Status": ["Finished", "Retired"]}, index=["4", "7"])
+    out = _extract(SimpleNamespace(results=df), {"4": "NOR", "7": "DOO"})
+    assert out == {"NOR": "Finished", "DOO": "Retired"}
+
+
+def test_a_missing_or_empty_status_is_absent_not_guessed():
+    """Unknown is absent: gaps.py falls back per driver, never a stored guess."""
+    df = pd.DataFrame({"Status": ["Finished", float("nan"), ""]}, index=["4", "1", "63"])
+    out = _extract(SimpleNamespace(results=df), {"4": "NOR", "1": "VER", "63": "RUS", "99": "GHO"})
+    assert out == {"NOR": "Finished"}
+
+
+def test_an_unreadable_results_table_degrades_to_empty(caplog):
+    """DataNotLoadedError subclasses Exception directly (the weather scar)."""
+    import fastf1.core
+
+    class _Boom:
+        @property
+        def results(self):
+            raise fastf1.core.DataNotLoadedError("not loaded")
+
+    out = _extract(_Boom(), {"4": "NOR"})
+    assert out == {}
+    assert any("falls back to the derived rule" in r.message for r in caplog.records)
+
+
+def test_a_none_or_empty_results_table_is_empty():
+    assert _extract(SimpleNamespace(results=None), {"4": "NOR"}) == {}
+    assert _extract(SimpleNamespace(results=pd.DataFrame()), {"4": "NOR"}) == {}


### PR DESCRIPTION
Closes #879.

## Why a fourth derived rule was not the answer

Three telemetry rules were tried and all three were a new way of guessing: past the leader's flag distance (a final-lap retirement ranked P1, #873), first to reach the final lap (a crasher reaches it too), leading at its own end (**the winner reads OUT**, this issue). The replay always replays a **completed** session, so who took the flag is a recorded fact in the object `data.py` already opens.

## What changed

| | |
|---|---|
| `SessionData.official_status` | abbreviation → FastF1 `Status`, keyed through the loader's own `driver_codes` so the keyspace cannot drift the way the circuit table did (#448) |
| `_flag_frames` | a dispatcher: official truth first, **today's rule kept verbatim** as `_derived_flag_frames` for synthetic sessions and the future live feed |
| the disagreement warning | every official-vs-derived split logged per driver — two paths answering one question is this repo's own defect class |
| `CACHE_VERSION` | v11 → **v12** (one rebuild per GP, no re-download) |

Nothing is deleted. The two-pass build stays, and #879's *"A now, C when live"* lands as one step.

## The find that changed the design

**The issue's example vocabulary was wrong, and so is FastF1's own predicate.** The seasons this replay serves carry exactly `Finished` / `Lapped` / `Retired` / `Disqualified`. Upstream's `DriverResult.dnf` is `not (Status[3:6] == "Lap" or Status == "Finished")` — and `"Lapped"[3:6]` is `"ped"`, so **it calls every lapped finisher a DNF**: the exact defect class this change exists to remove. Even its own docs' `"+ 1 Lap"` spelling fails its own slice. The shipped predicate is built on the executed vocabulary instead, and this is a second evidenced FastF1 upstream issue for the contribution thread.

## Verified against the real race, not only the suite

```
cache version: v12          official_status entries: 20
finishers: 14   retirements: 6
OUT: ['ALO', 'BOR', 'DOO', 'HAD', 'LAW', 'SAI']
NOR-VER at the flag: 0.880   NOR-RUS at the flag: 8.480
```

Driver for driver, that is the official Melbourne table. The intervals are unchanged from the pre-change measurement, and **the disagreement warning stayed silent** — all twenty agree, so the derived rule was right on this race and the change is behaviour-preserving where it can be checked.

## Red-ability

With the official path disabled (`if True: return derived`), **5 tests fail**, including both catastrophic cases:

```
test_the_wall_clock_winner_finishes_when_the_official_result_says_so
test_a_leading_final_lap_retiree_is_out_and_takes_nobody_with_it
test_official_truth_survives_a_telemetry_dropout[Lapped]
test_official_truth_survives_a_telemetry_dropout[+1 Lap]
test_a_disagreement_between_official_and_derived_is_logged
```

Restored: 37 pass. Whole `tests/surfaces` suite: **155 passed, 0 failed** — `test_cli_no_llm` included, which #883 unblocked.

## Named residuals

- A **mid-race black flag** would render FIN. Absent from every season in range, and the disagreement warning surfaces it.
- **DSQ is pinned synthetically only** — the race that has one is not in the curated download.

Closes #879