### PR TITLE
fix(arcade): no position data is an absence, not a car on the grid

### DIFF
--- a/src/arcade/gaps.py
+++ b/src/arcade/gaps.py
@@ -350,6 +350,10 @@ class RaceGapCalculator:
         self._dist: dict[str, np.ndarray] = {}
         self._default_lap_m = float(session.circuit_length_m or 0.0)
         self._finished: dict[str, bool] = {}
+        # Drivers FastF1 delivered NO position data for. Their whole `dist`
+        # array is zeros, so every distance-derived answer for them is the
+        # absence wearing the value a car on the grid also reads (#886).
+        self._no_position = {code for code, present in session.has_position.items() if not present}
         # TWO passes, and the order is the whole point. Deciding who took
         # the flag needs the race order, the race order needs `progress`,
         # and `progress` reads the crossings - so the crossings are built
@@ -478,7 +482,17 @@ class RaceGapCalculator:
         on `rel_dist` drew a car that had crashed at turn 1 as the race
         leader for 68 seconds of replay; this form draws him where his
         distance says he is, with no threshold to tune.
+
+        **A car FastF1 gave no position data for gets None, not 0.0.** Its
+        whole `dist` array is zeros (HAD, Melbourne 2025: 154,173 frames at
+        0.0, x and y at 0.0 too), and 0.0 is what every car legitimately
+        reads on the grid - so the absence and the start line were the same
+        number, on the coordinate the whole field is ordered by. The panel
+        already partitions None out and appends it last; it just never
+        received one (#886).
         """
+        if code in self._no_position:
+            return None
         dist = self._dist.get(code)
         if dist is None or frame_idx < 0 or frame_idx >= len(dist):
             return None

--- a/src/arcade/overlays.py
+++ b/src/arcade/overlays.py
@@ -587,11 +587,15 @@ class LeaderboardPanel:
         wrong on 1.7 % and reproduces the whole running order exactly on
         236 of 300.
 
-        A car whose progress is unknown (FastF1 delivered no
-        `RelativeDistance`, which is a whole driver on Melbourne 2025)
-        sorts last and carries `None` rather than a position it does not
-        have. It is still drawn, because a car with no position data is
-        still on the track.
+        A car whose progress is unknown sorts last and carries `None`
+        rather than a position it does not have. It is still drawn, because
+        a car with no position data is still on the track.
+
+        That claim used to name `RelativeDistance` as the cause and was
+        wrong twice: `progress` does not read `RelativeDistance` at all,
+        and the value it actually returned for such a car was 0.0, not
+        None - the same number every car reads on the grid. The signal is
+        `SessionData.has_position`, and it is honoured now (#886).
 
         **The tie-break is not decoration.** Every car that has finished
         sits at exactly the total laps, so from the leader's flag to the

--- a/tests/surfaces/test_arcade_leaderboard_gaps.py
+++ b/tests/surfaces/test_arcade_leaderboard_gaps.py
@@ -839,3 +839,30 @@ def test_no_warning_when_official_and_derived_agree(caplog):
         RaceGapCalculator(session)
 
     assert not [r for r in caplog.records if "Flag classification" in r.message]
+
+
+def test_a_car_with_no_position_data_has_no_progress_rather_than_zero():
+    """The absence must not wear the value a car on the grid also reads (#886).
+
+    FastF1 delivers nothing for one whole driver on Melbourne 2025: 154,173
+    frames with `dist`, `x` and `y` all at 0.0. `progress` computed 0.0 from
+    that and returned it, so "we have no data for this car" and "this car is
+    at the start line" were the same number - on the coordinate the entire
+    field is ordered by, one sprint before the wire starts publishing it.
+
+    The panel already partitions `None` out and appends it last. It simply
+    never received one.
+    """
+    session = _session(
+        max_lap_number=RACE_LAPS,
+        RUNNING=_car(50.0),
+        BLIND=[FrameData(**{**vars(f), "dist": 0.0, "x": 0.0, "y": 0.0}) for f in _car(50.0)],
+    )
+    session.has_position["BLIND"] = False
+    gaps = RaceGapCalculator(session)
+
+    assert gaps.progress("BLIND", 4000) is None, "no position data is an absence"
+    assert gaps.progress("RUNNING", 4000) is not None, "and the running car still has one"
+
+    order = _order(session, 4000)
+    assert order[-1] == "BLIND", "the unknown car sorts last rather than leading from the grid"


### PR DESCRIPTION
Closes #886. Found by the #857 design gate (M-3) and reproduced independently.

## The defect

`progress()` returned **`0.0`** for a driver FastF1 delivered nothing for, and `0.0` is what every car legitimately reads on the grid. Measured on the real session:

```
HAD frames: 154173 | has_position: False
  dist  first/mid/last: 0.0 0.0 0.0
  x,y   first: 0.0 0.0 | mid: 0.0 0.0

DOO (also retired) dist mid: 1738.80 | has_position: True
```

DOO retired too and has a real distance. HAD's zero **is** the absence — on the coordinate the entire field is ordered by.

## The docstring already promised the fix

`overlays.py:590-594` said such a car *"sorts last and carries `None` rather than a position it does not have"*. Both halves of its explanation were wrong: `progress` does not read `RelativeDistance` at all (its own docstring says so), and what it returned was a zero. The signal is `SessionData.has_position`. Corrected in place.

## Verified on the real race, not only the suite

```
progress(HAD) now: None
progress(NOR) mid: 17.639
board: [... SAI, DOO, HAD]      HAD position: 20 of 20
finishers still: 14
```

The consumer side needed **no** change — the panel already partitions `None` out and appends it last. It simply never received one. I checked that rather than assuming it, since the claim above was also unverified.

## Red-ability

With the guard removed, the new test fails. Whole suite: **156 passed, 0 failed**.

## Why now

**#857 is about to publish `progress` on the wire.** A PITWALL consumer would have received `0.0` for a car with no data and ranked it leading from the grid, with nothing to distinguish it — this repo's dominant defect class landing in a fourth place, one sprint before the surface that would show it.

Closes #886