### PR TITLE
docs(pitwall): the architecture doc promises two host methods that were never written

### DIFF
--- a/documents/research/PITWALL_DELIVERY_PLAN.md
+++ b/documents/research/PITWALL_DELIVERY_PLAN.md
@@ -190,9 +190,31 @@ window*, with the two rendered side by side.
 > something on screen" survives — band 1 being the frame the others sit in is a container
 > question, not a dependency.
 >
-> **⛔ Open before band 4 starts: does the wire carry everything it needs?** #857 asked exactly
-> that for band 1 and found the answer was no. Nobody has asked it for band 4. Do it the same
-> way, against `PITWALL_SPRINT4_SOURCES.md`, before writing any component.
+> ✅ **ASKED AND ANSWERED, 2026-08-10: the wire carries everything band 4 needs, with zero
+> blocking producer changes** — the opposite of band 1's answer. A Fable design gate measured it
+> on the real Melbourne 2025 session (154,173 frames × 20 drivers) by driving
+> `_build_arcade_snapshot`'s own functions; the report and its field-by-field implementation
+> contract are at `~/.claude/plans/pitwall-sprint4/wire-band4-design.md`. Not luck: #841's span,
+> #842's `rel_dist`/`active` and the #857 batch had already covered it.
+>
+> **Two scope lines the gate forced, because the prose above promises more than sprint 4 can do:**
+>
+> - **"Pinned rival" in sprint 4 means `driver_rival`, nothing else.** The wire carries telemetry
+>   spans for exactly two cars and BOTH are chosen in the arcade process; `host.get_lap_trace`
+>   and `session_data.py` do not exist (the architecture doc claimed otherwise and has been
+>   corrected). Arbitrary pinning arrives with the sprint-5 selector and the BULK reader. The Qt
+>   original renders exactly main + `driver_rival` too, so 1:1 is unaffected.
+> - **The ring is schematic, and it has to be.** `ref_lap_xy`, `circuit_rotation_deg`,
+>   `ref_lap_drs` and per-frame `x`/`y` all exist in the loader and none of them crosses the wire.
+>   `rel_dist` is a fraction of the car's OWN lap, so a dot sits a median 1.3° and up to 24° (a
+>   pit lap) from its true circuit position. An outline ring is a new host capability, not a tweak.
+>
+> **And one thing band 4 will NOT chart: gear and DRS.** They are on the wire and they carry real
+> values, but the Qt original charts neither, `§3.5` of the realism doc describes the *elevated*
+> surface rather than this port, and `drs` is the raw FastF1 code whose open set `{10, 12, 14}`
+> lives only in `src/arcade/track.py:40` — a TypeScript copy would be a cross-language twin of the
+> exact kind `driver_colors` is on the wire to prevent. If they are wanted, the producer publishes
+> a decoded `drs_open` first, in sprint 9.
 
 
 Built band by band so each sprint ends with something on screen.

--- a/documents/research/PITWALL_V2_ARCHITECTURE.md
+++ b/documents/research/PITWALL_V2_ARCHITECTURE.md
@@ -291,11 +291,24 @@ is not the Qt client renamed: that one is a `QThread` emitting Qt signals, and Q
 **`session_data.py`** is the BULK reader and the one place that touches disk. It exposes
 `lap_table(year, gp)`, `lap_trace(year, gp, driver, lap)` and `circuit_meta(year, gp)`, memoised.
 **It must reuse the project's existing loaders rather than reading parquet directly** (see the
-duplication risk in section 8).
+duplication risk in section 8). **NOT WRITTEN YET** — see the note under `host.py`.
 
-**`host.py`** is the js_api surface and nothing else. Methods map one-to-one to what the UI needs:
-`get_tick()`, `get_bulk()`, `get_lap_trace(driver, lap)`. It holds no rendering logic and no
+**`host.py`** is the js_api surface and nothing else. It holds no rendering logic and no
 formatting. Each method is small enough to read in one screen.
+
+| Method | State |
+|---|---|
+| `get_tick(since_seq)` | shipped, sprint 2 |
+| `get_agents_view(since_seq)` | shipped, sprint 3. Not in the original plan: the AGENTS window is 1:1 by calling the Qt formatters host-side, so the whole view arrives already formatted |
+| `get_bulk()` | **not written.** Arrives with the timing table and the bests, which the 2026-08-09 reorder moved to sprint 5 |
+| `get_lap_trace(driver, lap)` | **not written**, and band 4 does not need it — the traces come off the wire's telemetry span, and the pinned rival is `driver_rival` until the sprint-5 selector exists |
+
+> **The two unwritten methods were listed here as though they existed**, and a design gate found
+> them while asking whether the wire feeds band 4. That is a silent trap rather than a stale
+> sentence: an implementer who reads this section and calls `pywebview.api.get_lap_trace(...)`
+> gets an `AttributeError` **across the bridge**, which this file's own §5 names as the worst kind
+> of failure because nothing surfaces it. Anything added to `host.py` gets a row here in the same
+> PR.
 
 **`bridge.ts`** is the only TypeScript module that knows `window.pywebview` exists. Everything above
 it consumes typed functions. When the transport is upgraded (section 3.5), this is the only file


### PR DESCRIPTION
## What

`PITWALL_V2_ARCHITECTURE.md` §5 described `host.py`'s js_api surface as `get_tick()`, `get_bulk()`, `get_lap_trace(driver, lap)`. Only `get_tick` exists. `get_agents_view` — which shipped in sprint 3 and is the entire content layer of the AGENTS window — was not listed at all, and `src/pitwall/session_data.py` has never been written.

Replaced with a state table (shipped / not written, and when each arrives), plus the rule that a new host method gets its row in the same PR.

`PITWALL_DELIVERY_PLAN.md` §5 gets the two scope lines the same gate forced, and closes out the ⛔ marker the previous session left there.

## Why it is not cosmetic

An implementer who reads §5 and calls `pywebview.api.get_lap_trace(...)` gets an `AttributeError` **across the bridge**. The same document's §5 names that as the worst kind of failure, because nothing surfaces it: the window renders empty and no log anywhere says why. Sprint 4 was one paragraph away from walking into it.

## Where it came from

The Fable design gate that asked band 4 the question #857 asked band 1 — *does the wire carry what this band needs?* It does (that answer is the good news, and it is measured on the real Melbourne 2025 session). While enumerating the payload the gate found the doc drift instead.

The delivery-plan edit records the two scope limits it also forced:

- sprint 4's "pinned rival" can only be `driver_rival` — the wire carries spans for exactly two cars, both chosen in the arcade process
- the ring is schematic — `ref_lap_xy`, `circuit_rotation_deg`, `ref_lap_drs` and per-frame `x`/`y` all exist in the loader and none of them crosses the wire

and the one deliberate omission from the port: gear and DRS charts, because `drs` is the raw FastF1 code whose open set lives only in `src/arcade/track.py:40` and a TypeScript copy would fork it across languages.

## Checks

Docs only — no code path touched. `documents/research/**` is outside every CI job's path filter, so `test` / `lint` / `typecheck` have nothing to say about this diff either way.

Refs #894, #895