### PR TITLE
fix(arcade,pitwall): close a pruned subscriber, and drop the AGENTS history when the producer restarts

### DIFF
--- a/src/arcade/stream.py
+++ b/src/arcade/stream.py
@@ -43,6 +43,7 @@ import json
 import logging
 import math
 import queue
+import select
 import socket
 import threading
 import time
@@ -57,6 +58,11 @@ logger = logging.getLogger(__name__)
 # about 130 s to 0.7 s. A real dashboard on localhost accepts a 30 KB message
 # in microseconds, so anything past 50 ms is not slow, it is gone.
 CLIENT_SEND_TIMEOUT_S = 0.05
+# A transient `accept()` error is retried rather than treated as shutdown, but
+# a listening socket that keeps failing is not going to recover, and a hot
+# retry loop is worse than an honest surrender.
+ACCEPT_RETRY_DELAY_S = 0.1
+ACCEPT_ERROR_LIMIT = 20
 
 
 def _json_safe(value):
@@ -271,7 +277,11 @@ class TelemetryStreamServer:
                 except OSError:
                     # socket.timeout is an OSError subclass, so a subscriber
                     # that stopped reading is pruned by the same path as one
-                    # that closed. The Qt client already reconnects.
+                    # that closed. `_prune_clients` CLOSES it, which is what
+                    # lets the peer reconnect: a stalled subscriber's socket
+                    # is still perfectly healthy at the TCP level, so merely
+                    # forgetting it left the consumer reading a connection
+                    # that would never carry another byte and never end.
                     dead.append(client)
             if dead:
                 self._prune_clients(dead)
@@ -283,13 +293,32 @@ class TelemetryStreamServer:
     # --- internals --------------------------------------------------------
 
     def _accept_loop(self) -> None:
+        # A transient accept error is not the same event as `stop()` closing
+        # the listening socket, and the two used to share one unconditional
+        # `return`. Any winsock hiccup while running therefore ended the only
+        # thread that admits subscribers, for the rest of the session, leaving
+        # one DEBUG line the arcade's INFO level never shows: no PITWALL or Qt
+        # window could ever attach again and nothing said why.
+        consecutive_errors = 0
         while self._running and self._server_socket is not None:
             try:
                 client_socket, addr = self._server_socket.accept()
-            except OSError:
-                if self._running:
-                    logger.debug("Accept interrupted")
-                return
+            except OSError as err:
+                if not self._running:
+                    return  # `stop()` closed the socket; this is the exit path
+                consecutive_errors += 1
+                if consecutive_errors >= ACCEPT_ERROR_LIMIT:
+                    logger.error(
+                        "Stream server giving up on accept after %d consecutive errors; "
+                        "no further subscribers can attach: %s",
+                        consecutive_errors,
+                        err,
+                    )
+                    return
+                logger.warning("Stream server accept failed (%s); retrying", err)
+                time.sleep(ACCEPT_RETRY_DELAY_S)
+                continue
+            consecutive_errors = 0
             logger.info("Stream client connected from %s", addr)
             # Bounded so one stalled subscriber cannot freeze the replay's
             # own frame loop; a timeout is then treated as death, below.
@@ -304,27 +333,46 @@ class TelemetryStreamServer:
             ).start()
 
     def _keepalive_loop(self, client_socket: socket.socket) -> None:
-        """Hold a reference to the socket until the server stops.
+        """Watch one subscriber for its disconnect, and end when it does.
 
