### PR TITLE
fix(docs): generate the changelog page instead of hand-refreshing it, and show dates day-month-year

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,12 @@ on:
     paths:
       - "docs/**"
       - "scripts/prerender_docs.mjs"
+      - "scripts/sync_docs_changelog.mjs"
+      # A release only edits CHANGELOG.md, and the changelog PAGE is generated
+      # from it. Without this path the site keeps whatever version it was last
+      # deployed with - which is how it came to advertise 1.10.5 while the repo
+      # had shipped 2.5.1.
+      - "CHANGELOG.md"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
@@ -25,6 +31,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+
+      # Before staging, so the copy that ships is generated from the file
+      # release-please owns rather than from whenever someone last refreshed
+      # it by hand. Also rewrites the release dates to day-month-year, which
+      # is done HERE and not in a renderer because the site renders the same
+      # markdown twice - prerendered in Node and hydrated in the browser - and
+      # a render-time rule would be two implementations of one decision.
+      - name: Generate the changelog page from CHANGELOG.md
+        run: node scripts/sync_docs_changelog.mjs
+
       - name: Stage docs/ for deployment
         run: |
           mkdir -p _site
@@ -32,11 +52,6 @@ jobs:
           # Add a .nojekyll marker so GitHub Pages does not run Jekyll on the
           # output (we ship raw HTML + JSX + CSS that should be served as-is).
           touch _site/.nojekyll
-
-      - name: Set up Node
-        uses: actions/setup-node@v7
-        with:
-          node-version: "20"
 
       - name: Prerender doc pages (crawlable HTML + real-URL sitemap + llms-full)
         # Renders each docs/pages/*.md to a real /<slug>/index.html with per-page

