### PR TITLE
feat(pitwall): serve the same two windows on http://127.0.0.1, in any browser

### DIFF
--- a/src/pitwall/__main__.py
+++ b/src/pitwall/__main__.py
@@ -15,9 +15,17 @@ from __future__ import annotations
 import logging
 import sys
 
-from src.pitwall.config import STREAM_HOST, STREAM_PORT, WINDOWS, build_hint, ui_is_built
+from src.pitwall.config import (
+    STREAM_HOST,
+    STREAM_PORT,
+    WINDOWS,
+    build_hint,
+    ui_dist,
+    ui_is_built,
+)
 from src.pitwall.host import PitwallHost
 from src.pitwall.stream_client import ArcadeStreamClient
+from src.pitwall.webserver import BrowserServer
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +40,17 @@ def main() -> int:
 
     host = PitwallHost(ArcadeStreamClient(STREAM_HOST, STREAM_PORT), window_count=len(WINDOWS))
     host.start()
+
+    # The same two pages, additionally on loopback. The windows are still the
+    # product; this exists so the surface can also be opened in a browser -
+    # for devtools, for a second screen, or simply because a page is easier to
+    # arrange than an OS window. It reads through the same `get_tick`, so
+    # there is still ONE TCP client and one sequence however many consumers
+    # attach.
+    browser = BrowserServer(ui_dist(), host)
+    url = browser.start()
+    if url:
+        logger.info("Also serving the same windows at %sdata.html and %sagents.html", url, url)
 
     # The geometry in `WINDOWS` is what the layout wants; the screen decides
     # what it gets. A window taller than the desktop is not scrolled, it is
@@ -74,6 +93,7 @@ def main() -> int:
         # `webview.start()` returns when the last window closes, but it also
         # returns on an exception, and a leaked reader thread would hold the
         # socket open against the next run.
+        browser.stop()
         host.shutdown()
     return 0
 

--- a/src/pitwall/config.py
+++ b/src/pitwall/config.py
@@ -15,7 +15,15 @@ from typing import Final
 # the client would just retry forever against a closed port.
 from src.arcade.config import STREAM_HOST, STREAM_PORT
 
-__all__ = ["STREAM_HOST", "STREAM_PORT", "WINDOWS", "WindowSpec", "ui_asset", "ui_is_built"]
+__all__ = [
+    "STREAM_HOST",
+    "STREAM_PORT",
+    "WINDOWS",
+    "WindowSpec",
+    "ui_asset",
+    "ui_dist",
+    "ui_is_built",
+]
 
 _UI_DIR: Final[Path] = Path(__file__).resolve().parent / "ui"
 _UI_DIST: Final[Path] = _UI_DIR / "dist"
@@ -110,6 +118,11 @@ def ui_asset(name: str) -> Path:
     a setup mistake with a one-line fix, not a crash to decode.
     """
     return _UI_DIST / name
+
+
+def ui_dist() -> Path:
+    """The built bundle's directory, for anything that serves the whole tree."""
+    return _UI_DIST
 
 
 def ui_is_built() -> bool:

--- a/src/pitwall/ui/src/lib/agents.ts
+++ b/src/pitwall/ui/src/lib/agents.ts
@@ -9,7 +9,7 @@
  */
 
 import { useEffect, useRef, useState } from "react";
-import { whenBridgeReady } from "./bridge";
+import { getAgentsView, whenBridgeReady } from "./bridge";
 
 /** Matches the producer's own ~10 Hz. Polling faster only returns null more often. */
 const POLL_INTERVAL_MS = 100;
@@ -146,10 +146,6 @@ export interface AgentsView {
   status_bar: { text: string; transient: boolean };
 }
 