-        It never reads, so it CANNOT see the remote end close - measured: a
-        client that disconnects is still counted three seconds later, and
-        only disappears once a broadcast fails to send. A dead client is
-        detected by `_send_loop`, never here, so `client_count()` may
-        include ghosts until the next broadcast. The docstring used to
-        promise the prune this loop does not do.
+        It used to `time.sleep(1.0)` in a loop, which meant it could not see
+        the remote end close: a client that disconnected was still counted
+        until a LATER broadcast failed (the first send after a close lands in
+        the kernel buffer and succeeds), and the thread itself slept on until
+        the server stopped - measured at exactly one leaked thread per
+        connection, five cycles taking the count from 2 to 7.
+
+        `select` on the same cadence costs the same and answers the question.
+        Subscribers never send, so readable means the peer sent FIN or a
+        reset; either way this connection is over.
         """
         try:
             while self._running:
-                time.sleep(1.0)
+                readable, _, errored = select.select([client_socket], [], [client_socket], 1.0)
+                if errored:
+                    return
+                if not readable:
+                    continue
+                try:
+                    if client_socket.recv(1) == b"":
+                        return  # clean FIN from the peer
+                except OSError:
+                    return
         finally:
-            try:
-                client_socket.close()
-            except OSError:
-                # Remote end may have already dropped the connection.
-                pass
             self._prune_clients([client_socket])
 
     def _prune_clients(self, dead: list[socket.socket]) -> None:
+        """Forget these subscribers AND close their sockets.
+
+        The close is the load-bearing half. A subscriber pruned for a send
+        timeout has a perfectly healthy TCP connection - it simply stopped
+        reading - so dropping it from the list left the consumer holding a
+        socket that would never carry another byte and never reach EOF.
+        Measured: a 1.24-second stall was enough to be pruned, after which
+        that window sat on a dead feed showing a green "Connected" chip until
+        the arcade process itself exited. Closing here makes the peer's next
+        `recv` fail, which is the signal its reconnect loop already waits for.
+        """
         with self._clients_lock:
             for client in dead:
                 try:
@@ -332,3 +380,11 @@ class TelemetryStreamServer:
                 except ValueError:
                     # Another thread already pruned this socket first — fine.
                     pass
+        # Outside the lock: `close()` can block briefly and nothing else needs
+        # the list to stay held while it does.
+        for client in dead:
+            try:
+                client.close()
+            except OSError:
+                # Remote end may have already dropped the connection.
+                pass

--- a/src/pitwall/agents_view/builder.py
+++ b/src/pitwall/agents_view/builder.py
@@ -15,6 +15,7 @@ chart histories accumulate across ticks because `history_tail` strips
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from src.pitwall.agents_view.charts import build_pace_series, build_tire_series
@@ -27,6 +28,8 @@ from src.pitwall.agents_view.reasoning import build_reasoning
 # misread. Separate from the wire's `schema_version`, which describes the
 # producer: this describes what the host hands the window.
 AGENTS_VIEW_VERSION: int = 1
+
+logger = logging.getLogger(__name__)
 
 
 class AgentsViewBuilder:
@@ -42,12 +45,15 @@ class AgentsViewBuilder:
 
     def __init__(self) -> None:
         self._history = LapHistory()
+        self._run: dict[str, Any] | None = None
+        self._seq: int | None = None
 
     def build(self, payload: dict[str, Any], connection: str = "Connected") -> dict[str, Any]:
         """The whole view for one tick."""
         strategy = payload.get("strategy") or {}
         latest = strategy.get("latest") or {}
 
+        self._reset_if_the_producer_restarted(strategy.get("start"), payload.get("seq"))
         self._accumulate(strategy, latest)
 
         return {
@@ -75,6 +81,46 @@ class AgentsViewBuilder:
             },
             "status_bar": build_status_bar(payload),
         }
+
+    def _reset_if_the_producer_restarted(
+        self, start: dict[str, Any] | None, seq: int | None
+    ) -> None:
+        """Throw the history away when the tick stops being about the same run.
+
+        **This is the twin of the DATA window's eviction, and it never got
+        the signal.** `host.get_tick` deliberately follows a restarted
+        producer - relaunch the arcade with the windows open and they must
+        not freeze on the dead race - and band 4 evicts client-side, because
+        `FrameClock` sees the new run's frame index jump backwards. This
+        accumulator lives in the HOST process, which does not restart with
+        the arcade, so nothing here ever heard about it.
+
+        Measured before the fix: a Melbourne run to lap 23 followed by a
+        Suzuka payload at lap 3 rendered a `Suzuka · 2025` header over
+        Melbourne's laps 14-23, with lap 20 reading 81.20 s against Suzuka's
+        ~92 s. Worse, it did not simply correct itself: `seed_from_tail` uses
+        `setdefault` on purpose, so any lap whose only carrier in the new run
+        is the history tail keeps the DEAD run's number permanently.
+
+        Two signals, because one is not enough:
+
+        - **the `start` block changing** catches a different race or driver;
+        - **`seq` going backwards** catches the same race relaunched, where
+          `start` is identical. It cannot be confused with a rewind: the
+          sequence counts messages a producer SENT, so within one run it only
+          ever rises. A rewind must NOT evict, and does not - the frame index
+          moves, the sequence does not.
+        """
+        restarted = (start is not None and self._run is not None and start != self._run) or (
+            seq is not None and self._seq is not None and seq < self._seq
+        )
+        if restarted:
+            logger.info("Producer restarted - dropping the AGENTS lap history")
+            self._history = LapHistory()
+        if start is not None:
+            self._run = start
+        if seq is not None:
+            self._seq = seq
 
     def _accumulate(self, strategy: dict[str, Any], latest: dict[str, Any]) -> None:
         """Fold this tick into the chart history. A rewind evicts nothing.

