### PR TITLE
fix(pitwall): a chart that unmounts never comes back, and four smaller defects in band 4

### DIFF
--- a/documents/research/PITWALL_DELIVERY_PLAN.md
+++ b/documents/research/PITWALL_DELIVERY_PLAN.md
@@ -62,8 +62,16 @@ wiring — `host.py`, `stream_client.py` and the golden payload, so no proposal 
 the tick does not carry — and (4) `tokens.css`, so proposals speak the design system. It returns
 prioritised P0-P3 findings with `file:line` and a concrete fix, covering **layout** (hierarchy,
 density, what earns the top-left) and **surgical** changes (a colour semantic, a truncation, a
-chart baseline, an undesigned state). Install `interface-design`, `critique`, `typeset`, `audit`,
-`baseline-ui` and hallmark's Audit mode first.
+chart baseline, an undesigned state).
+
+**Where the skills come from, decided by Víctor 2026-08-10: the catalogue, not improvisation.**
+Before either elevate sprint runs its audit, install from `npx ui-skills` and from `nutlope/hallmark`
+per `~/.claude/FRONTEND_TOOLKIT.md`, which is the standing directive for all frontend work in every
+project and names the flow: `hallmark` **Audit** for the anti-AI-look dimension, `baseline-ui` for
+the deslop pass, `pbakaus/audit` for a11y and anti-patterns, `fixing-motion-performance` for
+anything that moves, `optimize` for load. Route with `npx ui-skills start` and pick by topic →
+stack → specificity rather than loading everything. The Fable agent is then handed the installed
+skills alongside the screenshots, so its findings speak the same vocabulary the fixes will use.
 
 **Sprint 8 (AGENTS)** also pays the debt sprint 3 takes on knowingly: the two tooltips still emit
 Qt's restricted rich-text dialect because the Python formatters are reused as-is, and whether the

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -90,6 +90,7 @@ function tick(
     main = MAIN_SPAN,
     rivalSpan = RIVAL_SPAN,
     rewound = false,
+    dropped = 0,
     mainDriver = {},
     drivers = null,
     order = null,
@@ -116,7 +117,7 @@ function tick(
       driver_colors:
         colors ?? Object.fromEntries(Object.keys(field).map((code) => [code, [255, 128, 0]])),
       track_status: "1",
-      telemetry: { main, rival: rivalSpan, rewound, dropped: 0 },
+      telemetry: { main, rival: rivalSpan, rewound, dropped },
     },
     playback: { speed: 1, paused: false, frame_index: 1000 + seq, total_frames: 154173 },
     strategy: {},
@@ -347,6 +348,63 @@ check(
   "the rival legend survives an empty buffer on all four charts",
 );
 
+// The eviction ORDER, which the accumulator's own docstring calls
+// load-bearing and which the rewind above structurally CANNOT see: the
+// producer sends `rewound` with an EMPTY span, so clearing before and
+// clearing after are the same outcome. A forward jump is the case that
+// separates them - `dropped` rides along with a valid post-jump span, and
+// clearing afterwards throws it away. Measured on the Qt panel before it was
+// fixed there: up to 250 samples, ten seconds of trace the payload had
+// already delivered, leaving four blank charts to refill.
+const JUMPED = [3100, 3200, 3300].map((dist, i) => ({
+  lap: 24,
+  t: 40 + i,
+  dist,
+  speed: 300 + i,
+  throttle: 100,
+  brake: 0,
+  gear: 8,
+  drs: 12,
+}));
+await page.evaluate(
+  (payload) => window.__ticks.push(payload),
+  tick(3, { main: JUMPED, rivalSpan: [], dropped: 60 }),
+);
+await page.waitForTimeout(400);
+const afterJump = await page.evaluate(() => {
+  const el = document.querySelectorAll(".trace-plot")[1];
+  return el.__pitwallChart.getOption().series[0].data.map(([x]) => x);
+});
+check(
+  afterJump.length === 3 && afterJump[0] === 3100,
+  `a forward jump keeps the span it arrived with (${JSON.stringify(afterJump)})`,
+);
+
+// The delta plot must SURVIVE going away and coming back. Its container is
+// unmounted whenever the session drops to single-driver mode and remounted
+// when a rival returns, and `useEChart` used to key its init effect on `[]` -
+// which runs once per component, not once per container. After one round trip
+// the instance pointed at a detached node and the chart was dead for the rest
+// of the session, silently. Nothing in the 37 checks before this one could
+// see it: they all measured a chart that had never been unmounted.
+await page.evaluate((payload) => window.__ticks.push(payload), tick(4, { rival: null, rivalSpan: [] }));
+await page.waitForTimeout(400);
+check(
+  (await page.locator(".trace-placeholder").count()) === 1,
+  "losing the rival shows the placeholder",
+);
+await page.evaluate((payload) => window.__ticks.push(payload), tick(5));
+await page.waitForTimeout(500);
+const revived = await page.evaluate(EXTENTS(0));
+check(
+  (await page.locator(".trace-plot canvas").count()) === 4,
+  "the delta plot comes back as a live canvas",
+);
+check(
+  revived !== null && revived.y[0] === -3 && revived.y[1] === 3,
+  `and it is a working chart, not a detached one (${JSON.stringify(revived)})`,
+);
+
 // The status bar, which is Qt's `showMessage(f"lap {lap} · live", 1500)`.
 // It has to be visible while the producer talks and blank 1.5 s after it
 // stops - the AGENTS window shipped BOTH halves of that wrong before #871
@@ -475,6 +533,27 @@ check(
 check(
   (await ringPage.locator(".ring-code").count()) === 2,
   "only the two featured cars are labelled",
+);
+
+// The two labels go on OPPOSITE sides of their dots. The main driver and the
+// car chosen to compare against are routinely seconds apart - on the real
+// session NOR and PIA sit 0.006 of a lap apart - and with both codes above
+// their dots they printed on top of each other. Asserted as rendered
+// geometry, because "two labels exist" was already true while they overlapped.
+const labels = await ringPage.evaluate(() =>
+  [...document.querySelectorAll(".ring-code")].map((el) => {
+    const dot = el.parentElement.querySelector("circle");
+    return {
+      code: el.textContent.trim(),
+      above: Number(el.getAttribute("y")) < Number(dot.getAttribute("cy")),
+    };
+  }),
+);
+const main = labels.find((l) => l.code === "NOR");
+const rival = labels.find((l) => l.code === "PIA");
+check(
+  main?.above === true && rival?.above === false,
+  `the main code sits above its dot and the rival's below (${JSON.stringify(labels)})`,
 );
 // `textContent`, not `innerText`: these are SVG <text> nodes, which are not
 // HTMLElements and have no `innerText` at all.

--- a/src/pitwall/ui/src/features/agents/useEChart.ts
+++ b/src/pitwall/ui/src/features/agents/useEChart.ts
@@ -11,6 +11,23 @@
 import type { EChartsOption } from "echarts";
 import { valueAxis } from "../../lib/chart";
 
+/**
+ * These two charts still ANIMATE, unlike band 4's, and the reason recorded
+ * for that was wrong.
+ *
+ * The claim was "they update once a lap, so the entrance completes". Measured:
+ * **40 `setOption` calls in 4 seconds** - the host returns a fresh view on
+ * every tick, so these redraw at the same ~10 Hz band 4 does, and their
+ * entrance animation is restarted just as often. The effect is nonetheless
+ * correct, by accident: their axis extent is constant across 97.7 % of ticks,
+ * so a restarted grow-from-the-left animation lands pixel-identical and
+ * nothing flickers. Band 4's is not - its X axis is a locked 0-5220 that the
+ * data does not fill, so the same restart left the delta baseline a stub.
+ *
+ * Written down because the next person to touch this will reach for the same
+ * false reason. If these charts ever gain a moving extent, they need
+ * `animation: false` too.
+ */
 /** Axis and grid styling shared by both cards, from the Qt charts' own look. */
 export const CHART_BASE: EChartsOption = {
   backgroundColor: "transparent",

--- a/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
+++ b/src/pitwall/ui/src/features/data/OwnCarTraces.tsx
@@ -36,8 +36,18 @@ import { TraceAccumulator, deltaSeries, type SortedTrace } from "./traceBuffer";
 
 /** `_SPEED_Y_RANGE`: Monza's straight tops out around 357 km/h. */
 const SPEED_Y: [number, number] = [0, 360];
-/** `_BRAKE_Y_RANGE` / `_THROTTLE_Y_RANGE`: padded so 0 and 100 do not kiss the frame. */
-const PEDAL_Y: [number, number] = [-5, 105];
+/**
+ * `_BRAKE_Y_RANGE`: padded so a trace at 0 or 100 does not kiss the frame.
+ *
+ * Separate from the throttle range even though the two hold the same pair.
+ * `telemetry_panel.py` declares them as two constants, and merging rules that
+ * agree by coincidence is a defect class this repo has already paid for: a
+ * compound-suitability floor and a minimum-stint bound shared a 12, so
+ * recalibrating one silently rewrote the other.
+ */
+const BRAKE_Y: [number, number] = [-5, 105];
+/** `_THROTTLE_Y_RANGE`. Equal to the brake range today, and its own rule. */
+const THROTTLE_Y: [number, number] = [-5, 105];
 /** `_DELTA_Y_RANGE`: generous for one lap, and it clips when the series wanders. */
 const DELTA_Y: [number, number] = [-3, 3];
 /** `_DEFAULT_X_RANGE`, used until a broadcast carries a real circuit length. */
@@ -144,7 +154,7 @@ export function OwnCarTraces({ tick, discontinuity }: OwnCarTracesProps) {
           subtitle="%"
           mainColour={TRACE_COLOURS.brake_main}
           rivalColour={TRACE_COLOURS.rival}
-          yRange={PEDAL_Y}
+          yRange={BRAKE_Y}
           xMax={xMax}
           mainCode={arcade.driver_main}
           rivalCode={rivalCode}
@@ -157,7 +167,7 @@ export function OwnCarTraces({ tick, discontinuity }: OwnCarTracesProps) {
           subtitle="%"
           mainColour={TRACE_COLOURS.throttle_main}
           rivalColour={TRACE_COLOURS.rival}
-          yRange={PEDAL_Y}
+          yRange={THROTTLE_Y}
           xMax={xMax}
           mainCode={arcade.driver_main}
           rivalCode={rivalCode}

--- a/src/pitwall/ui/src/features/data/TrackRing.tsx
+++ b/src/pitwall/ui/src/features/data/TrackRing.tsx
@@ -40,7 +40,8 @@ interface Dot {
   y: number;
   colour: string;
   status: DriverStatus;
-  featured: boolean;
+  /** null for the eighteen unlabelled cars; otherwise which side its code goes. */
+  label: "above" | "below" | null;
 }
 
 /**
@@ -63,7 +64,17 @@ function rgb(colour: [number, number, number] | undefined): string {
 }
 
 export function TrackRing({ arcade }: { arcade: ArcadeState }) {
-  const featured = new Set([arcade.driver_main, arcade.driver_rival].filter(Boolean));
+  // The two labelled cars go on OPPOSITE sides of their dots. They are the
+  // main driver and the car chosen to compare against, so they are routinely
+  // seconds apart - on the session this was built against, NOR and PIA sit
+  // 0.006 of a lap apart and both codes rendered above their dots, on top of
+  // each other and of the dots. Fixed sides beat a collision test: it is
+  // deterministic, so the same car is always in the same place.
+  const labelSide = (code: string): "above" | "below" | null => {
+    if (code === arcade.driver_main) return "above";
+    if (code === arcade.driver_rival) return "below";
+    return null;
+  };
 
   // `race_order` rather than the drivers map, so the DOM order is the running
   // order and the leader's dot paints last - on top of whoever it is lapping.
@@ -87,7 +98,7 @@ export function TrackRing({ arcade }: { arcade: ArcadeState }) {
       ...place(car.rel_dist),
       colour: rgb(arcade.driver_colors[code]),
       status: driverStatus(car),
-      featured: featured.has(code),
+      label: labelSide(code),
     });
   }
 
@@ -120,7 +131,7 @@ export function TrackRing({ arcade }: { arcade: ArcadeState }) {
             <circle
               cx={dot.x}
               cy={dot.y}
-              r={dot.featured ? MAIN_DOT_R : DOT_R}
+              r={dot.label ? MAIN_DOT_R : DOT_R}
               // `out` is the only state drawn hollow, so the fill is the one
               // that has to change with it rather than an opacity on the group.
               fill={dot.status === "out" ? "none" : dot.colour}
@@ -128,8 +139,13 @@ export function TrackRing({ arcade }: { arcade: ArcadeState }) {
               data-code={dot.code}
               data-status={dot.status}
             />
-            {dot.featured ? (
-              <text className="ring-code" x={dot.x} y={dot.y - 11} textAnchor="middle">
+            {dot.label ? (
+              <text
+                className="ring-code"
+                x={dot.x}
+                y={dot.label === "above" ? dot.y - 11 : dot.y + 17}
+                textAnchor="middle"
+              >
                 {dot.code}
               </text>
             ) : null}

--- a/src/pitwall/ui/src/lib/chart.ts
+++ b/src/pitwall/ui/src/lib/chart.ts
@@ -25,7 +25,7 @@
  * `tests/surfaces/test_pitwall_tokens.py`.
  */
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import * as echarts from "echarts";
 
 /** `palette.TEXT_SECONDARY` - axis names and tick labels. */
@@ -43,37 +43,51 @@ export const SPLIT_LINE = "rgba(255,255,255,0.06)";
  */
 export const CURSOR_LINE = "#9ca3af";
 
+/**
+ * Mount an ECharts instance on a div and push options into it imperatively.
+ *
+ * **The host is tracked as STATE behind a callback ref, not as a plain ref
+ * with an empty dependency list.** A ref does not re-render, so a mount
+ * effect keyed on `[]` runs exactly once for the life of the component - and
+ * band 4's delta chart swaps its plot for a "single-driver mode" placeholder
+ * and back, which unmounts and remounts the div underneath. After one such
+ * swap the effect never re-ran, the instance pointed at a detached node, and
+ * the chart was dead for the rest of the session with no error anywhere.
+ */
 export function useEChart(option: echarts.EChartsOption | null) {
-  const host = useRef<HTMLDivElement | null>(null);
+  const [host, setHost] = useState<HTMLDivElement | null>(null);
   const chart = useRef<echarts.ECharts | null>(null);
+  const ref = useCallback((node: HTMLDivElement | null) => setHost(node), []);
 
   useEffect(() => {
-    if (!host.current) return;
-    chart.current = echarts.init(host.current, undefined, { renderer: "canvas" });
+    if (!host) return;
+    const instance = echarts.init(host, undefined, { renderer: "canvas" });
+    chart.current = instance;
     // The headless smoke reads the COMPUTED axis extent and converts data
     // coordinates to pixels through this handle. Without it the only thing
     // a test can inspect is the option object it already knows we passed -
     // the mechanism - and the sprint-3 exit gate's whole lesson was that a
     // check written against the mechanism passes over a broken effect. An
     // ECharts instance is not reachable from outside the module otherwise.
-    (host.current as HTMLDivElement & { __pitwallChart?: echarts.ECharts }).__pitwallChart =
-      chart.current;
-    const resize = () => chart.current?.resize();
-    const observer = new ResizeObserver(resize);
-    observer.observe(host.current);
+    (host as HTMLDivElement & { __pitwallChart?: echarts.ECharts }).__pitwallChart = instance;
+    const observer = new ResizeObserver(() => instance.resize());
+    observer.observe(host);
     return () => {
       observer.disconnect();
-      chart.current?.dispose();
-      chart.current = null;
+      instance.dispose();
+      if (chart.current === instance) chart.current = null;
     };
-  }, []);
+  }, [host]);
 
+  // `host` is a dependency so the option is re-applied to a chart that was
+  // just re-created. Without it a remounted plot came back blank until the
+  // next tick happened to produce a new option object.
   useEffect(() => {
     if (!chart.current || !option) return;
     chart.current.setOption({ ...option, animationDurationUpdate: 0 }, { notMerge: true });
-  }, [option]);
+  }, [option, host]);
 
-  return host;
+  return ref;
 }
 
 export interface AxisSpec {

--- a/src/pitwall/ui/src/styles/data.css
+++ b/src/pitwall/ui/src/styles/data.css
@@ -280,7 +280,20 @@
 }
 
 .ring-dot.is-out {
-  opacity: 0.45;
+  opacity: 0.7;
+}
+
+/* A NEUTRAL ring, not the driver's own colour. Hollow at 45 % opacity, a dark
+ * team colour (VER's #0600ef) came out all but invisible on this panel - the
+ * state that most needs to read at a glance was the one that did not.
+ * Identity is carried by position and by the two code labels; legibility is
+ * what "out" needs.
+ *
+ * On the CIRCLE, not on the group. `stroke` is set as a presentation
+ * attribute on the circle itself, and an inherited value loses to that -
+ * a rule on the `<g>` would have changed nothing at all. */
+.ring-dot.is-out circle {
+  stroke: var(--qt-fg-3);
 }
 
 .ring-legend {

--- a/tests/surfaces/test_pitwall_tokens.py
+++ b/tests/surfaces/test_pitwall_tokens.py
@@ -51,6 +51,18 @@ def _rgb_to_hex(rgb: tuple[int, int, int]) -> str:
     return "#{:02x}{:02x}{:02x}".format(*rgb)
 
 
+def _without_comments(css: str) -> str:
+    """CSS with its `/* ... */` blocks removed.
+
+    The raw-hex freezes below scan a whole stylesheet, and a comment that
+    NAMES a colour as evidence is not a colour the stylesheet uses. One did:
+    a note explaining that VER's #0600ef was invisible on a dark panel failed
+    the guard that exists to catch an unguarded declaration. Scanning prose
+    is a false positive today and a reason to delete the evidence tomorrow.
+    """
+    return re.sub(r"/\*.*?\*/", "", css, flags=re.DOTALL)
+
+
 # --- The pair PITWALL introduces: must be identical, always -----------------
 
 
@@ -351,7 +363,12 @@ def test_the_data_stylesheets_raw_hexes_are_guarded_too():
     from src.arcade import palette
 
     raw = sorted(
-        {hex_.lower() for hex_ in re.findall(r"(#[0-9a-fA-F]{6})", DATA_CSS.read_text("utf-8"))}
+        {
+            hex_.lower()
+            for hex_ in re.findall(
+                r"(#[0-9a-fA-F]{6})", _without_comments(DATA_CSS.read_text("utf-8"))
+            )
+        }
     )
 
     assert raw == ["#3b82f6", "#f59e0b"], (
@@ -373,7 +390,7 @@ def test_the_two_raw_hexes_in_the_stylesheet_are_guarded_too():
     """
     from src.arcade import palette
 
-    css = AGENTS_CSS.read_text("utf-8")
+    css = _without_comments(AGENTS_CSS.read_text("utf-8"))
     declared = set(re.findall(r"--[\w-]+:\s*(#[0-9a-fA-F]{6})", css))
     raw = sorted({hex_.lower() for hex_ in re.findall(r"(#[0-9a-fA-F]{6})", css)} - declared)
 


### PR DESCRIPTION
Closes #900. Found by an adversarial exit gate over sprint 4, plus one caught by reading the real window.

## The functional one

`useEChart` keyed its init effect on `[]` — which runs once per **component**, not once per **container**. Band 4's delta chart swaps its plot for the `single-driver mode` placeholder and back, unmounting and remounting the div underneath. After one round trip the ECharts instance pointed at a detached node and the chart was dead for the rest of the session: no error, no blank state, just a chart that stopped being one.

It is the port's **only structural divergence from Qt** — `telemetry_panel.py` stacks the placeholder over the plot and hides one; the port replaces one with the other, which is better HTML and is what bites. Reachable in the product on any rival transition.

The host is now tracked as state behind a callback ref, and the option effect depends on it so a re-created chart is re-populated instead of coming back blank.

## The other four

| Defect | Fix |
|---|---|
| Both featured ring labels printed **above** their dots — measured on the wire, NOR and PIA never separate by more than 0.023 of a lap and share an RGB, so collision is the common case | Fixed sides, main above and rival below. Deterministic beats a collision test: the same car is always in the same place |
| An **OUT dot took the driver's own colour**, hollow at 45 % — VER's `#0600ef` on a dark panel is invisible, so the state that most needs to read at a glance was the one that did not | Neutral ring at 70 %, targeted at the `circle` because `stroke` is a presentation attribute there and an inherited value would lose to it |
| `PEDAL_Y` merged two Qt constants that agree by coincidence | Split. The repo has paid for this once already: a compound-suitability floor and a minimum-stint bound shared a 12, so recalibrating one silently rewrote the other |
| The smoke could not see the **eviction order** its own docstring calls load-bearing | The producer sends `rewound` with an empty span, so clear-before and clear-after are the same outcome. `dropped` is what separates them, and it rides with a valid post-jump span |

## A false claim of mine, retracted where I wrote it

I recorded that the AGENTS charts may keep animating because *they update once a lap, so the entrance completes*. **False** — 40 `setOption` in 4 seconds; the host returns a fresh view every tick. Their effect is correct **by accident**: their axis extent is constant across 97.7 % of ticks so a restarted animation lands pixel-identical, while band 4's locked 0-5220 axis is not. Wrong reasons get reused, so the correction sits next to the code it explains.

Also: the two raw-hex guards now strip comments before scanning. One failed on a hex quoted inside a comment **as evidence** — a false positive today and a reason to delete the evidence tomorrow. Verified the stripped guard still catches a hex in a real declaration.

## Checks

```
npm run typecheck                       clean
npm run smoke                           smoke OK: 14 · smoke-data OK: 42   (was 37)
uv run pytest tests/surfaces            171 passed
uvx ruff@0.15.22 check . / format --check .   all checks passed / 188 files already formatted
```

Guards watched RED, each on a rebuilt bundle:

| Mutation | What went red |
|---|---|
| init effect back to `[]` | the smoke never finds a canvas again after the placeholder round trip — the defect, live |
| both labels `above` | `[{"code":"PIA","above":true},{"code":"NOR","above":true}]` |
| a raw hex in a real `data.css` declaration | the DATA raw-hex guard, still, after comment-stripping |