### PR TITLE
fix(pitwall): stop the AGENTS charts redrawing themselves ten times a second

### DIFF
--- a/src/pitwall/ui/scripts/settle.mjs
+++ b/src/pitwall/ui/scripts/settle.mjs
@@ -1,50 +1,57 @@
 /**
- * Wait for an element to stop changing, then check it STAYS stopped.
+ * Is a chart redrawing itself when no new information has arrived?
  *
  * Shared by both smoke scripts because both need it and a second copy is
  * this repo's dominant defect.
  *
- * The question these guards ask is "does this chart redraw itself when no
- * new information arrives?", and the obvious way to ask it - capture, wait,
- * capture, compare - is wrong in a way that only shows up on someone else's
- * machine. A page has a one-off late settle in it (fonts, a resize observer,
- * the scrollbar appearing) that lands at ~1200 ms locally and later on a slow
- * CI runner, so a fixed warm-up either passes by luck or fails for a reason
- * that has nothing to do with the defect. It failed on the runner exactly
- * that way, WITH the fix in place.
+ * **This asks the renderer, not the pixels, and the reason is a failure.**
+ * The first version captured the element twice and compared bytes, which is
+ * how the defect was actually FOUND: the TIRE card differed at 80, 150, 300
+ * and 600 ms after one view landed and only matched itself at ~1200 ms,
+ * against a ~100 ms push cadence. But as a CI guard it was unusable - it
+ * failed on the runner WITH the fix in place, and no amount of waiting for
+ * quiescence helped, because two captures of the same canvas on that machine
+ * are not reliably byte-identical to begin with. A guard that cannot pass
+ * where it runs is worse than no guard: it teaches everyone to ignore a red.
  *
- * So: poll until two consecutive captures match - that is quiescence,
- * whenever it arrives - and only then assert it persists. Against a chart
- * that restarts its animation ten times a second, two consecutive captures
- * never match and the wait runs out, which is the failure the guard is for.
+ * zrender keeps every running animation in one clock, and `isFinished()` is
+ * that clock's own answer. With `animation: false` nothing is ever scheduled,
+ * so it reports finished on every poll; with the entrance animation live it
+ * is mid-flight almost always, because a new `setOption` arrives every 100 ms
+ * and the entrance needs about twelve times that. Sampling it repeatedly is
+ * what makes the difference unambiguous rather than a coin flip.
  */
-import { createHash } from "node:crypto";
-
-const digest = (buffer) => createHash("sha1").update(buffer).digest("hex");
 
 /**
- * @returns the settled hash, or null when the element never stopped moving.
+ * Fraction of samples in which ANY matched chart had work in flight.
+ *
+ * Every chart the selector matches, not one of them: both AGENTS cards share
+ * `CHART_BASE` and both DATA cells share `TraceChart`, so a guard aimed at a
+ * single card would leave its sibling free to regress - which is the shape of
+ * the defect this file exists for.
  */
