### PR TITLE
feat(arcade): publish the race order and the reveal coordinates on the wire

### DIFF
--- a/scripts/dev_pitwall_producer.py
+++ b/scripts/dev_pitwall_producer.py
@@ -26,6 +26,7 @@ from types import SimpleNamespace
 from src.arcade.app import F1ArcadeView
 from src.arcade.config import FPS, STREAM_HOST, STREAM_PORT
 from src.arcade.data import SessionLoader
+from src.arcade.gaps import RaceGapCalculator
 from src.arcade.strategy import (
     LapDecisionDTO,
     PerAgentOutputsDTO,
@@ -190,6 +191,7 @@ view = SimpleNamespace(
     _driver_main="NOR",
     _driver_rival="PIA",
     _year=2025,
+    _gaps=RaceGapCalculator(session),
     _stream_server=server,
     _strategy_state=state,
     _broadcast_tick=0,

--- a/src/arcade/app.py
+++ b/src/arcade/app.py
@@ -665,6 +665,34 @@ class F1ArcadeView(arcade.View):
                 # chart under a populated header.
                 "has_position": has_position,
             }
+        # --- Race order and the reveal coordinates (#857) -------------------
+        # Published by the producer so no consumer re-derives the order from
+        # `dist` (race-cumulative: the wrong leader on 37 % of sampled frames)
+        # or from `lap` (a rounded interpolation that flickers +-1 at the
+        # line). `_rank_drivers` is the SAME code the arcade leaderboard ranks
+        # with, so the wire and the panel cannot drift apart.
+        #
+        # Per driver:
+        # - `laps_completed` carries the DATA window's strict per-driver
+        #   reveal (reveal lap L iff L <= laps_completed). It reads the
+        #   crossing map, so it is monotone while playing forward and never
+        #   flashes a lap open a tick early the way the interpolated `lap`
+        #   can.
+        # - `progress` is the ordering coordinate, laps plus fraction of the
+        #   current lap; a consumer derives laps-down positionally from it.
+        #   None when the telemetry never places the car (#886).
+        # - `has_finished` separates a chequered flag from a retirement:
+        #   `active` alone reads the winner as OUT (#855). Its value is only
+        #   as good as the flag anchor, which since #879 is the official
+        #   classification rather than an inference.
+        ranked = LeaderboardPanel._rank_drivers({"drivers": drivers}, self._gaps, frame_idx)
+        race_order: list[str] = []
+        for code, data, progress in ranked:
+            race_order.append(code)
+            known = progress is not None and data["has_position"]
+            data["progress"] = round(progress, 4) if known else None
+            data["laps_completed"] = self._gaps.laps_completed(code, frame_idx)
+            data["has_finished"] = self._gaps.has_finished(code)
         main_frame = None
         main_frames = self._session.frames_by_driver.get(self._driver_main)
         if main_frames and frame_idx < len(main_frames):
@@ -733,6 +761,14 @@ class F1ArcadeView(arcade.View):
             # are keyed on. `t` alone is only `frame_index * DT`.
             "global_t_min": round(float(self._session.global_t_min), 3),
             "total_laps": self._session.max_lap_number,
+            "race_order": race_order,
+            # FastF1 TrackStatus digits for the lap on screen, the same source
+            # the arcade's own pill reads. "" when the loader has no entry for
+            # that lap, which a consumer renders as clear - the same collapse
+            # the arcade already makes.
+            "track_status": (
+                self._session.track_status_by_lap.get(int(main_frame.lap), "") if main_frame else ""
+            ),
             # Circuit length lets the telemetry window anchor the X axis
             # once and forget — without it the charts would autorange to
             # the current sample's max and shift every broadcast.

--- a/src/pitwall/ui/src/lib/bridge.ts
+++ b/src/pitwall/ui/src/lib/bridge.ts
@@ -22,6 +22,12 @@ export interface DriverState {
   tyre_life: number;
   active: boolean;
   has_position: boolean;
+  /** Laps completed per the crossing map. The reveal carrier: reveal lap L iff L <= laps_completed. */
+  laps_completed: number;
+  /** Laps plus fraction of the current lap, the ordering coordinate. Null when the telemetry never places the car (#886). */
+  progress: number | null;
+  /** Took the chequered flag. OUT = !active && !has_finished (#855); the value's quality is #879. */
+  has_finished: boolean;
 }
 
 export interface TelemetrySample {
@@ -47,6 +53,10 @@ export interface ArcadeState {
   driver_main: string;
   driver_rival: string | null;
   drivers: Record<string, DriverState>;
+  /** Every published driver, best first - the producer's own ranking, so no consumer re-derives it (#857). */
+  race_order: string[];
+  /** FastF1 TrackStatus digits for the lap on screen; "" when the loader has no entry, rendered as clear. */
+  track_status: string;
   telemetry: {
     /** Every sample the replay clock crossed since the previous tick, oldest first. */
     main: TelemetrySample[];

--- a/tests/surfaces/test_arcade_broadcast_wire.py
+++ b/tests/surfaces/test_arcade_broadcast_wire.py
@@ -32,6 +32,7 @@ from src.arcade.data import (  # noqa: E402
     SessionData,
     _lap_fraction_from_distance,
 )
+from src.arcade.gaps import RaceGapCalculator  # noqa: E402
 
 # The three numbers a synthetic session needs to be self-consistent: a
 # circuit length the distances accumulate against, a session-time origin
@@ -146,6 +147,7 @@ def _snapshot(
         _driver_main=MAIN,
         _driver_rival=rival,
         _year=session.year,
+        _gaps=RaceGapCalculator(session),
     )
     start = frame_idx if span_start is None else span_start
     return F1ArcadeView._build_arcade_snapshot(view, frame_idx, start, rewound, 0)

--- a/tests/surfaces/test_arcade_telemetry_span.py
+++ b/tests/surfaces/test_arcade_telemetry_span.py
@@ -34,6 +34,7 @@ from src.arcade.config import (  # noqa: E402
     STREAM_MAX_SPAN_FRAMES,
 )
 from src.arcade.data import FrameData, SessionData  # noqa: E402
+from src.arcade.gaps import RaceGapCalculator  # noqa: E402
 
 # The real cadence: `on_update` runs at the arcade library default 60 Hz and
 # every 6th call broadcasts, so a tick is one sixth of a second of wall
@@ -219,7 +220,13 @@ def test_the_snapshot_publishes_spans_and_the_rewind_flag():
         circuit_length_m=CIRCUIT_LENGTH_M,
         total_frames=50,
     )
-    view = SimpleNamespace(_session=session, _driver_main="NOR", _driver_rival="PIA", _year=2025)
+    view = SimpleNamespace(
+        _session=session,
+        _driver_main="NOR",
+        _driver_rival="PIA",
+        _year=2025,
+        _gaps=RaceGapCalculator(session),
+    )
 
     moving = F1ArcadeView._build_arcade_snapshot(view, 20, 16, False)["telemetry"]
     assert len(moving["main"]) == 5
@@ -243,7 +250,13 @@ def test_single_driver_mode_publishes_an_empty_rival_span():
         circuit_length_m=CIRCUIT_LENGTH_M,
         total_frames=50,
     )
-    view = SimpleNamespace(_session=session, _driver_main="NOR", _driver_rival=None, _year=2025)
+    view = SimpleNamespace(
+        _session=session,
+        _driver_main="NOR",
+        _driver_rival=None,
+        _year=2025,
+        _gaps=RaceGapCalculator(session),
+    )
 
     telemetry = F1ArcadeView._build_arcade_snapshot(view, 20, 16, False)["telemetry"]
 

--- a/tests/surfaces/test_arcade_wire_contract.py
+++ b/tests/surfaces/test_arcade_wire_contract.py
@@ -32,6 +32,7 @@ pytest.importorskip("arcade", reason="the arcade replay is an optional surface")
 from src.arcade.app import F1ArcadeView  # noqa: E402
 from src.arcade.config import DT, STREAM_SCHEMA_VERSION  # noqa: E402
 from src.arcade.data import FrameData, SessionData  # noqa: E402
+from src.arcade.gaps import RaceGapCalculator  # noqa: E402
 from src.arcade.strategy import (  # noqa: E402
     LapDecisionDTO,
     PerAgentOutputsDTO,
@@ -152,6 +153,7 @@ def _view(session: SessionData, state: StrategyState, rival: str | None, clients
         _driver_main="NOR",
         _driver_rival=rival,
         _year=2025,
+        _gaps=RaceGapCalculator(session),
         _stream_server=SimpleNamespace(client_count=lambda: clients, broadcast=_sent.append),
         _strategy_state=state,
         # `_broadcast_if_due` increments the tick then broadcasts when it
@@ -220,8 +222,11 @@ GOLDEN_SHAPE = {
                 "active": "bool",
                 "compound": "int",
                 "dist": "float",
+                "has_finished": "bool",
                 "has_position": "bool",
                 "lap": "int",
+                "laps_completed": "int",
+                "progress": "float",
                 "rel_dist": "float",
                 "speed": "float",
                 "tyre_life": "float",
@@ -230,8 +235,11 @@ GOLDEN_SHAPE = {
                 "active": "bool",
                 "compound": "int",
                 "dist": "float",
+                "has_finished": "bool",
                 "has_position": "bool",
                 "lap": "int",
+                "laps_completed": "int",
+                "progress": "float",
                 "rel_dist": "float",
                 "speed": "float",
                 "tyre_life": "float",
@@ -241,6 +249,7 @@ GOLDEN_SHAPE = {
         "gp_name": "str",
         "lap": "int",
         "location": "str",
+        "race_order": ["str"],
         "t": "float",
         "telemetry": {
             "main": [
@@ -271,6 +280,7 @@ GOLDEN_SHAPE = {
             ],
         },
         "total_laps": "int",
+        "track_status": "str",
         "year": "int",
     },
     "playback": {
@@ -702,3 +712,106 @@ def test_a_payload_that_cannot_be_encoded_is_dropped_rather_than_half_sent():
     payload["strategy"]["latest"]["reasoning"] = {1, 2}  # a set is not JSON
 
     assert _sent_bytes(payload) == []
+
+
+# --- #857: the wire can feed a leaderboard ----------------------------------
+
+
+def _drift_frames(n: int, speed_mps: float, drift_per_lap_m: float = 0.0) -> list[FrameData]:
+    """Frames whose odometer accumulates that car's OWN per-lap length.
+
+    `dist` is race-cumulative metres, so it looks like a progress axis and
+    is not one: each car accumulates the distance IT drove. On the real race
+    that drift reaches 1877 m on a 5220 m circuit, and sorting on it put the
+    wrong car in the lead on 37 % of sampled frames.
+    """
+    circuit = 5000.0
+    lap_length = circuit + drift_per_lap_m
+    out = []
+    for i in range(n):
+        travelled = speed_mps * i * DT
+        completed = int(travelled // circuit)
+        fraction = (travelled % circuit) / circuit
+        out.append(
+            FrameData(
+                t=i * DT,
+                x=1.0,
+                y=2.0,
+                speed=speed_mps * 3.6,
+                gear=7,
+                drs=0,
+                throttle=90.0,
+                brake=0.0,
+                lap=1 + completed,
+                dist=(completed + fraction) * lap_length,
+                rel_dist=fraction,
+                tyre=1,
+                tyre_life=9.0,
+                active=True,
+            )
+        )
+    return out
+
+
+def _order_snapshot(**cars) -> dict:
+    """One published snapshot from a session of the given cars."""
+    n = min(len(f) for f in cars.values())
+    session = SessionData(
+        gp_name="Melbourne",
+        location="Melbourne",
+        year=2025,
+        frames_by_driver=dict(cars),
+        circuit_length_m=5000.0,
+        max_lap_number=0,
+        total_frames=n,
+    )
+    view = SimpleNamespace(
+        _session=session,
+        _driver_main=next(iter(cars)),
+        _driver_rival=None,
+        _year=2025,
+        _gaps=RaceGapCalculator(session),
+    )
+    return F1ArcadeView._build_arcade_snapshot(view, n - 1, n - 26, False)
+
+
+def test_the_wire_publishes_an_order_a_dist_sort_would_get_wrong():
+    """`race_order` is the producer's answer, not something a consumer re-derives.
+
+    The fixture makes the two coordinates disagree: SLOW runs long per lap,
+    so its published `dist` exceeds FAST's while FAST is genuinely ahead on
+    track. A consumer sorting `dist` inverts them; the published key does
+    not, because it is `_rank_drivers` - the same code the arcade panel
+    ranks with, so the wire and the panel cannot drift apart.
+    """
+    snapshot = _order_snapshot(
+        # Long enough that every car has a PREVIOUS lap of its own: on a
+        # two-lap fixture nobody does, the circuit length stands in for all
+        # of them, and the per-car drift stops cancelling - which is the
+        # fixture being unrepresentative, not the coordinate failing.
+        FAST=_drift_frames(12000, 52.0),
+        SLOW=_drift_frames(12000, 50.0, drift_per_lap_m=900.0),
+    )
+    drivers = snapshot["drivers"]
+
+    assert drivers["SLOW"]["dist"] > drivers["FAST"]["dist"], "the fixture must invert dist"
+    assert snapshot["race_order"][0] == "FAST", "the published order gets it right anyway"
+
+
+def test_the_reveal_carrier_is_per_driver_and_not_the_main_driver_lap():
+    """Band 1-2 reveals lap L for driver d iff `L <= laps_completed`.
+
+    The tick carries only the MAIN driver's lap, and on the real race the
+    field spans two or three different laps at 96 % of instants - so masking
+    everyone at one lap lags the leaders and leaks look-ahead for the cars
+    behind, at the same time. `laps_completed` reads the crossing map, so it
+    is per driver and monotone forward, unlike the interpolated `lap`.
+    """
+    snapshot = _order_snapshot(FAST=_drift_frames(12000, 52.0), SLOW=_drift_frames(12000, 30.0))
+    fast = snapshot["drivers"]["FAST"]
+    slow = snapshot["drivers"]["SLOW"]
+
+    assert isinstance(fast["laps_completed"], int)
+    assert fast["laps_completed"] > slow["laps_completed"], (
+        "one shared lap number cannot express this, which is why the rule is per driver"
+    )


### PR DESCRIPTION
Closes #857 — **the formal prerequisite for sprint 4**.

## The gap

The wire carried only `lap`, `dist` and `rel_dist` per driver: the two coordinates #844 spent a sprint refuting, plus a fraction. No order, no `progress`, no interval — and a consumer attaching mid-race cannot rebuild the crossing map from a 10 Hz snapshot stream. The timing band would have re-derived the order from the refuted pair, one sprint after they were refuted.

## What the wire now carries

| Field | Why it and not something else |
|---|---|
| `race_order` | ranked by `LeaderboardPanel._rank_drivers` — **the panel's own code**, so the wire and the arcade cannot drift apart |
| `laps_completed` (per driver) | the reveal carrier: reveal lap L iff `L <= laps_completed`. Read off the crossing map, so it is monotone forward and per driver |
| `progress` (per driver) | the ordering coordinate; `None` when the telemetry never places the car (#886) |
| `has_finished` (per driver) | `active` alone reads the winner as OUT (#855); the value is official since #879 |
| `track_status` | the band-1 pill, from the source the arcade's own pill reads |

**Rejected with evidence** (in the design report): per-driver intervals — a second source of a number the BULK reader holds exactly, and two disagreeing paths is this repo's named defect class; the crossing map — 10-15 KB/tick for a worse copy of ; reveal-by-`lap` — non-monotone, and it never opens a finisher's final lap.

## Cost

**+1.3 KB/tick**, producer compute mean 87 µs / p95 126 µs — 0.1 % of the 100 ms tick. No version bump: purely additive, and every old consumer is a key reader.

## The issue named two fakes and there are four

Running the unmodified suite against the new producer **failed 17 tests** — that is how the mover set was found rather than assumed. `test_arcade_telemetry_span.py` and `test_arcade_broadcast_wire.py` build snapshot fakes too, and #857's "Where" list has neither.

## Verified on a real payload, not only the suite

```
--- final frame ---
  race_order: ['NOR','VER','RUS','ANT','ALB','STR'] ... ['SAI','DOO','HAD']
  NOR: laps_completed=57 progress=57.0 has_finished=True
  HAD: laps_completed=0  progress=None  has_finished=False
  payload bytes: 9101   (encodes with allow_nan=False)
```

That order **is** the official Melbourne classification.

## A fixture that lied, and what it taught

My first effect test failed: with a two-lap fixture the published order got the drift case wrong. Measured rather than assumed — on a two-lap fixture **no car has a previous lap of its own**, so the circuit length stands in for every one of them and the per-car drift stops cancelling. The fixture was unrepresentative, not the coordinate; lengthened to twelve laps it passes, and the comment says why so nobody shortens it back.

## Red-ability

With `race_order` removed: 2 failed (the shape freeze and the effect test). Suite: **158 passed**. `smoke OK: 14 checks`, `tsc` clean, ruff clean.

Closes #857