### PR TITLE
docs(pitwall): map every sprint-4 data source, and revoke a wrong scoping call

### DIFF
--- a/documents/research/PITWALL_DELIVERY_PLAN.md
+++ b/documents/research/PITWALL_DELIVERY_PLAN.md
@@ -315,13 +315,16 @@ over a threshold that could never fire.
 
 ## 9. Carried forward, unresolved
 
-- **Race control messages: DECIDED 2026-08-09, out of scope for sprint 4.** Band 1's status strip
-  is served by `track_status`, the FastF1 TrackStatus digits the wire has carried since #857 -
-  that is what renders the SC / VSC / yellow / red pill, and it is the same source the arcade's
-  own pill reads. The free-text MESSAGES are a different feature with a different producer
-  (`SessionData.events` is always empty, P3 finding A3, and nothing populates it), and building an
-  events pipeline is not bands 1-2. They belong with the RCM work, not here. **Overrule this if the
-  strip is meant to show message text rather than a flag state.**
+- **Race control messages: RESOLVED 2026-08-09 — they already exist, and an earlier note here was
+  wrong.** That note said they had no producer, on the strength of `SessionData.events` being
+  empty. `SessionData.events` is a dead field; the messages come from `src/nlp/radio_runner.py`
+  (out of `rcm.parquet`) as `RaceState.rcm_events`, and the **Radio card already renders them**
+  in its body and tooltip — so PITWALL's AGENTS window shows them today, alongside the radio
+  transcriptions and N29's verdict. A real Melbourne run reports 90 of them.
+  So the sprint-4 question is only WHERE they belong: the flag STATE is the status strip
+  (`track_status`, already on the wire); the message TEXT already has a home. If the DATA window
+  wants its own ticker, that is one additive wire field from an existing producer, not a pipeline.
+  Full source map: `PITWALL_SPRINT4_SOURCES.md`.
 - **A driver whose telemetry drops mid-race under-reveals** (OBS-4). An officially-Finished car
   with a dropout gets its flag crossing at the dropout frame, so `laps_completed` stops there and
   the reveal withholds that driver's later parquet laps. Data-honest - the replay has no telemetry