--- a/tests/surfaces/test_arcade_stream_server.py
+++ b/tests/surfaces/test_arcade_stream_server.py
@@ -192,3 +192,160 @@ def test_the_sanitiser_walks_tuples_like_the_blame_function_does():
     assert not any(
         isinstance(v, float) and not math.isfinite(v) for v in cleaned["quantiles"] if v is not None
     )
+
+
+# --- What happens to a subscriber the server gives up on --------------------
+#
+# Pruning used to mean "forget", not "close". A subscriber pruned for a send
+# timeout still has a perfectly healthy TCP connection - it simply stopped
+# reading - so it went on believing it was connected while no byte would ever
+# arrive and no EOF would ever come. Measured before the fix: a 1.24-second
+# stall was enough to be pruned, after which the socket drained its buffered
+# 219 KB and then sat ESTABLISHED-frozen, with the window showing a green
+# "Connected" chip over a dead feed until the arcade process itself exited.
+
+
+def _real_server() -> TelemetryStreamServer:
+    server = TelemetryStreamServer("127.0.0.1", 0)
+    server.start()
+    # Port 0 lets the OS choose; read back what it chose.
+    server.port = server._server_socket.getsockname()[1]
+    return server
+
+
+def _wait_for_clients(server: TelemetryStreamServer, count: int, timeout: float = 5.0) -> None:
+    """Block until the server has actually registered the connection.
+
+    `create_connection` returns as soon as the handshake completes, which is
+    BEFORE `_accept_loop` appends the socket. Without this the "wait until
+    pruned" loop below could exit on the first iteration having never seen a
+    client at all - measured, 1 run in 6 - and then assert about an empty set,
+    which is this repo's bug class 5 committed inside a test written to catch
+    bug class 5.
+    """
+    deadline = time.time() + timeout
+    while server.client_count() != count and time.time() < deadline:
+        time.sleep(0.02)
+    assert server.client_count() == count, (
+        f"server has {server.client_count()} clients, expected {count}"
+    )
+
+
+def test_a_pruned_subscriber_is_closed_so_it_can_notice_and_reconnect():
+    """The EFFECT: the peer reaches EOF. Asserting that the socket left the
+    server's list would have been green throughout the whole defect."""
+    import socket as socket_module
+
+    server = _real_server()
+    peer = socket_module.create_connection(("127.0.0.1", server.port), timeout=5)
+    try:
+        _wait_for_clients(server, 1)
+        # Never read. A 20 KB payload fills the socket buffers in a handful of
+        # broadcasts, which is what the real span-sized message does.
+        payload = {"filler": "x" * 20000}
+        deadline = time.time() + 15
+        while server.client_count() > 0 and time.time() < deadline:
+            server.broadcast(payload)
+            time.sleep(0.02)
+        assert server.client_count() == 0, "the server never pruned the stalled subscriber"
+
+        # Drain whatever was buffered, then require an actual end of stream.
+        #
+        # **A timeout is NOT an ending, and the first version of this check
+        # counted it as one.** `socket.timeout` is a `TimeoutError` and so an
+        # `OSError`, so a blanket `except OSError: reached_eof = True` marked
+        # "nothing arrived for five seconds" as success - which is precisely
+        # the frozen-forever state this test exists to forbid. It passed
+        # against the unfixed server. Only EOF or a reset is an ending.
+        peer.settimeout(2.0)
+        reached_eof = False
+        end = time.time() + 10
+        while time.time() < end:
+            try:
+                if peer.recv(65536) == b"":
+                    reached_eof = True
+                    break
+            except TimeoutError:
+                continue  # still frozen; keep waiting for a real ending
+            except OSError:
+                reached_eof = True  # a reset is an ending too
+                break
+        assert reached_eof, "the pruned socket never ended - the consumer would wait forever"
+    finally:
+        peer.close()
+        server.stop()
+
+
+def test_a_subscriber_that_leaves_takes_its_thread_with_it():
+    """One leaked thread per connection, held until the server stopped.
+
+    Measured before the fix: five connect/disconnect cycles took the watcher
+    count from 2 to 7, exactly +1 each, never reclaimed. The watcher slept
+    instead of reading, so it could not see the peer close.
+    """
+    import socket as socket_module
+
+    def watchers() -> int:
+        return sum(1 for t in threading.enumerate() if t.name == "TelemetryStreamClient")
+
+    server = _real_server()
+    try:
+        baseline = watchers()
+        for _ in range(5):
+            peer = socket_module.create_connection(("127.0.0.1", server.port), timeout=5)
+            _wait_for_clients(server, 1)
+            peer.close()
+            time.sleep(0.3)
+        deadline = time.time() + 5
+        while watchers() > baseline and time.time() < deadline:
+            time.sleep(0.1)
+        assert watchers() == baseline, f"{watchers() - baseline} watcher threads leaked"
+    finally:
+        server.stop()
+
+
+def test_a_transient_accept_error_does_not_shut_the_door_forever():
+    """One `OSError` used to end the accept loop for the whole session, with
+    a DEBUG line the arcade's INFO level never prints. After that no window
+    could attach again, and nothing said why."""
+    import socket as socket_module
+
+    server = TelemetryStreamServer("127.0.0.1", 0)
+
+    class _FlakyOnce:
+        """The real listening socket, with one transient failure in it."""
+
+        def __init__(self, inner: socket_module.socket) -> None:
+            self._inner = inner
+            self.raised = False
+
+        def accept(self):
+            if not self.raised:
+                self.raised = True
+                raise OSError("transient winsock hiccup")
+            return self._inner.accept()
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    listening = socket_module.socket(socket_module.AF_INET, socket_module.SOCK_STREAM)
+    listening.setsockopt(socket_module.SOL_SOCKET, socket_module.SO_REUSEADDR, 1)
+    listening.bind(("127.0.0.1", 0))
+    listening.listen(5)
+    port = listening.getsockname()[1]
+
+    server._server_socket = _FlakyOnce(listening)  # type: ignore[assignment]
+    server._running = True
+    threading.Thread(target=server._accept_loop, daemon=True).start()
+
+    try:
+        time.sleep(0.3)  # let the first accept fail and the retry arm
+        peer = socket_module.create_connection(("127.0.0.1", port), timeout=5)
+        deadline = time.time() + 5
+        while server.client_count() == 0 and time.time() < deadline:
+            time.sleep(0.05)
+        assert server.client_count() == 1, "the accept loop died on a transient error"
+        peer.close()
+    finally:
+        server.stop()
+        listening.close()