--- a/docs/pages/changelog.md
+++ b/docs/pages/changelog.md
@@ -1,10 +1,11 @@
-> **Note:** this page is a manually-refreshed mirror. The canonical source
-> is [CHANGELOG.md](https://github.com/VforVitorio/F1-StratLab/blob/main/CHANGELOG.md)
-> on GitHub.
+> **Note:** this page is generated from
+> [CHANGELOG.md](https://github.com/VforVitorio/F1-StratLab/blob/main/CHANGELOG.md)
+> by `scripts/sync_docs_changelog.mjs`, which the docs workflow runs on every
+> deploy. Do not edit it by hand — edit the canonical file, or the generator.
 
-> Mirrored from the repo root `CHANGELOG.md`. Maintained automatically by
-> [release-please](https://github.com/googleapis/release-please) on each
-> merge to `main` — see [CI/CD pipeline](#/ci-cd) for the full flow.
+> Maintained by [release-please](https://github.com/googleapis/release-please)
+> on each merge to `main` — see [CI/CD pipeline](#/ci-cd) for the full flow.
+> Dates are shown day-month-year.
 
 # Changelog
 
@@ -19,9 +20,250 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 
 <!-- next-version-placeholder -->
 
-## [1.10.5](https://github.com/VforVitorio/F1-StratLab/compare/v1.10.4...v1.10.5) (2026-07-16)
+## [2.5.1](https://github.com/VforVitorio/F1-StratLab/compare/v2.5.0...v2.5.1) (28-07-2026)
+### Bug Fixes
+
+* **dashboard:** give the orchestrator tab the height the card was hoarding ([84b41c0](https://github.com/VforVitorio/F1-StratLab/commit/84b41c0ecbdd5cd57ca9cfa6fbb15ca9e42aad92))
 
 
+### Documentation
+
+* **roadmap:** renumber the planned milestones to v2.6.0, v2.8.0 and v3.0.0 ([48548a4](https://github.com/VforVitorio/F1-StratLab/commit/48548a443703e824758f05eb4f55dc5eae995efa))
+
+## [2.5.0](https://github.com/VforVitorio/F1-StratLab/compare/v2.4.0...v2.5.0) (28-07-2026)
+### Features
+
+* **arcade:** show the decision-memory block when the call changes ([6877788](https://github.com/VforVitorio/F1-StratLab/commit/687778820b897aba724bed1a666682f2c120f827)), closes [#694](https://github.com/VforVitorio/F1-StratLab/issues/694)
+* **backend:** bump telemetry to the lap payload carrying the decision-memory block ([c4d7bb4](https://github.com/VforVitorio/F1-StratLab/commit/c4d7bb4d52f0aa20fd580fbcb9cadab97dcdeb5d)), closes [#694](https://github.com/VforVitorio/F1-StratLab/issues/694)
+* **cli:** show the decision-memory block when the call changes ([41dd804](https://github.com/VforVitorio/F1-StratLab/commit/41dd8041ba71e1056a9b805873ec956ad134bfb1)), closes [#694](https://github.com/VforVitorio/F1-StratLab/issues/694)
+* **memory:** expose whether the last recorded call changed ([7b69c13](https://github.com/VforVitorio/F1-StratLab/commit/7b69c1358ce8f5535667ceaae4fc4b02ef93a7b3)), closes [#694](https://github.com/VforVitorio/F1-StratLab/issues/694)
+
+
+### Bug Fixes
+
+* **tests:** skip the payload tests when model weights are absent ([4aa4424](https://github.com/VforVitorio/F1-StratLab/commit/4aa4424e432171730a8b5539f2d440ae9d596093))
+
+## [2.4.0](https://github.com/VforVitorio/F1-StratLab/compare/v2.3.0...v2.4.0) (28-07-2026)
+### Features
+
+* **engine:** accept a caller-owned DecisionMemory and render it into the prompt ([10e4832](https://github.com/VforVitorio/F1-StratLab/commit/10e4832429d39d6c5285ee8fabce73b510bdc67b)), closes [#684](https://github.com/VforVitorio/F1-StratLab/issues/684)
+* **orchestrator:** render a decision-memory block in the Layer 3 prompt ([5f8f789](https://github.com/VforVitorio/F1-StratLab/commit/5f8f789d378250b712dd87128728cf7e5e4a71a0)), closes [#680](https://github.com/VforVitorio/F1-StratLab/issues/680)
+* **orchestrator:** scope the STAY_OUT continuation framing to actual holds ([282f668](https://github.com/VforVitorio/F1-StratLab/commit/282f668c8f4265e61c65334a300cc55db3676b75)), closes [#685](https://github.com/VforVitorio/F1-StratLab/issues/685)
+* **surfaces:** give the CLI, arcade and backend a per-race decision memory ([c463c8c](https://github.com/VforVitorio/F1-StratLab/commit/c463c8c0a7e956679d789131c06b0196dbd13f16)), closes [#684](https://github.com/VforVitorio/F1-StratLab/issues/684)
+
+
+### Documentation
+
+* **audit:** record what Sprint 2 built and the three findings the build produced ([349384f](https://github.com/VforVitorio/F1-StratLab/commit/349384f409d4edc8ae0e4934f49467929593e745))
+* **memory:** say precisely when the block does and does not change the call ([b9a93c5](https://github.com/VforVitorio/F1-StratLab/commit/b9a93c52e3532be0bd6c8f3ffe9f734148a72194))
+* **orchestrator:** declare that /recommend and MCP have no decision memory ([243e6d2](https://github.com/VforVitorio/F1-StratLab/commit/243e6d2f81ed1f05d4c255ec9e9a1097b184ea50)), closes [#681](https://github.com/VforVitorio/F1-StratLab/issues/681)
+
+## [2.3.0](https://github.com/VforVitorio/F1-StratLab/compare/v2.2.4...v2.3.0) (27-07-2026)
+### Features
+
+* **strategy:** add the per-race decision memory accumulator ([7ffd527](https://github.com/VforVitorio/F1-StratLab/commit/7ffd5277e008611586a0df05500b32cddeca02ad))
+
+
+### Bug Fixes
+
+* **agents:** band threat_level on the served calibrated scale, not raw-scale operating points ([ec0601e](https://github.com/VforVitorio/F1-StratLab/commit/ec0601e3aa2ca0876c020d199b2bb60257429fad)), closes [#665](https://github.com/VforVitorio/F1-StratLab/issues/665)
+* **orchestrator:** warn when the client discards the requested temperature ([169376e](https://github.com/VforVitorio/F1-StratLab/commit/169376e8bfda15fc3782a8cd5edf5b50c2ec0a34))
+
+
+### Documentation
+
+* **audits:** add the adversarial audit of the orchestrator memory layer ([25e8566](https://github.com/VforVitorio/F1-StratLab/commit/25e85668742c05bfc18909544ef8d4f997221bca))
+
+## [2.2.4](https://github.com/VforVitorio/F1-StratLab/compare/v2.2.3...v2.2.4) (27-07-2026)
+### Bug Fixes
+
+* **orchestrator:** frame a held STAY_OUT as monitoring instead of as a blocked pit ([3f0a118](https://github.com/VforVitorio/F1-StratLab/commit/3f0a118460a934df304670fa74ae8a726543480b))
+
+
+### Documentation
+
+* **mc:** price the lap-number neutralisation union in all three places it lives ([86c4659](https://github.com/VforVitorio/F1-StratLab/commit/86c4659c04e1f721fd1e5d307043269d9d3543c8))
+
+## [2.2.3](https://github.com/VforVitorio/F1-StratLab/compare/v2.2.2...v2.2.3) (27-07-2026)
+### Bug Fixes
+
+* **engine:** repath the test files the module docstring names after the move ([2502ec3](https://github.com/VforVitorio/F1-StratLab/commit/2502ec3be8e8a1e5ad999226515f9534297e2180))
+* **mc:** break an exact tie by a stated rule instead of by dict insertion order ([e1723bc](https://github.com/VforVitorio/F1-StratLab/commit/e1723bcb1411fcf9ba9df10f133b6f16bf37dcb1)), closes [#645](https://github.com/VforVitorio/F1-StratLab/issues/645)
+
+
+### Documentation
+
+* **audits:** record the MONITOR layer audit and the decision not to build it ([185d0f5](https://github.com/VforVitorio/F1-StratLab/commit/185d0f5335c6882c53675a4460552b5cd13adb47))
+
+## [2.2.2](https://github.com/VforVitorio/F1-StratLab/compare/v2.2.1...v2.2.2) (26-07-2026)
+### Bug Fixes
+
+* **agents,arcade:** land six filed behaviour bugs and kill the constant that kept drifting ([4000f84](https://github.com/VforVitorio/F1-StratLab/commit/4000f84e3f9f7a1d9363ab6fd8f9a1af1fba6c04)), closes [#613](https://github.com/VforVitorio/F1-StratLab/issues/613) [#614](https://github.com/VforVitorio/F1-StratLab/issues/614) [#615](https://github.com/VforVitorio/F1-StratLab/issues/615) [#616](https://github.com/VforVitorio/F1-StratLab/issues/616) [#620](https://github.com/VforVitorio/F1-StratLab/issues/620) [#628](https://github.com/VforVitorio/F1-StratLab/issues/628)
+* **arcade:** widen the weather catch and stop claiming a drift is closed when it is not ([3e56432](https://github.com/VforVitorio/F1-StratLab/commit/3e56432b527216cc5ee3877aa03e2971cc03123c))
+* **eval:** measure the RCM parser that ships, not a private copy of it ([10311f9](https://github.com/VforVitorio/F1-StratLab/commit/10311f9300c9a3e9ab1945452ec596d19c02ecba)), closes [#632](https://github.com/VforVitorio/F1-StratLab/issues/632)
+* **eval:** resolve team rebrands in the pit holdout and make an unknown team loud ([9366346](https://github.com/VforVitorio/F1-StratLab/commit/9366346202f7f6df4ff85a920c4d74940da12aa6)), closes [#629](https://github.com/VforVitorio/F1-StratLab/issues/629)
+* **nlp:** classify the black-and-white flag, which the copy we replaced could and we could not ([fb8c208](https://github.com/VforVitorio/F1-StratLab/commit/fb8c208f8b83aaa98143554d07fb28c226453e05)), closes [#641](https://github.com/VforVitorio/F1-StratLab/issues/641)
+* **tests:** correct a golden that was born red, and say why CI could never tell us ([fdf49bb](https://github.com/VforVitorio/F1-StratLab/commit/fdf49bb90e147b3d5cd28a0f0711e0302f31f7fc)), closes [#634](https://github.com/VforVitorio/F1-StratLab/issues/634)
+
+
+### Refactoring
+
+* **arcade:** name the unit conversion the previous commit claimed to have named ([8c419f8](https://github.com/VforVitorio/F1-StratLab/commit/8c419f8043e194390196fced64695744019053b1))
+* **readability:** apply the four findings that earn it and close the audit ([9d71873](https://github.com/VforVitorio/F1-StratLab/commit/9d71873ca5f6ae876a96ecf364d75704ac4f9454)), closes [#643](https://github.com/VforVitorio/F1-StratLab/issues/643)
+
+## [2.2.1](https://github.com/VforVitorio/F1-StratLab/compare/v2.2.0...v2.2.1) (26-07-2026)
+### Bug Fixes
+
+* **agents:** define DEFAULT_RACING_LAPS_UNDER_VSC and turn on the check that would have caught it ([14093cc](https://github.com/VforVitorio/F1-StratLab/commit/14093cc7c9c7a6ddcf974358dcf315115fb53feb)), closes [#619](https://github.com/VforVitorio/F1-StratLab/issues/619)
+* **domain:** correct eight places that assert a stronger F1 fact than the code measures ([f1c3f1c](https://github.com/VforVitorio/F1-StratLab/commit/f1c3f1cc9a4f830c460dcd08f873660689e08b10)), closes [#617](https://github.com/VforVitorio/F1-StratLab/issues/617)
+
+
+### Documentation
+
+* **src:** fix contradicting docstrings, thin prose, and LLM-sounding wording ([3c6f038](https://github.com/VforVitorio/F1-StratLab/commit/3c6f0383d21708fb6e52a7b6e494a78cf9f8ba01)), closes [#621](https://github.com/VforVitorio/F1-StratLab/issues/621)
+
+## [2.2.0](https://github.com/VforVitorio/F1-StratLab/compare/v2.1.2...v2.2.0) (26-07-2026)
+### Features
+
+* **eval:** publish the projection accuracy and the measured tables as a report ([00e66ba](https://github.com/VforVitorio/F1-StratLab/commit/00e66babd39ecc07dc0bb80fb7d1aa18dc4b38d1)), closes [#609](https://github.com/VforVitorio/F1-StratLab/issues/609)
+
+
+### Bug Fixes
+
+* **engine:** thread cliff_p50 and total_laps so the stint-end guard is not dead ([0c95c1b](https://github.com/VforVitorio/F1-StratLab/commit/0c95c1b5eaa2fea3eabbcb576e9087ddcccb7f48)), closes [#566](https://github.com/VforVitorio/F1-StratLab/issues/566)
+
+## [2.1.2](https://github.com/VforVitorio/F1-StratLab/compare/v2.1.1...v2.1.2) (26-07-2026)
+### Documentation
+
+* bring the drawio sources back in line with the code ([9733ca8](https://github.com/VforVitorio/F1-StratLab/commit/9733ca8a842216c2ee26683ba0f0b82e0b2026e2)), closes [#592](https://github.com/VforVitorio/F1-StratLab/issues/592)
+
+## [2.1.1](https://github.com/VforVitorio/F1-StratLab/compare/v2.1.0...v2.1.1) (26-07-2026)
+### Bug Fixes
+
+* **readme:** animate the CLI demo instead of showing a still frame ([34d16c6](https://github.com/VforVitorio/F1-StratLab/commit/34d16c6cce77fbdb5fb456f129ec43f69b0b50f0))
+
+
+### Documentation
+
+* **agents:** correct the agent signatures and delete a ritual that recreates deleted drift ([18c2933](https://github.com/VforVitorio/F1-StratLab/commit/18c2933c97a5d098e08b5bb71d522e0764fb5e8c)), closes [#585](https://github.com/VforVitorio/F1-StratLab/issues/585)
+* caveat the two-compound article, and state what the API lap_state really carries ([5a0bb3f](https://github.com/VforVitorio/F1-StratLab/commit/5a0bb3f89d00ef50d84216d06eac83490244251c)), closes [#590](https://github.com/VforVitorio/F1-StratLab/issues/590)
+* correct the package READMEs against the packages they describe ([c6ed75c](https://github.com/VforVitorio/F1-StratLab/commit/c6ed75c9c559a844837bc5e9b10c8559b63826cb)), closes [#589](https://github.com/VforVitorio/F1-StratLab/issues/589)
+* diagram the three things the docs site had no picture of ([a1045f7](https://github.com/VforVitorio/F1-StratLab/commit/a1045f776933934bb884b71c897de610152e3c6b)), closes [#592](https://github.com/VforVitorio/F1-StratLab/issues/592)
+* make the first example runnable, and stop describing fields that do not exist ([e6d52a3](https://github.com/VforVitorio/F1-StratLab/commit/e6d52a3b5a2597bd725c8cb963b03ef6e91f5d9a)), closes [#588](https://github.com/VforVitorio/F1-StratLab/issues/588) [#567](https://github.com/VforVitorio/F1-StratLab/issues/567)
+* remove em-dashes from prose across every documentation surface ([eb5c380](https://github.com/VforVitorio/F1-StratLab/commit/eb5c380f377dae55338d26241889b20f3abccced)), closes [#594](https://github.com/VforVitorio/F1-StratLab/issues/594)
+* send contributors at dev, and repair six links that resolve nowhere ([0d5983a](https://github.com/VforVitorio/F1-StratLab/commit/0d5983ada82c0e8384a4ad8f4beb5a6212af16be))
+* stop describing Streamlit as a live surface, and document the one that replaced it ([f01bd55](https://github.com/VforVitorio/F1-StratLab/commit/f01bd55e811188b3f1198d7590c4e3e0b297639c)), closes [#587](https://github.com/VforVitorio/F1-StratLab/issues/587)
+
+## [2.1.0](https://github.com/VforVitorio/F1-StratLab/compare/v2.0.1...v2.1.0) (25-07-2026)
+### Features
+
+* **cli:** retire f1-streamlit and add the f1-webapp launcher ([d9151d4](https://github.com/VforVitorio/F1-StratLab/commit/d9151d455abccfa3255a4de8ea369a28573ed98e)), closes [#551](https://github.com/VforVitorio/F1-StratLab/issues/551)
+* **mc:** measure the tables the projection layer needs ([48092d6](https://github.com/VforVitorio/F1-StratLab/commit/48092d6bdeec2ac91dfdacebc4ed22699c7aaf9a)), closes [#553](https://github.com/VforVitorio/F1-StratLab/issues/553)
+* **mc:** name the target we will actually be racing ([f36464e](https://github.com/VforVitorio/F1-StratLab/commit/f36464e0219f0326637c017981d3a836239e8219))
+* **mc:** price clean air per circuit so the overcut becomes a real move ([0e30689](https://github.com/VforVitorio/F1-StratLab/commit/0e30689b0fa12656411aff7f79f39fe998ea56a5)), closes [#550](https://github.com/VforVitorio/F1-StratLab/issues/550)
+* **mc:** price the lap an overcut spends waiting for a neutralisation ([8044fd5](https://github.com/VforVitorio/F1-StratLab/commit/8044fd52beb57ab24396f9e4ba3f9780932ecdb8)), closes [#550](https://github.com/VforVitorio/F1-StratLab/issues/550)
+* **mc:** project track position from per-rival gaps ([7f91d1d](https://github.com/VforVitorio/F1-StratLab/commit/7f91d1de94b0807ae1f8c04f0279487c804e539c)), closes [#554](https://github.com/VforVitorio/F1-StratLab/issues/554)
+* **mc:** score the candidates in projected track position ([8052343](https://github.com/VforVitorio/F1-StratLab/commit/8052343368bdaf20698828216f77d338ab1c8175)), closes [#555](https://github.com/VforVitorio/F1-StratLab/issues/555)
+* **mc:** thread race context to the MC boundary ([fa0932b](https://github.com/VforVitorio/F1-StratLab/commit/fa0932b67e3e787af916fefc1a73524d6cb5708a)), closes [#552](https://github.com/VforVitorio/F1-StratLab/issues/552)
+* **mc:** wire the projection into every surface ([97514b4](https://github.com/VforVitorio/F1-StratLab/commit/97514b4812ed9e96e117586cbf88af9f26e877e7)), closes [#556](https://github.com/VforVitorio/F1-StratLab/issues/556)
+
+
+### Bug Fixes
+
+* **ci:** pin ruff so a linter release cannot turn every branch red ([7e69340](https://github.com/VforVitorio/F1-StratLab/commit/7e69340bc4dea4c6954d75dd5da61d0e90a3f48a))
+* **data:** share one FastF1 cache and stop download_data pulling the whole hub ([cc612ad](https://github.com/VforVitorio/F1-StratLab/commit/cc612adb8555f9d786a924e893819039e75f4a7d))
+* **deps:** drop python-jose, which nothing imported ([8993b69](https://github.com/VforVitorio/F1-StratLab/commit/8993b69bceb0eff5afbd6c8861ee81a4f6a4c389))
+* **docs:** correct two published diagram errors ([e040fcf](https://github.com/VforVitorio/F1-StratLab/commit/e040fcf2d5aead66b4c6d6281a4df472d0e66d93))
+* **mc:** bound the window by the race end and gate the undercut by regime ([6767490](https://github.com/VforVitorio/F1-StratLab/commit/67674905282a9fcc5bd2d6c2902b481ebcfc8ec8)), closes [#550](https://github.com/VforVitorio/F1-StratLab/issues/550)
+* **mc:** floor the hazard, resolve every circuit spelling, restore the O(1) lap state ([f1563c7](https://github.com/VforVitorio/F1-StratLab/commit/f1563c7108f7dd8f30b296cc2dcd1f268be4c585)), closes [#550](https://github.com/VforVitorio/F1-StratLab/issues/550)
+* **mc:** reject NaN, honour an explicit zero, and project on every surface ([bb4b4c6](https://github.com/VforVitorio/F1-StratLab/commit/bb4b4c64b1030cdfac90ca05f8f28d5350ade1c8)), closes [#550](https://github.com/VforVitorio/F1-StratLab/issues/550)
+
+
+### Documentation
+
+* bring every surface up to the shipped Monte Carlo and data layer ([e5e5882](https://github.com/VforVitorio/F1-StratLab/commit/e5e58826fd501da36154dfb1203668754dbe21f8))
+* **mc:** add the waiting term to the overcut section ([4a9d527](https://github.com/VforVitorio/F1-StratLab/commit/4a9d527af2de0c3600d9ad71628e2a66fb4d4ec1))
+* **mc:** describe what the Monte Carlo now scores ([fbbae7f](https://github.com/VforVitorio/F1-StratLab/commit/fbbae7f110715a17f00605dcc2dc487b91182667)), closes [#557](https://github.com/VforVitorio/F1-StratLab/issues/557)
+* **mc:** describe where the overcut works instead of calling it a limitation ([1fab451](https://github.com/VforVitorio/F1-StratLab/commit/1fab451b28e71e01a3ed604ae027b4202877f664))
+* **readme:** restore the arcade hero, pair the CLI and web app demos, add a citation section ([049316e](https://github.com/VforVitorio/F1-StratLab/commit/049316e8a70c1a856d0752ae44a44e4fe456857a))
+
+
+### Refactoring
+
+* **mc:** name the racing bucket for what it holds ([406a0e8](https://github.com/VforVitorio/F1-StratLab/commit/406a0e810cce2a329ea1f0c47d864116dd1f60b7)), closes [#553](https://github.com/VforVitorio/F1-StratLab/issues/553)
+
+## [2.0.1](https://github.com/VforVitorio/F1-StratLab/compare/v2.0.0...v2.0.1) (22-07-2026)
+### Bug Fixes
+
+* **deps:** bump gitpython to 3.1.54 to clear a high advisory ([3ae5af2](https://github.com/VforVitorio/F1-StratLab/commit/3ae5af2a072fea6458e6d56831e2faaa517ff433))
+
+
+### Documentation
+
+* **site:** expand the roadmap (v2.5 modern arcade, v2.8 rival, v3.0 live) ([7564e73](https://github.com/VforVitorio/F1-StratLab/commit/7564e733b5f01f5eed20b6820edbe74b7a60c28f))
+* **site:** mark the v2 migration shipped, refresh author bio and getting-started hero ([c9681b9](https://github.com/VforVitorio/F1-StratLab/commit/c9681b9130c78f97a4c591cda2f775f369947926))
+
+
+### Refactoring
+
+* retire the voice surface on the parent side; bump telemetry submodule ([d916368](https://github.com/VforVitorio/F1-StratLab/commit/d916368b4b98449ae5742a691fcc15bb0b3ed8b8))
+
+## [2.0.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.10.6...v2.0.0) (21-07-2026)
+### Bug Fixes
+
+* **agents:** bound the retired-car lap fallback by presence and make searchable defaults loud ([662102c](https://github.com/VforVitorio/F1-StratLab/commit/662102c337bf0afc32bd7ec3b7622a07196632cd)), closes [#477](https://github.com/VforVitorio/F1-StratLab/issues/477)
+* **agents:** guard the pit prompt-build NaN crash and correct the calibration docstring ([df988e7](https://github.com/VforVitorio/F1-StratLab/commit/df988e70ac38ecf03b018a9c1a8f388a24f4f6db))
+* **agents:** resolve the pit-agent circuit lookups by slug on the FastF1 path too ([ba0be59](https://github.com/VforVitorio/F1-StratLab/commit/ba0be59bd403f1675543f003e49c9fb542d15ffd))
+* **agents:** split Safety Car from Virtual Safety Car in the strategy engine ([4f124cf](https://github.com/VforVitorio/F1-StratLab/commit/4f124cf3c63b8dcd6b3e90e2dd07b9b4d963ee2e)), closes [#471](https://github.com/VforVitorio/F1-StratLab/issues/471)
+* **agents:** validate LLM tool inputs and fix model-fidelity defects across the strategy engine ([5f84218](https://github.com/VforVitorio/F1-StratLab/commit/5f842187a3b22f20f313085619f0f8fef703e891))
+* **agents:** yellow laps read as green, empty-roster vs unknown, and two raw parquet readers ([52aa560](https://github.com/VforVitorio/F1-StratLab/commit/52aa5605cfe046c57ebf50f8d8c14de0bf016e50)), closes [#486](https://github.com/VforVitorio/F1-StratLab/issues/486)
+* **arcade:** stop reading the featured parquet raw ([79ce0ba](https://github.com/VforVitorio/F1-StratLab/commit/79ce0ba1563b52f7a82c6d3f6236237d7ca17594)), closes [#447](https://github.com/VforVitorio/F1-StratLab/issues/447)
+* **cli:** derive the data defaults from --year so a 2024 run loads 2024 data ([8951cb3](https://github.com/VforVitorio/F1-StratLab/commit/8951cb3959de8360b4534bae26807f7d39190048)), closes [#443](https://github.com/VforVitorio/F1-StratLab/issues/443)
+* **deps:** bump pyasn1 to 0.6.4 to clear two high advisories ([5123d42](https://github.com/VforVitorio/F1-StratLab/commit/5123d42e2e9e4cd4075de53f29ec58e0378353ea))
+* **engine:** guard DNF laps in arcade and bump telemetry for rival threading ([3b4606c](https://github.com/VforVitorio/F1-StratLab/commit/3b4606cf2094e199939c406914459ea65da45a98)), closes [#431](https://github.com/VforVitorio/F1-StratLab/issues/431) [#441](https://github.com/VforVitorio/F1-StratLab/issues/441)
+* **engine:** thread live_drivers, guard both undercut drivers, and stop promising a test that never existed ([fbcb690](https://github.com/VforVitorio/F1-StratLab/commit/fbcb6909d3bc7a43a91f6d4ba7a62fd0776c89af)), closes [#462](https://github.com/VforVitorio/F1-StratLab/issues/462)
+* **N26:** stop overwriting trained TCN features and NaN-fill before scaling ([775bd13](https://github.com/VforVitorio/F1-StratLab/commit/775bd1371d6cc9664902a8f02ea8589a132424b1)), closes [#485](https://github.com/VforVitorio/F1-StratLab/issues/485)
+* **orchestrator:** charge OVERCUT for its pit stop so the Monte Carlo decides ([bc1c34a](https://github.com/VforVitorio/F1-StratLab/commit/bc1c34ad05711f6a195669d89c3fac20b9c05036)), closes [#470](https://github.com/VforVitorio/F1-StratLab/issues/470)
+
+
+### Performance
+
+* **agents:** lazy package __init__ so one agent doesn't load the whole family ([b7f4cda](https://github.com/VforVitorio/F1-StratLab/commit/b7f4cda98ada41f4418ae5d4c590ba7f2f95e75b))
+
+
+### Documentation
+
+* **agents:** regenerate the N31 Monte Carlo figure with the OVERCUT fix ([305778b](https://github.com/VforVitorio/F1-StratLab/commit/305778baa4e30429b938f487d3379a10cf188b3d)), closes [#470](https://github.com/VforVitorio/F1-StratLab/issues/470)
+* **demo:** re-record the web-app demo with the brand favicon; bump telemetry submodule ([efb7a83](https://github.com/VforVitorio/F1-StratLab/commit/efb7a832d83fd10b7470eaec372ec582563e00f1))
+* fact-check and refresh the project + site documentation against the current code ([9490fe4](https://github.com/VforVitorio/F1-StratLab/commit/9490fe419f67c398d31a8987be89713e9d71d23e))
+* **orchestrator:** correct the post-fix sweep split and a stale [0,1] score claim ([6777998](https://github.com/VforVitorio/F1-StratLab/commit/6777998848ee7d893dd2796be6d0af67715a9aee)), closes [#470](https://github.com/VforVitorio/F1-StratLab/issues/470)
+* **readme:** v2 web-app demo GIF + Streamlit-&gt;web-app rewrite; bump telemetry submodule ([586aed9](https://github.com/VforVitorio/F1-StratLab/commit/586aed94883f2b75fb8d112c3d64a907ef44a71e))
+
+
+### Refactoring
+
+* **agents:** extract _clamp_expected_stint_end so the [#433](https://github.com/VforVitorio/F1-StratLab/issues/433) clamp is CI-testable ([bf1ede8](https://github.com/VforVitorio/F1-StratLab/commit/bf1ede8a6453ef69e595357cbe6ed5129deaff7c))
+
+
+### Chores
+
+* release 2.0.0 ([5f3804c](https://github.com/VforVitorio/F1-StratLab/commit/5f3804c18e64d03d499522f2eacbc15020fc20b8))
+
+## [1.10.6](https://github.com/VforVitorio/F1-StratLab/compare/v1.10.5...v1.10.6) (16-07-2026)
+### Bug Fixes
+
+* **agents:** force what the SC regulation makes certain, not a strategy opinion ([281fb32](https://github.com/VforVitorio/F1-StratLab/commit/281fb3210026c7a52354708f50d3c333c7ef0b97)), closes [#464](https://github.com/VforVitorio/F1-StratLab/issues/464)
+* **cli:** feed the PMV the real overtake gap, and give the augmentation one home ([dc9914d](https://github.com/VforVitorio/F1-StratLab/commit/dc9914d21e0667e90fb84b852bd287e589420763))
+* **N26:** scope the TCN window to this stint, up to now, and zero-pad as trained ([20a7a06](https://github.com/VforVitorio/F1-StratLab/commit/20a7a068c1de5f328607fc36ae7e2fdfccd71aaf)), closes [#449](https://github.com/VforVitorio/F1-StratLab/issues/449)
+* **N28:** refuse to score an undercut against a car that is not racing ([018f910](https://github.com/VforVitorio/F1-StratLab/commit/018f9107abdc5f72a13d0eb895d0bff433ed3628)), closes [#462](https://github.com/VforVitorio/F1-StratLab/issues/462)
+* **orchestrator:** stop the LLM overriding the validated undercut target ([fc2c42f](https://github.com/VforVitorio/F1-StratLab/commit/fc2c42f30bf51b96b6b089db28b2a5816f8e696b)), closes [#462](https://github.com/VforVitorio/F1-StratLab/issues/462)
+
+
+### Documentation
+
+* **multi-agent:** document the SC rails as rules, not as a forced stop ([d5f8709](https://github.com/VforVitorio/F1-StratLab/commit/d5f87094d397fe5e940beb14d0b36547804e1fc8)), closes [#464](https://github.com/VforVitorio/F1-StratLab/issues/464)
+
+## [1.10.5](https://github.com/VforVitorio/F1-StratLab/compare/v1.10.4...v1.10.5) (16-07-2026)
 ### Bug Fixes
 
 * **agents:** compute FuelEffect from the stint baseline, not a hardcoded fuel_load factor ([7ac17e5](https://github.com/VforVitorio/F1-StratLab/commit/7ac17e59495c4d8a3a8cc735c442cc8efe99139e)), closes [#446](https://github.com/VforVitorio/F1-StratLab/issues/446)
@@ -39,17 +281,13 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 * **agents:** fix the entry-point table and make the examples actually run ([59b02e0](https://github.com/VforVitorio/F1-StratLab/commit/59b02e071b296802f12489f2ebe187e1394d008e)), closes [#438](https://github.com/VforVitorio/F1-StratLab/issues/438)
 * **strategy:** correct the pages the engine fixes made wrong ([62fa3c5](https://github.com/VforVitorio/F1-StratLab/commit/62fa3c55c3f03cb65cff280b2bdfbaac35c4f6a1)), closes [#438](https://github.com/VforVitorio/F1-StratLab/issues/438)
 
-## [1.10.4](https://github.com/VforVitorio/F1-StratLab/compare/v1.10.3...v1.10.4) (2026-07-15)
-
-
+## [1.10.4](https://github.com/VforVitorio/F1-StratLab/compare/v1.10.3...v1.10.4) (15-07-2026)
 ### Bug Fixes
 
 * **deps:** bump click/kafka-python/transformers past CVEs; waive blocked pillow and setuptools ([97d273d](https://github.com/VforVitorio/F1-StratLab/commit/97d273d3bce732b6f772e56c53d41e045427f113))
 * **deps:** resolve OSV Python CVE backlog (bump click/kafka-python/transformers; waive blocked pillow and setuptools) ([fbd6df2](https://github.com/VforVitorio/F1-StratLab/commit/fbd6df27ba0f826f33859ae9971b7675a7d78a4a))
 
-## [1.10.3](https://github.com/VforVitorio/F1-StratLab/compare/v1.10.2...v1.10.3) (2026-07-12)
-
-
+## [1.10.3](https://github.com/VforVitorio/F1-StratLab/compare/v1.10.2...v1.10.3) (12-07-2026)
 ### Bug Fixes
 
 * **nlp:** DOUBLE YELLOW severity + time-penalty routing ([#398](https://github.com/VforVitorio/F1-StratLab/issues/398) follow-up) ([7f3f7a7](https://github.com/VforVitorio/F1-StratLab/commit/7f3f7a79d9ef96eb92538e702ca4d579332101e1))
@@ -63,9 +301,7 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 * **cli:** skip double model load in --no-llm prewarm ([#389](https://github.com/VforVitorio/F1-StratLab/issues/389)) ([56c24f7](https://github.com/VforVitorio/F1-StratLab/commit/56c24f7aa37695f2e2a0026f9abcbf84dd686048))
 * **cli:** skip the tire/situation/pit singleton prewarm in --no-llm mode ([#389](https://github.com/VforVitorio/F1-StratLab/issues/389)) ([f0ba4b4](https://github.com/VforVitorio/F1-StratLab/commit/f0ba4b4b96ecca4146f353252eeb92302bacf626))
 
-## [1.10.2](https://github.com/VforVitorio/F1-StratLab/compare/v1.10.1...v1.10.2) (2026-07-12)
-
-
+## [1.10.2](https://github.com/VforVitorio/F1-StratLab/compare/v1.10.1...v1.10.2) (12-07-2026)
 ### Bug Fixes
 
 * **data:** resolve every GP's radio + compound labels via a canonical name (F-01) ([2ab70d1](https://github.com/VforVitorio/F1-StratLab/commit/2ab70d12fb9d127c7ec95efdfcc647f2dbd70f06))
@@ -87,17 +323,13 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 * **security:** add the Phase A security-boundary design for review ([#224](https://github.com/VforVitorio/F1-StratLab/issues/224)) ([c71eac9](https://github.com/VforVitorio/F1-StratLab/commit/c71eac9e6fb26da59ca3572f7817ff8de3c46a28))
 * **security:** Phase A security-boundary design for review ([#224](https://github.com/VforVitorio/F1-StratLab/issues/224)) ([ed4e829](https://github.com/VforVitorio/F1-StratLab/commit/ed4e8295b200cab373769378f9095335c090d113))
 
-## [1.10.1](https://github.com/VforVitorio/F1-StratLab/compare/v1.10.0...v1.10.1) (2026-07-12)
-
-
+## [1.10.1](https://github.com/VforVitorio/F1-StratLab/compare/v1.10.0...v1.10.1) (12-07-2026)
 ### Bug Fixes
 
 * **cli:** wire the simulation CLI to the shared inference engine ([#236](https://github.com/VforVitorio/F1-StratLab/issues/236)) ([32dcc4b](https://github.com/VforVitorio/F1-StratLab/commit/32dcc4b38a71afd31debf7bccb4359b76a911c2f))
 * **cli:** wire the simulation CLI to the shared inference engine ([#236](https://github.com/VforVitorio/F1-StratLab/issues/236)) ([0694299](https://github.com/VforVitorio/F1-StratLab/commit/06942991dfbd31521ff087841fb2e95754132bf0))
 
-## [1.10.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.9.0...v1.10.0) (2026-07-11)
-
-
+## [1.10.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.9.0...v1.10.0) (11-07-2026)
 ### Features
 
 * **agents:** give every sub-agent ChatOpenAI a finite provider timeout (L-1) ([3eb0eb8](https://github.com/VforVitorio/F1-StratLab/commit/3eb0eb8b48ac88b49e3119d99946017447c34fec))
@@ -109,9 +341,7 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 * **ci:** skip the tiktoken vocab roundtrip on an upstream network outage ([6c26ec2](https://github.com/VforVitorio/F1-StratLab/commit/6c26ec23134029213c365cde787afebfc0069f56))
 * **ci:** skip the tiktoken vocab roundtrip on an upstream network outage ([cdd9f4a](https://github.com/VforVitorio/F1-StratLab/commit/cdd9f4ac895f7a26f21bfd306069d64423b57398))
 
-## [1.9.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.8.0...v1.9.0) (2026-07-11)
-
-
+## [1.9.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.8.0...v1.9.0) (11-07-2026)
 ### Features
 
 * **eval:** reproduce the pace MAE 0.4104 from the featured-laps holdout ([2a2c982](https://github.com/VforVitorio/F1-StratLab/commit/2a2c9827e46e093d35ba426b1e839de395116f0f))
@@ -131,9 +361,7 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 * **eval:** resolve the circuit_cluster hygiene item as an accepted non-target limitation ([33ff301](https://github.com/VforVitorio/F1-StratLab/commit/33ff301fdf756c6870bee2a7e8eaf4c854afdf3e))
 * **eval:** resolve the circuit_cluster hygiene item as an accepted non-target limitation ([c72c9fe](https://github.com/VforVitorio/F1-StratLab/commit/c72c9fe35e4155f21459bceac7f6f39a8e5e46a2))
 
-## [1.8.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.7.0...v1.8.0) (2026-07-11)
-
-
+## [1.8.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.7.0...v1.8.0) (11-07-2026)
 ### Features
 
 * **eval:** add LLM-judge alert-precision module over unlabeled radios ([b727baa](https://github.com/VforVitorio/F1-StratLab/commit/b727baabba5304fa55eac99df2b03e0a8de06812))
@@ -171,9 +399,7 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 * **roadmap:** reconcile published metrics to thesis/IEEE finals ([2758ec5](https://github.com/VforVitorio/F1-StratLab/commit/2758ec524c37cc79bf3f7a9bc315d5cf058a8bca))
 * **roadmap:** reconcile published metrics to thesis/IEEE finals ([#213](https://github.com/VforVitorio/F1-StratLab/issues/213)) ([50b7ecf](https://github.com/VforVitorio/F1-StratLab/commit/50b7ecfc01681dec372b1bcdeb20f8d0c90bd30d))
 
-## [1.7.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.8...v1.7.0) (2026-07-11)
-
-
+## [1.7.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.8...v1.7.0) (11-07-2026)
 ### Features
 
 * **strategy:** add no-llm engine profile (fixes the --no-llm crash) ([f32e38b](https://github.com/VforVitorio/F1-StratLab/commit/f32e38b32acbca0a21defcc569a9aba32433d083))
@@ -181,9 +407,7 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 * **strategy:** no-llm engine profile (fixes the --no-llm crash, [#166](https://github.com/VforVitorio/F1-StratLab/issues/166)) ([91b98d3](https://github.com/VforVitorio/F1-StratLab/commit/91b98d3274c0027d3c846ebffcac79a09923f1a7))
 * **strategy:** shared inference engine (rich profile) + arcade delegate ([0e1b793](https://github.com/VforVitorio/F1-StratLab/commit/0e1b793e1a60a637870aa972bad446937a2c7a03))
 
-## [1.6.8](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.7...v1.6.8) (2026-07-09)
-
-
+## [1.6.8](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.7...v1.6.8) (09-07-2026)
 ### Documentation
 
 * **audits:** add program completeness review + reconcile roadmap and Rival design ([d4bdb4e](https://github.com/VforVitorio/F1-StratLab/commit/d4bdb4e29c8c636b82ace36615a4220a79348dec))
@@ -205,9 +429,7 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 * **research:** promote agent-orchestration-flow design to main ([f5b61f4](https://github.com/VforVitorio/F1-StratLab/commit/f5b61f420224da15a752e56acdabad423f8da7eb))
 * **research:** promote ecosystem data-contracts spec to main ([f8e7303](https://github.com/VforVitorio/F1-StratLab/commit/f8e7303082dcceed77c169a324dad4a01d308805))
 
-## [1.6.7](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.6...v1.6.7) (2026-07-07)
-
-
+## [1.6.7](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.6...v1.6.7) (07-07-2026)
 ### Documentation
 
 * **audits:** add cross-audit implementation roadmap ([3e42914](https://github.com/VforVitorio/F1-StratLab/commit/3e42914a3b5687a16a52b8c31cbaa3aa892eafb8))
@@ -217,9 +439,7 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 * **research:** add box-bot multi-platform design ([6677167](https://github.com/VforVitorio/F1-StratLab/commit/6677167c3bd3ce8630e0f5b731e0df661ec0743e))
 * **research:** promote box-bot design to main ([793afd7](https://github.com/VforVitorio/F1-StratLab/commit/793afd75eab7c691d672571e02521e018d598258))
 
-## [1.6.6](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.5...v1.6.6) (2026-07-07)
-
-
+## [1.6.6](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.5...v1.6.6) (07-07-2026)
 ### Documentation
 
 * **audits:** add DevEx contributor-setup audit plan ([3c5c0b3](https://github.com/VforVitorio/F1-StratLab/commit/3c5c0b3994406bdd6ee13421b7d1b40faca53d99))
@@ -256,9 +476,7 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 * **research:** promote real-time OpenF1 consumer design to main ([b220ed1](https://github.com/VforVitorio/F1-StratLab/commit/b220ed1eeb0692bb854fcc73d0bb996f4876f8ae))
 * **research:** promote Rival Agent TFM design to main ([7a314f5](https://github.com/VforVitorio/F1-StratLab/commit/7a314f5e13789b64c738b70117b2f611b8e0cf8a))
 
-## [1.6.5](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.4...v1.6.5) (2026-07-05)
-
-
+## [1.6.5](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.4...v1.6.5) (05-07-2026)
 ### Documentation
 
 * **audits:** add P4 CLI surface audit plan ([fef83ab](https://github.com/VforVitorio/F1-StratLab/commit/fef83abb1762a2a48edf0767bc440d19431976e0))
@@ -272,26 +490,20 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 * **audits:** promote security audit plan to main ([af3b2ef](https://github.com/VforVitorio/F1-StratLab/commit/af3b2eff1adf2db5fb0881fdc48862b5a77bdde0))
 * **readme:** lead with product value and fix agent count ([05212ef](https://github.com/VforVitorio/F1-StratLab/commit/05212ef533176b8c860ac7222ceb9bf87a269cd7))
 
-## [1.6.4](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.3...v1.6.4) (2026-07-05)
-
-
+## [1.6.4](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.3...v1.6.4) (05-07-2026)
 ### Documentation
 
 * **audits:** add arcade, ML-eval and docs-accuracy audit plans ([dd390bd](https://github.com/VforVitorio/F1-StratLab/commit/dd390bd67d9ec68abd1d1e6540e146614a6b2a73))
 * **audits:** add arcade, ML-eval and docs-accuracy audit plans ([caf4347](https://github.com/VforVitorio/F1-StratLab/commit/caf4347365528f1d879e00d4be4eea77e2f95f2e))
 * **audits:** promote arcade, ML-eval and docs-accuracy audit plans ([574acca](https://github.com/VforVitorio/F1-StratLab/commit/574accaf25fc48c2032ca56a5ea2517d08f888f0))
 
-## [1.6.3](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.2...v1.6.3) (2026-07-05)
-
-
+## [1.6.3](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.2...v1.6.3) (05-07-2026)
 ### Documentation
 
 * add 2026-regulation concept-drift readiness audit ([36148d6](https://github.com/VforVitorio/F1-StratLab/commit/36148d645504a9a492e54c8b23c731b72d3d302a))
 * add 2026-regulation concept-drift readiness audit ([c708b8e](https://github.com/VforVitorio/F1-StratLab/commit/c708b8ec58e270c35c35fbb2d36ab751ca77be71))
 
-## [1.6.2](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.1...v1.6.2) (2026-07-04)
-
-
+## [1.6.2](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.1...v1.6.2) (04-07-2026)
 ### Documentation
 
 * **audits:** add backend, loading and core-compute audit plans ([0b628f2](https://github.com/VforVitorio/F1-StratLab/commit/0b628f2904de4aa69fc010f3bcbfd44e2a140be0))
@@ -299,9 +511,7 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 * **audits:** P1, P2 and P2b audit plans ([dc90de9](https://github.com/VforVitorio/F1-StratLab/commit/dc90de966b9b3f88142dd30818671f54b63a8f8f))
 * **audits:** testing and QA strategy audit + tests/fixtures carve-out ([bfb9d0f](https://github.com/VforVitorio/F1-StratLab/commit/bfb9d0fb42bbb10a8c9a74071ccc44f0eca89a9e))
 
-## [1.6.1](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.0...v1.6.1) (2026-06-29)
-
-
+## [1.6.1](https://github.com/VforVitorio/F1-StratLab/compare/v1.6.0...v1.6.1) (29-06-2026)
 ### Bug Fixes
 
 * **docs:** accessibility (WCAG AA) pass on the docs site ([1577d9a](https://github.com/VforVitorio/F1-StratLab/commit/1577d9a3f9ea6b6320a760e738a0626dc72e83cd))
@@ -325,9 +535,7 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 * describe the real React stack, drop MkDocs references ([c944640](https://github.com/VforVitorio/F1-StratLab/commit/c944640d56204b993a238d8db9abfdba4397ab80))
 * describe the real React stack, drop MkDocs references ([9b781d4](https://github.com/VforVitorio/F1-StratLab/commit/9b781d48b64c5e5bbbf0a6e752ce85016180407a)), closes [#156](https://github.com/VforVitorio/F1-StratLab/issues/156)
 
-## [1.6.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.5.5...v1.6.0) (2026-06-28)
-
-
+## [1.6.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.5.5...v1.6.0) (28-06-2026)
 ### Features
 
 * **docs:** add GEO quick wins (llms.txt, JSON-LD, AI robots, prod React) ([133c66f](https://github.com/VforVitorio/F1-StratLab/commit/133c66fb51d9989a82a6a602f5b11ff1b46ecc48)), closes [#117](https://github.com/VforVitorio/F1-StratLab/issues/117)
@@ -353,48 +561,36 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 * remove em-dashes from README and ROADMAP prose ([5086e58](https://github.com/VforVitorio/F1-StratLab/commit/5086e58d19ba8f1ab8afcc891b3e4d959723083e))
 * update README, CONTRIBUTING, INDEX and ROADMAP; add TFG thesis and IEEE report PDFs ([5a9371c](https://github.com/VforVitorio/F1-StratLab/commit/5a9371cc27f2c766a2f6c54ba6b013bd5e17abce))
 
-## [1.5.5](https://github.com/VforVitorio/F1-StratLab/compare/v1.5.4...v1.5.5) (2026-05-23)
-
-
+## [1.5.5](https://github.com/VforVitorio/F1-StratLab/compare/v1.5.4...v1.5.5) (23-05-2026)
 ### Documentation
 
 * **telemetry:** bump submodule to refreshed README (601fd23) ([195d4aa](https://github.com/VforVitorio/F1-StratLab/commit/195d4aa541de8317bdb98c2a13dbab3b16ae6096))
 
-## [1.5.4](https://github.com/VforVitorio/F1-StratLab/compare/v1.5.3...v1.5.4) (2026-05-22)
-
-
+## [1.5.4](https://github.com/VforVitorio/F1-StratLab/compare/v1.5.3...v1.5.4) (22-05-2026)
 ### Documentation
 
 * añade memoria del TFG y paper bajo documents/thesis/ ([16497cc](https://github.com/VforVitorio/F1-StratLab/commit/16497cc1c4d6379eeb755be28fd4389f10454412))
 
-## [1.5.3](https://github.com/VforVitorio/F1-StratLab/compare/v1.5.2...v1.5.3) (2026-05-21)
-
-
+## [1.5.3](https://github.com/VforVitorio/F1-StratLab/compare/v1.5.2...v1.5.3) (21-05-2026)
 ### Bug Fixes
 
 * **ci:** replace autoupdate action with direct gh api call ([810b9b0](https://github.com/VforVitorio/F1-StratLab/commit/810b9b0f250daab415b9f75d22f35cd1f73d74f3))
 * **ci:** replace autoupdate action with direct gh api call ([5a89b6e](https://github.com/VforVitorio/F1-StratLab/commit/5a89b6efc2d5fd09a210e7a098a6960f887524c5))
 * **ci:** replace autoupdate action with direct gh api call ([a175266](https://github.com/VforVitorio/F1-StratLab/commit/a1752661d82730f7e3befea8097a81ac68205b47))
 
-## [1.5.2](https://github.com/VforVitorio/F1-StratLab/compare/v1.5.1...v1.5.2) (2026-05-20)
-
-
+## [1.5.2](https://github.com/VforVitorio/F1-StratLab/compare/v1.5.1...v1.5.2) (20-05-2026)
 ### Bug Fixes
 
 * **tests:** suppress catboost_info dir creation ([5a5b87d](https://github.com/VforVitorio/F1-StratLab/commit/5a5b87db1392df8e329ea2f37097d334f56ce095))
 * **tests:** suppress catboost_info dir creation on dep-imports test ([d49fa94](https://github.com/VforVitorio/F1-StratLab/commit/d49fa9446940fb3f988b2cc019371011b4ac5679))
 
-## [1.5.1](https://github.com/VforVitorio/F1-StratLab/compare/v1.5.0...v1.5.1) (2026-05-17)
-
-
+## [1.5.1](https://github.com/VforVitorio/F1-StratLab/compare/v1.5.0...v1.5.1) (17-05-2026)
 ### Bug Fixes
 
 * **ci:** key uv cache off pyproject.toml since uv.lock is gitignored ([7fafc9b](https://github.com/VforVitorio/F1-StratLab/commit/7fafc9b04345cb43df062195a9ac12358cb22153))
 * **ci:** set cache-dependency-glob on lint job too ([df90899](https://github.com/VforVitorio/F1-StratLab/commit/df908992d9ec2c515016a00fef73b6fd8daf4594))
 
-## [1.5.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.4.3...v1.5.0) (2026-05-15)
-
-
+## [1.5.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.4.3...v1.5.0) (15-05-2026)
 ### Features
 
 * **agents:** N27 detects deployed Safety Car via RCM events and forces sc_prob=1.0 ([ea8ac95](https://github.com/VforVitorio/F1-StratLab/commit/ea8ac95f59d4ef6eb13f6800033c0ebe281a1e4e))
@@ -417,32 +613,24 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 
 * **multi-agent:** document RCM Safety Car override (N27 + N28 + routing) ([9a740dd](https://github.com/VforVitorio/F1-StratLab/commit/9a740ddd44e2cee934099a30bd6906ef09fa22bd))
 
-## [1.4.3](https://github.com/VforVitorio/F1-StratLab/compare/v1.4.2...v1.4.3) (2026-05-14)
-
-
+## [1.4.3](https://github.com/VforVitorio/F1-StratLab/compare/v1.4.2...v1.4.3) (14-05-2026)
 ### Bug Fixes
 
 * **chat:** wire Download Report button to live /tool-message endpoint (submodule a921032) ([1dd018d](https://github.com/VforVitorio/F1-StratLab/commit/1dd018d29a874b5622650794c0cd72102392c889))
 
-## [1.4.2](https://github.com/VforVitorio/F1-StratLab/compare/v1.4.1...v1.4.2) (2026-05-13)
-
-
+## [1.4.2](https://github.com/VforVitorio/F1-StratLab/compare/v1.4.1...v1.4.2) (13-05-2026)
 ### Documentation
 
 * **dev:** update chat smoke commands to /tool-message + MCP examples ([b7526d0](https://github.com/VforVitorio/F1-StratLab/commit/b7526d05cc2cde1e08e56545e0730df7298074d5))
 
-## [1.4.1](https://github.com/VforVitorio/F1-StratLab/compare/v1.4.0...v1.4.1) (2026-05-13)
-
-
+## [1.4.1](https://github.com/VforVitorio/F1-StratLab/compare/v1.4.0...v1.4.1) (13-05-2026)
 ### Documentation
 
 * **api:** document MCP-driven chat endpoints and module layout ([30a5120](https://github.com/VforVitorio/F1-StratLab/commit/30a51208d7e5666d7ffc872629d053620ad8edc5))
 * **diagrams:** rename lmstudio_service.py to llm_service.py in chat MCP flow ([68efe8f](https://github.com/VforVitorio/F1-StratLab/commit/68efe8ff469c9cf5f68c2aadb5572a0013390484))
 * **frontend:** point chat tool-result renderer at /chat/tool-message-stream ([fdaeb6e](https://github.com/VforVitorio/F1-StratLab/commit/fdaeb6ec3356df8eb39dd37da9301779be3e3b01))
 
-## [1.4.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.3.1...v1.4.0) (2026-05-12)
-
-
+## [1.4.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.3.1...v1.4.0) (12-05-2026)
 ### Features
 
 * **docs:** add agents API reference with entry points and schemas ([5ec358a](https://github.com/VforVitorio/F1-StratLab/commit/5ec358aea2f0bd7faca5843857347f36f45003ae))
@@ -515,9 +703,7 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 * **pages:** point meet-the-author HF link at dataset URL ([5f56064](https://github.com/VforVitorio/F1-StratLab/commit/5f560640ab435b563999d49808b63a2bfc3775bb))
 * **readme:** add status badges and link to docs.f1stratlab.com ([922f462](https://github.com/VforVitorio/F1-StratLab/commit/922f4626a9d1f42b8698b03f335fb3f907729a47))
 
-## [1.3.1](https://github.com/VforVitorio/F1-StratLab/compare/v1.3.0...v1.3.1) (2026-05-12)
-
-
+## [1.3.1](https://github.com/VforVitorio/F1-StratLab/compare/v1.3.0...v1.3.1) (12-05-2026)
 ### Bug Fixes
 
 * **docs:** repair slate scheme contrast and add brand-aligned theme variables ([6516709](https://github.com/VforVitorio/F1-StratLab/commit/6516709ffbe2d6ff36f8b96f0c0aca7b9ea58512))
@@ -532,18 +718,14 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 * redesign landing with hero, agent grid, mermaid system diagram and stats ([e6525cc](https://github.com/VforVitorio/F1-StratLab/commit/e6525ccb7e4f51c391d31c5ca8aee4112c3ead7c))
 * ship docs site revamp with CI/CD narrative and contrast fix ([b64ce12](https://github.com/VforVitorio/F1-StratLab/commit/b64ce12471fd1ecc0cd4272f403ca079224e0f3c))
 
-## [1.3.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.2.0...v1.3.0) (2026-05-12)
-
-
+## [1.3.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.2.0...v1.3.0) (12-05-2026)
 ### Features
 
 * **docs:** point GitHub Pages at docs.f1stratlab.com via CNAME ([52b3238](https://github.com/VforVitorio/F1-StratLab/commit/52b3238454e1ac702cc80d4976ed55a1809ed818))
 * **docs:** update mkdocs site_url to docs.f1stratlab.com ([cf6cda6](https://github.com/VforVitorio/F1-StratLab/commit/cf6cda6679d1eb14d3624046fa812484320acc7c))
 * **docs:** wire docs.f1stratlab.com custom domain ([1fcf6ea](https://github.com/VforVitorio/F1-StratLab/commit/1fcf6ea756a661d554676b0359b018adfba1f187))
 
-## [1.2.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.1.1...v1.2.0) (2026-05-12)
-
-
+## [1.2.0](https://github.com/VforVitorio/F1-StratLab/compare/v1.1.1...v1.2.0) (12-05-2026)
 ### Features
 
 * **docs:** add F1 StratLab brand theme and external-image hook ([0dc3db1](https://github.com/VforVitorio/F1-StratLab/commit/0dc3db1f84540864c8ac2d20a5452d5ca1ddd31f))
@@ -554,9 +736,7 @@ above v1.1.0 was seeded retroactively from the GitHub Releases history.
 
 * add landing, getting started, thesis results and maintenance pages ([defed4e](https://github.com/VforVitorio/F1-StratLab/commit/defed4e689508bcbce397292f1bbc8469abfcad8))
 
-## [1.1.1](https://github.com/VforVitorio/F1-StratLab/compare/v1.1.0...v1.1.1) (2026-05-12)
-
-
+## [1.1.1](https://github.com/VforVitorio/F1-StratLab/compare/v1.1.0...v1.1.1) (12-05-2026)
 ### Bug Fixes
 
 * **ci:** use PAT for release-please so required checks run on release PRs ([b293342](https://github.com/VforVitorio/F1-StratLab/commit/b29334288c1c852dd0617b337de6451fd187652a))
@@ -786,4 +966,3 @@ First CLI release (R1 milestone). Distributed as the
 [0.7.0]: https://github.com/VforVitorio/F1-StratLab/releases/tag/v0.7.0
 [0.6.0]: https://github.com/VforVitorio/F1-StratLab/releases/tag/v0.6
 [0.1.1]: https://github.com/VforVitorio/F1-StratLab/releases/tag/v0.1.1
-</content>

--- a/scripts/sync_docs_changelog.mjs
+++ b/scripts/sync_docs_changelog.mjs
@@ -1,0 +1,85 @@
+/**
+ * Generate the docs site's changelog page from the canonical CHANGELOG.md.
+ *
+ * The page used to be a hand-refreshed copy, and it rotted exactly the way a
+ * hand-refreshed copy does: the site sat on **1.10.5** while the repo had
+ * shipped **2.5.1**, a whole major version of releases missing from the only
+ * public record of them. Nobody forgot on purpose - release-please writes
+ * `CHANGELOG.md` on every merge to `main` and there was no step that carried
+ * that across.
+ *
+ * So the page is generated now, from the file release-please owns:
+ *
+ *   node scripts/sync_docs_changelog.mjs
+ *
+ * `.github/workflows/docs.yml` runs it before staging, and lists
+ * `CHANGELOG.md` in its trigger paths, so a release publishes its own entry.
+ * The committed copy is regenerated too, so the repo and the site agree and a
+ * local preview is not a lie.
+ *
+ * --- WHERE TO CHANGE IF THE DATE FORMAT CHANGES ---
+ * Here, and only here. The transformation deliberately does NOT live in the
+ * renderer: `docs/app/markdown.js` renders in the browser and
+ * `scripts/prerender_docs.mjs` renders the same markdown in Node, so a
+ * render-time rule would be two implementations of one decision - this
+ * repo's dominant defect. Rewriting the source once means both agree by
+ * construction.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SOURCE = resolve(ROOT, "CHANGELOG.md");
+const TARGET = resolve(ROOT, "docs", "pages", "changelog.md");
+
+/**
+ * What the site adds on top of the canonical file.
+ *
+ * It says GENERATED rather than "manually-refreshed mirror", because the old
+ * wording was an instruction nobody followed and a promise the page could not
+ * keep.
+ */
+const FRONT_MATTER = `> **Note:** this page is generated from
+> [CHANGELOG.md](https://github.com/VforVitorio/F1-StratLab/blob/main/CHANGELOG.md)
+> by \`scripts/sync_docs_changelog.mjs\`, which the docs workflow runs on every
+> deploy. Do not edit it by hand — edit the canonical file, or the generator.
+
+> Maintained by [release-please](https://github.com/googleapis/release-please)
+> on each merge to \`main\` — see [CI/CD pipeline](#/ci-cd) for the full flow.
+> Dates are shown day-month-year.
+
+`;
+
+/**
+ * Release headings only: `## [2.5.1](compare-url) (2026-07-28)`.
+ *
+ * Anchored to the end of a heading line so it can never touch a date inside a
+ * commit subject, which is prose the generator has no business rewriting.
+ * The month is kept two-digit rather than spelled out: the column stays
+ * aligned down a thousand lines, and it needs no locale.
+ */
+const RELEASE_HEADING_DATE = /^(#{2,3} .*)\((\d{4})-(\d{2})-(\d{2})\)\s*$/gm;
+
+export function toDayMonthYear(markdown) {
+  return markdown.replace(
+    RELEASE_HEADING_DATE,
+    (_match, heading, year, month, day) => `${heading}(${day}-${month}-${year})`,
+  );
+}
+
+function main() {
+  const canonical = readFileSync(SOURCE, "utf-8");
+  const page = FRONT_MATTER + toDayMonthYear(canonical);
+  writeFileSync(TARGET, page, "utf-8");
+
+  const releases = (page.match(/^#{2,3} \[\d+\.\d+\.\d+\]/gm) || []).length;
+  const latest = page.match(/^#{2,3} \[(\d+\.\d+\.\d+)\][^\n]*\((\d{2}-\d{2}-\d{4})\)/m);
+  console.log(
+    `sync_docs_changelog: ${releases} releases, newest ${latest ? latest[1] : "?"} ` +
+      `(${latest ? latest[2] : "?"}) -> docs/pages/changelog.md`,
+  );
+}
+
+main();

--- a/tests/surfaces/test_docs_changelog_page.py
+++ b/tests/surfaces/test_docs_changelog_page.py
@@ -1,0 +1,109 @@
+"""The docs site's changelog page must not fall behind the repo's own.
+
+It did, badly: the public page advertised **1.10.5** while the repo had shipped
+**2.5.1** — a whole major version of releases missing from the only public
+record of them. Nobody forgot on purpose. It was a hand-refreshed copy of a
+file that release-please rewrites on every merge to `main`, and there was no
+step carrying one across to the other.
+
+`scripts/sync_docs_changelog.mjs` generates the page now, and the docs
+workflow runs it on every deploy. These are the guards that make the rot
+visible in the repo too, rather than only on the site.
+
+They assert the EFFECT — what the page SAYS — rather than diffing it against
+the generator's output. A byte-diff would only prove the generator is
+deterministic, which is not the property that was broken.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL = REPO_ROOT / "CHANGELOG.md"
+PAGE = REPO_ROOT / "docs" / "pages" / "changelog.md"
+
+_ISO_HEADING = re.compile(r"^#{2,3} .*\((\d{4})-(\d{2})-(\d{2})\)\s*$", re.MULTILINE)
+_RELEASE = re.compile(r"^#{2,3} \[(\d+\.\d+\.\d+)\]", re.MULTILINE)
+
+
+def _newest(text: str) -> str:
+    found = _RELEASE.search(text)
+    assert found, "no release heading at all - has the format changed?"
+    return found.group(1)
+
+
+def test_the_page_carries_the_newest_release_the_repo_has_shipped():
+    """The whole defect, in one assertion.
+
+    Pinned against `CHANGELOG.md` rather than a hardcoded version: a literal
+    would need editing on every release, which is the same manual step that
+    failed in the first place.
+    """
+    newest_shipped = _newest(CANONICAL.read_text(encoding="utf-8"))
+    newest_published = _newest(PAGE.read_text(encoding="utf-8"))
+
+    assert newest_published == newest_shipped, (
+        f"the docs page stops at {newest_published} but the repo has shipped "
+        f"{newest_shipped}. Run: node scripts/sync_docs_changelog.mjs"
+    )
+
+
+def test_every_release_in_the_repo_reaches_the_page():
+    """Newest-only would pass on a page that lost its middle.
+
+    A generator bug, or a bad hand-edit, can drop releases anywhere in the
+    file while leaving the top intact — and the top is the only thing anyone
+    checks by eye.
+    """
+    shipped = set(_RELEASE.findall(CANONICAL.read_text(encoding="utf-8")))
+    published = set(_RELEASE.findall(PAGE.read_text(encoding="utf-8")))
+
+    assert shipped, "the canonical changelog has no releases; this test is checking nothing"
+    assert not shipped - published, f"missing from the docs page: {sorted(shipped - published)}"
+
+
+def test_release_dates_are_shown_day_month_year():
+    """Víctor's call, 2026-08-10: day-month-year, not the ISO the tool emits.
+
+    Asserted as the ABSENCE of ISO headings plus the presence of day-first
+    ones, because a page with no dates at all would satisfy either half on
+    its own.
+    """
+    page = PAGE.read_text(encoding="utf-8")
+
+    iso = _ISO_HEADING.findall(page)
+    assert not iso, f"{len(iso)} release headings still carry an ISO date, first {iso[0]}"
+
+    # Counted against the CANONICAL file, not against a number chosen here.
+    # The first version of this asserted `>= 50` and failed at 47 — because ten
+    # of the 57 releases are the pre-1.2.0 ones seeded retroactively from the
+    # GitHub Releases history and carry no date in their heading at all. A
+    # floor picked by eye tests the guess; this tests the transformation.
+    dated_upstream = len(_ISO_HEADING.findall(CANONICAL.read_text(encoding="utf-8")))
+    day_first = re.findall(r"^#{2,3} .*\((\d{2})-(\d{2})-(\d{4})\)\s*$", page, re.MULTILINE)
+    assert dated_upstream > 0, "the canonical file has no dated headings; this checks nothing"
+    assert len(day_first) == dated_upstream, (
+        f"{dated_upstream} dated headings upstream but {len(day_first)} on the page"
+    )
+    # A day-month-year date has a day that can exceed 12; a month never can.
+    # If the two components were swapped, nothing here would ever be > 12.
+    assert any(int(day) > 12 for day, _month, _year in day_first), (
+        "no day above 12 anywhere - the day and month look swapped"
+    )
+    assert all(1 <= int(month) <= 12 for _day, month, _year in day_first), (
+        "a month outside 1-12 - the day and month are definitely swapped"
+    )
+
+
+def test_the_page_says_it_is_generated():
+    """The old header told the reader it was a "manually-refreshed mirror",
+    which was an instruction nobody followed and a promise it could not keep.
+    A wrong instruction in a header is how the next person edits the wrong
+    file."""
+    header = PAGE.read_text(encoding="utf-8")[:600]
+
+    assert "generated" in header.lower(), "the page no longer says it is generated"
+    assert "sync_docs_changelog" in header, "the header does not name the generator"
+    assert "manually-refreshed" not in header, "the stale instruction came back"


### PR DESCRIPTION
Closes #909.

The public page listed **1.10.5** as the newest release while the repo had shipped **2.5.1** — a whole major version of releases missing from the only public record of them. Verified on the live site, not inferred:

```
Most recent version listed: 1.10.5 (2026-07-16)
Date format: (YYYY-MM-DD)
```

## It did not rot through neglect

The page was a hand-refreshed **copy** of a file release-please rewrites on every merge to `main`. The design required a human to remember, forever. And its own header named the wrong instruction — *"this page is a manually-refreshed mirror"* — which is how the next person edits the wrong file.

So it is generated now. `scripts/sync_docs_changelog.mjs` writes it from `CHANGELOG.md`; the workflow runs it before staging and **lists `CHANGELOG.md` in its trigger paths**, because a release edits nothing under `docs/` and would otherwise never publish its own entry.

```
sync_docs_changelog: 57 releases, newest 2.5.1 (28-07-2026) -> docs/pages/changelog.md
```

## Where the date reformat lives, and why it matters

In the generator, and nowhere else. The site renders the same markdown **twice** — prerendered in Node by `prerender_docs.mjs`, then hydrated in the browser by `docs/app/markdown.js`. A render-time rule would be two implementations of one decision, and the two could disagree. Rewriting the source once makes them agree by construction.

The regex is anchored to the end of a heading line, so it can never touch a date inside a commit subject — that is prose the generator has no business rewriting.

## The guards assert what the page SAYS

Not that the generator is deterministic, which is not the property that broke:

| Guard | Catches |
|---|---|
| newest release == `CHANGELOG.md`'s newest | the exact defect |
| every shipped release appears | a page that lost its middle — the top is the only part anyone checks by eye |
| no ISO date survives in a heading | a half-done conversion |
| at least one day > 12, every month ≤ 12 | day and month swapped back, which no count can see |
| the header says "generated" and names the generator | the stale instruction returning |

All watched **red**: against a page truncated at 1.10.5 (two failed) and against a page with the two components exchanged (`no day above 12 anywhere - the day and month look swapped`).

**One of them was wrong first**, and it is the usual shape: the date guard asserted `>= 50` dated headings and failed at 47, because ten of the 57 releases are the pre-1.2.0 ones seeded retroactively from the GitHub Releases history and carry no date at all. A floor picked by eye tests the guess. It counts against the canonical file now.

## Checks

```
uv run pytest tests/surfaces            181 passed  (4 new)
uvx ruff@0.15.22 check . / format --check .   all checks passed / 191 files already formatted
node scripts/sync_docs_changelog.mjs    57 releases, newest 2.5.1 (28-07-2026)
```

## ⚠️ This does not update the site, and that needs your call

`.github/workflows/docs.yml` deploys **on push to `main` only**, and `main` is **100 commits behind `dev`** because the PITWALL programme is deliberately held there until sprint 7.

Landing this on `dev` fixes the repo and not the site. Either it also goes to `main` on its own branch — which is possible without dragging the 100 PITWALL commits — or docs.f1stratlab.com keeps advertising 1.10.5 until the sprint-7 promotion.