-interface AgentsApi {
-  get_agents_view: (sinceSeq: number) => Promise<AgentsView | null>;
-}
-
 export interface AgentsState {
   view: AgentsView | null;
   /** False until the first view lands, so the window can say "waiting" honestly. */
@@ -175,8 +171,7 @@ export function useAgentsView(): AgentsState {
     let timer: number | undefined;
 
     const poll = async () => {
-      const api = (window.pywebview?.api ?? null) as AgentsApi | null;
-      const view = api ? await api.get_agents_view(lastSeq.current) : null;
+      const view = await getAgentsView<AgentsView>(lastSeq.current);
       if (cancelled) return;
       if (view) {
         if (view.seq !== null) lastSeq.current = view.seq;

--- a/src/pitwall/ui/src/lib/bridge.ts
+++ b/src/pitwall/ui/src/lib/bridge.ts
@@ -90,16 +90,53 @@ declare global {
 }
 
 /**
+ * Is this page inside a PITWALL window, or in a browser tab?
+ *
+ * The same bundle serves both. In a window the host injects
+ * `window.pywebview.api`; over http there is no such object and the same
+ * payload arrives from `/api/tick` on the loopback server the host runs
+ * alongside the windows. Everything above this module is unaware of which.
+ *
+ * `file:` is the giveaway a window ALWAYS has and a browser never does, but
+ * it is not sufficient on its own: pywebview announces its API
+ * asynchronously, so a page that has finished loading may not have it yet.
+ * Hence the wait below rather than a single check here.
+ */
+const IN_A_WINDOW = window.location.protocol === "file:";
+
+/**
  * pywebview injects `window.pywebview.api` asynchronously and announces it
  * with a `pywebviewready` event. Code that reads the API at module scope
  * therefore sees `undefined` and fails silently, which renders an empty
  * window with nothing in any log.
+ *
+ * Over http there is nothing to wait for, and waiting for an event that will
+ * never fire is how the browser path would render an empty page with nothing
+ * in any log - the same failure, one transport over.
  */
 export function whenBridgeReady(): Promise<void> {
-  if (window.pywebview?.api) return Promise.resolve();
+  if (window.pywebview?.api || !IN_A_WINDOW) return Promise.resolve();
   return new Promise((resolve) => {
     window.addEventListener("pywebviewready", () => resolve(), { once: true });
   });
+}
+
+/**
+ * One tick, from whichever transport this page has.
+ *
+ * A network error resolves to null rather than throwing: null already means
+ * "nothing new, keep what you have", which is exactly the right behaviour
+ * while a server restarts, and it is what the poll loop above already
+ * handles. Throwing would kill the loop on the first hiccup.
+ */
+async function fetchJson<T>(route: string, sinceSeq: number): Promise<T | null> {
+  try {
+    const response = await fetch(`${route}?since=${sinceSeq}`, { cache: "no-store" });
+    if (!response.ok) return null;
+    return (await response.json()) as T | null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -111,6 +148,22 @@ export function whenBridgeReady(): Promise<void> {
  */
 export async function getTick(sinceSeq: number): Promise<Tick | null> {
   const api = window.pywebview?.api;
-  if (!api) return null;
-  return api.get_tick(sinceSeq);
+  if (api) return api.get_tick(sinceSeq);
+  if (IN_A_WINDOW) return null;
+  return fetchJson<Tick>("/api/tick", sinceSeq);
+}
+
+/**
+ * The whole AGENTS view, from whichever transport this page has.
+ *
+ * It lives here rather than in `agents.ts` for the same reason `getTick`
+ * does: this module is the ONE place that knows how a payload arrives, and
+ * the browser fallback would otherwise have to be written twice - which is
+ * this repo's dominant defect, one copy fixed and its twin not.
+ */
+export async function getAgentsView<T>(sinceSeq: number): Promise<T | null> {
+  const api = window.pywebview?.api as { get_agents_view?: (s: number) => Promise<T | null> };
+  if (api?.get_agents_view) return api.get_agents_view(sinceSeq);
+  if (IN_A_WINDOW) return null;
+  return fetchJson<T>("/api/agents", sinceSeq);
 }

--- a/src/pitwall/webserver.py
+++ b/src/pitwall/webserver.py
@@ -1,0 +1,183 @@
+"""Serve the same two windows over http://127.0.0.1, in any browser.
+
+**Additive, and deliberately so.** The 2026-08-07 decision stands: PITWALL is
+a desktop surface built with web technology, and the pywebview windows are the
+product. That decision killed the FastAPI WebSocket relay (#283) because a
+BROWSER cannot open a raw TCP socket - but the PITWALL host already holds that
+socket and the payload it produces, so handing the same payload to a browser
+costs a small HTTP server rather than a backend.
+
+What it buys, and why it is worth ~100 lines:
+
+- the pages open on a second machine, a phone, or a browser window the user
+  can arrange however they like;
+- devtools, which a pywebview window does not give you;
+- the surface stops being invisible to anything that is not this desktop.
+
+`bridge.ts` is the one module that knows how a tick arrives, which is exactly
+why this is cheap: it falls back to `fetch` when `window.pywebview` is absent
+and nothing above it changes.
+
+Two deliberate constraints:
+
+- **Bound to the loopback interface.** The broadcast carries a whole race's
+  live state and there is no authentication here at all. This is a local
+  developer surface, not a deployment.
+- **The bundle is read into memory at startup and served from a dict.** No
+  request is ever turned into a filesystem path. `serve-dist.mjs` learned this
+  twice - a URL can carry `../`, which CodeQL correctly called a path
+  injection, and the `stat`-per-entry version that replaced it was a
+  filesystem race. Reading the tree once removes the question rather than
+  guarding it, and a built bundle is a few hundred kilobytes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import mimetypes
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Protocol
+from urllib.parse import parse_qs, urlparse
+
+logger = logging.getLogger(__name__)
+
+# Loopback only. See the module docstring: the payload is unauthenticated.
+BROWSER_HOST = "127.0.0.1"
+# 0 lets the OS pick a free one, which is what a dev surface wants: two arcades
+# side by side must not fight, and the chosen port is logged.
+BROWSER_PORT = 0
+
+_TEXT_TYPES = {".html": "text/html", ".js": "text/javascript", ".css": "text/css"}
+
+
+class TickSource(Protocol):
+    """What the server needs from the host, and nothing more.
+
+    Deliberately narrower than `PitwallHost`: the browser path must be unable
+    to reach `release_window` or `shutdown`, which belong to the OS windows.
+    """
+
+    def get_tick(self, since_seq: int = -1) -> dict[str, Any] | None: ...
+
+    def get_agents_view(self, since_seq: int = -1) -> dict[str, Any] | None: ...
+
+
+def _read_bundle(root: Path) -> dict[str, tuple[bytes, str]]:
+    """The whole built bundle, URL path -> (bytes, content type)."""
+    files: dict[str, tuple[bytes, str]] = {}
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        url = "/" + path.relative_to(root).as_posix()
+        suffix = path.suffix.lower()
+        content_type = _TEXT_TYPES.get(suffix) or mimetypes.guess_type(path.name)[0]
+        files[url] = (path.read_bytes(), content_type or "application/octet-stream")
+    return files
+
+
+def _since(query: str) -> int:
+    """`?since=N`, or -1 for a caller that has rendered nothing yet."""
+    values = parse_qs(query).get("since")
+    if not values:
+        return -1
+    try:
+        return int(values[0])
+    except ValueError:
+        # A browser typing the URL by hand is not a reason to 500. Treating a
+        # junk value as "I have seen nothing" returns the newest tick, which
+        # is what the caller wanted.
+        return -1
+
+
+def _handler(bundle: dict[str, tuple[bytes, str]], source: TickSource):
+    class PitwallHTTPHandler(BaseHTTPRequestHandler):
+        # `BaseHTTPRequestHandler` logs every request to stderr, which at
+        # 10 Hz across two pages buries everything else the arcade says.
+        def log_message(self, fmt: str, *args: Any) -> None:  # noqa: A003 - stdlib name
+            logger.debug("pitwall-http: " + fmt, *args)
+
+        def do_GET(self) -> None:  # noqa: N802 - stdlib name
+            parsed = urlparse(self.path)
+            route = parsed.path
+
+            if route in ("/api/tick", "/api/agents"):
+                reader = source.get_tick if route == "/api/tick" else source.get_agents_view
+                self._send_json(reader(_since(parsed.query)))
+                return
+
+            if route in ("/", ""):
+                route = "/data.html"
+            entry = bundle.get(route)
+            if entry is None:
+                self.send_error(404)
+                return
+            body, content_type = entry
+            self._send(200, content_type, body)
+
+        def _send_json(self, payload: dict[str, Any] | None) -> None:
+            # `null` is the honest answer to "nothing new since N", and the
+            # bridge already treats it that way over the pywebview path.
+            body = json.dumps(payload, allow_nan=False).encode("utf-8")
+            self._send(200, "application/json", body, cache=False)
+
+        def _send(self, status: int, content_type: str, body: bytes, cache: bool = True) -> None:
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            if not cache:
+                self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            try:
+                self.wfile.write(body)
+            except (BrokenPipeError, ConnectionResetError):
+                # The browser navigated away mid-response. Routine, not an
+                # error, and letting it propagate prints a traceback per tick.
+                pass
+
+    return PitwallHTTPHandler
+
+
+class BrowserServer:
+    """The bundle plus a tick endpoint, on loopback, in a daemon thread.
+
+    Invariants:
+
+    - it never touches the TCP client: it reads through the same `get_tick`
+      the windows call, so there is one client and one sequence however many
+      consumers attach;
+    - it serves from memory, so a request can never name a file.
+    """
+
+    def __init__(self, dist: Path, source: TickSource, port: int = BROWSER_PORT) -> None:
+        self._dist = dist
+        self._source = source
+        self._port = port
+        self._server: ThreadingHTTPServer | None = None
+
+    def start(self) -> str | None:
+        """Serve, and return the URL to open. None when there is no bundle."""
+        if not self._dist.is_dir():
+            return None
+        bundle = _read_bundle(self._dist)
+        if "/data.html" not in bundle:
+            return None
+        self._server = ThreadingHTTPServer(
+            (BROWSER_HOST, self._port), _handler(bundle, self._source)
+        )
+        threading.Thread(
+            target=self._server.serve_forever,
+            daemon=True,
+            name="PitwallBrowserServer",
+        ).start()
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}/"
+
+    def stop(self) -> None:
+        if self._server is None:
+            return
+        self._server.shutdown()
+        self._server.server_close()
+        self._server = None

--- a/tests/surfaces/test_pitwall_browser_server.py
+++ b/tests/surfaces/test_pitwall_browser_server.py
@@ -1,0 +1,124 @@
+"""The same two pages, over http on loopback (`src/pitwall/webserver.py`).
+
+Additive to the pywebview windows, which remain the product. The 2026-08-07
+decision that PITWALL is a desktop surface killed the FastAPI relay because a
+browser cannot open a raw TCP socket - but the host already holds that socket,
+so handing the same payload to a browser costs a small server rather than a
+backend.
+
+What these pin is the part that is easy to get wrong in a hurry: the payload a
+browser gets is the SAME sequenced payload a window gets, a request can never
+name a file, and nothing here listens beyond the loopback interface.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from src.pitwall.webserver import BROWSER_HOST, BrowserServer
+
+
+class _FakeHost:
+    """The narrow `TickSource` the server takes, and nothing else.
+
+    Narrow on purpose: the browser path must not be able to reach
+    `release_window` or `shutdown`, which belong to the OS windows.
+    """
+
+    def __init__(self) -> None:
+        self.tick = {"seq": 7, "arcade": {"lap": 23}}
+        self.view = {"seq": 7, "header": {"session": "Melbourne · 2025"}}
+
+    def get_tick(self, since_seq: int = -1):
+        return None if since_seq == self.tick["seq"] else self.tick
+
+    def get_agents_view(self, since_seq: int = -1):
+        return None if since_seq == self.view["seq"] else self.view
+
+
+@pytest.fixture
+def served(tmp_path: Path):
+    dist = tmp_path / "dist"
+    (dist / "assets").mkdir(parents=True)
+    (dist / "data.html").write_text("<html>data</html>", encoding="utf-8")
+    (dist / "agents.html").write_text("<html>agents</html>", encoding="utf-8")
+    (dist / "assets" / "app.js").write_text("console.log(1)", encoding="utf-8")
+    server = BrowserServer(dist, _FakeHost())
+    url = server.start()
+    assert url, "the server must come up on a real bundle"
+    yield url.rstrip("/")
+    server.stop()
+
+
+def _get(url: str) -> tuple[int, str, str]:
+    with urllib.request.urlopen(url, timeout=5) as response:
+        return response.status, response.headers.get("Content-Type", ""), response.read().decode()
+
+
+def test_the_bundle_is_served_including_the_root(served: str):
+    for route, expected in (("/data.html", "data"), ("/agents.html", "agents"), ("/", "data")):
+        status, content_type, body = _get(served + route)
+        assert status == 200 and expected in body, f"{route} served {body!r}"
+        assert content_type == "text/html", f"{route} served as {content_type}"
+    assert _get(served + "/assets/app.js")[1] == "text/javascript"
+
+
+def test_a_browser_gets_the_same_sequenced_payload_a_window_gets(served: str):
+    """The sequencing is the whole reason two consumers do not disagree.
+
+    Gate A measured two pollers against a blind latest-payload slot reading a
+    different frame on 58 % of polls. Adding a transport that ignored `since`
+    would put that back for the browser.
+    """
+    status, content_type, body = _get(served + "/api/tick?since=-1")
+    tick = json.loads(body)
+    assert status == 200 and content_type == "application/json"
+    assert tick["seq"] == 7 and tick["arcade"]["lap"] == 23
+
+    assert json.loads(_get(served + "/api/tick?since=7")[2]) is None, "a seen tick must be null"
+    assert json.loads(_get(served + "/api/agents?since=-1")[2])["header"]["session"].startswith(
+        "Melbourne"
+    )
+
+
+def test_a_junk_since_is_treated_as_having_seen_nothing(served: str):
+    """A URL typed by hand is not a reason to 500 - it is a reason to answer."""
+    assert json.loads(_get(served + "/api/tick?since=nonsense")[2])["seq"] == 7
+    assert json.loads(_get(served + "/api/tick")[2])["seq"] == 7
+
+
+def test_a_request_can_never_name_a_file(served: str):
+    """The bundle is read into memory at startup and served from a dict.
+
+    `serve-dist.mjs` learned this twice - a URL can carry `../`, which CodeQL
+    called a path injection, and the `stat`-per-entry version that replaced it
+    was a filesystem race. Reading the tree once removes the question rather
+    than guarding it, so these are 404s and not near-misses.
+    """
+    for attempt in ("/../pyproject.toml", "/..%2fpyproject.toml", "/assets/../../secret"):
+        with pytest.raises(urllib.error.HTTPError) as caught:
+            _get(served + attempt)
+        assert caught.value.code == 404, f"{attempt} returned {caught.value.code}"
+
+
+def test_it_listens_on_loopback_only(served: str):
+    """The broadcast carries a whole race's live state and there is no auth.
+
+    Asserted on the URL the server reports, which is the address it bound.
+    """
+    assert served.startswith(f"http://{BROWSER_HOST}:"), served
+    assert BROWSER_HOST == "127.0.0.1"
+
+
+def test_no_bundle_means_no_server_rather_than_a_crash(tmp_path: Path):
+    """`f1-arcade` spawns PITWALL; a missing build must not take the arcade
+    down with it. `__main__` already refuses to open windows in that case."""
+    assert BrowserServer(tmp_path / "nothing", _FakeHost()).start() is None
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert BrowserServer(empty, _FakeHost()).start() is None


### PR DESCRIPTION
Closes #905.

Víctor asked why the surface shows up as Python windows rather than a page on localhost, given that the point of migrating was web technology.

**It is web technology** — React and ECharts in a Chromium engine — and the desktop framing is his own decision of 2026-08-07, recorded in `PITWALL_V2_ARCHITECTURE.md` §1: *PITWALL is a desktop surface built with web technology, not a web app.* That decision killed the FastAPI relay on the correct observation that **a browser cannot open a raw TCP socket**.

**This does not revoke it.** The windows are still the product; the same pages are now *also* reachable over loopback. The relay argument no longer applies because the host **already owns that socket** and the sequenced payload it produces — handing that payload to a browser costs a small server inside a process that is already running, not a backend.

## Why it is small

`bridge.ts` was built as the ONE module that knows how a tick arrives. It falls back to `fetch` when `window.pywebview` is absent, and nothing above it changes. `agents.ts` had grown its own copy of that lookup and now goes through the bridge too — the fallback exists once rather than twice, which is the difference between a seam and this repo's dominant defect.

## Two deliberate constraints

- **Loopback only.** The broadcast carries a whole race's live state and there is no authentication here at all. Local developer surface, not a deployment.
- **No request can name a file.** The bundle is read into memory at startup and served from a dict. `serve-dist.mjs` learned this twice — a URL can carry `../`, which CodeQL correctly called a path injection, and the `stat`-per-entry version that replaced it was a filesystem race. Reading the tree once removes the question rather than guarding it.

## Checks

```
npm run typecheck                       clean
npm run smoke                           smoke OK: 14 · smoke-data OK: 42
uv run pytest tests/surfaces            177 passed  (6 new)
uvx ruff@0.15.22 check . / format --check .   all checks passed
```

The six new tests pin what is easy to get wrong in a hurry: the bundle serves including `/`, a browser gets the **same sequenced payload** a window gets (and `null` for a seq it has seen), a junk `?since=` answers instead of 500ing, three traversal shapes all 404, the bind address is loopback, and a missing bundle returns no server rather than taking the arcade down with it.

## And the real path, twice

**Against the live wire**, not a stub:

```
/data.html     200 text/html 567 bytes
/agents.html   200 text/html 573 bytes
/api/tick      200 application/json 18656 bytes  seq=16
   lap=23 main=NOR drivers=20 span=5
   same seq again -> None
/api/agents    200 9783 bytes  header='Melbourne · 2025'
junk since     200 -> seq=16
traversal      blocked: HTTPError 404
```

**In an actual browser**, driving the page rather than the endpoint: 47 fetches in 6 s, every one a 200, band 4 fully rendered — `LAP 23 | NOR | vs | PIA | Δ Time (s) …` — with **zero console errors** on both pages.

And the full entry point still does what it did, plus one line:

```
INFO src.pitwall.stream_client: Pitwall connected to the arcade broadcast
INFO __main__: Also serving the same windows at http://127.0.0.1:62042/data.html and http://127.0.0.1:62042/agents.html
INFO __main__: PITWALL · DATA opens at 1500x870 rather than 1500x950 - the 1707x960 screen is smaller
INFO __main__: PITWALL · AGENTS opens at 1320x870 rather than 1320x900 - the 1707x960 screen is smaller
```

*(One debugging note worth keeping: the first browser attempt rendered the waiting state, and I nearly blamed the fallback. It was a previous server process still holding the port and serving a stale bundle from memory. Instrumenting `window.fetch` inside the page — 47 calls, all 200 — is what separated "the code is wrong" from "you are talking to yesterday's server".)*
