### PR TITLE
fix(pitwall): hide the scrollbars inside the AGENTS cards, and stop the DATA cursor shimmering

### DIFF
--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -216,6 +216,47 @@ check(clip.onScreen, "the tooltip stays inside the viewport");
 
 // Qt's `showMessage(text, 1500)` clears itself. The port typed a
 // `transient` flag and read it nowhere until #871.
+// The scrollbars are HIDDEN, not deleted. Víctor asked for the bars inside
+// the cards to go; the tempting wrong fix is `overflow: hidden`, which puts
+// back the clipping the migration README records as a defect of the Qt window
+// being replaced ("the right column clipped mid-card"). So this asserts the
+// content is still REACHABLE, which is the part that can regress silently -
+// the chrome being gone is visible to anyone who looks.
+//
+// With a REAL WHEEL, not `el.scrollTop = 999`. An `overflow: hidden` element
+// is still scrollable from script - only the USER is blocked - so the
+// scripted version passed against the exact mutation it was written to
+// catch. Same mechanism-instead-of-effect trap the sprint-3 gate found in
+// this file's tooltip check.
+const overflowing = await page.evaluate(() =>
+  [...document.querySelectorAll(".agent-card-body, .reasoning-body")]
+    .map((el, i) => ({ i, over: el.scrollHeight - el.clientHeight }))
+    .filter((e) => e.over > 0)
+    .map((e) => e.i),
+);
+check(overflowing.length > 0, `something overflows, or this checks nothing`);
+
+const wheeled = [];
+for (const index of overflowing) {
+  const box = await page
+    .locator(".agent-card-body, .reasoning-body")
+    .nth(index)
+    .boundingBox();
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.wheel(0, 200);
+  await page.waitForTimeout(120);
+  wheeled.push(
+    await page.evaluate(
+      (i) => document.querySelectorAll(".agent-card-body, .reasoning-body")[i].scrollTop,
+      index,
+    ),
+  );
+}
+check(
+  wheeled.every((top) => top > 0),
+  `a wheel over an overflowing body still reaches its content (${JSON.stringify(wheeled)})`,
+);
+
 check(
   (await page.locator(".status-bar").innerText()).includes("lap 23"),
   "the status bar starts with the lap",

--- a/src/pitwall/ui/src/features/data/TraceChart.tsx
+++ b/src/pitwall/ui/src/features/data/TraceChart.tsx
@@ -69,7 +69,14 @@ export function TraceChart(props: TraceChartProps) {
       marks.push({ yAxis: 0, lineStyle: { color: mainColour, width: 2, type: "solid" } });
     }
     if (cursorX !== null) {
-      marks.push({ xAxis: cursorX, lineStyle: { color: CURSOR_LINE, width: 1, type: "dashed" } });
+      // SOLID, not dashed. The car covers about 6 m per 100 ms tick, which on
+      // a ~700 px plot spanning 5220 m is under one pixel - so a dashed
+      // cursor never moves a whole dash, it shifts its pattern by a fraction
+      // of a pixel ten times a second and shimmers. Measured while chasing
+      // it: the line is never actually absent (328 cursor pixels on all 40
+      // samples over 3 s), so it was not blinking, it was crawling. A solid
+      // line at the same width slides instead.
+      marks.push({ xAxis: cursorX, lineStyle: { color: CURSOR_LINE, width: 1, type: "solid" } });
     }
 
     return {

--- a/src/pitwall/ui/src/styles/qt-base.css
+++ b/src/pitwall/ui/src/styles/qt-base.css
@@ -50,3 +50,28 @@ body {
   color: var(--qt-fg-3);
   font-size: 11px;
 }
+
+/* --- Scrollbars: reachable, invisible ------------------------------------
+ *
+ * Víctor, on seeing the AGENTS window: get rid of the bars that appear for
+ * scrolling inside the cards. They are visual noise on a surface whose whole
+ * job is to be read at a glance, and the overflow that summons them is
+ * usually trivial - measured, four of the six card bodies overflow by
+ * FOURTEEN pixels and each was drawing a full-height scrollbar for it.
+ *
+ * Hidden, not removed. The bodies stay `overflow: auto`, so a wheel, a
+ * trackpad, a touch drag and the keyboard all still reach the content. What
+ * goes is the chrome. Deleting the scroll instead would go back to CLIPPING,
+ * which is what Qt did and what the migration README records as a defect of
+ * the window being replaced ("the right column clipped mid-card").
+ *
+ * The one thing this does not give back is the AFFORDANCE - nothing now hints
+ * that a card has more below. That is a design question, not a CSS one, and
+ * it belongs to the elevate pass along with the hover treatment.
+ */
+* {
+  scrollbar-width: none; /* Firefox */
+}
+*::-webkit-scrollbar {
+  display: none; /* Chromium, which is what WebView2 is */
+}


### PR DESCRIPTION
Closes #907. The two things Víctor asked for before moving on, after approving sprint 4 otherwise.

## The scrollbars are hidden, not removed

Every AGENTS card body was drawing a full-height scrollbar. Measured: **four of the six overflow by fourteen pixels** and each summoned a whole bar for it.

The bodies stay `overflow: auto`, so a wheel, a trackpad, a touch drag and the keyboard all still reach the content — only the chrome goes. `overflow: hidden` would have been the tempting fix and it is wrong: it puts back the **clipping** the migration README records as a defect of the Qt window being replaced (*"the right column clipped mid-card"*).

**Verified where it actually matters.** Headless Chromium uses overlay scrollbars and physically cannot show this difference, so I captured the real WebView2 window before and after and counted the columns that look like a Windows scrollbar:

```
scrollbar-like columns  BEFORE=30  AFTER=0
  before at: [9, 10, 1354…1366, 1918…1922]
```

The 30 sat exactly on the right edges of the two card columns and the reasoning pane. Zero after.

## The cursor was not flickering

Measured before assuming anything: it is **never absent** — 328 cursor pixels in all 40 samples over three seconds.

```
cursor pixel counts over 40 samples: 328,328,328,…,327,328
ABSENT in 0/40 samples  min=327 max=328
```

What it was doing: the car covers about 6 m per 100 ms tick, which on a ~700 px plot spanning 5220 m is **under one pixel**. A dashed line therefore never moves a whole dash — it shifts its pattern by a fraction of a pixel ten times a second, which is exactly what a shimmer is. Solid at the same width slides instead of crawling.

## My first guard was wrong, again, in the same way

The reachability check started as `el.scrollTop = 999`. It **passed against `overflow: hidden`** — an element with hidden overflow is still scrollable from script, only the *user* is blocked. Mechanism instead of effect, which is the same trap the sprint-3 exit gate found in this very file's tooltip check.

It is a real `page.mouse.wheel()` now, and it goes red:

```
smoke FAILED (1):
  - a wheel over an overflowing body still reaches its content ([0,0,0,0])
```

## Deferred, deliberately, and Víctor said so

- **The hover treatment** — *retocarlos en su momento*. It is entangled with the debt sprint 3 took on knowingly: the tooltips still emit Qt's restricted rich-text dialect because the Python formatters are reused as-is, and whether they get a TypeScript reimplementation at all is sprint 8's call.
- **The scroll affordance.** Hiding the bar means nothing hints a card has more below. A design question, not a CSS one; it belongs with the same pass.

## Checks

```
npm run typecheck                       clean
npm run smoke                           smoke OK: 16 checks  (was 14) · smoke-data OK: 42
uv run pytest tests/surfaces            177 passed
uvx ruff@0.15.22 check . / format --check .   all checks passed / 190 files already formatted
```
