### PR TITLE
docs(site): fix everything the audit found, from a dead command to a deleted module

### DIFF
--- a/docs/app/nav.js
+++ b/docs/app/nav.js
@@ -130,6 +130,15 @@ window.PAGES = [
     tags: ["arcade", "pyside6", "ui", "telemetry", "threading"],
   },
   {
+    slug: "pitwall",
+    title: "PITWALL windows",
+    section: "Arcade",
+    file: "pages/pitwall.md",
+    description: "The React strategy surfaces: two pywebview windows, one shared client, and the same pages on loopback.",
+    eyebrow: "React",
+    tags: ["arcade", "ui", "telemetry", "frontend"],
+  },
+  {
     slug: "arcade-strategy-pipeline",
     title: "Strategy pipeline",
     section: "Arcade",

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -18,6 +18,7 @@
 - [Streamlit frontend (legacy)](https://docs.f1stratlab.com/pages/streamlit.md): Retired Streamlit app, kept for historical reference; the React web app replaced it.
 - [Arcade quick start](https://docs.f1stratlab.com/pages/arcade-quick-start.md): One-command launch of the three-window arcade.
 - [Dashboard architecture](https://docs.f1stratlab.com/pages/arcade-dashboard.md): PySide6 package layout, wire protocol, thread model.
+- [PITWALL windows](https://docs.f1stratlab.com/pages/pitwall.md): The React strategy surfaces, two pywebview windows sharing one broadcast client.
 - [Arcade strategy pipeline](https://docs.f1stratlab.com/pages/arcade-strategy-pipeline.md): Why the arcade duplicates the N31 orchestrator body.
 - [Driver colors](https://docs.f1stratlab.com/pages/driver-colors.md): Year-aware color palette covering 2023–2025 seasons.
 

--- a/docs/pages/agents-api.md
+++ b/docs/pages/agents-api.md
@@ -43,12 +43,15 @@ Only the RAG agent (N30) exposes a module-level `get_rag_react_agent()` factory 
 
 | Field | Type | Description |
 |---|---|---|
-| `compound` | str | Current compound name (SOFT, MEDIUM, HARD) |
+| `compound` | str \| None | The **Pirelli compound ID**, e.g. `C2`, `C3` — not the SOFT/MEDIUM/HARD name. `None` when the compound is not in the slick map (a wet or intermediate lap). Verified on a served run: Melbourne lap 35 on HARD returns `'C3'` |
 | `current_tyre_life` | int | Current tire age in laps |
 | `deg_rate` | float | Degradation rate (seconds lost per lap) |
 | `laps_to_cliff_p10` | float | 10th percentile laps until cliff |
 | `laps_to_cliff_p50` | float | 50th percentile laps until cliff |
 | `laps_to_cliff_p90` | float | 90th percentile laps until cliff |
+| `gp_name` | str | The race the prediction was made for |
+| `cumulative_deg_s` | float | Seconds lost to degradation so far this stint |
+| `deg_cost_s` | float | **The field the scorers consume** — the degradation cost the Monte Carlo prices a stay-out against |
 | `warning_level` | str | OK, MONITOR, or PIT_SOON (derived from `laps_to_cliff_p10` against circuit-cluster-aware thresholds; there is no CRITICAL value) |
 | `reasoning` | str | LLM-generated reasoning text |
 
@@ -94,6 +97,7 @@ Only the RAG agent (N30) exposes a module-level `get_rag_react_agent()` factory 
 
 | Field | Type | Description |
 |---|---|---|
+| `question` | str | The question that was asked of the retriever |
 | `answer` | str | Synthesized answer from regulation passages |
 | `articles` | list[str] | Referenced FIA article numbers |
 | `chunks` | list | Raw retrieved text chunks |

--- a/docs/pages/arcade-dashboard.md
+++ b/docs/pages/arcade-dashboard.md
@@ -2,17 +2,18 @@
 
 Developer-level reference for the PySide6 dashboard that ships alongside the arcade replay. Written for someone who plans to extend or modify either window (add a new sub-agent card, a new telemetry chart, retheme the palette, change the wire protocol).
 
-Phase 3.5 Proceso B shipped thirteen files under `src/arcade/dashboard/` plus a new `src/arcade/strategy_pipeline.py` and the rewritten `src/arcade/strategy.py::SimConnector`. The arcade autolaunches the dashboard subprocess when the user enables strategy mode; the user never runs a second command.
+Phase 3.5 Proceso B shipped the `src/arcade/dashboard/` package (fifteen modules today, `reasoning_lines.py` among them) plus a new `src/arcade/strategy_pipeline.py` and the rewritten `src/arcade/strategy.py::SimConnector`. The arcade autolaunches the dashboard subprocess when the user enables strategy mode; the user never runs a second command.
 
-## Three-window split
-
-Three windows, two processes.
+## The window split
 
 - **Arcade replay**: `pyglet`-backed, owned by `F1ArcadeView`. Drives the simulation loop, owns the `StrategyState`, runs `TelemetryStreamServer` on `127.0.0.1:9998`, and renders the track.
 - **Strategy dashboard**: `PySide6` `MainWindow`. Orchestrator card, six sub-agent cards with embedded `pyqtgraph` charts, scenario bars, six-tab reasoning panel.
 - **Telemetry window**: `PySide6` `TelemetryWindow`. Standalone `QMainWindow` with a 2x2 grid of `pyqtgraph` plots (Delta, Speed, Brake, Throttle) in F1-broadcast style.
+- **PITWALL**: a third process, `python -m src.pitwall`, opening **PITWALL · DATA** and **PITWALL · AGENTS** — two pywebview windows rendering React over the same broadcast, through one shared TCP client. It also serves the same two pages on loopback and logs the URL.
 
-The pyglet window runs in the arcade process. The two Qt windows live together inside one subprocess spawned by the arcade.
+The pyglet window runs in the arcade process. The two Qt windows live together inside one subprocess; PITWALL is another.
+
+> **Both follower stacks run at once, deliberately.** PITWALL is the replacement for the two Qt windows, and keeping the originals alive beside it during the migration is what lets every ported panel be compared against the window it replaces while that window still exists (`_spawn_pitwall`, `src/arcade/app.py`). The Qt pair retires at the end of the migration; this page describes it until then.
 
 ## Process topology
 
@@ -89,7 +90,7 @@ The 2x2 grid of telemetry plots. Lives in its own module so `TelemetryWindow` ca
 
 ## Wire protocol
 
-The arcade broadcasts one JSON dict per frame, roughly 10 Hz, as a newline-terminated payload. The full shape:
+The arcade broadcasts one JSON dict per frame, roughly 10 Hz, as a newline-terminated payload. The shape below is the shape the **Qt** dashboard consumes; the wire has since grown the fields PITWALL needs, listed after it.
 
 ```json
 {
@@ -127,6 +128,26 @@ The arcade broadcasts one JSON dict per frame, roughly 10 Hz, as a newline-termi
 
 Top-level keys: `arcade`, `strategy`, `playback`. The dashboard's fan-out router reads from these three roots and nothing else, extending the protocol is additive.
 
+### What the wire gained for PITWALL
+
+Every one of these is additive — the Qt dashboard ignores them and is unaffected — and each exists because a consumer would otherwise have to re-derive it and drift from the producer:
+
+| Field | What it carries |
+|---|---|
+| `arcade.race_order` | every published driver, best first, ranked by the arcade leaderboard's OWN code, so the wire and the panel cannot disagree |
+| `arcade.drivers.<code>.laps_completed` | laps completed off the crossing map. The reveal carrier: show lap *L* for a driver iff `L <= laps_completed` |
+| `arcade.drivers.<code>.progress` | laps plus fraction, the ordering coordinate. `null` when the telemetry never placed the car |
+| `arcade.drivers.<code>.has_finished` | chequered flag versus retirement, from FastF1's official classification. **`active` alone reads the winner as retired** |
+| `arcade.drivers.<code>.active` / `.rel_dist` / `.has_position` | on track, fraction of the current lap, and whether the car was ever placed at all |
+| `arcade.driver_colors` | per-driver RGB from the arcade's own palette, published so no consumer hardcodes a sixth copy of it |
+| `arcade.track_status` | FastF1 TrackStatus digits for the lap on screen |
+| `arcade.telemetry.main` / `.rival` | a **span** of samples since the last tick, oldest first — not one point. At 8x, one point per tick discarded 95 % of the trace |
+| `arcade.telemetry.rewound` / `.dropped` | the eviction signals: a backwards seek, and frames a forward jump could not carry |
+| `arcade.global_t_min` / `.location` | the session-time origin, and FastF1's authoritative Location for resolving the race directory |
+| `schema_version` / `seq` | the payload version, and a strictly increasing sequence per message SENT — which is what lets two consumers on independent timers agree on a frame |
+
+Bumping `CACHE_VERSION` to v12 came with these; the first launch of a given GP after upgrading rebuilds its session pickle.
+
 ## Extension points
 
 ### Adding a new sub-agent card
@@ -146,7 +167,7 @@ Top-level keys: `arcade`, `strategy`, `playback`. The dashboard's fan-out router
 Five threads cooperate.
 
 - **Arcade main thread** (pyglet), runs the `F1ArcadeView.on_update` tick, mutates the `StrategyState` under `_lock`, calls `TelemetryStreamServer.broadcast(snapshot)`.
-- **SimConnector background thread**, iterates `RaceReplayEngine.replay()` and calls `run_strategy_pipeline(race_state, laps_df)` per lap. One thread, one lap at a time, so the main pyglet thread never blocks on LLM inference.
+- **SimConnector background thread**, iterates `RaceReplayEngine.replay()` and calls `run_strategy_pipeline(race_state, laps_df, lap_state, memory=self._memory)` per lap. Passing `lap_state` is not optional: with it `None` the Monte Carlo falls back to the legacy seconds path and the projection layer is silently amputated, which is the one call shape these pages used to show. One thread, one lap at a time, so the main pyglet thread never blocks on LLM inference.
 - **TelemetryStreamServer accept thread**, daemon thread inside the arcade process. Blocks on `server_socket.accept()`.
 - **Qt main thread** (dashboard subprocess), runs `QApplication.exec()`. Drives all UI updates. Never touches the network.
 - **QThread stream clients** (one per top-level Qt window), each owns its own TCP socket.

--- a/docs/pages/arcade-quick-start.md
+++ b/docs/pages/arcade-quick-start.md
@@ -1,13 +1,15 @@
 # Arcade Quick Start
 
-> End-user guide for running the F1 StratLab arcade replay with the live strategy dashboard. Aimed at someone who has cloned the repository and wants to see three synchronised windows on screen inside ten minutes.
+> End-user guide for running the F1 StratLab arcade replay with the live strategy surfaces. Aimed at someone who has cloned the repository and wants everything on screen inside ten minutes.
 
-One command launches everything: the arcade replay window (pyglet), the strategy dashboard (PySide6), and the telemetry window (PySide6). The arcade process owns the simulation loop and broadcasts merged state on a local TCP port; the dashboard subprocess subscribes and renders.
+One command launches everything. The arcade process owns the simulation loop and broadcasts merged state on a local TCP port; the follower surfaces subscribe and render.
+
+**Two follower stacks run side by side right now, on purpose.** PITWALL is the web-technology replacement — two pywebview windows rendering React — and the original PySide6 pair is kept alive beside it through the migration so every PITWALL panel can be compared against the window it replaces while that window still exists (`_spawn_pitwall`, `src/arcade/app.py`). The Qt pair retires at the end of the migration; the pyglet replay stays either way.
 
 <p align="center">
   <video src="/assets/demo/arcade-demo.mp4" poster="/assets/demo/arcade-demo-poster.jpg" width="760" autoplay loop muted playsinline preload="metadata" aria-label="F1 StratLab arcade replay in action"></video>
   <br/>
-  <sub>The three-window arcade: 2D replay, strategy dashboard and live telemetry, all in sync.</sub>
+  <sub>The arcade: 2D replay, strategy dashboard and live telemetry, all in sync. Recorded before PITWALL joined; the pyglet replay on the left is unchanged.</sub>
 </p>
 
 ## Prerequisites
@@ -33,8 +35,9 @@ What happens:
 3. The view loads the 2025 Round 3 (Suzuka) parquet for Verstappen.
 4. With `--strategy` set, the view starts a `TelemetryStreamServer` on `127.0.0.1:9998`, owns a `StrategyState`, and spawns the dashboard subprocess with `python -m src.arcade.dashboard`.
 5. The dashboard opens two PySide6 windows that both connect back to the stream.
+6. It also spawns `python -m src.pitwall`, which opens **PITWALL · DATA** and **PITWALL · AGENTS** — two pywebview windows rendering React against the same broadcast, through a single shared TCP client.
 
-Three windows are now on screen. The arcade window drives playback; the two Qt windows react to broadcasts.
+The arcade window drives playback; every other window reacts to broadcasts. PITWALL additionally serves the same two pages over loopback, and prints the URL on startup, so you can open them in a browser (and get devtools) instead of, or as well as, the windows.
 
 ## What each window shows
 
@@ -78,11 +81,20 @@ Pass `--driver2 LEC` and:
 
 Hotkeys handled by `F1ArcadeView.on_key_press`:
 
-- `Space`, pause / resume
-- `Right Arrow`, step one lap forward
-- `Left Arrow`, step one lap backward
-- `+` / `-`, increase / decrease playback speed
-- `Escape`, return to the menu (or exit if launched with `--viewer`)
+| Key | What it does |
+|---|---|
+| `Space` | pause / resume |
+| `Left` / `Right` | **hold** to scrub backwards or forwards. Holding pauses playback; releasing restores whatever state you were in before. Not a one-lap step |
+| `Up` / `Down` | next / previous playback speed |
+| `1` `2` `3` `4` | jump straight to 0.5x, 1x, 2x, 4x |
+| `R` | restart: back to frame zero, default speed, playing |
+| `D` | show / hide the DRS zones on the track |
+| `B` | show / hide the progress bar |
+| `A` | show / hide the eighteen non-featured cars |
+| `Escape` | close the window |
+
+`Escape` quits rather than returning to the menu, and it does so whether or not
+you launched with `--viewer`.
 
 ## Known limitations
 
@@ -95,7 +107,7 @@ Hotkeys handled by `F1ArcadeView.on_key_press`:
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `FileNotFoundError: data/raw/.../laps.parquet` | FastF1 cache not built | Run once without `--strategy`, or `python -m src.simulation.builder 2025 3` |
+| `FileNotFoundError: data/raw/.../laps.parquet` | the race is not in the local cache | `uv run python -c "from src.f1_strat_manager.data_cache import ensure_race; ensure_race(2025, 'Melbourne')"`, or just pick the race from the `f1-strat` menu, which calls the same function |
 | "Backend offline" / "Connection refused" | Arcade did not start the stream server | Restart the arcade with `--strategy` |
 | "No module named pyqtgraph" | `uv sync` did not complete | Re-run `uv sync` from the repo root |
 | "OpenAI api_key missing" | `.env` missing or `OPENAI_API_KEY` unset | Add the key to `.env`, or `F1_LLM_PROVIDER=lmstudio` |
@@ -104,5 +116,5 @@ Hotkeys handled by `F1ArcadeView.on_key_press`:
 ## Related reading
 
 - [Arcade dashboard](#/arcade-dashboard), developer-level architecture deep dive on the dashboard package.
-- [Arcade strategy pipeline](#/arcade-strategy-pipeline), why the arcade keeps its own copy of the orchestrator body.
+- [Arcade strategy pipeline](#/arcade-strategy-pipeline), why the arcade delegates to the shared engine instead of keeping its own copy of the orchestrator.
 - [Multi-agent system](#/multi-agent): N25–N31 multi-agent pipeline reference.

--- a/docs/pages/arcade-strategy-pipeline.md
+++ b/docs/pages/arcade-strategy-pipeline.md
@@ -37,7 +37,7 @@ Every surface needs the same six sub-agents, the same MoE routing, the same Mont
 ```
 src/strategy/inference/engine.py
     run_lap(race_state, laps_df, lap_state=None, *, profile="rich",
-            return_agent_outputs=True)
+            return_agent_outputs=True, memory=None)
         -> tuple[StrategyRecommendation, dict | None, dict[str, float]]
 ```
 
@@ -61,9 +61,16 @@ The sub-agents are imported through their public `*_from_state` entry points; th
 `src/arcade/strategy_pipeline.py::run_strategy_pipeline` keeps its old public signature so `src/arcade/strategy.py` and the dashboard formatters are untouched. Its body is one call:
 
 ```python
-rec, agent_outputs, _timings = run_lap(race_state, laps_df, lap_state, profile="rich")
+rec, agent_outputs, _timings = run_lap(
+    race_state, laps_df, lap_state, profile="rich", memory=memory
+)
 return rec, agent_outputs
 ```
+
+`memory` is the `DecisionMemory` the surface owns. It arrived after this page
+was first written and both snippets above used to omit it, which made the
+delegate look thinner than it is.
+
 
 The arcade needs the raw outputs and the CLI does not, but that is a difference in **consumption**, not in pipeline. `run_lap` returns both and each surface takes what it renders.
 
@@ -80,7 +87,7 @@ So: **before writing a second path that shapes race data, check whether a clean 
 The arcade strategy driver is `src/arcade/strategy.py::SimConnector`. It is a plain Python class, not a Qt object, spawned as a `threading.Thread` from `F1ArcadeView._init_strategy_layer`.
 
 - Owns a `StrategyState` dataclass caching the latest `LapDecision`, the per-agent outputs and playback metadata, behind a `threading.Lock`.
-- Owns the background thread that iterates `RaceReplayEngine.replay()` and calls `run_strategy_pipeline(race_state, laps_df, lap_state=None)` per lap.
+- Owns the background thread that iterates `RaceReplayEngine.replay()` and calls `run_strategy_pipeline(race_state, laps_df, lap_state, memory=self._memory)` per lap. Passing `lap_state` is not optional: with it `None` the Monte Carlo falls back to the legacy seconds path and the projection layer is silently amputated, which is the one call shape these pages used to show.
 - Emits `StartEventDTO` once on the first frame, then `LapDecisionDTO` per lap.
 
 ## Why not SSE from the backend

--- a/docs/pages/architecture.md
+++ b/docs/pages/architecture.md
@@ -39,7 +39,7 @@ Six layers, six pages, each linked from the agent graph and from this page.
 - **[Agents API reference](#/agents-api)**, per-agent input / output schemas, model artefacts and entry-point signatures.
 - **[Backend API](#/backend-api)**: FastAPI routers, the SSE simulation endpoint, the contract the web app and the Arcade speak.
 - **[Streamlit frontend (legacy)](#/streamlit)**, walkthrough of the retired Streamlit app, kept for historical reference.
-- **[Arcade dashboard](#/arcade-quick-start)**, three independent windows coordinated by a single Python process.
+- **[Arcade dashboard](#/arcade-quick-start)**, several independent windows coordinated across two Python processes (pyglet owns the replay and broadcasts; the follower surfaces subscribe from a child process).
 
 > **Looking for a specific file?** The narratives on this site stop at the contract level. For per-file deep-dives, every function in `src/agents/`, every notebook from N06 to N34, every helper in `src/arcade/`, jump to the [F1 StratLab DeepWiki](https://deepwiki.com/VforVitorio/F1-StratLab). It is regenerated on every push to `main`.
 
@@ -64,7 +64,7 @@ The structured output the orchestrator emits per decision tick (called `Strategy
 Three independent release tracks ship the system so that consumers can pick the surface that fits their workflow:
 
 - **R1: CLI wheel.** `uv tool install` straight from the GitHub release. Headless, batchable, no GPU needed for the inference path.
-- **R2: Arcade.** The three-window PySide6 + pyglet experience. Same wheel, but the `f1-arcade` entry point boots the GUI and spawns the strategy subprocess locally.
+- **R2: Arcade.** The pyglet 2D replay plus its live strategy surfaces. Same wheel, but the `f1-arcade` entry point boots the GUI and spawns the strategy subprocess locally.
 - **R3: Backend + web app.** The FastAPI server (SSE simulator, MCP tools) plus the React SPA. The docker-compose recipe ships the whole stack; `f1-webapp` launches it.
 
 See [Setup and deployment](#/setup) for the full install matrix per surface and platform.

--- a/docs/pages/backend-api.md
+++ b/docs/pages/backend-api.md
@@ -13,7 +13,7 @@ There is no `auth` router. Authentication is a single ASGI middleware wrapping e
 | Router | Prefix | Tags | Source |
 |---|---|---|---|
 | telemetry | `/api/v1/telemetry` | telemetry | `api/v1/endpoints/telemetry.py` |
-| circuit_domination | `/api/v1` | circuit_domination | `api/v1/endpoints/circuit_domination.py` |
+| circuit_domination | `/api/v1/circuit-domination` | telemetry | `api/v1/endpoints/circuit_domination.py` |
 | comparison | `/api/v1/comparison` | comparison | `api/v1/endpoints/comparison.py` |
 | chat | `/api/v1/chat` | chat | `api/v1/endpoints/chat.py` |
 | strategy | `/api/v1/strategy` | strategy | `api/v1/endpoints/strategy.py` |
@@ -36,7 +36,7 @@ This means `F1_API_KEY` and `F1_HOST` (see [Setup and deployment](#/setup)) are 
 
 ## Rate limiting
 
-Every prediction and strategy endpoint (and `/simulate`) sits behind an in-process token-bucket limiter (`backend/core/rate_limit.py`, Security C2 / S-7) keyed on client IP. No external dependency, a stdlib bucket is enough for a single-process local backend. Buckets are per-route, so hammering `/pace` does not exhaust the `/recommend` bucket.
+Every prediction and strategy endpoint (and `/simulate`) sits behind an in-process token-bucket limiter (`backend/core/rate_limit.py`, Security C2 / S-7) keyed on client IP. No external dependency, a stdlib bucket is enough for a single-process local backend. Buckets are per-route, so hammering `/pace` does not exhaust the `/recommend` bucket. The four chat routes carry buckets too (capacity 10, 20/min), so the chat surface is metered as well.
 
 | Route | Burst capacity | Refill rate |
 |---|---|---|
@@ -56,6 +56,7 @@ An exhausted bucket returns `429` with a `Retry-After` hint. Set `F1_RATE_LIMIT_
 | GET | `/api/v1/telemetry/sessions` | List sessions for a GP |
 | GET | `/api/v1/telemetry/drivers` | List drivers for a session |
 | GET | `/api/v1/telemetry/race-data` | Full-field featured-parquet frame for a GP (positions, lap times, inter-driver gaps), optionally filtered to driver codes |
+| POST | `/api/v1/telemetry/prewarm` | Warm the session cache in the background; returns 202 immediately |
 
 **Query parameters** vary by endpoint. `year` (int) and `gp` (str) are common to all of them; `session` (str) applies to the lap-time and telemetry endpoints; `drivers` (comma-separated) to the comparison ones. `/race-data` takes `driver`, **singular**, and treats it as an optional filter over the full-field frame.
 

--- a/docs/pages/ci-cd.md
+++ b/docs/pages/ci-cd.md
@@ -2,7 +2,7 @@
 
 Single source of truth for how F1 StratLab is built, tested, released and deployed. Read this once and you will know how a commit becomes a published release and the live docs site.
 
-The pipeline is split across three GitHub Actions workflows, a release-please bot for versioning, Dependabot for dependency hygiene, and a few repository-level toggles that quietly make everything work.
+The pipeline is split across eight GitHub Actions workflows, a release-please bot for versioning, Dependabot for dependency hygiene, and a few repository-level toggles that quietly make everything work. Three of them carry the weight and get a section each below; the other five are the security scanners and the automation.
 
 ## Branching strategy
 
@@ -31,13 +31,24 @@ The default flow is `feature branch → dev → main`. Hotfixes go via a `chore/
 
 ## CI workflows
 
-Three workflows live under `.github/workflows/`. They run independently, on different triggers, and have different blast radii.
+Eight workflows live under `.github/workflows/`. They run independently, on different triggers, and have different blast radii. The three below do the heavy lifting; the rest are listed after them.
+
+| Workflow | What it is for |
+|---|---|
+| `ci.yml` | test / lint / typecheck / pip-audit, plus the PITWALL UI job |
+| `release-please.yml` | version bumps, the CHANGELOG and the release PR |
+| `docs.yml` | builds and publishes this site |
+| `codeql.yml` | SAST over our own code |
+| `osv-scanner.yml` | cross-ecosystem vulnerability scan |
+| `gitleaks.yml` | secret scanning over the repo and its diffs |
+| `labeler.yml` | applies `area:` labels from the changed paths |
+| `auto-update-prs.yml` | rebases low-touch PRs when `dev` moves |
 
 ### `.github/workflows/ci.yml`
 
 Triggered on push to `main`, `dev`, `test`, `feat/**`, `fix/**`, `docs/**`, and on pull request targeting `main` or `dev`. Four jobs run in parallel on `ubuntu-latest`:
 
-- `test`, path-filter gated on `src/**`, `tests/**`, `pyproject.toml`, `uv.lock` (via `dorny/paths-filter@v3`; skips entirely on a docs-only or unrelated diff). When triggered: `uv sync --all-extras --frozen` (Python 3.12), a "collected-count floor" check (`pytest --co -q` must collect at least 40 nodes, guarding against a refactor silently gutting the suite), then `uv run pytest -v --cov=src --cov-report=term-missing`.
+- `test`, path-filter gated on `src/**`, `tests/**`, `pyproject.toml`, `uv.lock` (via `dorny/paths-filter@v4`; skips entirely on a docs-only or unrelated diff). When triggered: `uv sync --all-extras --frozen` (Python 3.12), a "collected-count floor" check (`pytest --co -q` must collect at least 40 nodes, guarding against a refactor silently gutting the suite), then `uv run pytest -v --cov=src --cov-report=term-missing`.
 - `lint`, always runs, no `uv sync` needed. `uvx ruff check .` and `uvx ruff format --check .` as ephemeral tools, so it skips installing the whole ML/torch stack just to lint style.
 - `typecheck`, same path-filter gate as `test`. `uv sync --extra dev --frozen` then `uv run mypy src/rag/`. Narrow scope: only production-ready typed modules are checked. Caches `.mypy_cache/` keyed on `pyproject.toml` + `src/rag/**`.
 - `pip-audit`, always runs, no path filter. Exports the locked dependency set (`uv export --frozen --all-extras`) and runs `pip-audit` against it for same-day CVE alerts, independent of whether the diff touches `uv.lock`. Advisory (`continue-on-error: true`) while baselining.

--- a/docs/pages/docs-maintenance.md
+++ b/docs/pages/docs-maintenance.md
@@ -114,7 +114,7 @@ flowchart LR
 ```
 ````
 
-For more complex diagrams (draw.io sources in `docs/diagrams/`), export as SVG or PNG from [diagrams.net](https://app.diagrams.net/) and embed the image in the markdown.
+For more complex diagrams (Mermaid fenced blocks inside the page markdown (there is no `docs/diagrams/`; the draw.io sources live in `documents/dev_docs/diagrams/` in the repo, not on the site)), export as SVG or PNG from [diagrams.net](https://app.diagrams.net/) and embed the image in the markdown.
 
 ## Where to change if X
 

--- a/docs/pages/driver-colors.md
+++ b/docs/pages/driver-colors.md
@@ -2,81 +2,89 @@
 
 ## Location
 
-`src/telemetry/frontend/components/common/driver_colors.py`
+`src/telemetry/webapp/src/lib/drivers.ts`
 
-**This is not shared with the backend.** `src/telemetry/backend/core/driver_colors.py` is a separate, older implementation, a single flat `DRIVER_COLORS` dict labelled "F1 2024 Driver Colors" with its own (different) hex values and no `year` parameter at all: `get_driver_color(driver_code, default='#A259F7')`. It predates the 2025 driver-swap handling described below (it still maps `HAM` to a Mercedes-silver hex and has no entry for `ANT`, `BOR`, `HAD`, or the 2025 `SAI`-to-Williams move). Used only by `backend/api/v1/endpoints/comparison.py` and `backend/services/telemetry_service.py`. Treat the two files as independent palettes to keep in sync by hand, not one shared module, a known piece of tech debt, not a design intent.
+> **This page used to document a Python module that no longer exists.** The
+> year-aware palette was born in the Streamlit frontend at
+> `frontend/components/common/driver_colors.py`, and that whole tree was
+> deleted when the React web app replaced Streamlit in v2.0.0 (#551). The
+> *design* survived the move intact — it was ported one for one — so this page
+> now describes the TypeScript implementation that is actually running.
+
+**It is still not shared with the backend.** `src/telemetry/backend/core/driver_colors.py`
+is a separate, older implementation: a single flat `DRIVER_COLORS` dict labelled
+"F1 2024 Driver Colors", with its own (different) hex values and no `year`
+parameter at all. It predates the 2025 driver-swap handling described below — it
+still maps `HAM` to a Mercedes-silver hex and has no entry for `ANT`, `BOR`,
+`HAD`, or the 2025 `SAI`-to-Williams move. Used by
+`backend/api/v1/endpoints/comparison.py` and `backend/services/telemetry_service.py`.
+Treat the two as independent palettes kept in sync by hand: known tech debt, not
+design intent.
 
 ## Purpose
 
-F1 driver lineups change every season. A driver may switch teams between years, so the color associated with a driver abbreviation must be season-specific. This module provides a year-aware color palette covering 2023–2025 seasons.
+F1 driver lineups change every season. A driver may switch teams between years,
+so the colour associated with a driver abbreviation must be season-specific.
+This module provides a year-aware palette covering the 2023–2025 seasons.
 
 ## Design
 
-### Team base colors
+### Team base colours
 
-Each team has two hex constants, one for the primary driver, one for the secondary. For example:
+Each team has two hex constants, one for the primary driver and one for the
+secondary:
 
-```python
-_RED_BULL   = '#3671C6'   # Primary (e.g., VER)
-_RED_BULL_2 = '#1B3D8E'   # Secondary (e.g., LAW in 2025, PER in 2024)
+```ts
+const RED_BULL = '#3671C6'     // primary (e.g. VER)
+const RED_BULL_2 = '#1B3D8E'   // secondary
 ```
 
-All ten teams follow this pattern: Ferrari, Mercedes, McLaren, Aston Martin, Alpine, Williams, Racing Bulls (RB), Sauber, Haas.
+### Per-year lineups
 
-### Per-year mapping
-
-`DRIVER_COLORS_BY_YEAR` is a dict keyed by year (2023, 2024, 2025), each containing a driver-code-to-hex mapping. Mid-season replacements are included (e.g., COL and LAW in 2024).
-
-Notable changes across seasons:
-
-- **Alpine** switched from pink (`#FF87BC`) in 2023–2024 to blue (`#0093CC`) in 2025.
-- **HAM** moved from Mercedes (teal) to Ferrari (red) in 2025.
-- **SAI** moved from Ferrari to Williams in 2025.
+`DRIVER_COLORS_BY_YEAR` maps a season to a `{ driverCode: hex }` record, so the
+same code can resolve to different teams in different years.
 
 ### Flat fallback
 
-`DRIVER_COLORS = DRIVER_COLORS_BY_YEAR[2025]` provides backward compatibility for code that does not pass a year.
+`DRIVER_COLORS_FLAT = DRIVER_COLORS_BY_YEAR[2025]` serves any caller that does
+not pass a year, and `DEFAULT_DRIVER_COLOR` (`#A259F7`) is returned for a code
+the palette does not know.
 
-## Public API (frontend module)
+## Public API
 
-### `get_driver_color(driver_code, default='#A259F7', year=None) -> str`
+### `getDriverColor(code: string, year?: number): string`
 
-Returns the hex color for a driver in a given season. Falls back to the 2025 flat dict when `year` is None. Returns `default` if the driver code is not found.
+Team colour for a driver in a given season. The code is case-insensitive. With
+no `year`, or with a year the palette has no lineup for, it falls back to the
+flat 2025 record; an unknown code returns `DEFAULT_DRIVER_COLOR`.
 
-### `get_driver_colors_for_list(driver_codes, year=None) -> list`
+### `DEFAULT_DRIVER_COLOR`
 
-Batch version, returns a list of hex colors matching the input list of driver codes.
-
-The backend's `core/driver_colors.py` exposes the same two function names but without the `year` parameter (`get_driver_color(driver_code, default='#A259F7')`), always reading its own static 2024-era `DRIVER_COLORS` dict.
+The purple used for anything unrecognised, exported so callers can compare
+against it rather than hardcoding the hex a second time.
 
 ## Usage
 
-```python
-from components.common.driver_colors import get_driver_color
+```ts
+import { getDriverColor } from '@/lib/drivers'
 
-# Year-aware lookup
-color = get_driver_color("HAM", year=2024)  # '#27F4D2' (Mercedes teal)
-color = get_driver_color("HAM", year=2025)  # '#A30000' (Ferrari dark red)
-
-# Fallback (uses 2025)
-color = get_driver_color("VER")  # '#3671C6'
+getDriverColor('HAM', 2024)  // Mercedes teal
+getDriverColor('HAM', 2025)  // Ferrari red — same driver, different team
+getDriverColor('VER')        // flat 2025 fallback
 ```
 
 ## Where it is used
 
-Frontend (year-aware module, `components/common/driver_colors.py`):
+It lives in `src/lib/` rather than a feature folder because several features
+consume it, so shared code stays app-level and the features stay decoupled
+siblings:
 
-- `pages/race_analysis.py`, tire and gap chart color assignment
-- `pages/strategy.py`, strategy tab driver color assignment
-- `components/race_analysis/tire_charts.py`, per-driver tire degradation plots
-- `components/race_analysis/gap_charts.py`, gap evolution charts
-- `components/chatbot/chart_builders.py`, chat tool-result chart colors
-- `components/common/data_selectors.py` and `components/dashboard/data_selectors.py`, driver selectors
-- `components/dashboard/css_styles.py`, dashboard CSS color injection
-- `utils/race_viz.py`, general race visualization helpers
-- `utils/chat_navigation.py`, chat navigation color tagging
+- `features/dashboard/components/`, lap and channel chart line colours
+- `features/comparison/`, toolbar and replay channel colours
+- `features/chat/charts/`, colours for chat tool-result charts
+- `components/radio/RadioBrowser.tsx`, per-driver radio tagging
 
 Backend (static module, `backend/core/driver_colors.py`):
 
-- `backend/api/v1/endpoints/comparison.py`, comparison endpoint color assignment
-- `backend/services/telemetry_service.py`, telemetry data color tagging
+- `backend/api/v1/endpoints/comparison.py`, comparison endpoint colour assignment
+- `backend/services/telemetry_service.py`, telemetry data colour tagging

--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -23,7 +23,7 @@ After install you have five console entry points:
 ```bash
 f1-strat       # interactive launcher (recommended starting point)
 f1-sim         # headless CLI simulation against a saved race
-f1-arcade      # three-window PySide6 + pyglet experience
+f1-arcade      # pyglet 2D replay plus the live strategy surfaces
 f1-webapp      # post-race web app (wraps `docker compose up`)
 f1-eval        # regenerate the evaluation reports (registry, calibration, hygiene, projection, ...)
 ```
@@ -42,7 +42,7 @@ cd F1-StratLab
 uv sync --all-extras
 ```
 
-`uv sync` reads `pyproject.toml`, resolves the lockfile and pulls the CUDA-routed PyTorch wheel automatically on Windows and Linux (CPU build on macOS).
+`uv sync` reads `pyproject.toml`, resolves the lockfile and pulls the CUDA-routed PyTorch wheel automatically **on Windows**. Everything else, Linux and macOS included, resolves to the CPU wheel: CI runners and CPU-only Linux boxes were downloading about 5 GB of unused CUDA libraries, so the markers were narrowed deliberately (`pyproject.toml`, #251). A Linux GPU box opts back in by editing those markers.
 
 Run the simulation against a saved race:
 
@@ -67,7 +67,7 @@ For a reproducible all-in-one setup, see [Setup and deployment](#/setup) for the
 
 ### Do I need a GPU?
 
-No, but it helps. `uv sync` pulls the CUDA-routed PyTorch wheel on Windows and Linux (a CPU build on macOS), so the stack runs on CPU. A GPU mainly accelerates Whisper radio transcription and the TCN tire model, the benchmark latencies on the [thesis results](#/thesis) page (Whisper 233.9 ms, NLP pipeline 42.1 ms) are GPU figures; on CPU it is slower but fully functional.
+No, but it helps. `uv sync` pulls the CUDA-routed wheel **on Windows only**; Linux and macOS get the CPU build, so out of the box the stack runs on CPU almost everywhere. A GPU mainly accelerates Whisper radio transcription and the TCN tire model, the benchmark latencies on the [thesis results](#/thesis) page (Whisper 233.9 ms, NLP pipeline 42.1 ms) are GPU figures; on CPU it is slower but fully functional.
 
 ### Why is the first run slow?
 

--- a/docs/pages/meet-the-author.md
+++ b/docs/pages/meet-the-author.md
@@ -38,7 +38,7 @@ and a plan for the next pit window.
 
 The same engine drives three operator surfaces: a React web app
 for analysts (backed by a FastAPI/MCP API for programmatic access and
-chat tool-calling), a CLI for headless replays, and a three-window
+chat tool-calling), a CLI for headless replays, and a multi-window
 arcade (race replay, strategy dashboard, live telemetry) built in
 PySide6 + pyglet for the demo experience. The whole stack is open
 under Apache-2.0 and shipped as wheels and GitHub releases through

--- a/docs/pages/multi-agent.md
+++ b/docs/pages/multi-agent.md
@@ -63,7 +63,7 @@ graph TD
 
 ## Three-window arcade
 
-Since Phase 3.5 Proceso B (April 2026), the `python -m src.arcade.main ... --strategy` launcher runs three windows driven by one shared telemetry stream. The layout is:
+Since Phase 3.5 Proceso B (April 2026), the `python -m src.arcade.main ... --strategy` launcher runs several windows driven by one shared telemetry stream. The three below are the original set; the launcher additionally spawns the two PITWALL windows, which read the same broadcast and are documented in [Arcade dashboard](#/arcade-dashboard). The layout is:
 
 ```mermaid
 graph LR

--- a/docs/pages/pitwall.md
+++ b/docs/pages/pitwall.md
@@ -1,0 +1,110 @@
+# PITWALL: the strategy surfaces, in web technology
+
+Two windows — **PITWALL · DATA** and **PITWALL · AGENTS** — rendering React
+against the arcade's live broadcast. They are the replacement for the two
+PySide6 windows the [arcade dashboard](#/arcade-dashboard) page describes, and
+during the migration both stacks run side by side so every ported panel can be
+compared against the window it replaces while that window still exists.
+
+## Desktop surface, web technology
+
+The distinction matters and it was a deliberate decision.
+
+What renders inside those windows is React, ECharts and CSS in a real Chromium
+engine. What surrounds them is a native OS window, because the host process is
+Python and [pywebview](https://pywebview.flowrl.com/) embeds the browser engine
+in one.
+
+The alternative — a page in a browser, served by a relay — was designed first
+and rejected for a concrete reason: **a browser cannot open a raw TCP socket**,
+so a page would have needed a FastAPI WebSocket relay in front of the arcade's
+broadcast, which makes the backend a runtime dependency of a surface that
+otherwise has none. A Python host opens the socket itself.
+
+That said, the same pages are **also served over loopback**. The host already
+holds the socket and the payload, so handing that payload to a browser costs a
+small HTTP server rather than a relay:
+
+```
+INFO __main__: Also serving the same windows at
+      http://127.0.0.1:62042/data.html and http://127.0.0.1:62042/agents.html
+```
+
+The URL is printed on startup. It binds the loopback interface only — the
+broadcast carries a whole race's live state and there is no authentication —
+and it exists for devtools, a second screen, and anything that is not this
+desktop.
+
+## Launching
+
+Nothing extra to run. `f1-arcade --strategy` (or `python -m src.arcade.main …
+--strategy`) spawns it, exactly the way it spawns the Qt dashboard. To develop
+against an already-running arcade:
+
+```bash
+python -m src.pitwall
+```
+
+The UI is a Vite project under `src/pitwall/ui/`. It ships as built static
+files, so a source checkout needs `npm install && npm run build` in that
+directory once before the windows have anything to show — the entry point says
+so rather than opening blank.
+
+## The two windows
+
+### PITWALL · DATA
+
+Four bands, delivered one per sprint. Band 4 is the one that exists today: the
+own car's lap as **four locked-axis traces against distance** — Δ Time, Speed,
+Brake, Throttle — ported field by field from the Qt telemetry panel, plus a
+shared vertical cursor marking where the car is on the lap, and a schematic
+**track ring** placing the whole field by lap fraction.
+
+Two details that are not cosmetic:
+
+- The rival's traces carry a **BROADCAST** tag. Rival car data is real and
+  public, but it is the coarse low-rate channel every team sees, not
+  pit-wall-grade telemetry. The Qt window rendered it unlabelled.
+- The ring is **schematic, not the circuit**. No track geometry crosses the
+  wire, and `rel_dist` is a fraction of the car's *own* lap, so a dot sits a
+  median 1.3° and up to 24° (on a pit lap) from its true circuit position. It
+  answers *where is everyone* — the pyglet window next to it answers *where
+  exactly*.
+
+### PITWALL · AGENTS
+
+A 1:1 port of the Qt strategy window: header, the orchestrator card, scenario
+bars, the six-tab reasoning panel, and the 3x2 grid of sub-agent cards with
+their embedded charts.
+
+It is 1:1 **by construction** rather than by inspection. The host calls the Qt
+window's own formatters and hands the React side an already-formatted view, so
+the two surfaces cannot describe the same lap differently.
+
+## How it is wired
+
+```
+arcade process                    pitwall process
+  pyglet replay                     ArcadeStreamClient  (ONE socket)
+  TelemetryStreamServer  ──TCP──▶     └─ latest payload slot
+  127.0.0.1:9998                          │
+                                          ├─ window: DATA    ┐ js_api
+                                          ├─ window: AGENTS  ┘ get_tick(since_seq)
+                                          └─ loopback HTTP    /api/tick
+```
+
+**One client, however many consumers.** Both windows and any browser tab read
+through the same `get_tick(since_seq)`, and the sequence is what makes them
+agree: against a blind latest-payload slot, two pollers on independent 10 Hz
+timers were measured reading a different frame on 58 % of polls.
+
+**Closing one window does not blind the other.** The client belongs to the
+host, not to a window; a window closing only decrements a count, and the last
+one out tears the client down.
+
+## Related reading
+
+- [Arcade dashboard](#/arcade-dashboard), the Qt windows PITWALL replaces, and
+  the wire protocol both stacks read.
+- [Arcade quick start](#/arcade-quick-start), running the whole thing.
+- [Roadmap](#/roadmap), the v2.6.0 milestone this belongs to.

--- a/docs/pages/roadmap.md
+++ b/docs/pages/roadmap.md
@@ -451,6 +451,19 @@
   </div>
 </li>
 
+<li class="rl-item">
+  <div class="rl-dot done"></div>
+  <div class="rl-card">
+    <div class="rl-header">
+      <span class="rl-version"><span class="sr-only">Version: </span>v2.1.0 to v2.5.1</span>
+      <span class="rl-date"><span class="sr-only">Date: </span>2026-07-28</span>
+      <span class="rl-badge done-badge"><span class="sr-only">Status: </span>Shipped</span>
+    </div>
+    <p class="rl-title">Decision memory, and a round of correctness hardening</p>
+    <p class="rl-summary">The orchestrator gained a per-race <strong>decision memory</strong>: a caller-owned accumulator rendered into the Layer 3 prompt, wired through the CLI, the arcade and the backend, so a recommendation can say what changed since the last lap and why. Alongside it, a run of correctness work on the Monte Carlo and the agents, including banding <code>threat_level</code> on the served calibrated scale rather than on raw-scale operating points, pricing the lap-number neutralisation union in all three places it lives, and breaking an exact scenario tie by a stated rule instead of by dictionary insertion order. Full detail in the <a href="https://github.com/VforVitorio/F1-StratLab/blob/main/CHANGELOG.md" target="_blank" rel="noopener noreferrer">changelog</a>.</p>
+  </div>
+</li>
+
 </ul>
 
 <p class="rl-section-label">Planned milestones</p>
@@ -465,7 +478,7 @@
       <span class="rl-badge planned-badge"><span class="sr-only">Status: </span>Planned</span>
     </div>
     <p class="rl-title">Arcade, modernized: a web-native trackside frontend</p>
-    <p class="rl-summary">Bring the web app's modern frontend to part of the live Arcade experience, running alongside the PySide6 / pyglet 2D replay rather than replacing it. The strategy and telemetry surfaces move to a web-native view; the <code>lap_state</code> contract and the agents stay unchanged.</p>
+    <p class="rl-summary">Bring the web app's modern frontend to part of the live Arcade experience, running alongside the pyglet 2D replay rather than replacing it. The strategy and telemetry surfaces move to a web-native view; the <code>lap_state</code> contract and the agents stay unchanged.</p>
   </div>
 </li>
 

--- a/docs/pages/setup.md
+++ b/docs/pages/setup.md
@@ -68,10 +68,17 @@ See [Backend API reference → Authentication](#/backend-api) for how `F1_API_KE
 
 ```bash
 cd src/telemetry
-uvicorn backend.main:app --host 0.0.0.0 --port 8000 --reload
+uvicorn backend.main:app --host 127.0.0.1 --port 8000 --reload
 ```
 
 Verify at `http://localhost:8000/docs` (Swagger UI).
+
+> **Bind to loopback, not `0.0.0.0`.** `enforce_startup_security()` refuses to
+> start a keyless backend on a non-loopback address — but it reads the `F1_HOST`
+> setting, not the address uvicorn was actually given on the command line. So
+> `--host 0.0.0.0` with `F1_HOST` left at its default sails past the guard and
+> puts an unauthenticated API on the network. If you do need to bind wider, set
+> `F1_HOST` to match and give it an `F1_API_KEY`.
 
 ### 5. Run the web app
 

--- a/docs/pages/simulation.md
+++ b/docs/pages/simulation.md
@@ -4,7 +4,7 @@
 
 Offline replay of a race from a stored parquet snapshot. Emits `lap_state` dicts, the canonical data contract consumed by all seven strategy agents.
 
-This is the **demo path** for the thesis defence. The live path (Kafka consumer feeding real telemetry) will replace the iterator in v0.14+ without touching any agent code, because agents only see `lap_state` dicts regardless of source.
+This is the **demo path** for the thesis defence. The live path will replace the iterator at the **v3.0.0** milestone ([roadmap](#/roadmap)) without touching any agent code, because agents only see `lap_state` dicts regardless of source.
 
 ## Architecture
 
@@ -81,7 +81,10 @@ Known limitations:
 |---|---|
 | `race_state_manager.py` | Data boundary, per-lap state construction |
 | `replay_engine.py` | Parquet loading, lap iterator, Arcade frame builder |
+| `stint_history.py` | Per-driver stint tracking; emits the Art. 30.5(m) `stint_flags` and `rival_stop_pending` this page documents |
+| `data_validation.py` | Parquet quality checks, including the `IsAccurate` / `Deleted` warning the CLI prints on load |
 | `__main__.py` | Terminal CLI for quick testing |
+| `README.md` | Package-level notes |
 
 ## Running
 
@@ -107,17 +110,24 @@ python -m src.simulation Silverstone VER "Red Bull Racing" --data-dir data/raw/2
 ------------------------------------------------------------------------
    Lap  Pos      Compound   LapTime  Gap Leader                     Ahead                    Behind
 ------------------------------------------------------------------------
-     1    1  INT( 1L)  1:57.099    +0.000s                            P2:VER INT( 1L)  +2.293s
-     2    1  INT( 2L)    ---.-     +0.000s                            P2:VER INT( 2L)  +4.586s [IN]
-    20    1  INT(20L)  1:30.710    +0.000s                            P2:PIA INT(20L) +13.836s
-    34    1  INT(34L)  2:02.273    +0.000s                            P2:PIA INT(34L) +19.398s [IN]
-    35    1  HAR( 2L)  2:03.448    +0.000s                            P2:PIA HAR( 2L) +19.731s [OUT]
-    44    6  HAR(11L)  1:45.587   +34.252s  P5:LEC HAR(11L) +56.481s  P7:LAW MED(11L) +79.194s [IN]
-    46    3  INT( 2L)  1:31.567   -62.788s  P2:LEC HAR(13L) +56.205s  P4:TSU MED(13L) +62.387s
-    57    1  INT(13L)  1:27.126    +0.000s                            P2:VER INT(11L) -18.289s
-------------------------------------------------------------------------
-  Replay complete - 57 laps shown.
+     1    1  INT( 1L)  1:57.099    +0.000s                            P2:VER INT(1L)  +2.276s
+     2    1  INT( 2L)    ---.-     +0.000s                            P2:VER INT(2L)  +1.695s [IN]
+    20    1  INT(20L)  1:30.710    +0.000s                            P2:PIA INT(20L)  +2.623s
+    34    1  INT(34L)  2:02.273    +0.000s                            P2:PIA INT(34L)  +8.185s [IN]
+    35    1  HAR-C3( 2L)  2:03.448    +0.000s                            P2:PIA HAR-C3(2L)  +8.518s [OUT]
+    44    6  HAR-C3(11L)  1:45.587   +15.061s  P5:LEC HAR-C3(11L)  -0.138s  P7:LAW MED-C4(11L)  +4.589s [IN]
+    46    3  INT( 2L)  1:31.567    +4.415s  P2:LEC HAR-C3(13L)  -0.414s  P4:TSU MED-C4(13L)  +0.381s
+    57    1  INT(13L)  1:27.126    +0.000s                            P2:VER INT(11L)  +0.902s
 ```
+
+> Captured from a real run of the command above, on 2026-08-10. The block it
+> replaced had the same lap times and **pre-fix gaps** — it showed P2 at
+> +13.836 s on lap 20 where the code now emits +2.623 s, because it predated
+> the `Time_s` correction the *Gap computation* section below describes. A
+> stale example that demonstrates the exact failure its own page warns about
+> is worse than no example. The compound labels also gained their Pirelli
+> compound ID (`HAR-C3`) since the old block was captured.
+
 
 **Reading the output:**
 
@@ -233,9 +243,11 @@ python -m src.simulation Silverstone VER "Red Bull Racing" --data-dir data/raw/2
 }
 ```
 
-## Future: Kafka integration (v0.14)
+## Future: live ingestion (v3.0.0)
 
-Replace `RaceReplayEngine.replay()` with a `LiveKafkaConsumer.consume_lap()` iterator that emits the same `lap_state` dict from a live Kafka topic. Zero changes to agents or orchestrator.
+Replace `RaceReplayEngine.replay()` with a consumer that emits the same `lap_state` dict from a live feed. Zero changes to agents or orchestrator.
+
+> The sketch below is written against Kafka because that was the assumed transport when this page was drafted; the [roadmap](#/roadmap)'s v3.0.0 entry names the **OpenF1 WebSocket**. The shape of the change is what matters and it is the same either way: swap the iterator, leave the contract alone. The old `v0.14` numbering here predated the 1.0 release and is long dead.
 
 ```python
 # Current (offline)

--- a/docs/pages/tags.md
+++ b/docs/pages/tags.md
@@ -31,8 +31,8 @@ Tags that appear on a single page are listed under **Other** at the end.
 | `frontend` | [Web app](#/webapp), [Driver colors](#/driver-colors), [Streamlit frontend](#/streamlit) (legacy) |
 | `ui` | [Web app](#/webapp), [Dashboard architecture](#/arcade-dashboard), [Streamlit frontend](#/streamlit) (legacy) |
 | `api` | [Agents API reference](#/agents-api), [Backend API](#/backend-api) |
-| `telemetry` | [Race replay engine](#/simulation), [Backend API](#/backend-api), [Web app](#/webapp), [Dashboard architecture](#/arcade-dashboard) |
-| `chat` | [Backend API](#/backend-api), [Web app](#/webapp) |
+| `telemetry` | [Race replay engine](#/simulation), [Backend API](#/backend-api), [Web app](#/webapp), [Dashboard architecture](#/arcade-dashboard), [Streamlit frontend](#/streamlit) (legacy) |
+| `chat` | [Backend API](#/backend-api), [Web app](#/webapp), [Streamlit frontend](#/streamlit) (legacy) |
 | `voice` | [Streamlit frontend](#/streamlit) (legacy, the voice surface was retired in v2) |
 | `mcp` | [Backend API](#/backend-api), [Web app](#/webapp) |
 

--- a/docs/pages/webapp.md
+++ b/docs/pages/webapp.md
@@ -16,13 +16,16 @@ You need a `.env` with `OPENAI_API_KEY`, or `F1_LLM_PROVIDER=lmstudio` if you ar
 
 ## What is in it
 
-| Tab | What it answers |
-|---|---|
-| Telemetry | What the car did, lap by lap: speed traces, sector times, tyre life |
-| Comparison | Two drivers at 60 fps over the same lap, synchronised |
-| Lab | The ML models themselves, with their calibration and thresholds |
-| Race | The multi-agent pit-wall call for any lap, with each agent's reasoning |
-| Chat | Natural language over the finished race, streaming, rendering tool results inline |
+Six tabs, grouped into three sections by the nav rail (`webapp/src/app/Rail.tsx`):
+
+| Section | Tab | What it answers |
+|---|---|---|
+| Telemetry | Dashboard | What the car did, lap by lap: speed traces, sector times, tyre life |
+| Telemetry | Comparison | Two drivers at 60 fps over the same lap, synchronised |
+| Telemetry | Lab | The ML models themselves, with their calibration and thresholds |
+| Pit wall | Strategy | The strategy surface: scenarios, projections and the decision trail |
+| Pit wall | Race | The multi-agent pit-wall call for any lap, with each agent's reasoning |
+| Assist | Chat | Natural language over the finished race, streaming, rendering tool results inline |
 
 The Chat tab is an MCP client: it reaches the same fourteen tools the agents expose, so an answer about lap 32 runs the same code path the Race tab does rather than a parallel implementation.
 


### PR DESCRIPTION
Closes #914. Every finding from the docs-site audit, fixed against the code.

A Fable gate went through all 22 pages, executing every command and example it safely could. The deep reference pages held up down to constants, schemas and rate-limit numbers, all links resolved, and the version-placeholder discipline was already perfect. The damage was concentrated — and **I re-verified each finding before touching anything**, because a gate can be wrong too.

## The three that faced a user mid-failure

| | |
|---|---|
| **A rescue command that does not exist** | The quick start answered a missing-parquet error with `python -m src.simulation.builder 2025 3`. Executed: `No module named src.simulation.builder`. Someone hitting that error got a second error. Replaced with an `ensure_race` call I ran before writing it down |
| **The hotkey table was wrong in almost every row** | `+`/`-` are unhandled (speed is UP/DOWN and 1-4), LEFT/RIGHT are **hold-to-scrub**, not one-lap steps, and ESCAPE **closes the window** rather than returning to the menu. R, D, B and A existed and were undocumented. Rewritten from `on_key_press` |
| **`driver-colors.md` documented a deleted module** | Its declared path and all nine usage paths died with the Streamlit app (#551). The year-aware design *survived*, reimplemented in TypeScript, so the page is re-pointed at `webapp/src/lib/drivers.ts` rather than deleted — the design is still true, only the language changed |

## Documentation that taught the bug

Two pages showed `run_strategy_pipeline(race_state, laps_df, lap_state=None)` — **the one call shape that makes the Monte Carlo fall back to the legacy seconds path** and silently amputate the projection layer. Both now show the call the arcade really makes, `memory` included, and say why `lap_state` is not optional. The quick start also still explained *"why the arcade keeps its own copy of the orchestrator body"* — a design deleted after it drifted and shipped wrong results (#166).

## One security-adjacent

`setup.md` told a fresh developer to bind `--host 0.0.0.0`. That sails past `enforce_startup_security()`, because the guard reads the **`F1_HOST` setting** and not the address uvicorn was actually given — so a keyless backend comes up open on the network via the exact command the docs gave. Now `127.0.0.1`, with a note explaining the trap for anyone who does need to bind wider.

## The rest

- **CUDA claimed for Linux** when the markers route cu128 to Windows only — stated **twice**, the twin pattern.
- **The example output block regenerated from a real run.** The old one taught pre-fix gaps (P2 at +13.836 s on lap 20 where the code now emits +2.623 s) and predated the compound labels gaining their Pirelli ID. A stale example demonstrating the exact failure its own page warns about.
- "Three workflows" → **eight**, with a table naming the five security and automation ones.
- Five webapp tabs → **six**, in their three rail sections (the Strategy tab was missing entirely).
- The roadmap's inverted sentence (two words that made PITWALL run alongside the windows it replaces), and its timeline carried from v2.0.0 to **2.5.1**.
- The `v0.14` Kafka promise repointed at the **v3.0.0** milestone; `TireOutput` now lists all 11 fields including `deg_cost_s`, *"the field the scorers consume"*; `circuit_domination`'s real prefix and tag; `/prewarm`; the chat rate limits; file and workflow counts.

## PITWALL

It appeared **nowhere on the site**. It gets [a page](docs/pages/pitwall.md) — the desktop-surface-in-web-technology decision and why the relay was rejected, the loopback URL, the two windows, the one-client wiring — plus the wire fields it added to a protocol `arcade-dashboard.md` advertises as *"the full shape"*.

**Every field in that new table was checked against a captured payload**, not against the producer's source:

```
top-level : schema_version ✓  seq ✓
arcade    : race_order ✓ driver_colors ✓ track_status ✓ global_t_min ✓ location ✓
per driver: laps_completed ✓ progress ✓ has_finished ✓ active ✓ rel_dist ✓ has_position ✓
telemetry : main ✓ rival ✓ rewound ✓ dropped ✓   (main is a list of 5 samples, not one point)
```

## What I deliberately did NOT change

The "three windows" phrasing in `home.md` and in the roadmap **timeline**. Those sentences are about versions that shipped, and they were true when they shipped. Only the four present-tense ones moved. Rewriting history to match today is how a changelog stops being one.

## Checks

```
uv run pytest tests/surfaces            181 passed  (incl. the link guards on the new page)
uvx ruff@0.15.22 check . / format --check .   all checks passed / 191 files already formatted
```

Claims verified by execution rather than transcription: the broken command run, the hotkeys read out of `on_key_press`, the simulation example captured from a real Melbourne run, `getDriverColor`'s signature read from `drivers.ts`, `TireOutput`'s field list introspected and compared to the table (`doc == code: True`), the workflow inventory from `ls`, the tab labels from `Rail.tsx`, the router prefix and tag from `circuit_domination.py`.

## When this reaches the site

Not at this merge. `docs.yml` publishes from **`main`**, which is held for the PITWALL programme, so the site keeps its current content until the promotion — at which point PITWALL will be on `main` too, which is exactly why the PITWALL additions are in this PR rather than deferred.