--- a/documents/research/PITWALL_SPRINT4_SOURCES.md
+++ b/documents/research/PITWALL_SPRINT4_SOURCES.md
@@ -1,0 +1,98 @@
+# Sprint 4 — where every piece of data comes from
+
+One page, written 2026-08-09, so nobody building bands 1-2 has to rediscover a producer or
+re-invent one that already exists. Every row was verified by execution on the real Melbourne 2025
+session, not by reading code. Where a number is quoted, it was measured.
+
+**Read the dead ends section too.** Half the cost of this sprint is picking the wrong source, and
+three of the wrong sources look exactly like the right ones.
+
+---
+
+## 1. What the wire carries (TCP, ~10 Hz, `src/arcade/app.py::_build_arcade_snapshot`)
+
+Everything here is published by the producer so no consumer re-derives it. Types are in
+`src/pitwall/ui/src/lib/bridge.ts`.
+
+| Field | Where it comes from | What it means, and the catch |
+|---|---|---|
+| `race_order` | `LeaderboardPanel._rank_drivers` — **the arcade panel's own code**, so the wire and the panel cannot drift apart | Best first. **Meaningless until every car has completed a lap**: on frame 0 the field is ordered by millimetres (measured: 6 mm), and through lap 1 each fraction is normalised by that car's OWN first-lap length, reading a P7 start as P2. Render the tower provisional until `laps_completed >= 1` |
+| `drivers.<code>.laps_completed` | the crossing map in `gaps.py` | **The reveal carrier**: reveal lap *L* iff `L <= laps_completed`. Monotone forward (swept 20 × 154,173 frames, no counter-example) but **not frame-exact**: 76 of 921 crossings (8.3 %) open before the parquet's `Time`, worst 0.463 s. A **rewind un-reveals** — a cache keyed on "seen once" leaks the whole future after one seek to the end |
+| `drivers.<code>.progress` | `gaps.progress` | Laps + fraction, the ordering coordinate. **`null` = the telemetry never placed the car** (#886). Never `0.0` for that case any more |
+| `drivers.<code>.has_finished` | `gaps.has_finished` ← FastF1's official `Status` (#879) | Chequered flag vs retirement. **OUT is the pair `!active && !has_finished`** — `active` alone reads the winner as OUT. Silent path: a driver missing from the official table falls back to the derived rule with **no** warning |
+| `track_status` | `SessionData.track_status_by_lap`, the same source the arcade's own pill reads | **This is the band-1 status strip**: FastF1 TrackStatus digits → SC / VSC / yellow / red. `""` when the loader has no entry, rendered as clear |
+| `driver_colors` | `_color_for` ← `src/arcade/palette.py` | RGB per driver. Published precisely so the tower does not hardcode a sixth copy of the palette — five copies have already been found in this repo |
+| `drivers.<code>.active`, `.lap`, `.dist`, `.rel_dist`, `.has_position` | the resampled frames | `lap` is an interpolation of a step function; `dist` is race-cumulative and per-car. **Neither is a race-progress axis** — that is what `progress` and `laps_completed` are for |
+
+Cost of the whole addition: **+1.3 KB/tick**, producer compute p95 **126 µs** — 0.1 % of the tick.
+
+## 2. What the BULK reader carries (`laps.parquet`, read directly, not over the wire)
+
+| Need | Source | Catch |
+|---|---|---|
+| Lap times, sectors, compounds, stints | `laps.parquet` for the race, `(927, 35)` on the race checked | Everything the tower and the bests need is here |
+| The gap column | the same parquet, **lap-quantised**, labelled at-the-line on screen | A precise-looking wrong number on a fidelity surface is the defect class this project exists to avoid |
+| Personal bests | recompute from the **revealed** subset | `IsPersonalBest` is a running flag and safe under masking (18-24 per driver), but the two sequences are not identical |
+
+## 3. Race control messages and radio — they EXIST and are already rendered
+
+Corrected on 2026-08-09. An earlier note in the delivery plan said race-control messages had no
+producer. **That was true of one dead field and false of the project.**
+
+| Piece | Producer | Already rendered in |
+|---|---|---|
+| Race control messages | `src/nlp/radio_runner.py`, from `rcm.parquet` → `RaceState.rcm_events` | The **Radio card** body and tooltip — `agent_formatters.py:280-325`. Ported 1:1 into PITWALL's AGENTS window |
+| Radio transcriptions | the same runner → `RaceState.radio_msgs` / `radio_events` | Same card, `<b>Radio</b>` section |
+| The radio agent's verdict | N29 → `RadioOutput.alerts` | Same card's headline and status glyph |
+
+Executed, with the real formatter:
+
+```
+CARD BODY: ('no alerts', …, [('1 radios · 2 rcm', …),
+            ('RCM L23 PENALTY: CAR 44 (HAM) 5 SECOND TIME PENALTY - TRACK LIMITS', …),
+            ('NOR INFO: "box this lap the rear is gone"', …)], 'OK')
+
+TOOLTIP:
+  <b>RCM</b>
+  L23 YELLOW: YELLOW FLAG IN TRACK SECTOR 7
+  L23 PENALTY: CAR 44 (HAM) 5 SECOND TIME PENALTY - TRACK LIMITS
+  <b>Radio</b>
+  NOR INFO: "box this lap the rear is gone"
+```
+
+A real Melbourne run reports `radio src corpus/14r·90rcm` — **90 race-control messages** in that
+race alone.
+
+**So the sprint-4 question is not "can we have them" but "where do they belong":** the flag STATE
+is the status strip (`track_status`, already on the wire); the message TEXT already has a home in
+the AGENTS window. If the DATA window wants its own ticker, it needs `rcm_events` put on the wire
+— which is one additive field from a producer that exists, not a pipeline.
+
+## 4. Dead ends — sources that look right and are not
+
+| Looks like the source | Why it is not |
+|---|---|
+| `SessionData.events` | **Always empty. Nothing populates it.** This is the field that made the plan claim race control had no producer. The RCM live in `rcm_events`, from `radio_runner` |
+| `get_rival_states` | A **simulation-layer** method. PITWALL cannot reach it |
+| `overlays._gap_value` | **Deleted by #844.** It was the hardcoded-55.56-m/s gap |
+| `FrameData.dist` for ordering | Race-cumulative and per-car: puts the wrong car in the lead on **37 %** of sampled frames |
+| `FrameData.lap` for the reveal | A rounded interpolation of a step function: non-monotone on 101 of 2.49 M frames, and it never opens a finisher's final lap |
+| `FrameData.rel_dist` for progress | FastF1 leaves it NaN for a whole driver, and the resampler clamps it past a car's last sample — it drew a crashed car as the leader for 68 s |
+| `active` alone for OUT | Reads the winner as OUT (#855) |
+| A hardcoded TypeScript palette | `driver_colors` is on the wire for exactly this reason |
+
+## 5. Cache and environment facts a sprint-4 session will hit
+
+- `CACHE_VERSION` is **v12**. First launch per GP rebuilds (< 3 min, no re-download).
+- `data/` is a **curated** download: only 2025/Melbourne has raw laps. Anything scoring across
+  races needs `data_cache.ensure_race()`.
+- The orchestrator imports on a clean install since #883; `tests/agents` runs **236 tests** where
+  it used to skip two thirds of them.
+- The submodule's lite CI installs neither pandas nor fastmcp, so its strategy tests **skip
+  entirely**. A green CI there is not coverage.
+
+---
+
+Related: `PITWALL_DELIVERY_PLAN.md` §5 (the sprint's rules) · `src/arcade/gaps.py` (the coordinate
+and every candidate refuted on the way) · `~/.claude/plans/pitwall-sprint3/pre-sprint4-gate.md`
+(the exit gate that produced most of this page).


### PR DESCRIPTION
Two things: a correction I owe, and the reference sprint 4 should be built from.

## The correction

Hours ago I decided race-control messages were out of scope because *"their producer does not exist"*. **Wrong, and wrong in this repo's signature way**: true of one dead field, false of the project.

`SessionData.events` is indeed always empty — and it is a dead field. The messages come from `src/nlp/radio_runner.py` out of `rcm.parquet` as `RaceState.rcm_events`, and the **Radio card already renders them**, in its body *and* its tooltip. PITWALL's AGENTS window shows them today, next to the radio transcriptions and N29's verdict. Executed:

```
CARD BODY: ('no alerts', …, [('1 radios · 2 rcm', …),
            ('RCM L23 PENALTY: CAR 44 (HAM) 5 SECOND TIME PENALTY - TRACK LIMITS', …),
            ('NOR INFO: "box this lap the rear is gone"', …)], 'OK')
TOOLTIP:  <b>RCM</b>  L23 YELLOW: …  L23 PENALTY: …   <b>Radio</b>  NOR INFO: "…"
```

A real Melbourne run reports `radio src corpus/14r·90rcm` — **90 of them in that race**. The sprint-4 question was never *can we have them*; it is only *where they belong*.

## The reference — `PITWALL_SPRINT4_SOURCES.md`

One page mapping every piece of data bands 1-2 need to its producer, with the caveat that matters for each. Every row verified by execution on the real session, not by reading code.

- **What the wire carries** — the seven fields, what each means, and where each one lies: `race_order` is meaningless through lap 1; `laps_completed` is monotone but not frame-exact (8.3 % open early, worst 0.463 s); a rewind un-reveals; `has_finished` has one silent path.
- **What the BULK reader carries** — lap times, the lap-quantised gap column, and why bests must recompute from the revealed subset.
- **RCM and radio** — producer, consumer, and what is already on screen.
- **Dead ends** — eight sources that look right and are not: `SessionData.events`, `get_rival_states` (unreachable from PITWALL), `overlays._gap_value` (deleted by #844), `dist` for ordering (wrong leader 37 %), `lap` for the reveal, `rel_dist` for progress, `active` alone for OUT, a hardcoded TS palette.
- **Environment facts** a sprint-4 session will hit on day one: cache v12, the curated download, and the submodule CI that skips its strategy tests entirely.

The dead-ends table is the part worth the page: half the cost of this sprint is picking the wrong source, and three of the wrong ones look exactly like the right ones.