--- a/tests/surfaces/test_pitwall_agents_view.py
+++ b/tests/surfaces/test_pitwall_agents_view.py
@@ -821,3 +821,101 @@ def test_a_rule_cannot_paint_across_a_line_break():
     on_one_line = {seg["text"] for seg in highlight("lap 22 and +0.42 s") if seg["bold"] is False}
     assert "lap 22" in on_one_line
     assert "+0.42 s" in on_one_line
+
+
+# --- A restarted producer must not leave the last race on the charts --------
+#
+# `host.get_tick` deliberately follows a restarted producer: relaunching the
+# arcade with the windows open must not leave them frozen on a dead race. Band
+# 4 evicts client-side because `FrameClock` sees the frame index jump
+# backwards. This accumulator lives in the HOST process, which does not
+# restart with the arcade, so nothing here ever heard about it - the twin that
+# never got the signal, and the fix for the frozen window is what armed it.
+
+
+def _other_race_payload(seq: int, lap: int) -> dict:
+    """A DIFFERENT race, as a relaunched arcade would send it."""
+    payload = _payload(seq=seq, lap=lap, latest=_latest(lap))
+    payload["arcade"]["gp_name"] = "Suzuka"
+    payload["strategy"]["start"] = {"gp": "Suzuka", "year": 2025, "driver": "NOR"}
+    return payload
+
+
+def test_a_different_race_does_not_inherit_the_last_ones_laps():
+    """Measured before the fix: a `Suzuka · 2025` header over Melbourne's
+    laps 14-23, with lap 20 reading Melbourne's pace."""
+    from src.pitwall.agents_view import AgentsViewBuilder
+
+    builder = AgentsViewBuilder()
+    for lap in range(14, 24):
+        builder.build(_payload(seq=lap, lap=lap))
+    melbourne = builder.build(_payload(seq=30, lap=23))
+    assert len(melbourne["history"]["pace"]) >= 9, "the fixture never accumulated anything"
+
+    suzuka = builder.build(_other_race_payload(seq=1, lap=3))
+    laps = [row["lap"] for row in suzuka["history"]["pace"]]
+    assert laps == [3], f"the new race inherited {laps}"
+
+
+def test_the_same_race_relaunched_is_a_restart_too():
+    """`start` is identical, so only the sequence can tell.
+
+    It cannot be confused with a rewind: `seq` counts messages the producer
+    SENT, so within one run it only rises. A rewind moves the frame index and
+    must evict nothing - the case the test below pins.
+    """
+    from src.pitwall.agents_view import AgentsViewBuilder
+
+    builder = AgentsViewBuilder()
+    for lap in range(14, 24):
+        builder.build(_payload(seq=lap, lap=lap))
+
+    relaunched = builder.build(_payload(seq=1, lap=2))
+    laps = [row["lap"] for row in relaunched["history"]["pace"]]
+    assert laps == [2], f"the relaunched run inherited {laps}"
+
+
+def test_a_rewind_inside_one_run_still_evicts_nothing():
+    """The deliberate behaviour this fix must not break.
+
+    The laps ahead of a backwards seek are real, deterministic observations,
+    and the predictions among them are broadcast exactly once. A rewind moves
+    `frame_index`; the sequence keeps rising, which is what makes the two
+    events distinguishable at all.
+    """
+    from src.pitwall.agents_view import AgentsViewBuilder
+
+    builder = AgentsViewBuilder()
+    for lap in range(14, 24):
+        builder.build(_payload(seq=lap, lap=lap))
+
+    rewound = _payload(seq=99, lap=15)
+    rewound["playback"]["frame_index"] = 10
+    view = builder.build(rewound)
+    laps = [row["lap"] for row in view["history"]["pace"]]
+    assert max(laps) == 23, f"a rewind evicted the future: {laps}"
+
+
+def test_the_stale_lap_that_setdefault_would_have_made_permanent():
+    """The half of the defect that never self-corrected.
+
+    `seed_from_tail` uses `setdefault` on purpose, so a lap whose only carrier
+    in the NEW run is the history tail keeps whatever the DEAD run left there.
+    Asserting the VALUE, not the lap count: a store that still holds lap 18
+    at Melbourne's 81.18 under a Suzuka header is the actual damage.
+    """
+    from src.pitwall.agents_view import AgentsViewBuilder
+
+    builder = AgentsViewBuilder()
+    for lap in range(14, 24):
+        builder.build(_payload(seq=lap, lap=lap))
+
+    fresh = _other_race_payload(seq=1, lap=3)
+    fresh["strategy"]["history_tail"] = [
+        {"lap_number": 18, "lap_time_s": 92.18, "tyre_life": 4, "compound": "MEDIUM"}
+    ]
+    view = builder.build(fresh)
+    lap18 = next((row for row in view["history"]["pace"] if row["lap"] == 18), None)
+    assert lap18 is not None and lap18["actual"] == 92.18, (
+        f"lap 18 kept the dead race's number: {lap18}"
+    )


