### PR TITLE
fix(pitwall): both windows are born taller than the desktop, hiding both status bars

### DIFF
--- a/src/pitwall/__main__.py
+++ b/src/pitwall/__main__.py
@@ -33,13 +33,34 @@ def main() -> int:
     host = PitwallHost(ArcadeStreamClient(STREAM_HOST, STREAM_PORT), window_count=len(WINDOWS))
     host.start()
 
-    for spec in WINDOWS:
+    # The geometry in `WINDOWS` is what the layout wants; the screen decides
+    # what it gets. A window taller than the desktop is not scrolled, it is
+    # clipped from the bottom - which is exactly where both windows keep their
+    # status bar, so the honest "the producer went quiet" signal was invisible
+    # on the machine this was found on.
+    screen = webview.screens[0]
+
+    for index, spec in enumerate(WINDOWS):
+        x, y, width, height = spec.place(index, screen.width, screen.height)
+        if (width, height) != (spec.width, spec.height):
+            logger.info(
+                "%s opens at %dx%d rather than %dx%d - the %dx%d screen is smaller",
+                spec.title,
+                width,
+                height,
+                spec.width,
+                spec.height,
+                screen.width,
+                screen.height,
+            )
         window = webview.create_window(
             spec.title,
             spec.url,
             js_api=host,
-            width=spec.width,
-            height=spec.height,
+            width=width,
+            height=height,
+            x=x,
+            y=y,
         )
         # The client belongs to the host, so a window closing only decrements
         # a count. Wiring `client.stop` here instead is the regression this