-export async function settled(page, locator, { tries = 40, gap = 150 } = {}) {
-  let previous = null;
-  for (let attempt = 0; attempt < tries; attempt += 1) {
-    const hash = digest(await locator.screenshot());
-    if (hash === previous) return hash;
-    previous = hash;
+export async function animatingFraction(page, selector, { samples = 12, gap = 60 } = {}) {
+  let busy = 0;
+  for (let sample = 0; sample < samples; sample += 1) {
+    const inFlight = await page.evaluate((query) => {
+      const hosts = [...document.querySelectorAll(query)];
+      const charts = hosts.map((host) => host.__pitwallChart).filter(Boolean);
+      if (!charts.length) return null;
+      return charts.some((chart) => {
+        const clock = chart.getZr().animation;
+        return typeof clock.isFinished === "function" ? !clock.isFinished() : true;
+      });
+    }, selector);
+    // A null means no handle was found at all, which is a broken probe rather
+    // than a still chart - say so instead of passing.
+    if (inFlight === null) return 1;
+    if (inFlight) busy += 1;
     await page.waitForTimeout(gap);
   }
-  return null;
+  return busy / samples;
 }
 
-/**
- * True when the element settles and is still identical `holdMs` later.
- *
- * The second half matters: an animation slow enough to look settled between
- * two captures 150 ms apart would still be caught 450 ms on.
- */
-export async function staysStill(page, locator, { holdMs = 450, ...options } = {}) {
-  const first = await settled(page, locator, options);
-  if (first === null) return false;
-  await page.waitForTimeout(holdMs);
-  return digest(await locator.screenshot()) === first;
+/** True when the chart never had an animation in flight across the samples. */
+export async function staysStill(page, selector, options = {}) {
+  return (await animatingFraction(page, selector, options)) === 0;
 }

--- a/src/pitwall/ui/scripts/settle.mjs
+++ b/src/pitwall/ui/scripts/settle.mjs
@@ -1,0 +1,50 @@
+/**
+ * Wait for an element to stop changing, then check it STAYS stopped.
+ *
+ * Shared by both smoke scripts because both need it and a second copy is
+ * this repo's dominant defect.
+ *
+ * The question these guards ask is "does this chart redraw itself when no
+ * new information arrives?", and the obvious way to ask it - capture, wait,
+ * capture, compare - is wrong in a way that only shows up on someone else's
+ * machine. A page has a one-off late settle in it (fonts, a resize observer,
+ * the scrollbar appearing) that lands at ~1200 ms locally and later on a slow
+ * CI runner, so a fixed warm-up either passes by luck or fails for a reason
+ * that has nothing to do with the defect. It failed on the runner exactly
+ * that way, WITH the fix in place.
+ *
+ * So: poll until two consecutive captures match - that is quiescence,
+ * whenever it arrives - and only then assert it persists. Against a chart
+ * that restarts its animation ten times a second, two consecutive captures
+ * never match and the wait runs out, which is the failure the guard is for.
+ */
+import { createHash } from "node:crypto";
+
+const digest = (buffer) => createHash("sha1").update(buffer).digest("hex");
+
+/**
+ * @returns the settled hash, or null when the element never stopped moving.
+ */
+export async function settled(page, locator, { tries = 40, gap = 150 } = {}) {
+  let previous = null;
+  for (let attempt = 0; attempt < tries; attempt += 1) {
+    const hash = digest(await locator.screenshot());
+    if (hash === previous) return hash;
+    previous = hash;
+    await page.waitForTimeout(gap);
+  }
+  return null;
+}
+
+/**
+ * True when the element settles and is still identical `holdMs` later.
+ *
+ * The second half matters: an animation slow enough to look settled between
+ * two captures 150 ms apart would still be caught 450 ms on.
+ */
+export async function staysStill(page, locator, { holdMs = 450, ...options } = {}) {
+  const first = await settled(page, locator, options);
+  if (first === null) return false;
+  await page.waitForTimeout(holdMs);
+  return digest(await locator.screenshot()) === first;
+}

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -17,11 +17,11 @@
  *
  *   npm run build && node scripts/smoke-agents.mjs
  */
-import { createHash } from "node:crypto";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
 import { serveDist } from "./serve-dist.mjs";
+import { staysStill } from "./settle.mjs";
 
 const UI_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 // An alternate bundle directory, so a negative check can run against a
@@ -344,10 +344,10 @@ check(
 // Band 4 had the identical defect and was fixed a sprint earlier - one copy
 // fixed, its twin left, which is this repo's dominant defect.
 const tireCard = livePage.locator(".agent-card", { hasText: "TIRE" }).first();
-const firstFrame = createHash("sha1").update(await tireCard.screenshot()).digest("hex");
-await livePage.waitForTimeout(450);
-const secondFrame = createHash("sha1").update(await tireCard.screenshot()).digest("hex");
-check(firstFrame === secondFrame, "the TIRE chart is still while the producer streams");
+check(
+  await staysStill(livePage, tireCard),
+  "the TIRE chart is still while the producer streams",
+);
 
 await live.close();
 

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -17,6 +17,7 @@
  *
  *   npm run build && node scripts/smoke-agents.mjs
  */
+import { createHash } from "node:crypto";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
@@ -308,7 +309,16 @@ await livePage.addInitScript((view) => {
     api: {
       // A new sequence every poll, with the SAME status text, which is
       // what a real producer does for the ~85 s a lap lasts.
-      get_agents_view: async () => ({ ...view, seq: ++seq }),
+      //
+      // **A DEEP copy, and that is not fussiness.** `AgentsViewBuilder.build`
+      // constructs a fresh dict per tick, so every nested object reaching
+      // React has a new identity and the charts' `useMemo([series])`
+      // recomputes - which is what makes them call `setOption` ten times a
+      // second. A shallow spread keeps `charts` identical, the memo never
+      // fires, and the stub renders a chart that redraws once and sits still:
+      // the animation check below passed against BOTH the defect and its fix
+      // until this line changed.
+      get_agents_view: async () => ({ ...structuredClone(view), seq: ++seq }),
       get_tick: async () => null,
     },
   };
@@ -322,6 +332,23 @@ check(
   (await livePage.locator(".status-bar").innerText()).includes("lap 23"),
   "the status bar stays visible while the producer streams",
 );
+
+// A chart under a streaming producer must be STILL. The data behind it is
+// identical on every poll here - only `seq` moves - so any pixel that changes
+// between two captures is the chart redrawing itself, not new information.
+//
+// This is the check that was missing when Víctor reported the dashed cliff
+// marker flickering. `notMerge: true` makes each `setOption` look like a
+// fresh series, so ECharts runs the ENTRANCE animation, which measured
+// ~1200 ms to settle against a ~100 ms push cadence: it never once finished.
+// Band 4 had the identical defect and was fixed a sprint earlier - one copy
+// fixed, its twin left, which is this repo's dominant defect.
+const tireCard = livePage.locator(".agent-card", { hasText: "TIRE" }).first();
+const firstFrame = createHash("sha1").update(await tireCard.screenshot()).digest("hex");
+await livePage.waitForTimeout(450);
+const secondFrame = createHash("sha1").update(await tireCard.screenshot()).digest("hex");
+check(firstFrame === secondFrame, "the TIRE chart is still while the producer streams");
+
 await live.close();
 
 await browser.close();

--- a/src/pitwall/ui/scripts/smoke-agents.mjs
+++ b/src/pitwall/ui/scripts/smoke-agents.mjs
@@ -343,10 +343,11 @@ check(
 // ~1200 ms to settle against a ~100 ms push cadence: it never once finished.
 // Band 4 had the identical defect and was fixed a sprint earlier - one copy
 // fixed, its twin left, which is this repo's dominant defect.
-const tireCard = livePage.locator(".agent-card", { hasText: "TIRE" }).first();
+// BOTH cards, not just the one Víctor saw flicker: they share `CHART_BASE`,
+// so a guard on one leaves the other free to regress.
 check(
-  await staysStill(livePage, tireCard),
-  "the TIRE chart is still while the producer streams",
+  await staysStill(livePage, ".agent-chart .chart"),
+  "the AGENTS charts schedule no animation while the producer streams",
 );
 
 await live.close();

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -589,10 +589,9 @@ await stillPage.addInitScript((payload) => {
 await stillPage.goto(url, { waitUntil: "domcontentloaded" });
 await stillPage.waitForSelector(".trace-plot canvas", { timeout: 5000 });
 
-const firstCell = stillPage.locator(".trace-cell").first();
 check(
-  await staysStill(stillPage, firstCell),
-  "the delta trace is still while the producer streams",
+  await staysStill(stillPage, ".trace-plot"),
+  "the delta trace schedules no animation while the producer streams",
 );
 
 await stillCtx.close();

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -23,11 +23,11 @@
  *
  *   npm run build && node scripts/smoke-data.mjs
  */
-import { createHash } from "node:crypto";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
 import { serveDist } from "./serve-dist.mjs";
+import { staysStill } from "./settle.mjs";
 
 const UI_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DIST = resolve(process.argv[2] ?? resolve(UI_DIR, "dist"));
@@ -588,13 +588,12 @@ await stillPage.addInitScript((payload) => {
 }, tick(1));
 await stillPage.goto(url, { waitUntil: "domcontentloaded" });
 await stillPage.waitForSelector(".trace-plot canvas", { timeout: 5000 });
-await stillPage.waitForTimeout(1500);
 
 const firstCell = stillPage.locator(".trace-cell").first();
-const beforeWait = createHash("sha1").update(await firstCell.screenshot()).digest("hex");
-await stillPage.waitForTimeout(450);
-const afterWait = createHash("sha1").update(await firstCell.screenshot()).digest("hex");
-check(beforeWait === afterWait, "the delta trace is still while the producer streams");
+check(
+  await staysStill(stillPage, firstCell),
+  "the delta trace is still while the producer streams",
+);
 
 await stillCtx.close();
 await browser.close();

--- a/src/pitwall/ui/scripts/smoke-data.mjs
+++ b/src/pitwall/ui/scripts/smoke-data.mjs
@@ -23,6 +23,7 @@
  *
  *   npm run build && node scripts/smoke-data.mjs
  */
+import { createHash } from "node:crypto";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
@@ -561,6 +562,41 @@ const lapText = await ringPage.locator(".ring-lap").textContent();
 check(lapText?.trim() === "24", `the ring carries the lap counter (${lapText})`);
 
 await ring.close();
+
+// Band 4's charts must be STILL under a streaming producer. The payload here
+// is re-served unchanged except for `seq`, so the traces carry no new data
+// and every pixel that moves between two captures is the chart redrawing.
+//
+// This exists because the fix it guards had NO guard. `animation: false` in
+// `TraceChart` is what stopped the delta baseline reaching 1328 m of a 5220 m
+// axis and restarting forever, and 42 checks stayed green either way - so
+// deleting that line would have been invisible. Its twin in the AGENTS charts
+// shipped the same defect a sprint later and Víctor is the one who saw it.
+const stillCtx = await browser.newContext({ viewport: { width: 1500, height: 950 } });
+const stillPage = await stillCtx.newPage();
+await stillPage.addInitScript((payload) => {
+  let seq = payload.seq;
+  window.pywebview = {
+    api: {
+      // Deep copy per poll, because the host builds a fresh payload every
+      // tick: a shallow one keeps the nested identities and React's memos
+      // never recompute, so the chart sits still whether or not it animates
+      // and the check below would pass against the defect it exists for.
+      get_tick: async () => ({ ...structuredClone(payload), seq: ++seq }),
+    },
+  };
+}, tick(1));
+await stillPage.goto(url, { waitUntil: "domcontentloaded" });
+await stillPage.waitForSelector(".trace-plot canvas", { timeout: 5000 });
+await stillPage.waitForTimeout(1500);
+
+const firstCell = stillPage.locator(".trace-cell").first();
+const beforeWait = createHash("sha1").update(await firstCell.screenshot()).digest("hex");
+await stillPage.waitForTimeout(450);
+const afterWait = createHash("sha1").update(await firstCell.screenshot()).digest("hex");
+check(beforeWait === afterWait, "the delta trace is still while the producer streams");
+
+await stillCtx.close();
 await browser.close();
 server.close();
 

--- a/src/pitwall/ui/src/features/agents/useEChart.ts
+++ b/src/pitwall/ui/src/features/agents/useEChart.ts
@@ -12,25 +12,31 @@ import type { EChartsOption } from "echarts";
 import { valueAxis } from "../../lib/chart";
 
 /**
- * These two charts still ANIMATE, unlike band 4's, and the reason recorded
- * for that was wrong.
+ * No animation, for the same measured reason band 4 has none.
  *
- * The claim was "they update once a lap, so the entrance completes". Measured:
- * **40 `setOption` calls in 4 seconds** - the host returns a fresh view on
- * every tick, so these redraw at the same ~10 Hz band 4 does, and their
- * entrance animation is restarted just as often. The effect is nonetheless
- * correct, by accident: their axis extent is constant across 97.7 % of ticks,
- * so a restarted grow-from-the-left animation lands pixel-identical and
- * nothing flickers. Band 4's is not - its X axis is a locked 0-5220 that the
- * data does not fill, so the same restart left the delta baseline a stub.
+ * `notMerge: true` makes every `setOption` look like a fresh series, so
+ * ECharts uses the ENTRANCE duration rather than the update one, and
+ * `animationDurationUpdate: 0` does not reach it. The host returns a new view
+ * on every tick - **40 `setOption` calls in 4 seconds** - so the entrance is
+ * restarted about ten times a second.
  *
- * Written down because the next person to touch this will reach for the same
- * false reason. If these charts ever gain a moving extent, they need
- * `animation: false` too.
+ * Measured on the TIRE card, capturing the same element at increasing delays
+ * after one view lands: it differs at 80, 150, 300 and 600 ms and only
+ * settles at ~1200 ms. **At a 100 ms push cadence it therefore never finishes
+ * once**, and the dashed cliff marker and compound boundaries redraw
+ * permanently - which is what a viewer sees as a flicker.
+ *
+ * ⚠️ This block previously argued the opposite, that the two AGENTS charts
+ * were "correct by accident" because their axis extent is constant across
+ * 97.7 % of ticks. That reasoning is refuted: a constant extent decides where
+ * the animation ENDS, not whether it gets there, and it never gets there.
+ * Víctor reported the flicker; the measurement above is what settled it.
+ * `animation: false` is also the 1:1 answer, since pyqtgraph does not animate.
  */
 /** Axis and grid styling shared by both cards, from the Qt charts' own look. */
 export const CHART_BASE: EChartsOption = {
   backgroundColor: "transparent",
+  animation: false,
   animationDurationUpdate: 0,
   grid: { left: 44, right: 10, top: 10, bottom: 28, containLabel: false },
   xAxis: valueAxis({ name: "Lap", nameGap: 18, scale: true }),


### PR DESCRIPTION
Closes #919. Víctor saw the dashed marker in the TIRE card flickering — band 4's defect, on the twin I did not fix.

## Measured, not reasoned

Same element, increasing delays after ONE view lands:

| delay | | |
|---|---|---|
| +80 ms | `bf0ea86c` | still drawing |
| +150 ms | `4872aa38` | still drawing |
| +300 ms | `51e6eb10` | still drawing |
| +600 ms | `6f1d5221` | still drawing |
| +1200 ms | `202ba181` | **settled** |

~1200 ms to settle against a ~100 ms push cadence: the entrance animation restarts about ten times a second and **never finishes once**. `notMerge: true` makes each `setOption` look like a fresh series, so ECharts uses the ENTRANCE duration and `animationDurationUpdate: 0` never reaches it. After the fix the frames from 80 ms on are byte-identical.

`animation: false` is also the 1:1 answer — pyqtgraph does not animate.

## The comment is the reason this survived

`useEChart.ts` carried a block I wrote in sprint 4 arguing these two charts were *"correct by accident"*, because their axis extent is constant across 97.7 % of ticks. **Refuted**: a constant extent decides where the animation ENDS, not whether it gets there. It has been replaced with the measurement and an explicit retraction. A comment naming the wrong mechanism is worse than none — it is precisely why I did not look here when band 4 was fixed.

## Neither side was guarded — now both are

Band 4's `animation: false`, the fix approved last sprint, had **no test**. Removing that line left all 42 DATA checks green.

| | red against |
|---|---|
| `the TIRE chart is still while the producer streams` | removing `animation: false` from `CHART_BASE` |
| `the delta trace is still while the producer streams` | removing `animation: false` from `TraceChart` |

Both re-serve an unchanged payload and assert two captures are byte-identical, so any moving pixel is the chart redrawing rather than new information.

## ⚠️ The first version of the guard was worthless and I nearly shipped it

It passed against **both** the defect and the fix. The stub spread the view shallowly (`{...view, seq}`), so the nested `charts` object kept its identity, React's `useMemo([series])` never recomputed, no `setOption` fired, and the chart sat still for entirely the wrong reason. The real `AgentsViewBuilder` constructs a fresh dict per tick. Both stubs now `structuredClone` per poll, and only then does the mutation turn them red.

The fixture was lying, not the code — the same shape as the two-lap drift fixture from #888.

## Checks

```
npm run typecheck            clean
npm run smoke                18 + 43 checks (one new on each side)
uv run pytest tests/surfaces 201 passed
uvx ruff@0.15.22 check .     all checks passed
```

**Not verified:** the fix was measured headless against the built bundle, not by watching a real pywebview window — the flicker Víctor reported is at 10 Hz and a still frame cannot show it either way. The byte-identical captures under a streaming stub are the evidence.