### PR DESCRIPTION
Closes #901. Found by an adversarial gate over the Python wiring — producer, wire, host, client, process lifecycle. All evidence executed headlessly on a private port; no GUI, no LLM.

Both defects **pre-date sprint 4**. Sprint 4 is what made them load-bearing: there is now a second window rendering real data off this wire, and sprint 5 builds the timing tower on it.

## H2 — a pruned subscriber is abandoned but never closed

Pruning meant *forget*, not *close*. A subscriber pruned for a **send timeout** still has a perfectly healthy TCP connection — it simply stopped reading — so dropping it from the list left the consumer holding a socket that would never carry another byte and never reach EOF.

Measured, 20 KB messages at 10 Hz: a stall of **1.24 s over 13 broadcasts** is enough to be pruned. The peer then drains its buffered 219 KB and receives nothing further and no EOF, ever, while its header shows a green **Connected over a dead feed** — the precise failure the connection channel exists to prevent. Recovery was impossible until the arcade process exited.

The comment claiming *the Qt client already reconnects* was false for exactly this path: reconnect needs an `OSError` or an empty `recv`, and a pruned-but-open socket produces neither.

## H1 — the AGENTS history outlives the race it belongs to

`get_tick` deliberately follows a restarted producer, so relaunching the arcade with the windows open does not freeze them on a dead race (#854). Band 4 evicts client-side because `FrameClock` sees the frame index jump backwards. **This accumulator lives in the host process, which does not restart with the arcade** — the twin that never got the signal, armed by the fix for the frozen window.

Measured: Melbourne to lap 23, then a Suzuka payload at lap 3, renders a `Suzuka · 2025` header over Melbourne's laps 14-23, lap 20 reading **81.20 s** against Suzuka's ~92.

And it does not self-correct. `seed_from_tail` uses `setdefault` **on purpose** — the tail is stripped of `per_agent`, so a richer observed value must not be overwritten — which means any lap whose only carrier in the new run is the tail keeps the **dead** run's number permanently.

Two signals, because one is not enough: **`start` changing** catches a different race; **`seq` going backwards** catches the same race relaunched, where `start` is identical. Neither can be confused with a rewind, which must evict nothing — a rewind moves the frame index, and `seq` counts messages the producer *sent*, so within one run it only rises. There is a test pinning that.

## Two more from the same gate

- **One transient `OSError` in `accept()` killed the accept loop for the session**, behind a DEBUG line invisible at the arcade's INFO level: no window could attach again and nothing said why. The `stop()` case now returns; a live error retries with a WARNING and a bounded surrender.
- **One thread leaked per accepted connection** — measured 2 → 7 over five cycles — because the watcher slept instead of reading and could not see the peer close. It `select`s now, which kills the leak and the ghost client count together.

## Checks

```
uv run pytest tests/surfaces            171 passed  (4 runs of the stream file, no flake)
uvx ruff@0.15.22 check . / format --check .   all checks passed / 188 files already formatted
uv run mypy src/rag/                    no issues
```

Guards watched RED against the reverted code:

| Mutation | What went red |
|---|---|
| prune forgets without closing | `the pruned socket never ended - the consumer would wait forever` |
| the watcher sleeps instead of reading | `1 watcher threads leaked` |
| any accept error returns | `the accept loop died on a transient error` |
| no restart eviction | all three history tests; the rewind test stayed green, which is the point |

**One of my own guards was wrong first**, and it is worth recording: the pruned-socket test caught `socket.timeout` in a blanket `except OSError` and counted it as an ending — so *nothing arrived for five seconds* read as success, which is precisely the frozen state it forbids. It passed against the unfixed server. It also raced the accept loop: `create_connection` returns before the server registers the client, so 1 run in 6 the wait-until-pruned loop exited having never seen a client and asserted about the empty set — bug class 5, inside a test written to catch bug class 5. Both fixed, then four consecutive green runs.