--- a/src/pitwall/config.py
+++ b/src/pitwall/config.py
@@ -20,6 +20,24 @@ __all__ = ["STREAM_HOST", "STREAM_PORT", "WINDOWS", "WindowSpec", "ui_asset", "u
 _UI_DIR: Final[Path] = Path(__file__).resolve().parent / "ui"
 _UI_DIST: Final[Path] = _UI_DIR / "dist"
 
+# Room the OS keeps for itself, in the same logical pixels pywebview sizes
+# windows in. Measured on the machine this was found on (2560x1440 at 150 %,
+# so 1707x960 logical): the taskbar takes 48 and the window's own title bar
+# another 37. 90 covers both with a little slack.
+#
+# It is not decoration. At 1500x950 the DATA window is BORN taller than the
+# 912-pixel work area, so its status bar renders underneath the taskbar and
+# the bottom row's "Distance (m)" axis label is sliced in half. Both windows
+# did it, and no headless screenshot can show it because a headless viewport
+# has no desktop to not fit on.
+_OS_CHROME_ALLOWANCE_PX: Final[int] = 90
+
+# Horizontal offset between the two windows, so the one underneath still has a
+# grabbable title bar. Vertical staggering is what pywebview does by default
+# and it is exactly what pushed the second window off the bottom of the work
+# area, so there is none here.
+_WINDOW_STAGGER_PX: Final[int] = 40
+
 
 class WindowSpec:
     """One PITWALL window: what it is called, how big it opens, what it loads.
@@ -41,6 +59,37 @@ class WindowSpec:
     def url(self) -> str:
         """Absolute path to the built HTML entry point."""
         return str(ui_asset(self.entry))
+
+    def place(self, index: int, screen_width: int, screen_height: int) -> tuple[int, int, int, int]:
+        """Where and how big to open, as `(x, y, width, height)`.
+
+        A window bigger than the desktop does not get scrollbars - it gets
+        CLIPPED, and the part that goes missing is the bottom, where both
+        windows keep their status bar. On the display this was found on, a
+        950-pixel-tall window overflowed a 912-pixel work area and the status
+        bar was simply never visible.
+
+        **Size and position are one decision, which is why this is one
+        method.** Clamping the size alone did not fix it: pywebview CASCADES,
+        so the second window started 38 pixels lower than the first and fell
+        straight back off the bottom - measured, with DATA's status bar
+        visible and AGENTS' still under the taskbar. So the origin is set
+        here rather than left to the toolkit, and `y` is always 0.
+
+        The windows overlap. They always did, and on a 1707-wide desktop a
+        1500 and a 1320 cannot do anything else; the small `x` stagger exists
+        so both title bars stay grabbable.
+
+        Pure, and takes the screen rather than reading it, so this module
+        still imports on a machine with no system webview and so the rule can
+        be tested without one. It never GROWS a window: a `WindowSpec` is a
+        layout decision and a big monitor is not a reason to override it.
+        """
+        usable_height = max(1, screen_height - _OS_CHROME_ALLOWANCE_PX)
+        width = min(self.width, screen_width)
+        height = min(self.height, usable_height)
+        x = min(index * _WINDOW_STAGGER_PX, max(0, screen_width - width))
+        return x, 0, width, height
 
 
 # DATA is the wider of the two: it holds a full timing tower plus traces.

--- a/tests/surfaces/test_pitwall_host.py
+++ b/tests/surfaces/test_pitwall_host.py
@@ -259,3 +259,74 @@ def test_shutdown_stops_the_client_whatever_is_open(window_count):
     host.shutdown()
 
     assert client.stopped is True
+
+
+# --- Window geometry against a real desktop ---------------------------------
+#
+# A window bigger than the desktop is not scrolled, it is CLIPPED, and the part
+# that goes missing is the bottom - where both PITWALL windows keep their
+# status bar. Found by opening the real windows on a 2560x1440 display at
+# 150 %, which is 1707x960 logical with a 912-pixel work area: DATA asks for
+# 950 and its status bar rendered under the taskbar, with the bottom row's
+# "Distance (m)" axis label sliced in half.
+#
+# No headless screenshot can catch this. A Playwright viewport is exactly the
+# size you ask for and has no desktop to not fit on.
+
+
+def test_every_window_opens_fully_inside_the_work_area():
+    """The measured case: both windows on Victor's own display.
+
+    1707x960 logical is a 2560x1440 panel at 150 %, and its work area is 912
+    tall. DATA asks for 950, so its status bar rendered under the taskbar and
+    the bottom row's "Distance (m)" label was sliced in half.
+
+    Asserted as `y + height`, not as `height`, because clamping the size ALONE
+    did not fix it: pywebview cascades, the second window started 38 pixels
+    lower and fell straight back off the bottom. A height-only assertion was
+    green while AGENTS was still broken.
+    """
+    from src.pitwall.config import WINDOWS
+
+    for index, spec in enumerate(WINDOWS):
+        x, y, width, height = spec.place(index, 1707, 960)
+        assert y + height <= 912, f"{spec.key} reaches {y + height}, past the 912 work area"
+        assert x + width <= 1707, f"{spec.key} reaches {x + width}, past the 1707 screen"
+
+
+def test_a_big_screen_does_not_inflate_a_window():
+    """`place` clamps, it never grows.
+
+    A `WindowSpec` is a layout decision - AGENTS mirrors the 540 + 740 Qt
+    columns it ports - and a 4K monitor is not a reason to override it.
+    """
+    from src.pitwall.config import WINDOWS
+
+    for index, spec in enumerate(WINDOWS):
+        _, _, width, height = spec.place(index, 3840, 2160)
+        assert (width, height) == (spec.width, spec.height)
+
+
+def test_every_shipped_window_fits_a_small_laptop():
+    """1366x768 is the floor this has to survive, and both windows exceed it.
+
+    Asserting the EFFECT - where the window actually lands - rather than the
+    constant. A test that pinned `height == 950` would have passed for the
+    whole life of the defect.
+    """
+    from src.pitwall.config import WINDOWS
+
+    for index, spec in enumerate(WINDOWS):
+        x, y, width, height = spec.place(index, 1366, 768)
+        assert x + width <= 1366 and y + height <= 768 - 90, (
+            f"{spec.key} opens at {x},{y} {width}x{height}"
+        )
+
+
+def test_the_second_window_is_still_grabbable():
+    """The two windows overlap - they must, at these sizes - so the one
+    underneath needs its title bar reachable. A zero stagger would bury it."""
+    from src.pitwall.config import WINDOWS
+
+    origins = [spec.place(index, 1707, 960)[0] for index, spec in enumerate(WINDOWS)]
+    assert len(set(origins)) == len(origins), f"two windows share an origin: {origins}"


### PR DESCRIPTION
Closes #899.

Found by **opening the real windows**. 2560x1440 at 150 % is 1707x960 logical with a **912-pixel work area**; DATA asks for 950.

A window bigger than the desktop is not scrolled, it is clipped, and the missing part is the bottom — where both windows keep their status bar. On screen: DATA's line under the taskbar with `Distance (m)` sliced in half, AGENTS' gone entirely. That bar's 1.5 s auto-clear is the only honest *the producer went quiet* signal either window has, and #871/#874 were spent getting it right. It had never once been visible on this machine.

## Clamping the size was half the fix

pywebview **cascades**: the second window starts 38 logical pixels lower and fell straight back off the bottom. Measured, with one status bar visible and the other still hidden. So size and position are one decision and one method — `WindowSpec.place(index, screen_w, screen_h)`, pure, testable without a webview, and it clamps without ever growing a window.

## Why no test could have caught it

A Playwright viewport is exactly the size you ask for and has no desktop to not fit on. The smoke and the screenshot tool both render band 4 perfectly at 1500x950.

So the guard asserts **`y + height` against the work area**, not `height` alone — and that distinction is not theoretical: I wrote the height-only version first and it was green while AGENTS was still broken.

## Checks

```
uv run pytest tests/surfaces            171 passed
uvx ruff@0.15.22 check . / format --check .   all checks passed / 188 files already formatted
```

Guards watched RED against two mutations, on a rebuilt tree:

| Mutation | What went red |
|---|---|
| `place()` returns the requested size unclamped | `950 <= 912` and the laptop case |
| size clamped but the origin left to pywebview's real cascade (76 + 38·i) | `data reaches 946, past the 912 work area` |

**And the real path**, which is the only place this exists: relaunched `python -m src.pitwall` against the live producer and captured both windows DPI-aware. Log says `DATA opens at 1500x870 rather than 1500x950 - the 1707x960 screen is smaller`, and the captures show `lap 23 · live` and `lap 27 · streaming`.

*(One aside worth recording: my FIRST capture looked like a catastrophic layout overflow — ring off-screen, charts clipped. It was the capture, not the app: a DPI-unaware PowerShell process reads a virtualised desktop and hands back the top-left two thirds of the window, magnified. Measuring the page's own `innerWidth`/`scrollWidth` from inside the webview said 1486/1486, no overflow. I nearly filed a layout bug that was my measurement.)*